### PR TITLE
Filtering by Department is not working

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #706 Filtering by Department is not working
 - #698 Fix Publish Actions for Batches
 - #696 Filter worksheets by department. The worksheet count in the dashboard is now properly updated accordingly to the selected departments
 

--- a/bika/lims/browser/js/bika.lims.site.js
+++ b/bika/lims/browser/js/bika.lims.site.js
@@ -57,11 +57,11 @@
       this.init_client_combogrid();
       this.init_datepickers();
       this.init_referencedefinition();
+      this.department_filter_cookie = "filter_by_department_info";
+      this.department_filter_disabled_cookie = "dep_filter_disabled";
       this.init_department_filtering();
       this.bind_eventhandler();
-      this.allowed_keys = [8, 9, 13, 35, 36, 37, 39, 46, 44, 60, 62, 45, 69, 101, 61];
-      this.department_filter_cookie = "filter_by_department_info";
-      return this.department_filter_disabled_cookie = "dep_filter_disabled";
+      return this.allowed_keys = [8, 9, 13, 35, 36, 37, 39, 46, 44, 60, 62, 45, 69, 101, 61];
     };
 
 

--- a/bika/lims/browser/js/coffee/bika.lims.site.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.site.coffee
@@ -27,7 +27,12 @@ class window.SiteView
     # initialze reference definition selection
     @init_referencedefinition()
 
-    # initialze department filtering
+    # Department Filtering
+    # The name of the department filter cookies
+    @department_filter_cookie = "filter_by_department_info"
+    @department_filter_disabled_cookie = "dep_filter_disabled"
+
+    # initialize department filtering
     @init_department_filtering()
 
     # bind the event handler to the elements
@@ -51,11 +56,6 @@ class window.SiteView
       101,  # e,
       61    # =
     ]
-
-    # The name of the department filter cookies
-    @department_filter_cookie = "filter_by_department_info"
-    @department_filter_disabled_cookie = "dep_filter_disabled"
-
 
   ### INITIALIZERS ###
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
`Filtering By Department` in listing views doesn't work.

## Current behavior before PR
Variables regarding Department Filtering in `bika.lims.site.coffee` are used before their definition and JS function for Department Cookie setter and getter always return `undefined`.

## Desired behavior after PR is merged
Department values are saved in the cookie properly and the system filters by department if functionality is enabled.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
