### PR TITLE
Using new "default_url_fetcher" method from weasyprint 0.42

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ Changelog
 
 
 **Fixed**
-
+- #539 Using new "default_url_fetcher" method from WeasyPrint v0.42. Images
+aren't rendered.
 
 **Security**
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

After updating to WeasyPrint 0.42 we haven't change "default_url_fetcher" function and images weren't generated.

## Current behavior before PR

Creating PDFs doesn't fails, but images aren't rendered.

## Desired behavior after PR is merged

Images are rendered in PDFs

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
