### PR TITLE
Fixed undefined Symbols in Sample Transition Guards

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ Changelog
 
 **Fixed**
 
+- #634 Fix undefined Symbols in Sample Transition Guards
 - #616 Fix character encodings in analysisservice duplication
 - #624 TypeError: "Can't pickle objects in acquisition wrappers" (WorksheetTemplate)
 - #530 Calculated results do not get updated when importing instrument results

--- a/bika/lims/workflow/sample/guards.py
+++ b/bika/lims/workflow/sample/guards.py
@@ -6,9 +6,9 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 from Products.CMFCore.utils import getToolByName
+from Products.CMFCore.WorkflowCore import WorkflowException
 
 from bika.lims import logger
-from bika.lims.workflow import doActionFor
 from bika.lims.workflow import isBasicTransitionAllowed
 
 
@@ -65,7 +65,7 @@ def sample_prep_complete(obj):
         return False
     except AssertionError:
         logger.warn("'%s': cannot get 'sampleprep_review_state'" %
-                    sampleprep_wf_name)
+                    sp_wf_name)
         return False
 
     # get state from workflow - error = allow transition


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/633

## Current behavior before PR

AR listing raised a Traceback in the background and no WF buttons were shown.

## Desired behavior after PR is merged

AR listing raises no Traceback and WF buttons are shown

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
