### PR TITLE
Ability to select the number of sample sticker copies for printing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog
 
 **Added**
 
+- #618 When previewing stickers the number of copies to print for each sticker can be modified.
+- #618 The default number of sticker copies can be set and edited in the setup Sticker's tab.  
 
 **Removed**
 

--- a/bika/lims/browser/stickers.py
+++ b/bika/lims/browser/stickers.py
@@ -91,6 +91,9 @@ class Sticker(BrowserView):
             # Default fallback, load from context
             self.items = [self.context, ]
 
+        # before retrieving the required data for each type of object copy
+        # each object as many times as the number of desired sticker copies
+        self.items = self._resolve_number_of_copies(self.items)
         new_items = []
         for i in self.items:
             outitems = self._populateItems(i)
@@ -161,8 +164,7 @@ class Sticker(BrowserView):
             return [[None, None, item]]
         items = []
         for part in parts:
-            for copy in range(self.copies_count):
-                items.append([ar, sample, part])
+            items.append([ar, sample, part])
         return items
 
     def getAvailableTemplates(self):
@@ -337,6 +339,21 @@ class Sticker(BrowserView):
         pdf_fn = tempfile.mktemp(suffix='.pdf')
         pdf_file = createPdf(htmlreport=reporthtml, outfile=pdf_fn)
         return pdf_file
+
+    def _resolve_number_of_copies(self, items):
+        """For the given objects generate as many copies as the desired
+        number of stickers. The desired number of stickers for each
+        object is given by copies_count
+
+        :param items: list of objects whose stickers are going to be previewed.
+        :returns: list containing n copies of each object in the items list,
+        where n is self.copies_count
+        """
+        copied_items = []
+        for obj in items:
+            for copy in range(self.copies_count):
+                copied_items.append(obj)
+        return copied_items
 
     def get_copies_count(self):
         """Return the copies_count number request parameter

--- a/bika/lims/browser/stickers.py
+++ b/bika/lims/browser/stickers.py
@@ -342,7 +342,7 @@ class Sticker(BrowserView):
         try:
             copies_count = int(self.request.form.get("copies_count"))
         except (TypeError, ValueError):
-            # default number of copies is a mandatory integer field in bika setup
+            # default number of copies is a mandatory integer field in senaite setup
             # so theoretically this should never fail
             copies_count = self.context.bika_setup.getDefaultNumberOfCopies()
 

--- a/bika/lims/browser/stickers.py
+++ b/bika/lims/browser/stickers.py
@@ -64,8 +64,6 @@ class Sticker(BrowserView):
         self.context = context
         self.request = request
 
-
-
     def __call__(self):
         # Need to generate a PDF with the stickers?
         if self.request.form.get('pdf', '0') == '1':

--- a/bika/lims/browser/stickers.py
+++ b/bika/lims/browser/stickers.py
@@ -54,6 +54,8 @@ class Sticker(BrowserView):
     template = ViewPageTemplateFile("templates/stickers_preview.pt")
 
     def __init__(self, context, request):
+        super(Sticker, self).__init__(context, request)
+
         self.item_index = 0
         self.current_item = None
         self.rendered_items = []
@@ -62,7 +64,7 @@ class Sticker(BrowserView):
         self.context = context
         self.request = request
 
-        super(Sticker, self).__init__(context, request)
+
 
     def __call__(self):
         # Need to generate a PDF with the stickers?

--- a/bika/lims/browser/stickers.py
+++ b/bika/lims/browser/stickers.py
@@ -327,7 +327,7 @@ class Sticker(BrowserView):
         return pdf_file
 
     def get_copies_count(self):
-        """Return the copies_count request paramteter
+        """Return the copies_count request parameter
         """
         try:
             copies_count = int(self.request.form.get("copies_count", 1))

