### PR TITLE
Added IFrontPageAdapter, to make front page custom-redirections easier

### DIFF
--- a/bika/lims/browser/bika-frontpage.py
+++ b/bika/lims/browser/bika-frontpage.py
@@ -8,9 +8,9 @@ from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
 from plone import api as ploneapi
-
 from bika.lims.browser import BrowserView
-
+from bika.lims.interfaces import IFrontPageAdapter
+from zope.component import getAdapters
 
 class FrontPageView(BrowserView):
     """Bika default Front Page
@@ -35,6 +35,11 @@ class FrontPageView(BrowserView):
         # Authenticated Users get either the Dashboard, the std. Bika Frontpage
         # or the custom landing page. Furthermore, they can switch between the
         # Dashboard and the landing page.
+        # Add-ons can have an adapter for front-page-url as well.
+        for name, adapter in getAdapters((self.context,), IFrontPageAdapter):
+            redirect_to = adapter.get_front_page_url()
+            if redirect_to:
+                return self.request.response.redirect(self.portal_url + redirect_to)
 
         # First precedence: Request parameter `redirect_to`
         redirect_to = self.request.form.get("redirect_to", None)

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -744,3 +744,11 @@ class IAcquireFieldDefaults(Interface):
     def __call__(context, field):
         """This function must return the surrogate (source) value directly.
         """
+
+
+class IFrontPageAdapter(Interface):
+
+    """ Bika Front Page Url Finder Adapter's Interface"""
+
+    def get_front_page_url(self):
+        """ Get url of necessary front-page """


### PR DESCRIPTION
By default, on Bika Lims, there is a front-page, which in some cases redirects users to Dashboard, Samples page or etc. But for some add-ons we may need to redirect users to another pages. Thus, added new Interface, to enable that functionality on new add-ons bu using 'Adapter'.
P.S: New adapter will work only for authorized users. 