### PR TITLE
No ID Server key error message logged

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Changelog
 - #559 Fix numeric field event handler in bika.lims.site.js
 - #553 Fixed that images and barcodes were not printed in reports
 - #551 Traceback in Worksheet Templates list when there are Instruments assigned
+- #571 Added try/except around id-template format function to log key errors in ID generation
 
 **Security**
 

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -373,7 +373,12 @@ def generateUniqueId(context, **kw):
     id_template = config.get("form", "")
 
     # Interpolate the ID template
-    new_id = id_template.format(**variables)
+    try:
+        new_id = id_template.format(**variables)
+    except KeyError, e:
+        logger.error('KeyError: {} not in id_template {}'.format(
+            e, id_template))
+        raise 
     normalized_id = api.normalize_filename(new_id)
     logger.info("generateUniqueId: {}".format(normalized_id))
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
No key error messages are logged in the ID Server when formatting the id-template

Linked issue: https://github.com/senaite/senaite.core/issues/571

## Current behavior before PR
AR Add does not complete and no message appear in the log file.

## Desired behavior after PR is merged
KeyErrors should at least appear in the log file.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