--- a/bika/lims/browser/stickers.py
+++ b/bika/lims/browser/stickers.py
@@ -51,12 +51,18 @@ class Sticker(BrowserView):
             -- code_...mm.{css,pt}
             -- other_worksheet_stickers_...
     """
-    def __init__(self):
-        self.template = ViewPageTemplateFile("templates/stickers_preview.pt")
+    template = ViewPageTemplateFile("templates/stickers_preview.pt")
+
+    def __init__(self, context, request):
         self.item_index = 0
         self.current_item = None
         self.rendered_items = []
         self.copies_count = None
+
+        self.context = context
+        self.request = request
+
+        super(Sticker, self).__init__(context, request)
 
     def __call__(self):
         # Need to generate a PDF with the stickers?
@@ -68,10 +74,7 @@ class Sticker(BrowserView):
             pdfstream = self.pdf_from_post()
             return pdfstream
 
-        if self.copies_count is None:
-            self.copies_count = self.context.bika_setup.getDefaultNumberOfCopies()
-        else:
-            self.copies_count = self.get_copies_count()
+        self.copies_count = self.get_copies_count()
 
         self.rendered_items = []
         items = self.request.get('items', '')
@@ -336,8 +339,8 @@ class Sticker(BrowserView):
     def get_copies_count(self):
         """Return the copies_count request parameter
         """
-        try:
+        if self.request.form.get('copies_count', None) is None:
+            copies_count = self.context.bika_setup.getDefaultNumberOfCopies()
+        else:
             copies_count = int(self.request.form.get("copies_count", 1))
-        except (TypeError, ValueError):
-            copies_count = 1
         return copies_count

--- a/bika/lims/browser/stickers.py
+++ b/bika/lims/browser/stickers.py
@@ -318,7 +318,7 @@ class Sticker(BrowserView):
         for the stickers deppending on the filter_by_type.
         :param resource_name: The name of the resource folder.
         :type resource_name: string
-        :resturns: a string as a path
+        :returns: a string as a path
         """
         templates_dir =\
             queryResourceDirectory('stickers', resource_name).directory
@@ -339,7 +339,10 @@ class Sticker(BrowserView):
         return pdf_file
 
     def get_copies_count(self):
-        """Return the copies_count request parameter
+        """Return the copies_count number request parameter
+
+        :returns: the number of copies for each sticker as stated
+        in the request
         """
         try:
             copies_count = int(self.request.form.get("copies_count"))

--- a/bika/lims/browser/stickers.py
+++ b/bika/lims/browser/stickers.py
@@ -51,10 +51,12 @@ class Sticker(BrowserView):
             -- code_...mm.{css,pt}
             -- other_worksheet_stickers_...
     """
-    template = ViewPageTemplateFile("templates/stickers_preview.pt")
-    item_index = 0
-    current_item = None
-    rendered_items = []
+    def __init__(self):
+        self.template = ViewPageTemplateFile("templates/stickers_preview.pt")
+        self.item_index = 0
+        self.current_item = None
+        self.rendered_items = []
+        self.copies_count = None
 
     def __call__(self):
         # Need to generate a PDF with the stickers?
@@ -66,7 +68,11 @@ class Sticker(BrowserView):
             pdfstream = self.pdf_from_post()
             return pdfstream
 
-        self.copies_count = self.get_copies_count()
+        if self.copies_count is None:
+            self.copies_count = self.context.bika_setup.getDefaultNumberOfCopies()
+        else:
+            self.copies_count = self.get_copies_count()
+
         self.rendered_items = []
         items = self.request.get('items', '')
         # If filter by type is given in the request, only the templates under

--- a/bika/lims/browser/stickers.py
+++ b/bika/lims/browser/stickers.py
@@ -58,7 +58,6 @@ class Sticker(BrowserView):
 
         self.item_index = 0
         self.current_item = None
-        self.rendered_items = []
         self.copies_count = None
 
         self.context = context
@@ -76,7 +75,6 @@ class Sticker(BrowserView):
 
         self.copies_count = self.get_copies_count()
 
-        self.rendered_items = []
         items = self.request.get('items', '')
         # If filter by type is given in the request, only the templates under
         # the path with the type name will be given as vocabulary.
@@ -256,9 +254,7 @@ class Sticker(BrowserView):
         """
         if self.item_index == len(self.items):
             self.item_index = 0
-            self.rendered_items = []
         self.current_item = self.items[self.item_index]
-        self.rendered_items.append(self.current_item[2].getId())
         self.item_index += 1
         return self.current_item
 

--- a/bika/lims/browser/stickers.py
+++ b/bika/lims/browser/stickers.py
@@ -346,8 +346,10 @@ class Sticker(BrowserView):
         object is given by copies_count
 
         :param items: list of objects whose stickers are going to be previewed.
+        :type items: list
         :returns: list containing n copies of each object in the items list,
         where n is self.copies_count
+        :rtype: list
         """
         copied_items = []
         for obj in items:
@@ -360,6 +362,7 @@ class Sticker(BrowserView):
 
         :returns: the number of copies for each sticker as stated
         in the request
