### PR TITLE
Slow Searches in Listing Views

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+-  #771 Slow Searches in Listing Views
 
 **Security**
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -1,6 +1,15 @@
 Release notes
 =============
 
+Update from 1.2.4 to 1.2.5
+--------------------------
+
+- This update requires the execution of `bin/buildout`, because
+  Products.TextIndexNG3 has been added. It will help to search by wildcards in
+  TextIndexNG3 indexes instead of looking for the keyword inside wildcards.
+  For now, it is used only in AR listing catalog.
+  https://pypi.python.org/pypi/Products.TextIndexNG3/
+
 Update from 1.2.3 to 1.2.4
 --------------------------
 

--- a/bika/lims/api/__init__.py
+++ b/bika/lims/api/__init__.py
@@ -5,13 +5,15 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
+import Missing
+
 from Acquisition import aq_base
 from AccessControl.PermissionRole import rolesForPermissionOn
 
 from datetime import datetime
 from DateTime import DateTime
 
-from Products.CMFPlone.utils import base_hasattr
+from Products.CMFPlone.utils import base_hasattr, safe_unicode
 from Products.CMFCore.interfaces import ISiteRoot
 from Products.CMFCore.interfaces import IFolderish
 from Products.Archetypes.BaseObject import BaseObject
@@ -1234,3 +1236,30 @@ def to_float(value, default=_marker):
             return to_float(default)
         fail("Value %s is not floatable" % repr(value))
     return float(value)
+
+
+def to_searchable_text_metadata(value):
+    """Parse the given metadata value to searchable text
+
+    :param value: The raw value of the metadata column
+    :returns: Searchable and translated unicode value or None
+    """
+    if not value:
+        return u""
+    if value is Missing.Value:
+        return u""
+    if is_uid(value):
+        return u""
+    if isinstance(value, (bool)):
+        return u""
+    if isinstance(value, (list, tuple)):
+        for v in value:
+            return to_searchable_text_metadata(v)
+    if isinstance(value, (dict)):
+        for k, v in value.items():
+            return to_searchable_text_metadata(v)
+    if is_date(value):
+        return value.strftime("%Y-%m-%d")
+    if not isinstance(value, basestring):
+        value = str(value)
+    return safe_unicode(value)

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -1340,6 +1340,8 @@ class BikaListingView(BrowserView):
         """
         logger.info(u"ListingView::search: Prepare NG3 index query for '{}'"
                     .format(self.catalog))
+        # Remove quotation mark
+        searchterm = searchterm.replace('"', '')
         # If the keyword is not encoded in searches, TextIndexNG3 encodes by
         # default encoding which we cannot always trust
         searchterm = searchterm.encode("utf-8")

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -1301,19 +1301,20 @@ class BikaListingView(BrowserView):
         # search the catalog
         catalog = api.get_tool(self.catalog)
 
-        # return the unfiltered catalog results
+        # return the unfiltered catalog results if no searchterm
         if not searchterm:
             brains = catalog(query)
             logger.info(u"ListingView::search: return {} results"
                         .format(len(brains)))
-            return brains
 
-        # Always expand all categories if we have a searchterm
-        self.expand_all_categories = True
-
-        if "listing_searchable_text" in catalog.indexes():
+        # check if there is ng3 index in the catalog to query by wildcards
+        elif "listing_searchable_text" in catalog.indexes():
+            # Always expand all categories if we have a searchterm
+            self.expand_all_categories = True
             brains = self.ng3_index_search(catalog, query, searchterm)
+
         else:
+            self.expand_all_categories = True
             brains = self.metadata_search(catalog, query, searchterm, ignorecase)
 
         # Sort manually?

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -1328,9 +1328,13 @@ class BikaListingView(BrowserView):
                     .format(searchterm, end - start, len(brains)))
         return brains
 
-    def zcindex_search(self, catalog, query, searchterm):
+    def ng3_index_search(self, catalog, query, searchterm):
         """ Searches given catalog by query and also looks for a keyword in the
         specific index called 'listing_searchable_text'
