### PR TITLE
Allow AT Links to be created in the context of an Analysis Request

### DIFF
--- a/bika/lims/profiles/default/metadata.xml
+++ b/bika/lims/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
   <dependencies>
     <dependency>profile-jarn.jsi18n:default</dependency>
     <dependency>profile-Products.ATExtensions:default</dependency>

--- a/bika/lims/profiles/default/types/AnalysisRequest.xml
+++ b/bika/lims/profiles/default/types/AnalysisRequest.xml
@@ -17,6 +17,7 @@
  <property name="allowed_content_types">
   <element value="Analysis"/>
   <element value="ARReport"/>
+  <element value="Link"/>
  </property>
  <property name="allow_discussion">False</property>
  <property name="default_view_fallback">False</property>

--- a/bika/lims/tests/doctests/AnalysisRequestReportLinks.rst
+++ b/bika/lims/tests/doctests/AnalysisRequestReportLinks.rst
@@ -1,0 +1,126 @@
+Analysis Requests Report Links
+==============================
+
+Analysis Requests in Bika LIMS describe an Analysis Order from a Client to the
+Laboratory. Each Analysis Request manages a Sample, which holds the data of the
+physical Sample from the Client. The Sample is currently not handled by its own
+in Bika LIMS. So the managing Analysis Request is the primary interface from the
+User (Client) to the Sample.
+
+Running this test from the buildout directory::
+
+    bin/test test_textual_doctests -t AnalysisRequestReportLinks
+
+
+Test Setup
+----------
+
+Needed Imports::
+
+    >>> import transaction
+    >>> from DateTime import DateTime
+    >>> from plone import api as ploneapi
+
+    >>> from bika.lims import api
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from Products.CMFPlone.utils import _createObjectByType
+
+Functional Helpers::
+
+    >>> def start_server():
+    ...     from Testing.ZopeTestCase.utils import startZServer
+    ...     ip, port = startZServer()
+    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
+
+    >>> def timestamp(format="%Y-%m-%d"):
+    ...     return DateTime().strftime(format)
+
+Variables::
+
+    >>> date_now = timestamp()
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> bika_setup = portal.bika_setup
+    >>> bika_sampletypes = bika_setup.bika_sampletypes
+    >>> bika_samplepoints = bika_setup.bika_samplepoints
+    >>> bika_analysiscategories = bika_setup.bika_analysiscategories
+    >>> bika_analysisservices = bika_setup.bika_analysisservices
+    >>> bika_labcontacts = bika_setup.bika_labcontacts
+    >>> bika_storagelocations = bika_setup.bika_storagelocations
+    >>> bika_samplingdeviations = bika_setup.bika_samplingdeviations
+    >>> bika_sampleconditions = bika_setup.bika_sampleconditions
+    >>> portal_url = portal.absolute_url()
+    >>> bika_setup_url = portal_url + "/bika_setup"
+
+Test user::
+
+We need certain permissions to create and access objects used in this test,
+so here we will assume the role of Lab Manager.
+
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import setRoles
+    >>> setRoles(portal, TEST_USER_ID, ['Manager',])
+
+
+Analysis Requests (AR)
+----------------------
+
+An `AnalysisRequest` can only be created inside a `Client`::
+
+    >>> clients = self.portal.clients
+    >>> client = api.create(clients, "Client", Name="RIDING BYTES", ClientID="RB")
+    >>> client
+    <Client at /plone/clients/client-1>
+
+To create a new AR, a `Contact` is needed::
+
+    >>> contact = api.create(client, "Contact", Firstname="Ramon", Surname="Bartl")
+    >>> contact
+    <Contact at /plone/clients/client-1/contact-1>
+
+A `SampleType` defines how long the sample can be retained, the minimum volume
+needed, if it is hazardous or not, the point where the sample was taken etc.::
+
+    >>> sampletype = api.create(bika_sampletypes, "SampleType", Prefix="water", MinimumVolume="100 ml")
+    >>> sampletype
+    <SampleType at /plone/bika_setup/bika_sampletypes/sampletype-1>
+
+A `SamplePoint` defines the location, where a `Sample` was taken::
+
+    >>> samplepoint = api.create(bika_samplepoints, "SamplePoint", title="Lake of Constance")
+    >>> samplepoint
+    <SamplePoint at /plone/bika_setup/bika_samplepoints/samplepoint-1>
+
+An `AnalysisCategory` categorizes different `AnalysisServices`::
+
+    >>> analysiscategory = api.create(bika_analysiscategories, "AnalysisCategory", title="Water")
+    >>> analysiscategory
+    <AnalysisCategory at /plone/bika_setup/bika_analysiscategories/analysiscategory-1>
+
+An `AnalysisService` defines a analysis service offered by the laboratory::
+
+    >>> analysisservice = api.create(bika_analysisservices, "AnalysisService", title="PH", ShortTitle="ph", Category=analysiscategory, Keyword="PH")
+    >>> analysisservice
+    <AnalysisService at /plone/bika_setup/bika_analysisservices/analysisservice-1>
+
+Finally, the `AnalysisRequest` can be created::
+
+    >>> values = {
+    ...           'Client': client.UID(),
+    ...           'Contact': contact.UID(),
+    ...           'SamplingDate': date_now,
+    ...           'DateSampled': date_now,
+    ...           'SampleType': sampletype.UID(),
+    ...           'Priority': '1',
+    ...          }
+
+    >>> service_uids = [analysisservice.UID()]
+    >>> ar = create_analysisrequest(client, request, values, service_uids)
+    >>> ar
+    <AnalysisRequest at /plone/clients/client-1/water-0001-R01>
+
+An ATLink can be created in the context of the Analysis Request::
+
+    >>> link = _createObjectByType("Link", ar, 'link1')
+    >>> link
+    <ATLink at /plone/clients/client-1/water-0001-R01/link1>

--- a/bika/lims/upgrade/configure.zcml
+++ b/bika/lims/upgrade/configure.zcml
@@ -101,4 +101,12 @@
        handler="bika.lims.upgrade.v01_02_001.upgrade"
        profile="bika.lims:default"/>
 
+ <genericsetup:upgradeDepends
+       description="Allow Link types in the context of an AR"
+       title="Upgrade to SENAITE.CORE 1.2.2"
+       source="1.2.1"
+       destination="1.2.2"
+       import_steps="typeinfo"
+       profile="bika.lims:default"/>
+
 </configure>

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup, find_packages
 
-version = '1.2.1'
+version = '1.2.2'
 
 setup(
     name='senaite.core',


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This is a new feature that allows for Links to be created in the context of an Analysis Report.

The usecase:
When generating an ARReport sourced from multiple source ARs, currently an ARReport object (and csv and pdf data) is created in each of these source ARs objects. To prevent the duplication and to have only one canonical location where the report pdf and csv data are stored, only one ARReport object is created in the context of the first AR. The remaining ARs that are part of this multiply sourced ARReport, contain Links that point to this canonical ARReport object stored in the 1st AR.

## Current behavior before PR

Creating Links in the context of an AR is not allowed. 

## Desired behavior after PR is merged

Creating Links in the context of an AR is allowed.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
