### PR TITLE
Instrument validity not updated in accordance with latest QC tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Changelog
 
 **Fixed**
 
+- #695 Instrument validity not updated in accordance with latest QC tests
+
 
 **Security**
 

--- a/bika/lims/content/instrument.py
+++ b/bika/lims/content/instrument.py
@@ -13,6 +13,8 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from Products.Archetypes.atapi import DisplayList, PicklistWidget
 from Products.Archetypes.atapi import registerType
+from bika.lims.catalog.analysis_catalog import CATALOG_ANALYSIS_LISTING
+from zope.component._api import getAdapters
 
 from zope.interface import implements
 from plone.app.folder.folder import ATFolder
@@ -50,7 +52,7 @@ from bika.lims import logger
 from bika.lims.utils import t
 from bika.lims.utils import to_utf8
 from bika.lims.config import PROJECTNAME
-from bika.lims.interfaces import IInstrument
+from bika.lims.interfaces import IInstrument, IResultOutOfRange
 from bika.lims.config import QCANALYSIS_TYPES
 from bika.lims.content.bikaschema import BikaSchema
 from bika.lims.content.bikaschema import BikaFolderSchema
@@ -558,6 +560,8 @@ class Instrument(ATFolder):
             [1]: RefAnalysis for Ethanol, QC-002 (Control)
             [2]: RefAnalysis for Methanol, QC-001 (Blank)
         """
+        ref_analyses = self.getReferenceAnalyses()
+
         field = self.getField('_LatestReferenceAnalyses')
         refs = field and field.get(self) or []
         if len(refs) == 0:
@@ -580,35 +584,49 @@ class Instrument(ATFolder):
         return refs
 
     def isQCValid(self):
-        """ Returns True if the instrument succeed for all the latest
-            Analysis QCs performed (for diferent types of AS)
+        """ Returns True if the results of the last batch of QC Analyses
+        performed against this instrument was within the valid range.
+
+        For a given Reference Sample, more than one Reference Analyses assigned
+        to this same instrument can be performed and the Results Capture Date
+        might slightly differ amongst them. Thus, this function gets the latest
+        QC Analysis performed, looks for siblings (through RefAnalysisGroupID)
+        and if the results for all them are valid, then returns True. If there
+        is one single Reference Analysis from the group with an out-of-range
+        result, the function returns False
         """
-        for last in self.getLatestReferenceAnalyses():
-            rr = last.aq_parent.getResultsRangeDict()
-            uid = last.getServiceUID()
-            if uid not in rr:
-                # This should never happen.
-                # All QC Samples must have specs for its own AS
-                continue
+        query = {"portal_type": "ReferenceAnalysis",
+                 "getInstrumentUID": self.UID(),
+                 "sort_on": "getResultCaptureDate",
+                 "sort_order": "reverse",
+                 "sort_limit": 1,}
+        brains = api.search(query, CATALOG_ANALYSIS_LISTING)
+        if len(brains) == 0:
+            # There are no Reference Analyses assigned to this instrument yet
+            return True
 
-            specs = rr[uid]
-            try:
-                smin = float(specs.get('min', 0))
-                smax = float(specs.get('max', 0))
-                error = float(specs.get('error', 0))
-                target = float(specs.get('result', 0))
-                result = float(last.getResult())
-                error_amount = ((target / 100) * error) if target > 0 else 0
-                upper = smax + error_amount
-                lower = smin - error_amount
-                if result < lower or result > upper:
+        # Look for siblings. These are the QC Analyses that were created
+        # together with this last ReferenceAnalysis and for the same Reference
+        # Sample. If they were added through "Add Reference Analyses" in a
+        # Worksheet, they typically appear in the same slot.
+        group_id = brains[0].getReferenceAnalysesGroupID
+        query = {"portal_type": "ReferenceAnalysis",
+                 "getInstrumentUID": self.UID(),
+                 "getReferenceAnalysesGroupID": group_id,}
+        brains = api.search(query, CATALOG_ANALYSIS_LISTING)
+        for brain in brains:
+            results_range = brain.getResultsRange
+            if not results_range:
+                continue
+            # Is out of range?
+            analysis = api.get_object(brain)
+            adapters = getAdapters((analysis,), IResultOutOfRange)
+            for name, adapter in adapters:
+                if adapter(specification=results_range):
+                    # Out of range, no need to go further
                     return False
-            except:
-                # This should never happen.
-                # All Reference Analysis Results and QC Samples specs
-                # must be floatable
-                continue
 
+        # By default, in range
         return True
 
     def isOutOfDate(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Instrument's automatic validation based on QC Analyses (`isQCValid`) was not behaving properly. In some cases, the instrument was automatically set to "Valid" while an "in-range" result for a QC Analysis was submitted after a failing QC Analysis being submitted previously.

## Current behavior before PR

System does not automagically validates an Instrument when a QC analysis with in-range result is submitted.

## Desired behavior after PR is merged

System does automagically validates an Instrument when a QC analysis with in-range result is submitted.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
