### PR TITLE
Listings: Fix sort_on change on Show More click

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ Changelog
 
 **Fixed**
 
+- #670 Listings: Fix sort_on change on Show More click
 - #653 Points in QC Charts are not displayed in accordance with capture date
 - #662 Viewing Cancelled AR's fails
 - #550 Wrong Listings of Analyses called from Dashboard

--- a/bika/lims/browser/templates/bika_listing_table.pt
+++ b/bika/lims/browser/templates/bika_listing_table.pt
@@ -86,12 +86,12 @@
     <input type="hidden"
            tal:omit-tag="python:table_only"
            tal:attributes="name python:form_id+'_sort_on';
-                           value python:request.get(form_id+'_sort_on', 'id')"/>
+                           value python:request.get(form_id+'_sort_on', '')"/>
 
     <input type="hidden"
            tal:omit-tag="python:table_only"
            tal:attributes="name python:form_id+'_sort_order';
-                           value python:request.get(form_id+'_sort_order', 'ascending')"/>
+                           value python:request.get(form_id+'_sort_order', '')"/>
 
     <input type="hidden"
            name="ajax_categories"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/669

## Current behavior before PR

The sort_on index changed on "Show More" click from `created` to `id`. Duplicate items were shown.

## Desired behavior after PR is merged

The sort_on index does not change on "Show More" click and initially keeps the `created` value from the view.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
