### PR TITLE
Invalidated Analysis Requests do not appear on Dashboard's evo chart

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ Changelog
 
 **Fixed**
 
+- #681 Invalidated Analysis Requests do not appear on Dashboard's evo chart
 - #679 Analysis could not set to "Hidden" in results view
 - #677 Fix category toggling when the category name contains spaces
 - #672 Traceback on automatic sticker printing in batch context

--- a/bika/lims/browser/dashboard/dashboard.py
+++ b/bika/lims/browser/dashboard/dashboard.py
@@ -699,6 +699,7 @@ class DashboardView(BrowserView):
                     'scheduled_sampling':  _('Sampling scheduled'),
                     'sample_due':          _('Reception pending'),
                     'rejected':            _('Rejected'),
+                    'invalid':             _('Invalid'),
                     'sample_received':     _('Results pending'),
                     'assigned':            _('Results pending'),
                     'attachment_due':      _('Results pending'),
@@ -746,6 +747,9 @@ class DashboardView(BrowserView):
             'retracted':                    '#FF6B6B',
             _('Rejected'):                  '#FF6B6B',
             _('Retracted'):                 '#FF6B6B',
+
+            'invalid':                      '#C44D58',
+            _('Invalid'):                   '#C44D58',
 
             'to_be_verified':               '#A7DBD8',
             _('To be verified'):            '#A7DBD8',


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

It also removes the following annoying warning:
```
WARNING Bika 'invalid' State for 'AnalysisRequest' not available
```

## Current behavior before PR

Invalidated Analysis Requests appear under "Other states" in evo chart and a warning is displayed in the log.

## Desired behavior after PR is merged

Invalidated Analysis Requests appear under "Invalid" state in evo chart and no warning is displayed.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
