### PR TITLE
Fix Chameleon Parse Error in Productivity report(s)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,7 @@ Changelog
 
 **Fixed**
 
-- #734 Chameleon parse error in "Analyses performed and published as % of total" productivity reports
+- #734 Chameleon parse error in "Analyses performed and published as % of total" and "Analyses summary per department" productivity reports
 - #721 Fix filter functionality of Worksheets after sort/pagination
 - #738 Traceback when Invalidating Analysis Requests
 - #694 Bad calculation of min and max in ReferenceResults on negative result

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ Changelog
 
 **Fixed**
 
+- #734 Chameleon parse error in "Analyses performed and published as % of total" productivity reports
 - #721 Fix filter functionality of Worksheets after sort/pagination
 - #738 Traceback when Invalidating Analysis Requests
 - #694 Bad calculation of min and max in ReferenceResults on negative result

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,7 @@ Changelog
 
 **Fixed**
 
-- #734 Chameleon parse error in "Analyses performed and published as % of total" and "Analyses summary per department" productivity reports
+- #734 Chameleon parse error in "Analyses performed and published as % of total", "Analyses summary per department" and "Data entry day book" productivity reports
 - #721 Fix filter functionality of Worksheets after sort/pagination
 - #738 Traceback when Invalidating Analysis Requests
 - #694 Bad calculation of min and max in ReferenceResults on negative result

--- a/bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt
+++ b/bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt
@@ -63,8 +63,8 @@ Available attributes:
 
    footlines {
        Total: {
-           Requested,    	-- total requested analyses count
-           Published,		-- total published analyses count
+           Requested,    	- total requested analyses count
+           Published,		- total published analyses count
            PerformedRequestedRatio,
            PerformedRequestedRatioPercentage,
            PublishedPerformedRatio,

--- a/bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt
+++ b/bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt
@@ -63,8 +63,8 @@ Available attributes:
 
    footlines {
        Total: {
-           Requested,    	-- total requested analyses count
-           Published,		-- total published analyses count
+           Requested,    	- total requested analyses count
+           Published,		- total published analyses count
            PerformedRequestedRatio,
            PerformedRequestedRatioPercentage,
            PublishedPerformedRatio,

--- a/bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt
+++ b/bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt
@@ -48,10 +48,10 @@ Available attributes:
 
    footlines {
        Total: {
-           Created,    	-- total count of ARs created
-           Received,		-- total count of ARs received
-           Published,		-- total count of ARs published
-           ReceivedCreatedRatio, -- ratio of AR received amongst created
+           Created,    	         - total count of ARs created
+           Received,		     - total count of ARs received
+           Published,		     - total count of ARs published
+           ReceivedCreatedRatio, - ratio of AR received amongst created
            ReceivedCreatedRatioPercentage,
            PublishedCreatedRatio,
            PublishedCreatedRatioPercentage

--- a/bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt
+++ b/bika/lims/browser/reports/templates/productivity_dataentrydaybook.pt
@@ -48,10 +48,10 @@ Available attributes:
 
    footlines {
        Total: {
-           Created,    	         - total count of ARs created
-           Received,		     - total count of ARs received
-           Published,		     - total count of ARs published
-           ReceivedCreatedRatio, - ratio of AR received amongst created
+           Created,                 - total count of ARs created
+           Received,                - total count of ARs received
+           Published,               - total count of ARs published
+           ReceivedCreatedRatio,    - ratio of AR received amongst created
            ReceivedCreatedRatioPercentage,
            PublishedCreatedRatio,
            PublishedCreatedRatioPercentage


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #734 

**Note**: The use of double dashes/hyphens inside comments is invalid in HTML, XML, and XHTML.

## Current behavior before PR

When generating one of the following productivity reports

* "Analyses performed and published as % of total" 
* "Analyses summary per department"
* "Data entry day book"
 
an error is raised. Furthermore, the traceback of the error appears on the page the user is viewing.

The traceback of the error is (the one listed is for "Analyses performed and published as % of total"):

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.reports, line 293, in __call__
  Module bika.lims.browser.reports.productivity_analysesperformedpertotal, line 198, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 126, in pt_render
   - Warning: Compilation failed
   - Warning: chameleon.exc.ParseError: The string '--' is not allowed in a comment.

 - String:     "--"
 - Filename:   /home/foo/bar/zeocluster/src/senaite.core/bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt
 - Location:   (line 66: col 26)
 - Source:     Requested,    	-- total requested analyses count
                              ^^

PageTemplateFile: Error in template /home/foo/bar/zeocluster/src/senaite.core/bika/lims/browser/reports/templates/productivity_analysesperformedpertotal.pt: Compilation failed
chameleon.exc.ParseError: The string '--' is not allowed in a comment.
```

## Desired behavior after PR is merged

No traceback is raised and the reports are generated.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
