### PR TITLE
When retracting an Analysis Request retract also its Analyses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,7 @@ Changelog
 
 **Fixed**
 
+- #774 When retracting an Analysis Requests its analyses are also retracted
 - #763 Datetime conversion error in CSV Importer of Taqman 48
 - #761 Dormant Reference Definitions were listed for selection on WS Templates
 - #735 Interim fields not created for QC Analyses on WSs

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -107,7 +107,7 @@ class WorkflowAction:
 
         if items:
             # If the items have descendants add them to the items list to also
-            # transition them
+            # transition them (for example, the Analyses of an AR)
             child_objs = []
             for item in items:
                 if not hasattr(item, "getChildNodes"):

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -106,6 +106,15 @@ class WorkflowAction:
             items = self._get_selected_items().values()
 
         if items:
+            # If the items have descendants add them to the items list to also
+            # transition them
+            child_objs = []
+            for item in items:
+                if not hasattr(item, "getChildNodes"):
+                    continue
+                child_objs += [child_obj for child_obj in item.getChildNodes()]
+            items.extend(child_objs)
+
             trans, dest = self.submitTransition(action, came_from, items)
             if trans:
                 message = PMF('Changes saved.')

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -106,15 +106,6 @@ class WorkflowAction:
             items = self._get_selected_items().values()
 
         if items:
-            # If the items have descendants add them to the items list to also
-            # transition them (for example, the Analyses of an AR)
-            child_objs = []
-            for item in items:
-                if not hasattr(item, "getChildNodes"):
-                    continue
-                child_objs += [child_obj for child_obj in item.getChildNodes()]
-            items.extend(child_objs)
-
             trans, dest = self.submitTransition(action, came_from, items)
             if trans:
                 message = PMF('Changes saved.')

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -3042,6 +3042,10 @@ class AnalysisRequest(BaseFolder):
     def workflow_script_reject(self):
         events.after_reject(self)
 
