### PR TITLE
Adding Leonardo Rojas as contributtor

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -28,6 +28,7 @@ contributions descending.
 - Pieter van der Merwe, pieter_vdm@debortoli.com.au
 - Anderson Smith, andersonsmith183@gmail.com
 - Jean Jordaan, jean.jordaan@gmail.com
+- Leonardo Rojas, leonardorojass@gmail.com
 - Aleksandr Melnikov, aleksandr.melnikov@limelyte.com
 - Henrique Chehad, hchehad@gmail.com
 - jpsinghgoud, jaipal.singh@research.iiit.ac.in


### PR DESCRIPTION
Leonardo Rojas has been a key contributor not only during Bika LIMS development, but also during the previous days of SENAITE.

He helped Naralabs to improve the system performance and stability a lot during Summer 2017 and all that work was included in SENAITE.

He also has contributed in Bika from advising and sponsoring some important feature, the most notorious one is the calculation system.

So, I propose him as an official contributor.

Apart from this PR, I would like to suggest to **sort contributors by name**, and not by "supposed" contributions since this way is absolutely subjective and could be a source of problems.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
