### PR TITLE
Added getPriorityText method to AR and included in AR doctest

### DIFF
--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -3117,5 +3117,14 @@ class AnalysisRequest(BaseFolder):
         # Concatenate all strings to one text blob
         return " ".join(entries)
 
+    def getPriorityText(self):
+        """
+        This function looks up the priority text from priorities vocab
+        :returns: the priority text or ''
+        """
+        if self.getPriority():
+            return PRIORITIES.getValue(self.getPriority())
+        return ''
+
 
 registerType(AnalysisRequest, PROJECTNAME)

--- a/bika/lims/tests/doctests/AnalysisRequests.rst
+++ b/bika/lims/tests/doctests/AnalysisRequests.rst
@@ -109,13 +109,18 @@ Finally, the `AnalysisRequest` can be created::
     ...           'Contact': contact.UID(),
     ...           'SamplingDate': date_now,
     ...           'DateSampled': date_now,
-    ...           'SampleType': sampletype.UID()
+    ...           'SampleType': sampletype.UID(),
+    ...           'Priority': '1',
     ...          }
 
     >>> service_uids = [analysisservice.UID()]
     >>> ar = create_analysisrequest(client, request, values, service_uids)
     >>> ar
     <AnalysisRequest at /plone/clients/client-1/water-0001-R01>
+    >>> ar.getPriority()
+    '1'
+    >>> ar.getPriorityText()
+    u'Highest'
 
 
 Proxy Fields


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
Extended the AR content type with method getPriorityText that looks up the priority from the vocabulatry

Linked issue: https://github.com/senaite/bika.lims/issues/497

## Current behavior before PR
No method to get the text for an AR priority

## Desired behavior after PR is merged
getPriorityText on AR returns the priority text

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
