### PR TITLE
Default to empty the Analysis Specification title

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Changelog
 
 **Fixed**
 
+- #760 Default to empty the Title field when creating a new Analysis Specification (it was showing the UID).
 - #734 Chameleon parse error in "Analyses performed and published as % of total", "Analyses summary per department" and "Data entry day book" productivity reports
 - #750 Wrong redirect after Batch Label edit or creation
 - #721 Fix filter functionality of Worksheets after sort/pagination

--- a/bika/lims/content/analysisspec.py
+++ b/bika/lims/content/analysisspec.py
@@ -130,14 +130,13 @@ class AnalysisSpec(BaseFolder, HistoryAwareMixin):
         """ Return the title if possible, else return the Sample type.
         Fall back on the instance's ID if there's no sample type or title.
         """
+        title = ''
         if self.title:
             title = self.title
         else:
             sampletype = self.getSampleType()
             if sampletype:
                 title = sampletype.Title()
-            else:
-                title = self.id
         return safe_unicode(title).encode('utf-8')
 
     def contextual_title(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #600 

## Current behavior before PR

When creating a new Analysis Specification the current default value for the title is its UID.

## Desired behavior after PR is merged

When creating a new Analysis Specification the Title field is empty by default.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
