### PR TITLE
Refactored and improved client folder listing view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Changelog
 
 **Changed**
 
+- #690 Refactored and improved client folder listing view
 - #685 Display the stacked bars in evo charts sorted by number of occurrences
 - #685 Small changes in colours palette for evo charts from Dashboard
 - #684 Aggregated lists of analyses set to read-only mode

--- a/bika/lims/browser/clientfolder.py
+++ b/bika/lims/browser/clientfolder.py
@@ -5,27 +5,25 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
+import collections
 import json
 
-from bika.lims import api
 from bika.lims import bikaMessageFactory as _
-from bika.lims import logger
+from bika.lims import api, logger
 from bika.lims.browser import BrowserView
 from bika.lims.browser.bika_listing import BikaListingView
-from bika.lims.permissions import AddClient
-from bika.lims.permissions import ManageAnalysisRequests
-from bika.lims.permissions import ManageClients
-from bika.lims.utils import get_email_link, get_link, get_registry_value, \
-    check_permission
+from bika.lims.permissions import (AddClient, ManageAnalysisRequests,
+                                   ManageClients)
+from bika.lims.utils import (check_permission, get_email_link, get_link,
+                             get_registry_value)
 from plone import protect
 from plone.app.content.browser.interfaces import IFolderContentsView
 from zope.interface import implements
 
 
 class ClientFolderContentsView(BikaListingView):
+    """Listing view for all Clients
     """
-    Listing view for all Clients
-       """
     implements(IFolderContentsView)
 
     _LANDING_PAGE_REGISTRY_KEY = "bika.lims.client.default_landing_page"
@@ -39,95 +37,88 @@ class ClientFolderContentsView(BikaListingView):
         self.form_id = "list_clientsfolder"
         self.sort_on = "sortable_title"
         # Landing page to be added to the link of each client from the list
-        self.landing_page = get_registry_value(self._LANDING_PAGE_REGISTRY_KEY,
-                                               self._DEFAULT_LANDING_PAGE)
-        self.contentFilter = {'portal_type': 'Client',
-                              'sort_on': 'sortable_title',
-                              'sort_order': 'ascending'}
+        self.landing_page = get_registry_value(
+            self._LANDING_PAGE_REGISTRY_KEY, self._DEFAULT_LANDING_PAGE)
 
-        self.filter_indexes = ['title', 'SearchableText']
+        self.contentFilter = {
+            "portal_type": "Client",
+            "sort_on": "sortable_title",
+            "sort_order": "ascending"
+        }
 
         self.show_sort_column = False
         self.show_select_row = False
         self.show_select_all_checkbox = False
         self.show_select_column = False
         self.pagesize = 25
-        self.icon = '{}/{}'.\
-            format(self.portal_url,
-            "++resource++bika.lims.images/client_big.png")
-        request.set('disable_border', 1)
+        self.icon = "{}/{}".format(
+            self.portal_url, "++resource++bika.lims.images/client_big.png")
+        request.set("disable_border", 1)
 
-        self.columns = {
-            'title': {'title': _('Name'), 'index': 'sortable_title'},
-            'EmailAddress': {'title': _('Email Address')},
-            'getCountry': {'title': _('Country')},
-            'getProvince': {'title': _('Province')},
-            'getDistrict': {'title': _('District')},
-            'Phone': {'title': _('Phone')},
-            'Fax': {'title': _('Fax')},
-            'ClientID': {'title': _('Client ID')},
-            'BulkDiscount': {'title': _('Bulk Discount')},
-            'MemberDiscountApplies': {'title': _('Member Discount')},
-        }
+        self.columns = collections.OrderedDict((
+            ("title", {
+                "title": _("Name"),
+                "index": "sortable_title"},),
+            ("ClientID", {
+                "title": _("Client ID")}),
+            ("EmailAddress", {
+                "title": _("Email Address")}),
+            ("getCountry", {
+                "title": _("Country")}),
+            ("getProvince", {
+                "title": _("Province")}),
+            ("getDistrict", {
+                "title": _("District")}),
+            ("Phone", {
+                "title": _("Phone")}),
+            ("Fax", {
+                "title": _("Fax")}),
+            ("BulkDiscount", {
+                "title": _("Bulk Discount")}),
+            ("MemberDiscountApplies", {
+                "title": _("Member Discount")}),
+        ))
 
-        self.review_states = [  # leave these titles and ids alone
-            {'id': 'default',
-             'contentFilter': {'inactive_state': 'active'},
-             'title': _('Active'),
-             'transitions': [{'id': 'deactivate'}, ],
-             'columns': ['title',
-                         'ClientID',
-                         'getCountry',
-                         'getProvince',
-                         'getDistrict',
-                         'EmailAddress',
-                         'Phone',
-                         'Fax', ]
-             },
-            {'id': 'inactive',
-             'title': _('Dormant'),
-             'contentFilter': {'inactive_state': 'inactive'},
-             'transitions': [{'id': 'activate'}, ],
-             'columns': ['title',
-                         'ClientID',
-                         'getCountry',
-                         'getProvince',
-                         'getDistrict',
-                         'EmailAddress',
-                         'Phone',
-                         'Fax', ]
-             },
-            {'id': 'all',
-             'title': _('All'),
-             'contentFilter': {},
-             'transitions': [],
-             'columns': ['title',
-                         'ClientID',
-                         'getCountry',
-                         'getProvince',
-                         'getDistrict',
-                         'EmailAddress',
-                         'Phone',
-                         'Fax', ]
-             },
+        self.review_states = [
+            {
+                "id": "default",
+                "contentFilter": {"inactive_state": "active"},
+                "title": _("Active"),
+                "transitions": [{"id": "deactivate"}, ],
+                "columns": self.columns,
+            }, {
+                "id": "inactive",
+                "title": _("Dormant"),
+                "contentFilter": {"inactive_state": "inactive"},
+                "transitions": [{"id": "activate"}, ],
+                "columns": self.columns,
+            }, {
+                "id": "all",
+                "title": _("All"),
+                "contentFilter": {},
+                "transitions": [],
+                "columns": self.columns,
+            },
         ]
 
-    def __call__(self):
+    def before_render(self):
+        """Before template render hook
+        """
+        # Render the Add button if the user has the AddClient permission
         if check_permission(AddClient, self.context):
-            self.context_actions[_('Add')] = \
-                {'url': 'createObject?type_name=Client',
-                 'icon': '++resource++bika.lims.images/add.png'}
+            self.context_actions[_("Add")] = {
+                "url": "createObject?type_name=Client",
+                "icon": "++resource++bika.lims.images/add.png"
+            }
 
-        # Display a checkbox next to each client in the list only if the user
-        # has rights for ManageClients
+        # Display a checkbox next to each client in the list if the user has
+        # rights for ManageClients
         self.show_select_column = check_permission(ManageClients, self.context)
 
-        return super(ClientFolderContentsView, self).__call__()
-
     def isItemAllowed(self, obj):
-        """
-        Returns true if the current user has Manage AR rights for the current
-        Client (item) to be rendered.
+        """Returns true if the current user has Manage AR rights for the
+        current Client (item) to be rendered.
+
         :param obj: client to be rendered as a row in the list
         :type obj: ATContentType/DexterityContentType
         :return: True if the current user can see this Client. Otherwise, False.
@@ -136,9 +127,9 @@ class ClientFolderContentsView(BikaListingView):
         return check_permission(ManageAnalysisRequests, obj)
 
     def folderitem(self, obj, item, index):
-        """
-        Applies new properties to the item (Client) that is currently being
+        """Applies new properties to the item (Client) that is currently being
         rendered as a row in the list
+
         :param obj: client to be rendered as a row in the list
         :param item: dict representation of the client, suitable for the list
         :param index: current position of the item within the list
@@ -148,9 +139,19 @@ class ClientFolderContentsView(BikaListingView):
         :return: the dict representation of the item
         :rtype: dict
         """
