### PR TITLE
Aggregated list of analyses set to read-only

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Changelog
 
 **Changed**
 
+- #683 Aggregated lists of analyses have been set to read-only
 - #674 Dashboard with slightly better performance
 - #621 AnalysesView code refactoring
 - #668 AR Add: Debounce expensive XHR calls

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Changelog
 
 **Changed**
 
-- #683 Aggregated lists of analyses have been set to read-only
+- #684 Aggregated lists of analyses set to read-only mode
 - #674 Dashboard with slightly better performance
 - #621 AnalysesView code refactoring
 - #668 AR Add: Debounce expensive XHR calls

--- a/bika/lims/browser/aggregatedanalyses/aggregatedanalyses.py
+++ b/bika/lims/browser/aggregatedanalyses/aggregatedanalyses.py
@@ -44,7 +44,7 @@ class AggregatedAnalysesView(AnalysesView):
 
         # each editable item needs it's own allow_edit
         # which is a list of field names.
-        self.allow_edit = True
+        self.allow_edit = False
 
         self.columns['AnalysisRequest'] = {
             'title': _('Analysis Request'),
@@ -143,6 +143,12 @@ class AggregatedAnalysesView(AnalysesView):
 
     def getPOSTAction(self):
         return 'aggregatedanalyses_workflow_action'
+
+    def is_analysis_edition_allowed(self, analysis_brain):
+        """Overrides the function from the parent, cause we don't want in any
+        case the analyses displayed in aggregated list to be editable. The
+        correct way to introduce results is by using Worksheets!"""
+        return False
 
     def isItemAllowed(self, obj):
         """

--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -1218,8 +1218,17 @@ class AnalysesView(BikaListingView):
         item['ResultDM'] = ''
 
     def _folder_item_remarks(self, analysis_brain, item):
+        """Renders the Remarks field for the passed in analysis and if the
+        edition of the analysis is permitted, adds a button to toggle the
+        visibility of remarks field
+
+        :param analysis_brain: Brain that represents an analysis
+        :param item: analysis' dictionary counterpart that represents a row"""
         item['Remarks'] = analysis_brain.getRemarks
+
         if not self.is_analysis_edition_allowed(analysis_brain):
+            # Edition not allowed, do not add the remarks toggle button, the
+            # remarks field will be displayed without the option to hide it
             return
 
         # Analysis can be edited. Add the remarks toggle button

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -259,19 +259,12 @@ function WorksheetManageResultsView() {
     }
 
     function loadRemarksEventHandlers() {
-        // Add a baloon icon before Analyses' name when you'd add a remark. If you click on, it'll display remarks textarea.
-        var txt1 = '<a href="#" class="add-remark"><img src="'+window.portal_url+'/++resource++bika.lims.images/comment_ico.png" title="'+_('Add Remark')+'")"></a>';
-        var pointer = $(".listing_remarks:contains('')").closest('tr').prev().find('td.service_title span.before');
-        $(pointer).append(txt1);
-
+        // On click, toggle the remarks field
         $("a.add-remark").click(function(e){
             e.preventDefault();
             var rmks = $(this).closest('tr').next('tr').find('td.remarks');
-            if (rmks.length > 0) {
-                rmks.toggle();
-            }
+            $(rmks).find('div.remarks-placeholder').toggle();
         });
-        $("a.add-remark").click();
     }
 
     function loadDetectionLimitsEventHandlers() {

--- a/bika/lims/browser/templates/bika_listing_table_items.pt
+++ b/bika/lims/browser/templates/bika_listing_table_items.pt
@@ -452,8 +452,7 @@
                   isanalysis python:'obj' in item and item['obj'].meta_type in ['Analysis', 'DuplicateAnalysis', 'ReferenceAnalysis'];
                   hasremarks python:True if item.get('Remarks','') else False;
                   remarksedit python: remarksenabled and 'Remarks' in item.get('allow_edit',[]);
-                  isforaggregatedlist python: True if review_state_id=='to_be_verified' else False;
-                  showremarks python:isanalysis and (hasremarks or remarksedit or isforaggregatedlist)">
+                  showremarks python:isanalysis and (hasremarks or remarksedit)">
 
       <tr tal:condition="showremarks"
           tal:define="keyword python:item.has_key('Keyword') and item['Keyword'] or '';"
@@ -467,6 +466,8 @@
         <td tal:attributes="colspan python:int(nr_cols)-1;
                             class string:${item/state_class} result remarks"
             style="padding-right:10px;padding-bottom:5px;">
+          <div class="remarks-placeholder"
+               tal:attributes="style python:'' if hasremarks else 'display:none'">
           <span i18n:translate="">Remarks:</span>&nbsp;
           <textarea style="width:100%;display:block;"
                     autocomplete="off"
@@ -485,6 +486,7 @@
                 tal:attributes="class python:'listing_remarks';
                                 name string:Remarks.${item/uid}:records;"
                 tal:content="python:item.get('Remarks', '') if hasremarks else 'No Remarks.'"/>
+          </div>
         </td>
       </tr>
     </tal:remarks_condition>

--- a/bika/lims/skins/bika/bika_listing.css.dtml
+++ b/bika/lims/skins/bika/bika_listing.css.dtml
@@ -81,8 +81,8 @@ table.bika-listing-table {
 }
 
 .bika-listing-table .listing_remarks {
+  color:#444;
   width:99%;
-  border:1px solid #ababab;
   margin:2px 0px;
 }
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Is totally meaningless to allow the user to introduce results in aggregated list of analyses. The introduction of results must be done through Worksheets or, alternatively through the Analysis Request' manage results view.

Apart from this functional consideration, allowing the introduction of results in aggregated list of analyses was causing a lot of problems because when "Show more" button was clicked, the js events responsible of managing things like instruments, methods, calculation or remarks balloon was not working properly.

With this PR, the remarks toggle button (balloon) is not rendered by js anymore. Rather is managed by the Analyses view and the template. The js is only responsible of the click event. In addition, some styling to remarks field has been added.

By default, remarks field is always displayed in read-only analyses that have remarks set. For analyses that are in edit mode, a balloon is displayed to toggle the field.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
