### PR TITLE
Empty value for Analysis Request column in aggregated list of analyses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Changelog
 
 **Fixed**
 
+- #585 Empty value for Analysis Request column in aggregated list of analyses
 - #578 Fix translation for review state titles in listings
 - #580 Fix calculations using built-ins
 - #563 Deactivated Analyses are added in new ARs when using Analysis Profiles/Template

--- a/bika/lims/browser/aggregatedanalyses/aggregatedanalyses.py
+++ b/bika/lims/browser/aggregatedanalyses/aggregatedanalyses.py
@@ -48,7 +48,7 @@ class AggregatedAnalysesView(AnalysesView):
 
         self.columns['AnalysisRequest'] = {
             'title': _('Analysis Request'),
-            'attr': 'getRequestTitle',
+            'attr': 'getRequestID',
             'replace_url': 'getRequestURL',
             'sortable': False
             }


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: [Empty value for Analysis Request column in aggregated list of analyses #583](https://github.com/senaite/senaite.core/issues/583)

## Current behavior before PR

No values displayed in the Analysis Request column from Aggregated analyses view

## Desired behavior after PR is merged

Analysis Request ID, together with a link is displayed for each row in the column Analysis Request.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
