### PR TITLE
'StringField' to 'UIDReferenceField' for Default Department of Lab Contact 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Changed**
 
+- #746 StringField to UIDReferenceField for Default Department of Lab Contact
 - #694 Out of range/shoulders logic redux, ported to `api.analysis`
 - #694 Make getResultRange functions from Analysis-types consistent
 - #694 Out of range/shoulders icons are rendered in AnalysesView

--- a/bika/lims/content/labcontact.py
+++ b/bika/lims/content/labcontact.py
@@ -15,7 +15,8 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 
 from Products.Archetypes import atapi
-from Products.Archetypes.public import StringField
+# Bika Fields
+from bika.lims.browser.fields import UIDReferenceField
 from Products.Archetypes.public import SelectionWidget
 from Products.Archetypes.references import HoldingReference
 from Products.Archetypes.utils import DisplayList
@@ -59,7 +60,7 @@ schema = Person.schema.copy() + atapi.Schema((
                              label=_("Departments"),
                              description=_("The laboratory departments"),
                          )),
-    StringField('DefaultDepartment',
+    UIDReferenceField('DefaultDepartment',
                 required=0,
                 vocabulary_display_path_bound=sys.maxint,
                 vocabulary='_defaultDepsVoc',

--- a/bika/lims/skins/bika/portlet_department_filter.pt
+++ b/bika/lims/skins/bika/portlet_department_filter.pt
@@ -22,7 +22,7 @@
                 deps_from_cookie python: cookie.split(',') if cookie and len(deps)>0
                     else [];
                 first_from_cat python: deps[0].UID if is_admin and deps else
-                          brains[0].getObject().getDefaultDepartment() if brains and brains[0].getObject().getDefaultDepartment()
+                          brains[0].getObject().getDefaultDepartment().UID() if brains and brains[0].getObject().getDefaultDepartment()
                           else deps[0].UID() if deps else '';
                 first_dep python: deps_from_cookie[0] if len(deps_from_cookie)>1
                     else first_from_cat if not cookie else '';">

--- a/bika/lims/subscribers/dep_cookie.py
+++ b/bika/lims/subscribers/dep_cookie.py
@@ -87,7 +87,7 @@ def SetDepartmentCookies(event):
             elif brain[0].portal_type == 'LabContact':
                 lab_con = brain[0].getObject()
                 if lab_con.getDefaultDepartment():
-                    dep_for_cookie = lab_con.getDefaultDepartment()
+                    dep_for_cookie = lab_con.getDefaultDepartment().UID()
                 else:
                     departments = lab_con.getSortedDepartments()
                     dep_for_cookie = \


### PR DESCRIPTION
## Current behavior before PR
Default Department field of Lab Contacts is a `StringField` which saves `UID` of the Department and 'getter' method just gives the UID as a String.

## Desired behavior after PR is merged
Use `UIDReferenceField` instead which is aimed to save the same data but return the referring objects in the 'getter' method.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
