### PR TITLE
Department Filtering Improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Changed**
 
+- #765 Department Filtering Improvements
 - #746 StringField to UIDReferenceField for Default Department of Lab Contact
 - #744 Updated WeasyPrint to 0.42.2
 - #694 Out of range/shoulders logic redux, ported to `api.analysis`

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -62,6 +62,13 @@ class AnalysisRequestsView(BikaListingView):
             "cancellation_state": "active",
         }
 
+        # Filter by Department
+        if self.context.bika_setup.getAllowDepartmentFiltering():
+            deps = self.request.get('filter_by_department_info', '')
+            dep_uids = deps.split(",")
+            dep_query = {"query": dep_uids, "operator": "or"}
+            self.contentFilter['getDepartmentUIDs'] = dep_query
+
         self.context_actions = {}
 
         if self.view_url.find("analysisrequests") == -1:
@@ -613,31 +620,10 @@ class AnalysisRequestsView(BikaListingView):
         self.review_states = new_states
 
     def isItemAllowed(self, obj):
+        """ If Adnvanced Filter bar is enabled, this method checks if the item
+        matches advanced filter bar criteria
         """
-        It checks if the analysis request can be added to the list depending
-        on the department filter. It checks the department of each analysis
-        service from each analysis belonguing to the given analysis request.
-        If department filtering is disabled in bika_setup, will return True.
-        @Obj: it is an analysis request brain.
-        @return: boolean
-        """
-        if self.filter_bar_enabled and not self.filter_bar_check_item(obj):
-            return False
-        if not self.context.bika_setup.getAllowDepartmentFiltering():
-            return True
-        # Getting the department from analysis service
-        deps = obj.getDepartmentUIDs if hasattr(obj, "getDepartmentUIDs")\
-            else []
-        result = True
-        if deps:
-            # Getting the cookie value
-            cookie_dep_uid = self.request.get("filter_by_department_info", "")
-            # Comparing departments" UIDs
-            deps_uids = set(deps)
-            filter_uids = set(cookie_dep_uid.split(","))
-            matches = deps_uids & filter_uids
-            result = len(matches) > 0
-        return result
+        return not self.filter_bar_enabled or self.filter_bar_check_item(obj)
 
     def folderitems(self, full_objects=False, classic=False):
         # We need to get the portal catalog here in roder to save process

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -58,7 +58,6 @@ class AnalysisRequestsView(BikaListingView):
         self.contentFilter = {
             "sort_on": "created",
             "sort_order": "descending",
-            "path": {"query": "/", "depth": 2},
             "cancellation_state": "active",
         }
 

--- a/bika/lims/skins/bika/portlet_department_filter.pt
+++ b/bika/lims/skins/bika/portlet_department_filter.pt
@@ -5,23 +5,23 @@
 <div metal:define-macro="portlet"
     tal:define="
         member python: context.portal_membership.getAuthenticatedMember();
-        is_admin python: member.has_role('Manager');
+        is_manager python: member.has_role('Manager') or member.has_role('LabManager');
         user_name python: member.getUserName();
-        brains python: [] if is_admin  else here.portal_catalog(portal_type='LabContact',
+        brains python: [] if is_manager  else here.portal_catalog(portal_type='LabContact',
                                     getUsername=user_name);"
-    tal:condition="python:context.bika_setup.getAllowDepartmentFiltering() and (len(brains)>0 or is_admin) ">
+    tal:condition="python:context.bika_setup.getAllowDepartmentFiltering() and (len(brains)>0 or is_manager) ">
 <!-- Defining the base variables -->
 <tal:departments
     tal:define="portal context/portal_url/getPortalObject;
                 plone_view context/@@plone;
                 dep_disabled python:request.cookies.get('dep_filter_disabled','');
                 deps python: here.portal_catalog(portal_type='Department',sort_on='sortable_title', sort_order='ascending',
-                                            inactive_state='active') if is_admin else brains[0].getObject().getSortedDepartments();
+                                            inactive_state='active') if is_manager else brains[0].getObject().getSortedDepartments();
                 cookie python:request.cookies.get(
                     'filter_by_department_info','');
                 deps_from_cookie python: cookie.split(',') if cookie and len(deps)>0
                     else [];
-                first_from_cat python: deps[0].UID if is_admin and deps else
+                first_from_cat python: deps[0].UID if is_manager and deps else
                           brains[0].getObject().getDefaultDepartment().UID() if brains and brains[0].getObject().getDefaultDepartment()
                           else deps[0].UID() if deps else '';
                 first_dep python: deps_from_cookie[0] if len(deps_from_cookie)>1
@@ -40,13 +40,13 @@
                 <input type="checkbox"
                        name="admin_dep_filter_enabled"
                        id="admin_dep_filter_enabled"
-                       tal:condition= "python: is_admin"/>
-                       <label tal:condition= "python: is_admin">Select All Departments<br><br></label>
+                       tal:condition= "python: is_manager"/>
+                       <label tal:condition= "python: is_manager">Select All Departments<br><br></label>
 
                 <tal:option repeat="dep deps" tal:condition="python: len(deps)>1">
                     <ul>
-                        <li tal:define="dep_name python:dep.Title if is_admin else dep.Title();
-                                        dep_uid python: dep.UID if is_admin else dep.UID()">
+                        <li tal:define="dep_name python:dep.Title if is_manager else dep.Title();
+                                        dep_uid python: dep.UID if is_manager else dep.UID()">
                             <input type="checkbox"
                                 tal:attributes="
                                     value python: dep_uid;
@@ -61,7 +61,7 @@
                 <label
                     i18n:translate=""
                     tal:condition="python: len(deps)<2"
-                    tal:content="python: deps[0].Title if is_admin and deps else deps[0].Title() if deps else ''"
+                    tal:content="python: deps[0].Title if is_manager and deps else deps[0].Title() if deps else ''"
                     >Department</label>
             </dd><br>
             <!-- The submit form button -->

--- a/bika/lims/subscribers/configure.zcml
+++ b/bika/lims/subscribers/configure.zcml
@@ -46,12 +46,12 @@
 
   <subscriber
       for="Products.PlonePAS.events.UserLoggedOutEvent"
-      handler="bika.lims.subscribers.dep_cookie.ClearDepartmentCookies"
+      handler="bika.lims.subscribers.dep_cookie.clear_department_cookies"
       />
 
   <subscriber
       for="Products.PluggableAuthService.interfaces.events.IUserLoggedInEvent"
-      handler="bika.lims.subscribers.dep_cookie.SetDepartmentCookies"
+      handler="bika.lims.subscribers.dep_cookie.set_department_cookies"
       />
 
 </configure>

--- a/bika/lims/subscribers/dep_cookie.py
+++ b/bika/lims/subscribers/dep_cookie.py
@@ -5,7 +5,7 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from plone import api
+from bika.lims import api
 
 from bika.lims import logger
 
@@ -22,7 +22,7 @@ def SetDepartmentCookies(event):
         return
 
     # get the bika_setup object
-    portal = api.portal.get()
+    portal = api.get_portal()
     bika_setup = portal.get("bika_setup")
 
     # just to be sure...
@@ -33,11 +33,11 @@ def SetDepartmentCookies(event):
 
     # Getting request, response and username
 
-    request = api.env.getRequest()
+    request = api.get_request()
     response = request.RESPONSE
-    user = api.user.get_current()
+    user = api.get_current_user()
     username = user and user.getUserName() or None
-    portal_catalog = api.portal.get_tool("portal_catalog")
+    portal_catalog = api.get_tool("portal_catalog")
 
     if bika_setup.getAllowDepartmentFiltering():
         dep_for_cookie = ''
@@ -116,7 +116,7 @@ def ClearDepartmentCookies(event):
             "Package 'bika.lims' is not installed, skipping event handler "
             "for IUserLoggedOutEvent.")
         return
-    request = api.env.getRequest()
+    request = api.get_request()
     response = request.RESPONSE
 
     # Voiding our special cookie on logout
@@ -129,5 +129,5 @@ def ClearDepartmentCookies(event):
 def is_bika_installed():
     """Check if Bika LIMS is installed in the Portal
     """
-    qi = api.portal.get_tool("portal_quickinstaller")
+    qi = api.get_tool("portal_quickinstaller")
     return qi.isProductInstalled("bika.lims")

--- a/bika/lims/subscribers/dep_cookie.py
+++ b/bika/lims/subscribers/dep_cookie.py
@@ -103,6 +103,9 @@ def set_department_cookies(event):
                 departments = lab_con.getSortedDepartments()
                 selected_deps = [departments[0]] if departments else []
 
+            response.setCookie(
+                'dep_filter_disabled', None, path='/', max_age=0)
+
     selected_dep_uids = ','.join([api.get_uid(dep) for dep in selected_deps])
     response.setCookie(
         'filter_by_department_info',

--- a/bika/lims/subscribers/dep_cookie.py
+++ b/bika/lims/subscribers/dep_cookie.py
@@ -13,7 +13,13 @@ from bika.lims import logger
 def set_department_cookies(event):
     """
     Login event handler.
