### PR TITLE
Sampler field is not displayed in Analysis Request Add form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Fixed**
 
+- #561 Sampler field is not displayed in Analysis Request Add form
 - #553 Fixed that images and barcodes were not printed in reports
 - #551 Traceback in Worksheet Templates list when there are Instruments assigned
 

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -567,6 +567,7 @@ schema = BikaSchema.copy() + Schema((
             visible={
                 'edit': 'visible',
                 'view': 'visible',
+                'add': 'edit',
                 'header_table': 'prominent',
                 'sample_registered': {'view': 'invisible', 'edit': 'invisible'},
                 'to_be_sampled': {'view': 'invisible', 'edit': 'visible'},


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

With this Pull Request, the Sampler field is displayed in Analysis Request Add form, but only when the setting "Enable Sampling" in "Setup > Sampling and coc" is checked.

Linked issue: [ Sampler field is not displayed in Analysis Request Add form #546](https://github.com/senaite/senaite.core/issues/546)

## Current behavior before PR

Sampler field is never displayed in Analysis Request Add form, regardless of the setting "Enable Sampling" from Setup.

## Desired behavior after PR is merged

Sampler field is displayed in Analysis Request Add form, but only when the setting "Enable Sampling" in "Setup > Sampling and coc" is checked

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
