### PR TITLE
Fix failing/exhausting Unit/Doc Tests

### DIFF
--- a/bika/lims/testing.py
+++ b/bika/lims/testing.py
@@ -5,15 +5,11 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from plone.app.testing import FunctionalTesting
-from plone.app.testing import PLONE_FIXTURE
-from plone.app.testing import PloneSandboxLayer
-from plone.testing import z2
-
-from plone.app.testing import SITE_OWNER_NAME
-from plone.app.testing import login
-from plone.app.testing import logout
 from bika.lims.exportimport.load_setup_data import LoadSetupData
+from plone.app.testing import (PLONE_FIXTURE, SITE_OWNER_NAME,
+                               FunctionalTesting, PloneSandboxLayer, login,
+                               logout)
+from plone.testing import z2
 
 
 class BaseLayer(PloneSandboxLayer):

--- a/bika/lims/tests/base.py
+++ b/bika/lims/tests/base.py
@@ -8,20 +8,9 @@
 import os
 from re import match
 
-import transaction
-from plone.app.testing import SITE_OWNER_NAME
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import TEST_USER_PASSWORD
-from plone.app.testing import login
-from plone.app.testing import logout
-from plone.protect.authenticator import AuthenticatorView
-from plone.testing.z2 import Browser
-
-from bika.lims import logger
-from bika.lims.exportimport.load_setup_data import LoadSetupData
-from bika.lims.testing import BASE_TESTING
-from bika.lims.testing import DATA_TESTING
+from bika.lims.testing import BASE_TESTING, DATA_TESTING
 from plone.app.testing import TEST_USER_NAME, TEST_USER_PASSWORD
+from plone.protect.authenticator import AuthenticatorView
 from plone.testing.z2 import Browser
 
 try:

--- a/bika/lims/tests/base.py
+++ b/bika/lims/tests/base.py
@@ -9,7 +9,6 @@ import os
 from re import match
 
 import transaction
-from plone.app.testing import DEFAULT_LANGUAGE
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
@@ -20,7 +19,8 @@ from plone.testing.z2 import Browser
 
 from bika.lims import logger
 from bika.lims.exportimport.load_setup_data import LoadSetupData
-from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
+from bika.lims.testing import BASE_TESTING
+from bika.lims.testing import DATA_TESTING
 from plone.app.testing import TEST_USER_NAME, TEST_USER_PASSWORD
 from plone.testing.z2 import Browser
 
@@ -30,11 +30,13 @@ except ImportError:  # Python 2.7
     import unittest
 
 
-class BikaFunctionalTestCase(unittest.TestCase):
-    layer = BIKA_LIMS_FUNCTIONAL_TESTING
+class BaseTestCase(unittest.TestCase):
+    """Use for test cases which do not rely on the demo data
+    """
+    layer = BASE_TESTING
 
     def setUp(self):
-        super(BikaFunctionalTestCase, self).setUp()
+        super(BaseTestCase, self).setUp()
 
         self.app = self.layer['app']
         self.portal = self.layer['portal']
@@ -45,10 +47,11 @@ class BikaFunctionalTestCase(unittest.TestCase):
         os.environ["PLONE_CSRF_DISABLED"] = "true"
 
     def getBrowser(self,
-            username=TEST_USER_NAME,
-            password=TEST_USER_PASSWORD,
-            loggedIn=True):
-        """ instantiate and return a testbrowser for convenience """
+                   username=TEST_USER_NAME,
+                   password=TEST_USER_PASSWORD,
+                   loggedIn=True):
+
+        # Instantiate and return a testbrowser for convenience
         browser = Browser(self.portal)
         browser.addHeader('Accept-Language', 'en-US')
         browser.handleErrors = False
@@ -60,20 +63,13 @@ class BikaFunctionalTestCase(unittest.TestCase):
             self.assertTrue('You are now logged in' in browser.contents)
         return browser
 
-    def setup_data_load(self):
-        transaction.commit()
-        login(self.portal.aq_parent, SITE_OWNER_NAME)  # again
-
-        # load test data
-        self.request.form['setupexisting'] = 1
-        self.request.form['existing'] = "bika.lims:test"
-        lsd = LoadSetupData(self.portal, self.request)
-        logger.info('Loading datas...')
-        lsd()
-        logger.info('Loading data finished...')
-        logout()
-
     def getAuthenticator(self):
         tag = AuthenticatorView('context', 'request').authenticator()
         pattern = '<input .*name="(\w+)".*value="(\w+)"'
         return match(pattern, tag).groups()[1]
+
+
+class DataTestCase(BaseTestCase):
+    """Use for test cases which rely on the demo data
+    """
+    layer = DATA_TESTING

--- a/bika/lims/tests/doctests/ShowPrices.rst
+++ b/bika/lims/tests/doctests/ShowPrices.rst
@@ -37,12 +37,10 @@ Functional Helpers:
     >>> def enableShowPrices():
     ...     self.portal.bika_setup.setShowPrices(True)
     ...     transaction.commit()
-    ...     sleep(1)
 
     >>> def disableShowPrices():
     ...     self.portal.bika_setup.setShowPrices(False)
     ...     transaction.commit()
-    ...     sleep(1)
 
 Variables:
 

--- a/bika/lims/tests/test_ARImport.py
+++ b/bika/lims/tests/test_ARImport.py
@@ -18,8 +18,7 @@ from plone.app.testing import setRoles
 
 from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
 from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
-from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
-from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.tests.base import BaseTestCase
 from bika.lims.utils import tmpID
 from bika.lims.workflow import doActionFor
 from bika.lims.workflow import getCurrentState
@@ -30,7 +29,7 @@ except ImportError:  # Python 2.7
     import unittest
 
 
-class TestARImports(BikaFunctionalTestCase):
+class TestARImports(BaseTestCase):
     def addthing(self, folder, portal_type, **kwargs):
         thing = _createObjectByType(portal_type, folder, tmpID())
         thing.unmarkCreationFlag()
@@ -245,5 +244,4 @@ Total price excl Tax,,,,,,,,,,,,,,
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestARImports))
-    suite.layer = BIKA_LIMS_FUNCTIONAL_TESTING
     return suite

--- a/bika/lims/tests/test_ARImport.py
+++ b/bika/lims/tests/test_ARImport.py
@@ -8,20 +8,15 @@
 import re
 
 import transaction