+        #REMEMBER TextIndexNG indexes are the only indexes that wildcards can be
+        used in the beginning of the string.
+        http://zope.readthedocs.io/en/latest/zope2book/SearchingZCatalog.html#textindexng
+
         :param catalog: catalog to search
         :param query:
         :param searchterm: a keyword to look for in 'listing_searchable_text'
@@ -1338,7 +1342,7 @@ class BikaListingView(BrowserView):
         """
         logger.info(u"ListingView::search: Prepare zcindex query for '{}'"
                     .format(self.catalog))
-        query["listing_searchable_text"] = searchterm + "*"
+        query["listing_searchable_text"] = "*" + searchterm + "*"
         return catalog(query)
 
     def metadata_search(self, catalog, query, searchterm, ignorecase=True):

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -1314,7 +1314,7 @@ class BikaListingView(BrowserView):
         self.expand_all_categories = True
 
         if "listing_searchable_text" in catalog.indexes():
-            brains = self.zcindex_search(catalog, query, searchterm)
+            brains = self.ng3_index_search(catalog, query, searchterm)
         else:
             brains = self.metadata_search(catalog, query, searchterm, ignorecase)
 

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -1291,8 +1291,6 @@ class BikaListingView(BrowserView):
 
         # strip whitespaces off the searchterm
         searchterm = searchterm.strip()
-        # strip illegal characters off the searchterm
-        searchterm = searchterm.strip(u"*.!$%&/()=-+:'`´^")
         logger.info(u"ListingView::search:searchterm='{}'".format(searchterm))
 
         # create a catalog query
@@ -1354,6 +1352,9 @@ class BikaListingView(BrowserView):
         :param ignorecase:
         :return: brains matching search result
         """
+        # Strip illegal characters of the searchterm
+        searchterm = searchterm.strip(u"*.!$%&/()=-+:'`´^")
+
         # create a catalog query
         logger.info(u"ListingView::search: Prepare metadata query for '{}'"
                     .format(self.catalog))

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -1304,8 +1304,6 @@ class BikaListingView(BrowserView):
         # return the unfiltered catalog results if no searchterm
         if not searchterm:
             brains = catalog(query)
-            logger.info(u"ListingView::search: return {} results"
-                        .format(len(brains)))
 
         # check if there is ng3 index in the catalog to query by wildcards
         elif "listing_searchable_text" in catalog.indexes():
@@ -1333,7 +1331,6 @@ class BikaListingView(BrowserView):
         #REMEMBER TextIndexNG indexes are the only indexes that wildcards can be
         used in the beginning of the string.
         http://zope.readthedocs.io/en/latest/zope2book/SearchingZCatalog.html#textindexng
-
         :param catalog: catalog to search
         :param query:
         :param searchterm: a keyword to look for in 'listing_searchable_text'

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -1340,6 +1340,8 @@ class BikaListingView(BrowserView):
         """
         logger.info(u"ListingView::search: Prepare NG3 index query for '{}'"
                     .format(self.catalog))
+        # If the keyword is not encoded in searches, TextIndexNG3 encodes by
+        # default encoding which we cannot always trust
         searchterm = searchterm.encode("utf-8")
         query["listing_searchable_text"] = "*" + searchterm + "*"
         return catalog(query)

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -1338,7 +1338,7 @@ class BikaListingView(BrowserView):
         :param searchterm: a keyword to look for in 'listing_searchable_text'
         :return: brains matching the search result
         """
