### PR TITLE
Fix AbbottM2000rtImportInterface doctest

### DIFF
--- a/bika/lims/tests/doctests/AbbottM2000rtImportInterface.rst
+++ b/bika/lims/tests/doctests/AbbottM2000rtImportInterface.rst
@@ -174,10 +174,8 @@ Load results test file and import the results::
 Check from the importer logs that the file from where the results have been imported is indeed
 the specified file::
 
-    >>> import re
-    >>> matches = re.search('(/bika.lims.+)', importer.logs[0])
-    >>> matches.group(0)
-    '/bika.lims/bika/lims/tests/files/Results.log.123'
+    >>> '/Results.log.123' in importer.logs[0]
+    True
 
 Check the rest of the importer logs to verify that the values were correctly imported::
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the `AbbottM2000rtImportInterface.rst` doctest to not fail because of the renaming from `bika.lims` to `senaite.core`

## Current behavior before PR

```
AssertionError: Failed doctest test for AbbottM2000rtImportInterface.rst
  File "/home/travis/build/senaite/senaite.core/bika/lims/tests/doctests/AbbottM2000rtImportInterface.rst", line 0
----------------------------------------------------------------------
File "/home/travis/build/senaite/senaite.core/bika/lims/tests/doctests/AbbottM2000rtImportInterface.rst", line 179, in AbbottM2000rtImportInterface.rst
Failed example:
    matches.group(0)
Differences (ndiff with -expected +actual):
    - '/bika.lims/bika/lims/tests/files/Results.log.123'
    ?  ----------
    + '/bika/lims/tests/files/Results.log.123'
```

## Desired behavior after PR is merged

 `AbbottM2000rtImportInterface.rst` doctest passes without errors.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