-from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.utils import _createObjectByType
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import TEST_USER_PASSWORD
-from plone.app.testing import login
-from plone.app.testing import setRoles
-
-from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
-from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
+from bika.lims.catalog import (CATALOG_ANALYSIS_LISTING,
+                               CATALOG_ANALYSIS_REQUEST_LISTING)
 from bika.lims.tests.base import BaseTestCase
 from bika.lims.utils import tmpID
-from bika.lims.workflow import doActionFor
-from bika.lims.workflow import getCurrentState
+from bika.lims.workflow import doActionFor, getCurrentState
+from plone.app.testing import (TEST_USER_ID, TEST_USER_NAME,
+                               TEST_USER_PASSWORD, login, setRoles)
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import _createObjectByType
 
 try:
     import unittest2 as unittest

--- a/bika/lims/tests/test_AnalysisRequest_retract.py
+++ b/bika/lims/tests/test_AnalysisRequest_retract.py
@@ -5,13 +5,10 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from Products.CMFCore.utils import getToolByName
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import login, logout
-from plone.app.testing import setRoles
-
 from bika.lims.tests.base import DataTestCase
+from plone.app.testing import (TEST_USER_ID, TEST_USER_NAME, login, logout,
+                               setRoles)
+from Products.CMFCore.utils import getToolByName
 
 try:
     import unittest2 as unittest
@@ -38,8 +35,8 @@ class TestAnalysisRequestRetract(DataTestCase):
                   'SamplingDate': '2015-01-01',
                   'SampleType': sampletype.UID()}
         # Getting some services
-        services = catalog(portal_type = 'AnalysisService',
-                            inactive_state = 'active')[:3]
+        services = catalog(portal_type='AnalysisService',
+                            inactive_state='active')[:3]
         service_uids = [service.getObject().UID() for service in services]
         request = {}
         ar = create_analysisrequest(client, request, values, service_uids)
@@ -48,26 +45,27 @@ class TestAnalysisRequestRetract(DataTestCase):
 
         # Cheking if everything is going OK
         self.assertEquals(ar.portal_workflow.getInfoFor(ar, 'review_state'),
-                                                        'sample_received')
+                          'sample_received')
         for analysis in ar.getAnalyses(full_objects=True):
             analysis.setResult('12')
             wf.doActionFor(analysis, 'submit')
-            self.assertEquals(analysis.portal_workflow.getInfoFor(analysis,
-                            'review_state'),'to_be_verified')
+            self.assertEquals(analysis.portal_workflow.getInfoFor(
+                analysis, 'review_state'), 'to_be_verified')
             # retracting results
             wf.doActionFor(analysis, 'retract')
-            self.assertEquals(analysis.portal_workflow.getInfoFor(analysis,
-                            'review_state'),'retracted')
+            self.assertEquals(analysis.portal_workflow.getInfoFor(
+                analysis, 'review_state'), 'retracted')
         for analysis in ar.getAnalyses(full_objects=True):
-            if analysis.portal_workflow.getInfoFor(analysis,
-                'review_state') == 'retracted':
+            if analysis.portal_workflow.getInfoFor(
+                    analysis, 'review_state') == 'retracted':
                 continue
             wf.doActionFor(analysis, 'submit')
-            self.assertEquals(analysis.portal_workflow.getInfoFor(analysis,
-                            'review_state'),'to_be_verified')
+            self.assertEquals(
+                analysis.portal_workflow.getInfoFor(analysis, 'review_state'),
+                'to_be_verified')
         wf.doActionFor(ar, 'retract')
         self.assertEquals(ar.portal_workflow.getInfoFor(ar, 'review_state'),
-                                                        'sample_received')
+                          'sample_received')
 
     def tearDown(self):
         logout()

--- a/bika/lims/tests/test_AnalysisRequest_retract.py
+++ b/bika/lims/tests/test_AnalysisRequest_retract.py
@@ -11,21 +11,18 @@ from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import login, logout
 from plone.app.testing import setRoles
 
-from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
-from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.tests.base import DataTestCase
 
 try:
     import unittest2 as unittest
-except ImportError: # Python 2.7
+except ImportError:  # Python 2.7
     import unittest
 
 
-class TestAnalysisRequestRetract(BikaFunctionalTestCase):
-    layer = BIKA_LIMS_FUNCTIONAL_TESTING
+class TestAnalysisRequestRetract(DataTestCase):
 
     def setUp(self):
         super(TestAnalysisRequestRetract, self).setUp()
-        self.setup_data_load()
         setRoles(self.portal, TEST_USER_ID, ['Member', 'LabManager'])
         login(self.portal, TEST_USER_NAME)
 
@@ -80,5 +77,4 @@ class TestAnalysisRequestRetract(BikaFunctionalTestCase):
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestAnalysisRequestRetract))
-    suite.layer = BIKA_LIMS_FUNCTIONAL_TESTING
     return suite

--- a/bika/lims/tests/test_MultiVerificationTypes.py
+++ b/bika/lims/tests/test_MultiVerificationTypes.py
@@ -5,14 +5,11 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from Products.CMFPlone.utils import _createObjectByType
 from bika.lims.tests.base import DataTestCase
 from bika.lims.utils import tmpID
 from bika.lims.utils.analysis import create_analysis
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import login
-from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID, TEST_USER_NAME, login, setRoles
+from Products.CMFPlone.utils import _createObjectByType
 
 try:
     import unittest2 as unittest
@@ -21,9 +18,9 @@ except ImportError:
 
 
 class TestMultiVerificationType(DataTestCase):