+        :rtype: int
         """
         try:
             copies_count = int(self.request.form.get("copies_count"))

--- a/bika/lims/browser/stickers.py
+++ b/bika/lims/browser/stickers.py
@@ -149,8 +149,8 @@ class Sticker(BrowserView):
         elif portal_type == 'Batch':
             return [[None, None, item]]
         items = []
-        for copy in range(self.copies_count):
-            for part in parts:
+        for part in parts:
+            for copy in range(self.copies_count):
                 items.append([ar, sample, part])
         return items
 

--- a/bika/lims/browser/stickers.py
+++ b/bika/lims/browser/stickers.py
@@ -66,6 +66,7 @@ class Sticker(BrowserView):
             pdfstream = self.pdf_from_post()
             return pdfstream
 
+        self.copies_count = self.get_copies_count()
         self.rendered_items = []
         items = self.request.get('items', '')
         # If filter by type is given in the request, only the templates under
@@ -324,3 +325,13 @@ class Sticker(BrowserView):
         pdf_fn = tempfile.mktemp(suffix='.pdf')
         pdf_file = createPdf(htmlreport=reporthtml, outfile=pdf_fn)
         return pdf_file
+
+    def get_copies_count(self):
+        """Return the copies_count request paramteter
+        """
+        copies_count = 1
+        try:
+            copies_count = int(self.request.form.get("copies_count", 1))
+        except (TypeError, ValueError):
+            copies_count = 1
+        return copies_count

--- a/bika/lims/browser/stickers.py
+++ b/bika/lims/browser/stickers.py
@@ -149,8 +149,9 @@ class Sticker(BrowserView):
         elif portal_type == 'Batch':
             return [[None, None, item]]
         items = []
-        for part in parts:
-            items.append([ar, sample, part])
+        for copy in range(self.copies_count):
+            for part in parts:
+                items.append([ar, sample, part])
         return items
 
     def getAvailableTemplates(self):

--- a/bika/lims/browser/stickers.py
+++ b/bika/lims/browser/stickers.py
@@ -329,7 +329,6 @@ class Sticker(BrowserView):
     def get_copies_count(self):
         """Return the copies_count request paramteter
         """
-        copies_count = 1
         try:
             copies_count = int(self.request.form.get("copies_count", 1))
         except (TypeError, ValueError):

--- a/bika/lims/browser/stickers.py
+++ b/bika/lims/browser/stickers.py
@@ -55,11 +55,9 @@ class Sticker(BrowserView):
 
     def __init__(self, context, request):
         super(Sticker, self).__init__(context, request)
-
         self.item_index = 0
         self.current_item = None
         self.copies_count = None
-
         self.context = context
         self.request = request
 

--- a/bika/lims/browser/stickers.py
+++ b/bika/lims/browser/stickers.py
@@ -339,8 +339,11 @@ class Sticker(BrowserView):
     def get_copies_count(self):
         """Return the copies_count request parameter
         """
-        if self.request.form.get('copies_count', None) is None:
+        try:
+            copies_count = int(self.request.form.get("copies_count"))
+        except (TypeError, ValueError):
+            # default number of copies is a mandatory integer field in bika setup
+            # so theoretically this should never fail
             copies_count = self.context.bika_setup.getDefaultNumberOfCopies()
-        else:
-            copies_count = int(self.request.form.get("copies_count", 1))
+
         return copies_count

--- a/bika/lims/browser/templates/stickers_preview.pt
+++ b/bika/lims/browser/templates/stickers_preview.pt
@@ -162,7 +162,7 @@
                 reload($('select#template').val(), $('#copies_count').val());
             });
             $('#copies_count').change(function(e) {
-                update_sticker_copies($('#copies_count').val(), $('select#template').val());
+                reload($('select#template').val(), $('#copies_count').val());
             });
             var stickwidth = $('.sticker').first().width();
             $('#sticker-rule').css({'width':stickwidth,'max-width':stickwidth});

--- a/bika/lims/browser/templates/stickers_preview.pt
+++ b/bika/lims/browser/templates/stickers_preview.pt
@@ -161,6 +161,9 @@
             $('select#template').change(function(e) {
                 reload($('select#template').val());
             });
+            $('#copies_count').change(function(e) {
+                update_sticker_copies($('#copies_count').val());
+            });
             var stickwidth = $('.sticker').first().width();
             $('#sticker-rule').css({'width':stickwidth,'max-width':stickwidth});
             $('#sticker-rule').fadeIn();
@@ -181,6 +184,31 @@
                     var htmldata = data;
                     htmldata = $(htmldata).find('#stickers-wrapper').html();
                     $('#stickers-wrapper').html(htmldata);
+                    $('#stickers-wrapper').fadeTo('fast', 1);
+                    // reload barcoding
+                    bika.lims.BarcodeUtils.load();
+                    var stickwidth = $('.sticker').first().width();
+                    $('#sticker-rule').css({'width':stickwidth,'max-width':stickwidth});
+                    $('#sticker-rule').fadeIn();
+                });
+            }
+
+            /**
+             * Re-loads the stickers preview when the number of copies changes
+             */
+            function update_sticker_copies(copies) {
+                var baseurl = $('body').attr('data-itemsurl');
+                $('#stickers-wrapper').fadeTo('fast', 0.4);
+                $.ajax({
+                    url: baseurl,
+                    type: 'POST',
+                    async: true,
+                    data: {"copies_count": copies}
+                })
+                .always(function(data) {
+                    var htmldata = data;
+                    htmldata = $(htmldata).find('#copies_count').html();
+                    $('#copies_count').html(htmldata);
                     $('#stickers-wrapper').fadeTo('fast', 1);
                     // reload barcoding
                     bika.lims.BarcodeUtils.load();
@@ -240,7 +268,7 @@
                 </div>
                 <div id='sticker-copies'>
                     <label for="copies_count" i18n:translate="">Number of copies</label>
-                    <input name="copies_count"
+                    <input name="copies_count" id="copies_count"
                         type="number"
                         min="1"
                         tal:attributes="value view/copies_count"/>

--- a/bika/lims/browser/templates/stickers_preview.pt
+++ b/bika/lims/browser/templates/stickers_preview.pt
@@ -61,6 +61,23 @@
               background-color: #bbb;
               text-shadow: 1px 1px 1px #aaa;
         }
+        #sticker-preview-header #sticker-copies input {
+            text-align:center;
+            width:15mm;
+            margin:0 0 10px 0;
+            background-color: #aaa;
+            border-radius: 5px;
+            color: #fff;
+            font-family: Helvetica,Arial;
+            font-size: 9pt;
+            font-weight: bold;
+            padding: 4px 2px;
+            text-decoration: none;
+            text-shadow: 1px 1px 1px #999;
+            text-transform: uppercase;
+            border:none;
+            cursor:pointer;
+        }
         #sticker-rule {
             color: rgb(51, 51, 51);
             height: 10mm;
@@ -220,6 +237,15 @@
                                   tal:condition="not:tpl/selected"></option>
                     </tal:formats>
                     </select>
+                </div>
+                <div id='sticker-copies'>
+                    <label for="copies_count" i18n:translate="">Number of copies</label>
+                    <input name="copies_count"
+                        class="copies_count context_action_link"
+                        type="number"
+                        min="1"
+                    />
+                    />
                 </div>
             </div>
             <div id='sticker-buttons'>

--- a/bika/lims/browser/templates/stickers_preview.pt
+++ b/bika/lims/browser/templates/stickers_preview.pt
@@ -193,32 +193,6 @@
                 });
             }
 
-            /**
-             * Re-loads the stickers preview when the number of copies changes
-             */
-            function update_sticker_copies(copies, template) {
-                var baseurl = $('body').attr('data-itemsurl');
-                $('#stickers-wrapper').fadeTo('fast', 0.4);
-                $.ajax({
-                    url: baseurl,
-                    type: 'POST',
-                    async: true,
-                    data: {"copies_count": copies, "template": template}
-                })
-                .always(function(data) {
-                    var htmldata = data;
-                    htmldata = $(htmldata).find('#stickers-wrapper').html();
-                    $('#stickers-wrapper').html(htmldata);
-                    $('#stickers-wrapper').fadeTo('fast', 1);
-                    // reload barcoding
-                    bika.lims.BarcodeUtils.load();
-                    var stickwidth = $('.sticker').first().width();
-                    $('#sticker-rule').css({'width':stickwidth,'max-width':stickwidth});
-                    $('#sticker-rule').fadeIn();
-                    $('#stickers-wrapper').fadeIn();
-                });
-            }
-
             function printPdf() {
                 var url = window.location.href;
                 // Get the stickers style

--- a/bika/lims/browser/templates/stickers_preview.pt
+++ b/bika/lims/browser/templates/stickers_preview.pt
@@ -159,10 +159,10 @@
                 window.location = $(this).attr('data-url');
             });
             $('select#template').change(function(e) {
-                reload($('select#template').val());
+                reload($('select#template').val(), $('#copies_count').val());
             });
             $('#copies_count').change(function(e) {
-                update_sticker_copies($('#copies_count').val());
+                update_sticker_copies($('#copies_count').val(), $('select#template').val());
             });
             var stickwidth = $('.sticker').first().width();
             $('#sticker-rule').css({'width':stickwidth,'max-width':stickwidth});
@@ -171,14 +171,14 @@
             /**
              * Re-loads the stickers preview by using the template specified
              */
-            function reload(template) {
+            function reload(template, copies_count) {
                 var baseurl = $('body').attr('data-itemsurl');
                 $('#stickers-wrapper').fadeTo('fast', 0.4);
                 $.ajax({
                     url: baseurl,
                     type: 'POST',
                     async: true,
-                    data: {"template": template}
+                    data: {"template": template, "copies_count": copies_count}
                 })
                 .always(function(data) {
                     var htmldata = data;
@@ -196,25 +196,26 @@
             /**
              * Re-loads the stickers preview when the number of copies changes
              */
-            function update_sticker_copies(copies) {
+            function update_sticker_copies(copies, template) {
                 var baseurl = $('body').attr('data-itemsurl');
                 $('#stickers-wrapper').fadeTo('fast', 0.4);
                 $.ajax({
                     url: baseurl,
                     type: 'POST',
                     async: true,
-                    data: {"copies_count": copies}
+                    data: {"copies_count": copies, "template": template}
                 })
                 .always(function(data) {
                     var htmldata = data;
-                    htmldata = $(htmldata).find('#copies_count').html();
-                    $('#copies_count').html(htmldata);
+                    htmldata = $(htmldata).find('#stickers-wrapper').html();
+                    $('#stickers-wrapper').html(htmldata);
                     $('#stickers-wrapper').fadeTo('fast', 1);
                     // reload barcoding
                     bika.lims.BarcodeUtils.load();
                     var stickwidth = $('.sticker').first().width();
                     $('#sticker-rule').css({'width':stickwidth,'max-width':stickwidth});
                     $('#sticker-rule').fadeIn();
+                    $('#stickers-wrapper').fadeIn();
                 });
             }
 
@@ -293,11 +294,10 @@
               </tal:tick>
             </div>
             <tal:stickers repeat="sticker view/items">
-            <tal:sticker define="item_id python:sticker[2].getId() if sticker else None;"
-                         condition="python:not item_id or item_id not in view.rendered_items">
-            <div class='sticker'
-                 tal:content='structure python:view.renderItem()'></div>
-            </tal:sticker>
+                    <tal:sticker define="item_id python:sticker[2].getId() if sticker else None;">
+                    <div class='sticker'
+                         tal:content='structure python:view.renderItem()'></div>
+                    </tal:sticker>
             </tal:stickers>
         </div>
     </div>

--- a/bika/lims/browser/templates/stickers_preview.pt
+++ b/bika/lims/browser/templates/stickers_preview.pt
@@ -270,6 +270,7 @@
             <tal:stickers repeat="sticker view/items">
                     <tal:sticker define="item_id python:sticker[2].getId() if sticker else None;">
                     <div class='sticker'
+                         tal:condition="python:item_id is not None"
                          tal:content='structure python:view.renderItem()'></div>
                     </tal:sticker>
             </tal:stickers>

--- a/bika/lims/browser/templates/stickers_preview.pt
+++ b/bika/lims/browser/templates/stickers_preview.pt
@@ -241,11 +241,9 @@
                 <div id='sticker-copies'>
                     <label for="copies_count" i18n:translate="">Number of copies</label>
                     <input name="copies_count"
-                        class="copies_count context_action_link"
                         type="number"
                         min="1"
-                    />
-                    />
+                        tal:attributes="value view/copies_count"/>
                 </div>
             </div>
             <div id='sticker-buttons'>

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -735,6 +735,16 @@ schema = BikaFolderSchema.copy() + Schema((
             description=_("Select which sticker should be used as the 'large' sticker by default")
         )
     ),
+    IntegerField(
+        'DefaultNumberOfCopies',
+        schemata="Sticker",
+        required="1",
+        default="1",
+        widget=IntegerWidget(
+            label=_("Number of copies"),
+            description=_("Set the default number of copies to be printed for each sticker")
+        )
+    ),
     IDFormattingField(
         'IDFormatting',
         schemata="ID Server",


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Add the possibility of selecting the number of copies to print for sample/sample partition/batch/worksheet stickers.  Also, add a setup field to set the default number of copies.

## Current behavior before PR

There wasn't the option of selecting the number of copies to print for sample/sample partition/batch/worksheet stickers.

## Desired behavior after PR is merged

The number of copies for sample/sample partition/batch/worksheet stickers can be modified from the view and a default number of sticker copies can be set in the Stickers setup page. 

## Screenshots (optional)
Below there are two screenshots presenting the new functionality:

**Stickers setup**
![selection_003](https://user-images.githubusercontent.com/9968427/35564497-a482b6a0-05ba-11e8-9158-f14d6bb3885f.png)

**Stickers preview**

![selection_004](https://user-images.githubusercontent.com/9968427/35564508-a91e64a2-05ba-11e8-9bd4-6c3e1df0c082.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
