### PR TITLE
ConfigurationConflictError in "The workflow actions menu".

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Changelog
 
 **Fixed**
 
+- #657 ConfigurationConflictError in "The workflow actions menu".
 - #654 Default's Multi Analysis Request report gives a Traceback
 - #649 Specification fields decimal-mark validator not working for new opened categories
 - #637 Analysis Requests are never transitioned to assigned/unassigned

--- a/bika/lims/browser/overrides.zcml
+++ b/bika/lims/browser/overrides.zcml
@@ -36,6 +36,12 @@
                  permission="zope2.View"
              />
 
+            <browser:menu
+                id="plone_contentmenu_workflow"
+                title="The workflow actions menu"
+                class="bika.lims.browser.contentmenu.WorkflowMenu"
+            />
+
         </unconfigure>
     </configure>
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
We are overriding Plone's "The workflow actions menu" page [here](https://github.com/senaite/senaite.core/blob/master/bika/lims/browser/overrides.zcml#L74)  without unconfiguring it, which makes instances fail to run.

## Current behavior before PR
Running instance fails because of `ConfigurationConflictError`.

## Desired behavior after PR is merged
Plone's default view with ID 'plone_contentmenu_workflow' is unconfigured before being overriden.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