-    """
-    In Bika Setup, When Multi verification is enabled, one of 3 types of Multi Verification
-    option should be chosen. Functional Testing of this new feature.
+    """In Bika Setup, When Multi verification is enabled, one of 3 types of
+    Multi Verification option should be chosen. Functional Testing of this new
+    feature.
     """
 
     def setUp(self):
@@ -35,19 +32,16 @@ class TestMultiVerificationType(DataTestCase):
         super(TestMultiVerificationType, self).tearDown()
 
     def test_MultiVerificationType(self):
-        #Testing when the same user can verify multiple times
-        self.portal.bika_setup.setNumberOfRequiredVerifications(4)
-        self.portal.bika_setup.setTypeOfmultiVerification('self_multi_enabled')
+        bika_setup = self.portal.bika_setup
+
+        # Testing when the same user can verify multiple times
+        bika_setup.setNumberOfRequiredVerifications(4)
+        bika_setup.setTypeOfmultiVerification('self_multi_enabled')
 
         client = self.portal.clients['client-1']
-        sampletype = self.portal.bika_setup.bika_sampletypes['sampletype-1']
-        values = {'Client': client.UID(),
-                  'Contact': client.getContacts()[0].UID(),
-                  'SamplingDate': '2016-12-12',
-                  'SampleType': sampletype.UID()}
         ar = _createObjectByType("AnalysisRequest", client, tmpID())
-        servs = self.portal.bika_setup.bika_analysisservices
-        service=servs['analysisservice-3']
+        servs = bika_setup.bika_analysisservices
+        service = servs['analysisservice-3']
         service.setSelfVerification(True)
         an = create_analysis(ar, service)
         member = self.portal.portal_membership.getMemberById('admin')
@@ -55,20 +49,22 @@ class TestMultiVerificationType(DataTestCase):
         an.setNumberOfRequiredVerifications(4)
         self.assertEquals(an.isUserAllowedToVerify(member), True)
 
-        #Testing when the same user can verify multiple times but not consequetively
-        self.portal.bika_setup.setTypeOfmultiVerification('self_multi_not_cons')
+        # Testing when the same user can verify multiple times but not
+        # consequetively
+        bika_setup.setTypeOfmultiVerification('self_multi_not_cons')
         self.assertEquals(an.isUserAllowedToVerify(member), False)
 
-        #Testing when the same user can not verify more than once
-        self.portal.bika_setup.setTypeOfmultiVerification('self_multi_disabled')
+        # Testing when the same user can not verify more than once
+        bika_setup.setTypeOfmultiVerification('self_multi_disabled')
         self.assertEquals(an.isUserAllowedToVerify(member), False)
 
         an.addVerificator(TEST_USER_NAME)
-        self.portal.bika_setup.setTypeOfmultiVerification('self_multi_not_cons')
+        bika_setup.setTypeOfmultiVerification('self_multi_not_cons')
         self.assertEquals(an.isUserAllowedToVerify(member), True)
 
-        self.portal.bika_setup.setTypeOfmultiVerification('self_multi_disabled')
+        bika_setup.setTypeOfmultiVerification('self_multi_disabled')
         self.assertEquals(an.isUserAllowedToVerify(member), False)
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/bika/lims/tests/test_MultiVerificationTypes.py
+++ b/bika/lims/tests/test_MultiVerificationTypes.py
@@ -6,8 +6,7 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 from Products.CMFPlone.utils import _createObjectByType
-from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
-from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.tests.base import DataTestCase
 from bika.lims.utils import tmpID
 from bika.lims.utils.analysis import create_analysis
 from plone.app.testing import TEST_USER_ID
@@ -21,17 +20,15 @@ except ImportError:
     import unittest
 
 
-class TestMultiVerificationType(BikaFunctionalTestCase):
+class TestMultiVerificationType(DataTestCase):
     """
     In Bika Setup, When Multi verification is enabled, one of 3 types of Multi Verification
     option should be chosen. Functional Testing of this new feature.
     """
-    layer = BIKA_LIMS_FUNCTIONAL_TESTING
 
     def setUp(self):
         super(TestMultiVerificationType, self).setUp()
         setRoles(self.portal, TEST_USER_ID, ['Member', 'LabManager'])
-        self.setup_data_load()
         login(self.portal, TEST_USER_NAME)
 
     def tearDown(self):
@@ -76,5 +73,4 @@ class TestMultiVerificationType(BikaFunctionalTestCase):
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestMultiVerificationType))
-    suite.layer = BIKA_LIMS_FUNCTIONAL_TESTING
     return suite

--- a/bika/lims/tests/test_barcode_entry.py
+++ b/bika/lims/tests/test_barcode_entry.py
@@ -8,18 +8,14 @@
 import json
 
 import transaction
-from DateTime import DateTime
-from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.utils import _createObjectByType
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import login
-from plone.app.testing import setRoles
-
 from bika.lims.barcode import barcode_entry
 from bika.lims.tests.base import BaseTestCase
-from bika.lims.utils import tmpID, changeWorkflowState
+from bika.lims.utils import changeWorkflowState, tmpID
 from bika.lims.workflow import doActionFor
+from DateTime import DateTime
+from plone.app.testing import TEST_USER_ID, TEST_USER_NAME, login, setRoles
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import _createObjectByType
 
 try:
     import unittest2 as unittest
@@ -43,30 +39,39 @@ class TestBarcodeEntry(BaseTestCase):
         clients = self.portal.clients
         bs = self.portal.bika_setup
         # @formatter:off
-        self.client = self.addthing(clients, 'Client', title='Happy Hills', ClientID='HH')
-        contact = self.addthing(self.client, 'Contact', Firstname='Rita', Lastname='Mohale')
-        container = self.addthing(bs.bika_containers, 'Container', title='Bottle', capacity="10ml")
-        sampletype = self.addthing(bs.bika_sampletypes, 'SampleType', title='Water', Prefix='H2O')
-        samplepoint = self.addthing(bs.bika_samplepoints, 'SamplePoint', title='Toilet')
-        service = self.addthing(bs.bika_analysisservices, 'AnalysisService', title='Ecoli', Keyword="ECO")
+        self.client = self.addthing(
+            clients, 'Client', title='Happy Hills', ClientID='HH')
+        contact = self.addthing(
+            self.client, 'Contact', Firstname='Rita', Lastname='Mohale')
+        container = self.addthing(
+            bs.bika_containers, 'Container', title='Bottle', capacity="10ml")
+        sampletype = self.addthing(
+            bs.bika_sampletypes, 'SampleType', title='Water', Prefix='H2O')
+        service = self.addthing(
+            bs.bika_analysisservices, 'AnalysisService', title='Ecoli',
+            Keyword="ECO")
         batch = self.addthing(self.portal.batches, 'Batch', title='B1')
         # Create Sample with single partition
-        self.sample1 = self.addthing(self.client, 'Sample', SampleType=sampletype)
-        self.sample2 = self.addthing(self.client, 'Sample', SampleType=sampletype)
+        self.sample1 = self.addthing(
+            self.client, 'Sample', SampleType=sampletype)
+        self.sample2 = self.addthing(
+            self.client, 'Sample', SampleType=sampletype)
         self.addthing(self.sample1, 'SamplePartition', Container=container)
         self.addthing(self.sample2, 'SamplePartition', Container=container)
         # Create an AR
-        self.ar1 = self.addthing(self.client, 'AnalysisRequest', Contact=contact,
-                                Sample=self.sample1, Analyses=[service], SamplingDate=DateTime())
+        self.ar1 = self.addthing(
+            self.client, 'AnalysisRequest', Contact=contact,
+            Sample=self.sample1, Analyses=[service], SamplingDate=DateTime())
         # Create a secondary AR - linked to a Batch
-        self.ar2 = self.addthing(self.client, 'AnalysisRequest', Contact=contact,
-                                Sample=self.sample1, Analyses=[service], SamplingDate=DateTime(),
-                                Batch=batch)
+        self.ar2 = self.addthing(
+            self.client, 'AnalysisRequest', Contact=contact,
+            Sample=self.sample1, Analyses=[service], SamplingDate=DateTime(),
+            Batch=batch)
         # Create an AR - single AR on sample2
-        self.ar3 = self.addthing(self.client, 'AnalysisRequest', Contact=contact,
-                                Sample=self.sample2, Analyses=[service], SamplingDate=DateTime())
+        self.ar3 = self.addthing(
+            self.client, 'AnalysisRequest', Contact=contact,
+            Sample=self.sample2, Analyses=[service], SamplingDate=DateTime())
         # @formatter:on
-        wf = getToolByName(self.portal, 'portal_workflow')
         for ar in self.ar1, self.ar2, self.ar3:
             # Set initial AR state
             doActionFor(ar, 'no_sampling_workflow')

--- a/bika/lims/tests/test_barcode_entry.py
+++ b/bika/lims/tests/test_barcode_entry.py
@@ -17,8 +17,7 @@ from plone.app.testing import login
 from plone.app.testing import setRoles
 
 from bika.lims.barcode import barcode_entry
-from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
-from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.tests.base import BaseTestCase
 from bika.lims.utils import tmpID, changeWorkflowState
 from bika.lims.workflow import doActionFor
 
@@ -28,8 +27,7 @@ except ImportError:  # Python 2.7
     import unittest
 
 
-class TestBarcodeEntry(BikaFunctionalTestCase):
-    layer = BIKA_LIMS_FUNCTIONAL_TESTING
+class TestBarcodeEntry(BaseTestCase):
 
     def addthing(self, folder, portal_type, **kwargs):
         thing = _createObjectByType(portal_type, folder, tmpID())
@@ -145,5 +143,4 @@ def test_sample_with_single_ar_redirects_to_AR(self):
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestBarcodeEntry))
-    suite.layer = BIKA_LIMS_FUNCTIONAL_TESTING
     return suite

--- a/bika/lims/tests/test_bika_installation.py
+++ b/bika/lims/tests/test_bika_installation.py
@@ -5,12 +5,10 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
-from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.tests.base import BaseTestCase
 
 
-class InstallationSuccessful(BikaFunctionalTestCase):
-    layer = BIKA_LIMS_FUNCTIONAL_TESTING
+class InstallationSuccessful(BaseTestCase):
 
     def test_Installation_Success(self):
         """Let's see if bika is correctly installed.

