### PR TITLE
Display the stacked bars in evo charts sorted by number of occurrences

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ Changelog
 
 **Fixed**
 
+- #681 Invalidated Analysis Requests do not appear on Dashboard's evo chart
 - #679 Analysis could not set to "Hidden" in results view
 - #677 Fix category toggling when the category name contains spaces
 - #672 Traceback on automatic sticker printing in batch context

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Changelog
 
 **Changed**
 
+- #685 Display the stacked bars in evo charts sorted by number of occurrences
+- #685 Small changes in colours palette for evo charts from Dashboard
 - #674 Dashboard with slightly better performance
 - #621 AnalysesView code refactoring
 - #668 AR Add: Debounce expensive XHR calls

--- a/bika/lims/browser/dashboard/dashboard.py
+++ b/bika/lims/browser/dashboard/dashboard.py
@@ -699,6 +699,7 @@ class DashboardView(BrowserView):
                     'scheduled_sampling':  _('Sampling scheduled'),
                     'sample_due':          _('Reception pending'),
                     'rejected':            _('Rejected'),
+                    'invalid':             _('Invalid'),
                     'sample_received':     _('Results pending'),
                     'assigned':            _('Results pending'),
                     'attachment_due':      _('Results pending'),
@@ -746,6 +747,9 @@ class DashboardView(BrowserView):
             'retracted':                    '#FF6B6B',
             _('Rejected'):                  '#FF6B6B',
             _('Retracted'):                 '#FF6B6B',
+
+            'invalid':                      '#C44D58',
+            _('Invalid'):                   '#C44D58',
 
             'to_be_verified':               '#A7DBD8',
             _('To be verified'):            '#A7DBD8',

--- a/bika/lims/browser/dashboard/dashboard.py
+++ b/bika/lims/browser/dashboard/dashboard.py
@@ -683,8 +683,8 @@ class DashboardView(BrowserView):
 
     def get_states_map(self, portal_type):
         if portal_type == 'Analysis':
-            return {'to_be_sampled':   _('Sample reception pending'),
-                    'sample_due':      _('Sample reception pending'),
+            return {'to_be_sampled':   _('Reception pending'),
+                    'sample_due':      _('Reception pending'),
                     'sample_received': _('Assignment pending'),
                     'assigned':        _('Results pending'),
                     'attachment_due':  _('Results pending'),
@@ -722,21 +722,21 @@ class DashboardView(BrowserView):
 
     def get_colors_palette(self):
         return {
-            'to_be_sampled':                '#FA6900',
-            _('To be sampled'):             '#FA6900',
+            'to_be_sampled':                '#917A4C',
+            _('To be sampled'):             '#917A4C',
 
-            'to_be_preserved':              '#C44D58',
-            _('To be preserved'):           '#C44D58',
+            'to_be_preserved':              '#C2803E',
+            _('To be preserved'):           '#C2803E',
 
-            'scheduled_sampling':           '#FA6900',
-            _('Sampling scheduled'):        '#FA6900',
+            'scheduled_sampling':           '#F38630',
+            _('Sampling scheduled'):        '#F38630',
 
-            'sample_due':                   '#F38630',
-            _('Sample reception pending'):  '#F38630',
-            _('Reception pending'):         '#F38630',
+            'sample_due':                   '#FA6900',
+            _('Reception pending'):         '#FA6900',
 
             'sample_received':              '#E0E4CC',
             _('Assignment pending'):        '#E0E4CC',
+            _('Sample received'):           '#E0E4CC',
 
             'assigned':                     '#dcdcdc',
             'attachment_due':               '#dcdcdc',

--- a/bika/lims/browser/dashboard/dashboard.py
+++ b/bika/lims/browser/dashboard/dashboard.py
@@ -9,6 +9,7 @@ import collections
 import datetime
 import json
 from calendar import monthrange
+from operator import itemgetter
 from time import time
 
 from DateTime import DateTime
@@ -855,9 +856,9 @@ class DashboardView(BrowserView):
                 logger.warn("'%s' State for '%s' not available" % (state, query['portal_type']))
             state = statesmap[state] if state in statesmap else otherstate
             created = self._getDateStr(periodicity, created)
+            statscount[state] += 1
             if created in outevoidx:
                 oidx = outevoidx[created]
-                statscount[state] += 1
                 if state in outevo[oidx]:
                     outevo[oidx][state] += 1
                 else:
@@ -875,7 +876,11 @@ class DashboardView(BrowserView):
                 if r in o:
                     del o[r]
 
-        return outevo
+        # Sort available status by number of occurences descending
+        sorted_states = sorted(statscount.items(), key=itemgetter(1))
+        sorted_states = map(lambda item: item[0], sorted_states)
+        sorted_states.reverse()
+        return {'data': outevo, 'states': sorted_states}
 
     def search_count(self, query, catalog_name):
         sorted_query = collections.OrderedDict(sorted(query.items()))

--- a/bika/lims/browser/dashboard/templates/dashboard.pt
+++ b/bika/lims/browser/dashboard/templates/dashboard.pt
@@ -288,10 +288,16 @@
     function loadBarChart(id) {
         var container = $('#'+id);
         $(container).find('svg').remove();
-        var data = $.parseJSON($(container).attr('data'));
+        var raw_data = $.parseJSON($(container).attr('data'));
+        var data = raw_data.data;
         if (data.length == 0 || Object.keys(data[0]).length < 2) {
             return;
         }
+        // All available states come sorted from by quantity descending, but we
+        // only want those for which there is at least one entry in data
+        var states = raw_data.states;
+        states = states.filter(function(key) { return key in data[0] });
+
         $(container).html("");
         var margin = {top: 10, right: 200, bottom: 50, left: 50},
             width = $(container).innerWidth() - margin.left - margin.right,
@@ -301,7 +307,7 @@
         var y = d3.scale.linear().range([height, 0]);
         colors = $.parseJSON($(container).attr('data-colors'));
         var color = d3.scale.ordinal().range(colors);
-        color.domain(d3.keys(data[0]).filter(function(key) { return key !== "date"; }));
+        color.domain(states);
 
         var xAxis = d3.svg.axis()
             .scale(x)
@@ -319,9 +325,6 @@
           .append("g")
             .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
-        var statusNames = d3.keys(data[0]).filter(function(key) {
-            return key !== "date";
-        });
         data.forEach(function(d) {
             var y0=0;
             d.statuses=color.domain().map(function(name) {
@@ -388,7 +391,7 @@
                 });
 
         var legend = svg.selectAll(".legend")
-                .data(statusNames.slice().reverse())
+                .data(states.slice().reverse())
                 .enter().append("g")
                     .attr("class", "legend")
                     .attr("transform", function(d, i) {


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR superseeds [Invalidated Analysis Requests do not appear on Dashboard's evo chart #682](https://github.com/senaite/senaite.core/pull/682)

The bars in evo charts from Dashboard were not displayed consistently (e.g. while one status were displayed at the bottom of the stack for a given item in x-axis position, but the same status was displayed at the top of the stack for x-axis+1 position).

This Pull Request also contains some small changes regarding the colors palette used to render the bars. The following palette is used now:

![dashboard-palette](https://user-images.githubusercontent.com/832627/36511366-4ebca04a-175e-11e8-87a6-ba21b480516b.png)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
