### PR TITLE
Viewing Cancelled AR's fails.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Changelog
 
 **Fixed**
 
+- #662 Viewing Cancelled AR's fails
 - #654 Default's Multi Analysis Request report gives a Traceback
 - #649 Specification fields decimal-mark validator not working for new opened categories
 - #637 Analysis Requests are never transitioned to assigned/unassigned

--- a/bika/lims/browser/analysisrequest/view.py
+++ b/bika/lims/browser/analysisrequest/view.py
@@ -10,6 +10,7 @@ from DateTime import DateTime
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims import bikaMessageFactory as _
+from bika.lims import api
 from bika.lims.browser import BrowserView
 from bika.lims.browser.analyses import AnalysesView
 from bika.lims.browser.analyses import QCAnalysesView
@@ -58,8 +59,8 @@ class AnalysisRequestViewView(BrowserView):
             wasTransitionPerformed(self.context, 'receive') and
             not wasTransitionPerformed(self.context, 'verify')):
             # Redirect to manage results view if not cancelled
-            workflow = getToolByName(ar, 'portal_workflow')
-            if workflow.getInfoFor(ar, 'cancellation_state') != "cancelled":
+            if api.get_workflow_status_of(ar, 'cancellation_state') != \
+                    "cancelled":
                 manage_results_url = "/".join([self.context.absolute_url(),
                                                'manage_results'])
                 self.request.response.redirect(manage_results_url)

--- a/bika/lims/browser/analysisrequest/view.py
+++ b/bika/lims/browser/analysisrequest/view.py
@@ -57,10 +57,13 @@ class AnalysisRequestViewView(BrowserView):
             check_permission(EditFieldResults, self.context) and
             wasTransitionPerformed(self.context, 'receive') and
             not wasTransitionPerformed(self.context, 'verify')):
-            # Redirect to manage results view
-            manage_results_url = self.context.absolute_url() + '/manage_results'
-            self.request.response.redirect(manage_results_url)
-            return
+            # Redirect to manage results view if not cancelled
+            workflow = getToolByName(ar, 'portal_workflow')
+            if workflow.getInfoFor(ar, 'cancellation_state') != "cancelled":
+                manage_results_url = "/".join([self.context.absolute_url(),
+                                               'manage_results'])
+                self.request.response.redirect(manage_results_url)
+                return
 
         # Contacts get expanded for view
         contact = self.context.getContact()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
There is an infinite redirection between 'manage_results' and 'view' pages of Cancelled Ar's.

## Current behavior before PR
Browser returns and error when trying to access Cancelled AR's.

## Desired behavior after PR is merged
'View' view of Cancelled AR's doesn't fail. 
_____________________________________________________________

This fix brings a question (even maybe an issue) with itself: "If an AR is Cancelled and we still show its `View` view, can any of its fields be updated?! ". 
____________________
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
