### PR TITLE
Date error in invoice batch creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Changelog
 
 **Fixed**
 
+- #759 Date error raised in invoice batch creation although End date is after Start date
 - #743 Traceback when accessing the view of a Statement
 - #734 Chameleon parse error in "Analyses performed and published as % of total", "Analyses summary per department" and "Data entry day book" productivity reports
 - #750 Wrong redirect after Batch Label edit or creation

--- a/bika/lims/validators.py
+++ b/bika/lims/validators.py
@@ -8,6 +8,7 @@
 import re
 import string
 import types
+from time import strptime as _strptime
 
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
@@ -203,15 +204,16 @@ class InvoiceBatch_EndDate_Validator:
     name = "invoicebatch_EndDate_validator"
 
     def __call__(self, value, *args, **kwargs):
-        instance = kwargs['instance']
-        startdate = instance.getBatchStartDate()
-        # request = kwargs.get('REQUEST', {})
-        # form = request.get('form', {})
-        enddate = value
-        startdate = startdate.strftime('%Y-%m-%d %H:%M')
+        instance = kwargs.get('instance')
+        request = kwargs.get('REQUEST')
+        if request:
+            startdate = _strptime(request.form.get('BatchStartDate'), '%Y-%m-%d %H:%M')
+        else:
+            startdate = _strptime(instance.getBatchStartDate(), '%Y-%m-%d %H:%M')
+
+        enddate = _strptime(value, '%Y-%m-%d %H:%M')
 
         translate = getToolByName(instance, 'translation_service').translate
-
         if not enddate >= startdate:
             msg = _("Start date must be before End Date")
             return to_utf8(translate(msg))

--- a/bika/lims/validators.py
+++ b/bika/lims/validators.py
@@ -15,9 +15,11 @@ from Products.CMFPlone.utils import safe_unicode
 from Products.ZCTextIndex.ParseTree import ParseError
 from Products.validation import validation
 from Products.validation.interfaces.IValidator import IValidator
+from zope.interface import implements
+
+from senaite import api as senaiteapi
 from bika.lims import bikaMessageFactory as _
 from bika.lims.utils import to_utf8
-from zope.interface import implements
 from bika.lims import api
 from bika.lims import logger
 
@@ -206,6 +208,7 @@ class InvoiceBatch_EndDate_Validator:
     def __call__(self, value, *args, **kwargs):
         instance = kwargs.get('instance')
         request = kwargs.get('REQUEST')
+
         if request:
             startdate = _strptime(request.form.get('BatchStartDate'), '%Y-%m-%d %H:%M')
         else:
@@ -213,7 +216,7 @@ class InvoiceBatch_EndDate_Validator:
 
         enddate = _strptime(value, '%Y-%m-%d %H:%M')
 
-        translate = getToolByName(instance, 'translation_service').translate
+        translate = senaiteapi.get_tool('translation_service', instance).translate
         if not enddate >= startdate:
             msg = _("Start date must be before End Date")
             return to_utf8(translate(msg))

--- a/bika/lims/validators.py
+++ b/bika/lims/validators.py
@@ -17,7 +17,6 @@ from Products.validation import validation
 from Products.validation.interfaces.IValidator import IValidator
 from zope.interface import implements
 
-from senaite import api as senaiteapi
 from bika.lims import bikaMessageFactory as _
 from bika.lims.utils import to_utf8
 from bika.lims import api
@@ -216,7 +215,7 @@ class InvoiceBatch_EndDate_Validator:
 
         enddate = _strptime(value, '%Y-%m-%d %H:%M')
 
-        translate = senaiteapi.get_tool('translation_service', instance).translate
+        translate = api.get_tool('translation_service', instance).translate
         if not enddate >= startdate:
             msg = _("Start date must be before End Date")
             return to_utf8(translate(msg))

--- a/bika/lims/validators.py
+++ b/bika/lims/validators.py
@@ -209,7 +209,7 @@ class InvoiceBatch_EndDate_Validator:
         instance = kwargs.get('instance')
         request = kwargs.get('REQUEST')
 
-        if request:
+        if request and request.form.get('BatchStartDate'):
             startdate = _strptime(request.form.get('BatchStartDate'), '%Y-%m-%d %H:%M')
         else:
             startdate = _strptime(instance.getBatchStartDate(), '%Y-%m-%d %H:%M')


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #756 

## Current behavior before PR

When a new InvoiceBatch is created an error regarding dates is raised although the dates are set correctly. The error message is: "Start date must be before End Date".

## Desired behavior after PR is merged

The InvoiceBatch dates are properly validated and the error is only raised when the End Date is before the Start Date (or equal). 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
