### PR TITLE
Better style for reference widgets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Changelog
 
 **Changed**
 
+- #660 Better style for reference widgets
 - #627 Unassigned filter on Analysis Requests view does not work
 - #659 Display the Unit in Profile Analyses Listing
 - #636 Do not display "Advanced..." item in object's workflow actions menu

--- a/bika/lims/skins/bika/ploneCustom.css.dtml
+++ b/bika/lims/skins/bika/ploneCustom.css.dtml
@@ -614,6 +614,18 @@ a.duplicate {
  color:#00B027 !important;
 }
 
+/* Reference Browser Widget */
+.cg-comboItem {
+    height: 45px;
+}
+#cg-divHeader,
+.ui-state-default {
+    background: #f5f5f5!important;
+    color: black!important;
+}
+.ui-icon {
+    background-image: url(++resource++bika.lims.css/images/ui-icons_72a7cf_256x240.png)!important;
+}
 
 
 /*


### PR DESCRIPTION
## Before

<img width="604" alt="happy hills senaite 2018-02-15 21-47-01" src="https://user-images.githubusercontent.com/713193/36280283-173125a6-129a-11e8-9b73-feaaa0a06b0b.png">

## After

<img width="597" alt="happy hills senaite 2018-02-15 21-47-52" src="https://user-images.githubusercontent.com/713193/36280285-193c88e0-129a-11e8-9d96-43f497ae4fb2.png">

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
