### PR TITLE
Out of range Icons are not displayed through all Analysis states

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Changelog
 
 **Fixed**
 
+- #603 Out of range Icons are not displayed through all Analysis states
 - #598 BadRequest error when changing Calculation on Analysis Service
 - #593 Fixed Price/Spec/Interim not set in AR Manage Analyses
 - #585 Empty value for Analysis Request column in aggregated list of analyses

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -1321,6 +1321,13 @@ class BikaListingView(BrowserView):
             results_dict['state_title'] = st_title
 
             results_dict['class'] = {}
+
+            # As far as I am concerned, adapters for IFieldIcons are only used
+            # for Analysis content types. Since AnalysesView is not using this
+            # "classic" folderitems from bikalisting anymore, this logic has
+            # been added in AnalysesView. Even though, this logic hasn't been
+            # removed from here, cause this _folderitems function is marked as
+            # deprecated, so it will be eventually removed alltogether.
             for name, adapter in getAdapters((obj,), IFieldIcons):
                 auid = obj.UID() if hasattr(obj, 'UID') and callable(
                     obj.UID) else None


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Out of range icons were not displayed in analyses views and were only working on results input cause in that scenario, the rendering of out-of-range icons was managed through js.

With this Pull Request, out of range icons (as well as the icons returned by any `IFieldIcons` adapter for Analysis content type) are displayed again in all views.

Linked issue: [Out of range Icons should be displayed through all Analysis states #568](https://github.com/senaite/senaite.core/issues/568)

## Current behavior before PR

Out of range icons were not displayed in analyses view.

## Desired behavior after PR is merged

Out of range icons are displayed in analyses views, regardless of the analysis state.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
