### PR TITLE
NMRL-383 Sanitize async task to regularize department value for old Analysis Requests w/o department assigned

### DIFF
--- a/bika/lims/databasesanitize/Enable_Task_Queue.txt
+++ b/bika/lims/databasesanitize/Enable_Task_Queue.txt
@@ -1,0 +1,23 @@
+For some big processes which do not affect users' use of Bika, it is possible to add
+ASYNCHRONOUS tasks which will run in background. In order to enable that, you must add tho following
+lines in buildout.cfg:
+
+1. Eggs part:
+
+egg=
+...
+collective.taskqueue
+...
+
+
+
+2. and the following lines under [instance] section
+
+zope-conf-additional =
+    %import collective.taskqueue
+    <taskqueue>
+    queue sanitation-tasks
+    </taskqueue>
+    <taskqueue-server>
+    queue sanitation-tasks
+    </taskqueue-server>

--- a/bika/lims/databasesanitize/ar_deps.py
+++ b/bika/lims/databasesanitize/ar_deps.py
@@ -1,0 +1,29 @@
+import transaction
+from plone.api.portal import get_tool
+
+from bika.lims import logger
+from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
+from .analyses import commit_action
+
+
+def set_ar_departments():
+    """
+    Some of old Analysis Request may not have Departments assigned. This task
+    will assign their departments according to their 'analyses'.
+    :return: boolean - success state of the process.
+    """
+
+    ar_catalog = get_tool(CATALOG_ANALYSIS_REQUEST_LISTING)
+    # Getting all Analysis Requests to walk through
+    ar_brains = ar_catalog()
+    total_ars = len(ar_brains)
+    total_iterated = 0
+    logger.info("Analysis Requests to walk over: {}".format(total_ars))
+    total_modified = 0
+    for ar_brain in ar_brains:
+        total_modified = total_modified+1
+        total_iterated = commit_action(
+            total_ars, total_iterated, total_modified)
+    transaction.commit()
+    logger.info("AR Department assignment is done.")
+    return True

--- a/bika/lims/databasesanitize/ar_deps.py
+++ b/bika/lims/databasesanitize/ar_deps.py
@@ -21,9 +21,23 @@ def set_ar_departments():
     logger.info("Analysis Requests to walk over: {}".format(total_ars))
     total_modified = 0
     for ar_brain in ar_brains:
+        if ar_brain.getDepartmentUIDs:
+            continue
+        ar = ar_brain.getObject()
+        ans = ar.getAnalyses()
+        for an_brain in ans:
+            dep = None
+            an = an_brain.getObject()
+            dep = an.getAnalysisService().getDepartment()
+            if dep:
+                an.setDepartment(dep)
+                an.reindexObject()
+
+        ar.reindexObject()
         total_modified = total_modified+1
         total_iterated = commit_action(
             total_ars, total_iterated, total_modified)
     transaction.commit()
-    logger.info("AR Department assignment is done.")
+    logger.info("AR Department assignment is finished. Total # of modified ARs: \
+                {0}".format(str(total_modified)))
     return True

--- a/bika/lims/databasesanitize/configure.zcml
+++ b/bika/lims/databasesanitize/configure.zcml
@@ -22,6 +22,14 @@
 
     <browser:page
       for="*"
+      name="st_ar_dep_assignment"
+      class="bika.lims.databasesanitize.controller_view.ARDepartmentAssignment"
+      permission="cmf.ModifyPortalContent"
+      layer="bika.lims.interfaces.IBikaLIMS"
+    />
+
+    <browser:page
+      for="*"
       name="queued_sanitation_tasks"
       class="bika.lims.databasesanitize.controller_view.QueuedSanitationTasksCount"
       permission="zope.Public"

--- a/bika/lims/databasesanitize/templates/main_template.pt
+++ b/bika/lims/databasesanitize/templates/main_template.pt
@@ -21,6 +21,13 @@
                     will set the Analysis creation date with the one stored
                     in the request.
                 </label>
+                <br>
+                <label>
+                    <input type="checkbox"
+                           name="sanitize_ar_departments"
+                           value="1">
+                    Reassign AR Departments.
+                </label>
             </p>
     </div>
 


### PR DESCRIPTION
Some of old Analysis Requests were missing 'getDepartment()' values, because Analsysis Services of their Analyses hadn't had any Department assigned. For this kind of ARs, we have created a Sync Task which will iterate their analysis, and if there is a Department assigned to their Analysis Service, then will add that Department to Analysis's Department field.