### PR TITLE
Fix inconsistencies on statuses amongst Analysis Services

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changelog
 
 **Added**
 
+- #555 Don't allow the inactivation Analysis Services with active dependencies
+- #555 Don't allow the activation of Analysis Services with inactive dependents
+- #555 Don't allow the activation of Analysis Services with inactive calculation
 
 **Removed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,9 +6,8 @@ Changelog
 
 **Added**
 
-- #555 Don't allow the inactivation Analysis Services with active dependencies
+- #555 Don't allow the deactivation Analysis Services with active dependencies
 - #555 Don't allow the activation of Analysis Services with inactive dependents
-- #555 Don't allow the activation of Analysis Services with inactive calculation
 
 **Removed**
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -1,8 +1,13 @@
 Release notes
 =============
 
-Update from 1.2.x to 1.2.1
+Update from 1.2.0 to 1.2.1
 --------------------------
 
 - This update requires the execution of `bin/buildout`, because a new dependency has
   been added: `Plone Subrequest <https://pypi.python.org/pypi/plone.subrequest/>`_
+
+- With this update, Analyses Services that are inactive, but have active
+  dependent services, will be automatically transitioned to `active` state. This
+  procedure fixes eventual inconsistencies amongst the statuses of Analyses
+  Services. See #555

--- a/bika/lims/content/analysisservice.py
+++ b/bika/lims/content/analysisservice.py
@@ -581,36 +581,5 @@ class AnalysisService(AbstractBaseAnalysis):
         deps_uids = [service.UID() for service in deps]
         return deps_uids
 
-    def workflow_script_activate(self):
-        workflow = getToolByName(self, 'portal_workflow')
-        pu = getToolByName(self, 'plone_utils')
-        # A service cannot be activated if it's calculation is inactive
-        calc = self.getCalculation()
-        inactive_state = workflow.getInfoFor(calc, "inactive_state")
-        if calc and inactive_state == "inactive":
-            message = _(
-                "This Analysis Service cannot be activated because it's "
-                "calculation is inactive.")
-            pu.addPortalMessage(message, 'error')
-            transaction.get().abort()
-            raise WorkflowException
-
-    def workflow_scipt_deactivate(self):
-        bsc = getToolByName(self, 'bika_setup_catalog')
-        pu = getToolByName(self, 'plone_utils')
-        # A service cannot be deactivated if "active" calculations list it
-        # as a dependency.
-        active_calcs = bsc(portal_type='Calculation', inactive_state="active")
-        calculations = (c.getObject() for c in active_calcs)
-        for calc in calculations:
-            deps = [dep.UID() for dep in calc.getDependentServices()]
-            if self.UID() in deps:
-                message = _(
-                    "This Analysis Service cannot be deactivated because one "
-                    "or more active calculations list it as a dependency")
-                pu.addPortalMessage(message, 'error')
-                transaction.get().abort()
-                raise WorkflowException
-
 
 registerType(AnalysisService, PROJECTNAME)

--- a/bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
@@ -114,6 +114,7 @@
   <transition transition_id="activate" title="Activate" new_state="active" trigger="USER" before_script="" after_script="" i18n:attributes="title">
     <action url="" category="workflow" icon="">Activate</action>
     <guard>
+      <guard-expression>python:here.guard_activate_transition()</guard-expression>
       <guard-permission>Modify portal content</guard-permission>
     </guard>
   </transition>
@@ -121,6 +122,7 @@
   <transition transition_id="deactivate" title="Deactivate" new_state="inactive" trigger="USER" before_script="" after_script="" i18n:attributes="title">
     <action url="" category="workflow" icon="">Deactivate</action>
     <guard>
+      <guard-expression>python:here.guard_deactivate_transition()</guard-expression>
       <guard-permission>Modify portal content</guard-permission>
     </guard>
   </transition>

--- a/bika/lims/skins/bika/guard_activate_transition.py
+++ b/bika/lims/skins/bika/guard_activate_transition.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE
+#
+# Copyright 2018 by it's authors.
+# Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
+
+## Script (Python) "guard_activate_transition"
+##bind container=container
+##bind context=context
+##bind namespace=
+##bind script=script
+##bind subpath=traverse_subpath
+##parameters=
+##title=
+##
+if context.portal_type == 'AnalysisService':
+    workflow = context.portal_workflow
+    calculation = context.getCalculation()
+    if not calculation:
+        return True
+
+    # If the calculation is inactive, we cannot activate the service
+    status = workflow.getInfoFor(calculation, 'inactive_state')
+    if status and status == 'inactive':
+        return False
+
+    # All services that we depend on to calculate our result are active or we
+    # don't depend on other services.
+    dependencies = calculation.getDependentServices()
+    for dependency in dependencies:
+        status = workflow.getInfoFor(dependency, 'inactive_state')
+        if status and status == 'inactive':
+            return False
+return True