-        link_url = "{}/{}".format(item['url'], self.landing_page)
-        item['replace']['title'] = get_link(link_url, item['title'])
-        item['replace']['EmailAddress'] = get_email_link(item['EmailAddress'])
+        # render a link to the defined start page
+        link_url = "{}/{}".format(item["url"], self.landing_page)
+        item["replace"]["title"] = get_link(link_url, item["title"])
+        item["replace"]["ClientID"] = get_link(link_url, item["ClientID"])
+        # render an email link
+        item["replace"]["EmailAddress"] = get_email_link(item["EmailAddress"])
+        # translate True/FALSE values
+        item["replace"]["BulkDiscount"] = obj.getBulkDiscount() and _("Yes") or _("No")
+        item["replace"]["MemberDiscountApplies"] = obj.getMemberDiscountApplies() and _("Yes") or _("No")
+        # render a phone link
+        phone = obj.getPhone()
+        if phone:
+            item["replace"]["Phone"] = get_link("tel:{}".format(phone), phone)
         return item
 
 
@@ -173,11 +174,11 @@ class ajaxGetClients(BrowserView):
 
     def __call__(self):
         protect.CheckAuthenticator(self.request)
-        searchTerm = self.request.get('searchTerm', '').lower()
-        page = self.request.get('page', 1)
-        nr_rows = self.request.get('rows', 20)
-        sort_order = self.request.get('sord') or 'ascending'
-        sort_index = self.request.get('sidx') or 'sortable_title'
+        searchTerm = self.request.get("searchTerm", "").lower()
+        page = self.request.get("page", 1)
+        nr_rows = self.request.get("rows", 20)
+        sort_order = self.request.get("sord") or "ascending"
+        sort_index = self.request.get("sidx") or "sortable_title"
 
         if sort_order == "desc":
             sort_order = "descending"
@@ -213,10 +214,13 @@ class ajaxGetClients(BrowserView):
 
         pages = len(rows) / int(nr_rows)
         pages += divmod(len(rows), int(nr_rows))[1] and 1 or 0
-        ret = {'page': page,
-               'total': pages,
-               'records': len(rows),
-               'rows': rows[(int(page) - 1) * int(nr_rows):
-                             int(page) * int(nr_rows)]}
+        ret = {
+            "page": page,
+            "total": pages,
+            "records": len(rows),
+            "rows": rows[
+                (int(page) - 1) * int(nr_rows): int(page) * int(nr_rows)
+            ]
+        }
 
         return json.dumps(ret)

--- a/bika/lims/browser/clientfolder.py
+++ b/bika/lims/browser/clientfolder.py
@@ -64,18 +64,24 @@ class ClientFolderContentsView(BikaListingView):
             ("EmailAddress", {
                 "title": _("Email Address")}),
             ("getCountry", {
+                "toggle": False,
                 "title": _("Country")}),
             ("getProvince", {
+                "toggle": False,
                 "title": _("Province")}),
             ("getDistrict", {
+                "toggle": False,
                 "title": _("District")}),
             ("Phone", {
                 "title": _("Phone")}),
             ("Fax", {
+                "toggle": False,
                 "title": _("Fax")}),
             ("BulkDiscount", {
+                "toggle": False,
                 "title": _("Bulk Discount")}),
             ("MemberDiscountApplies", {
+                "toggle": False,
                 "title": _("Member Discount")}),
         ))
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Improves the client folder listing view (Mainly PEP8 and folder-item improvement)

## Current behavior before PR

Not all columns were selectable and correctly rendered

## Desired behavior after PR is merged

All available columns are selectable and correctly rendered

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