+    @security.public
+    def workflow_script_retract(self):
+        events.after_retract(self)
+
     def SearchableText(self):
         """
         Override searchable text logic based on the requirements.

--- a/bika/lims/tests/doctests/AnalysisRequestRetract.rst
+++ b/bika/lims/tests/doctests/AnalysisRequestRetract.rst
@@ -1,0 +1,193 @@
+Analysis Request retract
+========================
+
+Running this test from the buildout directory::
+
+    bin/test test_textual_doctests -t AnalysisRequestRetract
+
+
+Test Setup
+----------
+
+Needed Imports::
+
+    >>> import transaction
+    >>> from DateTime import DateTime
+    >>> from plone import api as ploneapi
+
+    >>> from bika.lims import api
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+
+
+Functional Helpers::
+
+    >>> def start_server():
+    ...     from Testing.ZopeTestCase.utils import startZServer
+    ...     ip, port = startZServer()
+    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
+
+    >>> def timestamp(format="%Y-%m-%d"):
+    ...     return DateTime().strftime(format)
+
+
+Variables::
+
+    >>> date_now = timestamp()
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> bika_setup = portal.bika_setup
+    >>> bika_sampletypes = bika_setup.bika_sampletypes
+    >>> bika_samplepoints = bika_setup.bika_samplepoints
+    >>> bika_analysiscategories = bika_setup.bika_analysiscategories
+    >>> bika_analysisservices = bika_setup.bika_analysisservices
+    >>> bika_labcontacts = bika_setup.bika_labcontacts
+    >>> bika_storagelocations = bika_setup.bika_storagelocations
+    >>> bika_samplingdeviations = bika_setup.bika_samplingdeviations
+    >>> bika_sampleconditions = bika_setup.bika_sampleconditions
+    >>> portal_url = portal.absolute_url()
+    >>> bika_setup_url = portal_url + "/bika_setup"
+
+Test user::
+
+We need certain permissions to create and access objects used in this test,
+so here we will assume the role of Lab Manager.
+
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import setRoles
+    >>> setRoles(portal, TEST_USER_ID, ['Manager',])
+
+
+Create Analysis Requests (AR)
+-----------------------------
+
+An `AnalysisRequest` can only be created inside a `Client`::
+
+    >>> clients = self.portal.clients
+    >>> client = api.create(clients, "Client", Name="NARALABS", ClientID="JG")
+    >>> client
+    <Client at /plone/clients/client-1>
+
+To create a new AR, a `Contact` is needed::
+
+    >>> contact = api.create(client, "Contact", Firstname="Juan", Surname="Gallostra")
+    >>> contact
+    <Contact at /plone/clients/client-1/contact-1>
+
+A `SampleType` defines how long the sample can be retained, the minimum volume
+needed, if it is hazardous or not, the point where the sample was taken etc.::
+
+    >>> sampletype = api.create(bika_sampletypes, "SampleType", Prefix="water", MinimumVolume="100 ml")
+    >>> sampletype
+    <SampleType at /plone/bika_setup/bika_sampletypes/sampletype-1>
+
+A `SamplePoint` defines the location, where a `Sample` was taken::
+
+    >>> samplepoint = api.create(bika_samplepoints, "SamplePoint", title="Lake of Constance")
+    >>> samplepoint
+    <SamplePoint at /plone/bika_setup/bika_samplepoints/samplepoint-1>
+
+An `AnalysisCategory` categorizes different `AnalysisServices`::
+
+    >>> analysiscategory = api.create(bika_analysiscategories, "AnalysisCategory", title="Water")
+    >>> analysiscategory
+    <AnalysisCategory at /plone/bika_setup/bika_analysiscategories/analysiscategory-1>
+
+An `AnalysisService` defines a analysis service offered by the laboratory::
+
+    >>> analysisservice = api.create(bika_analysisservices, "AnalysisService", title="PH", ShortTitle="ph", Category=analysiscategory, Keyword="PH")
+    >>> analysisservice
+    <AnalysisService at /plone/bika_setup/bika_analysisservices/analysisservice-1>
+
+Finally, the `AnalysisRequest` can be created::
+
+    >>> values = {
+    ...           'Client': client.UID(),
+    ...           'Contact': contact.UID(),
+    ...           'SamplingDate': date_now,
+    ...           'DateSampled': date_now,
+    ...           'SampleType': sampletype.UID(),
+    ...           'Priority': '1',
+    ...          }
+
+    >>> service_uids = [analysisservice.UID()]
+    >>> ar = create_analysisrequest(client, request, values, service_uids)
+    >>> ar
+    <AnalysisRequest at /plone/clients/client-1/water-0001-R01>
+
+Also, make sure that the Analysis Request only has one analysis. You will
+see why later::
+
+    >>> len(ar.getAnalyses())
+    1
+
+
+Submit Analyses results for the current Analysis Request
+--------------------------------------------------------
+
+First transition the Analysis Request to received::
+
+    >>> transitioned = do_action_for(ar, 'receive')
+    >>> transitioned[0]
+    True
+    >>> ar.portal_workflow.getInfoFor(ar, 'review_state')
+    'sample_received'
+
+Set the results of the Analysis and transition them for verification::
+
+    >>> for analysis in ar.getAnalyses(full_objects=True):
+    ...     analysis.setResult('12')
+    ...     transitioned = do_action_for(analysis, 'submit')
+    >>> transitioned[0]
+    True
+
+Check that both the Analysis Request and its analyses have been transitioned
+to 'to_be_verified'::
+
+    >>> ar.portal_workflow.getInfoFor(ar, 'review_state')
+    'to_be_verified'
+    >>> not_to_be_verified = 0
+    >>> for analysis in ar.getAnalyses(full_objects=True):
+    ...     if analysis.portal_workflow.getInfoFor(analysis, 'review_state') != 'to_be_verified':
+    ...         not_to_be_verified += 1
+    >>> not_to_be_verified
+    0
+
+
+Retract the Analysis Request
+----------------------------
+When an Analysis Request is retracted two things should happen:
+
+    1- The Analysis Request is transitioned to 'sample_received'. Since
+    the results have been retracted its review state goes back to just
+    before the submission of results.
+
+    2- Its current analyses are transitioned to 'retracted' and a duplicate
+    of each analysis is created (so that results can be introduced again) with
+    review state 'sample_received'.
+
+Retract the Analysis Request::
+
+    >>> transitioned = do_action_for(ar, 'retract')
+    >>> transitioned[0]
+    True
+    >>> ar.portal_workflow.getInfoFor(ar, 'review_state')
+    'sample_received'
+
+Verify that its analyses have also been retracted and that a new analysis has been
+created with review status 'sample_received'. Since we previously checked that the AR
+had only one analyses the count for both 'retracted' and 'sample_received' analyses
+should be one::
+
+    >>> sample_received = 0
+    >>> retracted = 0
+    >>> for analysis in ar.getAnalyses(full_objects=True):
+    ...     if analysis.portal_workflow.getInfoFor(analysis, 'review_state') == 'retracted':
+    ...         retracted += 1
+    ...     if analysis.portal_workflow.getInfoFor(analysis, 'review_state') != 'sample_received':
+    ...         sample_received += 1
+    >>> sample_received
+    1
+    >>> retracted
+    1
+

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -145,7 +145,7 @@ def isActive(obj):
     """
     # The import is performed here because if placed
     # at the beginning of the file we get circular imports
