### PR TITLE
Traceback in Worksheet Templates list when there are Instruments assigned

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #551 Traceback in Worksheet Templates list when there are Instruments assigned
 
 **Security**
 

--- a/bika/lims/controlpanel/bika_worksheettemplates.py
+++ b/bika/lims/controlpanel/bika_worksheettemplates.py
@@ -79,7 +79,7 @@ class WorksheetTemplatesView(BikaListingView):
         item['replace']['Title'] = get_link(item['url'], item['Title'])
         item['Instrument'] = ''
         instrument = obj.getInstrument()
-        item['Instrument'] = instrument and instrument.getTitle() or ''
+        item['Instrument'] = instrument and instrument.Title() or ''
         return item
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: [Traceback in Worksheet Templates list when there are Instruments assigned #541](https://github.com/senaite/senaite.core/issues/541)

## Current behavior before PR

The following Traceback is displayed in Worksheet Templates list

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.bika_listing, line 939, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 289, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module 176e0e5f05234e6e23ec2c5fa376b519.py, line 425, in render
  Module b386bc4d392bd557c0373715f258b088.py, line 1406, in render_master
  Module b386bc4d392bd557c0373715f258b088.py, line 571, in render_content
  Module 176e0e5f05234e6e23ec2c5fa376b519.py, line 355, in __fill_content_core
  Module five.pt.expressions, line 161, in __call__
  Module bika.lims.browser.bika_listing, line 1379, in contents_table
  Module bika.lims.browser.bika_listing, line 1557, in __init__
  Module bika.lims.browser.bika_listing, line 1015, in folderitems
  Module bika.lims, line 212, in wrapper
  Module bika.lims.browser.bika_listing, line 1360, in _folderitems
  Module bika.lims.controlpanel.bika_worksheettemplates, line 82, in folderitem
AttributeError: getTitle

 - Expression: "here/main_template/macros/master"
 - Filename:   ... senaite.core/bika/lims/browser/templates/bika_listing.pt
 - Location:   (line 5: col 21)
 - Source:     metal:use-macro="here/main_template/macros/master"
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  repeat: {...} (0)
               template: <ViewPageTemplateFile - at 0x7f7f93ed6bd0>
               views: <ViewMapper - at 0x7f7f9213b150>
               modules: <instance - at 0x7f7fbb47f560>
               args: <tuple - at 0x7f7f920b1b90>
               here: <ImplicitAcquisitionWrapper bika_worksheettemplates at 0x7f7f92779a50>
               user: <ImplicitAcquisitionWrapper - at 0x7f7f91f2dd20>
               nothing: <NoneType - at 0x8fd4d0>
               translate: <function translate at 0x7f7f920790c8>
               container: <ImplicitAcquisitionWrapper bika_worksheettemplates at 0x7f7f92779a50>
               request: <instance - at 0x7f7f92668200>
               wrapped_repeat: <SafeMapping - at 0x7f7f92e71050>
               traverse_subpath: <list - at 0x7f7f926c9560>
               default: <object - at 0x7f7fc3174540>
               loop: {...} (2)
               context: <ImplicitAcquisitionWrapper bika_worksheettemplates at 0x7f7f92779a50>
               view: <WorksheetTemplatesView folder_view at 0x7f7f98383090>
               target_language: <NoneType - at 0x8fd4d0>
               root: <ImplicitAcquisitionWrapper Zope at 0x7f7f91ddf820>
               options: {...} (0)
```

## Desired behavior after PR is merged

The Worksheet Templates list is displayed without errors.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
