### PR TITLE
Traceback when Invalidating Analysis Requests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Changelog
 
 **Fixed**
 
+- #738 Traceback when Invalidating Analysis Requests
 - #694 Bad calculation of min and max in ReferenceResults on negative result
 - #694 Instrument validity not updated in accordance with latest QC tests
 - #694 Result range shoulders computed badly on full/partial negative specs

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -20,6 +20,7 @@ from AccessControl import allow_module
 from AccessControl import getSecurityManager
 from DateTime import DateTime
 from Products.Archetypes.public import DisplayList
+from Products.Archetypes.interfaces.field import IComputedField
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from bika.lims import api as api
@@ -750,6 +751,8 @@ def copy_field_values(src, dst, ignore_fieldnames=None, ignore_fieldtypes=None):
     dst_schema = dst.Schema()
 
     for field in src_schema.fields():
+        if IComputedField.providedBy(field):
+            continue
         fieldname = field.getName()
         if fieldname in ignore_fields \
                 or field.type in ignore_types \


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.health/issues/58

## Current behavior before PR
When trying to clone AR's, the `copy_field_values` function tries to set Computed Field values and fails. 

## Desired behavior after PR is merged
Computed Fields are skipped when cloning objects.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
