### PR TITLE
Analysis Requests from inside Batch are not filtered correctly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,7 @@ Changelog
 
 **Fixed**
 
+- #639 Analysis Requests from inside Batch are not filtered correctly
 - #634 Fix undefined Symbols in Sample Transition Guards
 - #616 Fix character encodings in analysisservice duplication
 - #624 TypeError: "Can't pickle objects in acquisition wrappers" (WorksheetTemplate)

--- a/bika/lims/browser/batch/analysisrequests.py
+++ b/bika/lims/browser/batch/analysisrequests.py
@@ -26,7 +26,7 @@ class AnalysisRequestsView(_ARV, _ARAV):
         super(AnalysisRequestsView, self).__init__(context, request)
         self.contentFilter = {'portal_type': 'AnalysisRequest',
                               'getBatchUID': api.get_uid(self.context),
-                              'sort_on': 'Created',
+                              'sort_on': 'created',
                               'sort_order': 'reverse',
                               'cancellation_state':'active'}
 

--- a/bika/lims/browser/batch/analysisrequests.py
+++ b/bika/lims/browser/batch/analysisrequests.py
@@ -6,6 +6,7 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 from operator import itemgetter
+from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims.utils import t
 from bika.lims.browser.analysisrequest import AnalysisRequestAddView as _ARAV
@@ -25,13 +26,11 @@ class AnalysisRequestsView(_ARV, _ARAV):
 
     def __init__(self, context, request):
         super(AnalysisRequestsView, self).__init__(context, request)
-
-    def contentsMethod(self, contentFilter):
-        """
-        Using batch's 'getAnalysisRequests' method in order to get the
-        analysisrequests assigned to it.
-        """
-        return self.context.getAnalysisRequestsBrains(**contentFilter)
+        self.contentFilter = {'portal_type': 'AnalysisRequest',
+                              'getBatchUID': api.get_uid(self.context),
+                              'sort_on': 'Created',
+                              'sort_order': 'reverse',
+                              'cancellation_state':'active'}
 
     def __call__(self):
         self.context_actions = {}

--- a/bika/lims/browser/batch/analysisrequests.py
+++ b/bika/lims/browser/batch/analysisrequests.py
@@ -5,16 +5,14 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from operator import itemgetter
+from Products.CMFCore.utils import getToolByName
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t
 from bika.lims.browser.analysisrequest import AnalysisRequestAddView as _ARAV
 from bika.lims.browser.analysisrequest import AnalysisRequestsView as _ARV
 from bika.lims.permissions import *
 from plone.app.layout.globals.interfaces import IViewView
-from Products.CMFCore.utils import getToolByName
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.interface import implements
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

All Analysis Requests from the system are displayed inside Batch's Analysis Requests view
Linked issue: [Analysis Requests list from inside Batch is not filtered #638](https://github.com/senaite/senaite.core/issues/638)

## Current behavior before PR

All Analysis Requests are listed inside Batch

## Desired behavior after PR is merged

Only the Analysis Requests assigned to the Batch in context are displayed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
