### PR TITLE
Fix Publish Actions for Batches

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,6 @@ Changelog
 **Fixed**
 
 - #698 Fix Publish Actions for Batches
-
 - #696 Filter worksheets by department. The worksheet count in the dashboard is now properly updated accordingly to the selected departments
 
 **Security**

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Changelog
 
 **Fixed**
 
+- #698 Fix Publish Actions for Batches
+
 
 **Security**
 

--- a/bika/lims/browser/batch/workflow.py
+++ b/bika/lims/browser/batch/workflow.py
@@ -5,11 +5,9 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from bika.lims.browser.bika_listing import WorkflowAction
+from bika.lims.browser.analysisrequest.workflow import AnalysisRequestWorkflowAction
 
 
-class BatchWorkflowAction(WorkflowAction):
-    """This function is called to do the worflow actions on objects
-    acted on in bika-listing views in batch context
+class BatchWorkflowAction(AnalysisRequestWorkflowAction):
+    """Button Action Handler for Batches
     """
-    pass


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/477

## Current behavior before PR

Publish, Prepublish and Republish Action Buttons did not work for Batches

## Desired behavior after PR is merged

Publish, Prepublish and Republish Action Buttons redirect to the publication view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
