### PR TITLE
Analysis could not set to "Hidden" in results view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Changelog
 
 **Fixed**
 
+- #679 Analysis could not set to "Hidden" in results view
 - #672 Traceback on automatic sticker printing in batch context
 - #673 QC Analyses and Samples not totaled correctly in Worksheets list
 - #670 Listings: Fix sort_on change on Show More click

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -749,7 +749,7 @@
        *
        * Used in Analysis Listing when the "Hidden" checkbox is clicked
        */
-      var $el, el, fieldname, fieldvalue, form_data, obj, rowname, tr, uid, url;
+      var $el, el, fieldname, fieldvalue, form_data, rowname, tr, uid, url;
       console.debug("°°° ListingTableView::on_autosave_field_change °°°");
       el = event.currentTarget;
       $el = $(el);
@@ -762,12 +762,9 @@
       if ($el.is(":checkbox")) {
         fieldvalue = $el[0].checked;
       }
-      form_data = (
-        obj = {},
-        obj["" + fieldname] = fieldvalue,
-        obj["obj_uid"] = uid,
-        obj
-      );
+      form_data = {};
+      form_data[fieldname] = fieldvalue;
+      form_data["obj_uid"] = uid;
       return this.ajax_submit({
         url: url,
         data: form_data

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -51,6 +51,8 @@
 
     BikaListingTableView.prototype.load = function() {
       console.debug("ListingTableView::load");
+      jarn.i18n.loadCatalog('bika');
+      this._ = window.jarn.i18n.MessageFactory('bika');
       this.bind_eventhandler();
       this.loading_transitions = false;
       this.toggle_cols_cookie = "toggle_cols";
@@ -744,9 +746,42 @@
        * This function looks for the column defined as 'autosave' and if its value
        * is true, the result of this input will be saved after each change via
        * ajax.
+       *
+       * Used in Analysis Listing when the "Hidden" checkbox is clicked
        */
-      console.warn("BBB: Autosave is deprecated and not supported anymore");
-      return false;
+      var $el, el, fieldname, fieldvalue, form_data, obj, rowname, tr, uid, url;
+      console.debug("°°° ListingTableView::on_autosave_field_change °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      url = (this.get_portal_url()) + "/@@API/update";
+      tr = $el.closest("tr");
+      rowname = tr.attr("title");
+      uid = $el.attr("uid");
+      fieldname = $el.attr("field");
+      fieldvalue = $el.val();
+      if ($el.is(":checkbox")) {
+        fieldvalue = $el[0].checked;
+      }
+      form_data = (
+        obj = {},
+        obj["" + fieldname] = fieldvalue,
+        obj["obj_uid"] = uid,
+        obj
+      );
+      return this.ajax_submit({
+        url: url,
+        data: form_data
+      }).done(function(data) {
+        var level, message, success;
+        success = data && data.success === true ? true : false;
+        if (success) {
+          message = this._(rowname + " saved");
+        } else {
+          message = this._("Failed to update " + rowname);
+        }
+        level = success ? "succeed" : "error";
+        return bika.lims.SiteView.notify_in_panel(message, level);
+      });
     };
 
     BikaListingTableView.prototype.on_workflow_button_click = function(event) {

--- a/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
@@ -834,9 +834,10 @@ class window.BikaListingTableView
     if $el.is ":checkbox"
       # note: only the element has the checked property
       fieldvalue = $el[0].checked
-    form_data =
-      "#{fieldname}": fieldvalue
-      "obj_uid": uid
+
+    form_data = {}
+    form_data[fieldname] = fieldvalue
+    form_data["obj_uid"] = uid
 
     # send the new data to the server
     @ajax_submit

--- a/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
@@ -11,6 +11,10 @@ class window.BikaListingTableView
   load: =>
     console.debug "ListingTableView::load"
 
+    # load translations
+    jarn.i18n.loadCatalog 'bika'
+    @_ = window.jarn.i18n.MessageFactory('bika')
+
     # bind the event handler to the elements
     @bind_eventhandler()
 
@@ -812,9 +816,40 @@ class window.BikaListingTableView
      * This function looks for the column defined as 'autosave' and if its value
      * is true, the result of this input will be saved after each change via
      * ajax.
+     *
+     * Used in Analysis Listing when the "Hidden" checkbox is clicked
     ###
-    console.warn "BBB: Autosave is deprecated and not supported anymore"
-    return false
+    console.debug "°°° ListingTableView::on_autosave_field_change °°°"
+
+    el = event.currentTarget
+    $el = $(el)
+
+    url = "#{@get_portal_url()}/@@API/update"
+
+    tr = $el.closest "tr"
+    rowname = tr.attr "title"
+    uid = $el.attr "uid"
+    fieldname = $el.attr "field"
+    fieldvalue = $el.val()
+    if $el.is ":checkbox"
+      # note: only the element has the checked property
+      fieldvalue = $el[0].checked
+    form_data =
+      "#{fieldname}": fieldvalue
+      "obj_uid": uid
+
+    # send the new data to the server
+    @ajax_submit
+      url: url
+      data: form_data
+    .done (data) ->
+      success = if data and data.success is true then true else false
+      if success
+        message = @_ "#{rowname} saved"
+      else
+        message = @_ "Failed to update #{rowname}"
+      level = if success then "succeed" else "error"
+      bika.lims.SiteView.notify_in_panel message, level
 
 
   on_workflow_button_click: (event) =>

--- a/bika/lims/skins/bika/ploneCustom.css.dtml
+++ b/bika/lims/skins/bika/ploneCustom.css.dtml
@@ -1054,12 +1054,12 @@ div#viewlet-above-content-title #panel-notification {
     box-shadow: 1px 1px 10px #fff;
 }
 div#viewlet-above-content-title #panel-notification div.error-notification-item {
-    background: url("/Plone/++resource++bika.lims.images/warning.png") no-repeat scroll 15px center #fff680;
+    background: url("&dtml-portal_url;/++resource++bika.lims.images/warning.png") no-repeat scroll 15px center #fff680;
     border-radius: 5px;
     padding: 15px 30px 15px 40px;
 }
 div#viewlet-above-content-title #panel-notification div.succeed-notification-item {
-    background: url("/Plone/++resource++bika.lims.images/ok.png") no-repeat scroll 15px center #dfdfdf;
+    background: url("&dtml-portal_url;/++resource++bika.lims.images/ok.png") no-repeat scroll 15px center #dfdfdf;
     border-radius: 5px;
     padding: 15px 30px 15px 40px;
 }


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The Auto-Save feature of Listing was not implemented.

Linked issue: #678 

## Current behavior before PR

Click on the "hidden" checkbox of Analyses had no effect

## Desired behavior after PR is merged

Click on the "hidden" checkbox of Analyses saves the value asynchronously

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
