### PR TITLE
Traceback when submitting duplicate when Duplicate Variation is not set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Changelog
 
 **Fixed**
 
+- #769 Traceback when submitting duplicate when Duplicate Variation is not set
+
 
 **Security**
 

--- a/bika/lims/content/abstractbaseanalysis.py
+++ b/bika/lims/content/abstractbaseanalysis.py
@@ -351,6 +351,7 @@ MaxTimeAllowed = DurationField(
 # The amount of difference allowed between this analysis, and any duplicates.
 DuplicateVariation = FixedPointField(
     'DuplicateVariation',
+    default='0.00',
     schemata="Method",
     widget=DecimalWidget(
         label=_("Duplicate Variation %"),

--- a/bika/lims/upgrade/v01_02_005.py
+++ b/bika/lims/upgrade/v01_02_005.py
@@ -29,6 +29,38 @@ def upgrade(tool):
 
     # -------- ADD YOUR STUFF HERE --------
 
+    # Traceback when submitting duplicate when Duplicate Variation is not set
+    # Walkthrough all analyses and analyses services and set 0.00 value for
+    # DuplicateVariation if returns None
+    # https://github.com/senaite/senaite.core/issues/768
+    fix_duplicate_variation_nonfloatable_values()
+
     logger.info("{0} upgraded to version {1}".format(product, version))
 
     return True
+
+def fix_duplicate_variation_nonfloatable_values():
+    # Update Analysis Services
+    catalog = api.get_tool('bika_setup_catalog')
+    brains = catalog(portal_type='AnalysisService')
+    for brain in brains:
+        service = api.get_object(brain)
+        dup_var = service.getDuplicateVariation()
+        if api.is_floatable(dup_var):
+            continue
+        service.setDuplicateVariation(0.0)
+        logger.info("Updated Duplicate Variation for Service '%s': '0.0'" % (
+                    service.Title()))
+
+    # Update Analyses
+    catalog = api.get_tool('bika_analysis_catalog')
+    portal_types = ['Analysis', 'ReferenceAnalysis', 'DuplicateAnalysis']
+    brains = catalog(portal_type=portal_types)
+    for brain in brains:
+        analysis = api.get_object(brain)
+        dup_var = analysis.getDuplicateVariation()
+        if api.is_floatable(dup_var):
+            continue
+        analysis.setDuplicateVariation(0.0)
+        logger.info("Updated Duplicate Variation for Analysis '%s': '0.0'" % (
+                    analysis.Title()))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Traceback when submitting duplicate when Duplicate Variation is not set.
With this Pull Request, default value 0.0 is assigned for Duplicate Variation field. Also, an upgrade step that updates all non-floatable Duplicate Variation values for both Analysis Services and Analyses

Linked issue: https://github.com/senaite/senaite.core/issues/768

## Current behavior before PR

When creating Analysis Service, no default value is set for field "DuplicateVariation". This causes a traceback later, when submitting results for corresponding duplicate analyses.

## Desired behavior after PR is merged

Not traceback appear when submitting duplicates and Analysis Services have default value for "Duplicate Variation" field set to 0.0 after creation.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
