### PR TITLE
Removed hyphen from senaite-frontpage.py filename to allow imports

### DIFF
--- a/bika/lims/browser/senaite-frontpage.zcml
+++ b/bika/lims/browser/senaite-frontpage.zcml
@@ -13,7 +13,7 @@
     <browser:page
         for="Products.CMFPlone.interfaces.IPloneSiteRoot"
         name="bika-frontpage"
-        class="bika.lims.browser.senaite-frontpage.FrontPageView"
+        class="bika.lims.browser.senaitefrontpage.FrontPageView"
         permission="zope2.View"
         layer="bika.lims.interfaces.IBikaLIMS"
     />
@@ -21,7 +21,7 @@
     <browser:page
         for="Products.CMFPlone.interfaces.IPloneSiteRoot"
         name="senaite-frontpage"
-        class="bika.lims.browser.senaite-frontpage.FrontPageView"
+        class="bika.lims.browser.senaitefrontpage.FrontPageView"
         permission="zope2.View"
         layer="bika.lims.interfaces.IBikaLIMS"
     />

--- a/bika/lims/browser/senaitefrontpage.py
+++ b/bika/lims/browser/senaitefrontpage.py
@@ -95,7 +95,6 @@ class FrontPageView(BrowserView):
         self.upgrades = {}
         qi = getToolByName(self.context, "portal_quickinstaller")
         for key in qi.keys():
-            info = qi.upgradeInfo('senaite.core')
             self.versions[key] = qi.getProductVersion(key)
             info = qi.upgradeInfo(key)
             if info and 'installedVersion' in info:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Is not possible to import classes from inside py files their filename contains an hyphen. This renaming is necessary for the upcoming release of `senaite.health`

## Current behavior before PR

The following does not work:

```python
from bika.lims.browser.senaite-frontpage import FrontPageView
```

## Desired behavior after PR is merged

The following works:

```python
from bika.lims.browser.senaitefrontpage import FrontPageView
```
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
