### PR TITLE
AR Rejection Fails when e-mail Notification is enabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Changelog
 
 **Fixed**
 
+- #715 AR Rejection Fails when e-mail Notification is enabled
 - #709 Fix removal not possible of last non-verified Analysis in Manage Analysis View
 - #706 Filtering by Department is not working
 - #712 Dates in date picker are visible again

--- a/bika/lims/browser/analysisrequest/templates/analysisrequest_retract_mail.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequest_retract_mail.pt
@@ -9,7 +9,7 @@
 
     <tal:multiplereasons condition="python:len(reasons)&gt;1">
     <p tal:content="python: 'The analysis request %s has been rejected because of the following reasons: ' % ar.id"></p>
-    <tal:reason repeat="reason python:r for r in reasons">
+    <tal:reason repeat="reason reasons">
     - <span tal:replace="reason"></span><br/>
     </tal:reason>
     </tal:multiplereasons>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/702

## Current behavior before PR
E-mail template rendering fails because of syntax error in the template file.

## Desired behavior after PR is merged
AR Rejection works properly and e-mails are sent successfully.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
