### PR TITLE
Handle unicode queries in Client ReferenceWidgetVocabulary

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Changelog
 
 **Fixed**
 
+- #606 Handle unicode queries in Client ReferenceWidgetVocabulary
 - #603 Out of range Icons are not displayed through all Analysis states
 - #598 BadRequest error when changing Calculation on Analysis Service
 - #593 Fixed Price/Spec/Interim not set in AR Manage Analyses

--- a/bika/lims/browser/client/ajax.py
+++ b/bika/lims/browser/client/ajax.py
@@ -23,7 +23,11 @@ class ReferenceWidgetVocabulary(DefaultReferenceWidgetVocabulary):
         portal_type = base_query.get('portal_type', [])
         if 'Contact' in portal_type:
             base_query['getParentUID'] = [self.context.UID(), ]
-        self.request['base_query'] = json.dumps(base_query)
+            # If ensure_ascii is false, a result may be a unicode instance. This
+            # usually happens if the input contains unicode strings or the encoding
+            # parameter is used.
+            # see: https://github.com/senaite/senaite.core/issues/605
+            self.request['base_query'] = json.dumps(base_query, ensure_ascii=False)
         return DefaultReferenceWidgetVocabulary.__call__(self)
 
 

--- a/bika/lims/browser/client/ajax.py
+++ b/bika/lims/browser/client/ajax.py
@@ -5,8 +5,9 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-import plone, json
+import json
 
+import plone
 from bika.lims.adapters.referencewidgetvocabulary import \
     DefaultReferenceWidgetVocabulary
 from bika.lims.browser import BrowserView
@@ -14,6 +15,9 @@ from Products.CMFCore.utils import getToolByName
 
 
 class ReferenceWidgetVocabulary(DefaultReferenceWidgetVocabulary):
+    """Implements IReferenceWidgetVocabulary for Clients
+    """
+
     def __call__(self):
         base_query = json.loads(self.request['base_query'])
         portal_type = base_query.get('portal_type', [])
@@ -24,6 +28,9 @@ class ReferenceWidgetVocabulary(DefaultReferenceWidgetVocabulary):
 
 
 class ajaxGetClientInfo(BrowserView):
+    """Public exposed getClientInfo to be used by the JSON API
+    """
+
     def __call__(self):
         plone.protect.CheckAuthenticator(self.request)
         wf = getToolByName(self.context, 'portal_workflow')


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/605

## Current behavior before PR

Analysis Specification are not found in AR Add Form for Sample Types containing a unicode character, e.g. `Ö`

## Desired behavior after PR is merged

Analysis Specification are found in AR Add Form for Sample Types containing a unicode character, e.g. `Ö`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
