### PR TITLE
Refactored bika.lims.bikalisting.js + several functional fixtures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Changelog
 
 **Changed**
 
+- #647 Refactored bika.lims.bikalisting.js + several functional fixtures
 - #637 Deassociate Analysis Request portal type from `worksheetanalysis_workflow`
 
 **Removed**

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -3,241 +3,524 @@
     coffee --no-header -w -o ../ -c bika.lims.bikalisting.coffee
  */
 
-
-/*
- * Controller class for Bika Listing Table view
- */
-
 (function() {
-  window.BikaListingTableView = function() {
-    var autosave, build_typical_save_request, category_header_clicked, column_header_clicked, column_toggle_context_menu, column_toggle_context_menu_selection, filter_search_button_click, filter_search_keypress, listing_string_input_keypress, listing_string_select_changed, loadNewRemarksEventHandlers, load_transitions, loading_transitions, pagesize_change, positionTooltip, render_transition_buttons, save_elements, select_all_clicked, select_one_clicked, show_more_clicked, that, workflow_action_button_click;
-    that = this;
-    loading_transitions = false;
-    show_more_clicked = function() {
-      $('a.bika_listing_show_more').click(function(e) {
-        var filter_options, filterbar, filters, filters1, filters2, formid, limit_from, pagesize, tbody, url;
-        e.preventDefault();
-        formid = $(this).attr('data-form-id');
-        pagesize = parseInt($(this).attr('data-pagesize'));
-        url = $(this).attr('data-ajax-url');
-        limit_from = parseInt($(this).attr('data-limitfrom'));
-        url = url.replace('_limit_from=', '_olf=');
-        url += '&' + formid + '_limit_from=' + limit_from;
-        $('#' + formid + ' a.bika_listing_show_more').fadeOut();
-        tbody = $('table.bika-listing-table[form_id="' + formid + '"] tbody.item-listing-tbody');
-        filter_options = [];
-        filters1 = $('.bika_listing_filter_bar input[name][value!=""]');
-        filters2 = $('.bika_listing_filter_bar select option:selected[value!=""]');
-        filters = $.merge(filters1, filters2);
-        $(filters).each(function(e) {
-          var opt;
-          opt = [$(this).attr('name'), $(this).val()];
-          filter_options.push(opt);
-        });
-        filterbar = {};
-        if (filter_options.length > 0) {
-          filterbar.bika_listing_filter_bar = $.toJSON(filter_options);
-        }
-        $.post(url, filterbar).done(function(data) {
-          var rows;
-          try {
-            rows = $('<html><table>' + data + '</table></html>').find('tr');
-            $(tbody).append(rows);
-            $('#' + formid + ' a.bika_listing_show_more').attr('data-limitfrom', limit_from + pagesize);
-            loadNewRemarksEventHandlers();
-          } catch (error) {
-            e = error;
-            $('#' + formid + ' a.bika_listing_show_more').hide();
-            console.log(e);
-          }
-          load_transitions();
-        }).fail(function() {
-          $('#' + formid + ' a.bika_listing_show_more').hide();
-          console.log('bika_listing_show_more failed');
-        }).always(function() {
-          var numitems;
-          numitems = $('table.bika-listing-table[form_id="' + formid + '"] tbody.item-listing-tbody tr').length;
-          $('#' + formid + ' span.number-items').html(numitems);
-          if (numitems % pagesize === 0) {
-            $('#' + formid + ' a.bika_listing_show_more').fadeIn();
-          }
-        });
-      });
-    };
-    loadNewRemarksEventHandlers = function() {
-      var pointer, txt1;
-      $('a.add-remark').remove();
-      txt1 = '<a href="#" class="add-remark"><img src="' + window.portal_url + '/++resource++bika.lims.images/comment_ico.png" title="' + _('Add Remark') + '")"></a>';
-      pointer = $('.listing_remarks:contains(\'\')').closest('tr').prev().find('td.service_title span.before');
-      $(pointer).append(txt1);
-      $('a.add-remark').click(function(e) {
-        var rmks;
-        e.preventDefault();
-        rmks = $(this).closest('tr').next('tr').find('td.remarks');
-        if (rmks.length > 0) {
-          rmks.toggle();
-        }
-      });
-      $('td.remarks').hide();
-    };
-    column_header_clicked = function() {
-      $('th.sortable').live('click', function() {
-        var column_id, column_index, form, form_id, options, sort_on, sort_on_selector, sort_order, sort_order_selector, stored_form_action;
-        form = $(this).parents('form');
-        form_id = $(form).attr('id');
-        column_id = this.id.split('-')[1];
-        column_index = $(this).parent().children('th').index(this);
-        sort_on_selector = '[name=' + form_id + '_sort_on]';
-        sort_on = $(sort_on_selector).val();
-        sort_order_selector = '[name=' + form_id + '_sort_order]';
-        sort_order = $(sort_order_selector).val();
-        if (sort_on === column_id) {
-          if (sort_order === 'descending') {
-            sort_order = 'ascending';
-          } else {
-            sort_order = 'descending';
-          }
-        } else {
-          sort_on = column_id;
-          sort_order = 'ascending';
-        }
-        $(sort_on_selector).val(sort_on);
-        $(sort_order_selector).val(sort_order);
-        stored_form_action = $(form).attr('action');
-        $(form).attr('action', window.location.href);
-        $(form).append('<input type=\'hidden\' name=\'table_only\' value=\'' + form_id + '\'>');
-        options = {
-          target: $(this).parents('table'),
-          replaceTarget: true,
-          data: form.formToArray()
-        };
-        form.ajaxSubmit(options);
-        $('[name=\'table_only\']').remove();
-        $(form).attr('action', stored_form_action);
-      });
-    };
+  var bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
+
+  window.BikaListingTableView = (function() {
+    function BikaListingTableView() {
+      this.on_show_more_click = bind(this.on_show_more_click, this);
+      this.on_column_header_click = bind(this.on_column_header_click, this);
+      this.on_ajax_submit_end = bind(this.on_ajax_submit_end, this);
+      this.on_ajax_submit_start = bind(this.on_ajax_submit_start, this);
+      this.on_checkbox_click = bind(this.on_checkbox_click, this);
+      this.on_select_all_click = bind(this.on_select_all_click, this);
+      this.on_search_button_click = bind(this.on_search_button_click, this);
+      this.on_search_field_keypress = bind(this.on_search_field_keypress, this);
+      this.on_contextmenu_item_click = bind(this.on_contextmenu_item_click, this);
+      this.on_contextmenu = bind(this.on_contextmenu, this);
+      this.on_workflow_button_click = bind(this.on_workflow_button_click, this);
+      this.on_autosave_field_change = bind(this.on_autosave_field_change, this);
+      this.on_category_header_click = bind(this.on_category_header_click, this);
+      this.on_listing_entry_keypress = bind(this.on_listing_entry_keypress, this);
+      this.on_listing_entry_change = bind(this.on_listing_entry_change, this);
+      this.on_review_state_filter_click = bind(this.on_review_state_filter_click, this);
+      this.on_click = bind(this.on_click, this);
+      this.parse_int = bind(this.parse_int, this);
+      this.show_more = bind(this.show_more, this);
+      this.filter_state = bind(this.filter_state, this);
+      this.toggle_category = bind(this.toggle_category, this);
+      this.sort_column = bind(this.sort_column, this);
+      this.toggle_column = bind(this.toggle_column, this);
+      this.get_toggle_cols = bind(this.get_toggle_cols, this);
+      this.toggle_sort_order = bind(this.toggle_sort_order, this);
+      this.get_toggle_cookie_key = bind(this.get_toggle_cookie_key, this);
+      this.set_cookie = bind(this.set_cookie, this);
+      this.get_cookie = bind(this.get_cookie, this);
+      this.get_authenticator = bind(this.get_authenticator, this);
+      this.get_base_url = bind(this.get_base_url, this);
+      this.get_portal_url = bind(this.get_portal_url, this);
+      this.ajax_submit = bind(this.ajax_submit, this);
+      this.bind_eventhandler = bind(this.bind_eventhandler, this);
+      this.load = bind(this.load, this);
+    }
+
 
     /*
-    * Fetch allowed transitions for all the objects listed in bika_listing and
-    * sets the value for the attribute 'data-valid_transitions' for each check
-    * box next to each row.
-    * The process requires an ajax call, so the function keeps checkboxes
-    * disabled until the allowed transitions for the associated object are set.
+    * Controller class for Bika Listing Table view
      */
-    load_transitions = function(blisting) {
-      'use strict';
-      var blistings, buttonspane, checkall, request_data, uids, wo_trans;
-      if (blisting === '' || typeof blisting === 'undefined') {
-        blistings = $('table.bika-listing-table');
-        $(blistings).each(function(i) {
-          load_transitions($(this));
+
+    BikaListingTableView.prototype.load = function() {
+      console.debug("ListingTableView::load");
+      this.bind_eventhandler();
+      this.loading_transitions = false;
+      this.toggle_cols_cookie = "toggle_cols";
+      this.load_transitions();
+      return window.tv = this;
+    };
+
+
+    /* INITIALIZERS */
+
+    BikaListingTableView.prototype.bind_eventhandler = function() {
+
+      /*
+       * Binds callbacks on elements
+       *
+       * N.B. We attach all the events to the form and refine the selector to
+       * delegate the event: https://learn.jquery.com/events/event-delegation/
+       *
+       */
+      console.debug("ListingTableView::bind_eventhandler");
+      $("form[name=bika_listing_form]").on("click", "th.sortable", this.on_column_header_click);
+      $("form[name=bika_listing_form]").on("click", "a.bika_listing_show_more", this.on_show_more_click);
+      $("form[name=bika_listing_form]").on("click", "input[type='checkbox'][id*='_cb_']", this.on_checkbox_click);
+      $("form[name=bika_listing_form]").on("click", "input[id*='select_all']", this.on_select_all_click);
+      $("form[name=bika_listing_form]").on("keypress", ".filter-search-input", this.on_search_field_keypress);
+      $("form[name=bika_listing_form]").on("click", ".filter-search-button", this.on_search_button_click);
+      $("form[name=bika_listing_form]").on('contextmenu', "th[id^='foldercontents-']", this.on_contextmenu);
+      $("form[name=bika_listing_form]").on("click", "input.workflow_action_button", this.on_workflow_button_click);
+      $("form[name=bika_listing_form]").on("change", "input.autosave, select.autsave", this.on_autosave_field_change);
+      $("form[name=bika_listing_form]").on("click", "th.collapsed, th.expanded", this.on_category_header_click);
+      $("form[name=bika_listing_form]").on("change", ".listing_string_entry, .listing_select_entry", this.on_listing_entry_change);
+      $("form[name=bika_listing_form]").on("keypress", ".listing_string_entry, .listing_select_entry", this.on_listing_entry_keypress);
+      $("form[name=bika_listing_form]").on("click", "td.review_state_selector a", this.on_review_state_filter_click);
+      $(document).on("click", this.on_click);
+      $(document).on("click", ".contextmenu tr", this.on_contextmenu_item_click);
+      $(this).on("ajax:submit:start", this.on_ajax_submit_start);
+      return $(this).on("ajax:submit:end", this.on_ajax_submit_end);
+    };
+
+
+    /* METHODS */
+
+    BikaListingTableView.prototype.ajax_submit = function(options) {
+      var done;
+      if (options == null) {
+        options = {};
+      }
+
+      /*
+       * Ajax Submit with automatic event triggering and some sane defaults
+       */
+      console.debug("°°° ajax_submit °°°");
+      if (options.type == null) {
+        options.type = "POST";
+      }
+      if (options.url == null) {
+        options.url = window.location.href;
+      }
+      if (options.context == null) {
+        options.context = this;
+      }
+      console.debug(">>> ajax_submit::options=", options);
+      $(this).trigger("ajax:submit:start");
+      done = (function(_this) {
+        return function() {
+          return $(_this).trigger("ajax:submit:end");
+        };
+      })(this);
+      return $.ajax(options).done(done);
+    };
+
+    BikaListingTableView.prototype.get_portal_url = function() {
+
+      /*
+       * Return the portal url (calculated in code)
+       */
+      var url;
+      url = $("input[name=portal_url]").val();
+      return url || window.portal_url;
+    };
+
+    BikaListingTableView.prototype.get_base_url = function() {
+
+      /*
+       * Return the current base url
+       */
+      var url;
+      url = window.location.href;
+      return url.split('?')[0];
+    };
+
+    BikaListingTableView.prototype.get_authenticator = function() {
+
+      /*
+       * Get the authenticator value
+       */
+      return $("input[name='_authenticator']").val();
+    };
+
+    BikaListingTableView.prototype.get_cookie = function(name) {
+
+      /*
+       * read the value of the cookie
+       */
+      var c, cookies, i;
+      name = name + "=";
+      cookies = document.cookie.split(";");
+      i = 0;
+      while (i < cookies.length) {
+        c = cookies[i];
+        while (c.charAt(0) === " ") {
+          c = c.substring(1, c.length);
+        }
+        if (c.indexOf(name) === 0) {
+          return unescape(c.substring(name.length, c.length));
+        }
+        i = i + 1;
+      }
+      return null;
+    };
+
+    BikaListingTableView.prototype.set_cookie = function(name, value, days) {
+
+      /*
+       * set the value of the cookie
+       */
+      var cookie, date, expires;
+      if (days) {
+        date = new Date;
+        date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
+        expires = date.toGMTString();
+      } else {
+        expires = "";
+      }
+      cookie = name + "=" + (escape(value)) + "; expires=" + expires + "; path=/;";
+      document.cookie = cookie;
+      return true;
+    };
+
+    BikaListingTableView.prototype.get_toggle_cookie_key = function(form_id) {
+
+      /*
+       * Make a unique toggle cookie key for the current listing site
+       */
+      var portal_type;
+      portal_type = $("#" + form_id + " input[name=portal_type]").val();
+      return "" + portal_type + form_id;
+    };
+
+    BikaListingTableView.prototype.toggle_sort_order = function(sort_order) {
+
+      /*
+       * Toggle the sort_order value
+       */
+      if (sort_order === "ascending") {
+        return "descending";
+      }
+      return "ascending";
+    };
+
+    BikaListingTableView.prototype.get_toggle_cols = function(form_id) {
+
+      /*
+       * Get the value of the toggle cols input field
+       */
+      var toggle_cols;
+      toggle_cols = $("#" + form_id + "_toggle_cols");
+      if (toggle_cols.length === 0) {
+        return {};
+      }
+      return $.parseJSON(toggle_cols.val());
+    };
+
+    BikaListingTableView.prototype.toggle_column = function(form_id, col_id) {
+
+      /*
+       * Toggle column by form and column id
+       */
+      var all_cols, columns, cookie, cookie_key, form, form_data, table, toggle_cols;
+      form = $("form#" + form_id);
+      table = $("table.bika-listing-table", form);
+      toggle_cols = this.get_toggle_cols(form_id);
+      cookie = $.parseJSON(this.get_cookie(this.toggle_cols_cookie) || "{}");
+      cookie_key = this.get_toggle_cookie_key(form_id);
+      columns = cookie[cookie_key];
+      if (!columns) {
+        columns = [];
+        $.each(toggle_cols, function(name, record) {
+          if ($("#foldercontents-" + name + "-column").length > 0) {
+            return columns.push(name);
+          }
         });
+      }
+      if (col_id === _('Default')) {
+        console.debug("*** Set DEFAULT toggle columns ***");
+        delete cookie[cookie_key];
+      } else if (col_id === _('All')) {
+        console.debug("*** Set ALL toggle columns ***");
+        all_cols = [];
+        $.each(toggle_cols, function(name, record) {
+          return all_cols.push(name);
+        });
+        cookie[cookie_key] = all_cols;
+      } else {
+        if (!(col_id in toggle_cols)) {
+          console.warn("Invalid column name: '" + col_id + "'");
+          return;
+        }
+        if (columns.indexOf(col_id) > -1) {
+          console.debug("*** Toggle " + col_id + " OFF ***");
+          columns.splice(columns.indexOf(col_id), 1);
+        } else {
+          console.debug("*** Toggle " + col_id + " ON ***");
+          columns.push(col_id);
+        }
+        cookie[cookie_key] = columns;
+      }
+      this.set_cookie(this.toggle_cols_cookie, $.toJSON(cookie), 365);
+      form_data = new FormData(form[0]);
+      form_data.set("table_only", form_id);
+      return this.ajax_submit({
+        data: form_data,
+        processData: false,
+        contentType: false
+      }).done(function(data) {
+        var menu, style, tooltip;
+        $(table).replaceWith(data);
+        table = $("table.bika-listing-table", form);
+        tooltip = $(".tooltip");
+        if (tooltip.length > 0) {
+          style = tooltip.attr("style");
+          menu = this.make_context_menu(table);
+          menu = $(menu).appendTo("body");
+          return menu.attr("style", style);
+        }
+      });
+    };
+
+    BikaListingTableView.prototype.sort_column = function(form_id, sort_index) {
+
+      /*
+       * Sort column by form and sort index
+       */
+      var form, form_data, sort_on, sort_on_value, sort_order, sort_order_value, table;
+      form = $("form#" + form_id);
+      table = $("table.bika-listing-table", form);
+      sort_on = $("[name=" + form_id + "_sort_on]");
+      sort_order = $("[name=" + form_id + "_sort_order]");
+      sort_on_value = sort_on.val();
+      sort_order_value = sort_order.val();
+      sort_on.val(sort_index);
+      sort_order.val(this.toggle_sort_order(sort_order_value));
+      form_data = new FormData(form[0]);
+      form_data.set("table_only", form_id);
+      return this.ajax_submit({
+        data: form_data,
+        processData: false,
+        contentType: false
+      }).done(function(data) {
+        return $(table).replaceWith(data);
+      });
+    };
+
+    BikaListingTableView.prototype.toggle_category = function(form_id, cat_id) {
+
+      /*
+       * Toggle category by form and category id
+       */
+      var base_url, cat, cat_items, cat_url, expanded, form, form_data, placeholder, url;
+      form = $("form#" + form_id);
+      cat = $("th.cat_header[cat=" + cat_id + "]");
+      placeholder = $("tr[data-ajax_category=" + cat_id);
+      expanded = cat.hasClass("expanded");
+      cat_items = $("tr[cat=" + cat_id + "]");
+      cat.toggleClass("expanded collapsed");
+      if (cat_items.length > 0) {
+        console.debug("ListingTableView::toggle_category: Category " + cat_id + " is already expanded -> Toggle only");
+        cat_items.toggle();
         return;
       }
-      buttonspane = $(blisting).find('span.workflow_action_buttons');
-      if (loading_transitions || $(buttonspane).length === 0) {
+      cat_url = $("input[name=ajax_categories_url]").val();
+      base_url = this.get_base_url();
+      url = cat_url || base_url;
+      form_data = new FormData();
+      form_data.set("cat", cat_id);
+      form_data.set("form_id", form_id);
+      form_data.set("ajax_category_expand", 1);
+      return this.ajax_submit({
+        data: form_data,
+        processData: false,
+        contentType: false
+      }).done(function(data) {
+        placeholder.replaceWith(data);
+        return this.load_transitions();
+      });
+    };
+
+    BikaListingTableView.prototype.filter_state = function(form_id, state_id) {
+
+      /*
+       * Filter listing by review_state
+       */
+      var form, form_data, input, input_name, table;
+      form = $("form#" + form_id);
+      table = $("table.bika-listing-table", form);
+      input_name = form_id + "_review_state";
+      input = $("input[name=" + input_name + "]", form);
+      if (input.length === 0) {
+        input = form.append("<input name='" + input_name + "' type='hidden'/>");
+      }
+      input.val(state_id);
+      form_data = new FormData(form[0]);
+      form_data.set("table_only", form_id);
+      form_data.set(form_id + "_review_state", state_id);
+      return this.ajax_submit({
+        data: form_data,
+        processData: false,
+        contentType: false
+      }).done(function(data) {
+        return $(table).replaceWith(data);
+      });
+    };
+
+    BikaListingTableView.prototype.show_more = function(form_id, pagesize, limit_from) {
+
+      /*
+       * Show more
+       */
+      var filter_options, filters, filters1, filters2, form, form_data, show_more, table, tbody;
+      form = $("form#" + form_id);
+      table = $("table.bika-listing-table", form);
+      tbody = $("tbody.item-listing-tbody", table);
+      show_more = $("#" + form_id + " a.bika_listing_show_more");
+      if (pagesize == null) {
+        pagesize = 30;
+      }
+      if (limit_from == null) {
+        limit_from = 0;
+      }
+      form_data = new FormData(form[0]);
+      form_data.set("rows_only", form_id);
+      form_data.set(form_id + "_pagesize", pagesize);
+      form_data.set(form_id + "_limit_from", limit_from);
+      filter_options = [];
+      filters1 = $(".bika_listing_filter_bar input[name][value!='']");
+      filters2 = $(".bika_listing_filter_bar select option:selected[value!='']");
+      filters = $.merge(filters1, filters2);
+      $(filters).each(function(e) {
+        return filter_options.push([$(this).attr('name'), $(this).val()]);
+      });
+      if (filter_options.length > 0) {
+        form_data.set("bika_listing_filter_bar", $.toJSON(filter_options));
+      }
+      show_more.fadeOut();
+      return this.ajax_submit({
+        data: form_data,
+        processData: false,
+        contentType: false
+      }).done(function(data) {
+        var numitems, rows;
+        rows = $(data).filter("tr");
+        if (rows.length % pagesize === 0) {
+          show_more.fadeIn();
+        }
+        if (limit_from === 0) {
+          $(tbody).empty();
+        }
+        $(tbody).append(rows);
+        numitems = $("table.bika-listing-table[form_id=" + form_id + "] tbody.item-listing-tbody tr").length;
+        $("#" + form_id + " span.number-items").html(numitems);
+        show_more.attr("data-limitfrom", numitems);
+        show_more.attr("data-pagesize", pagesize);
+        return this.load_transitions();
+      });
+    };
+
+    BikaListingTableView.prototype.parse_int = function(thing, fallback) {
+      var number;
+      if (fallback == null) {
+        fallback = 0;
+      }
+
+      /*
+       * Safely parse to an integer
+       */
+      number = parseInt(thing);
+      return number || fallback;
+    };
+
+    BikaListingTableView.prototype.load_transitions = function(table) {
+
+      /*
+       * Fetch allowed transitions for all the objects listed in bika_listing and
+       * sets the value for the attribute 'data-valid_transitions' for each check
+       * box next to each row.
+       * The process requires an ajax call, so the function keeps checkboxes
+       * disabled until the allowed transitions for the associated object are set.
+       */
+      var $table, checkall, self, uids, wf_buttons, wo_trans;
+      self = this;
+      if (!table) {
+        $("table.bika-listing-table").each(function(index) {
+          return self.load_transitions(this);
+        });
+      }
+      $table = $(table);
+      wf_buttons = $(table).find("span.workflow_action_buttons");
+      if (this.loading_transitions || $(wf_buttons).length === 0) {
         return;
       }
-      loading_transitions = true;
       uids = [];
-      checkall = $("input[id*='select_all']");
+      checkall = $("input[id*='select_all']", $table);
       $(checkall).hide();
       wo_trans = $("input[data-valid_transitions='{}']");
-      $(wo_trans).prop('disabled', true);
+      $(wo_trans).prop("disabled", true);
       $(wo_trans).each(function(e) {
-        uids.push($(this).val());
+        return uids.push($(this).val());
       });
-      if (uids.length > 0) {
-        request_data = {
-          _authenticator: $('input[name=\'_authenticator\']').val(),
-          uid: $.toJSON(uids)
-        };
-        window.jsonapi_cache = window.jsonapi_cache || {};
-        $.ajax({
-          type: 'POST',
-          dataType: 'json',
-          url: window.portal_url + '/@@API/allowedTransitionsFor_many',
-          data: request_data,
-          success: function(data) {
-            var el, i, trans, uid;
-            if ('transitions' in data) {
-              i = 0;
-              while (i < data.transitions.length) {
-                uid = data.transitions[i].uid;
-                trans = data.transitions[i].transitions;
-                el = $("input[id*='_cb_'][value='" + uid + "']");
-                el.attr('data-valid_transitions', $.toJSON(trans));
-                $(el).prop('disabled', false);
-                i++;
-              }
-              $("input[id*='select_all']").fadeIn();
-            }
-          }
-        });
+      if (uids.length === 0) {
+        return;
       }
-      loading_transitions = false;
-    };
-
-    /*
-    * Controls the behavior when a checkbox of row selection is clicked.
-    * Updates the status of the 'select all' checkbox accordingly and also
-    * re-renders the workflow action buttons from the bottom of the list
-    * based on the allowed transitions of the currently selected items
-     */
-    select_one_clicked = function() {
-      'use strict';
-      $('input[type=\'checkbox\'][id*=\'_cb_\']').live('click', function() {
-        var all, blst, checkall, checked;
-        blst = $(this).parents('table.bika-listing-table');
-        render_transition_buttons(blst);
-        checked = $('input[type=\'checkbox\'][id*=\'_cb_\']:checked');
-        all = $('input[type=\'checkbox\'][id*=\'_cb_\']');
-        checkall = $(blst).find('input[id*=\'select_all\']');
-        checkall.prop('checked', checked.length === all.length);
+      this.loading_transitions = true;
+      return this.ajax_submit({
+        url: (this.get_portal_url()) + "/@@API/allowedTransitionsFor_many",
+        data: {
+          _authenticator: this.get_authenticator(),
+          uid: $.toJSON(uids)
+        }
+      }).done(function(data) {
+        this.loading_transitions = false;
+        $("input[id*='select_all']").fadeIn();
+        if ("transitions" in data) {
+          return $.each(data.transitions, function(index, record) {
+            var checkbox, trans, uid;
+            uid = record.uid;
+            trans = record.transitions;
+            checkbox = $("input[id*='_cb_'][value='" + uid + "']");
+            checkbox.attr("data-valid_transitions", $.toJSON(trans));
+            return $(checkbox).prop("disabled", false);
+          });
+        }
       });
     };
 
-    /*
-    * Controls the behavior when the 'select all' checkbox is clicked.
-    * Checks/Unchecks all the row selection checkboxes and once done,
-    * re-renders the workflow action buttons from the bottom of the list,
-    * based on the allowed transitions for the currently selected items
-     */
-    select_all_clicked = function() {
-      'use strict';
-      $('input[id*=\'select_all\']').live('click', function() {
-        var blst, checkboxes;
-        blst = $(this).parents('table.bika-listing-table');
-        checkboxes = $(blst).find('[id*=\'_cb_\']');
-        $(checkboxes).prop('checked', $(this).prop('checked'));
-        render_transition_buttons(blst);
-      });
-    };
+    BikaListingTableView.prototype.render_transition_buttons = function(table) {
 
-    /*
-    * Re-generates the workflow action buttons from the bottom of the list in
-    * accordance with the allowed transitions for the currently selected items.
-    * This is, makes the intersection within all allowed transitions and adds
-    * the corresponding buttons to the workflow action bar.
-     */
-    render_transition_buttons = function(blst) {
-      'use strict';
-      var _button, allowed_transitions, buttonspane, checked, custom_transitions, hidden_transitions, i, restricted_transitions, trans;
-      buttonspane = $(blst).find('span.workflow_action_buttons');
-      if ($(buttonspane).length === 0) {
+      /* Render workflow transition buttons to the table
+       *
+       * Re-generates the workflow action buttons from the bottom of the list in
+       * accordance with the allowed transitions for the currently selected items.
+       * This is, makes the intersection within all allowed transitions and adds
+       * the corresponding buttons to the workflow action bar.
+       */
+      var allowed_transitions, checked, custom_transitions, hidden_transitions, restricted_transitions, self, wf_buttons;
+      self = this;
+      wf_buttons = $(table).find("span.workflow_action_buttons");
+      if ($(wf_buttons).length === 0) {
         return;
       }
       allowed_transitions = [];
-      hidden_transitions = $(blst).find('input[id="hide_transitions"]');
+      hidden_transitions = $(table).find("input[id='hide_transitions']");
       hidden_transitions = $(hidden_transitions).length === 1 ? $(hidden_transitions).val() : '';
       hidden_transitions = hidden_transitions === '' ? [] : hidden_transitions.split(',');
-      restricted_transitions = $(blst).find('input[id="restricted_transitions"]');
+      restricted_transitions = $(table).find("input[id='restricted_transitions']");
       restricted_transitions = $(restricted_transitions).length === 1 ? $(restricted_transitions).val() : '';
       restricted_transitions = restricted_transitions === '' ? [] : restricted_transitions.split(',');
-      checked = $(blst).find("input[id*='_cb_']:checked");
-      $(checked).each(function(e) {
+      checked = $(table).find("input[id*='_cb_']:checked");
+      $(checked).each(function(index) {
         var transitions;
-        transitions = $.parseJSON($(this).attr('data-valid_transitions'));
+        transitions = $.parseJSON($(this).attr("data-valid_transitions"));
         if (!transitions.length) {
           return;
         }
@@ -252,404 +535,407 @@
           });
         }
         if (allowed_transitions.length > 0) {
-          transitions = transitions.filter(function(el) {
+          return transitions = transitions.filter(function(el) {
             return allowed_transitions.indexOf(el) > -1;
           });
         } else {
           allowed_transitions = transitions;
-        }
-        if (transitions.length > 0) {
-          allowed_transitions = allowed_transitions.filter(function(el) {
-            return transitions.indexOf(el) > -1;
-          });
-        }
-      });
-      $(buttonspane).html('');
-      i = 0;
-      while (i < allowed_transitions.length) {
-        trans = allowed_transitions[i];
-        _button = "<input id='" + trans['id'] + "_transition' class='context workflow_action_button action_button allowMultiSubmit' type='submit' value='" + (PMF(trans['title'])) + "' transition='" + trans['id'] + "' name='workflow_action_button'/>&nbsp;";
-        $(buttonspane).append(_button);
-        i++;
-      }
-      if ($(checked).length > 0) {
-        custom_transitions = $(blst).find('input[type="hidden"].custom_transition');
-        $(custom_transitions).each(function(i, e) {
-          var _title, _trans, _url;
-          _trans = $(e).val();
-          _url = $(e).attr('url');
-          _title = $(e).attr('title');
-          _button = "<input id='" + _trans + "_transition' class='context workflow_action_button action_button allowMultiSubmit' type='submit' url='" + _url + "' value='" + _title + "' transition='" + _trans + "' name='workflow_action_button'/>&nbsp;";
-          $(buttonspane).append(_button);
-        });
-      }
-    };
-    listing_string_input_keypress = function() {
-      'use strict';
-      $('.listing_string_entry,.listing_select_entry').live('keypress', function(event) {
-        var blst, checkbox, enter, tr, uid;
-        enter = 13;
-        if (event.which === enter) {
-          event.preventDefault();
-        }
-        uid = $(this).attr('uid');
-        tr = $(this).parents('tr#folder-contents-item-' + uid);
-        checkbox = tr.find('input[id$="_cb_' + uid + '"]');
-        if ($(checkbox).length === 1) {
-          blst = $(checkbox).parents('table.bika-listing-table');
-          $(checkbox).prop('checked', true);
-          render_transition_buttons(blst);
-        }
-      });
-    };
-    listing_string_select_changed = function() {
-      $('.listing_select_entry').live('change', function() {
-        var blst, checkbox, tr, uid;
-        uid = $(this).attr('uid');
-        tr = $(this).parents('tr#folder-contents-item-' + uid);
-        checkbox = tr.find('input[id$="_cb_' + uid + '"]');
-        if ($(checkbox).length === 1) {
-          blst = $(checkbox).parents('table.bika-listing-table');
-          $(checkbox).prop('checked', true);
-          render_transition_buttons(blst);
-        }
-      });
-    };
-    pagesize_change = function() {
-      $('select.pagesize').live('change', function() {
-        var form, form_id, new_query, pagesize;
-        form = $(this).parents('form');
-        form_id = $(form).attr('id');
-        pagesize = $(this).val();
-        new_query = $.query.set(form_id + '_pagesize', pagesize).set(form_id + '_pagenumber', 1).toString();
-        window.location = window.location.href.split('?')[0] + new_query;
-      });
-    };
-    category_header_clicked = function() {
-      $('.bika-listing-table th.collapsed').live('click', function() {
-        if (!$(this).hasClass('ignore_bikalisting_default_handler')) {
-          that.category_header_expand_handler(this);
-        }
-      });
-      $('.bika-listing-table th.expanded').live('click', function() {
-        if (!$(this).hasClass('ignore_bikalisting_default_handler')) {
-          $(this).parent().nextAll('tr[cat=\'' + $(this).attr('cat') + '\']').toggle();
-          if ($(this).hasClass('expanded')) {
-            $(this).removeClass('expanded').addClass('collapsed');
-          } else if ($(this).hasClass('collapsed')) {
-            $(this).removeClass('collapsed').addClass('expanded');
-          }
-        }
-      });
-    };
-    filter_search_keypress = function() {
-      $('.filter-search-input').live('keypress', function(event) {
-        var enter;
-        enter = 13;
-        if (event.which === enter) {
-          $('.filter-search-button').click();
-          return false;
-        }
-      });
-    };
-    filter_search_button_click = function() {
-      $('.filter-search-button').live('click', function(event) {
-        var form, form_id, stored_form_action, table, url;
-        form = $(this).parents('form');
-        form_id = $(form).attr('id');
-        stored_form_action = $(form).attr('action');
-        $(form).attr('action', window.location.href);
-        $(form).append('<input type=\'hidden\' name=\'table_only\' value=\'' + form_id + '\'>');
-        table = $(this).parents('table');
-        url = window.location.href;
-        $.post(url, form.formToArray()).done(function(data) {
-          $(table).html(data);
-          load_transitions();
-          show_more_clicked();
-        });
-        $('[name="table_only"]').remove();
-        $(form).attr('action', stored_form_action);
-        return false;
-      });
-    };
-    workflow_action_button_click = function() {
-      $('.workflow_action_button').live('click', function(event) {
-        var e, focus, form, form_id;
-        form = $(this).parents('form');
-        form_id = $(form).attr('id');
-        $(form).append('<input type=\'hidden\' name=\'workflow_action_id\' value=\'' + $(this).attr('transition') + '\'>');
-        if (this.id === 'submit_transition') {
-          focus = $('.ajax_calculate_focus');
-          if (focus.length > 0) {
-            e = $(focus[0]);
-            if ($(e).attr('focus_value') === $(e).val()) {
-              $(e).removeAttr('focus_value');
-              $(e).removeClass('ajax_calculate_focus');
-            } else {
-              $(e).parents('form').attr('submit_after_calculation', 1);
-              event.preventDefault();
-            }
-          }
-        }
-        if ($(this).attr('url') !== '') {
-          form = $(this).parents('form');
-          $(form).attr('action', $(this).attr('url'));
-          $(form).submit();
-        }
-      });
-    };
-    column_toggle_context_menu = function() {
-      $('th[id^="foldercontents-"]').live('contextmenu', function(event) {
-        var col, col_id, col_title, enabled, form_id, i, portal_url, sorted_toggle_cols, toggle_cols, txt;
-        event.preventDefault();
-        form_id = $(this).parents('form').attr('id');
-        portal_url = window.portal_url;
-        toggle_cols = $('#' + form_id + '_toggle_cols').val();
-        if (toggle_cols === '' || toggle_cols === void 0 || toggle_cols === null) {
-          return false;
-        }
-        sorted_toggle_cols = [];
-        $.each($.parseJSON(toggle_cols), function(col_id, v) {
-          v['id'] = col_id;
-          sorted_toggle_cols.push(v);
-        });
-        sorted_toggle_cols.sort(function(a, b) {
-          var titleA, titleB;
-          titleA = a['title'].toLowerCase();
-          titleB = b['title'].toLowerCase();
-          if (titleA < titleB) {
-            return -1;
-          }
-          if (titleA > titleB) {
-            return 1;
-          }
-          return 0;
-        });
-        txt = '<div class="tooltip"><table class="contextmenu" cellpadding="0" cellspacing="0">';
-        txt = txt + '<tr><th colspan=\'2\'>' + _('Display columns') + '</th></tr>';
-        i = 0;
-        while (i < sorted_toggle_cols.length) {
-          col = sorted_toggle_cols[i];
-          col_id = col['id'];
-          col_title = _(col['title']);
-          enabled = $('#foldercontents-' + col_id + '-column');
-          if (enabled.length > 0) {
-            txt = txt + '<tr class=\'enabled\' col_id=\'' + col_id + '\' form_id=\'' + form_id + '\'>';
-            txt = txt + '<td>';
-            txt = txt + '<img style=\'height:1em;\' src=\'' + portal_url + '/++resource++bika.lims.images/ok.png\'/>';
-            txt = txt + '</td>';
-            txt = txt + '<td>' + col_title + '</td></tr>';
-          } else {
-            txt = txt + '<tr col_id=\'' + col_id + '\' form_id=\'' + form_id + '\'>';
-            txt = txt + '<td>&nbsp;</td>';
-            txt = txt + '<td>' + col_title + '</td></tr>';
-          }
-          i++;
-        }
-        txt = txt + '<tr col_id=\'' + _('All') + '\' form_id=\'' + form_id + '\'>';
-        txt = txt + '<td style=\'border-top:1px solid #ddd\'>&nbsp;</td>';
-        txt = txt + '<td style=\'border-top:1px solid #ddd\'>' + _('All') + '</td></tr>';
-        txt = txt + '<tr col_id=\'' + _('Default') + '\' form_id=\'' + form_id + '\'>';
-        txt = txt + '<td>&nbsp;</td>';
-        txt = txt + '<td>' + _('Default') + '</td></tr>';
-        txt = txt + '</table></div>';
-        $(txt).appendTo('body');
-        positionTooltip(event);
-        return false;
-      });
-    };
-    column_toggle_context_menu_selection = function() {
-      $('.contextmenu tr').live('click', function(event) {
-        var col_id, col_title, cookie, cookie_key, enabled, form, form_id, toggle_cols;
-        form_id = $(this).attr('form_id');
-        form = $('form#' + form_id);
-        col_id = $(this).attr('col_id');
-        col_title = $(this).text();
-        enabled = $(this).hasClass('enabled');
-        cookie = readCookie('toggle_cols');
-        cookie = $.parseJSON(cookie);
-        cookie_key = $(form[0].portal_type).val() + form_id;
-        if (cookie === null || cookie === void 0) {
-          cookie = {};
-        }
-        if (col_id === _('Default')) {
-          delete cookie[cookie_key];
-          createCookie('toggle_cols', $.toJSON(cookie), 365);
-        } else if (col_id === _('All')) {
-          toggle_cols = [];
-          $.each($.parseJSON($('#' + form_id + '_toggle_cols').val()), function(i, v) {
-            toggle_cols.push(i);
-          });
-          cookie[cookie_key] = toggle_cols;
-          createCookie('toggle_cols', $.toJSON(cookie), 365);
-        } else {
-          toggle_cols = cookie[cookie_key];
-          if (toggle_cols === null || toggle_cols === void 0) {
-            toggle_cols = [];
-            $.each($.parseJSON($('#' + form_id + '_toggle_cols').val()), function(i, v) {
-              if (!(col_id === i && enabled) && v['toggle']) {
-                toggle_cols.push(i);
-              }
+          if (transitions.length > 0) {
+            return allowed_transitions = allowed_transitions.filter(function(el) {
+              return transitions.indexOf(el) > -1;
             });
-          } else {
-            if (enabled) {
-              toggle_cols.splice(toggle_cols.indexOf(col_id), 1);
-            } else {
-              toggle_cols.push(col_id);
-            }
           }
-          cookie[cookie_key] = toggle_cols;
-          createCookie('toggle_cols', $.toJSON(cookie), 365);
         }
-        $(form).attr('action', window.location.href);
-        $('.tooltip').remove();
-        form.submit();
-        return false;
       });
-    };
-    positionTooltip = function(event) {
-      var tPosX, tPosY;
-      tPosX = event.pageX - 5;
-      tPosY = event.pageY - 5;
-      $('div.tooltip').css({
-        'border': '1px solid #fff',
-        'border-radius': '.25em',
-        'background-color': '#fff',
-        'position': 'absolute',
-        'top': tPosY,
-        'left': tPosX
+      $(wf_buttons).html("");
+      $.each(allowed_transitions, function(index, record) {
+        var button, transition, url, value;
+        transition = record.id;
+        url = "";
+        value = PMF(record.title);
+        button = self.make_wf_button(transition, url, value);
+        return $(wf_buttons).append(button);
       });
-    };
-    autosave = function() {
-
-      /*
-      This function looks for the column defined as 'autosave' and if
-      its value is true, the result of this input will be saved after each
-      change via ajax.
-       */
-      $('select.autosave, input.autosave').not('[type="hidden"]').each(function(i) {
-        $(this).change(function() {
-          var pointer;
-          pointer = this;
-          build_typical_save_request(pointer);
+      if ($(checked).length > 0) {
+        custom_transitions = $(table).find("input[type='hidden'].custom_transition");
+        return $.each(custom_transitions, function(index, element) {
+          var button, transition, url, value;
+          transition = $(element).val();
+          url = $(element).attr("url");
+          value = $(element).attr("title");
+          button = self.make_wf_button(transition, url, value);
+          return $(wf_buttons).append(button);
         });
-      });
-    };
-    build_typical_save_request = function(pointer) {
-
-      /*
-       * Build an array with the data to be saved for the typical data fields.
-       * @pointer is the object which has been modified and we want to save its new data.
-       */
-      var fieldname, fieldvalue, requestdata, tr, uid;
-      fieldvalue = void 0;
-      fieldname = void 0;
-      requestdata = {};
-      uid = void 0;
-      tr = void 0;
-      fieldvalue = $(pointer).val();
-      if ($(pointer).is(':checkbox')) {
-        fieldvalue = $(pointer).is(':checked');
       }
-      fieldname = $(pointer).attr('field');
-      tr = $(pointer).closest('tr');
-      uid = $(pointer).attr('uid');
-      requestdata[fieldname] = fieldvalue;
-      requestdata['obj_uid'] = uid;
-      save_elements(requestdata, tr);
     };
-    save_elements = function(requestdata, tr) {
+
+    BikaListingTableView.prototype.make_wf_button = function(transition, url, value) {
 
       /*
-       * Given a dict with a fieldname and a fieldvalue, save this data via ajax petition.
-       * @requestdata should has the format {fieldname=fieldvalue, uid=xxxx} -> { ReportDryMatter=false, uid=xxx}.
+       * Make a workflow button
        */
-      var name, url;
-      url = window.location.href.replace('/base_view', '');
-      name = $(tr).attr('title');
-      $.ajax({
-        type: 'POST',
-        url: window.portal_url + '/@@API/update',
-        data: requestdata
+      var button;
+      button = "<input id='" + transition + "_transition' class='context workflow_action_button action_button allowMultiSubmit' type='submit' url='" + url + "' value='" + value + "' transition='" + transition + "' name='workflow_action_button'/>&nbsp;";
+      return button;
+    };
+
+    BikaListingTableView.prototype.search = function(form_id, searchterm) {
+
+      /*
+       * Search in table and expand the rows
+       */
+      var form, form_data, table;
+      form = $("form#" + form_id);
+      form_id = form.attr("id");
+      table = $("table.bika-listing-table", form);
+      form_data = new FormData(form[0]);
+      form_data.set("table_only", form_id);
+      form_data.set(form_id + "_filter", searchterm);
+      return this.ajax_submit({
+        data: form_data,
+        processData: false,
+        contentType: false
       }).done(function(data) {
-        var msg;
-        if (data !== null && data['success'] === true) {
-          bika.lims.SiteView.notificationPanel(name + ' updated successfully', 'succeed');
+        table = $(table).replaceWith(data);
+        return $(".filter-search-input", form).select();
+      });
+    };
+
+    BikaListingTableView.prototype.make_context_menu = function(table) {
+
+      /*
+       * Build context menu HTML
+       */
+      var form, form_id, menu, portal_url, sorted_toggle_cols, toggle_cols, toggleable_columns;
+      console.debug("°°° ListingTableView::make_context_menu °°°");
+      $(".tooltip").remove();
+      form = $(table).parents("form");
+      form_id = form.attr("id");
+      portal_url = this.get_portal_url();
+      toggle_cols = $("#" + form_id + "_toggle_cols");
+      if (!toggle_cols.val()) {
+        console.warn("Could not get toggle column info from input field " + toggle_cols);
+        return false;
+      }
+      sorted_toggle_cols = [];
+      $.each($.parseJSON(toggle_cols.val()), function(column, record) {
+        record.id = column;
+        record.title = _(record.title) || _(record.id);
+        sorted_toggle_cols.push(record);
+      });
+      sorted_toggle_cols.sort(function(a, b) {
+        var titleA, titleB;
+        titleA = a.title.toLowerCase();
+        titleB = b.title.toLowerCase();
+        if (titleA < titleB) {
+          return -1;
+        }
+        if (titleA > titleB) {
+          return 1;
+        }
+        return 0;
+      });
+      toggleable_columns = "";
+      $.each(sorted_toggle_cols, function(index, record) {
+        var col, column_exists;
+        column_exists = $("#foldercontents-" + record.id + "-column");
+        if (column_exists.length > 0) {
+          col = "<tr class=\"enabled\" col_id=\"" + record.id + "\" form_id=\"" + form_id + "\">\n  <td>&#10003;</td>\n  <td>" + (record.title || record.id) + "</td>\n</tr>";
         } else {
-          bika.lims.SiteView.notificationPanel('Error while updating ' + name, 'error');
-          msg = 'Error while updating ' + name;
-          console.warn(msg);
-          window.bika.lims.error(msg);
+          col = "<tr col_id=" + record.id + " form_id=\"" + form_id + "\">\n  <td>&nbsp;</td>\n  <td>" + (record.title || record.id) + "</td>\n</tr>";
         }
-      }).fail(function() {
-        var msg;
-        bika.lims.SiteView.notificationPanel('Error while updating ' + name, 'error');
-        msg = 'Error while updating ' + name;
-        console.warn(msg);
-        window.bika.lims.error(msg);
+        return toggleable_columns += col;
+      });
+      menu = "<div class=\"tooltip bottom\">\n  <div class=\"tooltip-inner\">\n    <table class=\"contextmenu\" cellpadding=\"0\" cellspacing=\"0\">\n      <tr>\n        <th colspan=\"2\">" + (_("Display columns")) + "</th>\n      </tr>\n      " + toggleable_columns + "\n      <tr col_id=\"" + (_("All")) + "\" form_id=\"" + form_id + "\">\n        <td style=\"border-top:1px solid #ddd;\">&nbsp;</td>\n        <td style=\"border-top:1px solid #ddd;\">" + (_("All")) + "</td>\n      </tr>\n      <tr col_id=\"" + (_("Default")) + "\" form_id=\"" + form_id + "\">\n        <td>&nbsp;</td>\n        <td>" + (_("Default")) + "</td>\n      </tr>\n    </table>\n  </div>\n  <div class=\"tooltip-arrow\"></div>\n</div>";
+      return menu;
+    };
+
+
+    /* EVENT HANDLER */
+
+    BikaListingTableView.prototype.on_click = function(event) {
+
+      /*
+       * Eventhandler for all clicks
+       */
+      var el;
+      el = $(event.target);
+      if (el.parents(".tooltip").length === 0) {
+        return $(".tooltip").remove();
+      }
+    };
+
+    BikaListingTableView.prototype.on_review_state_filter_click = function(event) {
+
+      /*
+       * Eventhandler for review state filter buttons
+       */
+      var $el, el, form, form_id, state_id;
+      console.debug("°°° ListingTableView::on_review_state_filter_click °°°");
+      event.preventDefault();
+      el = event.currentTarget;
+      $el = $(el);
+      form = $el.parents("form");
+      form_id = form.attr("id");
+      state_id = $el.attr("value");
+      return this.filter_state(form_id, state_id);
+    };
+
+    BikaListingTableView.prototype.on_listing_entry_change = function(event) {
+
+      /*
+       * Eventhandler for listing entries (results capturing)
+       */
+      var $el, checkbox, el, table, tr, uid;
+      console.debug("°°° ListingTableView::on_listing_entry_change °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      uid = $el.attr("uid");
+      tr = $el.parents("tr#folder-contents-item-" + uid);
+      checkbox = tr.find("input[id$=_cb_" + uid + "]");
+      if ($(checkbox).length === 1) {
+        table = $(checkbox).parents("table.bika-listing-table");
+        $(checkbox).prop('checked', true);
+        return this.render_transition_buttons(table);
+      }
+    };
+
+    BikaListingTableView.prototype.on_listing_entry_keypress = function(event) {
+
+      /*
+       * Eventhandler for listing entries (results capturing)
+       */
+      console.debug("°°° ListingTableView::on_listing_entry_keypress °°°");
+      if (event.which === 13) {
+        console.debug("ListingTableView::on_listing_entry_keypress: capture Enter key");
+        return event.preventDefault();
+      }
+    };
+
+    BikaListingTableView.prototype.on_category_header_click = function(event) {
+
+      /*
+       * Eventhandler for collapsed/expanded categories
+       */
+      var $el, cat_id, el, form, form_id;
+      console.debug("°°° ListingTableView::on_category_header_click °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      if ($el.hasClass("ignore_bikalisting_default_handler")) {
+        console.debug("Category toggling disabled by CSS class");
+        return;
+      }
+      form = $el.parents("form");
+      form_id = form.attr("id");
+      cat_id = $el.attr("cat");
+      return this.toggle_category(form_id, cat_id);
+    };
+
+    BikaListingTableView.prototype.on_autosave_field_change = function(event) {
+
+      /*
+       * Eventhandler for input fields with `autosave` css class
+       *
+       * This function looks for the column defined as 'autosave' and if its value
+       * is true, the result of this input will be saved after each change via
+       * ajax.
+       */
+      console.warn("BBB: Autosave is deprecated and not supported anymore");
+      return false;
+    };
+
+    BikaListingTableView.prototype.on_workflow_button_click = function(event) {
+
+      /*
+       * Eventhandler for the workflow buttons
+       */
+      var $el, e, el, focus, form, form_id, transition;
+      console.debug("°°° ListingTableView::on_workflow_button_click °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      form = $el.parents("form");
+      form_id = $(form).attr("id");
+      transition = $el.attr("transition");
+      $(form).append("<input type='hidden' name='workflow_action_id' value='" + transition + "' />");
+      if ($el.id === "submit_transition") {
+        focus = $(".ajax_calculate_focus");
+        if (focus.length > 0) {
+          e = $(focus[0]);
+          if ($(e).attr("focus_value") === $(e).val()) {
+            $(e).removeAttr("focus_value");
+            $(e).removeClass("ajax_calculate_focus");
+          } else {
+            $(e).parents("form").attr("submit_after_calculation", 1);
+            event.preventDefault();
+          }
+        }
+      }
+      if ($el.attr("url") !== "") {
+        form = $el.parents("form");
+        $(form).attr("action", $(this).attr("url"));
+        return $(form).submit();
+      }
+    };
+
+    BikaListingTableView.prototype.on_contextmenu = function(event) {
+
+      /*
+       * Eventhandler for the table contextmenu
+       */
+      var $el, el, menu, table;
+      console.debug("°°° ListingTableView::on_contextmenu °°°");
+      event.preventDefault();
+      el = event.currentTarget;
+      $el = $(el);
+      table = $el.parents("table.bika-listing-table");
+      menu = this.make_context_menu(table);
+      menu = $(menu).appendTo("body");
+      return $(menu).css({
+        "border": "1px solid #fff",
+        "border-radius": ".25em",
+        "background-color": "#fff",
+        "position": "absolute",
+        "top": event.pageY - 5,
+        "left": event.pageX - 5
       });
     };
-    that.load = function() {
-      column_header_clicked();
-      load_transitions();
-      select_one_clicked();
-      select_all_clicked();
-      listing_string_input_keypress();
-      listing_string_select_changed();
-      pagesize_change();
-      category_header_clicked();
-      filter_search_keypress();
-      filter_search_button_click();
-      workflow_action_button_click();
-      column_toggle_context_menu();
-      column_toggle_context_menu_selection();
-      show_more_clicked();
-      autosave();
-      $('*').click(function() {
-        if ($('.tooltip').length > 0) {
-          $('.tooltip').remove();
-        }
-      });
+
+    BikaListingTableView.prototype.on_contextmenu_item_click = function(event) {
+
+      /*
+       * Eventhandler when an item was clicked in the contextmenu
+       */
+      var $el, col_id, el, form_id;
+      console.debug("°°° ListingTableView::on_contextmenu_item_click °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      form_id = $el.attr("form_id");
+      col_id = $el.attr("col_id");
+      return this.toggle_column(form_id, col_id);
     };
-    that.category_header_expand_handler = function(element) {
-      var ajax_categories_enabled, cat_title, def, form_id, options, placeholder, url;
-      def = $.Deferred();
-      form_id = $(element).parents('[form_id]').attr('form_id');
-      cat_title = $(element).attr('cat');
-      url = $('input[name=\'ajax_categories_url\']').length > 0 ? $('input[name=\'ajax_categories_url\']').val() : window.location.href.split('?')[0];
-      placeholder = $('tr[data-ajax_category=\'' + cat_title + '\']');
-      if ($(element).hasClass('expanded')) {
-        def.resolve();
-        return def.promise();
+
+    BikaListingTableView.prototype.on_search_field_keypress = function(event) {
+
+      /*
+       * Eventhandler for the search field
+       */
+      var $el, el, form, form_id, searchfield, searchterm;
+      console.debug("°°° ListingTableView::on_search_field_keypress °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      if (event.which === 13) {
+        event.preventDefault();
+        form = $el.parents("form");
+        form_id = form.attr("id");
+        searchfield = $(".filter-search-input", form);
+        searchterm = searchfield.val();
+        return this.search(form_id, searchterm);
       }
-      ajax_categories_enabled = $('input[name=\'ajax_categories\']');
-      if (ajax_categories_enabled.length > 0 && placeholder.length > 0) {
-        options = {};
-        options['ajax_category_expand'] = 1;
-        options['cat'] = cat_title;
-        options['form_id'] = form_id;
-        url = $('input[name=\'ajax_categories_url\']').length > 0 ? $('input[name=\'ajax_categories_url\']').val() : url;
-        if ($('.review_state_selector a.selected').length > 0) {
-          options['review_state'] = $('.review_state_selector a.selected')[0].id;
-        }
-        $.ajax({
-          url: url,
-          data: options
-        }).done(function(data) {
-          var rows;
-          rows = $('<table>' + data + '</table>').find('tr');
-          $('[form_id=\'' + form_id + '\'] tr[data-ajax_category=\'' + cat_title + '\']').replaceWith(rows);
-          $(element).removeClass('collapsed').addClass('expanded');
-          def.resolve();
-          load_transitions();
-        });
-      } else {
-        $(element).parent().nextAll('tr[cat=\'' + $(element).attr('cat') + '\']').toggle(true);
-        $(element).removeClass('collapsed').addClass('expanded');
-        def.resolve();
-      }
-      return def.promise();
     };
-  };
+
+    BikaListingTableView.prototype.on_search_button_click = function(event) {
+
+      /*
+       * Eventhandler for the search field button
+       */
+      var $el, el;
+      console.debug("°°° ListingTableView::on_search_button_click °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      return this.on_search_field_keypress(event);
+    };
+
+    BikaListingTableView.prototype.on_select_all_click = function(event) {
+
+      /*
+       * Eventhandler when the select all checkbox was clicked
+       *
+       * Controls the behavior when the 'select all' checkbox is clicked.
+       * Checks/Unchecks all the row selection checkboxes and once done,
+       * re-renders the workflow action buttons from the bottom of the list,
+       * based on the allowed transitions for the currently selected items
+       */
+      var $el, checkboxes, el, table;
+      console.debug("°°° ListingTableView::on_select_all_click °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      table = $el.parents("table.bika-listing-table");
+      checkboxes = $(table).find("[id*='_cb_']");
+      $(checkboxes).prop("checked", $el.prop("checked"));
+      return this.render_transition_buttons(table);
+    };
+
+    BikaListingTableView.prototype.on_checkbox_click = function(event) {
+
+      /*
+       * Eventhandler when a Checkbox was clicked
+       *
+       * Controls the behavior when a checkbox of row selection is clicked.
+       * Updates the status of the 'select all' checkbox accordingly and also
+       * re-renders the workflow action buttons from the bottom of the list
+       * based on the allowed transitions of the currently selected items
+       */
+      var $el, all, checkall, checked, el, table;
+      console.debug("°°° ListingTableView::on_checkbox_click °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      table = $el.parents("table.bika-listing-table");
+      checked = $("input[type='checkbox'][id*='_cb_']:checked");
+      all = $("input[type='checkbox'][id*='_cb_']");
+      checkall = $(table).find("input[id*='select_all']");
+      checkall.prop("checked", checked.length === all.length);
+      return this.render_transition_buttons(table);
+    };
+
+    BikaListingTableView.prototype.on_ajax_submit_start = function(event) {
+
+      /*
+       * Eventhandler for Ajax form submit
+       */
+      return console.debug("°°° ListingTableView::on_ajax_submit_start °°°");
+    };
+
+    BikaListingTableView.prototype.on_ajax_submit_end = function(event) {
+
+      /*
+       * Eventhandler for Ajax form submit
+       */
+      return console.debug("°°° ListingTableView::on_ajax_submit_end °°°");
+    };
+
+    BikaListingTableView.prototype.on_column_header_click = function(event) {
+
+      /*
+       * Eventhandler for Table Column Header
+       */
+      var $el, el, form, form_id, sort_index;
+      console.debug("°°° ListingTableView::on_column_header_click °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      form = $el.parents("form");
+      form_id = form.attr("id");
+      sort_index = $el.attr("id").split("-")[1];
+      return this.sort_column(form_id, sort_index);
+    };
+
+    BikaListingTableView.prototype.on_show_more_click = function(event) {
+
+      /*
+       * Eventhandler for the Table "Show More" Button
+       */
+      var $el, el, form_id, limit_from, pagesize;
+      console.debug("°°° ListingTableView::on_show_more_click °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      event.preventDefault();
+      form_id = $el.attr("data-form-id");
+      pagesize = this.parse_int($el.attr("data-pagesize"));
+      limit_from = this.parse_int($el.attr("data-limitfrom"));
+      return this.show_more(form_id, pagesize, limit_from);
+    };
+
+    return BikaListingTableView;
+
+  })();
 
 }).call(this);

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -600,7 +600,8 @@
         contentType: false
       }).done(function(data) {
         table = $(table).replaceWith(data);
-        return $(".filter-search-input", form).select();
+        $(".filter-search-input", form).select();
+        return this.load_transitions();
       });
     };
 

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -372,7 +372,8 @@
         processData: false,
         contentType: false
       }).done(function(data) {
-        return $(table).replaceWith(data);
+        $(table).replaceWith(data);
+        return this.load_transitions();
       });
     };
 

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -71,19 +71,19 @@
        *
        */
       console.debug("ListingTableView::bind_eventhandler");
-      $("form[name=bika_listing_form]").on("click", "th.sortable", this.on_column_header_click);
-      $("form[name=bika_listing_form]").on("click", "a.bika_listing_show_more", this.on_show_more_click);
-      $("form[name=bika_listing_form]").on("click", "input[type='checkbox'][id*='_cb_']", this.on_checkbox_click);
-      $("form[name=bika_listing_form]").on("click", "input[id*='select_all']", this.on_select_all_click);
-      $("form[name=bika_listing_form]").on("keypress", ".filter-search-input", this.on_search_field_keypress);
-      $("form[name=bika_listing_form]").on("click", ".filter-search-button", this.on_search_button_click);
-      $("form[name=bika_listing_form]").on('contextmenu', "th[id^='foldercontents-']", this.on_contextmenu);
-      $("form[name=bika_listing_form]").on("click", "input.workflow_action_button", this.on_workflow_button_click);
-      $("form[name=bika_listing_form]").on("change", "input.autosave, select.autsave", this.on_autosave_field_change);
-      $("form[name=bika_listing_form]").on("click", "th.collapsed, th.expanded", this.on_category_header_click);
-      $("form[name=bika_listing_form]").on("change", ".listing_string_entry, .listing_select_entry", this.on_listing_entry_change);
-      $("form[name=bika_listing_form]").on("keypress", ".listing_string_entry, .listing_select_entry", this.on_listing_entry_keypress);
-      $("form[name=bika_listing_form]").on("click", "td.review_state_selector a", this.on_review_state_filter_click);
+      $("form").on("click", "th.sortable", this.on_column_header_click);
+      $("form").on("click", "a.bika_listing_show_more", this.on_show_more_click);
+      $("form").on("click", "input[type='checkbox'][id*='_cb_']", this.on_checkbox_click);
+      $("form").on("click", "input[id*='select_all']", this.on_select_all_click);
+      $("form").on("keypress", ".filter-search-input", this.on_search_field_keypress);
+      $("form").on("click", ".filter-search-button", this.on_search_button_click);
+      $("form").on('contextmenu', "th[id^='foldercontents-']", this.on_contextmenu);
+      $("form").on("click", "input.workflow_action_button", this.on_workflow_button_click);
+      $("form").on("change", "input.autosave, select.autsave", this.on_autosave_field_change);
+      $("form").on("click", "th.collapsed, th.expanded", this.on_category_header_click);
+      $("form").on("change", ".listing_string_entry, .listing_select_entry", this.on_listing_entry_change);
+      $("form").on("keypress", ".listing_string_entry, .listing_select_entry", this.on_listing_entry_keypress);
+      $("form").on("click", "td.review_state_selector a", this.on_review_state_filter_click);
       $(document).on("click", this.on_click);
       $(document).on("click", ".contextmenu tr", this.on_contextmenu_item_click);
       $(this).on("ajax:submit:start", this.on_ajax_submit_start);
@@ -310,7 +310,8 @@
         processData: false,
         contentType: false
       }).done(function(data) {
-        return $(table).replaceWith(data);
+        $(table).replaceWith(data);
+        return this.load_transitions();
       });
     };
 
@@ -319,6 +320,7 @@
       /*
        * Toggle category by form and category id
        */
+      debugger;
       var base_url, cat, cat_items, cat_url, expanded, form, form_data, placeholder, url;
       form = $("form#" + form_id);
       cat = $("th.cat_header[cat=" + cat_id + "]");
@@ -343,7 +345,9 @@
         processData: false,
         contentType: false
       }).done(function(data) {
-        placeholder.replaceWith(data);
+        var rows;
+        rows = $(data).find("tr");
+        placeholder.replaceWith(rows);
         return this.load_transitions();
       });
     };

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -320,7 +320,6 @@
       /*
        * Toggle category by form and category id
        */
-      debugger;
       var base_url, cat, cat_items, cat_url, expanded, form, form_data, placeholder, url;
       form = $("form#" + form_id);
       cat = $("th.cat_header[cat=" + cat_id + "]");
@@ -341,13 +340,12 @@
       form_data.set("form_id", form_id);
       form_data.set("ajax_category_expand", 1);
       return this.ajax_submit({
+        url: url,
         data: form_data,
         processData: false,
         contentType: false
       }).done(function(data) {
-        var rows;
-        rows = $(data).find("tr");
-        placeholder.replaceWith(rows);
+        placeholder.replaceWith(data);
         return this.load_transitions();
       });
     };

--- a/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
@@ -2,672 +2,1039 @@
     coffee --no-header -w -o ../ -c bika.lims.bikalisting.coffee
 ###
 
-###
-# Controller class for Bika Listing Table view
-###
 
-window.BikaListingTableView = ->
-    that = this
-    # To keep track if a transitions loading is taking place atm
-    loading_transitions = false
-    # Entry-point method for AnalysisServiceEditView
+class window.BikaListingTableView
+  ###
+  * Controller class for Bika Listing Table view
+  ###
 
-    show_more_clicked = ->
-        $('a.bika_listing_show_more').click (e) ->
-            e.preventDefault()
-            formid = $(this).attr('data-form-id')
-            pagesize = parseInt($(this).attr('data-pagesize'))
-            url = $(this).attr('data-ajax-url')
-            limit_from = parseInt($(this).attr('data-limitfrom'))
-            url = url.replace('_limit_from=', '_olf=')
-            url += '&' + formid + '_limit_from=' + limit_from
-            $('#' + formid + ' a.bika_listing_show_more').fadeOut()
-            tbody = $('table.bika-listing-table[form_id="' + formid + '"] tbody.item-listing-tbody')
-            # The results must be filtered?
-            filter_options = []
-            filters1 = $('.bika_listing_filter_bar input[name][value!=""]')
-            filters2 = $('.bika_listing_filter_bar select option:selected[value!=""]')
-            filters = $.merge(filters1, filters2)
-            $(filters).each (e) ->
-                opt = [
-                    $(this).attr('name')
-                    $(this).val()
-                ]
-                filter_options.push opt
-                return
-            filterbar = {}
-            if filter_options.length > 0
-                filterbar.bika_listing_filter_bar = $.toJSON(filter_options)
-            $.post(url, filterbar).done((data) ->
-                try
-                    # We must surround <tr> inside valid TABLE tags before extracting
-                    rows = $('<html><table>' + data + '</table></html>').find('tr')
-                    # Then we can simply append the rows to existing TBODY.
-                    $(tbody).append rows
-                    # Increase limit_from so that next iteration uses correct start point
-                    $('#' + formid + ' a.bika_listing_show_more').attr 'data-limitfrom', limit_from + pagesize
-                    loadNewRemarksEventHandlers()
-                catch e
-                    $('#' + formid + ' a.bika_listing_show_more').hide()
-                    console.log e
-                load_transitions()
-                return
-            ).fail(->
-                $('#' + formid + ' a.bika_listing_show_more').hide()
-                console.log 'bika_listing_show_more failed'
-                return
-            ).always ->
-                numitems = $('table.bika-listing-table[form_id="' + formid + '"] tbody.item-listing-tbody tr').length
-                $('#' + formid + ' span.number-items').html numitems
-                if numitems % pagesize == 0
-                    $('#' + formid + ' a.bika_listing_show_more').fadeIn()
-                return
-            return
-        return
+  load: =>
+    console.debug "ListingTableView::load"
 
-    loadNewRemarksEventHandlers = ->
-        # Add a baloon icon before Analyses' name when you'd add a remark. If you click on, it'll display remarks textarea.
-        $('a.add-remark').remove()
-        txt1 = '<a href="#" class="add-remark"><img src="' + window.portal_url + '/++resource++bika.lims.images/comment_ico.png" title="' + _('Add Remark') + '")"></a>'
-        pointer = $('.listing_remarks:contains(\'\')').closest('tr').prev().find('td.service_title span.before')
-        $(pointer).append txt1
-        $('a.add-remark').click (e) ->
-            e.preventDefault()
-            rmks = $(this).closest('tr').next('tr').find('td.remarks')
-            if rmks.length > 0
-                rmks.toggle()
-            return
-        $('td.remarks').hide()
-        return
+    # bind the event handler to the elements
+    @bind_eventhandler()
 
-    column_header_clicked = ->
-        # Click column header - set or modify sort order.
-        $('th.sortable').live 'click', ->
-            form = $(this).parents('form')
-            form_id = $(form).attr('id')
-            column_id = @id.split('-')[1]
-            column_index = $(this).parent().children('th').index(this)
-            sort_on_selector = '[name=' + form_id + '_sort_on]'
-            sort_on = $(sort_on_selector).val()
-            sort_order_selector = '[name=' + form_id + '_sort_order]'
-            sort_order = $(sort_order_selector).val()
-            # if this column_id is the current sort
-            if sort_on == column_id
-                # then we reverse sort order
-                if sort_order == 'descending'
-                    sort_order = 'ascending'
-                else
-                    sort_order = 'descending'
-            else
-                sort_on = column_id
-                sort_order = 'ascending'
-            # reset these values in the form (ajax sort uses them)
-            $(sort_on_selector).val sort_on
-            $(sort_order_selector).val sort_order
-            # request new table content
-            stored_form_action = $(form).attr('action')
-            $(form).attr 'action', window.location.href
-            $(form).append '<input type=\'hidden\' name=\'table_only\' value=\'' + form_id + '\'>'
-            options = 
-                target: $(this).parents('table')
-                replaceTarget: true
-                data: form.formToArray()
-            form.ajaxSubmit options
-            $('[name=\'table_only\']').remove()
-            $(form).attr 'action', stored_form_action
-            return
-        return
+    # flag to signal async wf button loading
+    @loading_transitions = no
 
+    # toggle columns cookie name
+    @toggle_cols_cookie = "toggle_cols"
+
+    # Initially load the transitions
+    @load_transitions()
+
+    # dev only
+    window.tv = @
+
+
+  ### INITIALIZERS ###
+
+  bind_eventhandler: =>
     ###
-    * Fetch allowed transitions for all the objects listed in bika_listing and
-    * sets the value for the attribute 'data-valid_transitions' for each check
-    * box next to each row.
-    * The process requires an ajax call, so the function keeps checkboxes
-    * disabled until the allowed transitions for the associated object are set.
+     * Binds callbacks on elements
+     *
+     * N.B. We attach all the events to the form and refine the selector to
+     * delegate the event: https://learn.jquery.com/events/event-delegation/
+     *
     ###
+    console.debug "ListingTableView::bind_eventhandler"
 
-    load_transitions = (blisting) ->
-        'use strict'
-        if blisting == '' or typeof blisting == 'undefined'
-            blistings = $('table.bika-listing-table')
-            $(blistings).each (i) ->
-                load_transitions $(this)
-                return
-            return
-        buttonspane = $(blisting).find('span.workflow_action_buttons')
-        if loading_transitions or $(buttonspane).length == 0
-            # If show_workflow_action_buttons param is set to False in the
-            # view, or transitions are being loaded already, do nothing
-            return
-        loading_transitions = true
-        uids = []
-        checkall = $("input[id*='select_all']")
-        $(checkall).hide()
-        # Update valid transitions for elements which have not yet been updated:
-        wo_trans = $("input[data-valid_transitions='{}']")
-        $(wo_trans).prop 'disabled', true
-        $(wo_trans).each (e) ->
-            uids.push $(this).val()
-            return
-        if uids.length > 0
-            request_data = 
-                _authenticator: $('input[name=\'_authenticator\']').val()
-                uid: $.toJSON(uids)
-            window.jsonapi_cache = window.jsonapi_cache or {}
-            $.ajax
-                type: 'POST'
-                dataType: 'json'
-                url: window.portal_url + '/@@API/allowedTransitionsFor_many'
-                data: request_data
-                success: (data) ->
-                    if 'transitions' of data
-                        i = 0
-                        while i < data.transitions.length
-                            uid = data.transitions[i].uid
-                            trans = data.transitions[i].transitions
-                            el = $("input[id*='_cb_'][value='#{uid}']")
-                            el.attr 'data-valid_transitions', $.toJSON(trans)
-                            $(el).prop 'disabled', false
-                            i++
-                        $("input[id*='select_all']").fadeIn()
-                    return
-        loading_transitions = false
-        return
+    # Table header clicked for sorting
+    $("form[name=bika_listing_form]").on "click", "th.sortable", @on_column_header_click
 
+    # Show More clickd
+    $("form[name=bika_listing_form]").on "click", "a.bika_listing_show_more", @on_show_more_click
+
+    # Single checkbox clicked
+    $("form[name=bika_listing_form]").on "click", "input[type='checkbox'][id*='_cb_']", @on_checkbox_click
+
+    # Check all checkbox clicked
+    $("form[name=bika_listing_form]").on "click", "input[id*='select_all']", @on_select_all_click
+
+    # Enter keypress in search field
+    $("form[name=bika_listing_form]").on "keypress", ".filter-search-input", @on_search_field_keypress
+
+    # Search button clicked (magnifier in search field)
+    $("form[name=bika_listing_form]").on "click", ".filter-search-button", @on_search_button_click
+
+    # Context menu
+    $("form[name=bika_listing_form]").on 'contextmenu', "th[id^='foldercontents-']", @on_contextmenu
+
+    # Workflow Button
+    $("form[name=bika_listing_form]").on "click", "input.workflow_action_button", @on_workflow_button_click
+
+    # Autosave – seems to be used by sample and analysis views
+    $("form[name=bika_listing_form]").on "change", "input.autosave, select.autsave", @on_autosave_field_change
+
+    # Category headers
+    $("form[name=bika_listing_form]").on "click", "th.collapsed, th.expanded", @on_category_header_click
+
+    # Results entry
+    $("form[name=bika_listing_form]").on "change", ".listing_string_entry, .listing_select_entry", @on_listing_entry_change
+    $("form[name=bika_listing_form]").on "keypress", ".listing_string_entry, .listing_select_entry", @on_listing_entry_keypress
+
+    # Review state filter buttons
+    $("form[name=bika_listing_form]").on "click", "td.review_state_selector a", @on_review_state_filter_click
+
+    # Document click
+    $(document).on "click", @on_click
+
+    # bind event handler for contextmenu clicks
+    $(document).on "click", ".contextmenu tr", @on_contextmenu_item_click
+
+    # Ajax form submit events
+    $(this).on "ajax:submit:start", @on_ajax_submit_start
+    $(this).on "ajax:submit:end", @on_ajax_submit_end
+
+
+  ### METHODS ###
+
+  ajax_submit: (options={}) =>
     ###
-    * Controls the behavior when a checkbox of row selection is clicked.
-    * Updates the status of the 'select all' checkbox accordingly and also
-    * re-renders the workflow action buttons from the bottom of the list
-    * based on the allowed transitions of the currently selected items
+     * Ajax Submit with automatic event triggering and some sane defaults
     ###
+    console.debug "°°° ajax_submit °°°"
 
-    select_one_clicked = ->
-        'use strict'
-        $('input[type=\'checkbox\'][id*=\'_cb_\']').live 'click', ->
-            blst = $(this).parents('table.bika-listing-table')
-            render_transition_buttons blst
-            # Modify all checkbox statuses
-            checked = $('input[type=\'checkbox\'][id*=\'_cb_\']:checked')
-            all = $('input[type=\'checkbox\'][id*=\'_cb_\']')
-            checkall = $(blst).find('input[id*=\'select_all\']')
-            checkall.prop 'checked', checked.length == all.length
-            return
-        return
+    # some sane option defaults
+    options.type ?= "POST"
+    options.url ?= window.location.href
+    options.context ?= this
 
+    console.debug ">>> ajax_submit::options=", options
+
+    $(this).trigger "ajax:submit:start"
+    done = =>
+        $(this).trigger "ajax:submit:end"
+    return $.ajax(options).done done
+
+
+  get_portal_url: =>
     ###
-    * Controls the behavior when the 'select all' checkbox is clicked.
-    * Checks/Unchecks all the row selection checkboxes and once done,
-    * re-renders the workflow action buttons from the bottom of the list,
-    * based on the allowed transitions for the currently selected items
+     * Return the portal url (calculated in code)
+    ###
+    url = $("input[name=portal_url]").val()
+    return url or window.portal_url
+
+
+  get_base_url: =>
+    ###
+     * Return the current base url
+    ###
+    url = window.location.href
+    return url.split('?')[0]
+
+
+  get_authenticator: =>
+    ###
+     * Get the authenticator value
+    ###
+    return $("input[name='_authenticator']").val()
+
+
+  get_cookie: (name) =>
+    ###
+     * read the value of the cookie
+    ###
+    name = "#{name}="
+    cookies = document.cookie.split ";"
+
+    i = 0
+    while i < cookies.length
+      c = cookies[i]
+      while c.charAt(0) == " "
+        c = c.substring(1, c.length)
+      if c.indexOf(name) == 0
+        return unescape(c.substring(name.length, c.length))
+      i = i + 1
+    return null
+
+
+  set_cookie: (name, value, days) =>
+    ###
+     * set the value of the cookie
+    ###
+    if days
+      date = new Date
+      date.setTime date.getTime() + days * 24 * 60 * 60 * 1000
+      expires = date.toGMTString()
+    else
+      expires = ""
+    cookie = "#{name}=#{escape(value)}; expires=#{expires}; path=/;"
+    document.cookie = cookie
+    return true
+
+
+  get_toggle_cookie_key: (form_id) =>
+    ###
+     * Make a unique toggle cookie key for the current listing site
+    ###
+    portal_type = $("##{form_id} input[name=portal_type]").val()
+    return "#{portal_type}#{form_id}"
+
+
+  toggle_sort_order: (sort_order) =>
+    ###
+     * Toggle the sort_order value
+    ###
+    if sort_order == "ascending"
+      return "descending"
+    return "ascending"
+
+
+  get_toggle_cols: (form_id) =>
+    ###
+     * Get the value of the toggle cols input field
+    ###
+    toggle_cols = $("##{form_id}_toggle_cols")
+    if toggle_cols.length == 0
+      return {}
+    return $.parseJSON toggle_cols.val()
+
+
+  toggle_column: (form_id, col_id) =>
+    ###
+     * Toggle column by form and column id
     ###
 
-    select_all_clicked = ->
-        'use strict'
-        # select all (on this page at least)
-        $('input[id*=\'select_all\']').live 'click', ->
-            blst = $(this).parents('table.bika-listing-table')
-            checkboxes = $(blst).find('[id*=\'_cb_\']')
-            $(checkboxes).prop 'checked', $(this).prop('checked')
-            render_transition_buttons blst
-            return
-        return
+    # get the form object
+    form = $("form##{form_id}")
+    # get the listing table within the form
+    table = $("table.bika-listing-table", form)
+    # get the toggle column settings of this page
+    toggle_cols = @get_toggle_cols form_id
+    # read the current value of the toggle cookie
+    cookie = $.parseJSON(@get_cookie(@toggle_cols_cookie) or "{}")
+    # get the right key for this page
+    cookie_key = @get_toggle_cookie_key form_id
+    # current set columns
+    columns = cookie[cookie_key]
 
+    # initialize columns if not yet set
+    if !columns
+      columns = []
+      $.each toggle_cols, (name, record) ->
+        # only append current visible columns
+        if $("#foldercontents-#{name}-column").length > 0
+          columns.push name
+
+    # Set default toggle columns
+    if col_id == _('Default')
+      console.debug "*** Set DEFAULT toggle columns ***"
+      # delete the settings for this page
+      delete cookie[cookie_key]
+
+    # Set all toggle columns
+    else if col_id == _('All')
+      console.debug "*** Set ALL toggle columns ***"
+      # add all possible columns which have the toggle state
+      all_cols = []
+      $.each toggle_cols, (name, record) ->
+        all_cols.push name
+      # set the cookie with the updated value
+      cookie[cookie_key] = all_cols
+
+    # Toggle individual columns
+    else
+      if col_id not of toggle_cols
+        console.warn "Invalid column name: '#{col_id}'"
+        return
+      if columns.indexOf(col_id) > -1
+        # toggle off
+        console.debug "*** Toggle #{col_id} OFF ***"
+        columns.splice columns.indexOf(col_id), 1
+      else
+        # toggle on
+        console.debug "*** Toggle #{col_id} ON ***"
+        columns.push col_id
+      # set the cookie with the updated value
+      cookie[cookie_key] = columns
+
+    # set the toggle config cookie
+    @set_cookie @toggle_cols_cookie, $.toJSON(cookie), 365
+
+    # prepare the form data
+    form_data = new FormData form[0]
+    form_data.set "table_only", form_id
+
+    # send the new data to the server
+    @ajax_submit
+      data: form_data
+      processData: no  # do not transform to a query string
+      contentType: no # do not set any content type header
+    .done (data) ->
+      $(table).replaceWith data
+      table = $("table.bika-listing-table", form)
+      tooltip = $(".tooltip")
+      # re-render the tooltip
+      if tooltip.length > 0
+        style = tooltip.attr "style"
+        menu = @make_context_menu table
+        menu = $(menu).appendTo "body"
+        menu.attr "style", style
+
+
+  sort_column: (form_id, sort_index) =>
     ###
-    * Re-generates the workflow action buttons from the bottom of the list in
-    * accordance with the allowed transitions for the currently selected items.
-    * This is, makes the intersection within all allowed transitions and adds
-    * the corresponding buttons to the workflow action bar.
+     * Sort column by form and sort index
     ###
 
-    render_transition_buttons = (blst) ->
-        'use strict'
-        buttonspane = $(blst).find('span.workflow_action_buttons')
-        if $(buttonspane).length == 0
-            # If show_workflow_action_buttons param is set to False in the
-            # view, do nothing
-            return
-        allowed_transitions = []
-        # hidden_transitions and restricted are hidden fields
-        # containing comma separated list of transition IDs.
-        hidden_transitions = $(blst).find('input[id="hide_transitions"]')
-        hidden_transitions = if $(hidden_transitions).length == 1 then $(hidden_transitions).val() else ''
-        hidden_transitions = if hidden_transitions == '' then [] else hidden_transitions.split(',')
-        restricted_transitions = $(blst).find('input[id="restricted_transitions"]')
-        restricted_transitions = if $(restricted_transitions).length == 1 then $(restricted_transitions).val() else ''
-        restricted_transitions = if restricted_transitions == '' then [] else restricted_transitions.split(',')
-        checked = $(blst).find("input[id*='_cb_']:checked")
+    # get the form object
+    form = $("form##{form_id}")
+    # get the listing table within the form
+    table = $("table.bika-listing-table", form)
 
-        $(checked).each (e) ->
-            transitions = $.parseJSON($(this).attr('data-valid_transitions'))
-            if ! transitions.length
-                return
-            # Do not want transitions other than those defined in bikalisting
-            if restricted_transitions.length > 0
-                transitions = transitions.filter (el) ->
-                    return restricted_transitions.indexOf(el.id) > -1
-            # Do not show hidden transitions
-            if hidden_transitions.length > 0
-                transitions = transitions.filter (el) ->
-                    return hidden_transitions.indexOf(el.id) < 0
-            # We only want the intersection within all selected items
-            if allowed_transitions.length > 0
-                transitions = transitions.filter (el) ->
-                    return allowed_transitions.indexOf(el) > -1
-            else
-                allowed_transitions = transitions
-            # and the inverse of the intersection
-            if transitions.length > 0
-                allowed_transitions = allowed_transitions.filter (el) ->
-                    return transitions.indexOf(el) > -1
-            return
+    # hidden input fields which holds the current sort_on value
+    sort_on = $("[name=#{form_id}_sort_on]")
+    # hidden input field which holds the current sort_order value
+    sort_order = $("[name=#{form_id}_sort_order]")
+    # current sort_on value
+    sort_on_value = sort_on.val()
+    # current sort_order value
+    sort_order_value = sort_order.val()
 
-        # Generate the action buttons
-        $(buttonspane).html ''
-        i = 0
-        while i < allowed_transitions.length
-            trans = allowed_transitions[i]
-            _button = "<input id='#{trans['id']}_transition'
-                       class='context workflow_action_button action_button allowMultiSubmit'
-                       type='submit'
-                       value='#{PMF(trans['title'])}'
-                       transition='#{trans['id']}'
-                       name='workflow_action_button'/>&nbsp;"
-            $(buttonspane).append _button
-            i++
-        # Add now custom actions
-        if $(checked).length > 0
-            custom_transitions = $(blst).find('input[type="hidden"].custom_transition')
-            $(custom_transitions).each (i, e) ->
-                _trans = $(e).val()
-                _url = $(e).attr('url')
-                _title = $(e).attr('title')
-                _button = "<input id='#{_trans}_transition'
-                           class='context workflow_action_button action_button allowMultiSubmit'
-                           type='submit'
-                           url='#{_url}'
-                           value='#{_title}'
-                           transition='#{_trans}'
-                           name='workflow_action_button'/>&nbsp;"
-                $(buttonspane).append _button
-                return
+    # update sort_on value
+    sort_on.val sort_index
+    # update sort_order value
+    sort_order.val @toggle_sort_order sort_order_value
+
+    # prepare the form data
+    form_data = new FormData form[0]
+    form_data.set "table_only", form_id
+
+    @ajax_submit
+      data: form_data
+      processData: no  # do not transform to a query string
+      contentType: no # do not set any content type header
+    .done (data) ->
+      $(table).replaceWith data
+
+
+  toggle_category: (form_id, cat_id) =>
+    ###
+     * Toggle category by form and category id
+    ###
+
+    # get the form object
+    form = $("form##{form_id}")
+
+    cat = $("th.cat_header[cat=#{cat_id}]")
+    placeholder = $("tr[data-ajax_category=#{cat_id}")
+    expanded = cat.hasClass "expanded"
+    cat_items = $("tr[cat=#{cat_id}]")
+
+    # Toggle expand/collapsed class
+    cat.toggleClass "expanded collapsed"
+
+    # Just hide/show if the items are already loaded
+    if cat_items.length > 0
+      console.debug "ListingTableView::toggle_category: Category #{cat_id} is already expanded -> Toggle only"
+      cat_items.toggle()
+      return
+
+    # load the items asynchronous
+    cat_url = $("input[name=ajax_categories_url]").val()
+    base_url = @get_base_url()
+    url = cat_url or base_url
+
+    # prepare a new form data
+    form_data = new FormData()
+    form_data.set "cat", cat_id
+    form_data.set "form_id", form_id
+    form_data.set "ajax_category_expand", 1
+
+    # send the new data to the server
+    @ajax_submit
+      data: form_data
+      processData: no  # do not transform to a query string
+      contentType: no # do not set any content type header
+    .done (data) ->
+      # replace the placeholder with the loaded rows
+      placeholder.replaceWith data
+      @load_transitions()
+
+
+  filter_state: (form_id, state_id) =>
+    ###
+     * Filter listing by review_state
+    ###
+
+    # get the form object
+    form = $("form##{form_id}")
+    table = $("table.bika-listing-table", form)
+
+    input_name = "#{form_id}_review_state"
+    input = $("input[name=#{input_name}]", form)
+    if input.length == 0
+      input = form.append "<input name='#{input_name}' type='hidden'/>"
+    input.val state_id
+
+    # prepare the form data
+    form_data = new FormData form[0]
+    form_data.set "table_only", form_id
+    form_data.set "#{form_id}_review_state", state_id
+
+    @ajax_submit
+      data: form_data
+      processData: no  # do not transform to a query string
+      contentType: no # do not set any content type header
+    .done (data) ->
+      $(table).replaceWith data
+
+
+  show_more: (form_id, pagesize, limit_from) =>
+    ###
+     * Show more
+    ###
+
+    # get the form object
+    form = $("form##{form_id}")
+    table = $("table.bika-listing-table", form)
+    tbody = $("tbody.item-listing-tbody", table)
+    show_more = $("##{form_id} a.bika_listing_show_more")
+
+    # sane defaults
+    pagesize ?= 30
+    limit_from ?= 0
+
+    # prepare the form data
+    form_data = new FormData form[0]
+    form_data.set "rows_only", form_id
+    form_data.set "#{form_id}_pagesize", pagesize
+    form_data.set "#{form_id}_limit_from", limit_from
+
+    # Advanced filter bar options
+    filter_options = []
+    filters1 = $(".bika_listing_filter_bar input[name][value!='']")
+    filters2 = $(".bika_listing_filter_bar select option:selected[value!='']")
+    filters = $.merge(filters1, filters2)
+    $(filters).each (e) ->
+      filter_options.push [
+        $(this).attr('name')
+        $(this).val()
+      ]
+    if filter_options.length > 0
+      form_data.set "bika_listing_filter_bar", $.toJSON(filter_options)
+
+    show_more.fadeOut()
+    @ajax_submit
+      data: form_data
+      processData: no  # do not transform to a query string
+      contentType: no # do not set any content type header
+    .done (data) ->
+      # filter out all <tr> elements
+      rows = $(data).filter "tr"
+      # probably further pages exist when this returns 0
+      if rows.length % pagesize == 0
+        show_more.fadeIn()
+      # flush the whole table when there is no limit from
+      if limit_from == 0
+        $(tbody).empty()
+      $(tbody).append rows
+      # update the counter with the number of rendered rows
+      numitems = $("table.bika-listing-table[form_id=#{form_id}] tbody.item-listing-tbody tr").length
+      $("##{form_id} span.number-items").html numitems
+      # update the show more control
+      show_more.attr "data-limitfrom", numitems
+      show_more.attr "data-pagesize", pagesize
+      # reload the transitions
+      @load_transitions()
+
+
+  parse_int: (thing, fallback=0) =>
+    ###
+     * Safely parse to an integer
+    ###
+    number = parseInt thing
+    return number or fallback
+
+
+  load_transitions: (table) ->
+    ###
+     * Fetch allowed transitions for all the objects listed in bika_listing and
+     * sets the value for the attribute 'data-valid_transitions' for each check
+     * box next to each row.
+     * The process requires an ajax call, so the function keeps checkboxes
+     * disabled until the allowed transitions for the associated object are set.
+    ###
+
+    self = this
+
+    # Recursively call for all listing tables of the current page
+    if !table
+      $("table.bika-listing-table").each (index) ->
+        self.load_transitions this
+
+    # The listing table object
+    $table = $(table)
+
+    wf_buttons = $(table).find("span.workflow_action_buttons")
+    if @loading_transitions or $(wf_buttons).length == 0
+        # If show_workflow_action_buttons param is set to False in the
+        # view, or transitions are being loaded already, do nothing
         return
 
-    listing_string_input_keypress = ->
-        'use strict'
-        $('.listing_string_entry,.listing_select_entry').live 'keypress', (event) ->
-            # Prevent automatic submissions of manage_results forms when enter is pressed
-            enter = 13
-            if event.which == enter
-                event.preventDefault()
-            # check the item's checkbox
-            uid = $(this).attr('uid')
-            tr = $(this).parents('tr#folder-contents-item-' + uid)
-            checkbox = tr.find('input[id$="_cb_' + uid + '"]')
-            if $(checkbox).length == 1
-                blst = $(checkbox).parents('table.bika-listing-table')
-                $(checkbox).prop 'checked', true
-                render_transition_buttons blst
-            return
+    uids = []
+    checkall = $("input[id*='select_all']", $table)
+
+    $(checkall).hide()
+
+    # Update valid transitions for elements which have not yet been updated:
+    wo_trans = $("input[data-valid_transitions='{}']")
+
+    $(wo_trans).prop "disabled", yes
+    $(wo_trans).each (e) ->
+      uids.push $(this).val()
+
+    if uids.length == 0
+      return
+
+    # load possible transitions
+    @loading_transitions = yes
+    @ajax_submit
+      url: "#{@get_portal_url()}/@@API/allowedTransitionsFor_many"
+      data:
+        _authenticator: @get_authenticator()
+        uid: $.toJSON(uids)
+    .done (data) ->
+      @loading_transitions = no
+      $("input[id*='select_all']").fadeIn()
+
+      # setting a data attribute on each checkbox
+      if "transitions" of data
+        $.each data.transitions, (index, record) ->
+          uid = record.uid
+          trans = record.transitions
+          checkbox = $("input[id*='_cb_'][value='#{uid}']")
+          checkbox.attr "data-valid_transitions", $.toJSON(trans)
+          $(checkbox).prop "disabled", false
+
+
+  render_transition_buttons: (table) ->
+    ### Render workflow transition buttons to the table
+     *
+     * Re-generates the workflow action buttons from the bottom of the list in
+     * accordance with the allowed transitions for the currently selected items.
+     * This is, makes the intersection within all allowed transitions and adds
+     * the corresponding buttons to the workflow action bar.
+    ###
+
+    # reference to this instance
+    self = this
+
+    wf_buttons = $(table).find("span.workflow_action_buttons")
+    if $(wf_buttons).length == 0
+        # If `show_workflow_action_buttons` param is set to False in the view,
+        # do nothing
         return
 
-    listing_string_select_changed = ->
-        # always select checkbox when selectable listing item is changed
-        $('.listing_select_entry').live 'change', ->
-            uid = $(this).attr('uid')
-            tr = $(this).parents('tr#folder-contents-item-' + uid)
-            checkbox = tr.find('input[id$="_cb_' + uid + '"]')
-            if $(checkbox).length == 1
-                blst = $(checkbox).parents('table.bika-listing-table')
-                $(checkbox).prop 'checked', true
-                render_transition_buttons blst
-            return
+    allowed_transitions = []
+
+    # hidden_transitions and restricted are hidden fields containing comma
+    # separated list of transition IDs.
+    hidden_transitions = $(table).find("input[id='hide_transitions']")
+    hidden_transitions = if $(hidden_transitions).length == 1 then $(hidden_transitions).val() else ''
+    hidden_transitions = if hidden_transitions == '' then [] else hidden_transitions.split(',')
+
+    restricted_transitions = $(table).find("input[id='restricted_transitions']")
+    restricted_transitions = if $(restricted_transitions).length == 1 then $(restricted_transitions).val() else ''
+    restricted_transitions = if restricted_transitions == '' then [] else restricted_transitions.split(',')
+
+    checked = $(table).find("input[id*='_cb_']:checked")
+
+    $(checked).each (index) ->
+      transitions = $.parseJSON($(this).attr("data-valid_transitions"))
+      if ! transitions.length
         return
 
-    pagesize_change = ->
-        # pagesize
-        $('select.pagesize').live 'change', ->
-            form = $(this).parents('form')
-            form_id = $(form).attr('id')
-            pagesize = $(this).val()
-            new_query = $.query.set(form_id + '_pagesize', pagesize).set(form_id + '_pagenumber', 1).toString()
-            window.location = window.location.href.split('?')[0] + new_query
-            return
-        return
+      # Do not want transitions other than those defined in bikalisting
+      if restricted_transitions.length > 0
+        transitions = transitions.filter (el) ->
+          return restricted_transitions.indexOf(el.id) > -1
 
-    category_header_clicked = ->
-        # expand/collapse categorised rows
-        $('.bika-listing-table th.collapsed').live 'click', ->
-            if !$(this).hasClass('ignore_bikalisting_default_handler')
-                that.category_header_expand_handler this
-            return
-        $('.bika-listing-table th.expanded').live 'click', ->
-            if !$(this).hasClass('ignore_bikalisting_default_handler')
-                # After ajax_category expansion, collapse and expand work as they would normally.
-                $(this).parent().nextAll('tr[cat=\'' + $(this).attr('cat') + '\']').toggle()
-                if $(this).hasClass('expanded')
-                    # Set collapsed class on TR
-                    $(this).removeClass('expanded').addClass 'collapsed'
-                else if $(this).hasClass('collapsed')
-                    # Set expanded class on TR
-                    $(this).removeClass('collapsed').addClass 'expanded'
-            return
-        return
+      # Do not show hidden transitions
+      if hidden_transitions.length > 0
+        transitions = transitions.filter (el) ->
+          return hidden_transitions.indexOf(el.id) < 0
 
-    filter_search_keypress = ->
-        # pressing enter on filter search will trigger
-        # a click on the search link.
-        $('.filter-search-input').live 'keypress', (event) ->
-            enter = 13
-            if event.which == enter
-                $('.filter-search-button').click()
-                return false
-            return
-        return
+      # We only want the intersection within all selected items
+      if allowed_transitions.length > 0
+        transitions = transitions.filter (el) ->
+          return allowed_transitions.indexOf(el) > -1
+      else
+        allowed_transitions = transitions
+        # and the inverse of the intersection
+        if transitions.length > 0
+          allowed_transitions = allowed_transitions.filter (el) ->
+            return transitions.indexOf(el) > -1
 
-    filter_search_button_click = ->
-        # trap the Clear search / Search buttons
-        $('.filter-search-button').live 'click', (event) ->
-            form = $(this).parents('form')
-            form_id = $(form).attr('id')
-            stored_form_action = $(form).attr('action')
-            $(form).attr 'action', window.location.href
-            $(form).append '<input type=\'hidden\' name=\'table_only\' value=\'' + form_id + '\'>'
-            table = $(this).parents('table')
-            url = window.location.href
-            $.post(url, form.formToArray()).done((data) ->
-                $(table).html(data)
-                load_transitions()
-                show_more_clicked()
-                return
-            )
-            $('[name="table_only"]').remove()
-            $(form).attr 'action', stored_form_action
-            false
-        return
+    # Flush existing Workflow buttons
+    $(wf_buttons).html ""
 
-    workflow_action_button_click = ->
-        # Workflow Action button was clicked.
-        $('.workflow_action_button').live 'click', (event) ->
-            # The submit buttons would like to put the translated action title
-            # into the request. Insert the real action name here to prevent the
-            # WorkflowAction handler from having to look it up (painful/slow).
-            form = $(this).parents('form')
-            form_id = $(form).attr('id')
-            $(form).append '<input type=\'hidden\' name=\'workflow_action_id\' value=\'' + $(this).attr('transition') + '\'>'
-            # This submit_transition cheat fixes a bug where hitting submit caused
-            # form to be posted before ajax calculation is returned
-            if @id == 'submit_transition'
-                focus = $('.ajax_calculate_focus')
-                if focus.length > 0
-                    e = $(focus[0])
-                    if $(e).attr('focus_value') == $(e).val()
-                        # value did not change - transparent blur handler.
-                        $(e).removeAttr 'focus_value'
-                        $(e).removeClass 'ajax_calculate_focus'
-                    else
-                        # The calcs.js code is now responsible for submitting
-                        # this form when the calculation ajax is complete
-                        $(e).parents('form').attr 'submit_after_calculation', 1
-                        event.preventDefault()
-            # If a custom_transitions action with a URL is clicked
-            # the form will be submitted there
-            if $(this).attr('url') != ''
-                form = $(this).parents('form')
-                $(form).attr 'action', $(this).attr('url')
-                $(form).submit()
-            return
-        return
+    # Generate the action buttons
+    $.each allowed_transitions, (index, record) ->
+      transition = record.id
+      url = ""
+      value = PMF(record.title)
+      button = self.make_wf_button transition, url, value
+      $(wf_buttons).append button
 
-    column_toggle_context_menu = ->
-        # show / hide columns - the right-click pop-up
-        $('th[id^="foldercontents-"]').live 'contextmenu', (event) ->
-            event.preventDefault()
-            form_id = $(this).parents('form').attr('id')
-            portal_url = window.portal_url
-            toggle_cols = $('#' + form_id + '_toggle_cols').val()
-            if toggle_cols == '' or toggle_cols == undefined or toggle_cols == null
-                return false
-            sorted_toggle_cols = []
-            $.each $.parseJSON(toggle_cols), (col_id, v) ->
-                v['id'] = col_id
-                sorted_toggle_cols.push v
-                return
-            sorted_toggle_cols.sort (a, b) ->
-                titleA = a['title'].toLowerCase()
-                titleB = b['title'].toLowerCase()
-                if titleA < titleB
-                    return -1
-                if titleA > titleB
-                    return 1
-                0
-            txt = '<div class="tooltip"><table class="contextmenu" cellpadding="0" cellspacing="0">'
-            txt = txt + '<tr><th colspan=\'2\'>' + _('Display columns') + '</th></tr>'
-            i = 0
-            while i < sorted_toggle_cols.length
-                col = sorted_toggle_cols[i]
-                col_id = col['id']
-                col_title = _(col['title'])
-                enabled = $('#foldercontents-' + col_id + '-column')
-                if enabled.length > 0
-                    txt = txt + '<tr class=\'enabled\' col_id=\'' + col_id + '\' form_id=\'' + form_id + '\'>'
-                    txt = txt + '<td>'
-                    txt = txt + '<img style=\'height:1em;\' src=\'' + portal_url + '/++resource++bika.lims.images/ok.png\'/>'
-                    txt = txt + '</td>'
-                    txt = txt + '<td>' + col_title + '</td></tr>'
-                else
-                    txt = txt + '<tr col_id=\'' + col_id + '\' form_id=\'' + form_id + '\'>'
-                    txt = txt + '<td>&nbsp;</td>'
-                    txt = txt + '<td>' + col_title + '</td></tr>'
-                i++
-            txt = txt + '<tr col_id=\'' + _('All') + '\' form_id=\'' + form_id + '\'>'
-            txt = txt + '<td style=\'border-top:1px solid #ddd\'>&nbsp;</td>'
-            txt = txt + '<td style=\'border-top:1px solid #ddd\'>' + _('All') + '</td></tr>'
-            txt = txt + '<tr col_id=\'' + _('Default') + '\' form_id=\'' + form_id + '\'>'
-            txt = txt + '<td>&nbsp;</td>'
-            txt = txt + '<td>' + _('Default') + '</td></tr>'
-            txt = txt + '</table></div>'
-            $(txt).appendTo 'body'
-            positionTooltip event
-            false
-        return
+    # Add now custom actions
+    if $(checked).length > 0
+      custom_transitions = $(table).find("input[type='hidden'].custom_transition")
 
-    column_toggle_context_menu_selection = ->
-        # show / hide columns - the action when a column is clicked in the menu
-        $('.contextmenu tr').live 'click', (event) ->
-            form_id = $(this).attr('form_id')
-            form = $('form#' + form_id)
-            col_id = $(this).attr('col_id')
-            col_title = $(this).text()
-            enabled = $(this).hasClass('enabled')
-            cookie = readCookie('toggle_cols')
-            cookie = $.parseJSON(cookie)
-            cookie_key = $(form[0].portal_type).val() + form_id
-            if cookie == null or cookie == undefined
-                cookie = {}
-            if col_id == _('Default')
-                # Remove entry from existing cookie if there is one
-                delete cookie[cookie_key]
-                createCookie 'toggle_cols', $.toJSON(cookie), 365
-            else if col_id == _('All')
-                # add all possible columns
-                toggle_cols = []
-                $.each $.parseJSON($('#' + form_id + '_toggle_cols').val()), (i, v) ->
-                    toggle_cols.push i
-                    return
-                cookie[cookie_key] = toggle_cols
-                createCookie 'toggle_cols', $.toJSON(cookie), 365
-            else
-                toggle_cols = cookie[cookie_key]
-                if toggle_cols == null or toggle_cols == undefined
-                    # this cookie key not yet defined
-                    toggle_cols = []
-                    $.each $.parseJSON($('#' + form_id + '_toggle_cols').val()), (i, v) ->
-                        if !(col_id == i and enabled) and v['toggle']
-                            toggle_cols.push i
-                        return
-                else
-                    # modify existing cookie
-                    if enabled
-                        toggle_cols.splice toggle_cols.indexOf(col_id), 1
-                    else
-                        toggle_cols.push col_id
-                cookie[cookie_key] = toggle_cols
-                createCookie 'toggle_cols', $.toJSON(cookie), 365
-            $(form).attr 'action', window.location.href
-            $('.tooltip').remove()
-            form.submit()
-            false
-        return
+      $.each custom_transitions, (index, element) ->
+        transition = $(element).val()
+        url = $(element).attr "url"
+        value = $(element).attr "title"
+        button = self.make_wf_button transition, url, value
+        $(wf_buttons).append button
 
-    positionTooltip = (event) ->
-        tPosX = event.pageX - 5
-        tPosY = event.pageY - 5
-        $('div.tooltip').css
-            'border': '1px solid #fff'
-            'border-radius': '.25em'
-            'background-color': '#fff'
-            'position': 'absolute'
-            'top': tPosY
-            'left': tPosX
-        return
 
-    autosave = ->
+  make_wf_button: (transition, url, value) ->
+    ###
+     * Make a workflow button
+    ###
+    button = "<input id='#{transition}_transition'
+                     class='context workflow_action_button action_button allowMultiSubmit'
+                     type='submit'
+                     url='#{url}'
+                     value='#{value}'
+                     transition='#{transition}'
+                     name='workflow_action_button'/>&nbsp;"
+    return button
 
-        ###
-        This function looks for the column defined as 'autosave' and if
-        its value is true, the result of this input will be saved after each
-        change via ajax.
-        ###
 
-        $('select.autosave, input.autosave').not('[type="hidden"]').each (i) ->
-            # Save select fields
-            $(this).change ->
-                pointer = this
-                build_typical_save_request pointer
-                return
-            return
-        return
+  search: (form_id, searchterm) ->
+    ###
+     * Search in table and expand the rows
+    ###
 
-    build_typical_save_request = (pointer) ->
+    # get the form object
+    form = $("form##{form_id}")
+    form_id = form.attr "id"
+    table = $("table.bika-listing-table", form)
 
-        ###
-        # Build an array with the data to be saved for the typical data fields.
-        # @pointer is the object which has been modified and we want to save its new data.
-        ###
+    form_data = new FormData form[0]
+    form_data.set "table_only", form_id
+    form_data.set "#{form_id}_filter", searchterm
 
-        fieldvalue = undefined
-        fieldname = undefined
-        requestdata = {}
-        uid = undefined
-        tr = undefined
-        fieldvalue = $(pointer).val()
-        if $(pointer).is(':checkbox')
-            fieldvalue = $(pointer).is(':checked')
-        fieldname = $(pointer).attr('field')
-        tr = $(pointer).closest('tr')
-        uid = $(pointer).attr('uid')
-        requestdata[fieldname] = fieldvalue
-        requestdata['obj_uid'] = uid
-        save_elements requestdata, tr
-        return
+    @ajax_submit
+      data: form_data
+      processData: no  # do not transform to a query string
+      contentType: no # do not set any content type header
+    .done (data) ->
+      # replace table with server data
+      table = $(table).replaceWith data
+      # focus on the search field
+      $(".filter-search-input", form).select()
 
-    save_elements = (requestdata, tr) ->
 
-        ###
-        # Given a dict with a fieldname and a fieldvalue, save this data via ajax petition.
-        # @requestdata should has the format {fieldname=fieldvalue, uid=xxxx} -> { ReportDryMatter=false, uid=xxx}.
-        ###
+  make_context_menu: (table) ->
+    ###
+     * Build context menu HTML
+    ###
+    console.debug "°°° ListingTableView::make_context_menu °°°"
 
-        url = window.location.href.replace('/base_view', '')
-        # Staff for the notification
-        name = $(tr).attr('title')
-        $.ajax(
-            type: 'POST'
-            url: window.portal_url + '/@@API/update'
-            data: requestdata).done((data) ->
-            #success alert
-            if data != null and data['success'] == true
-                bika.lims.SiteView.notificationPanel name + ' updated successfully', 'succeed'
-            else
-                bika.lims.SiteView.notificationPanel 'Error while updating ' + name, 'error'
-                msg = 'Error while updating ' + name
-                console.warn msg
-                window.bika.lims.error msg
-            return
-        ).fail ->
-            #error
-            bika.lims.SiteView.notificationPanel 'Error while updating ' + name, 'error'
-            msg = 'Error while updating ' + name
-            console.warn msg
-            window.bika.lims.error msg
-            return
-        return
+    # remove any existing tooltip
+    $(".tooltip").remove()
 
-    that.load = ->
-        column_header_clicked()
-        load_transitions()
-        select_one_clicked()
-        select_all_clicked()
-        listing_string_input_keypress()
-        listing_string_select_changed()
-        pagesize_change()
-        category_header_clicked()
-        filter_search_keypress()
-        filter_search_button_click()
-        workflow_action_button_click()
-        column_toggle_context_menu()
-        column_toggle_context_menu_selection()
-        show_more_clicked()
-        autosave()
-        $('*').click ->
-            if $('.tooltip').length > 0
-                $('.tooltip').remove()
-            return
-        return
+    form = $(table).parents "form"
+    form_id = form.attr "id"
+    portal_url = @get_portal_url()
 
-    that.category_header_expand_handler = (element) ->
-        # element is the category header TH.
-        # duplicated in bika.lims.analysisrequest.add_by_col.js
-        def = $.Deferred()
-        # with form_id allow multiple ajax-categorised tables in a page
-        form_id = $(element).parents('[form_id]').attr('form_id')
-        cat_title = $(element).attr('cat')
-        # URL can be provided by bika_listing classes, with ajax_category_url attribute.
-        url = if $('input[name=\'ajax_categories_url\']').length > 0 then $('input[name=\'ajax_categories_url\']').val() else window.location.href.split('?')[0]
-        # We will replace this element with downloaded items:
-        placeholder = $('tr[data-ajax_category=\'' + cat_title + '\']')
-        # If it's already been expanded, ignore
-        if $(element).hasClass('expanded')
-            def.resolve()
-            return def.promise()
-        # If ajax_categories are enabled, we need to go request items now.
-        ajax_categories_enabled = $('input[name=\'ajax_categories\']')
-        if ajax_categories_enabled.length > 0 and placeholder.length > 0
-            options = {}
-            options['ajax_category_expand'] = 1
-            options['cat'] = cat_title
-            options['form_id'] = form_id
-            url = if $('input[name=\'ajax_categories_url\']').length > 0 then $('input[name=\'ajax_categories_url\']').val() else url
-            if $('.review_state_selector a.selected').length > 0
-                # review_state must be kept the same after items are loaded
-                # (TODO does this work?)
-                options['review_state'] = $('.review_state_selector a.selected')[0].id
-            $.ajax(
-                url: url
-                data: options).done (data) ->
-                # The same as: LIMS-1970 Analyses from AR Add form not displayed properly
-                rows = $('<table>' + data + '</table>').find('tr')
-                $('[form_id=\'' + form_id + '\'] tr[data-ajax_category=\'' + cat_title + '\']').replaceWith rows
-                $(element).removeClass('collapsed').addClass 'expanded'
-                def.resolve()
-                load_transitions()
-                return
+    # toggle'able columns are stored in a hidden input field, e.g.
+    # {"getStorageLocation": {"index": "getStorageLocationTitle",
+    #  "toggle": false, "sortable": true, "title": "Storage Location"}, ...}
+    toggle_cols = $("##{form_id}_toggle_cols")
+
+    # return if the data was not found
+    if !toggle_cols.val()
+      console.warn "Could not get toggle column info from input field #{toggle_cols}"
+      return false
+
+    sorted_toggle_cols = []
+
+    $.each $.parseJSON(toggle_cols.val()), (column, record) ->
+      record.id = column
+      record.title = _(record.title) or _(record.id)
+      sorted_toggle_cols.push record
+      return
+
+    sorted_toggle_cols.sort (a, b) ->
+        titleA = a.title.toLowerCase()
+        titleB = b.title.toLowerCase()
+        if titleA < titleB
+            return -1
+        if titleA > titleB
+            return 1
+        return 0
+
+    toggleable_columns = ""
+    $.each sorted_toggle_cols, (index, record) ->
+      column_exists = $("#foldercontents-#{record.id}-column")
+      if column_exists.length > 0
+        col = """<tr class="enabled" col_id="#{record.id}" form_id="#{form_id}">
+          <td>&#10003;</td>
+          <td>#{record.title or record.id}</td>
+        </tr>
+        """
+      else
+        col = """<tr col_id=#{record.id} form_id="#{form_id}">
+          <td>&nbsp;</td>
+          <td>#{record.title or record.id}</td>
+        </tr>
+        """
+      # append row to list
+      toggleable_columns += col
+
+    # Note: This markup is bootstrap ready:
+    #       http://getbootstrap.com/docs/3.3/javascript/#tooltips
+    menu = """<div class="tooltip bottom">
+      <div class="tooltip-inner">
+        <table class="contextmenu" cellpadding="0" cellspacing="0">
+          <tr>
+            <th colspan="2">#{_("Display columns")}</th>
+          </tr>
+          #{toggleable_columns}
+          <tr col_id="#{_("All")}" form_id="#{form_id}">
+            <td style="border-top:1px solid #ddd;">&nbsp;</td>
+            <td style="border-top:1px solid #ddd;">#{_("All")}</td>
+          </tr>
+          <tr col_id="#{_("Default")}" form_id="#{form_id}">
+            <td>&nbsp;</td>
+            <td>#{_("Default")}</td>
+          </tr>
+        </table>
+      </div>
+      <div class="tooltip-arrow"></div>
+    </div>
+    """
+
+    return menu
+
+
+  ### EVENT HANDLER ###
+
+  on_click: (event) =>
+    ###
+     * Eventhandler for all clicks
+    ###
+    el = $(event.target)
+
+    # dismiss the tooltip
+    if el.parents(".tooltip").length == 0
+      $(".tooltip").remove()
+
+
+  on_review_state_filter_click: (event) =>
+    ###
+     * Eventhandler for review state filter buttons
+    ###
+    console.debug "°°° ListingTableView::on_review_state_filter_click °°°"
+
+    # prevent full page reload
+    event.preventDefault()
+
+    el = event.currentTarget
+    $el = $(el)
+
+    form = $el.parents "form"
+    form_id = form.attr "id"
+    state_id = $el.attr "value"
+
+    @filter_state form_id, state_id
+
+
+  on_listing_entry_change: (event) =>
+    ###
+     * Eventhandler for listing entries (results capturing)
+    ###
+    console.debug "°°° ListingTableView::on_listing_entry_change °°°"
+
+    el = event.currentTarget
+    $el = $(el)
+
+    uid = $el.attr "uid"
+    tr = $el.parents "tr#folder-contents-item-#{uid}"
+    checkbox = tr.find "input[id$=_cb_#{uid}]"
+
+    if $(checkbox).length == 1
+      table = $(checkbox).parents "table.bika-listing-table"
+      $(checkbox).prop 'checked', true
+      @render_transition_buttons table
+
+
+  on_listing_entry_keypress: (event) =>
+    ###
+     * Eventhandler for listing entries (results capturing)
+    ###
+    console.debug "°°° ListingTableView::on_listing_entry_keypress °°°"
+
+    # Prevent automatic submissions of manage_results forms when enter is pressed
+    if event.which == 13
+      console.debug "ListingTableView::on_listing_entry_keypress: capture Enter key"
+      event.preventDefault()
+
+
+  on_category_header_click: (event) =>
+    ###
+     * Eventhandler for collapsed/expanded categories
+    ###
+    console.debug "°°° ListingTableView::on_category_header_click °°°"
+
+    el = event.currentTarget
+    $el = $(el)
+
+    # disable category collapse
+    if $el.hasClass "ignore_bikalisting_default_handler"
+      console.debug "Category toggling disabled by CSS class"
+      return
+
+    form = $el.parents "form"
+    form_id = form.attr "id"
+    cat_id = $el.attr "cat"
+
+    @toggle_category form_id, cat_id
+
+
+  on_autosave_field_change: (event) =>
+    ###
+     * Eventhandler for input fields with `autosave` css class
+     *
+     * This function looks for the column defined as 'autosave' and if its value
+     * is true, the result of this input will be saved after each change via
+     * ajax.
+    ###
+    console.warn "BBB: Autosave is deprecated and not supported anymore"
+    return false
+
+
+  on_workflow_button_click: (event) =>
+    ###
+     * Eventhandler for the workflow buttons
+    ###
+    console.debug "°°° ListingTableView::on_workflow_button_click °°°"
+
+    el = event.currentTarget
+    $el = $(el)
+
+    form = $el.parents "form"
+    form_id = $(form).attr "id"
+
+    # The submit buttons would like to put the translated action title into the
+    # request. Insert the real action name here to prevent the WorkflowAction
+    # handler from having to look it up (painful/slow).
+    transition = $el.attr "transition"
+    $(form).append "<input type='hidden' name='workflow_action_id' value='#{transition}' />"
+
+    # This submit_transition cheat fixes a bug where hitting submit caused form
+    # to be posted before ajax calculation is returned
+    if $el.id == "submit_transition"
+      focus = $(".ajax_calculate_focus")
+      if focus.length > 0
+        e = $(focus[0])
+        if $(e).attr("focus_value") == $(e).val()
+          # value did not change - transparent blur handler.
+          $(e).removeAttr "focus_value"
+          $(e).removeClass "ajax_calculate_focus"
         else
-            # When ajax_categories are disabled, all cat items exist as TR elements:
-            $(element).parent().nextAll('tr[cat=\'' + $(element).attr('cat') + '\']').toggle true
-            $(element).removeClass('collapsed').addClass 'expanded'
-            def.resolve()
-        # Set expanded class on TR
-        def.promise()
+          # The calcs.js code is now responsible for submitting
+          # this form when the calculation ajax is complete
+          $(e).parents("form").attr "submit_after_calculation", 1
+          event.preventDefault()
 
-    return
+    # If a custom_transitions action with a URL is clicked the form will be
+    # submitted there
+    if $el.attr("url") != ""
+      form = $el.parents("form")
+      $(form).attr "action", $(this).attr("url")
+      $(form).submit()
+
+
+  on_contextmenu: (event) =>
+    ###
+     * Eventhandler for the table contextmenu
+    ###
+    console.debug "°°° ListingTableView::on_contextmenu °°°"
+
+    # prevent the system context menu
+    event.preventDefault()
+
+    el = event.currentTarget
+    $el = $(el)
+    table = $el.parents "table.bika-listing-table"
+
+    # create the context menu HTML
+    menu = @make_context_menu table
+
+    # append to the body
+    menu = $(menu).appendTo "body"
+
+    # position the contextmenu where the mouse clicked
+    $(menu).css
+      "border": "1px solid #fff"
+      "border-radius": ".25em"
+      "background-color": "#fff"
+      "position": "absolute"
+      "top": event.pageY - 5
+      "left": event.pageX - 5
+
+
+  on_contextmenu_item_click: (event) =>
+    ###
+     * Eventhandler when an item was clicked in the contextmenu
+    ###
+    console.debug "°°° ListingTableView::on_contextmenu_item_click °°°"
+
+    # current event target (table header)
+    el = event.currentTarget
+    # We're getting here the <tr> element from the context menu
+    $el = $(el)
+
+    # get the form and column id from the contextmenu <tr> element
+    form_id = $el.attr "form_id"
+    col_id = $el.attr "col_id"
+
+    # toggle the column
+    @toggle_column form_id, col_id
+
+
+  on_search_field_keypress: (event) =>
+    ###
+     * Eventhandler for the search field
+    ###
+    console.debug "°°° ListingTableView::on_search_field_keypress °°°"
+
+    # current event target (table header)
+    el = event.currentTarget
+    $el = $(el)
+
+    # only trigger search on enter
+    if event.which == 13
+      # prevent form submit on enter
+      event.preventDefault()
+      # get the form and column id from the contextmenu <tr> element
+      form = $el.parents "form"
+      form_id = form.attr "id"
+      searchfield = $(".filter-search-input", form)
+      searchterm = searchfield.val()
+      @search form_id, searchterm
+
+
+  on_search_button_click: (event) =>
+    ###
+     * Eventhandler for the search field button
+    ###
+    console.debug "°°° ListingTableView::on_search_button_click °°°"
+
+    # current event target (table header)
+    el = event.currentTarget
+    $el = $(el)
+
+    @on_search_field_keypress event
+
+
+  on_select_all_click: (event) =>
+    ###
+     * Eventhandler when the select all checkbox was clicked
+     *
+     * Controls the behavior when the 'select all' checkbox is clicked.
+     * Checks/Unchecks all the row selection checkboxes and once done,
+     * re-renders the workflow action buttons from the bottom of the list,
+     * based on the allowed transitions for the currently selected items
+    ###
+    console.debug "°°° ListingTableView::on_select_all_click °°°"
+
+    # current event target (table header)
+    el = event.currentTarget
+    $el = $(el)
+
+    table = $el.parents("table.bika-listing-table")
+    checkboxes = $(table).find("[id*='_cb_']")
+    $(checkboxes).prop "checked", $el.prop("checked")
+
+    # render transition buttons
+    @render_transition_buttons table
+
+
+  on_checkbox_click: (event) =>
+    ###
+     * Eventhandler when a Checkbox was clicked
+     *
+     * Controls the behavior when a checkbox of row selection is clicked.
+     * Updates the status of the 'select all' checkbox accordingly and also
+     * re-renders the workflow action buttons from the bottom of the list
+     * based on the allowed transitions of the currently selected items
+    ###
+    console.debug "°°° ListingTableView::on_checkbox_click °°°"
+
+    # current event target (table header)
+    el = event.currentTarget
+    $el = $(el)
+
+    table = $el.parents("table.bika-listing-table")
+
+    # Toggle select all checkbox
+    checked = $("input[type='checkbox'][id*='_cb_']:checked")
+    all = $("input[type='checkbox'][id*='_cb_']")
+    checkall = $(table).find("input[id*='select_all']")
+    checkall.prop "checked", checked.length == all.length
+
+    # render transition buttons
+    @render_transition_buttons table
+
+
+  on_ajax_submit_start: (event) =>
+    ###
+     * Eventhandler for Ajax form submit
+    ###
+    console.debug "°°° ListingTableView::on_ajax_submit_start °°°"
+
+
+  on_ajax_submit_end: (event) =>
+    ###
+     * Eventhandler for Ajax form submit
+    ###
+    console.debug "°°° ListingTableView::on_ajax_submit_end °°°"
+
+
+  on_column_header_click: (event) =>
+    ###
+     * Eventhandler for Table Column Header
+    ###
+    console.debug "°°° ListingTableView::on_column_header_click °°°"
+
+    # current event target (table header)
+    el = event.currentTarget
+    $el = $(el)
+
+    form = $el.parents "form"
+    form_id = form.attr "id"
+
+    # extract the sort on index
+    # XXX add the index directly to the table header
+    # foldercontents-getClientReference-column -> getClientReference
+    sort_index = $el.attr("id").split("-")[1]
+
+    # sort the table
+    @sort_column form_id, sort_index
+
+
+  on_show_more_click: (event) =>
+    ###
+     * Eventhandler for the Table "Show More" Button
+    ###
+    console.debug "°°° ListingTableView::on_show_more_click °°°"
+
+    # current event target (Show More button)
+    el = event.currentTarget
+    $el = $(el)
+
+    # prevent form submit on button click
+    event.preventDefault()
+
+    form_id = $el.attr "data-form-id"
+    pagesize = @parse_int $el.attr "data-pagesize"
+    limit_from = @parse_int $el.attr "data-limitfrom"
+
+    @show_more form_id, pagesize, limit_from

--- a/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
@@ -381,6 +381,7 @@ class window.BikaListingTableView
       contentType: no # do not set any content type header
     .done (data) ->
       $(table).replaceWith data
+      @load_transitions()
 
 
   show_more: (form_id, pagesize, limit_from) =>

--- a/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
@@ -40,41 +40,41 @@ class window.BikaListingTableView
     console.debug "ListingTableView::bind_eventhandler"
 
     # Table header clicked for sorting
-    $("form[name=bika_listing_form]").on "click", "th.sortable", @on_column_header_click
+    $("form").on "click", "th.sortable", @on_column_header_click
 
     # Show More clickd
-    $("form[name=bika_listing_form]").on "click", "a.bika_listing_show_more", @on_show_more_click
+    $("form").on "click", "a.bika_listing_show_more", @on_show_more_click
 
     # Single checkbox clicked
-    $("form[name=bika_listing_form]").on "click", "input[type='checkbox'][id*='_cb_']", @on_checkbox_click
+    $("form").on "click", "input[type='checkbox'][id*='_cb_']", @on_checkbox_click
 
     # Check all checkbox clicked
-    $("form[name=bika_listing_form]").on "click", "input[id*='select_all']", @on_select_all_click
+    $("form").on "click", "input[id*='select_all']", @on_select_all_click
 
     # Enter keypress in search field
-    $("form[name=bika_listing_form]").on "keypress", ".filter-search-input", @on_search_field_keypress
+    $("form").on "keypress", ".filter-search-input", @on_search_field_keypress
 
     # Search button clicked (magnifier in search field)
-    $("form[name=bika_listing_form]").on "click", ".filter-search-button", @on_search_button_click
+    $("form").on "click", ".filter-search-button", @on_search_button_click
 
     # Context menu
-    $("form[name=bika_listing_form]").on 'contextmenu', "th[id^='foldercontents-']", @on_contextmenu
+    $("form").on 'contextmenu', "th[id^='foldercontents-']", @on_contextmenu
 
     # Workflow Button
-    $("form[name=bika_listing_form]").on "click", "input.workflow_action_button", @on_workflow_button_click
+    $("form").on "click", "input.workflow_action_button", @on_workflow_button_click
 
     # Autosave – seems to be used by sample and analysis views
-    $("form[name=bika_listing_form]").on "change", "input.autosave, select.autsave", @on_autosave_field_change
+    $("form").on "change", "input.autosave, select.autsave", @on_autosave_field_change
 
     # Category headers
-    $("form[name=bika_listing_form]").on "click", "th.collapsed, th.expanded", @on_category_header_click
+    $("form").on "click", "th.collapsed, th.expanded", @on_category_header_click
 
     # Results entry
-    $("form[name=bika_listing_form]").on "change", ".listing_string_entry, .listing_select_entry", @on_listing_entry_change
-    $("form[name=bika_listing_form]").on "keypress", ".listing_string_entry, .listing_select_entry", @on_listing_entry_keypress
+    $("form").on "change", ".listing_string_entry, .listing_select_entry", @on_listing_entry_change
+    $("form").on "keypress", ".listing_string_entry, .listing_select_entry", @on_listing_entry_keypress
 
     # Review state filter buttons
-    $("form[name=bika_listing_form]").on "click", "td.review_state_selector a", @on_review_state_filter_click
+    $("form").on "click", "td.review_state_selector a", @on_review_state_filter_click
 
     # Document click
     $(document).on "click", @on_click

--- a/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
@@ -630,6 +630,7 @@ class window.BikaListingTableView
       table = $(table).replaceWith data
       # focus on the search field
       $(".filter-search-input", form).select()
+      @load_transitions()
 
 
   make_context_menu: (table) ->

--- a/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
@@ -307,6 +307,7 @@ class window.BikaListingTableView
       contentType: no # do not set any content type header
     .done (data) ->
       $(table).replaceWith data
+      @load_transitions()
 
 
   toggle_category: (form_id, cat_id) =>

--- a/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
@@ -345,6 +345,7 @@ class window.BikaListingTableView
 
     # send the new data to the server
     @ajax_submit
+      url: url
       data: form_data
       processData: no  # do not transform to a query string
       contentType: no # do not set any content type header

--- a/bika/lims/locales/bika-manual.pot
+++ b/bika/lims/locales/bika-manual.pot
@@ -109,3 +109,6 @@ msgstr ""
 
 msgid "Submit for verification"
 msgstr ""
+
+msgid "Display Columns"
+msgstr ""


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Complete refactored version of `bika.lims.bikalisting.coffee` to a maintainable chunk of code. Also remove all deprecated `jQuery.live` function calls.

The following functionalities should work in all listing tables:

- Async search
- Async column sorting
- Async column sort order change
- Async column display toggling
- Async show more
- Async category expansion
- Async filtering by the review state buttons
- Async transition/workflow button loading
- Async show all/single checkbox handling
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