-        logger.info(u"ListingView::search: Prepare zcindex query for '{}'"
+        logger.info(u"ListingView::search: Prepare NG3 index query for '{}'"
                     .format(self.catalog))
         query["listing_searchable_text"] = "*" + searchterm + "*"
         return catalog(query)

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -1291,6 +1291,8 @@ class BikaListingView(BrowserView):
 
         # strip whitespaces off the searchterm
         searchterm = searchterm.strip()
+        # Strip illegal characters of the searchterm
+        searchterm = searchterm.strip(u"*.!$%&/()=-+:'`´^")
         logger.info(u"ListingView::search:searchterm='{}'".format(searchterm))
 
         # create a catalog query
@@ -1338,6 +1340,7 @@ class BikaListingView(BrowserView):
         """
         logger.info(u"ListingView::search: Prepare NG3 index query for '{}'"
                     .format(self.catalog))
+        searchterm = searchterm.encode("utf-8")
         query["listing_searchable_text"] = "*" + searchterm + "*"
         return catalog(query)
 
@@ -1350,9 +1353,6 @@ class BikaListingView(BrowserView):
         :param ignorecase:
         :return: brains matching search result
         """
-        # Strip illegal characters of the searchterm
-        searchterm = searchterm.strip(u"*.!$%&/()=-+:'`´^")
-
         # create a catalog query
         logger.info(u"ListingView::search: Prepare metadata query for '{}'"
                     .format(self.catalog))

--- a/bika/lims/catalog/analysisrequest_catalog.py
+++ b/bika/lims/catalog/analysisrequest_catalog.py
@@ -40,6 +40,9 @@ _indexes_dict = {
     'getClientTitle': 'FieldIndex',
     'getPrioritySortkey': 'FieldIndex',
     'assigned_state': 'FieldIndex',
+    # Searchable Text Index by wildcards
+    # http://zope.readthedocs.io/en/latest/zope2book/SearchingZCatalog.html#textindexng
+    'listing_searchable_text': 'TextIndexNG3',
 }
 # Defining the columns for this catalog
 _columns_list = [

--- a/bika/lims/catalog/indexers/analysisrequest.py
+++ b/bika/lims/catalog/indexers/analysisrequest.py
@@ -33,14 +33,9 @@ def assigned_state(instance):
 
 @indexer(IAnalysisRequest)
 def listing_searchable_text(instance):
-    """ Indexes values of desired fields for searches in listing view. All the
-    field names added to 'plain_text_fields' will be available to search by
-    wildcards.
-    Please choose the searchable fields carefully and add only fields that
-    can be useful to search by. For example, there is no need to add 'SampleId'
-    since 'getId' of AR already contains that value. Nor 'ClientTitle' because
-    AR's are/can be filtered by client in Clients' 'AR Listing View'
-    :return: values of the fields defined as a string
+    """ Retrieves all the values of metadata columns in the catalog for
+    wildcard searches
+    :return: all metadata values joined in a string
     """
     entries = []
     catalog = api.get_tool(CATALOG_ANALYSIS_REQUEST_LISTING)

--- a/bika/lims/catalog/indexers/analysisrequest.py
+++ b/bika/lims/catalog/indexers/analysisrequest.py
@@ -7,6 +7,7 @@
 
 from bika.lims import api
 from bika.lims import logger
+from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.interfaces import IAnalysisRequest
 from plone.indexer import indexer
 
@@ -42,23 +43,21 @@ def listing_searchable_text(instance):
     :return: values of the fields defined as a string
     """
     entries = []
-    plain_text_fields = ('getId', 'getContactFullName', 'getSampleTypeTitle',
-                         'getSamplePointTitle', 'getCreatorFullName',
-                         'getProfilesTitle', 'getStorageLocationTitle',
-                         'getClientOrderNumber', 'getClientReference',
-                         'getClientSampleID', 'getTemplateTitle', )
+    catalog = api.get_tool(CATALOG_ANALYSIS_REQUEST_LISTING)
+    columns = catalog.schema()
 
     # Concatenate plain text fields as they are
-    for field_name in plain_text_fields:
+    for column in columns:
         try:
-            value = api.safe_getattr(instance, field_name)
+            value = api.safe_getattr(instance, column)
         except:
             logger.error("{} has no attribute called '{}' ".format(
-                            repr(instance), field_name))
+                            repr(instance), column))
             continue
 
         if not value:
             continue
+
         if isinstance(value, list):
             value = " ".join(value)
 

