### PR TITLE
Advanced filter bar: filter Analysis Requests by Service name not working

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Changelog
 
 **Fixed**
 
+- #611 Advanced filter bar: filter Analysis Requests by Service name not working
+
 
 **Security**
 

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -821,11 +821,11 @@ class AnalysisRequestsView(BikaListingView):
         @Obj: it is an analysis request brain.
         @return: boolean
         """
-        if not self.context.bika_setup.getAllowDepartmentFiltering():
-            return True
         if self.filter_bar_enabled and not self.filter_bar_check_item(obj):
             return False
-        # Gettin the department from analysis service
+        if not self.context.bika_setup.getAllowDepartmentFiltering():
+            return True
+        # Getting the department from analysis service
         deps = obj.getDepartmentUIDs if hasattr(obj, 'getDepartmentUIDs')\
             else []
         result = True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Using the advanced filter bar to filter Analysis Requests by Analysis Service name isn't working.

## Current behavior before PR

Using the advanced filter bar to filter Analysis Requests by Analysis Service name isn't working.

## Desired behavior after PR is merged

After changing the check order in isItemAllowed, analyss requests lists should be filteres by Analysis Service name.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
