### PR TITLE
Fix Traceback with periodicity in DashboardView

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ Changelog
 
 **Fixed**
 
+- #680 Fix Traceback with periodicity in DashboardView
 - #679 Analysis could not set to "Hidden" in results view
 - #677 Fix category toggling when the category name contains spaces
 - #672 Traceback on automatic sticker printing in batch context

--- a/bika/lims/browser/dashboard/dashboard.py
+++ b/bika/lims/browser/dashboard/dashboard.py
@@ -181,8 +181,8 @@ class DashboardView(BrowserView):
             return
 
         self.member = mtool.getAuthenticatedMember()
-        self.dashboard_cookie = self.check_dashboard_cookie()
         self.periodicity =  self.request.get('p', PERIODICITY_WEEKLY)
+        self.dashboard_cookie = self.check_dashboard_cookie()
         date_range = self.get_date_range(self.periodicity)
         self.date_from = date_range[0]
         self.date_to = date_range[1]


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Traceback in Dashboard view

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.dashboard.dashboard, line 184, in __call__
  Module bika.lims.browser.dashboard.dashboard, line 208, in check_dashboard_cookie
  Module bika.lims.browser.dashboard.dashboard, line 248, in _create_raw_data
  Module bika.lims.browser.dashboard.dashboard, line 323, in get_sections
  Module bika.lims.browser.dashboard.dashboard, line 588, in get_analyses_section
  Module bika.lims.browser.dashboard.dashboard, line 786, in fill_dates_evo
AttributeError: 'DashboardView' object has no attribute 'periodicity‘
```

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
