### PR TITLE
Dormant Reference Definitions are listed for selection on WS Templates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Changelog
 
 **Fixed**
 
+- #761 Dormant Reference Definitions were listed for selection on WS Templates
 - #760 Default to empty the Title field when creating a new Analysis Specification (it was showing the UID)
 - #759 Date error raised in invoice batch creation although End date is after Start date
 - #743 Traceback when accessing the view of a Statement

--- a/bika/lims/browser/widgets/worksheettemplatelayoutwidget.py
+++ b/bika/lims/browser/widgets/worksheettemplatelayoutwidget.py
@@ -9,6 +9,7 @@ from AccessControl import ClassSecurityInfo
 from Products.Archetypes.Registry import registerWidget
 from Products.ATExtensions.widget.records import RecordsWidget
 
+
 class WorksheetTemplateLayoutWidget(RecordsWidget):
     security = ClassSecurityInfo()
     _properties = RecordsWidget._properties.copy()
@@ -20,8 +21,10 @@ class WorksheetTemplateLayoutWidget(RecordsWidget):
 
     security.declarePublic('get_template_rows')
     def get_template_rows(self, num_positions, current_field_value):
-        try: num_pos = int(num_positions)
-        except ValueError: num_pos = 10
+        try:
+            num_pos = int(num_positions)
+        except ValueError:
+            num_pos = 10
 
         rows = []
         i = 1
@@ -40,7 +43,9 @@ class WorksheetTemplateLayoutWidget(RecordsWidget):
             rows.append(row)
         return rows
 
-registerWidget(WorksheetTemplateLayoutWidget,
-               title = 'WS Template Analyses Layout',
-               description = ('Worksheet analyses layout.'),
-               )
+
+registerWidget(
+    WorksheetTemplateLayoutWidget,
+    title='WS Template Analyses Layout',
+    description=('Worksheet analyses layout.'),
+)

