### PR TITLE
Traceback on automatic sticker printing in batch context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ Changelog
 
 **Fixed**
 
+- #672 Traceback on automatic sticker printing in batch context
 - #670 Listings: Fix sort_on change on Show More click
 - #653 Points in QC Charts are not displayed in accordance with capture date
 - #662 Viewing Cancelled AR's fails

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -256,6 +256,7 @@ class WorkflowAction:
         if transitioned and action == auto_stickers_action:
             self.request.form['uids'] = transitioned
             self.workflow_action_print_stickers()
+            dest = self.destination_url
 
         return len(transitioned), dest
 

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -158,6 +158,7 @@ class WorkflowAction:
             self.portal.bika_setup.getAutoStickerTemplate(),
             ','.join(uids)
         )
+        self.destination_url = url
         self.request.response.redirect(url)
 
     def __call__(self):
@@ -246,20 +247,15 @@ class WorkflowAction:
                     else:
                         success, message = doActionFor(item, action)
                     if success:
-                        transitioned.append(item.id)
+                        transitioned.append(item.UID())
                     else:
                         self.addPortalMessage(message, 'error')
 
         # automatic label printing
-        if transitioned \
-                and action == 'receive' \
-                and 'receive' in self.portal.bika_setup.getAutoPrintStickers():
-            q = "/sticker?template=%s&items=" % \
-                (self.portal.bika_setup.getAutoStickerTemplate())
-            # selected_items is a list of UIDs (stickers for AR_add use IDs)
-            q += ",".join(transitioned)
-            dest = self.context.absolute_url() + q
-            self.destination_url = dest
+        auto_stickers_action = self.portal.bika_setup.getAutoPrintStickers()
+        if transitioned and action == auto_stickers_action:
+            self.request.form['uids'] = transitioned
+            self.workflow_action_print_stickers()
 
         return len(transitioned), dest
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Traceback on rendering stickers from inside batch context on AR receive.

Linked issue: https://github.com/senaite/senaite.core/issues/671

## Current behavior before PR

The following traceback appears in stickers preview:
```
Traceback (most recent call last):
  File "/home/xispa/zinstance/src/senaite.core/bika/lims/browser/stickers.py", line 295, in renderItem
    return embed(self)
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/Products/Five/browser/pagetemplatefile.py", line 59, in __call__
    sourceAnnotations=getattr(debug_flags, 'sourceAnnotations', 0),
  File "/home/xispa/buildout-cache/eggs/zope.pagetemplate-3.6.3-py2.7.egg/zope/pagetemplate/pagetemplate.py", line 132, in pt_render
    strictinsert=0, sourceAnnotations=sourceAnnotations
  File "/home/xispa/buildout-cache/eggs/five.pt-2.2.4-py2.7.egg/five/pt/engine.py", line 98, in __call__
    return self.template.render(**kwargs)
  File "/home/xispa/buildout-cache/eggs/z3c.pt-3.1.0-py2.7.egg/z3c/pt/pagetemplate.py", line 158, in render
    return base_renderer(**context)
  File "/home/xispa/buildout-cache/eggs/Chameleon-3.2-py2.7.egg/chameleon/zpt/template.py", line 297, in render
    return super(PageTemplate, self).render(**_kw)
  File "/home/xispa/buildout-cache/eggs/Chameleon-3.2-py2.7.egg/chameleon/template.py", line 191, in render
    raise_with_traceback(exc, tb)
  File "/home/xispa/buildout-cache/eggs/Chameleon-3.2-py2.7.egg/chameleon/template.py", line 171, in render
    self._render(stream, econtext, rcontext)
  File "9d67db03324cd1649323746712e6c6a8.py", line 152, in render
AttributeError: 'NoneType' object has no attribute 'getSampler'

 - Expression: "        python:sample.getS"
 - Filename:   ... /bika/lims/browser/templates/stickers/Code_128_1x48mm.pt
 - Location:   (line 26: col 14)
 - Source:     sampler           python:sample.getSampler();
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  modules: 
               sample: 
               ar: 
               container: 
               wrapped_repeat: 
               portal_url: http://localhost:8080/senaite
               traverse_subpath: 
               partnr: 001
               template: 
               translate: 
               repeat: {...} (0)
               views: 
               args: 
               here: 
               part: 
               user: 
               nothing: 
               ar_id: 
               default: 
               request: 
               item: 
               loop: {...} (0)
               context: 
               portal_state: 
               view: 
               root: 
               options: {...} (0)
               target_language:
```

## Desired behavior after PR is merged

The PDF with the stickers correctly rendered for the received Analysis Requests is displayed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
