### PR TITLE
Client Batch lists are empty

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Fixed**
 
+- #562 Client Batch lists are empty
 - #561 Sampler field is not displayed in Analysis Request Add form
 - #559 Fix numeric field event handler in bika.lims.site.js
 - #553 Fixed that images and barcodes were not printed in reports

--- a/bika/lims/browser/client/views/batches.py
+++ b/bika/lims/browser/client/views/batches.py
@@ -7,6 +7,8 @@
 
 from bika.lims.browser.batchfolder import BatchFolderContentsView
 from Products.CMFCore.utils import getToolByName
+from bika.lims.catalog.analysisrequest_catalog import \
+    CATALOG_ANALYSIS_REQUEST_LISTING
 
 
 class ClientBatchesView(BatchFolderContentsView):
@@ -18,7 +20,7 @@ class ClientBatchesView(BatchFolderContentsView):
         return BatchFolderContentsView.__call__(self)
 
     def contentsMethod(self, contentFilter):
-        bc = getToolByName(self.context, "bika_catalog")
+        bc = getToolByName(self.context, CATALOG_ANALYSIS_REQUEST_LISTING)
         batches = {}
         for ar in bc(portal_type='AnalysisRequest',
                      getClientUID=self.context.UID()):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

With this Pull Request, the Batches list from inside Client displays the Batches assigned to the current Client. The reason was the view was querying for `AnalysisRequest` objects against `bika_catalog`, while Analysis Requests live in ' bika_catalog_analysisrequest_listing`.

Linked issue: [Client Batch lists are empty #548](https://github.com/senaite/senaite.core/issues/548)

Although this PR only addresses the above mentioned issue, this view needs to be improved in terms of performance still:
- Use brains instead of objects in `folderitem`
- Fetch the Batches from the client directly instead of fetching ARs.

## Current behavior before PR

No batches listed in Client > Batches

## Desired behavior after PR is merged

Client Batches are displayed in Client > Batches

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
