### PR TITLE
Client batch list is not filtered by state

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+#620: Fix client batch list filters
 
 **Security**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ Changelog
 
 **Fixed**
 
-- #620: Client batch list filters do not work
+- #620 Client batch list is not filtered by state
 
 **Security**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ Changelog
 
 **Fixed**
 
-#620: Fix client batch list filters
+- #620: Client batch list filters do not work
 
 **Security**
 

--- a/bika/lims/browser/client/views/batches.py
+++ b/bika/lims/browser/client/views/batches.py
@@ -6,9 +6,6 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 from bika.lims.browser.batchfolder import BatchFolderContentsView
-from Products.CMFCore.utils import getToolByName
-from bika.lims.catalog.analysisrequest_catalog import \
-    CATALOG_ANALYSIS_REQUEST_LISTING
 
 
 class ClientBatchesView(BatchFolderContentsView):
@@ -17,15 +14,5 @@ class ClientBatchesView(BatchFolderContentsView):
         self.view_url = self.context.absolute_url() + "/batches"
 
     def __call__(self):
+        self.contentFilter['getClientUID'] = self.context.UID()
         return BatchFolderContentsView.__call__(self)
-
-    def contentsMethod(self, contentFilter):
-        bc = getToolByName(self.context, CATALOG_ANALYSIS_REQUEST_LISTING)
-        batches = {}
-        for ar in bc(portal_type='AnalysisRequest',
-                     getClientUID=self.context.UID()):
-            ar = ar.getObject()
-            batch = ar.getBatch()
-            if batch is not None:
-                batches[batch.UID()] = batch
-        return batches.values()

--- a/bika/lims/content/batch.py
+++ b/bika/lims/content/batch.py
@@ -276,6 +276,14 @@ class Batch(ATFolder):
             return client.Title()
         return ""
 
+    def getClientUID(self):
+        """This index is required on batches so that batch listings can be
+        filtered by client
+        """
+        client = self.getClient()
+        if client:
+            return client.UID()
+
     def getContactTitle(self):
         return ""
 

--- a/bika/lims/upgrade/v01_02_002.py
+++ b/bika/lims/upgrade/v01_02_002.py
@@ -4,7 +4,8 @@
 #
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
-
+from Products.Archetypes.config import REFERENCE_CATALOG
+from Products.CMFCore.utils import getToolByName
 from bika.lims import logger
 from bika.lims.config import PROJECTNAME as product
 from bika.lims.upgrade import upgradestep
@@ -29,6 +30,18 @@ def upgrade(tool):
 
     # -------- ADD YOUR STUFF HERE --------
 
+    # Issue #574: Client batch listings are dumb.  This requires Batches to
+    # be reindexed, as thy now provide an accessor for getClientUID.
+    reindex_batch_getClientUID(portal)
+
     logger.info("{0} upgraded to version {1}".format(product, version))
 
     return True
+
+
+def reindex_batch_getClientUID(portal):
+    rc = getToolByName(portal, REFERENCE_CATALOG)
+    brains = rc(portal_type='Batch')
+    for brain in brains:
+        batch = brain.getObject()
+        batch.reindexObject(idxs=['getClientUID'])


### PR DESCRIPTION

## Description of the issue/feature this PR addresses

review_state filter in client/batch view is being ignored.  Linked issue: https://github.com/senaite/senaite.core/issues/574

## Current behavior before PR

Client level batch view tries to show all batches which contain one or more AR belonging to the client, and fails to respect contentFilter rules.

## Desired behavior after PR is merged

Correct batches are shown in Client/batch view.  "Client batch" now means only batches who have a specific client selected in their "Client" schema field.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
