### PR TITLE
Bug in ar workflows

### DIFF
--- a/bika/lims/api.py
+++ b/bika/lims/api.py
@@ -749,7 +749,7 @@ def get_workflow_status_of(brain_or_object, state_var="review_state"):
     """
     workflow = get_tool("portal_workflow")
     obj = get_object(brain_or_object)
-    return workflow.getInfoFor(ob=obj, name=state_var)
+    return workflow.getInfoFor(ob=obj, name=state_var, default='')
 
 
 def get_creation_date(brain_or_object):

--- a/bika/lims/browser/samplinground/analysisrequests.py
+++ b/bika/lims/browser/samplinground/analysisrequests.py
@@ -191,7 +191,7 @@ class AnalysisRequestsView(_ARV, _ARAV):
              'title': "<img title='%s'\
                        src='%s/++resource++bika.lims.images/assigned.png'/>" % (
                        t(_("Assigned")), self.portal_url),
-             'contentFilter': {'worksheetanalysis_review_state': 'assigned',
+             'contentFilter': {'assigned_state': 'assigned',
                                'review_state': ('sample_received', 'to_be_verified',
                                                 'attachment_due', 'verified',
                                                 'published'),
@@ -216,7 +216,7 @@ class AnalysisRequestsView(_ARV, _ARAV):
              'title': "<img title='%s'\
                        src='%s/++resource++bika.lims.images/unassigned.png'/>" % (
                        t(_("Unassigned")), self.portal_url),
-             'contentFilter': {'worksheetanalysis_review_state': 'unassigned',
+             'contentFilter': {'assigned_state': 'unassigned',
                                'review_state': ('sample_received', 'to_be_verified',
                                                 'attachment_due', 'verified',
                                                 'published'),

--- a/bika/lims/catalog/analysisrequest_catalog.py
+++ b/bika/lims/catalog/analysisrequest_catalog.py
@@ -100,6 +100,7 @@ _columns_list = [
     'getHazardous',
     'getSamplingWorkflowEnabled',
     'getDepartmentUIDs',
+    'assigned_state',
 ]
 # Adding basic indexes
 _base_indexes_copy = BASE_CATALOG_INDEXES.copy()

--- a/bika/lims/subscribers/analysis.py
+++ b/bika/lims/subscribers/analysis.py
@@ -27,7 +27,6 @@ def ObjectInitializedEventHandler(instance, event):
 
     ar = instance.getRequest()
     ar_state = wf_tool.getInfoFor(ar, 'review_state')
-    ar_ws_state = wf_tool.getInfoFor(ar, 'worksheetanalysis_review_state')
 
     # Set the state of the analysis depending on the state of the AR.
     if ar_state in ('sample_registered',

--- a/bika/lims/workflow/__init__.py
+++ b/bika/lims/workflow/__init__.py
@@ -370,7 +370,6 @@ def getReviewHistory(instance):
     review_history.reverse()
     return review_history
 
-@deprecated('Use api.get_workflow_status_of instead')
 def getCurrentState(obj, stateflowid='review_state'):
     """ The current state of the object for the state flow id specified
         Return empty if there's no workflow state for the object and flow id


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
`get_workflow_status_of` method didn't call 'getInfoFor' method with default value.
Column 'assigned_state' was missing in AR listing catalog.

## Current behavior before PR
Reindexing Analyses fails.
AR listing view fails to display with new instances.

## Desired behavior after PR is merged
Failures mentioned above are fixed.
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
