### PR TITLE
Department Filtering Portlet appears only for the manager with 'admin' username

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Changelog
 
 **Fixed**
 
+- #724 Department Filtering Portlet appears only for the manager with 'admin' username
 - #716 Samples from inside Batch are not filtered correctly
 - #707 AR Add: Set default contact on client change
 - #700 Fix filtering by review state in aggregated list of analyses

--- a/bika/lims/skins/bika/portlet_department_filter.pt
+++ b/bika/lims/skins/bika/portlet_department_filter.pt
@@ -5,22 +5,23 @@
 <div metal:define-macro="portlet"
     tal:define="
         member python: context.portal_membership.getAuthenticatedMember();
+        is_admin python: member.has_role('Manager');
         user_name python: member.getUserName();
-        brains python: [] if user_name=='admin'  else here.portal_catalog(portal_type='LabContact',
+        brains python: [] if is_admin  else here.portal_catalog(portal_type='LabContact',
                                     getUsername=user_name);"
-    tal:condition="python:context.bika_setup.getAllowDepartmentFiltering() and (len(brains)>0 or user_name=='admin') ">
+    tal:condition="python:context.bika_setup.getAllowDepartmentFiltering() and (len(brains)>0 or is_admin) ">
 <!-- Defining the base variables -->
 <tal:departments
     tal:define="portal context/portal_url/getPortalObject;
                 plone_view context/@@plone;
                 dep_disabled python:request.cookies.get('dep_filter_disabled','');
                 deps python: here.portal_catalog(portal_type='Department',sort_on='sortable_title', sort_order='ascending',
-                                            inactive_state='active') if user_name=='admin' else brains[0].getObject().getSortedDepartments();
+                                            inactive_state='active') if is_admin else brains[0].getObject().getSortedDepartments();
                 cookie python:request.cookies.get(
                     'filter_by_department_info','');
                 deps_from_cookie python: cookie.split(',') if cookie and len(deps)>0
                     else [];
-                first_from_cat python: deps[0].UID if user_name=='admin' and deps else
+                first_from_cat python: deps[0].UID if is_admin and deps else
                           brains[0].getObject().getDefaultDepartment() if brains and brains[0].getObject().getDefaultDepartment()
                           else deps[0].UID() if deps else '';
                 first_dep python: deps_from_cookie[0] if len(deps_from_cookie)>1
@@ -39,13 +40,13 @@
                 <input type="checkbox"
                        name="admin_dep_filter_enabled"
                        id="admin_dep_filter_enabled"
-                       tal:condition= "python: user_name=='admin'"/>
-                       <label tal:condition= "python: user_name=='admin'">Select All Departments<br><br></label>
+                       tal:condition= "python: is_admin"/>
+                       <label tal:condition= "python: is_admin">Select All Departments<br><br></label>
 
                 <tal:option repeat="dep deps" tal:condition="python: len(deps)>1">
                     <ul>
-                        <li tal:define="dep_name python:dep.Title if user_name=='admin' else dep.Title();
-                                        dep_uid python: dep.UID if user_name=='admin' else dep.UID()">
+                        <li tal:define="dep_name python:dep.Title if is_admin else dep.Title();
+                                        dep_uid python: dep.UID if is_admin else dep.UID()">
                             <input type="checkbox"
                                 tal:attributes="
                                     value python: dep_uid;
@@ -60,7 +61,7 @@
                 <label
                     i18n:translate=""
                     tal:condition="python: len(deps)<2"
-                    tal:content="python: deps[0].Title if user_name=='admin' and deps else deps[0].Title() if deps else ''"
+                    tal:content="python: deps[0].Title if is_admin and deps else deps[0].Title() if deps else ''"
                     >Department</label>
             </dd><br>
             <!-- The submit form button -->


### PR DESCRIPTION
## Current behavior before PR
When department filtering is enabled, a user with administrative privileges might miss the department filtering portlet. It happens because admin user verifier checks only the username not the role.

## Desired behavior after PR is merged
The Portlet checks if the user is admin by its role and lists all departments if he/she has the role `Manager`.

--

I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
