### PR TITLE
Solve Traceback on Print Sample Sheets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Changelog
 
 **Fixed**
 
+- #723 Solve Traceback on Print Samples Sheet
 - #716 Samples from inside Batch are not filtered correctly
 - #707 AR Add: Set default contact on client change
 - #700 Fix filtering by review state in aggregated list of analyses

--- a/bika/lims/browser/sample/printform.py
+++ b/bika/lims/browser/sample/printform.py
@@ -551,7 +551,7 @@ class SamplesPrint(BrowserView):
         # Checking if the day is correct after been computed
         if (day - default) <= 0:
             # substract a month
-            if (month-1) < 0:
+            if (month-1) <= 0:
                 year -= 1
                 month = 12
             else:


### PR DESCRIPTION
**Note** This P.R. only addresses the Traceback obtained when clicking "Print sample sheets" from Samples view. The raised 404 error is solved in #726 

## Description of the issue/feature this PR addresses

Linked issue: #545 (only the Traceback)

## Current behavior before PR

Traceback occurs

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.sample.printform, line 99, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 289, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module 5fe45578c385f85ce66397ea8771eb20.py, line 878, in render
  Module bika.lims.browser.sample.printform, line 559, in default_from_date
  Module calendar, line 120, in monthrange
IllegalMonthError: bad month number 0; must be 1-12

 - Expression: "python:view.ulocalized_time(
                                    view.default_from_date(),
                                    long_format=None,
                                    time_only=False)"
 - Filename:   ... te.core/bika/lims/browser/sample/templates/print_form.pt
 - Location:   (line 79: col 38)
 - Source:     ... python:view.ulocalized_time(
                   ^
 - Arguments:  repeat: {...} (0)
               template: <ViewPageTemplateFile - at 0x7f3baf0467d0>
               views: <ViewMapper - at 0x7f3bae8c8d10>
               modules: <instance - at 0x7f3bd5e1d560>
               args: <tuple - at 0x7f3bddbed050>
               here: <ImplicitAcquisitionWrapper samples at 0x7f3bd5875050>
               portal: <ImplicitAcquisitionWrapper senaite at 0x7f3bd5789730>
               user: <ImplicitAcquisitionWrapper - at 0x7f3bd57914b0>
               nothing: <NoneType - at 0x8fd4d0>
               plone_view: <Plone plone at 0x7f3bae5dc190>
               container: <ImplicitAcquisitionWrapper samples at 0x7f3bd5875050>
               request: <instance - at 0x7f3baec75908>
               wrapped_repeat: <SafeMapping - at 0x7f3bae8fc158>
               portal_url: https://senaite.ridingbytes.com
               traverse_subpath: <list - at 0x7f3baf06c3b0>
               default: <object - at 0x7f3bddb12540>
               loop: {...} (3)
               context: <ImplicitAcquisitionWrapper samples at 0x7f3bd5875050>
               view: <SamplesPrint print_sampling_sheets at 0x7f3baec47410>
               portal_state: <PortalState plone_portal_state at 0x7f3bae5dc150>
               translate: <function translate at 0x7f3bae80e578>
               root: <ImplicitAcquisitionWrapper Zope at 0x7f3bd5660910>
               options: {...} (0)
               target_language: <NoneType - at 0x8fd4d0>
```

## Desired behavior after PR is merged

No Traceback occurs and the Samples sheets are properly rendered.

The Traceback was due to the check we are doing here 
https://github.com/senaite/senaite.core/blob/0186adc1b6f22ecdd5e56b149e4819d14dc4beed/bika/lims/browser/sample/printform.py#L554-L558
where we will always end in the `else` clause since the minimum month is `1`. This means that when the month is January (which seems to be the case in the first screenshot) the month after the execution of this piece of code will be `0` which, of course, is a bad month number.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
