### PR TITLE
Solve traceback on samples rejected view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,8 +30,8 @@ Changelog
 
 
 **Fixed**
-- #688 A traceback was appearing when navigating to rejected samples
 
+- #688 A traceback was appearing when navigating to rejected samples
 - #686 Balloon button for adding Remarks is displayed while disabled in Setup
 - #681 Invalidated Analysis Requests do not appear on Dashboard's evo chart
 - #680 Fix Traceback with periodicity in DashboardView

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Changelog
 
 
 **Fixed**
+- #688 A traceback was appearing when navigating to rejected samples
 
 - #686 Balloon button for adding Remarks is displayed while disabled in Setup
 - #681 Invalidated Analysis Requests do not appear on Dashboard's evo chart

--- a/bika/lims/browser/sample/view.py
+++ b/bika/lims/browser/sample/view.py
@@ -384,7 +384,7 @@ class SamplesView(BikaListingView):
                          'AdHoc',
                          'SamplingDate',
                          'DateReceived',
-                         'getDateSampled',
+                         'DateSampled',
                          'getSampler',
                          'getDatePreserved',
                          'getPreserver',


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #675 

## Current behavior before PR

The following traceback appeared when clicking on rejected samples:
```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.bika_listing, line 549, in __call__
  Module bika.lims.browser.bika_listing, line 617, in update
  Module bika.lims.browser.bika_listing, line 779, in get_toggle_cols
KeyError: 'getDateSampled'
```

## Desired behavior after PR is merged

There is no traceback when clicking on rejected samples and they are listed propperly. 

**Notes**

There was a mismatch in the column naming.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
