### PR TITLE
Fix calculations using built-ins

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Changelog
 
 **Fixed**
 
+- #580 Fix calculations using built-ins
 - #563 Deactivated Analyses are added in new ARs when using Analysis Profiles/Template
 - #562 Client Batch lists are empty
 - #561 Sampler field is not displayed in Analysis Request Add form

--- a/bika/lims/content/calculation.py
+++ b/bika/lims/content/calculation.py
@@ -316,7 +316,15 @@ class Calculation(BaseFolder, HistoryAwareMixin):
         """Return the globals dictionary for the formula calculation
         """
         # Default globals
-        globs = {"__builtins__": None, 'math': math}
+        globs = {
+            "__builtins__": None,
+            "math": math,
+            "round": round,
+            "divmod": divmod,
+            "float": float,
+            "int": int,
+            "max": max,
+        }
         # Update with keyword arguments
         globs.update(kwargs)
         # Update with additional Python libraries


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/554

## Current behavior before PR

Python built-ins were not found in Calculations

## Desired behavior after PR is merged

Calculations can use these Python built-ins: int, float, round, max, divmod

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
