### PR TITLE
Batch Label Creation/Editing error: zope.traversing.namespace.view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ Changelog
 
 **Fixed**
 
+- #590 Wrong redirect after Batch Label edit or creation
 - #721 Fix filter functionality of Worksheets after sort/pagination
 - #738 Traceback when Invalidating Analysis Requests
 - #694 Bad calculation of min and max in ReferenceResults on negative result

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,7 @@ Changelog
 
 **Fixed**
 
-- #590 Wrong redirect after Batch Label edit or creation
+- #750 Wrong redirect after Batch Label edit or creation
 - #721 Fix filter functionality of Worksheets after sort/pagination
 - #738 Traceback when Invalidating Analysis Requests
 - #694 Bad calculation of min and max in ReferenceResults on negative result

--- a/bika/lims/profiles/default/types/BatchLabel.xml
+++ b/bika/lims/profiles/default/types/BatchLabel.xml
@@ -18,7 +18,7 @@
  <property name="allow_discussion">False</property>
  <property name="default_view_fallback">False</property>
 
- <alias from="(Default)" to="view"/>
+ <alias from="(Default)" to="base_edit"/>
  <alias from="view" to="base_edit"/>
  <alias from="edit" to="base_edit"/>
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #590 

## Current behavior before PR

For Batch Labels, both when:
* Clicking Save after creating a new one
* Clicking on the title of one of them in the Batch Labels listing (under bika Setup / Batch Labels)

the browser refreshes a blank page with the text:
```<zope.traversing.namespace.view object at 0x7fdf19e00550>```

## Desired behavior after PR is merged

In both cases the user is redirected to the Edit page of the Batch Label and the message showed in the previous section does not appear.

**Notes (Please read)**:
1. Issue #590 suggests redirecting to Batch Labels' listing view. However, after inspecting some of the other areas (AR Templates, Analysis Categories, Analysis Profiles, Analysis Services, Analysis Specifications, Attachment Types), I've noticed that all of them redirect after creation to the respective Edit view. So the changes included in this PR apply the same behavior to Batch Labels   
2. I don't know if I missed something, but for the change to be effective I had to setup a new instance. I wasn't able to find a way to make it work with an already installed instance. Can the `xml` files under `profiles/default/types` be reloaded in someway?
3. There is another possible approach which is to:
    3.1 In order to solve the editing problem: Modify in [bika_batchlabels.py](https://github.com/senaite/senaite.core/blob/master/bika/lims/controlpanel/bika_batchlabels.py), line 67, the piece of code `items[x]['url']` by `'/'.join([items[x]['url'], 'edit'])` so as to redirect when clicking the Title to the Batch Label's edit view.
         https://github.com/senaite/senaite.core/blob/ef7c16f51098b9a2743dcf8803f42daaf5755135/bika/lims/controlpanel/bika_batchlabels.py#L66-L67
    3.2 Change also the behavior of the Save button to redirect either to the Edit view or the listing.

    @xispa @ramonski Maybe this second approach is better?


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
