### PR TITLE
Fixes #630 Error while string to int conversion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -113,6 +113,7 @@ Changelog
 
 **Fixed**
 
+- #631 Traceback on stickers display
 - #494 Rejection reasons widget does not appear on rejection
 - #492 Fix AR Add Form: CC Contacts not set on Contact Change
 - #489 Worksheet Templates selection list is empty in Worksheets view

--- a/bika/lims/browser/stickers.py
+++ b/bika/lims/browser/stickers.py
@@ -10,7 +10,7 @@ from Products.CMFPlone.utils import safe_unicode
 from bika.lims import bikaMessageFactory as _, t
 from bika.lims import logger
 from bika.lims.browser import BrowserView
-from bika.lims.utils import createPdf
+from bika.lims.utils import createPdf, to_int
 from bika.lims.vocabularies import getStickerTemplates
 from plone.resource.utils import iterDirectoriesOfType, queryResourceDirectory
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -356,11 +356,6 @@ class Sticker(BrowserView):
         in the request
         :rtype: int
         """
-        try:
-            copies_count = int(self.request.form.get("copies_count"))
-        except (TypeError, ValueError):
-            # default number of copies is a mandatory integer field in senaite setup
-            # so theoretically this should never fail
-            copies_count = self.context.bika_setup.getDefaultNumberOfCopies()
-
-        return copies_count
+        default_num = self.context.bika_setup.getDefaultNumberOfCopies()
+        request_num = self.request.form.get("copies_count")
+        return to_int(request_num, default_num)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Traceback in sticker preview. This bug has been introduced because of [Ability to select the number of sample sticker copies for printing #618](https://github.com/senaite/senaite.core/pull/618)

Linked issue: https://github.com/senaite/senaite.core/issues/630


## Current behavior before PR

```
https://localhost:8080/senaite/clients/client-3/H2O-0007/sticker
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.stickers, line 90, in __call__
  Module bika.lims.browser.stickers, line 348, in _resolve_number_of_copies
TypeError: range() integer end argument expected, got str.
```

## Desired behavior after PR is merged

Stickers preview is displayed without Traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
