### PR TITLE
Allow to hide Analyses in any AR state

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Changelog
 
 **Changed**
 
+- #689 Allow to hide Analyses in any AR state
 - #685 Display the stacked bars in evo charts sorted by number of occurrences
 - #685 Small changes in colours palette for evo charts from Dashboard
 - #684 Aggregated lists of analyses set to read-only mode

--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -462,29 +462,10 @@ class AnalysesView(BikaListingView):
             enumerate(analysis_categories)])
 
     def before_render(self):
-        logger.warning("before_Render")
+        """Called before the template is rendered
+        """
         # Load analysis categories available in the system
         self.load_analysis_categories()
-
-        # Can the user edit?
-        if self.allow_edit:
-            if self.contentFilter.get('getPointOfCapture', '') == 'field':
-                # This is only loaded for Field' analyses list
-                self.allow_edit = self.has_permission(EditFieldResults)
-            else:
-                self.allow_edit = self.has_permission(EditResults)
-        self.show_select_column = self.allow_edit
-
-        # Users that can Add Analyses to an Analysis Request must be able to
-        # set the visibility of the analysis in results report, also if the
-        # current state of the Analysis Request (e.g. verified) does not allow
-        # the edition of other fields. Note that an analyst has no privileges
-        # by default to edit this value, cause this "visibility" field is
-        # related with results reporting and/or visibility from the client side.
-        # This behavior only applies to routine analyses, the visibility of QC
-        # analyses is managed in publish and are not visible to clients.
-        if not self.has_permission(AddAnalysis):
-            self.remove_column('Hidden')
 
     def isItemAllowed(self, obj):
         """Checks if the passed in Analysis must be displayed in the list.


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The option to show/hide Analyses in the report needs to be always available to customize the report printing.

## Current behavior before PR

The option to hide Analyses in the report is only available for AR states < Verified.

## Desired behavior after PR is merged

The option to hide Analyses in the report is available in any state.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