--- a/bika/lims/tests/test_calculations.py
+++ b/bika/lims/tests/test_calculations.py
@@ -10,22 +10,19 @@ from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import login
 from plone.app.testing import setRoles
 from bika.lims.workflow import doActionFor
-from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
-from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.tests.base import DataTestCase
 
 try:
     import unittest2 as unittest
-except ImportError: # Python 2.7
+except ImportError:  # Python 2.7
     import unittest
 
 
-class TestCalculations(BikaFunctionalTestCase):
-    layer = BIKA_LIMS_FUNCTIONAL_TESTING
+class TestCalculations(DataTestCase):
 
     def setUp(self):
         super(TestCalculations, self).setUp()
         setRoles(self.portal, TEST_USER_ID, ['Member', 'LabManager'])
-        self.setup_data_load()
         login(self.portal, TEST_USER_NAME)
 
         # Calculation: Total Hardness
@@ -532,5 +529,4 @@ class TestCalculations(BikaFunctionalTestCase):
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestCalculations))
-    suite.layer = BIKA_LIMS_FUNCTIONAL_TESTING
     return suite

--- a/bika/lims/tests/test_calculations.py
+++ b/bika/lims/tests/test_calculations.py
@@ -5,12 +5,9 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import login
-from plone.app.testing import setRoles
-from bika.lims.workflow import doActionFor
 from bika.lims.tests.base import DataTestCase
+from bika.lims.workflow import doActionFor
+from plone.app.testing import TEST_USER_ID, TEST_USER_NAME, login, setRoles
 
 try:
     import unittest2 as unittest
@@ -28,16 +25,19 @@ class TestCalculations(DataTestCase):
         # Calculation: Total Hardness
         # Initial formula: [Ca] + [Mg]
         calcs = self.portal.bika_setup.bika_calculations
-        self.calculation = [calcs[k] for k in calcs if calcs[k].title=='Total Hardness'][0]
+        self.calculation = [calcs[k] for k in calcs
+                            if calcs[k].title == 'Total Hardness'][0]
 
         # Service with calculation: Tot. Hardness (THCaCO3)
         servs = self.portal.bika_setup.bika_analysisservices
-        self.calcservice = [servs[k] for k in servs if servs[k].title=='Tot. Hardness (THCaCO3)'][0]
+        self.calcservice = [servs[k] for k in servs
+                            if servs[k].title == 'Tot. Hardness (THCaCO3)'][0]
         self.assertEqual(self.calcservice.getCalculation(), self.calculation)
         self.calcservice.setUseDefaultCalculation(False)
 
         # Analysis Services: Ca and Mg
-        self.services = [servs[k] for k in servs if servs[k].getKeyword() in ('Ca', 'Mg')]
+        self.services = [servs[k] for k in servs
+                         if servs[k].getKeyword() in ('Ca', 'Mg')]
 
         # Allow Manual DLs
         for s in self.services:
@@ -314,7 +314,7 @@ class TestCalculations(DataTestCase):
             self.assertEqual(self.calculation.getFormula(), f['formula'])
             interims = []
             for k,v in f['interims'].items():
