### PR TITLE
Year Validator for Datetime picker.

### DIFF
--- a/bika/lims/skins/bika/bika_widgets/datetimewidget.js
+++ b/bika/lims/skins/bika/bika_widgets/datetimewidget.js
@@ -63,5 +63,20 @@ $(document).ready(function(){
         }
       }
     });
+
+    $('[datetimepicker="1"]').change(function() {
+      if(!this.value.includes("-")){
+        alert("Please enter a valid date");
+        this.text='';
+        this.value='';
+      }else{
+        var d = $(this).datepicker('getDate');
+        if (d && d.getFullYear() < 1901){
+          alert("Please choose a valid year...");
+          this.text='';
+          this.value='';
+        }
+      }
+    });
 });
 });


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/565

## Current behavior before PR
It is possible to choose years before 1901 through GUI.
## Desired behavior after PR is merged
Users are not allowed to enter a date before 1901 the year.
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
