### PR TITLE
Issue 587 background process ar creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #587 Use TaskQueue to Process AR Creation in the background
 - #555 Don't allow the deactivation Analysis Services with active dependencies
 - #555 Don't allow the activation of Analysis Services with inactive dependents
 

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1827,7 +1827,10 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                 # Create the Analysis Request
                 try:
                     ar = crar(client, self.request, record, specifications=specifications)
-                except (KeyError, RuntimeError) as e:
+                except KeyError as e:
+                    errors["message"] = "Missing key {}.".format(e.message)
+                    return {"errors": errors}
+                except RuntimeError as e:
                     errors["message"] = e.message
                     return {"errors": errors}
                 ARs.append(ar.Title())

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -18,6 +18,7 @@ from plone.memoize.volatile import cache
 from plone.memoize.volatile import DontCache
 
 from zope.annotation.interfaces import IAnnotations
+from zope.component import queryUtility
 from zope.publisher.interfaces import IPublishTraverse
 from zope.interface import implements
 from zope.i18n.locales import locales
@@ -27,6 +28,7 @@ from Products.CMFPlone.utils import _createObjectByType
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
+from collective.taskqueue.interfaces import ITaskQueue
 from bika.lims import api
 from bika.lims import logger
 from bika.lims import bikaMessageFactory as _
@@ -1808,46 +1810,76 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             return {'errors': errors}
 
         # Process Form
-        ARs = []
-        for n, record in enumerate(valid_records):
-            client_uid = record.get("Client")
-            client = self.get_object_by_uid(client_uid)
 
-            if not client:
-                raise RuntimeError("No client found")
+        task_queue = queryUtility(ITaskQueue, name='ar-create')
+        if task_queue is None:
+            ARs = []
+            for n, record in enumerate(valid_records):
+                client_uid = record.get("Client")
+                client = self.get_object_by_uid(client_uid)
 
-            # get the specifications and pass them directly to the AR create function.
-            specifications = record.pop("Specifications", {})
+                if not client:
+                    raise RuntimeError("No client found")
 
-            # Create the Analysis Request
-            try:
-                ar = crar(client, self.request, record, specifications=specifications)
-            except (KeyError, RuntimeError) as e:
-                errors["message"] = e.message
-                return {"errors": errors}
-            ARs.append(ar.Title())
+                # get the specifications and pass them directly to the AR create function.
+                specifications = record.pop("Specifications", {})
 
-            _attachments = []
-            for attachment in attachments.get(n, []):
-                if not attachment.filename:
-                    continue
-                att = _createObjectByType("Attachment", self.context, tmpID())
-                att.setAttachmentFile(attachment)
-                att.processForm()
-                _attachments.append(att)
-            if _attachments:
-                ar.setAttachment(_attachments)
+                # Create the Analysis Request
+                try:
+                    ar = crar(client, self.request, record, specifications=specifications)
+                except (KeyError, RuntimeError) as e:
+                    errors["message"] = e.message
+                    return {"errors": errors}
+                ARs.append(ar.Title())
 