-                interims.append({'keyword': k, 'title':k, 'value': v,
+                interims.append({'keyword': k, 'title': k, 'value': v,
                                  'hidden': False, 'type': 'int',
                                  'unit': ''})
             self.calculation.setInterimFields(interims)
@@ -432,11 +432,11 @@ class TestCalculations(DataTestCase):
                         if i['keyword'] in f['interims']:
                             ival = float(f['interims'][i['keyword']])
                             intermap.append({'keyword': i['keyword'],
-                                            'value': ival,
-                                            'title': i['title'],
-                                            'hidden': i['hidden'],
-                                            'type': i['type'],
-                                            'unit': i['unit']})
+                                             'value': ival,
+                                             'title': i['title'],
+                                             'hidden': i['hidden'],
+                                             'type': i['type'],
+                                             'unit': i['unit']})
                         else:
                             intermap.append(i)
                     an.setInterimFields(intermap)
@@ -457,10 +457,10 @@ class TestCalculations(DataTestCase):
             self.calculation.setFormula(f['formula'])
             self.assertEqual(self.calculation.getFormula(), f['formula'])
             interims = []
-            for k,v in f['interims'].items():
-                interims.append({'keyword': k, 'title':k, 'value': v,
+            for k, v in f['interims'].items():
+                interims.append({'keyword': k, 'title': k, 'value': v,
                                  'hidden': False, 'type': 'int',
-                                 'unit': ''});
+                                 'unit': ''})
             self.calculation.setInterimFields(interims)
             self.assertEqual(self.calculation.getInterimFields(), interims)
 
@@ -508,11 +508,11 @@ class TestCalculations(DataTestCase):
                         if i['keyword'] in f['interims']:
                             ival = float(f['interims'][i['keyword']])
                             intermap.append({'keyword': i['keyword'],
-                                            'value': ival,
-                                            'title': i['title'],
-                                            'hidden': i['hidden'],
-                                            'type': i['type'],
-                                            'unit': i['unit']})
+                                             'value': ival,
+                                             'title': i['title'],
+                                             'hidden': i['hidden'],
+                                             'type': i['type'],
+                                             'unit': i['unit']})
                         else:
                             intermap.append(i)
                     an.setInterimFields(intermap)

--- a/bika/lims/tests/test_decimal-sci-notation.py
+++ b/bika/lims/tests/test_decimal-sci-notation.py
@@ -5,13 +5,10 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from Products.CMFCore.utils import getToolByName
 from bika.lims.tests.base import DataTestCase
 from bika.lims.utils.analysisrequest import create_analysisrequest
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import login
-from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID, TEST_USER_NAME, login, setRoles
+from Products.CMFCore.utils import getToolByName
 
 try:
     import unittest2 as unittest
@@ -32,7 +29,7 @@ class TestDecimalSciNotation(DataTestCase):
         # Original values
         self.orig_as_prec = self.service.getPrecision()
         self.orig_as_expf = self.service.getExponentialFormatPrecision()
-        self.orig_as_ldl  = self.service.getLowerDetectionLimit()
+        self.orig_as_ldl = self.service.getLowerDetectionLimit()
         self.orig_bs_expf = self.service.getExponentialFormatThreshold()
         self.orig_bs_scin = self.service.getScientificNotationResults()
 
@@ -338,8 +335,9 @@ class TestDecimalSciNotation(DataTestCase):
             self.assertEqual(an.getResult(), m[3])
             self.assertEqual(an.Schema().getField('Result').get(an), m[3])
             fr = an.getFormattedResult(sciformat=m[2])
-            #print '%s   %s   %s   %s  =>  \'%s\' ?= \'%s\'' % (m[0],m[1],m[2],m[3],m[4],fr)
+            # print '%s   %s   %s   %s  =>  \'%s\' ?= \'%s\'' % (m[0],m[1],m[2],m[3],m[4],fr)
             self.assertEqual(fr, m[4])
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/bika/lims/tests/test_decimal-sci-notation.py
+++ b/bika/lims/tests/test_decimal-sci-notation.py
@@ -6,8 +6,7 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 from Products.CMFCore.utils import getToolByName
-from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
-from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.tests.base import DataTestCase
 from bika.lims.utils.analysisrequest import create_analysisrequest
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
@@ -16,17 +15,15 @@ from plone.app.testing import setRoles
 
 try:
     import unittest2 as unittest
-except ImportError: # Python 2.7
+except ImportError:  # Python 2.7
     import unittest
 
 
-class TestDecimalSciNotation(BikaFunctionalTestCase):
-    layer = BIKA_LIMS_FUNCTIONAL_TESTING
+class TestDecimalSciNotation(DataTestCase):
 
     def setUp(self):
         super(TestDecimalSciNotation, self).setUp()
         setRoles(self.portal, TEST_USER_ID, ['Member', 'LabManager'])
-        self.setup_data_load()
         login(self.portal, TEST_USER_NAME)
         # analysis-service-3: Calcium (Ca)
         servs = self.portal.bika_setup.bika_analysisservices
@@ -347,5 +344,4 @@ class TestDecimalSciNotation(BikaFunctionalTestCase):
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestDecimalSciNotation))
-    suite.layer = BIKA_LIMS_FUNCTIONAL_TESTING
     return suite

--- a/bika/lims/tests/test_decimalmark-sci-notation.py
+++ b/bika/lims/tests/test_decimalmark-sci-notation.py
@@ -5,17 +5,14 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from Products.CMFCore.utils import getToolByName
 from bika.lims.tests.base import DataTestCase
 from bika.lims.utils.analysisrequest import create_analysisrequest
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import login
-from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID, TEST_USER_NAME, login, setRoles
+from Products.CMFCore.utils import getToolByName
 
 try:
     import unittest2 as unittest
-except ImportError: # Python 2.7
+except ImportError:  # Python 2.7
     import unittest
 
 
@@ -33,7 +30,7 @@ class TestDecimalMarkWithSciNotation(DataTestCase):
         # Original values
         self.orig_as_prec = self.service.getPrecision()
         self.orig_as_expf = self.service.getExponentialFormatPrecision()
-        self.orig_as_ldl  = self.service.getLowerDetectionLimit()
+        self.orig_as_ldl = self.service.getLowerDetectionLimit()
         self.orig_bs_expf = self.service.getExponentialFormatThreshold()
         self.orig_bs_scin = self.service.getScientificNotationResults()
         self.orig_dm = self.portal.bika_setup.getResultsDecimalMark()
@@ -124,8 +121,9 @@ class TestDecimalMarkWithSciNotation(DataTestCase):
             self.assertEqual(an.getResult(), m[3])
             self.assertEqual(an.Schema().getField('Result').get(an), m[3])
             fr = an.getFormattedResult(sciformat=m[2],decimalmark=bs.getResultsDecimalMark())
