### PR TITLE
Make dates in date picker visible again when not using SENAITE.LIMS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ Changelog
 
 **Fixed**
 
-- #712 Dates in date picker are visible again when not using `senaite.lims`
+- #712 Dates in date picker are visible again
 - #703 Containers of Duplicated Analyses are not found
 - #698 Fix Publish Actions for Batches
 - #696 Filter worksheets by department. The worksheet count in the dashboard is now properly updated accordingly to the selected departments

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #712 Dates in date picker are visible again when not using `senaite.lims`
 - #703 Containers of Duplicated Analyses are not found
 - #698 Fix Publish Actions for Batches
 - #696 Filter worksheets by department. The worksheet count in the dashboard is now properly updated accordingly to the selected departments

--- a/bika/lims/browser/css/jquery.ui.combogrid.css
+++ b/bika/lims/browser/css/jquery.ui.combogrid.css
@@ -200,4 +200,14 @@
   display: inline-block;
   margin-left: 3px;
 }
+/*
+ * Overwriting collective.js.jqueryui.custom.min.css white color
+ */
+#cg-divHeader,
+.ui-state-default,
+.ui-widget-content .ui-state-default,
+.ui-widget-header .ui-state-default{
+    background: #f5f5f5!important;
+    color: black!important;
+}
 

--- a/bika/lims/skins/bika/ploneCustom.css.dtml
+++ b/bika/lims/skins/bika/ploneCustom.css.dtml
@@ -618,6 +618,9 @@ a.duplicate {
 .cg-comboItem {
     height: 45px;
 }
+/*
+ * Overwriting collective.js.jqueryui.custom.min.css white color
+ */
 #cg-divHeader,
 .ui-state-default,
 .ui-widget-content .ui-state-default,

--- a/bika/lims/skins/bika/ploneCustom.css.dtml
+++ b/bika/lims/skins/bika/ploneCustom.css.dtml
@@ -619,14 +619,15 @@ a.duplicate {
     height: 45px;
 }
 #cg-divHeader,
-.ui-state-default {
+.ui-state-default,
+.ui-widget-content .ui-state-default,
+.ui-widget-header .ui-state-default{
     background: #f5f5f5!important;
     color: black!important;
 }
 .ui-icon {
     background-image: url(++resource++bika.lims.css/images/ui-icons_72a7cf_256x240.png)!important;
 }
-
 
 /*
  *  General Form Elements
@@ -1433,5 +1434,9 @@ div.bika-listing-table-top-hooks div.listing-hook-top-wide {
     clear:both;
     display:block;
 }
+
+
+
+
 
 </dtml-with>

--- a/bika/lims/skins/bika/ploneCustom.css.dtml
+++ b/bika/lims/skins/bika/ploneCustom.css.dtml
@@ -632,6 +632,7 @@ a.duplicate {
     background-image: url(++resource++bika.lims.css/images/ui-icons_72a7cf_256x240.png)!important;
 }
 
+
 /*
  *  General Form Elements
  */

--- a/bika/lims/skins/bika/ploneCustom.css.dtml
+++ b/bika/lims/skins/bika/ploneCustom.css.dtml
@@ -1438,8 +1438,4 @@ div.bika-listing-table-top-hooks div.listing-hook-top-wide {
     display:block;
 }
 
-
-
-
-
 </dtml-with>


### PR DESCRIPTION
After the changes introduced with #660 dates in date picker where no longer visible **when not using `senaite.lims` add-on**.

![seleccio_001](https://user-images.githubusercontent.com/9968427/37092905-ca7c978a-220d-11e8-9f06-7d2160bbb08e.png)


## Current behavior before PR

Dates in date picker aren't visible (or really hard to read) due to the white color of the numbers.

## Desired behavior after PR is merged

Dates are easy to read and visible again. They are rendered in black.

![seleccio_002](https://user-images.githubusercontent.com/9968427/37092997-16d56134-220e-11e8-8cb7-81b08db3b960.png)

**Tecnical note**

This has been done by overwriting the white color imposed by `collective.js.jqueryui.custom.min.css`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
