### PR TITLE
NMRL-404 "Select all" checkbox is missing in Aggregated List of Analyses

### DIFF
--- a/bika/lims/browser/aggregatedanalyses/aggregatedanalyses.py
+++ b/bika/lims/browser/aggregatedanalyses/aggregatedanalyses.py
@@ -34,7 +34,8 @@ class AggregatedAnalysesView(AnalysesView):
     def __init__(self, context, request, **kwargs):
         AnalysesView.__init__(self, context, request)
         self.title = _("Analyses pending")
-        self.show_select_all_checkbox = False
+        self.show_select_all_checkbox = self.context.bika_setup\
+            .getEnableSelectAllCheckboxInAggregatedanalyses()
         self.show_categories = False
         self.pagesize = 50
         # Get temp objects that are too time consuming to obtain every time

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -832,6 +832,18 @@ schema = BikaFolderSchema.copy() + Schema((
             description=_("Default value of the 'AR count' when users click 'ADD' button to create new Analysis Requests"),
         )
     ),
+    BooleanField(
+        'EnableSelectAllCheckboxInAggregatedanalyses',
+        schemata="Analyses",
+        default=False,
+        widget=BooleanWidget(
+            label=_("'Select all' checkbox in aggregated analyses view"),
+            description=_(
+                "Add a checkbox to select all listed items in aggregated"
+                " analyses view"
+            )
+        ),
+    ),
 ))
 
 schema['title'].validators = ()

--- a/bika/lims/subscribers/bikasetup.py
+++ b/bika/lims/subscribers/bikasetup.py
@@ -38,33 +38,10 @@ def BikaSetupModifiedEventHandler(instance, event):
     mp(AddClient, roles, 1)
     mp(EditClient, roles, 1)
     # Set permissions at object level
-    clients = portal.clients.objectValues()
-    if check_if_client_permissions_has_changed(clients[0], roles):
-        for obj in clients:
-            mp = obj.manage_permission
-            mp(AddClient, roles, 0)
-            mp(EditClient, roles, 0)
-            mp(permissions.ModifyPortalContent, roles, 0)
-            obj.reindexObject()
-
-
-def check_if_client_permissions_has_changed(client, roles):
-    """
-    Checks if client permissions have been changed.
-    :param client: a client archetype object
-    :param roles: a list of strings as role names
-    :return: Boolean
-    """
-    perms = client.rolesOfPermission(AddClient)
-    labclerk = 'LabClerk'
-    has_changed = False
-    for perm in perms:
-        if perm["name"] == labclerk:
-            # will be SELECTED if the permission is granted
-            if perm["selected"] == "" and labclerk in roles:
-                has_changed = True
-                break
-            elif perm["selected"] == "SELECTED" and labclerk not in roles:
-                has_changed = True
-                break
-    return has_changed
+    # TODO-performance: We are allways reindexing all clients
+    for obj in portal.clients.objectValues():
+        mp = obj.manage_permission
+        mp(AddClient, roles, 0)
+        mp(EditClient, roles, 0)
+        mp(permissions.ModifyPortalContent, roles, 0)
+        obj.reindexObject()

--- a/bika/lims/subscribers/bikasetup.py
+++ b/bika/lims/subscribers/bikasetup.py
@@ -38,10 +38,33 @@ def BikaSetupModifiedEventHandler(instance, event):
     mp(AddClient, roles, 1)
     mp(EditClient, roles, 1)
     # Set permissions at object level
-    # TODO-performance: We are allways reindexing all clients
-    for obj in portal.clients.objectValues():
-        mp = obj.manage_permission
-        mp(AddClient, roles, 0)
-        mp(EditClient, roles, 0)
-        mp(permissions.ModifyPortalContent, roles, 0)
-        obj.reindexObject()
+    clients = portal.clients.objectValues()
+    if check_if_client_permissions_has_changed(clients[0], roles):
+        for obj in clients:
+            mp = obj.manage_permission
+            mp(AddClient, roles, 0)
+            mp(EditClient, roles, 0)
+            mp(permissions.ModifyPortalContent, roles, 0)
+            obj.reindexObject()
+
+
+def check_if_client_permissions_has_changed(client, roles):
+    """
+    Checks if client permissions have been changed.
+    :param client: a client archetype object
+    :param roles: a list of strings as role names
+    :return: Boolean
+    """
+    perms = client.rolesOfPermission(AddClient)
+    labclerk = 'LabClerk'
+    has_changed = False
+    for perm in perms:
+        if perm["name"] == labclerk:
+            # will be SELECTED if the permission is granted
+            if perm["selected"] == "" and labclerk in roles:
+                has_changed = True
+                break
+            elif perm["selected"] == "SELECTED" and labclerk not in roles:
+                has_changed = True
+                break
+    return has_changed


### PR DESCRIPTION
It was decided not to show the 'select all' checkbox in aggregated analyses.

This PR enables this checkbox again, bit now it depends on a bikasetup boolean field.

This PR also defined a function (check_if_client_permissions_has_changed) that prevents bikasetup subscriber to reindex all clients each time it is modified.