-            #print '%s   %s   %s   %s  =>  \'%s\' ?= \'%s\'' % (m[0],m[1],m[2],m[3],m[4],fr)
+            # print '%s   %s   %s   %s  =>  \'%s\' ?= \'%s\'' % (m[0],m[1],m[2],m[3],m[4],fr)
             self.assertEqual(fr, m[4])
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/bika/lims/tests/test_decimalmark-sci-notation.py
+++ b/bika/lims/tests/test_decimalmark-sci-notation.py
@@ -6,8 +6,7 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 from Products.CMFCore.utils import getToolByName
-from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
-from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.tests.base import DataTestCase
 from bika.lims.utils.analysisrequest import create_analysisrequest
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
@@ -20,13 +19,11 @@ except ImportError: # Python 2.7
     import unittest
 
 
-class TestDecimalMarkWithSciNotation(BikaFunctionalTestCase):
-    layer = BIKA_LIMS_FUNCTIONAL_TESTING
+class TestDecimalMarkWithSciNotation(DataTestCase):
 
     def setUp(self):
         super(TestDecimalMarkWithSciNotation, self).setUp()
         setRoles(self.portal, TEST_USER_ID, ['Member', 'LabManager'])
-        self.setup_data_load()
         login(self.portal, TEST_USER_NAME)
 
         # analysis-service-3: Calcium (Ca)
@@ -133,5 +130,4 @@ class TestDecimalMarkWithSciNotation(BikaFunctionalTestCase):
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestDecimalMarkWithSciNotation))
-    suite.layer = BIKA_LIMS_FUNCTIONAL_TESTING
     return suite

--- a/bika/lims/tests/test_duplicate-analysis.py
+++ b/bika/lims/tests/test_duplicate-analysis.py
@@ -5,15 +5,12 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.utils import _createObjectByType
 from bika.lims.tests.base import DataTestCase
 from bika.lims.utils import tmpID
 from bika.lims.utils.analysisrequest import create_analysisrequest
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import login
-from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID, TEST_USER_NAME, login, setRoles
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import _createObjectByType
 
 try:
     import unittest2 as unittest

--- a/bika/lims/tests/test_duplicate-analysis.py
+++ b/bika/lims/tests/test_duplicate-analysis.py
@@ -7,8 +7,7 @@
 
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import _createObjectByType
-from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
-from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.tests.base import DataTestCase
 from bika.lims.utils import tmpID
 from bika.lims.utils.analysisrequest import create_analysisrequest
 from plone.app.testing import TEST_USER_ID
@@ -22,17 +21,15 @@ except ImportError:
     import unittest
 
 
-class TestAddDuplicateAnalysis(BikaFunctionalTestCase):
+class TestAddDuplicateAnalysis(DataTestCase):
     """
     When adding a duplicate for an AR in a worksheet, only the first analysis
     gets duplicated: https://jira.bikalabs.com/browse/LIMS-2001
     """
-    layer = BIKA_LIMS_FUNCTIONAL_TESTING
 
     def setUp(self):
         super(TestAddDuplicateAnalysis, self).setUp()
         setRoles(self.portal, TEST_USER_ID, ['Member', 'LabManager'])
-        self.setup_data_load()
         login(self.portal, TEST_USER_NAME)
 
     def tearDown(self):
@@ -169,5 +166,4 @@ class TestAddDuplicateAnalysis(BikaFunctionalTestCase):
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestAddDuplicateAnalysis))
-    suite.layer = BIKA_LIMS_FUNCTIONAL_TESTING
     return suite

--- a/bika/lims/tests/test_hiddenanalyses.py
+++ b/bika/lims/tests/test_hiddenanalyses.py
@@ -5,8 +5,7 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
-from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.tests.base import DataTestCase
 from bika.lims.utils.analysisrequest import create_analysisrequest
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
@@ -15,17 +14,15 @@ from plone.app.testing import setRoles
 
 try:
     import unittest2 as unittest
-except ImportError: # Python 2.7
+except ImportError:  # Python 2.7
     import unittest
 
 
-class TestHiddenAnalyses(BikaFunctionalTestCase):
-    layer = BIKA_LIMS_FUNCTIONAL_TESTING
+class TestHiddenAnalyses(DataTestCase):
 
     def setUp(self):
         super(TestHiddenAnalyses, self).setUp()
         setRoles(self.portal, TEST_USER_ID, ['Member', 'LabManager'])
-        self.setup_data_load()
         login(self.portal, TEST_USER_NAME)
 
         servs = self.portal.bika_setup.bika_analysisservices
@@ -376,5 +373,4 @@ class TestHiddenAnalyses(BikaFunctionalTestCase):
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestHiddenAnalyses))
-    suite.layer = BIKA_LIMS_FUNCTIONAL_TESTING
     return suite

--- a/bika/lims/tests/test_hiddenanalyses.py
+++ b/bika/lims/tests/test_hiddenanalyses.py
@@ -7,10 +7,7 @@
 
 from bika.lims.tests.base import DataTestCase
 from bika.lims.utils.analysisrequest import create_analysisrequest
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import login
-from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID, TEST_USER_NAME, login, setRoles
 
 try:
     import unittest2 as unittest
@@ -60,7 +57,6 @@ class TestHiddenAnalyses(DataTestCase):
 
     def test_service_hidden_service(self):
         service = self.services[1]
-        uid = service.UID()
         self.assertFalse(service.getHidden())
         self.assertFalse(service.Schema().getField('Hidden').get(service))
 
@@ -77,7 +73,7 @@ class TestHiddenAnalyses(DataTestCase):
     def test_service_hidden_profile(self):
         # Profile
         # For Calcium (unset)
-        uid = self.services[0].UID();
+        uid = self.services[0].UID()
         self.assertFalse(self.services[0].getHidden())
         self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(uid))
         self.assertFalse('hidden' in self.analysisprofile.getAnalysisServiceSettings(uid))
@@ -341,9 +337,9 @@ class TestHiddenAnalyses(DataTestCase):
         # AR with template, with changes
         values['Template'] = self.artemplate.UID()
         del values['Profiles']
-        matrix = [[2, 1,-2],  # AS = Not set
-                  [2, 1,-2],  # AS = False
-                  [2, 1,-1]]
+        matrix = [[2, 1, -2],  # AS = Not set
+                  [2, 1, -2],  # AS = False
+                  [2, 1, -1]]
         for i in range(len(matrix)):
             sets = {'uid': services[i]}
             opts = [0, 1, 2]
