### PR TITLE
common javascript function to update reference widgets (combogrid)

### DIFF
--- a/bika/lims/browser/js/bika.lims.common.js
+++ b/bika/lims/browser/js/bika.lims.common.js
@@ -123,6 +123,64 @@ function CommonUtils() {
             }
         };
 
+        /**
+         * Update or modify a query filter for a reference widget.
+         * This will set the options, then re-create the combogrid widget
+         * with the new filter key/value.
+         *
+         * @param {object} element - the input element as combogrid.
+         * @param {string} filterkey - the new filter key to filter by.
+         * @param {string} filtervalue - the value of the new filter.
+         * @param {string} querytype - it can be 'base_query' or 'search_query'
+         */
+        window.bika.lims.update_combogrid_query = function(
+                element, filterkey, filtervalue, querytype) {
+
+            if (!$(element).is(':visible')) {
+                return;
+            };
+            if (!querytype) {
+                querytype = 'base_query';
+            };
+            // Adding the new query filter
+            var query =  jQuery.parseJSON($(element).attr(querytype));
+            query[filterkey] = filtervalue;
+            $(element).attr(querytype, JSON.stringify(query));
+
+            var options = jQuery.parseJSON(
+                $(element).attr("combogrid_options"));
+
+            // Building new ajax request
+            options.url = window.portal_url + "/" + options.url;
+            options.url = options.url + "?_authenticator=" +
+                $("input[name='_authenticator']").val();
+            options.url = options.url + "&catalog_name=" +
+                $(element).attr("catalog_name");
+
+            options.url = options.url + "&base_query=" +
+                encodeURIComponent($(element).attr("base_query"));
+            options.url = options.url + "&search_query=" +
+                encodeURIComponent($.toJSON(query));
+
+            var col_model = options.colModel;
+            var search_fields = options.search_fields;
+            var discard_empty = options.discard_empty
+
+            options.url = options.url + "&colModel=" +
+                $.toJSON(col_model);
+
+            options.url = options.url + "&search_fields=" +
+                $.toJSON(search_fields)
+
+            options.url = options.url + "&discard_empty=" +
+                $.toJSON(discard_empty);
+
+            options.force_all = "false";
+
+            // Apply changes
+            $(element).combogrid(options);
+        };
+
         // Priority Selection Widget
         $('.ArchetypesPrioritySelectionWidget select').change(function(e){
             var val = $(this).find('option:selected').val();

--- a/bika/lims/browser/js/bika.lims.common.js
+++ b/bika/lims/browser/js/bika.lims.common.js
@@ -127,6 +127,7 @@ function CommonUtils() {
          * Update or modify a query filter for a reference widget.
          * This will set the options, then re-create the combogrid widget
          * with the new filter key/value.
+         * If filtervalue is empty, the function will delete the query element.
          *
          * @param {object} element - the input element as combogrid.
          * @param {string} filterkey - the new filter key to filter by.
@@ -142,9 +143,15 @@ function CommonUtils() {
             if (!querytype) {
                 querytype = 'base_query';
             };
-            // Adding the new query filter
             var query =  jQuery.parseJSON($(element).attr(querytype));
-            query[filterkey] = filtervalue;
+            // Adding the new query filter
+            if (filtervalue) {
+                query[filterkey] = filtervalue;
+                };
+            // Deleting the query filter
+            if (filtervalue === '' && query[filterkey]){
+                delete query[filterkey];
+            };
             $(element).attr(querytype, JSON.stringify(query));
 
             var options = jQuery.parseJSON(
@@ -164,7 +171,7 @@ function CommonUtils() {
 
             var col_model = options.colModel;
             var search_fields = options.search_fields;
-            var discard_empty = options.discard_empty
+            var discard_empty = options.discard_empty;
 
             options.url = options.url + "&colModel=" +
                 $.toJSON(col_model);


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Common function to update combrogrid options in reference widgets. This allows to update query filters through JS easily.

## Current behavior before PR

The coder needed to update each attribute manually.

## Desired behavior after PR is merged

Calling this function should be enough to update the filter.
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
