### PR TITLE
Added Pango dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         'plone.resource',
         'CairoSVG==1.0.20',
         'collective.taskqueue',
+        'Pango',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/589

WeasyPrint needs `Pango` as a dependency:
http://weasyprint.readthedocs.io/en/stable/install.html

## Current behavior before PR

Pango dependency not automatically pulled in

## Desired behavior after PR is merged

Pango dependency automatically pulled in

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