@@ -369,6 +365,7 @@ class TestHiddenAnalyses(DataTestCase):
 
         # Restore
         self.artemplate.setAnalysisServicesSettings([])
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/bika/lims/tests/test_limitdetections.py
+++ b/bika/lims/tests/test_limitdetections.py
@@ -5,17 +5,14 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from Products.CMFCore.utils import getToolByName
 from bika.lims.tests.base import DataTestCase
 from bika.lims.utils.analysisrequest import create_analysisrequest
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import login
-from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID, TEST_USER_NAME, login, setRoles
+from Products.CMFCore.utils import getToolByName
 
 try:
     import unittest2 as unittest
-except ImportError: # Python 2.7
+except ImportError:  # Python 2.7
     import unittest
 
 
@@ -41,7 +38,7 @@ class TestLimitDetections(DataTestCase):
             s.setAllowManualDetectionLimit(self.lds[idx]['manual'])
             s.setLowerDetectionLimit(self.lds[idx]['min'])
             s.setUpperDetectionLimit(self.lds[idx]['max'])
-            idx+=1
+            idx += 1
 
     def tearDown(self):
         for s in self.services:

--- a/bika/lims/tests/test_limitdetections.py
+++ b/bika/lims/tests/test_limitdetections.py
@@ -6,8 +6,7 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 from Products.CMFCore.utils import getToolByName
-from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
-from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.tests.base import DataTestCase
 from bika.lims.utils.analysisrequest import create_analysisrequest
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
@@ -20,13 +19,11 @@ except ImportError: # Python 2.7
     import unittest
 
 
-class TestLimitDetections(BikaFunctionalTestCase):
-    layer = BIKA_LIMS_FUNCTIONAL_TESTING
+class TestLimitDetections(DataTestCase):
 
     def setUp(self):
         super(TestLimitDetections, self).setUp()
         setRoles(self.portal, TEST_USER_ID, ['Member', 'LabManager'])
-        self.setup_data_load()
         login(self.portal, TEST_USER_NAME)
         servs = self.portal.bika_setup.bika_analysisservices
         # analysis-service-3: Calcium (Ca)
@@ -487,5 +484,4 @@ class TestLimitDetections(BikaFunctionalTestCase):
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestLimitDetections))
-    suite.layer = BIKA_LIMS_FUNCTIONAL_TESTING
     return suite

--- a/bika/lims/tests/test_manualuncertainty.py
+++ b/bika/lims/tests/test_manualuncertainty.py
@@ -7,14 +7,11 @@
 
 from bika.lims.tests.base import DataTestCase
 from bika.lims.utils.analysisrequest import create_analysisrequest
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import login
-from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID, TEST_USER_NAME, login, setRoles
 
 try:
     import unittest2 as unittest
-except ImportError: # Python 2.7
+except ImportError:  # Python 2.7
     import unittest
 
 
@@ -35,10 +32,10 @@ class TestManualUncertainty(DataTestCase):
         for s in self.services:
             s.setAllowManualUncertainty(True)
         uncs = [{'intercept_min': 0, 'intercept_max': 5, 'errorvalue': 0.0015},
-                {'intercept_min': 5, 'intercept_max':10, 'errorvalue': 0.02},
-                {'intercept_min':10, 'intercept_max':20, 'errorvalue': 0.4}]
-        self.services[1].setUncertainties(uncs);
-        self.services[2].setUncertainties(uncs);
+                {'intercept_min': 5, 'intercept_max': 10, 'errorvalue': 0.02},
+                {'intercept_min':10, 'intercept_max': 20, 'errorvalue': 0.4}]
+        self.services[1].setUncertainties(uncs)
+        self.services[2].setUncertainties(uncs)
         self.services[2].setPrecisionFromUncertainty(True)
 
     def tearDown(self):
@@ -92,7 +89,7 @@ class TestManualUncertainty(DataTestCase):
             self.assertFalse(an.getUncertainty())
 
         # Copper (advanced uncertainty)
-        cu = [a.getObject() for a in ar.getAnalyses() \
+        cu = [a.getObject() for a in ar.getAnalyses()
               if a.getObject().getServiceUID() == self.services[1].UID()][0]
         self.assertFalse(cu.getUncertainty())
 
@@ -124,7 +121,7 @@ class TestManualUncertainty(DataTestCase):
         self.assertFalse(cu.getUncertainty())
 
         # Iron (advanced uncertainty with precision)
-        fe = [a.getObject() for a in ar.getAnalyses() \
+        fe = [a.getObject() for a in ar.getAnalyses()
               if a.getObject().getServiceUID() == self.services[2].UID()][0]
         self.assertFalse(cu.getUncertainty())
 
@@ -200,10 +197,11 @@ class TestManualUncertainty(DataTestCase):
         self.assertEqual(formatDecimalMark(1), '1')
         self.assertEqual(formatDecimalMark(1.2), '1.2')
         self.assertEqual(formatDecimalMark('1.34'), '1.34')
-        self.assertEqual(formatDecimalMark('0.0021',decimalmark=','), '0,0021')
+        self.assertEqual(formatDecimalMark('0.0021', decimalmark=','), '0,0021')
         self.assertEqual(formatDecimalMark('2'), '2')
-        self.assertEqual(formatDecimalMark('< 2.1', decimalmark=','),'< 2,1')
-        self.assertEqual(formatDecimalMark('> 2.1', decimalmark=','),'> 2,1')
+        self.assertEqual(formatDecimalMark('< 2.1', decimalmark=','), '< 2,1')
+        self.assertEqual(formatDecimalMark('> 2.1', decimalmark=','), '> 2,1')
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/bika/lims/tests/test_manualuncertainty.py
+++ b/bika/lims/tests/test_manualuncertainty.py
@@ -5,8 +5,7 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
-from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.tests.base import DataTestCase
 from bika.lims.utils.analysisrequest import create_analysisrequest
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
@@ -19,13 +18,11 @@ except ImportError: # Python 2.7
     import unittest
 
 
-class TestManualUncertainty(BikaFunctionalTestCase):
-    layer = BIKA_LIMS_FUNCTIONAL_TESTING
+class TestManualUncertainty(DataTestCase):
 
     def setUp(self):
         super(TestManualUncertainty, self).setUp()
         setRoles(self.portal, TEST_USER_ID, ['Member', 'LabManager'])
-        self.setup_data_load()
         login(self.portal, TEST_USER_NAME)
 
         servs = self.portal.bika_setup.bika_analysisservices
@@ -211,5 +208,4 @@ class TestManualUncertainty(BikaFunctionalTestCase):
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestManualUncertainty))
-    suite.layer = BIKA_LIMS_FUNCTIONAL_TESTING
     return suite

