### PR TITLE
CSV Importer for 'Cobas Taqman 48' Instrument Interface

### DIFF
--- a/bika/lims/exportimport/instruments/__init__.py
+++ b/bika/lims/exportimport/instruments/__init__.py
@@ -100,7 +100,7 @@ PARSERS = [
            # ['generic.xml', ''],
            ['horiba.jobinyvon.icp', 'HoribaJobinYvonCSVParser'],
            ['rigaku.supermini.wxrf', 'RigakuSuperminiWXRFCSVParser'],
-           ['rochecobas.taqman.model48', 'RocheCobasTaqmanRSFParser'],
+           ['rochecobas.taqman.model48', 'RocheCobasTaqmanParser'],
            ['rochecobas.taqman.model96', 'RocheCobasTaqmanRSFParser'],
            ['thermoscientific.arena.xt20', 'ThermoArena20XTRPRCSVParser'],
            ['thermoscientific.gallery.Ts9861x', 'ThermoGallery9861xTSVParser'],

--- a/bika/lims/exportimport/instruments/rochecobas/taqman/model48.py
+++ b/bika/lims/exportimport/instruments/rochecobas/taqman/model48.py
@@ -29,13 +29,11 @@ class RocheCobasTaqmanParser(InstrumentCSVResultsFileParser):
         self._rownum = None
         self._end_header = False
         self._fileformat = fileformat
+        self._separator = ',' if self._fileformat == 'csv' else '\t'
 
     def _parseline(self, line):
 
-        if self._fileformat == "csv":
-            sline = line.replace('"', '').split(',')
-        else:
-            sline = line.replace('"', '').split('\t')
+        sline = line.replace('"', '').split(self._separator)
 
         if len(sline) > 0 and not self._end_header:
             self._columns = sline

--- a/bika/lims/exportimport/instruments/rochecobas/taqman/model48.py
+++ b/bika/lims/exportimport/instruments/rochecobas/taqman/model48.py
@@ -19,17 +19,24 @@ import traceback
 title = "Roche Cobas - Taqman - 48"
 
 
-class RocheCobasTaqmanRSFParser(InstrumentCSVResultsFileParser):
-    def __init__(self, rsf):
+class RocheCobasTaqmanParser(InstrumentCSVResultsFileParser):
+
+    def __init__(self, rsf, fileformat=None):
         InstrumentCSVResultsFileParser.__init__(self, rsf)
         self._columns = []  # The different columns names
         self._values = {}  # The analysis services from the same resid
         self._resid = ''  # A stored resid
         self._rownum = None
         self._end_header = False
+        self._fileformat = fileformat
 
     def _parseline(self, line):
-        sline = line.replace('"', '').split('\t')
+
+        if self._fileformat == "csv":
+            sline = line.replace('"', '').split(',')
+        else:
+            sline = line.replace('"', '').split('\t')
+
         if len(sline) > 0 and not self._end_header:
             self._columns = sline
             self._end_header = True
@@ -113,7 +120,9 @@ def Import(context, request):
     if not hasattr(infile, 'filename'):
         errors.append(_("No file selected"))
     if fileformat == 'rsf':
-        parser = RocheCobasTaqmanRSFParser(infile)
+        parser = RocheCobasTaqmanParser(infile)
+    if fileformat == 'csv':
+        parser = RocheCobasTaqmanParser(infile, "csv")
     else:
         errors.append(t(_("Unrecognized file format ${fileformat}",
                           mapping={"fileformat": fileformat})))
@@ -166,7 +175,7 @@ def Import(context, request):
 
     return json.dumps(results)
 
-class BeckmancoulterAccess2RSFParser(RocheCobasTaqmanRSFParser):
+class BeckmancoulterAccess2RSFParser(RocheCobasTaqmanParser):
     def getAttachmentFileType(self):
         return "Roche Cobas Taqman 48"
 

--- a/bika/lims/exportimport/instruments/rochecobas/taqman/model48_import.pt
+++ b/bika/lims/exportimport/instruments/rochecobas/taqman/model48_import.pt
@@ -6,6 +6,7 @@
     <label for='rochecobas_taqman_model48_format'>Format</label>&nbsp;
     <select name="rochecobas_taqman_model48_format" id="rochecobas_taqman_model48_format">
         <option value='rsf'>RFS</option>
+        <option value='csv'>CSV</option>
     </select>
     <p></p>
     <h3>Advanced options</h3>


### PR DESCRIPTION
## Current behavior before PR
Cobas Taqman 48 Instrument Interface can import only `rfs` files.
 
## Desired behavior after PR is merged
The Interface imports `csv` files as well.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
