### PR TITLE
Use already implemented function to get base url

### DIFF
--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -399,7 +399,7 @@
       form_data.set("table_only", form_id);
       form_data.set(`${form_id}_review_state`, state_id);
       return this.ajax_submit({
-        url: window.location.href.split("?")[0],
+        url: this.get_base_url(),
         data: form_data,
         processData: false, // do not transform to a query string
         contentType: false // do not set any content type header

--- a/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
@@ -380,7 +380,7 @@ class window.BikaListingTableView
     form_data.set "#{form_id}_review_state", state_id
 
     @ajax_submit
-      url: window.location.href.split("?")[0]
+      url: @get_base_url()
       data: form_data
       processData: no  # do not transform to a query string
       contentType: no # do not set any content type header


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

A task (get base url) for which there was a function was being performed _manually_. (See comments in #700).

## Current behavior before PR

The base url was being obtained _manually_.

## Desired behavior after PR is merged

The base url is obtained via the `get_base_url` function.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