--- a/bika/lims/skins/bika/guard_deactivate_transition.py
+++ b/bika/lims/skins/bika/guard_deactivate_transition.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE
+#
+# Copyright 2018 by it's authors.
+# Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
+
+## Script (Python) "guard_deactivate_transition"
+##bind container=container
+##bind context=context
+##bind namespace=
+##bind script=script
+##bind subpath=traverse_subpath
+##parameters=
+##title=
+##
+if context.portal_type == 'AnalysisService':
+    # Return true only if there are no services that depend on us to calculate
+    # their results or all them have been deactivated already.
+    dependants = context.getServiceDependants()
+    if not dependants:
+        return True
+
+    workflow = context.portal_workflow
+    for dependant in dependants:
+        status = workflow.getInfoFor(dependant, 'inactive_state')
+        if status and status == 'active':
+            return False
+return True

--- a/bika/lims/tests/doctests/AnalysisServiceInactivation.rst
+++ b/bika/lims/tests/doctests/AnalysisServiceInactivation.rst
@@ -1,0 +1,143 @@
+================================================
+Analysis Service - Activations and Inactivations
+================================================
+
+The inactivation and activation of Analysis Services relies on `bika_inactive_workflow`.
+To prevent inconsistencies that could have undesired effects, an Analysis Service
+can only be deactivated if it does not have active dependents (this is, other
+services that depends on the Analysis Service to calculate their results).
+
+Following the same reasoning, an Analysis Service can only be activated if does
+not have any calculation assigned or if does, the calculation is active, as well
+as its dependencies (this is, other services the Analysis Service depends on to
+calculate its result) are active .
+
+
+Test Setup
+==========
+
+Running this test from the buildout directory:
+
+    bin/test -t AnalysisServiceInactivation
+
+Needed Imports:
+
+    >>> from AccessControl.PermissionRole import rolesForPermissionOn
+    >>> from bika.lims import api
+    >>> from bika.lims.workflow import doActionFor
+    >>> from bika.lims.workflow import getAllowedTransitions
+    >>> from bika.lims.workflow import isActive
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+    >>> from plone.app.testing import setRoles
+
+Functional Helpers:
+
+    >>> def start_server():
+    ...     from Testing.ZopeTestCase.utils import startZServer
+    ...     ip, port = startZServer()
+    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> bikasetup = portal.bika_setup
+    >>> bika_analysiscategories = bikasetup.bika_analysiscategories
+    >>> bika_analysisservices = bikasetup.bika_analysisservices
+    >>> bika_calculations = bikasetup.bika_calculations
+    >>> bika_suppliers = bikasetup.bika_suppliers
+
+We need to create some basic objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
+    >>> labcontact = api.create(bikasetup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(bikasetup.bika_departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = api.create(bika_analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> supplier = api.create(bika_suppliers, "Supplier", Name="Naralabs")
+    >>> Ca = api.create(bika_analysisservices, "AnalysisService", title="Calcium", Keyword="Ca", Price="15", Category=category.UID())
+    >>> Mg = api.create(bika_analysisservices, "AnalysisService", title="Magnesium", Keyword="Mg", Price="10", Category=category.UID())
+    >>> Au = api.create(bika_analysisservices, "AnalysisService", title="Gold", Keyword="Au", Price="20", Category=category.UID())
+
+Deactivation of Analysis Service
+--------------------------------
+
+All services can be deactivated:
+
+    >>> getAllowedTransitions(Ca)
+    ['deactivate']
+    >>> getAllowedTransitions(Mg)
+    ['deactivate']
+    >>> getAllowedTransitions(Au)
+    ['deactivate']
+
+But if we create a new Analysis Service with a calculation that depends on them:
+
+    >>> calc = api.create(bika_calculations, "Calculation", title="Total Hardness")
+    >>> calc.setFormula("[Ca] + [Mg]")
+    >>> hardness = api.create(bika_analysisservices, "AnalysisService", title="Total Hardness", Keyword="TotalHardness")
+    >>> hardness.setCalculation(calc)
+
+Then, only `Au` can be deactivated, cause `harndess` is active and depends on
+`Ca` and `Mg`:
+
+    >>> getAllowedTransitions(Ca)
+    []
+    >>> getAllowedTransitions(Mg)
+    []
+    >>> getAllowedTransitions(Au)
+    ['deactivate']
+    >>> getAllowedTransitions(hardness)
+    ['deactivate']
+
+If we deactivate `Hardness`:
+
+    >>> performed = doActionFor(hardness, 'deactivate')
+    >>> isActive(hardness)
+    False
+
+    >>> getAllowedTransitions(hardness)
+    ['activate']
+
+Then we will be able to deactivate both `Ca` and `Mg`:
+
+    >>> getAllowedTransitions(Ca)
+    ['deactivate']
+    >>> getAllowedTransitions(Mg)
+    ['deactivate']
+
+
+Activation of Analysis Service
+------------------------------
+
+Deactivate the Analysis Service `Ca`:
+
+    >>> performed = doActionFor(Ca, 'deactivate')
+    >>> isActive(Ca)
+    False
+
+    >>> getAllowedTransitions(Ca)
+    ['activate']
+
+And now, we cannot activate `Hardness`, cause one of its dependencies (`Ca`) is
+not active:
+
+    >>> isActive(hardness)
+    False
+    >>> getAllowedTransitions(hardness)
+    []
+
+But if we activate `Ca` again:
+
+    >>> performed = doActionFor(Ca, 'activate')
+    >>> isActive(Ca)
+    True
+
+`Hardness` can be activated again:
+
+    >>> getAllowedTransitions(hardness)
+    ['activate']
+
+    >>> performed = doActionFor(hardness, 'activate')
+    >>> isActive(hardness)
+    True

--- a/bika/lims/upgrade/v01_02_001.py
+++ b/bika/lims/upgrade/v01_02_001.py
@@ -5,10 +5,15 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
+from Products.CMFCore.Expression import Expression
+from bika.lims import api
 from bika.lims import logger
 from bika.lims.config import PROJECTNAME as product
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
+from bika.lims.workflow import changeWorkflowState
+from bika.lims.workflow import isActive
+from DateTime import DateTime
 
 version = '1.2.1'  # Remember version number in metadata.xml and setup.py
 profile = 'profile-{0}:default'.format(product)
@@ -27,7 +32,62 @@ def upgrade(tool):
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
     # -------- ADD YOUR STUFF HERE --------
+    set_guards_to_inactive_workflow()
+    fix_service_status_inconsistences()
 
     logger.info("{0} upgraded to version {1}".format(product, version))
 
     return True
+
+def set_guards_to_inactive_workflow():
+    wtool = api.get_tool('portal_workflow')
+    workflow = wtool.getWorkflowById('bika_inactive_workflow')
+
+    deactivate = workflow.transitions['deactivate']
+    deactivate_guard = deactivate.getGuard()
+    deactivate_guard.expr = Expression('python:here.guard_deactivate_transition()')
+    deactivate.guard = deactivate_guard
+
+    activate = workflow.transitions['activate']
+    activate_guard = activate.getGuard()
+    activate_guard.expr = Expression('python:here.guard_activate_transition()')
+    activate.guard = activate_guard
+
+
+def fix_service_status_inconsistences(active=True):
+    catalog = api.get_tool('bika_setup_catalog')
+    brains = catalog(portal_type='AnalysisService')
+    for brain in brains:
+        obj = api.get_object(brain)
+        if not isActive(obj):
+            continue
+
+        # If this service is active, then all the services this service
+        # depends on must be active too, as well as the calculation
+        calculation = obj.getCalculation()
+        if not calculation:
+            continue
+
+        dependencies = calculation.getDependentServices()
+        for dependency in dependencies:
+            dependency = api.get_object(dependency)
+            if not isActive(dependency):
+                _change_inactive_state(dependency, 'active')
+
+
+def _change_inactive_state(service, new_state):
+    msg = "Upgrade v1.2.1: Updating status of {} to '{}'".\
+        format(service.getKeyword(), new_state)
+    logger.info(msg)
+    wtool = api.get_tool('portal_workflow')
+    workflow = wtool.getWorkflowById('bika_inactive_workflow')
+    wf_state = {
+        'action': None,
+        'actor': None,
+        'comments': msg,
+        'inactive_state': new_state,
+        'time': DateTime(),
+    }
+    wtool.setStatusOf('bika_inactive_workflow', service, wf_state)
+    workflow.updateRoleMappingsFor(service)
+    service.reindexObject(idxs=['allowedRolesAndUsers', 'inactive_state'])

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -318,7 +318,7 @@ def logged_in_client(context, member=None):
                 client = obj
     return client
 
-
+# TODO: This function dismiss other state_variables than review_state (e.g. inactive_state)
 def changeWorkflowState(content, wf_id, state_id, acquire_permissions=False,
                         portal_workflow=None, **kw):
     """Change the workflow state of an object


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The inactivation and activation of Analysis Services relies on `bika_inactive_workflow`. To prevent inconsistencies that could have undesired effects, this Pull Request makes that an Analysis Service can only be deactivated if it does not have active dependents (this is, other services that depends on the Analysis Service to calculate their results).

Following the same reasoning, an Analysis Service can only be activated if does not have any calculation assigned or if does, the calculation is active, as well as its dependencies (this is, other services the Analysis Service depends on to calculate its result) are active .

## Current behavior before PR

One can deactivate/activate Analysis Service regardless of their dependents/dependencies.

## Desired behavior after PR is merged

The possibility to deactivate or activate an Analysis Services ultimately relies on the status of its dependents or dependencies

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