--- a/bika/lims/catalog/indexers/analysisrequest.py
+++ b/bika/lims/catalog/indexers/analysisrequest.py
@@ -41,7 +41,6 @@ def listing_searchable_text(instance):
     catalog = api.get_tool(CATALOG_ANALYSIS_REQUEST_LISTING)
     columns = catalog.schema()
 
-    # Concatenate plain text fields as they are
     for column in columns:
         try:
             value = api.safe_getattr(instance, column)
@@ -49,14 +48,10 @@ def listing_searchable_text(instance):
             logger.error("{} has no attribute called '{}' ".format(
                             repr(instance), column))
             continue
-
         if not value:
             continue
-
-        if isinstance(value, list):
-            value = " ".join(value)
-
-        entries.append(value)
+        parsed = api.to_searchable_text_metadata(value)
+        entries.append(parsed)
 
     # Concatenate all strings to one text blob
     return " ".join(entries)

--- a/bika/lims/catalog/indexers/analysisrequest.py
+++ b/bika/lims/catalog/indexers/analysisrequest.py
@@ -6,8 +6,8 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 from bika.lims import api
+from bika.lims import logger
 from bika.lims.interfaces import IAnalysisRequest
-from bika.lims.workflow import getCurrentState
 from plone.indexer import indexer
 
 
@@ -47,7 +47,12 @@ def listing_searchable_text(instance):
 
     # Concatenate plain text fields as they are
     for field_name in plain_text_fields:
-        value = api.safe_getattr(instance, field_name)
+        try:
+            value = api.safe_getattr(instance, field_name)
+        except:
+            logger.error("{} has no attribute called '{}' ".format(
+                            repr(instance), field_name))
+            continue
         entries.append(value)
 
     # Concatenate all strings to one text blob

--- a/bika/lims/catalog/indexers/analysisrequest.py
+++ b/bika/lims/catalog/indexers/analysisrequest.py
@@ -43,7 +43,10 @@ def listing_searchable_text(instance):
     """
     entries = []
     plain_text_fields = ('getId', 'getContactFullName', 'getSampleTypeTitle',
-                         'getSamplePointTitle',)
+                         'getSamplePointTitle', 'getCreatorFullName',
+                         'getProfilesTitle', 'getStorageLocationTitle',
+                         'getClientOrderNumber', 'getClientReference',
+                         'getClientSampleID', 'getTemplateTitle', )
 
     # Concatenate plain text fields as they are
     for field_name in plain_text_fields:

--- a/bika/lims/catalog/indexers/analysisrequest.py
+++ b/bika/lims/catalog/indexers/analysisrequest.py
@@ -43,7 +43,6 @@ def listing_searchable_text(instance):
     # Concatenate plain text fields as they are
     for field_name in plain_text_fields:
         value = api.safe_getattr(instance, field_name)
-        value = value.replace("-", "=")
         entries.append(value)
 
     # Concatenate all strings to one text blob

--- a/bika/lims/catalog/indexers/analysisrequest.py
+++ b/bika/lims/catalog/indexers/analysisrequest.py
@@ -35,10 +35,15 @@ def listing_searchable_text(instance):
     """ Indexes values of desired fields for searches in listing view. All the
     field names added to 'plain_text_fields' will be available to search by
     wildcards.
