### PR TITLE
Datetime conversion error in CSV Importer of Taqman 48 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ Changelog
 
 **Fixed**
 
+- #763 Datetime conversion error in CSV Importer of Taqman 48
 - #761 Dormant Reference Definitions were listed for selection on WS Templates
 - #735 Interim fields not created for QC Analyses on WSs
 - #752 Published Date field of Analyses is never set

--- a/bika/lims/exportimport/instruments/rochecobas/taqman/model48.py
+++ b/bika/lims/exportimport/instruments/rochecobas/taqman/model48.py
@@ -78,7 +78,13 @@ class RocheCobasTaqmanParser(InstrumentCSVResultsFileParser):
         rawdict['DefaultResult'] = 'Result'
         rawdict['Remarks'] = ''.join([rawdict['Result'], " on Order Number.", resid]) \
             if rawdict['Result'] == "Target Not Detected" else ''
-        rawdict['DateTime'] = self.csvDate2BikaDate(rawdict['Accepted Date/Time'])
+
+        if self._fileformat == "csv":
+            rawdict['DateTime'] = rawdict['Accepted Date/Time']
+        else:
+            rawdict['DateTime'] = self.csvDate2BikaDate(
+                rawdict['Accepted Date/Time'])
+
         self._addRawResult(resid, {testname: rawdict}, False)
         return 0
 


### PR DESCRIPTION
## Current behavior before PR
While importing Results of Taqman 48 Instrument from CSV files, Import fails because of non-convertible date format.

## Desired behavior after PR is merged
If file format is CSV, do not convert the date string.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
