### PR TITLE
Added Sample Type, Partition ID and Date Sampled in sticker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Changelog
 
 **Changed**
 
+- #652 Added Sample Type, Partition ID and Date Sampled in Code_128_1x48mm sticker
 - #647 Refactored bika.lims.bikalisting.js + several functional fixtures
 - #637 Deassociate Analysis Request portal type from `worksheetanalysis_workflow`
 

--- a/bika/lims/browser/templates/stickers/Code_128_1x48mm.pt
+++ b/bika/lims/browser/templates/stickers/Code_128_1x48mm.pt
@@ -39,13 +39,6 @@
     smart_id          python:part.getId() if show_partitions else sample.getId();
     hazardous         python:sample.getSampleType().getHazardous();">
 
-    <!-- Sample ID -->
-    <div class="sample-id">
-        <!--span tal:replace="string:${smart_id}"/-->
-        <img tal:condition="hazardous | nothing"
-             tal:attributes="src string:${portal_url}/++resource++bika.lims.images/hazardous.png"/>
-    </div>
-
     <!-- Barcode -->
     <div class="barcode"
         tal:attributes="data-id smart_id;"
@@ -59,11 +52,14 @@
     <div class="analysisrequest-info">
         <table cellpadding="0" cellspacing="0" border="0">
             <tr>
-                <td colspan="2" class="client-sample-id" tal:content="python:smart_id"/>
+                <td rowspan="2" tal:condition="hazardous | nothing">
+                    <img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/hazardous.png"/>
+                </td>
+                <td colspan="2" class="client-sample-id" tal:content="python:smart_id"></td>
             </tr>
             <tr>
-		<td tal:content="python:sample_type"></td>
-		<td tal:content="python:date_sampled"></td>
+                <td tal:content="python:sample_type"></td>
+                <td tal:content="python:date_sampled"></td>
             </tr>
         </table>
     </div>

--- a/bika/lims/browser/templates/stickers/Code_128_1x48mm.pt
+++ b/bika/lims/browser/templates/stickers/Code_128_1x48mm.pt
@@ -59,7 +59,11 @@
     <div class="analysisrequest-info">
         <table cellpadding="0" cellspacing="0" border="0">
             <tr>
-                <td class="client-sample-id" tal:content="python:'%s: %s' % ('CSID', client_sample_id if client_sample_id else '---')"/>
+                <td colspan="2" class="client-sample-id" tal:content="python:smart_id"/>
+            </tr>
+            <tr>
+		<td tal:content="python:sample_type"></td>
+		<td tal:content="python:date_sampled"></td>
             </tr>
         </table>
     </div>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Added Sample Type, Partition ID and Date Sampled in Code_128_1x48mm sticker

## Current behavior before PR

Only the barcode with CSID is displayed

![stickers_old](https://user-images.githubusercontent.com/832627/36228165-6886c69c-11cb-11e8-9a03-9f8f0eff4ff0.png)

## Desired behavior after PR is merged

The barcode, together with the Sample Partition ID, the Sample Type and Date Sampled are displayed

![sticker](https://user-images.githubusercontent.com/832627/36228086-0e56ad72-11cb-11e8-809d-3f7ad700421f.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
