### PR TITLE
Fix DistributionNotFound: The 'bika.lims' distribution was not found …

### DIFF
--- a/bika/lims/__init__.py
+++ b/bika/lims/__init__.py
@@ -7,7 +7,12 @@
 
 import warnings
 import pkg_resources
-__version__ = pkg_resources.get_distribution("bika.lims").version
+
+try:
+    __version__ = pkg_resources.get_distribution("senaite.core").version
+except TypeError:
+    __version = pkg_resources.get_distribution("bika.lims").version
+    print 'Using old distribution name: bika.lims'
 
 # import this to create messages in the bika domain.
 from zope.i18nmessageid import MessageFactory

--- a/bika/lims/__init__.py
+++ b/bika/lims/__init__.py
@@ -11,7 +11,7 @@ import pkg_resources
 try:
     __version__ = pkg_resources.get_distribution("senaite.core").version
 except TypeError:
-    __version = pkg_resources.get_distribution("bika.lims").version
+    __version__ = pkg_resources.get_distribution("bika.lims").version
     print 'Using old distribution name: bika.lims'
 
 # import this to create messages in the bika domain.


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Installing `senaite.core` from scratch raises the following error:

```
DistributionNotFound: The 'bika.lims' distribution was not found and is required by the application
```

## Current behavior before PR

Cannot start `senaite.core` instance

## Desired behavior after PR is merged

Can start and have a fully functional `senaite.core` instance

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