-    When user logs in, departments must be selected if necessary.
+    When user logs in, departments must be selected if filtering by department
+    is enabled in Bika Setup.
+        - For (Lab)Managers and Client Contacts, all the departments from the
+          system must be selected.
+        - For regular Lab Contacts, default Department must be selected. If
+          the Contact doesn't have any default department assigned, then first
+          department in alphabetical order will be selected.
     """
     if not is_bika_installed():
         logger.warn(
@@ -32,7 +38,6 @@ def set_department_cookies(event):
             "bika_setup not found in this Bika LIMS installation")
 
     # Getting request, response and username
-
     request = api.get_request()
     response = request.RESPONSE
     user = api.get_current_user()
@@ -105,6 +110,7 @@ def set_department_cookies(event):
         path='/',
         max_age=24 * 3600)
 
+    return
 
 def clear_department_cookies(event):
     """


### PR DESCRIPTION
## Current behavior before PR
Filtering by Department Logic currently works with cookies which is set in Python files and handled in browser views by JS function and it is hard to follow/understand how everything works/is set. Since the logic underwent changes several times, the code is not very understandable nor well-written.   

## Desired behavior after PR is merged
I tried to make the code _better_ and more understandable in some files... Also tried to use Department Filtering in a mote efficient way in AR listing view (instead of filtering inside `is_item_allowed` function, AR's will be filtered by department while querying them).

#TODO: Requires some more improvements
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
