### PR TITLE
QC Analyses and Samples not totaled correctly in Worksheets list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ Changelog
 
 **Fixed**
 
+- #673 QC Analyses and Samples not totaled correctly in Worksheets list
 - #670 Listings: Fix sort_on change on Show More click
 - #653 Points in QC Charts are not displayed in accordance with capture date
 - #662 Viewing Cancelled AR's fails

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -389,6 +389,7 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         # Add the duplicate in the worksheet
         self.setAnalyses(self.getAnalyses() + [ref_analysis, ])
         doActionFor(ref_analysis, 'assign')
+        self.reindexObject()
         return ref_analysis
 
     def nextReferenceAnalysesGroupID(self, reference):
@@ -509,6 +510,7 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         # Add the duplicate in the worksheet
         self.setAnalyses(self.getAnalyses() + [duplicate, ])
         doActionFor(duplicate, 'assign')
+        self.reindexObject()
 
         return duplicate
 

--- a/bika/lims/upgrade/v01_02_003.py
+++ b/bika/lims/upgrade/v01_02_003.py
@@ -7,6 +7,7 @@
 from bika.lims import logger, api
 from bika.lims.catalog.analysisrequest_catalog import \
     CATALOG_ANALYSIS_REQUEST_LISTING
+from bika.lims.catalog.worksheet_catalog import CATALOG_WORKSHEET_LISTING
 from bika.lims.config import PROJECTNAME as product
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
@@ -34,6 +35,11 @@ def upgrade(tool):
     # FieldIndex 'assigned_state' in AR's catalog (for its use on searches)
     fix_assign_analysis_requests(portal, ut)
 
+    # The number of QC Analyses is not refreshed when a Duplicate or Reference
+    # Sample in a Worksheet. See #673. Thus, worksheets that are not yet in
+    # to_be_verified state needs to be reindexed
+    fix_worksheet_qc_number_analyses_inconsistences(portal, ut)
+
     logger.info("{0} upgraded to version {1}".format(product, version))
 
     return True
@@ -53,3 +59,12 @@ def fix_assign_analysis_requests(portal, ut):
     ut.addIndexAndColumn(CATALOG_ANALYSIS_REQUEST_LISTING, 'assigned_state',
                 'FieldIndex')
     ut.refreshCatalogs()
+
+
+def fix_worksheet_qc_number_analyses_inconsistences(portal, ut):
+    query = {'portal_type': 'Worksheet',
+             'review_state':'open'}
+    brains = api.search(query, CATALOG_WORKSHEET_LISTING)
+    for brain in brains:
+        worksheet = api.get_object(brain)
+        worksheet.reindexObject()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/635

## Current behavior before PR

After adding a QC Analysis (Duplicate or Reference Analysis) into a Worksheet, the numbers for QC Analyses and Samples are not updated correctly in Worksheets list.

## Desired behavior after PR is merged

When adding a QC Analysis (Duplicate or Reference Analysis) into a Worksheet, the numbers for QC Analyses and Samples are updated correctly in Worksheets list.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