--- a/bika/lims/content/worksheettemplate.py
+++ b/bika/lims/content/worksheettemplate.py
@@ -23,20 +23,23 @@ from zope.interface import implements
 import sys
 
 schema = BikaSchema.copy() + Schema((
-    RecordsField('Layout',
-        schemata = 'Layout',
-        required = 1,
-        type = 'templateposition',
-        subfields = ('pos', 'type', 'blank_ref', 'control_ref', 'dup'),
-        required_subfields = ('pos', 'type'),
-        subfield_labels = {'pos': _('Position'),
-                           'type': _('Analysis Type'),
-                           'blank_ref': _('Reference'),
-                           'control_ref': _('Reference'),
-                           'dup': _('Duplicate Of')},
-        widget = WorksheetTemplateLayoutWidget(
+    RecordsField(
+        'Layout',
+        schemata='Layout',
+        required=1,
+        type='templateposition',
+        subfields=('pos', 'type', 'blank_ref', 'control_ref', 'dup'),
+        required_subfields=('pos', 'type'),
+        subfield_labels={
+            'pos': _('Position'),
+            'type': _('Analysis Type'),
+            'blank_ref': _('Reference'),
+            'control_ref': _('Reference'),
+            'dup': _('Duplicate Of')
+        },
+        widget=WorksheetTemplateLayoutWidget(
             label=_("Worksheet Layout"),
-            description =_(
+            description=_(
                 "Specify the size of the Worksheet, e.g. corresponding to a "
                 "specific instrument's tray size. Then select an Analysis 'type' "
                 "per Worksheet position. Where QC samples are selected, also select "
@@ -44,16 +47,19 @@ schema = BikaSchema.copy() + Schema((
                 "selected, indicate which sample position it should be a duplicate of"),
         )
     ),
-    ReferenceField('Service',
-        schemata = 'Analyses',
-        required = 0,
-        multiValued = 1,
-        allowed_types = ('AnalysisService',),
-        relationship = 'WorksheetTemplateAnalysisService',
-        referenceClass = HoldingReference,
-        widget = ServicesWidget(
+    ReferenceField(
+        'Service',
+        schemata='Analyses',
+        required=0,
+        multiValued=1,
+        allowed_types=('AnalysisService',),
+        relationship='WorksheetTemplateAnalysisService',
+        referenceClass=HoldingReference,
+        widget=ServicesWidget(
             label=_("Analysis Service"),
-            description=_("Select which Analyses should be included on the Worksheet"),
+            description=_(
+                "Select which Analyses should be included on the Worksheet"
+            ),
         )
     ),
     ReferenceField(
@@ -65,34 +71,39 @@ schema = BikaSchema.copy() + Schema((
         allowed_types=('Method',),
         relationship='WorksheetTemplateMethod',
         referenceClass=HoldingReference,
-        widget = SelectionWidget(
+        widget=SelectionWidget(
             format='select',
             label=_("Method"),
             description=_(
                 "Restrict the available analysis services and instruments"
                 "to those with the selected method."
                 " In order to apply this change to the services list, you "
-                "should save the change first."),
+                "should save the change first."
+            ),
         ),
     ),
-    ReferenceField('Instrument',
-        schemata = "Description",
-        required = 0,
-        vocabulary_display_path_bound = sys.maxint,
-        vocabulary = 'getInstruments',
-        allowed_types = ('Instrument',),
-        relationship = 'WorksheetTemplateInstrument',
-        referenceClass = HoldingReference,
-        widget = ReferenceWidget(
-            checkbox_bound = 0,
+    ReferenceField(
+        'Instrument',
+        schemata="Description",
+        required=0,
+        vocabulary_display_path_bound=sys.maxint,
+        vocabulary='getInstruments',
+        allowed_types=('Instrument',),
+        relationship='WorksheetTemplateInstrument',
+        referenceClass=HoldingReference,
+        widget=ReferenceWidget(
+            checkbox_bound=0,
             label=_("Instrument"),
-            description=_("Select the preferred instrument"),
+            description=_(
+                "Select the preferred instrument"
+            ),
         ),
     ),
-    ComputedField('InstrumentTitle',
-        expression = "context.getInstrument() and context.getInstrument().Title() or ''",
-        widget = ComputedWidget(
-            visible = False,
+    ComputedField(
+        'InstrumentTitle',
+        expression="context.getInstrument() and context.getInstrument().Title() or ''",
+        widget=ComputedWidget(
+            visible=False,
         ),
     ),
     BooleanField(
@@ -101,9 +112,11 @@ schema = BikaSchema.copy() + Schema((
         schemata="Description",
         widget=BooleanWidget(
             label=_("Enable Multiple Use of Instrument in Worksheets."),
-            description=_("If unchecked, \
-                          Lab Managers won't be able to assign the same Instrument more than one Analyses while \
-                          creating a Worksheet.")
+            description=_(
+                "If unchecked, \
+                Lab Managers won't be able to assign the same Instrument more than one Analyses while \
+                creating a Worksheet."
+            )
         )
     ),
 ))
@@ -164,5 +177,6 @@ class WorksheetTemplate(BaseContent):
         items.sort(lambda x, y: cmp(x[1], y[1]))
         items.insert(0, ('', _("Not specified")))
         return DisplayList(list(items))
+
 
 registerType(WorksheetTemplate, PROJECTNAME)

--- a/bika/lims/controlpanel/bika_worksheettemplates.py
+++ b/bika/lims/controlpanel/bika_worksheettemplates.py
@@ -24,11 +24,17 @@ class WorksheetTemplatesView(BikaListingView):
     def __init__(self, context, request):
         super(WorksheetTemplatesView, self).__init__(context, request)
         self.catalog = 'bika_setup_catalog'
-        self.contentFilter = {'portal_type': 'WorksheetTemplate',
-                              'sort_on': 'sortable_title'}
-        self.context_actions = {_('Add'):
-                                {'url': 'createObject?type_name=WorksheetTemplate',
-                                 'icon': '++resource++bika.lims.images/add.png'}}
+        self.contentFilter = {
+            'portal_type': 'WorksheetTemplate',
+            'sort_on': 'sortable_title'
+        }
+        self.context_actions = {
+            _('Add'):
+            {
+                'url': 'createObject?type_name=WorksheetTemplate',
+                'icon': '++resource++bika.lims.images/add.png'
+            }
+        }
         self.title = self.context.translate(_("Worksheet Templates"))
         self.form_id = "list_worksheettemplates"
         self.description = ""
@@ -36,42 +42,72 @@ class WorksheetTemplatesView(BikaListingView):
         self.show_select_row = False
         self.show_select_column = True
         self.pagesize = 25
-        self.icon = '{}/{}/{}'.format(self.portal_url,
-                                      '++resource++bika.lims.images',
-                                      'worksheettemplate_big.png')
-
+        self.icon = '{}/{}/{}'.format(
+            self.portal_url,
+            '++resource++bika.lims.images',
+            'worksheettemplate_big.png'
+        )
         self.columns = {
-            'Title': {'title': _('Title'),
-                      'index': 'sortable_title'},
-            'Description': {'title': _('Description'),
-                            'index': 'description',
-                            'toggle': True},
-            'Instrument': {'title': _('Instrument'),
-                      'index':'getInstrumentTitle',
-                      'toggle': True},
+            'Title': {
+                'title': _('Title'),
+                'index': 'sortable_title'
+            },
+            'Description': {
+                'title': _('Description'),
+                'index': 'description',
+                'toggle': True
+            },
+            'Instrument': {
+                'title': _('Instrument'),
+                'index': 'getInstrumentTitle',
+                'toggle': True
+            },
         }
-
         self.review_states = [
-            {'id':'default',
-             'title': _('Active'),
-             'contentFilter': {'inactive_state': 'active'},
-             'transitions': [{'id':'deactivate'}, ],
-             'columns': ['Title',
-                         'Description',
-                         'Instrument']},
-            {'id':'inactive',
-             'title': _('Dormant'),
-             'contentFilter': {'inactive_state': 'inactive'},
-             'transitions': [{'id': 'activate'}, ],
-             'columns': ['Title',
-                         'Description',
-                         'Instrument']},
-            {'id':'all',
-             'title': _('All'),
-             'contentFilter':{},
-             'columns': ['Title',
-                         'Description',
-                         'Instrument']},
+            {
+                'id': 'default',
+                'title': _('Active'),
+                'contentFilter': {
+                    'inactive_state': 'active'
+                },
+                'transitions': [
+                    {
+                        'id': 'deactivate'
+                    },
+                ],
+                'columns': [
+                    'Title',
+                    'Description',
+                    'Instrument'
+                ]
+            },
+            {
+                'id': 'inactive',
+                'title': _('Dormant'),
+                'contentFilter': {
+                    'inactive_state': 'inactive'
+                },
+                'transitions': [
+                    {
+                        'id': 'activate'
+                    },
+                ],
+                'columns': [
+                    'Title',
+                    'Description',
+                    'Instrument'
+                ]
+            },
+            {
+                'id': 'all',
+                'title': _('All'),
+                'contentFilter': {},
+                'columns': [
+                    'Title',
+                    'Description',
+                    'Instrument'
+                ]
+            },
         ]
 
     def folderitem(self, obj, item, index):
@@ -84,10 +120,13 @@ class WorksheetTemplatesView(BikaListingView):
 
 
 schema = ATFolderSchema.copy()
+
+
 class WorksheetTemplates(ATFolder):
     implements(IWorksheetTemplates)
     displayContentsTab = False
     schema = schema
 
-schemata.finalizeATCTSchema(schema, folderish = True, moveDiscussion = False)
+
+schemata.finalizeATCTSchema(schema, folderish=True, moveDiscussion=False)
 atapi.registerType(WorksheetTemplates, PROJECTNAME)

--- a/bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt
+++ b/bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt
@@ -20,7 +20,8 @@
 					accessor python: field.getAccessor(context);
 					current_field_value accessor;
 					sort_on python:(('title', 'nocase', 'asc'),);
-					ReferenceDefinitions python:sequence.sort([p.getObject() for p in context.bika_setup_catalog(portal_type='ReferenceDefinition')], sort_on);
+					ReferenceDefinitions python:sequence.sort([p.getObject() for p in context.bika_setup_catalog(portal_type='ReferenceDefinition') \
+					                            if p.inactive_state=='active'], sort_on);
 					BlankDefinitions python: [r for r in ReferenceDefinitions if r['Blank']];
 					ControlDefinitions python: [r for r in ReferenceDefinitions if not r['Blank']];
 					types context/getAnalysisTypes;


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #644 

**Note**: The only functional commit in the P.R is https://github.com/senaite/senaite.core/commit/d5f9cae258afb72c52bfde08a6bf80c126b8b9ff. The rest of commits consist in the application of PEP8 style guidelines to the files I have checked while solving the issue.  

## Current behavior before PR

Dormant Reference Definitions are offered for selection when creating a new WS Template, and it can also be saved like that.

## Desired behavior after PR is merged

Only Active Reference Definitions are be available for selection on WS Templates.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
