### PR TITLE
Improved UID check in API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Changelog
 
 **Fixed**
 
+- #772 Improved UID check in API
+
 
 **Security**
 

--- a/bika/lims/api/__init__.py
+++ b/bika/lims/api/__init__.py
@@ -5,6 +5,8 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
+import re
+
 from Acquisition import aq_base
 from AccessControl.PermissionRole import rolesForPermissionOn
 
@@ -66,6 +68,8 @@ Thanks.
 """
 
 _marker = object()
+
+UID_RX = re.compile("[a-z0-9]{32}$")
 
 
 class BikaLIMSError(Exception):
@@ -1160,6 +1164,8 @@ def is_uid(uid, validate=False):
     if not isinstance(uid, basestring):
         return False
     if len(uid) != 32:
+        return False
+    if not UID_RX.match(uid):
         return False
     if not validate:
         return True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an edge case where strings were false identified as an UID 

## Current behavior before PR

False positive identification of strings with length 32 containing upper characters and spaces

## Desired behavior after PR is merged

No wrong positives

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
