### PR TITLE
Fix category toggling when the category name contains spaces

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Changelog
 
 **Fixed**
 
+- #677 Fix category toggling when the category name contains spaces
 - #672 Traceback on automatic sticker printing in batch context
 - #673 QC Analyses and Samples not totaled correctly in Worksheets list
 - #670 Listings: Fix sort_on change on Show More click

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -322,10 +322,10 @@
        */
       var base_url, cat, cat_items, cat_url, expanded, form, form_data, placeholder, url;
       form = $("form#" + form_id);
-      cat = $("th.cat_header[cat=" + cat_id + "]");
-      placeholder = $("tr[data-ajax_category=" + cat_id);
+      cat = $("th.cat_header[cat='" + cat_id + "']");
+      placeholder = $("tr[data-ajax_category='" + cat_id + "']");
       expanded = cat.hasClass("expanded");
-      cat_items = $("tr[cat=" + cat_id + "]");
+      cat_items = $("tr[cat='" + cat_id + "']");
       cat.toggleClass("expanded collapsed");
       if (cat_items.length > 0) {
         console.debug("ListingTableView::toggle_category: Category " + cat_id + " is already expanded -> Toggle only");

--- a/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
@@ -318,10 +318,10 @@ class window.BikaListingTableView
     # get the form object
     form = $("form##{form_id}")
 
-    cat = $("th.cat_header[cat=#{cat_id}]")
-    placeholder = $("tr[data-ajax_category=#{cat_id}")
+    cat = $("th.cat_header[cat='#{cat_id}']")
+    placeholder = $("tr[data-ajax_category='#{cat_id}']")
     expanded = cat.hasClass "expanded"
-    cat_items = $("tr[cat=#{cat_id}]")
+    cat_items = $("tr[cat='#{cat_id}']")
 
     # Toggle expand/collapsed class
     cat.toggleClass "expanded collapsed"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/676

## Current behavior before PR

Category "Water Chemistry" not toggled on click

## Desired behavior after PR is merged

Category "Water Chemistry" toggles on click

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
