### PR TITLE
Traceback in default's Multi AR template report

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Changelog
 
 **Fixed**
 
+- #654 Default's Multi Analysis Request report gives a Traceback
 - #637 Analysis Requests are never transitioned to assigned/unassigned
 - #641 Broken Analyses list on ReferenceSample in Supplier
 - #640 Broken Reference Sample Results view

--- a/bika/lims/browser/analysisrequest/templates/reports/Multi_AR_default.pt
+++ b/bika/lims/browser/analysisrequest/templates/reports/Multi_AR_default.pt
@@ -20,7 +20,7 @@
            lab             python:portal['obj'].bika_setup.laboratory;
            showqcanalyses  python:view.isQCAnalysesVisible();
            remarksenabled  python:view.context.bika_setup.getEnableAnalysisRemarks();">
-
+<div>
     <table width="100%" cellpadding="0" cellspacing="0">
       <tr>
         <td colspan="2" id="section-info-heading" i18n:translate="section-info-heading">
@@ -55,7 +55,7 @@
             </tr>
             <tr>
               <th i18n:translate="" class="label">Address</th>
-              <td tal:content="structure python:view._client_address(client)"/>
+              <td tal:content="structure python:analysisrequest['client']['address']"/>
             </tr>
           </table>
         </td>
@@ -139,13 +139,11 @@
         </div>
 
     </div>
-
-    <tal:comment replace="nothing">
-        Break before first AR section.
-        Subsequent AR sections have page breaks after each one.
-    </tal:comment>
-    <div class='manual-page-break'></div>
-
+</div>
+<div>
+<p>&nbsp;</p>
+<h2>RESULTS</h2>
+</div>
     <tal:page_iter repeat="ars arspage">
         <tal:page tal:define="
             firstar         python:ars[0];
@@ -168,7 +166,8 @@
                                 </a>
                             </td>
                             <td>
-                                <img tal:attributes="src python:lab.getAccreditationBodyLogo().absolute_url() if lab.getAccreditationBodyLogo() else ''"/>
+                                <img tal:attributes="src python:lab.getAccreditationBodyLogo().absolute_url() if lab.getAccreditationBodyLogo() else ''"
+                                     tal:condition="python:lab.getAccreditationBodyLogo()"/>
                             </td>
                         </tr>
                     </table>
@@ -269,13 +268,13 @@
                                 condition="interps">
                         <div tal:repeat="interp interps" class="resultsinterpretation">
                             <div class="resultsinterpretation_heading"
-                                 tal:condition="python:interp['uid'] == 'general'">
+                                 tal:condition="python:interp['uid'] == 'general' and 'richtext' in interp">
                                 General results interpretation for <span tal:replace="python:ar.id"/>
                             </div>
                             <div class="resultsinterpretation_heading"
-                                 tal:condition="python:interp['uid'] != 'general'"
+                                 tal:condition="python:interp['uid'] != 'general' and 'richtext' in interp"
                                  tal:content="python:'Interpreted results for %s (%s)'%(ar.id, uc(UID=interp['uid'])[0].title)"></div>
-                                <span tal:content="structure python:interp['richtext']"/>
+                                <span tal:content="structure python:interp.get('richtext', '')"/>
                         </div>
                     </tal:ri_def>
                 </tal:ri_ars>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a Traceback that appears when trying to render the default MultiAR report

## Current behavior before PR

```
Traceback (most recent call last):
  File "/home/xispa/senaite/zeocluster/src/senaite.core/bika/lims/browser/analysisrequest/publish.py", line 221, in getGroupedReportTemplate
    embedt, reptemplate = self._renderTemplate()
  File "/home/xispa/senaite/zeocluster/src/senaite.core/bika/lims/browser/analysisrequest/publish.py", line 195, in _renderTemplate
    return embedt, embed(self)
  File "/home/xispa/senaite/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/Products/Five/browser/pagetemplatefile.py", line 59, in __call__
    sourceAnnotations=getattr(debug_flags, 'sourceAnnotations', 0),
  File "/home/xispa/senaite/buildout-cache/eggs/zope.pagetemplate-3.6.3-py2.7.egg/zope/pagetemplate/pagetemplate.py", line 132, in pt_render
    strictinsert=0, sourceAnnotations=sourceAnnotations
  File "/home/xispa/senaite/buildout-cache/eggs/five.pt-2.2.4-py2.7.egg/five/pt/engine.py", line 98, in __call__
    return self.template.render(**kwargs)
  File "/home/xispa/senaite/buildout-cache/eggs/z3c.pt-3.1.0-py2.7.egg/z3c/pt/pagetemplate.py", line 158, in render
    return base_renderer(**context)
  File "/home/xispa/senaite/buildout-cache/eggs/Chameleon-3.2-py2.7.egg/chameleon/zpt/template.py", line 297, in render
    return super(PageTemplate, self).render(**_kw)
  File "/home/xispa/senaite/buildout-cache/eggs/Chameleon-3.2-py2.7.egg/chameleon/template.py", line 191, in render
    raise_with_traceback(exc, tb)
  File "/home/xispa/senaite/buildout-cache/eggs/Chameleon-3.2-py2.7.egg/chameleon/template.py", line 171, in render
    self._render(stream, econtext, rcontext)
  File "20fe39995a9a90ce8c808364af65cbc8.py", line 627, in render
AttributeError: 'AnalysisRequestPublishView' object has no attribute '_client_address'
```

## Desired behavior after PR is merged

![multi-ar](https://user-images.githubusercontent.com/832627/36233174-94c04e34-11dc-11e8-8cae-81695c65418e.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