-        level = "info"
-        if len(ARs) == 0:
-            message = _('No Analysis Requests could be created.')
-            level = "error"
-        elif len(ARs) > 1:
-            message = _('Analysis requests ${ARs} were successfully created.',
-                        mapping={'ARs': safe_unicode(', '.join(ARs))})
-        else:
-            message = _('Analysis request ${AR} was successfully created.',
+                _attachments = []
+                for attachment in attachments.get(n, []):
+                    if not attachment.filename:
+                        continue
+                    att = _createObjectByType("Attachment", self.context, tmpID())
+                    att.setAttachmentFile(attachment)
+                    att.processForm()
+                    _attachments.append(att)
+                if _attachments:
+                    ar.setAttachment(_attachments)
+
+            level = "info"
+            if len(ARs) == 0:
+                message = _(
+                        'No Analysis Requests could be queued for creation.')
+                level = "error"
+            elif len(ARs) > 1:
+                message = _('Analysis requests ${ARs} were successfully created.',
+                            mapping={'ARs': safe_unicode(', '.join(ARs))})
+            else:
+                message = _('Analysis request ${AR} was successfully created.',
                         mapping={'AR': safe_unicode(ARs[0])})
+
+        else:
+            path = [i for i in self.context.getPhysicalPath()]
+            path.append('async_create_analysisrequest')
+            path = '/'.join(path)
+            params = {
+                    'records': json.dumps(valid_records),
+                    'attachments': json.dumps(attachments),
+                    }
+            logger.info('Queue Task: path=%s' % path)
+            logger.debug('Que Task: path=%s, params=%s, attachments=%s' % (
+                            path, params, attachments))
+            task_id = task_queue.add(path,
+                    method='POST',
+                    params=params)
+
+            level = "info"
+            if len(valid_records) == 0:
+                message = _(
+                        'No Analysis Requests could be queued for creation.')
+                level = "error"
+            elif len(valid_records) > 1:
+                message = _('${ARs} Analysis requests were queue for creation.',
+                            mapping={'ARs': len(valid_records)})
+            else:
+                message = _('Analysis request was queued for creation.')
 
         # Display a portal message
         self.context.plone_utils.addPortalMessage(message, level)
@@ -1857,7 +1889,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         auto_print = bika_setup.getAutoPrintStickers()
 
         # https://github.com/bikalabs/bika.lims/pull/2153
-        new_ars = [a for a in ARs if a[-1] == '1']
+        new_ars = [] #[a for a in ARs if a[-1] == '1']
 
         if 'register' in auto_print and new_ars:
             return {

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1811,8 +1811,10 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
         # Process Form
 
+        bika_setup = api.get_bika_setup()
+        max_ars_async = bika_setup.getMaxARsBeforeAsync()
         task_queue = queryUtility(ITaskQueue, name='ar-create')
-        if task_queue is None:
+        if task_queue is None or len(valid_records) < max_ars_async:
             ARs = []
             for n, record in enumerate(valid_records):
                 client_uid = record.get("Client")
@@ -1888,7 +1890,6 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         self.context.plone_utils.addPortalMessage(message, level)
 
         # Automatic label printing won't print "register" labels for Secondary. ARs
-        bika_setup = api.get_bika_setup()
         auto_print = bika_setup.getAutoPrintStickers()
 
         # https://github.com/bikalabs/bika.lims/pull/2153

--- a/bika/lims/browser/analysisrequest/configure.zcml
+++ b/bika/lims/browser/analysisrequest/configure.zcml
@@ -75,6 +75,24 @@
       permission="zope.Public"
       layer="bika.lims.interfaces.IBikaLIMS"
   />
+
+  <browser:page
+      for="*"
+      name="async_create_analysisrequest"
+      class="bika.lims.utils.analysisrequest.Async_AR_Utils"
+      attribute="async_create_analysisrequest"
+      permission="zope.Public"
+      layer="bika.lims.interfaces.IBikaLIMS"
+    />
+
+  <browser:page
+      for="*"
+      name="queue_count"
+      class="bika.lims.utils.analysisrequest.Async_AR_Utils"
+      attribute="queue_count"
+      permission="zope.Public"
+      layer="bika.lims.interfaces.IBikaLIMS"
+    />
   <!-- /AR Add 2 -->
 
   <adapter

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -979,6 +979,16 @@ schema = BikaFolderSchema.copy() + Schema((
             label=_("COC Footer"),
         )
     ),
+    IntegerField(
+        'MaxARsBeforeAsync',
+        schemata="Analyses",
+        required=0,
+        default=1,
+        widget=IntegerWidget(
+            label=_("Maximum number of ARs before Async."),
+            description=_("If a user initiates the creation of more ARs than this number, they will be created in the background and an email will notify them when they are all created"),
+        )
+    ),
 ))
 
 schema['title'].validators = ()

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -5,8 +5,12 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
+import json
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
+from Products.CMFPlone.utils import _createObjectByType
+from Products.Five.browser import BrowserView
+from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
 from bika.lims.idserver import renameAfterCreation
