### PR TITLE
bika_arimports_workflow linked to ARImports folder

### DIFF
--- a/bika/lims/profiles/default/workflows.xml
+++ b/bika/lims/profiles/default/workflows.xml
@@ -6,6 +6,7 @@
   <object name="bika_analysis_workflow" meta_type="Workflow"/>
   <object name="bika_ar_workflow" meta_type="Workflow"/>
   <object name="bika_arimport_workflow" meta_type="Workflow"/>
+  <object name="bika_arimports_workflow" meta_type="Workflow"/>
   <object name="bika_batch_workflow" meta_type="Workflow"/>
   <object name="bika_cancellation_workflow" meta_type="Workflow"/>
   <object name="bika_duplicateanalysis_workflow" meta_type="Workflow"/>
@@ -32,11 +33,6 @@
     <default>
       <bound-workflow workflow_id="plone_workflow"/>
     </default>
-
-    <!-- AR Imports -->
-    <type type_id="ARImports">
-      <bound-workflow workflow_id="bika_arimports_workflow"/>
-    </type>
 
     <!-- AR Import -->
     <type type_id="ARImport">

--- a/bika/lims/setuphandlers.py
+++ b/bika/lims/setuphandlers.py
@@ -566,6 +566,8 @@ class BikaGenerator(object):
             # noinspection PyBroadException
             try:
                 workflow.doActionFor(obj, "hide")
+                wf = workflow.getWorkflowById("bika_arimports_workflow")
+                wf.updateRoleMappingsFor(obj)
             except:
                 pass
             obj.setLayout('@@arimports')

--- a/bika/lims/upgrade/v01_01_003.py
+++ b/bika/lims/upgrade/v01_01_003.py
@@ -26,10 +26,37 @@ def upgrade(tool):
 
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
+    # Updating profile steps:
+    # list of the generic setup import step names:
+    # --> portal.portal_setup.getSortedImportSteps() <---
+    #
+    # if you want more metadata use this:
+    # --> portal.portal_setup.getImportStepMetadata('jsregistry') <---
+    #
+    # important info about upgrade steps in
+    # http://stackoverflow.com/questions/7821498/is-there-a-good-reference-list-for-the-names-of-the-genericsetup-import-steps
+
+    # New ARImports workflow
+    setup.runImportStepFromProfile(profile, 'workflow')
+
     # Attachments must be present in a catalog, otherwise the idserver
     # will fall apart.  https://github.com/senaite/bika.lims/issues/323
     at = getToolByName(portal, 'archetype_tool')
     at.setCatalogsByType('Attachment', ['portal_catalog'])
-
+    update_arimport_workflow_and_permissions(portal, setup)
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
+
+
+def update_arimport_workflow_and_permissions(portal, setup):
+    """
+    Updates the workflow and permissions of ARImprt objects since a new
+    workflow has been created for them.
+    :param portal: Portal archetype object
+    :return: None
+    """
+    wf_tool = getToolByName(portal, 'portal_workflow')
+    logger.info("Updating workflow definitions...")
+    wf = wf_tool.getWorkflowById("bika_arimports_workflow")
+    wf.updateRoleMappingsFor(setup.arimports)
+    logger.info("Workflow definitions updated.")


### PR DESCRIPTION
https://github.com/senaite/bika.lims/pull/320/commits/6a6b58c1a9a079ffdfb1152aedfc002db24ae6f3 defined a new workflow, but this workflow was only installed on new instances. 

This PR contains an upgrade step to bind "bika_arimports_workflow" to the ARImport folder.

Since ARImport folder is actually a "Folder" content type, setuphandlers binds this workflow during runtime, instead of using "profiles.default.workflows.xml" to bind them.