### PR TITLE
Improved async transition loading and workflow button rendering in listing tables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Changelog
 
 **Fixed**
 
+- #664 Improved async transition loading and workflow button rendering in listing tables
 - #654 Default's Multi Analysis Request report gives a Traceback
 - #649 Specification fields decimal-mark validator not working for new opened categories
 - #637 Analysis Requests are never transitioned to assigned/unassigned

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -467,7 +467,7 @@
       uids = [];
       checkall = $("input[id*='select_all']", $table);
       $(checkall).hide();
-      wo_trans = $("input[data-valid_transitions='{}']");
+      wo_trans = $("input[id*='_cb_'][data-valid_transitions='{}']");
       $(wo_trans).prop("disabled", true);
       $(wo_trans).each(function(e) {
         return uids.push($(this).val());
@@ -486,7 +486,7 @@
         this.loading_transitions = false;
         $("input[id*='select_all']").fadeIn();
         if ("transitions" in data) {
-          return $.each(data.transitions, function(index, record) {
+          $.each(data.transitions, function(index, record) {
             var checkbox, trans, uid;
             uid = record.uid;
             trans = record.transitions;
@@ -495,6 +495,7 @@
             return $(checkbox).prop("disabled", false);
           });
         }
+        return this.render_transition_buttons(table);
       });
     };
 

--- a/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
@@ -482,7 +482,7 @@ class window.BikaListingTableView
     $(checkall).hide()
 
     # Update valid transitions for elements which have not yet been updated:
-    wo_trans = $("input[data-valid_transitions='{}']")
+    wo_trans = $("input[id*='_cb_'][data-valid_transitions='{}']")
 
     $(wo_trans).prop "disabled", yes
     $(wo_trans).each (e) ->
@@ -510,6 +510,10 @@ class window.BikaListingTableView
           checkbox = $("input[id*='_cb_'][value='#{uid}']")
           checkbox.attr "data-valid_transitions", $.toJSON(trans)
           $(checkbox).prop "disabled", false
+
+      # re-render the transition buttons in case the user clicked the back
+      # button of the browser
+      @render_transition_buttons table
 
 
   render_transition_buttons: (table) ->


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The async transition loading and transition button rendering was improved regarding re-rendering and checkbox selectors.

## Current behavior before PR

- WF buttons are not displayed after clicking the Back button of the browser when some items were selected
- Selectors for enabling/disabling checkboxes on transition loading matched different elements

## Desired behavior after PR is merged

- WF buttons are displayed after clicking the Back button of the browser when some items were selected
- Selectors for enabling/disabling checkboxes on transition loading match the same elements

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