@@ -25,8 +29,7 @@ from copy import deepcopy
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.Utils import formataddr
-from plone import api
-from Products.CMFPlone.utils import _createObjectByType
+from plone import api as ploneapi
 import os
 import tempfile
 
@@ -274,7 +277,7 @@ def _resolve_items_to_service_uids(items):
             continue
 
         # Maybe object UID.
-        portal = portal if portal else api.portal.get()
+        portal = portal if portal else ploneapi.portal.get()
         bsc = bsc if bsc else getToolByName(portal, 'bika_setup_catalog')
         brains = bsc(UID=item)
         if brains:
@@ -382,3 +385,79 @@ def notify_rejection(analysisrequest):
             "Email with subject %s was not sent (SMTP connection error)" % mailsubject)
 
     return True
+
+class Async_AR_Utils(BrowserView):
+
+    def async_create_analysisrequest(self):
+        msgs = []
+        form = self.request.form
+        records = json.loads(form.get('records', '[]'))
+        attachments = json.loads(form.get('attachments', '[]'))
+        ARs = []
+        logger.info('Async create %s records' % len(records))
+        for n, record in enumerate(records):
+            client_uid = record.get("Client")
+            client = api.get_object_by_uid(client_uid)
+
+            if not client:
+                msgs.append("Error: Client {} found".format(client_uid))
+                continue
+
+            # get the specifications and pass them directly to the AR create function.
+            specifications = record.pop("Specifications", {})
+
+
+            ## Create the Analysis Request
+            ar = create_analysisrequest(
+                client,
+                self.request,
+                values=record,
+                specifications=specifications)
+            ARs.append(ar.getId())
+
+        if len(ARs) == 1:
+            msgs.append('Created AR {}'.format(ARs[0]))
+        elif len(ARs) > 1:
+            msgs.append('Created ARs {}'.format(', '.join(ARs)))
+        else:
+            msgs.append('No ARs created')
+        message = '; '.join(msgs)
+        logger.info('AR Creation complete: {}'.format(message))
+        self._email_analyst(message)
+        return
+
+    def queue_count(self):
+        task_queue = queryUtility(ITaskQueue, name='ar-create')
+        if task_queue is None:
+            return 0
+        return 'Len = %s' % len(task_queue)
+
+    def _email_analyst(self, message):
+        mail_template = """
+Dear {name},
+
+Analysis request creation completed with the following messages:
+{message}
+
+Cheers
+Bika LIMS
+"""
+        portal = ploneapi.portal.get()
+        email_charset = portal.getProperty('email_charset')
+        member = ploneapi.user.get_current()
+        mail_host = ploneapi.portal.get_tool(name='MailHost')
+        from_email= mail_host.email_from_address
+        to_email = member.getProperty('email')
+        subject = 'AR Creation Complete'
+        if len(to_email) == 0:
+            to_email = from_email
+            subject = 'AR Creation by admin user is complete'
+        mail_text = mail_template.format(
+                        name=member.getProperty('fullname'),
+                        message=message)
+        try:
+            return mail_host.send(
+                        mail_text, to_email, from_email,
+                        subject=subject, charset="utf-8", immediate=False)
+        except smtplib.SMTPRecipientsRefused:
+            raise smtplib.SMTPRecipientsRefused('Recipient address rejected by server')


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/587

## Current behavior before PR
     When adding ARs the user has to wait until the ARs are finished being created.
## Desired behavior after PR is merged
     Add ARs, send them to the queue(Taskqueue), notify the user in the screen that the ARs are queued 
     and once they are created send an email that notifies the user that the ARs have been created.
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