+    Please choose the searchable fields carefully and add only fields that
+    can be useful to search by. For example, there is no need to add 'SampleId'
+    since 'getId' of AR already contains that value. Nor 'ClientTitle' because
+    AR's are/can be filtered by client in Clients' 'AR Listing View'
     :return: values of the fields defined as a string
     """
     entries = []
-    plain_text_fields = ("getId", "getSampleID")
+    plain_text_fields = ('getId', 'getContactFullName', 'getSampleTypeTitle',
+                         'getSamplePointTitle',)
 
     # Concatenate plain text fields as they are
     for field_name in plain_text_fields:

--- a/bika/lims/catalog/indexers/analysisrequest.py
+++ b/bika/lims/catalog/indexers/analysisrequest.py
@@ -56,8 +56,12 @@ def listing_searchable_text(instance):
             logger.error("{} has no attribute called '{}' ".format(
                             repr(instance), field_name))
             continue
+
+        if not value:
+            continue
         if isinstance(value, list):
             value = " ".join(value)
+
         entries.append(value)
 
     # Concatenate all strings to one text blob

--- a/bika/lims/catalog/indexers/analysisrequest.py
+++ b/bika/lims/catalog/indexers/analysisrequest.py
@@ -28,3 +28,23 @@ def assigned_state(instance):
             return 'unassigned'
 
     return 'assigned'
+
+
+@indexer(IAnalysisRequest)
+def listing_searchable_text(instance):
+    """
+
+    :param instance:
+    :return:
+    """
+    entries = []
+    plain_text_fields = ("getId", "getSampleID")
+
+    # Concatenate plain text fields as they are
+    for field_name in plain_text_fields:
+        value = api.safe_getattr(instance, field_name)
+        value = value.replace("-", "=")
+        entries.append(value)
+
+    # Concatenate all strings to one text blob
+    return " ".join(entries)

--- a/bika/lims/catalog/indexers/analysisrequest.py
+++ b/bika/lims/catalog/indexers/analysisrequest.py
@@ -56,6 +56,8 @@ def listing_searchable_text(instance):
             logger.error("{} has no attribute called '{}' ".format(
                             repr(instance), field_name))
             continue
+        if isinstance(value, list):
+            value = " ".join(value)
         entries.append(value)
 
     # Concatenate all strings to one text blob

--- a/bika/lims/catalog/indexers/analysisrequest.py
+++ b/bika/lims/catalog/indexers/analysisrequest.py
@@ -32,10 +32,10 @@ def assigned_state(instance):
 
 @indexer(IAnalysisRequest)
 def listing_searchable_text(instance):
-    """
-
-    :param instance:
-    :return:
+    """ Indexes values of desired fields for searches in listing view. All the
+    field names added to 'plain_text_fields' will be available to search by
+    wildcards.
+    :return: values of the fields defined as a string
     """
     entries = []
     plain_text_fields = ("getId", "getSampleID")

--- a/bika/lims/catalog/indexers/configure.zcml
+++ b/bika/lims/catalog/indexers/configure.zcml
@@ -5,5 +5,6 @@
   <adapter name="sortable_title" factory=".analysiscategory.sortable_title"/>
   <adapter name="sortable_title" factory=".baseanalysis.sortable_title"/>
   <adapter name="assigned_state" factory=".analysisrequest.assigned_state"/>
+  <adapter name="listing_searchable_text" factory=".analysisrequest.listing_searchable_text"/>
 
 </configure>

--- a/bika/lims/catalog/indexers/configure.zcml
+++ b/bika/lims/catalog/indexers/configure.zcml
@@ -5,6 +5,6 @@
   <adapter name="sortable_title" factory=".analysiscategory.sortable_title"/>
   <adapter name="sortable_title" factory=".baseanalysis.sortable_title"/>
   <adapter name="assigned_state" factory=".analysisrequest.assigned_state"/>
-  <adapter name="ar_listing_searchable_text" factory=".analysisrequest.listing_searchable_text"/>
+  <adapter name="listing_searchable_text" factory=".analysisrequest.listing_searchable_text"/>
 
 </configure>

--- a/bika/lims/catalog/indexers/configure.zcml
+++ b/bika/lims/catalog/indexers/configure.zcml
@@ -5,6 +5,6 @@
   <adapter name="sortable_title" factory=".analysiscategory.sortable_title"/>
   <adapter name="sortable_title" factory=".baseanalysis.sortable_title"/>
   <adapter name="assigned_state" factory=".analysisrequest.assigned_state"/>
-  <adapter name="listing_searchable_text" factory=".analysisrequest.listing_searchable_text"/>
+  <adapter name="ar_listing_searchable_text" factory=".analysisrequest.listing_searchable_text"/>
 
 </configure>

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2546,8 +2546,9 @@ class AnalysisRequest(BaseFolder):
         """Obtains the sampling round UID
         :returns: UID
         """