-    from bika.lims.workflow import is_active
+    from bika.lims.workflow import isActive as is_active
     return is_active(obj)
 
 

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -143,7 +143,7 @@ def getUsers(context, roles, allow_empty=True):
 def isActive(obj):
     """ Check if obj is inactive or cancelled.
     """
-    wf = getToolByName(obj, 'portal_workflow')
+    wf = api.get_tool('portal_workflow', obj)
     if (hasattr(obj, 'inactive_state') and obj.inactive_state == 'inactive') or \
        wf.getInfoFor(obj, 'inactive_state', 'active') == 'inactive':
         return False

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -143,8 +143,10 @@ def getUsers(context, roles, allow_empty=True):
 def isActive(obj):
     """ Check if obj is inactive or cancelled.
     """
-    from bika.lims.workflow import isActive
-    return isActive(obj)
+    # The import is performed here because if placed
+    # at the beginning of the file we get circular imports
+    from bika.lims.workflow import is_active
+    return is_active(obj)
 
 
 def formatDateQuery(context, date_id):

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -143,14 +143,8 @@ def getUsers(context, roles, allow_empty=True):
 def isActive(obj):
     """ Check if obj is inactive or cancelled.
     """
-    wf = api.get_tool('portal_workflow', obj)
-    if (hasattr(obj, 'inactive_state') and obj.inactive_state == 'inactive') or \
-       wf.getInfoFor(obj, 'inactive_state', 'active') == 'inactive':
-        return False
-    if (hasattr(obj, 'cancellation_state') and obj.inactive_state == 'cancelled') or \
-       wf.getInfoFor(obj, 'cancellation_state', 'active') == 'cancelled':
-        return False
-    return True
+    from bika.lims.workflow import isActive
+    return isActive(obj)
 
 
 def formatDateQuery(context, date_id):

--- a/bika/lims/workflow/analysisrequest/events.py
+++ b/bika/lims/workflow/analysisrequest/events.py
@@ -147,7 +147,7 @@ def after_retract(obj):
     :param obj: Analysis Request affected by the transition
     :type obj: AnalysisRequest
     """
-    ans = obj.getAnalyses(full_objects=True, cancellation_state='cancelled')
+    ans = obj.getAnalyses(full_objects=True)
     for analysis in ans:
         doActionFor(analysis, 'retract')
 

--- a/bika/lims/workflow/analysisrequest/events.py
+++ b/bika/lims/workflow/analysisrequest/events.py
@@ -140,6 +140,17 @@ def after_reject(obj):
         notify_rejection(obj)
 
 
+def after_retract(obj):
+    """Method triggered after a 'retract' transition for the Analysis Request
+    passed in is performed. Transitions and sets the analyses of the Analyses
+    Request to retracted.
+    :param obj: Analysis Request affected by the transition
+    :type obj: AnalysisRequest
+    """
+    for analysis in obj.getAnalyses(full_objects=True):
+        doActionFor(analysis, 'retract')
+
+
 def after_attach(obj):
     """Method triggered after an 'attach' transition for the Analysis Request
     passed in is performed.

--- a/bika/lims/workflow/analysisrequest/events.py
+++ b/bika/lims/workflow/analysisrequest/events.py
@@ -147,7 +147,8 @@ def after_retract(obj):
     :param obj: Analysis Request affected by the transition
     :type obj: AnalysisRequest
     """
-    for analysis in obj.getAnalyses(full_objects=True):
+    ans = obj.getAnalyses(full_objects=True, cancellation_state='cancelled')
+    for analysis in ans:
         doActionFor(analysis, 'retract')
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #770 

## Current behavior before PR

When retracting an Analysis Request its Analyses remain in "To be verified" state.

## Desired behavior after PR is merged

When an Analysis Request is retracted to received state its analyses are also retracted

## Screenshot (optional)

![seleccio_011](https://user-images.githubusercontent.com/9968427/38982932-6c33d8fa-43c3-11e8-8b43-481c6a36471d.png)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
