### PR TITLE
Points in QC Charts are not displayed in accordance with results capture date

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Changelog
 
 **Fixed**
 
+- #653 Points in QC Charts are not displayed in accordance with capture date
 - #637 Analysis Requests are never transitioned to assigned/unassigned
 - #641 Broken Analyses list on ReferenceSample in Supplier
 - #640 Broken Reference Sample Results view

--- a/bika/lims/api.py
+++ b/bika/lims/api.py
@@ -8,6 +8,9 @@
 from Acquisition import aq_base
 from AccessControl.PermissionRole import rolesForPermissionOn
 
+from datetime import datetime
+from DateTime import DateTime
+
 from Products.CMFPlone.utils import base_hasattr
 from Products.CMFCore.interfaces import ISiteRoot
 from Products.CMFCore.interfaces import IFolderish
@@ -1143,6 +1146,7 @@ def normalize_filename(string):
     normalizer = getUtility(IFileNameNormalizer).normalize
     return normalizer(string)
 
+
 def is_uid(uid, validate=False):
     """Checks if the passed in uid is a valid UID
 
@@ -1166,3 +1170,33 @@ def is_uid(uid, validate=False):
     if brains:
         assert (len(brains) == 1)
     return len(brains) > 0
+
+
+def is_date(date):
+    """Checks if the passed in value is a valid Zope's DateTime
+
+    :param date: The date to check
+    :type date: DateTime
+    :return: True if a valid date
+    :rtype: bool
+    """
+    if not date:
+        return False
+    return isinstance(date, DateTime) or isinstance(date, datetime)
+
+
+def get_date(value):
+    """Tries to convert the passed in value to Zope's DateTime
+
+    :param value: The value to be converted to a valid DateTime
+    :type value: str, DateTime or datetime
+    :return: The DateTime representation of the value passed in or None
+    """
+    if isinstance(value, DateTime):
+        return value
+    if not value:
+        return None
+    try:
+        return DateTime(value)
+    except:
+        return None

--- a/bika/lims/api.py
+++ b/bika/lims/api.py
@@ -1182,7 +1182,7 @@ def is_date(date):
     """
     if not date:
         return False
-    return isinstance(date, DateTime) or isinstance(date, datetime)
+    return isinstance(date, (DateTime, datetime))
 
 
 def to_date(value, default=None):

--- a/bika/lims/api.py
+++ b/bika/lims/api.py
@@ -1185,18 +1185,23 @@ def is_date(date):
     return isinstance(date, DateTime) or isinstance(date, datetime)
 
 
-def get_date(value):
+def to_date(value, default=None):
     """Tries to convert the passed in value to Zope's DateTime
 
     :param value: The value to be converted to a valid DateTime
     :type value: str, DateTime or datetime
-    :return: The DateTime representation of the value passed in or None
+    :return: The DateTime representation of the value passed in or default
     """
     if isinstance(value, DateTime):
         return value
     if not value:
-        return None
+        if default is None:
+            return None
+        return to_date(default)
     try:
+        if isinstance(value, str) and '.' in value:
+            # https://docs.plone.org/develop/plone/misc/datetime.html#datetime-problems-and-pitfalls
+            return DateTime(value, datefmt='international')
         return DateTime(value)
     except:
-        return None
+        return to_date(default)

--- a/bika/lims/browser/instrument.py
+++ b/bika/lims/browser/instrument.py
@@ -532,9 +532,10 @@ class InstrumentReferenceAnalysesView(AnalysesView):
                     error_amount = ((target / 100) * error) if target > 0 else 0
                     upper = smax + error_amount
                     lower = smin - error_amount
