### PR TITLE
ARAnalysesField setter doesn't accept Analysis objects.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changelog
 **Added**
 
 - #377 XML importer in Instrument Interface of Nuclisense EasyQ
+- #431 ARAnalysesField setter doesn't accept Analysis objects.
 
 **Removed**
 

--- a/bika/lims/api.py
+++ b/bika/lims/api.py
@@ -1113,3 +1113,25 @@ def normalize_filename(string):
     # get the file nomalizer utility
     normalizer = getUtility(IFileNameNormalizer).normalize
     return normalizer(string)
+
+def is_uid(uid, validate=False):
+    """Checks if the passed in uid is a valid UID
+
+    :param uid: The uid to check
+    :param validate: If False, checks if uid is a valid 23 alphanumeric uid. If
+    True, also verifies if a brain exists for the uid passed in
+    :type uid: string
+    :return: True if a valid uid
+    :rtype: bool
+    """
+    if not isinstance(uid, basestring):
+        return False
+    if len(uid) != 32:
+        return False
+    if not validate:
+        return True
+
+    # Check if a brain for this uid exists
+    uc =get_tool('uid_catalog')
+    brains = uc(UID=uid)
+    return len(brains) > 0

--- a/bika/lims/api.py
+++ b/bika/lims/api.py
@@ -1132,6 +1132,8 @@ def is_uid(uid, validate=False):
         return True
 
     # Check if a brain for this uid exists
-    uc =get_tool('uid_catalog')
+    uc = get_tool('uid_catalog')
     brains = uc(UID=uid)
+    if brains:
+        assert (len(brains) == 1)
     return len(brains) > 0

--- a/bika/lims/browser/fields/aranalysesfield.py
+++ b/bika/lims/browser/fields/aranalysesfield.py
@@ -100,7 +100,9 @@ class ARAnalysesField(ObjectField):
 
         service_uids is a list:
             The UIDs of all services which should exist in the AR.  If a service
-            is not included here, the corrosponding Analysis will be removed.
+            is not included here, the corresponding Analysis will be removed.
+            If that list contains Analysis objects, then service_uids will be
+            taken from them.
 
         prices is a dictionary:
             key = AnalysisService UID
@@ -115,6 +117,10 @@ class ARAnalysesField(ObjectField):
             return
 
         assert type(service_uids) in (list, tuple)
+
+        for i, item in enumerate(service_uids):
+            if hasattr(item, 'getServiceUID'):
+                service_uids[i] = item.getServiceUID()
 
         bsc = getToolByName(instance, 'bika_setup_catalog')
         workflow = getToolByName(instance, 'portal_workflow')

--- a/bika/lims/browser/fields/aranalysesfield.py
+++ b/bika/lims/browser/fields/aranalysesfield.py
@@ -116,10 +116,11 @@ class ARAnalysesField(ObjectField):
         if not items:
             return
 
-        assert type(items) in (list, tuple)
+        assert isinstance(items,
+                          (list, tuple)), "items must be a list or a tuple"
 
         # Convert the items list to a list of service uids and remove empties
-        service_uids = [self._get_service_uid(item) for item in items]
+        service_uids = map(self._get_service_uid, items)
         service_uids = filter(None, service_uids)
 
         bsc = getToolByName(instance, 'bika_setup_catalog')

--- a/bika/lims/browser/fields/aranalysesfield.py
+++ b/bika/lims/browser/fields/aranalysesfield.py
@@ -8,8 +8,9 @@ from Products.Archetypes.Registry import registerField
 from Products.Archetypes.public import *
 from Products.Archetypes.utils import shasattr
 from Products.CMFCore.utils import getToolByName
+from bika.lims import api
 from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
-from bika.lims.interfaces import IARAnalysesField
+from bika.lims.interfaces import IARAnalysesField, IAnalysisService, IAnalysis
 from bika.lims.permissions import ViewRetractedAnalyses
 from bika.lims.utils.analysis import create_analysis
 from plone.api.portal import get_tool
@@ -119,8 +120,12 @@ class ARAnalysesField(ObjectField):
         assert type(service_uids) in (list, tuple)
 
         for i, item in enumerate(service_uids):
-            if hasattr(item, 'getServiceUID'):
-                service_uids[i] = item.getServiceUID()
+            if api.is_object(item):
+                obj = api.get_object(item)
+                if IAnalysisService.providedBy(obj):
+                    service_uids[i] = api.get_uid(obj)
+                elif IAnalysis.providedBy(obj):
+                    service_uids[i] = obj.getServiceUID()
 
         bsc = getToolByName(instance, 'bika_setup_catalog')
         workflow = getToolByName(instance, 'portal_workflow')

--- a/bika/lims/tests/doctests/API.rst
+++ b/bika/lims/tests/doctests/API.rst
@@ -1097,3 +1097,48 @@ Normalizes a string to be usable as a file name:
     Traceback (most recent call last):
     [...]
     BikaLIMSError: Type of argument must be string, found '<type 'NoneType'>'
+
+
+Check if an UID is valid
+------------------------
+
+Checks if an UID is a valid 23 alphanumeric uid:
+
+    >>> api.is_uid("ajw2uw9")
+    False
+
+    >>> api.is_uid(None)
+    False
+
+    >>> api.is_uid("")
+    False
+
+    >>> api.is_uid("0")
+    False
+
+    >>> api.is_uid('0e1dfc3d10d747bf999948a071bc161e')
+    True
+
+Checks if an UID is a valid 23 alphanumeric uid and with a brain:
+
+    >>> api.is_uid("ajw2uw9", validate=True)
+    False
+
+    >>> api.is_uid(None, validate=True)
+    False
+
+    >>> api.is_uid("", validate=True)
+    False
+
+    >>> api.is_uid("0", validate=True)
+    False
+
+    >>> api.is_uid('0e1dfc3d10d747bf999948a071bc161e', validate=True)
+    False
+
+    >>> asfolder = self.portal.bika_setup.bika_analysisservices
+    >>> serv = api.create(asfolder, "AnalysisService", title="AS test")
+    >>> serv.setKeyword("as_test")
+    >>> uid = serv.UID()
+    >>> api.is_uid(uid, validate=True)
+    True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Setter of `AnalysesField` doesn't do anything when Analysis objects are sent, hence it accepts only `AS UID`s.

## Current behavior before PR
`ARAnalysesField` setter skips when `Analysis` objects are sent as parameters. 

## Desired behavior after PR is merged

`ARAnalysesField` works without problem either `Analysis` objects or `Analysis Service UID`s are sent.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
