### PR TITLE
Make it clear that senaite.core is not standalone

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,111 +27,23 @@
 Introduction
 ============
 
-SENAITE.CORE is an Open Source Laboratory Information Management System (LIMS)
-for enterprise environments, especially focused to behave with high speed,
-excellent performance and good stability.
+SENAITE.CORE is an Open Source Laboratory Information Management System (LIMS) for enterprise environments, especially focused to behave with excellent performance and stability.
 
-This software is a derivative work of BikaLIMS_
-software and comes with the same user interface. Since SENAITE.CORE provides the
-core functionalities and entities used by `SENAITE.LIMS <https://github.com/senaite/senaite.lims>`_,
-the installation of the latter is strongly recommended for an optimal user
-experience.
+This software is a direct derivative work of the Bika-LIMS software and comes with the same user interface.
 
 
 Installation
 ============
 
-SENAITE.CORE is built on top of `Plone CMS <https://plone.org>`_, so it must be
-installed first.
-Please, follow the `installation instructions for Plone 4.x <https://docs.plone.org/4/en/manage/installing/installation.html>`_
-first.
-
-Once Plone 4.x is installed successfully, you can choose any of the two options
-below:
-
-Ready-to-go installation
-------------------------
-With this installation modality, the sources from ``senaite.core`` will be
-downloaded automatically from `Python Package Index (Pypi) <https://pypi.python.org/pypi/senaite.core>`_.
-If you want the latest code from the `source code repository <https://github.com/senaite/senaite.core>`_,
-follow the `installation instructions for development <https://github.com/senaite/senaite.core/blob/master/README.rst#installation-for-development>`_.
-
-Create a new buildout file ``senaite.cfg`` which extends your existing
-``buildout.cfg`` – this way you can easily keep development stuff separate from
-your main buildout.cfg which you can also use on the production server::
-
-  [buildout]
-  index = https://pypi.python.org/simple
-  extends = buildout.cfg
-
-  [instance]
-  eggs +=
-      senaite.core
-
-Note that with this approach you do not need to modify the existing buildout.cfg
-file.
-
-Then build it out with this special config file::
-
-  bin/buildout -c senaite.cfg
-
-and buildout will automatically download and install all required dependencies.
-
-For further details about Buildout and how to install add-ons for Plone, please check
-`Installing add-on packages using Buildout from Plone documentation <https://docs.plone.org/4/en/manage/installing/installing_addons.html>`_.
-
-
-Installation for development
-----------------------------
-
-This is the recommended approach how to enable ``senaite.core`` for your
-development environment. With this approach, you'll be able to download the
-latest source code from `senaite.core's repository <https://github.com/senaite/senaite.core>`_
-and contribute as well.
-
-Use git to fetch ``senaite.core`` source code to your buildout environment::
-
-  cd src
-  git clone git://github.com/senaite/senaite.core.git senaite.core
-
-Create a new buildout file ``senaite.cfg`` which extends your existing
-``buildout.cfg`` – this way you can easily keep development stuff separate
-from your main buildout.cfg which you can also use on the production server.
-
-``senaite.cfg``::
-
-  [buildout]
-  index = https://pypi.python.org/simple
-  extends = buildout.cfg
-  develop +=
-      src/senaite.core
-
-  [instance]
-  eggs +=
-      senaite.core
-
-Note that with this approach you do not need to modify the existing buildout.cfg
-file.
-
-Then build it out with this special config file::
-
-  bin/buildout -c senaite.cfg
-
-and buildout will automatically download and install all required dependencies.
+SENAITE.CORE provides the core functionalities and entities used by `SENAITE.LIMS <https://github.com/senaite/senaite.lims>`_.  It is intended to be imported automatically as a dependency of SENAITE.LIMS and other SENAITE products, and it should not be installed directly unless you know what you are doing.
 
 
 Contribute
 ==========
 
-We want contributing to SENAITE.CORE to be fun, enjoyable, and educational for
-anyone, and everyone. This project adheres to the `Contributor Covenant <https://github.com/senaite/senaite.core/blob/master/CODE_OF_CONDUCT.md>`_.
-By participating, you are expected to uphold this code. Please report
-unacceptable behavior.
+We want contributing to SENAITE.CORE to be fun, enjoyable, and educational for anyone, and everyone. This project adheres to the `Contributor Covenant <https://github.com/senaite/senaite.core/blob/master/CODE_OF_CONDUCT.md>`_. By participating, you are expected to uphold this code. Please report unacceptable behavior.
 
-Contributions go far beyond pull requests and commits. Although we love giving
-you the opportunity to put your stamp on SENAITE.CORE, we also are thrilled to
-receive a variety of other contributions. Please, read `Contributing to senaite.core
-document <https://github.com/senaite/senaite.core/blob/master/CONTRIBUTING.md>`_.
+Contributions go far beyond pull requests and commits. Although we love giving you the opportunity to put your stamp on SENAITE.CORE, we also are thrilled to receive a variety of other contributions. Please, read `Contributing to senaite.core document <https://github.com/senaite/senaite.core/blob/master/CONTRIBUTING.md>`_.
 
 
 Feedback and support


### PR DESCRIPTION
It should not be installed, but rather pulled in as a dependency of senaite.lims or other product

## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/739 [and others similar]

## Current behavior before PR

Users attempt to install senaite.core directly, resulting in duplicate issues and mails to the userlist.

## Desired behavior after PR is merged

Users are made aware that the software is not intended to be directly installed unless you have a real reason not to be using SENAITE.LIMS or other product.
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