-
+                    cap_date = obj.getResultCaptureDate()
+                    cap_date = cap_date and cap_date.strftime('%Y-%m-%d %I:%M %p') or ''
                     anrow = {
-                        'date': item['CaptureDate'],
+                        'date': cap_date,
                         'min': smin,
                         'max': smax,
                         'target': target,

--- a/bika/lims/browser/instrument.py
+++ b/bika/lims/browser/instrument.py
@@ -12,7 +12,7 @@ import plone
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from bika.lims import bikaMessageFactory as _
+from bika.lims import bikaMessageFactory as _, api
 from bika.lims.browser import BrowserView
 from bika.lims.browser.analyses import AnalysesView
 from bika.lims.browser.bika_listing import BikaListingView
@@ -533,7 +533,8 @@ class InstrumentReferenceAnalysesView(AnalysesView):
                     upper = smax + error_amount
                     lower = smin - error_amount
                     cap_date = obj.getResultCaptureDate()
-                    cap_date = cap_date and cap_date.strftime('%Y-%m-%d %I:%M %p') or ''
+                    cap_date = api.is_date(cap_date) and \
+                               cap_date.strftime('%Y-%m-%d %I:%M %p') or ''
                     anrow = {
                         'date': cap_date,
                         'min': smin,

--- a/bika/lims/browser/referencesample.py
+++ b/bika/lims/browser/referencesample.py
@@ -198,9 +198,9 @@ class ReferenceAnalysesView(AnalysesView):
         trows = self.anjson.get(serviceref, {})
         anrows = trows.get(qcid, [])
         rr = parent.getResultsRangeDict()
-        cap_date = item.get('CaptureDate', None)
         cap_date = item['obj'].getResultCaptureDate
-        cap_date = cap_date and cap_date.strftime('%Y-%m-%d %I:%M %p') or ''
+        cap_date = api.is_date(cap_date) and \
+                   cap_date.strftime('%Y-%m-%d %I:%M %p') or ''
         if service_uid in rr:
             specs = rr.get(service_uid, None)
             try:

--- a/bika/lims/browser/referencesample.py
+++ b/bika/lims/browser/referencesample.py
@@ -199,6 +199,8 @@ class ReferenceAnalysesView(AnalysesView):
         anrows = trows.get(qcid, [])
         rr = parent.getResultsRangeDict()
         cap_date = item.get('CaptureDate', None)
+        cap_date = item['obj'].getResultCaptureDate
+        cap_date = cap_date and cap_date.strftime('%Y-%m-%d %I:%M %p') or ''
         if service_uid in rr:
             specs = rr.get(service_uid, None)
             try:

--- a/bika/lims/tests/doctests/API.rst
+++ b/bika/lims/tests/doctests/API.rst
@@ -1206,27 +1206,98 @@ Checks if a DateTime is valid:
     >>> api.is_date('2018-04-23')
     False
 
+Try conversions to Date
+-----------------------
+
 Try to convert to DateTime:
 
-    >>> zpdt = api.get_date(DateTime())
-    >>> api.is_date(zpdt)
+    >>> now = DateTime()
+    >>> zpdt = api.to_date(now)
+    >>> zpdt.ISO8601() == now.ISO8601()
     True
 
-    >>> pydt = datetime.now()
-    >>> zpdt = api.get_date(pydt)
-    >>> api.is_date(zpdt)
+    >>> now = datetime.now()
+    >>> zpdt = api.to_date(now)
+    >>> pydt = zpdt.asdatetime()
+
+Note that here, for the comparison between dates, we convert DateTime to python
+datetime, cause DateTime.strftime() is broken for timezones (always looks at
+system time zone, ignores the timezone and offset of the DateTime instance
+itself):
+
+    >>> pydt.strftime('%Y-%m-%dT%H:%M:%S') == now.strftime('%Y-%m-%dT%H:%M:%S')
     True
+
+Try the same, but with utcnow() instead:
+
+    >>> now = datetime.utcnow()
+    >>> zpdt = api.to_date(now)
+    >>> pydt = zpdt.asdatetime()
+    >>> pydt.strftime('%Y-%m-%dT%H:%M:%S') == now.strftime('%Y-%m-%dT%H:%M:%S')
+    True
+
+Now we convert just a string formatted date:
 
     >>> strd = "2018-12-01 17:50:34"
-    >>> zpdt = api.get_date(strd)
-    >>> api.is_date(zpdt)
-    True
+    >>> zpdt = api.to_date(strd)
+    >>> zpdt.ISO8601()
+    '2018-12-01T17:50:34'
+
+Now we convert just a string formatted date, but with timezone:
+
+    >>> strd = "2018-12-01 17:50:34 GMT+1"
+    >>> zpdt = api.to_date(strd)
+    >>> zpdt.ISO8601()
+    '2018-12-01T17:50:34+01:00'
+
+We also check a bad date here (note the month is 13):
 
     >>> strd = "2018-13-01 17:50:34"
-    >>> zpdt = api.get_date(strd)
+    >>> zpdt = api.to_date(strd)
     >>> api.is_date(zpdt)
     False
 
-    >>> zpdt = api.get_date(None)
-    >>> api.is_date(zpdt)
-    False
+And with European format:
+
+    >>> strd = "01.12.2018 17:50:34"
+    >>> zpdt = api.to_date(strd)
+    >>> zpdt.ISO8601()
+    '2018-12-01T17:50:34'
+
+    >>> zpdt = api.to_date(None)
+    >>> zpdt is None
+    True
+
+Use a string formatted date as fallback:
+
+    >>> strd = "2018-13-01 17:50:34"
+    >>> default_date = "2018-01-01 19:30:30"
+    >>> zpdt = api.to_date(strd, default_date)
+    >>> zpdt.ISO8601()
+    '2018-01-01T19:30:30'
+
+Use a DateTime object as fallback:
+
+    >>> strd = "2018-13-01 17:50:34"
+    >>> default_date = "2018-01-01 19:30:30"
+    >>> default_date = api.to_date(default_date)
+    >>> zpdt = api.to_date(strd, default_date)
+    >>> zpdt.ISO8601() == default_date.ISO8601()
+    True
+
+Use a datetime object as fallback:
+
+    >>> strd = "2018-13-01 17:50:34"
+    >>> default_date = datetime.now()
+    >>> zpdt = api.to_date(strd, default_date)
+    >>> dzpdt = api.to_date(default_date)
+    >>> zpdt.ISO8601() == dzpdt.ISO8601()
+    True
+
+Use a non-conversionable value as fallback:
+
+    >>> strd = "2018-13-01 17:50:34"
+    >>> default_date = "something wrong here"
+    >>> zpdt = api.to_date(strd, default_date)
+    >>> zpdt is None
+    True

--- a/bika/lims/tests/doctests/API.rst
+++ b/bika/lims/tests/doctests/API.rst
@@ -1177,3 +1177,56 @@ Checks if an UID is a valid 23 alphanumeric uid and with a brain:
     >>> uid = serv.UID()
     >>> api.is_uid(uid, validate=True)
     True
+
+Check if a Date is valid
+------------------------
+
+Do some imports first:
+
+    >>> from datetime import datetime
+    >>> from DateTime import DateTime
+
+Checks if a DateTime is valid:
+
+    >>> now = DateTime()
+    >>> api.is_date(now)
+    True
+
+    >>> now = datetime.now()
+    >>> api.is_date(now)
+    True
+
+    >>> now = DateTime(now)
+    >>> api.is_date(now)
+    True
+
+    >>> api.is_date(None)
+    False
+
+    >>> api.is_date('2018-04-23')
+    False
+
+Try to convert to DateTime:
+
+    >>> zpdt = api.get_date(DateTime())
+    >>> api.is_date(zpdt)
+    True
+
+    >>> pydt = datetime.now()
+    >>> zpdt = api.get_date(pydt)
+    >>> api.is_date(zpdt)
+    True
+
+    >>> strd = "2018-12-01 17:50:34"
+    >>> zpdt = api.get_date(strd)
+    >>> api.is_date(zpdt)
+    True
+
+    >>> strd = "2018-13-01 17:50:34"
+    >>> zpdt = api.get_date(strd)
+    >>> api.is_date(zpdt)
+    False
+
+    >>> zpdt = api.get_date(None)
+    >>> api.is_date(zpdt)
+    False


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The javascript that renders the chart expects the following format

https://github.com/senaite/senaite.core/blob/master/bika/lims/browser/js/bika.lims.graphics.controlchart.js#L180-L181

which does not match with what `self.ulocalized_time(results_date, long_format=1)` returns
https://github.com/senaite/senaite.core/blob/master/bika/lims/browser/analyses.py#L454-L455

Also, this `ulocalized_time` does not differentiate between PM and AM, so needs to be reviewed too.

## Current behavior before PR

![qc_chart_old](https://user-images.githubusercontent.com/832627/36232890-553261e0-11db-11e8-8214-f66accf04548.png)


## Desired behavior after PR is merged

![qc_chart_after](https://user-images.githubusercontent.com/832627/36232956-acce824e-11db-11e8-852e-7951d3f4e8ec.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