-        if self.getSamplingRound():
-            return self.getSamplingRound().UID()
+        sr = self.getSamplingRound()
+        if sr:
+            return sr.UID()
         else:
             return ''
 
@@ -2555,7 +2556,10 @@ class AnalysisRequest(BaseFolder):
         """ A method for AR listing catalog metadata
         :return: Title of Storage Location
         """
-        return self.getStorageLocation() and self.getStorageLocation().Title() or ''
+        sl = self.getStorageLocation()
+        if sl:
+            return sl.Title()
+        return ''
 
     @security.public
     def getResultsRange(self):

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2551,6 +2551,12 @@ class AnalysisRequest(BaseFolder):
         else:
             return ''
 
+    def getStorageLocationTitle(self):
+        """ A method for AR listing catalog metadata
+        :return: Title of Storage Location
+        """
+        return self.getStorageLocation() and self.getStorageLocation().Title() or ''
+
     @security.public
     def getResultsRange(self):
         """Returns the valid result ranges for the analyses this Analysis

--- a/bika/lims/upgrade/v01_02_005.py
+++ b/bika/lims/upgrade/v01_02_005.py
@@ -6,6 +6,7 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 from bika.lims import api
 from bika.lims import logger
+from bika.lims.catalog.analysisrequest_catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.config import PROJECTNAME as product
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
@@ -30,5 +31,7 @@ def upgrade(tool):
     # -------- ADD YOUR STUFF HERE --------
 
     logger.info("{0} upgraded to version {1}".format(product, version))
-
+    ut.addIndex(CATALOG_ANALYSIS_REQUEST_LISTING, "listing_searchable_text",
+                "TextIndexNG3")
+    ut.refreshCatalogs()
     return True

--- a/bika/lims/upgrade/v01_02_005.py
+++ b/bika/lims/upgrade/v01_02_005.py
@@ -29,9 +29,9 @@ def upgrade(tool):
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
     # -------- ADD YOUR STUFF HERE --------
-
-    logger.info("{0} upgraded to version {1}".format(product, version))
     ut.addIndex(CATALOG_ANALYSIS_REQUEST_LISTING, "listing_searchable_text",
                 "TextIndexNG3")
     ut.refreshCatalogs()
+    logger.info("{0} upgraded to version {1}".format(product, version))
+
     return True

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'Products.DataGridField',
         'Products.AdvancedQuery',
         'Products.TinyMCE',
+        'Products.TextIndexNG3',
         'collective.monkeypatcher',
         'collective.js.jqueryui',
         'plone.app.z3cform',
@@ -61,6 +62,7 @@ setup(
         'plone.resource',
         'CairoSVG==1.0.20',
         'collective.taskqueue',
+        'zopyx.txng3.ext==3.4.0'
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
## Current behavior before PR
When searching for a string in listing views, catalog metadata values are used to be searched. Basically, the system calls all the brains from the catalog and then filters them by string operations. It works pretty good with catalogs that don't contain big amount of data. But for example, with a AR catalog containing nearly 31.000 records, that filtering operation takes 24-25 seconds.

## Desired behavior after PR is merged
Instead of retrieving all the brains and filtering them after, the system should query the catalog. Unfortunately, Zope doesn't let query by wildcards through `Field , Keyword and etc.` indexes (see: http://zope.readthedocs.io/en/latest/zope2book/SearchingZCatalog.html#defining-indexes). Only `ZCTextIndexes` can be queried by wildcards if wildcard is in the end of the keyword. 
To solve all this problem, new Add-On can be used. [TextIndexNG3](https://pypi.python.org/pypi/Products.TextIndexNG3/)  helps to save indexes in another index type and then query them easily. So, for catalogs those are planned to be used with big amount of data, a new index- `listing_searchable_text` can be added (which type will be `TextIndexNG3`), and the query will be handled in `bika_listing`. In case `listing_searchable_text` doesn't exist in the catalog, the search will take place with the older method.

-----
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
