### PR TITLE
Fix numeric field event handler in bika.lims.site.js

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #559 Fix numeric field event handler in bika.lims.site.js
 - #553 Fixed that images and barcodes were not printed in reports
 - #551 Traceback in Worksheet Templates list when there are Instruments assigned
 

--- a/bika/lims/browser/js/bika.lims.site.js
+++ b/bika/lims/browser/js/bika.lims.site.js
@@ -61,8 +61,7 @@
       this.bind_eventhandler();
       this.allowed_keys = [8, 9, 13, 35, 36, 37, 39, 46, 44, 60, 62, 45, 69, 101, 61];
       this.department_filter_cookie = "filter_by_department_info";
-      this.department_filter_disabled_cookie = "dep_filter_disabled";
-      return window.sv = this;
+      return this.department_filter_disabled_cookie = "dep_filter_disabled";
     };
 
 

--- a/bika/lims/browser/js/bika.lims.site.js
+++ b/bika/lims/browser/js/bika.lims.site.js
@@ -1,557 +1,804 @@
-'use strict;'
 
-/**
- * Controller class for all site views
+/* Please use this command to compile this file into the parent `js` directory:
+    coffee --no-header -w -o ../ -c bika.lims.site.coffee
  */
-function SiteView() {
 
-    var that = this;
-    var pause_spinner = false;
+(function() {
+  var bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
 
-    that.load = function() {
+  window.SiteView = (function() {
+    function SiteView() {
+      this.on_ajax_error = bind(this.on_ajax_error, this);
+      this.on_ajax_end = bind(this.on_ajax_end, this);
+      this.on_ajax_start = bind(this.on_ajax_start, this);
+      this.on_analysis_service_title_click = bind(this.on_analysis_service_title_click, this);
+      this.on_reference_definition_list_change = bind(this.on_reference_definition_list_change, this);
+      this.on_numeric_field_keypress = bind(this.on_numeric_field_keypress, this);
+      this.on_numeric_field_paste = bind(this.on_numeric_field_paste, this);
+      this.on_at_float_field_keyup = bind(this.on_at_float_field_keyup, this);
+      this.on_at_integer_field_keyup = bind(this.on_at_integer_field_keyup, this);
+      this.on_autocomplete_keydown = bind(this.on_autocomplete_keydown, this);
+      this.on_admin_dep_filter_change = bind(this.on_admin_dep_filter_change, this);
+      this.on_department_filter_submit = bind(this.on_department_filter_submit, this);
+      this.on_department_list_change = bind(this.on_department_list_change, this);
+      this.on_date_range_end_change = bind(this.on_date_range_end_change, this);
+      this.on_date_range_start_change = bind(this.on_date_range_start_change, this);
+      this.filter_default_departments = bind(this.filter_default_departments, this);
+      this.load_analysis_service_popup = bind(this.load_analysis_service_popup, this);
+      this.stop_spinner = bind(this.stop_spinner, this);
+      this.start_spinner = bind(this.start_spinner, this);
+      this.notify_in_panel = bind(this.notify_in_panel, this);
+      this.notificationPanel = bind(this.notificationPanel, this);
+      this.set_cookie = bind(this.set_cookie, this);
+      this.setCookie = bind(this.setCookie, this);
+      this.read_cookie = bind(this.read_cookie, this);
+      this.readCookie = bind(this.readCookie, this);
+      this.log = bind(this.log, this);
+      this.portal_alert = bind(this.portal_alert, this);
+      this.portalAlert = bind(this.portalAlert, this);
+      this.get_authenticator = bind(this.get_authenticator, this);
+      this.get_portal_url = bind(this.get_portal_url, this);
+      this.init_department_filtering = bind(this.init_department_filtering, this);
+      this.init_referencedefinition = bind(this.init_referencedefinition, this);
+      this.init_datepickers = bind(this.init_datepickers, this);
+      this.init_client_combogrid = bind(this.init_client_combogrid, this);
+      this.init_spinner = bind(this.init_spinner, this);
+      this.init_client_add_overlay = bind(this.init_client_add_overlay, this);
+      this.bind_eventhandler = bind(this.bind_eventhandler, this);
+      this.load = bind(this.load, this);
+    }
 
-        loadCommonEvents();
-
-        loadClientEvents();
-
-        loadReferenceDefinitionEvents();
-
-        loadFilterByDepartment();
-        //Date range controllers
-        $('.date_range_start').bind("change", function () {
-            date_range_controller_0(this);
-        });
-        $('.date_range_end').bind("change", function () {
-            date_range_controller_1(this);
-        });
-
-        //Reset default dep list when departments change
-        $(function() {
-          $("select[name='Departments:list']").change(function() {
-            reset_default_deps(this);
-          });
-        });
+    SiteView.prototype.load = function() {
+      console.debug("SiteView::load");
+      jarn.i18n.loadCatalog('bika');
+      this._ = window.jarn.i18n.MessageFactory('bika');
+      this.init_spinner();
+      this.init_client_add_overlay();
+      this.init_client_combogrid();
+      this.init_datepickers();
+      this.init_referencedefinition();
+      this.init_department_filtering();
+      this.bind_eventhandler();
+      this.allowed_keys = [8, 9, 13, 35, 36, 37, 39, 46, 44, 60, 62, 45, 69, 101, 61];
+      this.department_filter_cookie = "filter_by_department_info";
+      this.department_filter_disabled_cookie = "dep_filter_disabled";
+      return window.sv = this;
     };
 
-    function loadClientEvents() {
 
-        // Client creation overlay
-        $('a.add_client').prepOverlay({
-                subtype: 'ajax',
-                filter: 'head>*,#content>*:not(div.configlet),dl.portalMessage.error,dl.portalMessage.info',
-                formselector: '#client-base-edit',
-                closeselector: '[name="form.button.cancel"]',
-                width:'70%',
-                noform:'close',
-                config: {
-                    closeOnEsc: false,
-                    onLoad: function() {
-                        // manually remove remarks
-                        this.getOverlay().find("#archetypes-fieldname-Remarks").remove();
-                    },
-                    onClose: function(){
-                        // here is where we'd populate the form controls, if we cared to.
-                    }
-                }
-        });
+    /* INITIALIZERS */
 
-        // Client combogrid searches by ID
-        $("input[id*='ClientID']").combogrid({
-            colModel: [{'columnName':'ClientUID','hidden':true},
-                       {'columnName':'ClientID','width':'20','label':_('Client ID')},
-                       {'columnName':'Title','width':'80','label':_('Title')}],
-            showOn: true,
-            width: '450px',
-            url: window.portal_url + "/getClients?_authenticator=" + $('input[name="_authenticator"]').val(),
-            select: function( event, ui ) {
-                $(this).val(ui.item.ClientID);
-                $(this).change();
-                return false;
-            }
-        });
+    SiteView.prototype.bind_eventhandler = function() {
 
-        // Display add Client button next to Client ID input for all
-        // views except from Client View
-        if($(".portaltype-client").length == 0){
-            $("input[id='ClientID']")
-                .after('<a style="border-bottom:none !important;margin-left:.5;"' +
-                       ' class="add_client"' +
-                       ' href="'+window.portal_url+'/clients/portal_factory/Client/new/edit"' +
-                       ' rel="#overlay">' +
-                       ' <img style="padding-bottom:1px;" src="'+window.portal_url+'/++resource++bika.lims.images/add.png"/>' +
-                       '</a>');
+      /*
+       * Binds callbacks on elements
+       */
+      console.debug("SiteView::bind_eventhandler");
+      $('.service_title span:not(.before)').on('click', this.on_analysis_service_title_click);
+      $("#ReferenceDefinition\\:list").on("change", this.on_reference_definition_list_change);
+      $('.numeric').on('keypress', this.on_numeric_field_keypress);
+      $('.numeric').on('paste', this.on_numeric_field_paste);
+      $("input[name*='\\:int\'], .ArchetypesIntegerWidget input").on("keyup", this.on_at_integer_field_keyup);
+      $("input[name*='\\:float\'], .ArchetypesDecimalWidget input").on("keyup", this.on_at_float_field_keyup);
+      $("input.autocomplete").on("keydown", this.on_autocomplete_keydown);
+      $("#department_filter_submit").on("click", this.on_department_filter_submit);
+      $("#admin_dep_filter_enabled").on("change", this.on_admin_dep_filter_change);
+      $("select[name='Departments:list']").on("change", this.on_department_list_change);
+      $(".date_range_start").on("change", this.on_date_range_start_change);
+      $(".date_range_end").on("change", this.on_date_range_end_change);
+      $(document).on("ajaxStart", this.on_ajax_start);
+      $(document).on("ajaxStop", this.on_ajax_end);
+      return $(document).on("ajaxError", this.on_ajax_error);
+    };
+
+    SiteView.prototype.init_client_add_overlay = function() {
+
+      /*
+       * Initialize Client Overlay
+       */
+      console.debug("SiteView::init_client_add_overlay");
+      return $('a.add_client').prepOverlay({
+        subtype: 'ajax',
+        filter: 'head>*,#content>*:not(div.configlet),dl.portalMessage.error,dl.portalMessage.info',
+        formselector: '#client-base-edit',
+        closeselector: '[name="form.button.cancel"]',
+        width: '70%',
+        noform: 'close',
+        config: {
+          closeOnEsc: false,
+          onLoad: function() {
+            this.getOverlay().find('#archetypes-fieldname-Remarks').remove();
+          },
+          onClose: function() {}
         }
+      });
+    };
 
-        // Confirm before resetting client specs to default lab specs
-        $("a[href*='set_to_lab_defaults']").click(function(event){
-            // always prevent default/
-            // url is activated manually from 'Yes' below.
-            url = $(this).attr("href");
-            event.preventDefault();
-            yes = _('Yes');
-            no = _('No');
-            var $confirmation = $("<div></div>")
-                .html(_("This will remove all existing client analysis specifications "+
-                        "and create copies of all lab specifications. "+
-                        "Are you sure you want to do this?"))
-                .dialog({
-                    resizable:false,
-                    title: _('Set to lab defaults'),
-                    buttons: {
-                        yes: function(event){
-                            $(this).dialog("close");
-                            window.location.href = url;
-                        },
-                        no: function(event){
-                            $(this).dialog("close");
-                        }
-                    }
-                });
-        });
-    }
+    SiteView.prototype.init_spinner = function() {
 
-    function loadReferenceDefinitionEvents() {
+      /*
+       * Initialize Spinner Overlay
+       */
+      console.debug("SiteView::init_spinner");
+      $(document).unbind('ajaxStart');
+      $(document).unbind('ajaxStop');
+      $('#ajax-spinner').remove();
+      this.counter = 0;
+      this.spinner = $("<div id='bika-spinner'><img src='" + (this.get_portal_url()) + "/spinner.gif' alt=''/></div>");
+      return this.spinner.appendTo('body').hide();
+    };
 
-        // a reference definition is selected from the dropdown
-        // (../../skins/bika/bika_widgets/referenceresultswidget.js)
-        $('#ReferenceDefinition\\:list').change(function(){
-            authenticator = $('input[name="_authenticator"]').val();
-            uid = $(this).val();
-            option = $(this).children(":selected").html();
+    SiteView.prototype.init_client_combogrid = function() {
 
-            if (uid == '') {
-                // No reference definition selected;
-                // render empty widget.
-                $("#Blank").prop('checked',false);
-                $("#Hazardous").prop('checked',false);
-                $('.bika-listing-table')
-                    .load('referenceresults', {'_authenticator': authenticator});
-                return;
-            }
-
-            if(option.search(_("(Blank)")) > -1){
-                $("#Blank").prop('checked',true);
-            } else {
-                $("#Blank").prop('checked',false);
-            }
-
-            if(option.search(_("(Hazardous)")) > -1){
-                $("#Hazardous").prop('checked',true);
-            } else {
-                $("#Hazardous").prop('checked',false);
-            }
-
-            $('.bika-listing-table')
-                .load('referenceresults',
-                    {'_authenticator': authenticator,
-                     'uid':uid});
-        });
-
-        // If validation failed, and user is returned to page - requires reload.
-        if ($('#ReferenceDefinition\\:list').val() != ''){
-            $('#ReferenceDefinition\\:list').change();
+      /*
+       * Initialize client combogrid, e.g. on the Client Add View
+       */
+      console.debug("SiteView::init_client_combogrid");
+      return $("input[id*='ClientID']").combogrid({
+        colModel: [
+          {
+            'columnName': 'ClientUID',
+            'hidden': true
+          }, {
+            'columnName': 'ClientID',
+            'width': '20',
+            'label': _('Client ID')
+          }, {
+            'columnName': 'Title',
+            'width': '80',
+            'label': _('Title')
+          }
+        ],
+        showOn: true,
+        width: '450px',
+        url: (this.get_portal_url()) + "/getClients?_authenticator=" + (this.get_authenticator()),
+        select: function(event, ui) {
+          $(this).val(ui.item.ClientID);
+          $(this).change();
+          return false;
         }
-    }
+      });
+    };
 
-    function loadCommonEvents() {
+    SiteView.prototype.init_datepickers = function() {
 
-        var curDate = new Date();
-        var y = curDate.getFullYear();
-        var limitString = "1900:" + y;
-        var dateFormat = _("date_format_short_datepicker");
-        if (dateFormat == 'date_format_short_datepicker'){
-            dateFormat = 'yy-mm-dd';
-        }
+      /*
+       * Initialize date pickers
+       *
+       * XXX Where are these event handlers used?
+       */
+      var curDate, dateFormat, limitString, y;
+      console.debug("SiteView::init_datepickers");
+      curDate = new Date;
+      y = curDate.getFullYear();
+      limitString = '1900:' + y;
+      dateFormat = this._('date_format_short_datepicker');
+      if (dateFormat === 'date_format_short_datepicker') {
+        dateFormat = 'yy-mm-dd';
+      }
+      $('input.datepicker_range').datepicker({
 
-        $("input.datepicker").live("click", function() {
-            $(this).datepicker({
-                showOn:"focus",
-                showAnim:"",
-                changeMonth:true,
-                changeYear:true,
-                dateFormat: dateFormat,
-                yearRange: limitString
-            })
-            .click(function(){$(this).attr("value", "");})
-            .focus();
-        });
         /**
         This function defines a datepicker for a date range. Both input
         elements should be siblings and have the class 'date_range_start' and
         'date_range_end'.
-        */
-        $("input.datepicker_range").datepicker({
-            showOn:"focus",
-            showAnim:"",
-            changeMonth:true,
-            changeYear:true,
-            dateFormat: dateFormat,
-            yearRange: limitString
-        });
-
-        $("input.datepicker_nofuture").live("click", function() {
-            $(this).datepicker({
-                showOn:"focus",
-                showAnim:"",
-                changeMonth:true,
-                changeYear:true,
-                maxDate: curDate,
-                dateFormat: dateFormat,
-                yearRange: limitString
-            })
-            .click(function(){$(this).attr("value", "");})
-            .focus();
-        });
-
-        $("input.datepicker_2months").live("click", function() {
-            $(this).datepicker({
-                showOn:"focus",
-                showAnim:"",
-                changeMonth:true,
-                changeYear:true,
-                maxDate: "+0d",
-                numberOfMonths: 2,
-                dateFormat: dateFormat,
-                yearRange: limitString
-            })
-            .click(function(){$(this).attr("value", "");})
-            .focus();
-        });
-
-
-        $("input.datetimepicker_nofuture").live("click", function() {
-            $(this).datetimepicker({
-                showOn:"focus",
-                showAnim:"",
-                changeMonth:true,
-                changeYear:true,
-                maxDate: curDate,
-                dateFormat: dateFormat,
-                yearRange: limitString,
-                timeFormat: "HH:mm",
-                beforeShow: function() {
-                        setTimeout(function(){
-                            $('.ui-datepicker').css('z-index', 99999999999999);
-                        }, 0);
-                    }
-            })
-            .click(function(){$(this).attr("value", "");})
-            .focus();
-        });
-
-        // Analysis Service popup trigger
-        $('.service_title span:not(.before)').live("click", function(){
-            var dialog = $("<div></div>");
-            dialog
-                .load(window.portal_url + "/analysisservice_popup",
-                    {'service_title':$(this).closest('td').find("span[class^='state']").html(),
-                    "analysis_uid":$(this).parents("tr").attr("uid"),
-                    "_authenticator": $("input[name='_authenticator']").val()}
-                )
-                .dialog({
-                    width:450,
-                    height:450,
-                    closeText: _("Close"),
-                    resizable:true,
-                    title: $(this).text()
-                });
-        });
-
-        $('.numeric').live('paste', function(event){
-            // Wait (next cycle) for value popluation and replace commas.
-            var $self = $(this);
-            window.setTimeout(function() {
-                $self.val($self.val().replace(',','.'));
-            }, 0);
-        });
-
-
-        $(".numeric").live("keypress", function(event) {
-            var allowedKeys = [
-                8,   // backspace
-                9,   // tab
-                13,  // enter
-                35,  // end
-                36,  // home
-                37,  // left arrow
-                39,  // right arrow
-                46,  // delete - We don't support the del key in Opera because del == . == 46.
-                44,  // ,
-                60,  // <
-                62,  // >
-                45,  // -
-                69,  // E
-                101, // e,
-                61   // =
-            ];
-            var isAllowedKey = allowedKeys.join(",").match(new RegExp(event.which)); // IE doesn't support indexOf
-            // Some browsers just don't raise events for control keys. Easy. e.g. Safari backspace.
-            if (!event.which || // Control keys in most browsers. e.g. Firefox tab is 0
-                (48 <= event.which && event.which <= 57) || // Always 0 through 9
-                isAllowedKey) { // Opera assigns values for control keys.
-                // Wait (next cycle) for value popluation and replace commas.
-                var $self = $(this);
-                window.setTimeout(function() {
-                    $self.val($self.val().replace(',','.'));
-                }, 0);
-                return;
-            } else {
-                event.preventDefault();
-            }
-        });
-        // autocomplete input controller
-        var availableTags = $.parseJSON($("input.autocomplete").attr('voc'));
-        function split( val ) {
-            return val.split( /,\s*/ );
-        }
-        function extractLast( term ) {
-            return split( term ).pop();
-        }
-        $("input.autocomplete")
-            // don't navigate away from the field on tab when selecting an item
-            .on( "keydown", function( event ) {
-              if ( event.keyCode === $.ui.keyCode.TAB &&
-                  $( this ).autocomplete( "instance" ).menu.active ) {
-                event.preventDefault();
-              }
-            })
-            .autocomplete({
-                minLength: 0,
-                source: function( request, response ) {
-                    // delegate back to autocomplete, but extract the last term
-                    response( $.ui.autocomplete.filter(
-                        availableTags, extractLast( request.term ) ) );
-                },
-                focus: function() {
-                    // prevent value inserted on focus
-                    return false;
-                },
-                select: function( event, ui ) {
-                    var terms = split( this.value );
-                    // remove the current input
-                    terms.pop();
-                    // add the selected item
-                    terms.push( ui.item.value );
-                    // add placeholder to get the comma-and-space at the end
-                    terms.push( "" );
-                    this.value = terms.join( ", " );
-                    return false;
-                }
-        });
-
-        // Archetypes :int and IntegerWidget inputs get filtered
-        $("input[name*='\\:int'], .ArchetypesIntegerWidget input").keyup(function(e) {
-            if (/\D/g.test(this.value)) {
-                this.value = this.value.replace(/\D/g, "");
-            }
-        });
-
-        // Archetypes :float and DecimalWidget inputs get filtered
-        $("input[name*='\\:float'], .ArchetypesDecimalWidget input").keyup(function(e) {
-            if (/[^.\d]/g.test(this.value)) {
-                this.value = this.value.replace(/[^.\d]/g, "");
-            }
-        });
-
-        /* Replace kss-bbb spinner with a quieter one */
-        var timer, spinner, counter = 0;
-        $(document).unbind("ajaxStart");
-        $(document).unbind("ajaxStop");
-        $('#ajax-spinner').remove();
-        spinner = $('<div id="bika-spinner"><img src="' + portal_url + '/spinner.gif" alt=""/></div>');
-        spinner.appendTo('body').hide();
-        $(document).ajaxStart(function () {
-            counter++;
-            setTimeout(function () {
-                if (counter > 0) {
-                    if (!pause_spinner) {
-                        spinner.show('fast');
-                    }
-                }
-            }, 500);
-        });
-        function stop_spinner(){
-            counter--;
-            if (counter < 0){ counter = 0; }
-            if (counter == 0) {
-                clearTimeout(timer);
-                spinner.stop();
-                spinner.hide();
-            }
-        }
-        $(document).ajaxStop(function () {
-            stop_spinner();
-        });
-        $( document ).ajaxError(function( event, jqxhr, settings, thrownError ) {
-            stop_spinner();
-            window.bika.lims.log("Error at " + settings.url + ": " + thrownError);
-        });
-    }
-
-    that.pauseSpinner = function() {
-        pause_spinner = true;
-    }
-    that.resumeSpinner = function() {
-        pause_spinner = false;
-    }
-
-    function portalAlert(html) {
-        if ($('#portal-alert').length == 0) {
-            $('#portal-header').append("<div id='portal-alert' style='display:none'><div class='portal-alert-item'>" + html + "</div></div>");
-        } else {
-            $('#portal-alert').append("<div class='portal-alert-item'>" + html + "</div>");
-        }
-        $('#portal-alert').fadeIn();
-    }
-
-    that.notificationPanel = function(data, mode) {
-    /**
-     * Render an alert inside the content panel. Used for autosave in ARView, for example.
-     */
-    $('#panel-notification').remove();
-        $('div#viewlet-above-content-title').append(
-            "<div id='panel-notification' style='display:none'>" +
-            "<div class='"+mode+"-notification-item'>"
-            + data +
-            "</div></div>");
-
-        $('#panel-notification').fadeIn("slow","linear", function(){
-            setTimeout(function() {
-                $('#panel-notification').fadeOut("slow","linear")
-            }, 3000)
-        });
+         */
+        showOn: 'focus',
+        showAnim: '',
+        changeMonth: true,
+        changeYear: true,
+        dateFormat: dateFormat,
+        yearRange: limitString
+      });
+      $('input.datepicker').on('click', function() {
+        console.warn("SiteView::datepicker.click: Refactor this event handler!");
+        $(this).datepicker({
+          showOn: 'focus',
+          showAnim: '',
+          changeMonth: true,
+          changeYear: true,
+          dateFormat: dateFormat,
+          yearRange: limitString
+        }).click(function() {
+          $(this).attr('value', '');
+        }).focus();
+      });
+      $('input.datepicker_nofuture').on('click', function() {
+        console.warn("SiteView::datetimepicker_nofuture.click: Refactor this event handler!");
+        $(this).datepicker({
+          showOn: 'focus',
+          showAnim: '',
+          changeMonth: true,
+          changeYear: true,
+          maxDate: curDate,
+          dateFormat: dateFormat,
+          yearRange: limitString
+        }).click(function() {
+          $(this).attr('value', '');
+        }).focus();
+      });
+      $('input.datepicker_2months').on('click', function() {
+        console.warn("SiteView::datetimepicker_2months.click: Refactor this event handler!");
+        $(this).datepicker({
+          showOn: 'focus',
+          showAnim: '',
+          changeMonth: true,
+          changeYear: true,
+          maxDate: '+0d',
+          numberOfMonths: 2,
+          dateFormat: dateFormat,
+          yearRange: limitString
+        }).click(function() {
+          $(this).attr('value', '');
+        }).focus();
+      });
+      return $('input.datetimepicker_nofuture').on('click', function() {
+        console.warn("SiteView::datetimepicker_nofuture.click: Refactor this event handler!");
+        $(this).datetimepicker({
+          showOn: 'focus',
+          showAnim: '',
+          changeMonth: true,
+          changeYear: true,
+          maxDate: curDate,
+          dateFormat: dateFormat,
+          yearRange: limitString,
+          timeFormat: 'HH:mm',
+          beforeShow: function() {
+            setTimeout((function() {
+              $('.ui-datepicker').css('z-index', 99999999999999);
+            }), 0);
+          }
+        }).click(function() {
+          $(this).attr('value', '');
+        }).focus();
+      });
     };
 
-    function loadFilterByDepartment() {
-        /**
-        This function sets up the filter by department cookie value by chosen departments.
-        Also it does auto-submit if admin wants to enable/disable the department filtering.
-        */
-        $('#department_filter_submit').click(function() {
-          if(!($('#admin_dep_filter_enabled').is(":checked"))) {
-            var deps =[];
-            $.each($("input[name^=chb_deps_]:checked"), function() {
-              deps.push($(this).val());
-            });
-            var cookiename = 'filter_by_department_info';
-            if (deps.length===0) {
-              deps.push($('input[name^=chb_deps_]:checkbox:not(:checked):visible:first').val());
-            }
-            setCookie(cookiename, deps.toString());
+    SiteView.prototype.init_referencedefinition = function() {
+
+      /*
+       * Initialize reference definition selection
+       * XXX: When is this used?
+       */
+      console.debug("SiteView::init_referencedefinition");
+      if ($('#ReferenceDefinition:list').val() !== '') {
+        console.warn("SiteView::init_referencedefinition: Refactor this method!");
+        return $('#ReferenceDefinition:list').change();
+      }
+    };
+
+    SiteView.prototype.init_department_filtering = function() {
+
+      /*
+       * Initialize department filtering (when enabled in Setup)
+       *
+       * This function checks if the cookie 'filter_by_department_info' is
+       * available. If the cookie exists, do nothing, if the cookie has not been
+       * created yet, checks the selected department in the checkbox group and
+       * creates the cookie with the UID of the first department. If cookie value
+       * "dep_filter_disabled" is true, it means the user is admin and filtering
+       * is disabled.
+       */
+      var cookie_val, dep_filter_disabled, dep_uid;
+      console.debug("SiteView::init_department_filtering");
+      cookie_val = this.read_cookie(this.department_filter_cookie);
+      if (cookie_val === null || cookie_val === '') {
+        dep_uid = $('input[name^=chb_deps_]:checkbox:visible:first').val();
+        this.set_cookie(this.department_filter_cookie, dep_uid);
+      }
+      dep_filter_disabled = this.read_cookie(this.department_filter_disabled_cookie);
+      if (dep_filter_disabled === 'true' || dep_filter_disabled === '"true"') {
+        $('#admin_dep_filter_enabled').prop('checked', true);
+      }
+    };
+
+
+    /* METHODS */
+
+    SiteView.prototype.get_portal_url = function() {
+
+      /*
+       * Return the portal url
+       */
+      return window.portal_url;
+    };
+
+    SiteView.prototype.get_authenticator = function() {
+
+      /*
+       * Get the authenticator value
+       */
+      return $("input[name='_authenticator']").val();
+    };
+
+    SiteView.prototype.portalAlert = function(html) {
+
+      /*
+       * BBB: Use portal_alert
+       */
+      console.warn("SiteView::portalAlert: Please use portal_alert method instead.");
+      return this.portal_alert(html);
+    };
+
+    SiteView.prototype.portal_alert = function(html) {
+
+      /*
+       * Display a portal alert box
+       */
+      var alerts;
+      console.debug("SiteView::portal_alert");
+      alerts = $('#portal-alert');
+      if (alerts.length === 0) {
+        $('#portal-header').append("<div id='portal-alert' style='display:none'><div class='portal-alert-item'>" + html + "</div></div>");
+      } else {
+        alerts.append("<div class='portal-alert-item'>" + html + "</div>");
+      }
+      alerts.fadeIn();
+    };
+
+    SiteView.prototype.log = function(message) {
+
+      /*
+       * Log message via bika.lims.log
+       */
+      console.debug("SiteView::log: message=" + message);
+      return window.bika.lims.log(message);
+    };
+
+    SiteView.prototype.readCookie = function(cname) {
+
+      /*
+       * BBB: Use read_cookie
+       */
+      console.warn("SiteView::readCookie: Please use read_cookie method instead.");
+      return this.read_cookie(cname);
+    };
+
+    SiteView.prototype.read_cookie = function(cname) {
+
+      /*
+       * Read cookie value
+       */
+      var c, ca, i, name;
+      console.debug("SiteView::read_cookie:" + cname);
+      name = cname + '=';
+      ca = document.cookie.split(';');
+      i = 0;
+      while (i < ca.length) {
+        c = ca[i];
+        while (c.charAt(0) === ' ') {
+          c = c.substring(1);
+        }
+        if (c.indexOf(name) === 0) {
+          return c.substring(name.length, c.length);
+        }
+        i++;
+      }
+      return null;
+    };
+
+    SiteView.prototype.setCookie = function(cname, cvalue) {
+
+      /*
+       * BBB: Use set_cookie
+       */
+      console.warn("SiteView::setCookie: Please use set_cookie method instead.");
+      return this.set_cookie(cname, cvalue);
+    };
+
+    SiteView.prototype.set_cookie = function(cname, cvalue) {
+
+      /*
+       * Read cookie value
+       */
+      var d, expires;
+      console.debug("SiteView::set_cookie:cname=" + cname + ", cvalue=" + cvalue);
+      d = new Date;
+      d.setTime(d.getTime() + 1 * 24 * 60 * 60 * 1000);
+      expires = 'expires=' + d.toUTCString();
+      document.cookie = cname + '=' + cvalue + ';' + expires + ';path=/';
+    };
+
+    SiteView.prototype.notificationPanel = function(data, mode) {
+
+      /*
+       * BBB: Use notify_in_panel
+       */
+      console.warn("SiteView::notificationPanel: Please use notfiy_in_panel method instead.");
+      return this.notify_in_panel(data, mode);
+    };
+
+    SiteView.prototype.notify_in_panel = function(data, mode) {
+
+      /*
+       * Render an alert inside the content panel, e.g.in autosave of ARView
+       */
+      var html;
+      console.debug("SiteView::notify_in_panel:data=" + data + ", mode=" + mode);
+      $('#panel-notification').remove();
+      html = "<div id='panel-notification' style='display:none'><div class='" + mode + "-notification-item'>" + data + "</div></div>";
+      $('div#viewlet-above-content-title').append(html);
+      $('#panel-notification').fadeIn('slow', 'linear', function() {
+        setTimeout((function() {
+          $('#panel-notification').fadeOut('slow', 'linear');
+        }), 3000);
+      });
+    };
+
+    SiteView.prototype.start_spinner = function() {
+
+      /*
+       * Start Spinner Overlay
+       */
+      console.debug("SiteView::start_spinner");
+      this.counter++;
+      this.timer = setTimeout(((function(_this) {
+        return function() {
+          if (_this.counter > 0) {
+            _this.spinner.show('fast');
           }
-          window.location.reload(true);
-        });
+        };
+      })(this)), 500);
+    };
 
-        $('#admin_dep_filter_enabled').change(function() {
-            var cookiename = 'filter_by_department_info';
-            if($(this).is(":checked")) {
-                var deps=[];
-                $.each($("input[name^=chb_deps_]:checkbox"), function() {
-                  deps.push($(this).val());
-                });
-                setCookie(cookiename, deps);
-                setCookie('dep_filter_disabled','true');
-                window.location.reload(true);
-              }else{
-                setCookie('dep_filter_disabled','false');
-                window.location.reload(true);
-              }
-            });
-          loadFilterByDepartmentCookie();
-    }
+    SiteView.prototype.stop_spinner = function() {
 
-    function loadFilterByDepartmentCookie(){
-        /**
-        This function checks if the cookie 'filter_by_department_info' is
-        available. If the cookie exists, do nothing, if the cookie has not been
-        created yet, checks the selected department in the checkbox group and creates the cookie with the UID of the first department.
-        If cookie value "dep_filter_disabled" is true, it means the user is admin and filtering is disabled.
-        */
-        // Gettin the cookie
-        var cookiename = 'filter_by_department_info';
-        var cookie_val = readCookie(cookiename);
+      /*
+       * Stop Spinner Overlay
+       */
+      console.debug("SiteView::stop_spinner");
+      this.counter--;
+      if (this.counter < 0) {
+        this.counter = 0;
+      }
+      if (this.counter === 0) {
+        clearTimeout(this.timer);
+        this.spinner.stop();
+        this.spinner.hide();
+      }
+    };
 
-        if (cookie_val === null || cookie_val===""){
-            var dep_uid = $('input[name^=chb_deps_]:checkbox:visible:first').val();
-            setCookie(cookiename, dep_uid);
-        }
-        var dep_filter_disabled=readCookie('dep_filter_disabled');
-        if (dep_filter_disabled=="true" || dep_filter_disabled=='"true"'){
-            $('#admin_dep_filter_enabled').prop("checked",true);
-        }
-    }
+    SiteView.prototype.load_analysis_service_popup = function(title, uid) {
 
+      /*
+       * Load the analysis service popup
+       */
+      var dialog;
+      console.debug("SiteView::show_analysis_service_popup:title=" + title + ", uid=" + uid);
+      if (!title || !uid) {
+        console.warn("SiteView::load_analysis_service_popup: title and uid are mandatory");
+        return;
+      }
+      dialog = $('<div></div>');
+      dialog.load((this.get_portal_url()) + "/analysisservice_popup", {
+        'service_title': title,
+        'analysis_uid': uid,
+        '_authenticator': this.get_authenticator()
+      }).dialog({
+        width: 450,
+        height: 450,
+        closeText: this._('Close'),
+        resizable: true,
+        title: $(this).text()
+      });
+    };
 
-    /**
-    This function updates the minimum selectable date of date_range_end
-    @param {object} input_element is the <input> object for date_range_start
-    */
-    function date_range_controller_0(input_element){
-        var date_element = $(input_element).datepicker("getDate");
-        var brother = $(input_element).siblings('.date_range_end');
-        $(brother).datepicker("option", "minDate", date_element );
-    }
-    /**
-    This function updates the maximum selectable date of date_range_start
-    @param {object} input_element is the <input> object for date_range_end
-    */
-    function date_range_controller_1(input_element){
-        var date_element = $(input_element).datepicker("getDate");
-        var brother = $(input_element).siblings('.date_range_start');
-        $(brother).datepicker("option", "maxDate", date_element );
-    }
+    SiteView.prototype.filter_default_departments = function(deps_element) {
 
-    /**
-    Updating default department list when assigned departments change
-    @param {object} deps_element is the multiple select of deparments
-    */
-    function reset_default_deps(deps_element){
-      //Resetting def_dep_list
-      def_deps=$("select[name='DefaultDepartment']")[0];
-      def_deps.options.length=0;
-      var null_opt = document.createElement("option");
-      null_opt.text = "";
-      null_opt.value = "";
-      null_opt.selected="selected";
+      /*
+       * Keep the list of default departments in sync with the selected departments
+       *
+       * 1. Go to a labcontact and select departments
+       * 2. The list of default departments is kept in sync with the selection
+       */
+      var def_deps, null_opt;
+      console.debug("SiteView::filter_default_departments");
+      def_deps = $("select[name='DefaultDepartment']")[0];
+      def_deps.options.length = 0;
+      null_opt = document.createElement('option');
+      null_opt.text = '';
+      null_opt.value = '';
+      null_opt.selected = 'selected';
       def_deps.add(null_opt);
-      //Adding selected deps
       $('option:selected', deps_element).each(function() {
-        var option = document.createElement("option");
+        var option;
+        option = document.createElement('option');
         option.text = $(this).text();
         option.value = $(this).val();
-        option.selected="selected";
+        option.selected = 'selected';
         def_deps.add(option);
       });
-    }
+    };
 
-    /**
-    This function sets cookie value
-    @param {String} cname is name of the cookie
-    @param {String} cvalue is value of the cookie
-    */
-    function setCookie(cname, cvalue) {
-        var d = new Date();
-        d.setTime(d.getTime() + (1 * 24 * 60 * 60 * 1000));
-        var expires = "expires="+d.toUTCString();
-        document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
-    }
 
-    /**
-    This function is to read cookie value
-    @param {String} cname is name of the cookie to be read
-    */
-    function readCookie(cname) {
-        var name = cname + "=";
-        var ca = document.cookie.split(';');
-        for(var i = 0; i < ca.length; i++) {
-            var c = ca[i];
-            while (c.charAt(0) == ' ') {
-                c = c.substring(1);
-            }
-            if (c.indexOf(name) == 0) {
-                return c.substring(name.length, c.length);
-            }
+    /* EVENT HANDLER */
+
+    SiteView.prototype.on_date_range_start_change = function(event) {
+
+      /*
+       * Eventhandler for Date Range Filtering
+       *
+       * 1. Go to Setup and enable advanced filter bar
+       * 2. Set the start date of adv. filter bar, e.g. in AR listing
+       */
+      var $el, brother, date_element, el;
+      console.debug("°°° SiteView::on_date_range_start_change °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      date_element = $el.datepicker('getDate');
+      brother = $el.siblings('.date_range_end');
+      return $(brother).datepicker('option', 'minDate', date_element);
+    };
+
+    SiteView.prototype.on_date_range_end_change = function(event) {
+
+      /*
+       * Eventhandler for Date Range Filtering
+       *
+       * 1. Go to Setup and enable advanced filter bar
+       * 2. Set the start date of adv. filter bar, e.g. in AR listing
+       */
+      var $el, brother, date_element, el;
+      console.debug("°°° SiteView::on_date_range_end_change °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      date_element = $el.datepicker('getDate');
+      brother = $el.siblings('.date_range_start');
+      return $(brother).datepicker('option', 'maxDate', date_element);
+    };
+
+    SiteView.prototype.on_department_list_change = function(event) {
+
+      /*
+       * Eventhandler for Department list on LabContacts
+       */
+      var $el, el;
+      console.debug("°°° SiteView::on_department_list_change °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      return this.filter_default_departments(el);
+    };
+
+    SiteView.prototype.on_department_filter_submit = function(event) {
+
+      /*
+       * Eventhandler for Department filter Portlet
+       *
+       * 1. Go to Setup and activate "Enable filtering by department"
+       * 2. The portlet contains the id="department_filter_submit"
+       */
+      var $el, deps, el;
+      console.debug("°°° SiteView::on_department_filter_submit °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      if (!$('#admin_dep_filter_enabled').is(':checked')) {
+        deps = [];
+        $.each($('input[name^=chb_deps_]:checked'), function() {
+          deps.push($(this).val());
+        });
+        if (deps.length === 0) {
+          deps.push($('input[name^=chb_deps_]:checkbox:not(:checked):visible:first').val());
         }
-        return null;
-    }
-}
+        this.set_cookie(this.department_filter_cookie, deps.toString());
+      }
+      window.location.reload(true);
+    };
+
+    SiteView.prototype.on_admin_dep_filter_change = function(event) {
+
+      /*
+       * Eventhandler for Department filter Portlet
+       *
+       * 1. Go to Setup and activate "Enable filtering by department"
+       * 2. The portlet contains the id="admin_dep_filter_enabled"
+       */
+      var $el, deps, el;
+      console.debug("°°° SiteView::on_admin_dep_filter_change °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      if ($el.is(':checked')) {
+        deps = [];
+        $.each($('input[name^=chb_deps_]:checkbox'), function() {
+          return deps.push($(this).val());
+        });
+        this.set_cookie(this.department_filter_cookie, deps);
+        this.set_cookie(this.department_filter_disabled_cookie, 'true');
+        window.location.reload(true);
+      } else {
+        this.set_cookie(this.department_filter_disabled_cookie, 'false');
+        window.location.reload(true);
+      }
+    };
+
+    SiteView.prototype.on_autocomplete_keydown = function(event) {
+
+      /*
+       * Eventhandler for Autocomplete fields
+       *
+       * XXX: Refactor if it is clear where this code is used!
+       */
+      var $el, availableTags, el, extractLast, split;
+      console.debug("°°° SiteView::on_autocomplete_keydown °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      availableTags = $.parseJSON($('input.autocomplete').attr('voc'));
+      split = function(val) {
+        return val.split(/,\s*/);
+      };
+      extractLast = function(term) {
+        return split(term).pop();
+      };
+      if (event.keyCode === $.ui.keyCode.TAB && $el.autocomplete('instance').menu.active) {
+        event.preventDefault();
+      }
+      return;
+      return $el.autocomplete({
+        minLength: 0,
+        source: function(request, response) {
+          response($.ui.autocomplete.filter(availableTags, extractLast(request.term)));
+        },
+        focus: function() {
+          return false;
+        },
+        select: function(event, ui) {
+          var terms;
+          terms = split($el.val());
+          terms.pop();
+          terms.push(ui.item.value);
+          terms.push('');
+          this.el.val(terms.join(', '));
+          return false;
+        }
+      });
+    };
+
+    SiteView.prototype.on_at_integer_field_keyup = function(event) {
+
+      /*
+       * Eventhandler for AT integer fields
+       */
+      var $el, el;
+      console.debug("°°° SiteView::on_at_integer_field_keyup °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      if (/\D/g.test($el.val())) {
+        $el.val($el.val().replace(/\D/g, ''));
+      }
+    };
+
+    SiteView.prototype.on_at_float_field_keyup = function(event) {
+
+      /*
+       * Eventhandler for AT float fields
+       */
+      var $el, el;
+      console.debug("°°° SiteView::on_at_float_field_keyup °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      if (/[^-.\d]/g.test($el.val())) {
+        $el.val($el.val().replace(/[^.\d]/g, ''));
+      }
+    };
+
+    SiteView.prototype.on_numeric_field_paste = function(event) {
+
+      /*
+       * Eventhandler when the user pasted a value inside a numeric field.
+       */
+      var $el, el;
+      console.debug("°°° SiteView::on_numeric_field_paste °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      window.setTimeout((function() {
+        $el.val($el.val().replace(',', '.'));
+      }), 0);
+    };
+
+    SiteView.prototype.on_numeric_field_keypress = function(event) {
+
+      /*
+       * Eventhandler when the user pressed a key inside a numeric field.
+       */
+      var isAllowedKey, key;
+      console.debug("°°° SiteView::on_numeric_field_keypress °°°");
+      key = event.which;
+      isAllowedKey = this.allowedKeys.join(',').match(new RegExp(key));
+      if (!key || 48 <= key && key <= 57 || isAllowedKey) {
+        window.setTimeout((function() {
+          $el.val($el.val().replace(',', '.'));
+        }), 0);
+        return;
+      } else {
+        event.preventDefault();
+      }
+    };
+
+    SiteView.prototype.on_reference_definition_list_change = function(event) {
+
+      /*
+       * Eventhandler when the user clicked on the reference defintion dropdown.
+       *
+       * 1. Add a ReferenceDefintion at /bika_setup/bika_referencedefinitions
+       * 2. Add a Supplier in /bika_setup/bika_suppliers
+       * 3. Add a ReferenceSample in /bika_setup/bika_suppliers/supplier-1/portal_factory/ReferenceSample
+       *
+       * The dropdown with the id="ReferenceDefinition:list" is rendered there.
+       */
+      var $el, authenticator, el, option, uid;
+      console.debug("°°° SiteView::on_reference_definition_list_change °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      authenticator = this.get_authenticator();
+      uid = $el.val();
+      option = $el.children(':selected').html();
+      if (uid === '') {
+        $('#Blank').prop('checked', false);
+        $('#Hazardous').prop('checked', false);
+        $('.bika-listing-table').load('referenceresults', {
+          '_authenticator': authenticator
+        });
+        return;
+      }
+      if (option.search(this._('(Blank)')) > -1 || option.search("(Blank)") > -1) {
+        $('#Blank').prop('checked', true);
+      } else {
+        $('#Blank').prop('checked', false);
+      }
+      if (option.search(this._('(Hazardous)')) > -1 || option.search("(Hazardous)") > -1) {
+        $('#Hazardous').prop('checked', true);
+      } else {
+        $('#Hazardous').prop('checked', false);
+      }
+      $('.bika-listing-table').load('referenceresults', {
+        '_authenticator': authenticator,
+        'uid': uid
+      });
+    };
+
+    SiteView.prototype.on_analysis_service_title_click = function(event) {
+
+      /*
+       * Eventhandler when the user clicked on an Analysis Service Title
+       */
+      var $el, el, title, uid;
+      console.debug("°°° SiteView::on_analysis_service_title_click °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      title = $el.closest('td').find("span[class^='state']").html();
+      uid = $el.parents('tr').attr('uid');
+      return this.load_analysis_service_popup(title, uid);
+    };
+
+    SiteView.prototype.on_ajax_start = function(event) {
+
+      /*
+       * Eventhandler if an global Ajax Request started
+       */
+      console.debug("°°° SiteView::on_ajax_start °°°");
+      return this.start_spinner();
+    };
+
+    SiteView.prototype.on_ajax_end = function(event) {
+
+      /*
+       * Eventhandler if an global Ajax Request ended
+       */
+      console.debug("°°° SiteView::on_ajax_end °°°");
+      return this.stop_spinner();
+    };
+
+    SiteView.prototype.on_ajax_error = function(event, jqxhr, settings, thrownError) {
+
+      /*
+       * Eventhandler if an global Ajax Request error
+       */
+      console.debug("°°° SiteView::on_ajax_error °°°");
+      this.stop_spinner();
+      return this.log("Error at " + settings.url + ": " + thrownError);
+    };
+
+    return SiteView;
+
+  })();
+
+}).call(this);

--- a/bika/lims/browser/js/coffee/bika.lims.site.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.site.coffee
@@ -56,9 +56,6 @@ class window.SiteView
     @department_filter_cookie = "filter_by_department_info"
     @department_filter_disabled_cookie = "dep_filter_disabled"
 
-    # develop only
-    window.sv = @
-
 
   ### INITIALIZERS ###
 

--- a/bika/lims/browser/js/coffee/bika.lims.site.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.site.coffee
@@ -1,0 +1,832 @@
+### Please use this command to compile this file into the parent `js` directory:
+    coffee --no-header -w -o ../ -c bika.lims.site.coffee
+###
+
+
+class window.SiteView
+
+  load: =>
+    console.debug "SiteView::load"
+
+    # load translations
+    jarn.i18n.loadCatalog 'bika'
+    @_ = window.jarn.i18n.MessageFactory('bika')
+
+    # initialze the loading spinner
+    @init_spinner()
+
+    # initialze the client add overlay
+    @init_client_add_overlay()
+
+    # initialze the client combogrid
+    @init_client_combogrid()
+
+    # initialze datepickers
+    @init_datepickers()
+
+    # initialze reference definition selection
+    @init_referencedefinition()
+
+    # initialze department filtering
+    @init_department_filtering()
+
+    # bind the event handler to the elements
+    @bind_eventhandler()
+
+    # allowed keys for numeric fields
+    @allowed_keys = [
+      8,    # backspace
+      9,    # tab
+      13,   # enter
+      35,   # end
+      36,   # home
+      37,   # left arrow
+      39,   # right arrow
+      46,   # delete - We don't support the del key in Opera because del == . == 46.
+      44,   # ,
+      60,   # <
+      62,   # >
+      45,   # -
+      69,   # E
+      101,  # e,
+      61    # =
+    ]
+
+    # The name of the department filter cookies
+    @department_filter_cookie = "filter_by_department_info"
+    @department_filter_disabled_cookie = "dep_filter_disabled"
+
+    # develop only
+    window.sv = @
+
+
+  ### INITIALIZERS ###
+
+  bind_eventhandler: =>
+    ###
+     * Binds callbacks on elements
+    ###
+    console.debug "SiteView::bind_eventhandler"
+
+    # Analysis service popup
+    $('.service_title span:not(.before)').on 'click', @on_analysis_service_title_click
+
+    # ReferenceSample selection changed
+    $("#ReferenceDefinition\\:list").on "change", @on_reference_definition_list_change
+
+    # Numeric field events
+    $('.numeric').on 'keypress', @on_numeric_field_keypress
+    $('.numeric').on 'paste', @on_numeric_field_paste
+
+    # AT field events
+    $("input[name*='\\:int\'], .ArchetypesIntegerWidget input").on "keyup", @on_at_integer_field_keyup
+    $("input[name*='\\:float\'], .ArchetypesDecimalWidget input").on "keyup", @on_at_float_field_keyup
+
+    # Autocomplete events
+    # XXX Where is this used?
+    $("input.autocomplete").on "keydown", @on_autocomplete_keydown
+
+    # Department filtering events
+    $("#department_filter_submit").on "click", @on_department_filter_submit
+    $("#admin_dep_filter_enabled").on "change", @on_admin_dep_filter_change
+    $("select[name='Departments:list']").on "change", @on_department_list_change
+
+    # Date Range Filtering
+    $(".date_range_start").on "change", @on_date_range_start_change
+    $(".date_range_end").on "change", @on_date_range_end_change
+
+    # handle Ajax events
+    $(document).on "ajaxStart", @on_ajax_start
+    $(document).on "ajaxStop", @on_ajax_end
+    $(document).on "ajaxError", @on_ajax_error
+
+
+  init_client_add_overlay: =>
+    ###
+     * Initialize Client Overlay
+    ###
+    console.debug "SiteView::init_client_add_overlay"
+
+    $('a.add_client').prepOverlay
+      subtype: 'ajax'
+      filter: 'head>*,#content>*:not(div.configlet),dl.portalMessage.error,dl.portalMessage.info'
+      formselector: '#client-base-edit'
+      closeselector: '[name="form.button.cancel"]'
+      width: '70%'
+      noform: 'close'
+      config:
+        closeOnEsc: false
+        onLoad: ->
+          # manually remove remarks
+          @getOverlay().find('#archetypes-fieldname-Remarks').remove()
+          return
+        onClose: ->
+          # here is where we'd populate the form controls, if we cared to.
+          return
+
+
+  init_spinner: =>
+    ###
+     * Initialize Spinner Overlay
+    ###
+    console.debug "SiteView::init_spinner"
+
+    # unbind default Plone loader
+    $(document).unbind 'ajaxStart'
+    $(document).unbind 'ajaxStop'
+    $('#ajax-spinner').remove()
+
+    # counter of active spinners
+    @counter = 0
+
+    # crate a spinner and append it to the body
+    @spinner = $("<div id='bika-spinner'><img src='#{@get_portal_url()}/spinner.gif' alt=''/></div>")
+    @spinner.appendTo('body').hide()
+
+
+  init_client_combogrid: =>
+    ###
+     * Initialize client combogrid, e.g. on the Client Add View
+    ###
+    console.debug "SiteView::init_client_combogrid"
+
+    $("input[id*='ClientID']").combogrid
+      colModel: [
+        'columnName': 'ClientUID'
+        'hidden': true
+      ,
+        'columnName': 'ClientID'
+        'width': '20'
+        'label': _('Client ID')
+      ,
+        'columnName': 'Title'
+        'width': '80'
+        'label': _('Title')
+      ]
+      showOn: true
+      width: '450px'
+      url: "#{@get_portal_url()}/getClients?_authenticator=#{@get_authenticator()}"
+      select: (event, ui) ->
+        $(this).val ui.item.ClientID
+        $(this).change()
+        false
+
+
+  init_datepickers: =>
+    ###
+     * Initialize date pickers
+     *
+     * XXX Where are these event handlers used?
+    ###
+    console.debug "SiteView::init_datepickers"
+
+    curDate = new Date
+    y = curDate.getFullYear()
+    limitString = '1900:' + y
+    dateFormat = @_('date_format_short_datepicker')
+
+    if dateFormat == 'date_format_short_datepicker'
+      dateFormat = 'yy-mm-dd'
+
+    $('input.datepicker_range').datepicker
+      ###*
+      This function defines a datepicker for a date range. Both input
+      elements should be siblings and have the class 'date_range_start' and
+      'date_range_end'.
+      ###
+      showOn: 'focus'
+      showAnim: ''
+      changeMonth: true
+      changeYear: true
+      dateFormat: dateFormat
+      yearRange: limitString
+
+    $('input.datepicker').on 'click', ->
+      console.warn "SiteView::datepicker.click: Refactor this event handler!"
+
+      $(this).datepicker(
+        showOn: 'focus'
+        showAnim: ''
+        changeMonth: true
+        changeYear: true
+        dateFormat: dateFormat
+        yearRange: limitString).click(->
+        $(this).attr 'value', ''
+        return
+      ).focus()
+      return
+
+    $('input.datepicker_nofuture').on 'click', ->
+      console.warn "SiteView::datetimepicker_nofuture.click: Refactor this event handler!"
+
+      $(this).datepicker(
+        showOn: 'focus'
+        showAnim: ''
+        changeMonth: true
+        changeYear: true
+        maxDate: curDate
+        dateFormat: dateFormat
+        yearRange: limitString).click(->
+        $(this).attr 'value', ''
+        return
+      ).focus()
+      return
+
+    $('input.datepicker_2months').on 'click', ->
+      console.warn "SiteView::datetimepicker_2months.click: Refactor this event handler!"
+
+      $(this).datepicker(
+        showOn: 'focus'
+        showAnim: ''
+        changeMonth: true
+        changeYear: true
+        maxDate: '+0d'
+        numberOfMonths: 2
+        dateFormat: dateFormat
+        yearRange: limitString).click(->
+        $(this).attr 'value', ''
+        return
+      ).focus()
+      return
+
+    $('input.datetimepicker_nofuture').on 'click', ->
+      console.warn "SiteView::datetimepicker_nofuture.click: Refactor this event handler!"
+
+      $(this).datetimepicker(
+        showOn: 'focus'
+        showAnim: ''
+        changeMonth: true
+        changeYear: true
+        maxDate: curDate
+        dateFormat: dateFormat
+        yearRange: limitString
+        timeFormat: 'HH:mm'
+        beforeShow: ->
+          setTimeout (->
+            $('.ui-datepicker').css 'z-index', 99999999999999
+            return
+          ), 0
+          return
+      ).click(->
+        $(this).attr 'value', ''
+        return
+      ).focus()
+      return
+
+
+  init_referencedefinition: =>
+    ###
+     * Initialize reference definition selection
+     * XXX: When is this used?
+    ###
+    console.debug "SiteView::init_referencedefinition"
+
+    if $('#ReferenceDefinition:list').val() != ''
+      console.warn "SiteView::init_referencedefinition: Refactor this method!"
+      $('#ReferenceDefinition:list').change()
+
+
+  init_department_filtering: =>
+    ###
+     * Initialize department filtering (when enabled in Setup)
+     *
+     * This function checks if the cookie 'filter_by_department_info' is
+     * available. If the cookie exists, do nothing, if the cookie has not been
+     * created yet, checks the selected department in the checkbox group and
+     * creates the cookie with the UID of the first department. If cookie value
+     * "dep_filter_disabled" is true, it means the user is admin and filtering
+     * is disabled.
+    ###
+    console.debug "SiteView::init_department_filtering"
+
+    cookie_val = @read_cookie(@department_filter_cookie)
+    if cookie_val == null or cookie_val == ''
+      dep_uid = $('input[name^=chb_deps_]:checkbox:visible:first').val()
+      @set_cookie @department_filter_cookie, dep_uid
+
+    dep_filter_disabled = @read_cookie @department_filter_disabled_cookie
+    if dep_filter_disabled == 'true' or dep_filter_disabled == '"true"'
+      $('#admin_dep_filter_enabled').prop 'checked', true
+
+    return
+
+
+  ### METHODS ###
+
+  get_portal_url: =>
+    ###
+     * Return the portal url
+    ###
+    return window.portal_url
+
+
+  get_authenticator: =>
+    ###
+     * Get the authenticator value
+    ###
+    return $("input[name='_authenticator']").val()
+
+
+  portalAlert: (html) =>
+    ###
+     * BBB: Use portal_alert
+    ###
+    console.warn "SiteView::portalAlert: Please use portal_alert method instead."
+    @portal_alert html
+
+
+  portal_alert: (html) =>
+    ###
+     * Display a portal alert box
+    ###
+    console.debug "SiteView::portal_alert"
+
+    alerts = $('#portal-alert')
+
+    if alerts.length == 0
+      $('#portal-header').append "<div id='portal-alert' style='display:none'><div class='portal-alert-item'>#{html}</div></div>"
+    else
+      alerts.append "<div class='portal-alert-item'>#{html}</div>"
+    alerts.fadeIn()
+    return
+
+
+  log: (message) =>
+    ###
+     * Log message via bika.lims.log
+    ###
+    console.debug "SiteView::log: message=#{message}"
+
+    # XXX: This should actually log via XHR to the server, but seem to not work.
+    window.bika.lims.log message
+
+
+  readCookie: (cname) =>
+    ###
+     * BBB: Use read_cookie
+    ###
+    console.warn "SiteView::readCookie: Please use read_cookie method instead."
+    @read_cookie cname
+
+
+  read_cookie: (cname) =>
+    ###
+     * Read cookie value
+    ###
+    console.debug "SiteView::read_cookie:#{cname}"
+    name = cname + '='
+    ca = document.cookie.split ';'
+    i = 0
+    while i < ca.length
+      c = ca[i]
+      while c.charAt(0) == ' '
+        c = c.substring(1)
+      if c.indexOf(name) == 0
+        return c.substring(name.length, c.length)
+      i++
+    return null
+
+
+  setCookie: (cname, cvalue) =>
+    ###
+     * BBB: Use set_cookie
+    ###
+    console.warn "SiteView::setCookie: Please use set_cookie method instead."
+    @set_cookie cname, cvalue
+
+
+  set_cookie: (cname, cvalue) =>
+    ###
+     * Read cookie value
+    ###
+    console.debug "SiteView::set_cookie:cname=#{cname}, cvalue=#{cvalue}"
+    d = new Date
+    d.setTime d.getTime() + 1 * 24 * 60 * 60 * 1000
+    expires = 'expires=' + d.toUTCString()
+    document.cookie = cname + '=' + cvalue + ';' + expires + ';path=/'
+    return
+
+
+  notificationPanel: (data, mode) =>
+    ###
+     * BBB: Use notify_in_panel
+    ###
+    console.warn "SiteView::notificationPanel: Please use notfiy_in_panel method instead."
+    @notify_in_panel data, mode
+
+
+  notify_in_panel: (data, mode) =>
+    ###
+     * Render an alert inside the content panel, e.g.in autosave of ARView
+    ###
+    console.debug "SiteView::notify_in_panel:data=#{data}, mode=#{mode}"
+
+    $('#panel-notification').remove()
+    html = "<div id='panel-notification' style='display:none'><div class='#{mode}-notification-item'>#{data}</div></div>"
+
+    $('div#viewlet-above-content-title').append html
+    $('#panel-notification').fadeIn 'slow', 'linear', ->
+      setTimeout (->
+        $('#panel-notification').fadeOut 'slow', 'linear'
+        return
+      ), 3000
+      return
+    return
+
+
+  start_spinner: =>
+    ###
+     * Start Spinner Overlay
+    ###
+    console.debug "SiteView::start_spinner"
+
+    # increase the counter
+    @counter++
+
+    @timer = setTimeout (=>
+      if @counter > 0
+        @spinner.show 'fast'
+      return
+    ), 500
+
+    return
+
+
+  stop_spinner: =>
+    ###
+     * Stop Spinner Overlay
+    ###
+    console.debug "SiteView::stop_spinner"
+
+    # decrease the counter
+    @counter--
+
+    if @counter < 0
+      @counter = 0
+    if @counter == 0
+      clearTimeout @timer
+      @spinner.stop()
+      @spinner.hide()
+    return
+
+
+  load_analysis_service_popup: (title, uid) =>
+    ###
+     * Load the analysis service popup
+    ###
+    console.debug "SiteView::show_analysis_service_popup:title=#{title}, uid=#{uid}"
+
+    if !title or !uid
+      console.warn "SiteView::load_analysis_service_popup: title and uid are mandatory"
+      return
+
+    dialog = $('<div></div>')
+    dialog.load "#{@get_portal_url()}/analysisservice_popup",
+      'service_title': title
+      'analysis_uid': uid
+      '_authenticator': @get_authenticator()
+    .dialog
+      width: 450
+      height: 450
+      closeText: @_('Close')
+      resizable: true
+      title: $(this).text()
+    return
+
+
+  filter_default_departments: (deps_element) =>
+    ###
+     * Keep the list of default departments in sync with the selected departments
+     *
+     * 1. Go to a labcontact and select departments
+     * 2. The list of default departments is kept in sync with the selection
+    ###
+    console.debug "SiteView::filter_default_departments"
+
+    def_deps = $("select[name='DefaultDepartment']")[0]
+    def_deps.options.length = 0
+    null_opt = document.createElement('option')
+    null_opt.text = ''
+    null_opt.value = ''
+    null_opt.selected = 'selected'
+    def_deps.add null_opt
+
+    #Adding selected deps
+    $('option:selected', deps_element).each ->
+      option = document.createElement('option')
+      option.text = $(this).text()
+      option.value = $(this).val()
+      option.selected = 'selected'
+      def_deps.add option
+      return
+    return
+
+
+  ### EVENT HANDLER ###
+
+  on_date_range_start_change: (event) =>
+    ###
+     * Eventhandler for Date Range Filtering
+     *
+     * 1. Go to Setup and enable advanced filter bar
+     * 2. Set the start date of adv. filter bar, e.g. in AR listing
+    ###
+    console.debug "°°° SiteView::on_date_range_start_change °°°"
+
+    el = event.currentTarget
+    $el = $(el)
+
+    # Set the min selectable end date to the start date
+    date_element = $el.datepicker('getDate')
+    brother = $el.siblings('.date_range_end')
+    $(brother).datepicker 'option', 'minDate', date_element
+
+
+  on_date_range_end_change: (event) =>
+    ###
+     * Eventhandler for Date Range Filtering
+     *
+     * 1. Go to Setup and enable advanced filter bar
+     * 2. Set the start date of adv. filter bar, e.g. in AR listing
+    ###
+    console.debug "°°° SiteView::on_date_range_end_change °°°"
+
+    el = event.currentTarget
+    $el = $(el)
+
+    # Set the max selectable start date to the end date
+    date_element = $el.datepicker('getDate')
+    brother = $el.siblings('.date_range_start')
+    $(brother).datepicker 'option', 'maxDate', date_element
+
+
+  on_department_list_change: (event) =>
+    ###
+     * Eventhandler for Department list on LabContacts
+    ###
+    console.debug "°°° SiteView::on_department_list_change °°°"
+
+    el = event.currentTarget
+    $el = $(el)
+
+    # filter the list of default departments
+    @filter_default_departments el
+
+
+  on_department_filter_submit: (event) =>
+    ###
+     * Eventhandler for Department filter Portlet
+     *
+     * 1. Go to Setup and activate "Enable filtering by department"
+     * 2. The portlet contains the id="department_filter_submit"
+    ###
+    console.debug "°°° SiteView::on_department_filter_submit °°°"
+
+    el = event.currentTarget
+    $el = $(el)
+
+    if !$('#admin_dep_filter_enabled').is(':checked')
+      deps = []
+      $.each $('input[name^=chb_deps_]:checked'), ->
+        deps.push $(this).val()
+        return
+
+      if deps.length == 0
+        deps.push $('input[name^=chb_deps_]:checkbox:not(:checked):visible:first').val()
+
+      @set_cookie @department_filter_cookie, deps.toString()
+
+    window.location.reload true
+    return
+
+
+  on_admin_dep_filter_change: (event) =>
+    ###
+     * Eventhandler for Department filter Portlet
+     *
+     * 1. Go to Setup and activate "Enable filtering by department"
+     * 2. The portlet contains the id="admin_dep_filter_enabled"
+    ###
+    console.debug "°°° SiteView::on_admin_dep_filter_change °°°"
+
+    el = event.currentTarget
+    $el = $(el)
+
+    if $el.is(':checked')
+      deps = []
+      $.each $('input[name^=chb_deps_]:checkbox'), ->
+        deps.push $(this).val()
+
+      @set_cookie @department_filter_cookie, deps
+      @set_cookie @department_filter_disabled_cookie, 'true'
+
+      window.location.reload true
+    else
+      @set_cookie @department_filter_disabled_cookie, 'false'
+      window.location.reload true
+    return
+
+
+  on_autocomplete_keydown: (event) =>
+    ###
+     * Eventhandler for Autocomplete fields
+     *
+     * XXX: Refactor if it is clear where this code is used!
+    ###
+    console.debug "°°° SiteView::on_autocomplete_keydown °°°"
+
+    el = event.currentTarget
+    $el = $(el)
+
+    availableTags = $.parseJSON($('input.autocomplete').attr('voc'))
+
+    split = (val) ->
+      val.split /,\s*/
+
+    extractLast = (term) ->
+      split(term).pop()
+
+    if event.keyCode == $.ui.keyCode.TAB and $el.autocomplete('instance').menu.active
+      event.preventDefault()
+    return
+
+    $el.autocomplete
+      minLength: 0
+      source: (request, response) ->
+        # delegate back to autocomplete, but extract the last term
+        response $.ui.autocomplete.filter(availableTags, extractLast(request.term))
+        return
+      focus: ->
+        # prevent value inserted on focus
+        return false
+      select: (event, ui) ->
+        terms = split($el.val())
+        # remove the current input
+        terms.pop()
+        # add the selected item
+        terms.push ui.item.value
+        # add placeholder to get the comma-and-space at the end
+        terms.push ''
+        @el.val terms.join(', ')
+        return false
+
+
+  on_at_integer_field_keyup: (event) =>
+    ###
+     * Eventhandler for AT integer fields
+    ###
+    console.debug "°°° SiteView::on_at_integer_field_keyup °°°"
+
+    el = event.currentTarget
+    $el = $(el)
+
+    if /\D/g.test($el.val())
+      $el.val $el.val().replace(/\D/g, '')
+    return
+
+
+  on_at_float_field_keyup: (event) =>
+    ###
+     * Eventhandler for AT float fields
+    ###
+    console.debug "°°° SiteView::on_at_float_field_keyup °°°"
+
+    el = event.currentTarget
+    $el = $(el)
+
+    if /[^-.\d]/g.test($el.val())
+      $el.val $el.val().replace(/[^.\d]/g, '')
+    return
+
+
+  on_numeric_field_paste: (event) =>
+    ###
+     * Eventhandler when the user pasted a value inside a numeric field.
+    ###
+    console.debug "°°° SiteView::on_numeric_field_paste °°°"
+
+    el = event.currentTarget
+    $el = $(el)
+
+    # Wait (next cycle) for value popluation and replace commas.
+    window.setTimeout (->
+      $el.val $el.val().replace(',', '.')
+      return
+    ), 0
+    return
+
+
+  on_numeric_field_keypress: (event) =>
+    ###
+     * Eventhandler when the user pressed a key inside a numeric field.
+    ###
+    console.debug "°°° SiteView::on_numeric_field_keypress °°°"
+
+
+    key = event.which
+    isAllowedKey = @allowedKeys.join(',').match(new RegExp(key))
+
+    # IE doesn't support indexOf
+    # Some browsers just don't raise events for control keys. Easy. e.g. Safari backspace.
+    if !key or 48 <= key and key <= 57 or isAllowedKey
+      # Opera assigns values for control keys.
+      # Wait (next cycle) for value popluation and replace commas.
+      window.setTimeout (->
+        $el.val $el.val().replace(',', '.')
+        return
+      ), 0
+      return
+    else
+      event.preventDefault()
+    return
+
+
+  on_reference_definition_list_change: (event) =>
+    ###
+     * Eventhandler when the user clicked on the reference defintion dropdown.
+     *
+     * 1. Add a ReferenceDefintion at /bika_setup/bika_referencedefinitions
+     * 2. Add a Supplier in /bika_setup/bika_suppliers
+     * 3. Add a ReferenceSample in /bika_setup/bika_suppliers/supplier-1/portal_factory/ReferenceSample
+     *
+     * The dropdown with the id="ReferenceDefinition:list" is rendered there.
+    ###
+    console.debug "°°° SiteView::on_reference_definition_list_change °°°"
+
+    el = event.currentTarget
+    $el = $(el)
+
+    authenticator = @get_authenticator()
+    uid = $el.val()
+    option = $el.children(':selected').html()
+
+    if uid == ''
+      # No reference definition selected;
+      # render empty widget.
+      $('#Blank').prop 'checked', false
+      $('#Hazardous').prop 'checked', false
+      $('.bika-listing-table').load 'referenceresults', '_authenticator': authenticator
+      return
+
+    if option.search(@_('(Blank)')) > -1 or option.search("(Blank)") > -1
+      $('#Blank').prop 'checked', true
+    else
+      $('#Blank').prop 'checked', false
+
+    if option.search(@_('(Hazardous)')) > -1 or option.search("(Hazardous)") > -1
+      $('#Hazardous').prop 'checked', true
+    else
+      $('#Hazardous').prop 'checked', false
+
+    $('.bika-listing-table').load 'referenceresults',
+      '_authenticator': authenticator
+      'uid': uid
+
+    return
+
+
+  on_analysis_service_title_click: (event) =>
+    ###
+     * Eventhandler when the user clicked on an Analysis Service Title
+    ###
+    console.debug "°°° SiteView::on_analysis_service_title_click °°°"
+
+    el = event.currentTarget
+    $el = $(el)
+
+    title = $el.closest('td').find("span[class^='state']").html()
+    uid = $el.parents('tr').attr('uid')
+
+    @load_analysis_service_popup title, uid
+
+
+  on_ajax_start: (event) =>
+    ###
+     * Eventhandler if an global Ajax Request started
+    ###
+    console.debug "°°° SiteView::on_ajax_start °°°"
+
+    # start the loading spinner
+    @start_spinner()
+
+
+  on_ajax_end: (event) =>
+    ###
+     * Eventhandler if an global Ajax Request ended
+    ###
+    console.debug "°°° SiteView::on_ajax_end °°°"
+
+    # stop the loading spinner
+    @stop_spinner()
+
+
+  on_ajax_error: (event, jqxhr, settings, thrownError) =>
+    ###
+     * Eventhandler if an global Ajax Request error
+    ###
+    console.debug "°°° SiteView::on_ajax_error °°°"
+
+    # stop the loading spinner
+    @stop_spinner()
+
+    @log "Error at #{settings.url}: #{thrownError}"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/543

Note: Also converted and Refactored `bika.lims.site.js` to CoffeeScript.

Changed the Regular Expression according to the original code:
https://github.com/bikalims/bika.lims/blob/master/bika/lims/browser/js/bika.lims.site.js#L342-L346

```
if (/[^-.\d]/g.test(this.value)) {
    this.value = this.value.replace(/[^-.\d]/g, "");
}
```

## Current behavior before PR

It was not possible to insert negative LDL for Analysis Services.

## Desired behavior after PR is merged

It is possible to insert negative LDL for Analysis Services

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html