--- a/bika/lims/tests/test_reflexrules.py
+++ b/bika/lims/tests/test_reflexrules.py
@@ -10,10 +10,7 @@ from bika.lims.tests.base import DataTestCase
 from bika.lims.utils import tmpID
 from bika.lims.utils.analysisrequest import create_analysisrequest
 from bika.lims.workflow import doActionFor
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import login
-from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID, TEST_USER_NAME, login, setRoles
 
 try:
     import unittest2 as unittest
@@ -179,7 +176,6 @@ class TestReflexRules(DataTestCase):
 
         """
         # Creating a rule
-        rules_list = []
         folder = self.portal.bika_setup.bika_reflexrulefolder
         _id = folder.invokeFactory('ReflexRule', id=tmpID())
         rule = folder[_id]

--- a/bika/lims/tests/test_reflexrules.py
+++ b/bika/lims/tests/test_reflexrules.py
@@ -6,8 +6,7 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 from bika.lims.idserver import renameAfterCreation
-from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
-from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.tests.base import DataTestCase
 from bika.lims.utils import tmpID
 from bika.lims.utils.analysisrequest import create_analysisrequest
 from bika.lims.workflow import doActionFor
@@ -23,8 +22,8 @@ except ImportError:  # Python 2.7
 
 
 # Tests related with reflex testing
-class TestReflexRules(BikaFunctionalTestCase):
-    layer = BIKA_LIMS_FUNCTIONAL_TESTING
+class TestReflexRules(DataTestCase):
+
     # A list with the created rules
     rules_list = []
     # A list with the created methods
@@ -197,7 +196,6 @@ class TestReflexRules(BikaFunctionalTestCase):
     def setUp(self):
         super(TestReflexRules, self).setUp()
         setRoles(self.portal, TEST_USER_ID, ['Member', 'LabManager'])
-        self.setup_data_load()
         login(self.portal, TEST_USER_NAME)
 
     def tearDown(self):
@@ -903,5 +901,4 @@ class TestReflexRules(BikaFunctionalTestCase):
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestReflexRules))
-    suite.layer = BIKA_LIMS_FUNCTIONAL_TESTING
     return suite

--- a/bika/lims/tests/test_textual_doctests.py
+++ b/bika/lims/tests/test_textual_doctests.py
@@ -11,7 +11,7 @@ from os.path import join
 import unittest2 as unittest
 from Testing import ZopeTestCase as ztc
 from bika.lims.config import PROJECTNAME
-from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.tests.base import BaseTestCase
 from pkg_resources import resource_listdir
 
 rst_filenames = [f for f in resource_listdir(PROJECTNAME, "tests/doctests")
@@ -28,7 +28,7 @@ def test_suite():
         suite.addTests([
             ztc.ZopeDocFileSuite(
                 doctestfile,
-                test_class=BikaFunctionalTestCase,
+                test_class=BaseTestCase,
                 optionflags=flags
             )
         ])

--- a/bika/lims/tests/test_textual_doctests.py
+++ b/bika/lims/tests/test_textual_doctests.py
@@ -8,11 +8,12 @@
 import doctest
 from os.path import join
 
+from pkg_resources import resource_listdir
+
 import unittest2 as unittest
-from Testing import ZopeTestCase as ztc
 from bika.lims.config import PROJECTNAME
 from bika.lims.tests.base import BaseTestCase
-from pkg_resources import resource_listdir
+from Testing import ZopeTestCase as ztc
 
 rst_filenames = [f for f in resource_listdir(PROJECTNAME, "tests/doctests")
                  if f.endswith('.rst')]

--- a/bika/lims/tests/test_validation.py
+++ b/bika/lims/tests/test_validation.py
@@ -13,18 +13,14 @@ from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import login
 from plone.app.testing import setRoles
 
-from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
-from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.tests.base import DataTestCase
 
 
-class Tests(BikaFunctionalTestCase):
-
-    layer = BIKA_LIMS_FUNCTIONAL_TESTING
+class Tests(DataTestCase):
 
     def setUp(self):
         super(Tests, self).setUp()
         setRoles(self.portal, TEST_USER_ID, ['Member', 'LabManager'])
-        self.setup_data_load()
         login(self.portal, TEST_USER_NAME)
 
     def test_UniqueFieldValidator(self):
@@ -459,5 +455,4 @@ class Tests(BikaFunctionalTestCase):
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(Tests))
-    suite.layer = BIKA_LIMS_FUNCTIONAL_TESTING
     return suite

--- a/bika/lims/tests/test_validation.py
+++ b/bika/lims/tests/test_validation.py
@@ -7,13 +7,9 @@
 
 import unittest
 
-from Products.validation import validation as validationService
-from plone.app.testing import TEST_USER_ID
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import login
-from plone.app.testing import setRoles
-
 from bika.lims.tests.base import DataTestCase
+from plone.app.testing import TEST_USER_ID, TEST_USER_NAME, login, setRoles
+from Products.validation import validation as validationService
 
 
 class Tests(DataTestCase):

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -135,6 +135,5 @@ scripts = ipython=ipzope
 
 [versions]
 setuptools =
-zc.buildout = 2.10.0
-CairoSVG = 1.0.20
+zc.buildout >= 2.10.0
 five.pt = 2.2.4

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -134,6 +134,6 @@ extra-paths =
 scripts = ipython=ipzope
 
 [versions]
-setuptools =
-zc.buildout >= 2.10.0
-five.pt = 2.2.4
+setuptools=
+zc.buildout=2.11.1
+five.pt=2.2.4


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The test setup imported the Demo data per tests, which increased the runtime up to 45 minutes, which is not acceptable.

This PR introduces now two test layers:

- BaseTestCase (for tests w/o demo data)
- DataTestCase (for tests which rely on imported demo data from the Excel sheet)

Therefore, depending packages have to update their imports, e.g. `senaite.jsonapi`, `senaite.api` etc.

## Current behavior before PR

- Travis CI is failing
- Tests take too long

## Desired behavior after PR is merged

- Travis CI is passing
- Tests take acceptable time (at least below the Travis timeout threshold)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
