### PR TITLE
Hide balloon button for remarks when remarks are disabled in setup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ Changelog
 
 **Fixed**
 
+- #686 Balloon button for adding Remarks is displayed while disabled in Setup
 - #681 Invalidated Analysis Requests do not appear on Dashboard's evo chart
 - #680 Fix Traceback with periodicity in DashboardView
 - #679 Analysis could not set to "Hidden" in results view

--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -1231,6 +1231,10 @@ class AnalysesView(BikaListingView):
             # remarks field will be displayed without the option to hide it
             return
 
+        if not self.context.bika_setup.getEnableAnalysisRemarks():
+            # Remarks not enabled in Setup, so don't display the balloon button
+            return
+
         # Analysis can be edited. Add the remarks toggle button
         title = t(_("Add Remark"))
         img = get_image('comment_ico.png', title=title)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The balloon button for adding remarks for Analyses was displayed also if the setting in Setup was disabled. With this PR, the balloon only appears if both the analysis can be edited and the option in Setup is enabled.

## Current behavior before PR

The balloon for the introduction of remarks appear in analyses list when the option is disabled in Setup.

## Desired behavior after PR is merged

The balloon for the introduction of remarks appear in analyses list only when the option is enabled in Setup and the analysis can be edited.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
