### PR TITLE
Fix issue #405, duplicated IdentifierType created by setuphandlers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #622 (Re-)Installation always adds another identifier type
 
 **Security**
 

--- a/bika/lims/setuphandlers.py
+++ b/bika/lims/setuphandlers.py
@@ -577,7 +577,7 @@ def create_CAS_IdentifierType(portal):
     """LIMS-1391 The CAS Nr IdentifierType is normally created by
     setuphandlers during site initialisation.
     """
-    bsc = getToolByName(portal, 'bika_catalog', None)
+    bsc = getToolByName(portal, 'bika_setup_catalog', None)
     idtypes = bsc(portal_type='IdentifierType', title='CAS Nr')
     if not idtypes:
         folder = portal.bika_setup.bika_identifiertypes


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/405

## Current behavior before PR

Setuphandlers always creates a new 'CAS' IdentifierType associated with analysisservices.

## Desired behavior after PR is merged

Only one 'CAS' IdentifierType exists after multiple reinstalls

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
