### PR TITLE
Hyperlink Analyses on ARs to their WSs if assigned 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #775 Analyses on Analysis Requests are hyperlinked to their Worksheets
 - #774 When retracting an Analysis Requests its analyses are also retracted
 - #772 Improved UID check in API
 

--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -1053,7 +1053,7 @@ class AnalysesView(BikaListingView):
         :param analysis_brain: Brain that represents an analysis
         :param item: analysis' dictionary counterpart that represents a row
         """
-        if IAnalysisRequest.providedBy(self.context):
+        if not IAnalysisRequest.providedBy(self.context):
             # We want this icon to only appear if the context is an AR
             return
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #722 

## Current behavior before PR

The Worksheet Analyses are not indicated as such on the AR view. No icon linking to the worksheet appears.

## Desired behavior after PR is merged

The Worksheet Analyses are indicated as such on the AR view with an icon linking to the worksheet.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
