### PR TITLE
Fix: AR Report Listing shows all Reports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Changelog
 
 **Fixed**
 
+- #663 Fix: AR Report Listing shows all Reports
 - #654 Default's Multi Analysis Request report gives a Traceback
 - #649 Specification fields decimal-mark validator not working for new opened categories
 - #637 Analysis Requests are never transitioned to assigned/unassigned

--- a/bika/lims/browser/analysisrequest/published_results.py
+++ b/bika/lims/browser/analysisrequest/published_results.py
@@ -6,9 +6,9 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 from bika.lims import bikaMessageFactory as _
+from bika.lims import api
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.utils import t
-# from bika.lims.permissions import *
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 
@@ -28,8 +28,15 @@ class AnalysisRequestPublishedResults(BikaListingView):
     def __init__(self, context, request):
         super(AnalysisRequestPublishedResults, self).__init__(context, request)
         self.catalog = "portal_catalog"
-        self.contentFilter = {'portal_type': 'ARReport',
-                              'sort_order': 'reverse'}
+        self.contentFilter = {
+            'portal_type': 'ARReport',
+            'path': {
+                'query': api.get_path(self.context),
+                'depth': 1,
+            },
+            'sort_order': 'reverse'
+        }
+
         self.context_actions = {}
         self.show_select_column = True
         self.show_workflow_action_buttons = False


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This bug was introduced with the refactoring of the listing tables in https://github.com/senaite/senaite.core/pull/619

## Current behavior before PR

All AR Reports are displayed in the published reports view

## Desired behavior after PR is merged

Only client local reports are displayed in the published reports view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
