### PR TITLE
Containers of Duplicated Analyses are not found.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #703 Containers of Duplicated Analyses are not found
 - #698 Fix Publish Actions for Batches
 - #696 Filter worksheets by department. The worksheet count in the dashboard is now properly updated accordingly to the selected departments
 

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -502,7 +502,7 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         layout = self.getLayout()
         dup_pos = {'position': destination_slot,
                    'type': 'd',
-                   'container_uid': duplicate.getRequestID(),
+                   'container_uid': duplicate.getRequest().UID(),
                    'analysis_uid': api.get_uid(duplicate)}
         layout.append(dup_pos)
         self.setLayout(layout)

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -502,7 +502,7 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         layout = self.getLayout()
         dup_pos = {'position': destination_slot,
                    'type': 'd',
-                   'container_uid': duplicate.getRequest().UID(),
+                   'container_uid': duplicate.getRequestUID(),
                    'analysis_uid': api.get_uid(duplicate)}
         layout.append(dup_pos)
         self.setLayout(layout)


### PR DESCRIPTION
## Current behavior before PR
When adding a Duplicate Analysis to a Worksheet, it saves `RequestID` instead of  `UID` to 'container_uid' field.
## Desired behavior after PR is merged
Set `AR UID` instead of `ID`.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
