### PR TITLE
Delete Permission on ARs for Lab Managers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #781 Delete Permission on ARs for Lab Managers
 - #775 Analyses on Analysis Requests are hyperlinked to their Worksheets
 - #769 Traceback when submitting duplicate when Duplicate Variation is not set
 - #771 Slow Searches in Listing Views

--- a/bika/lims/subscribers/objectmodified.py
+++ b/bika/lims/subscribers/objectmodified.py
@@ -32,6 +32,12 @@ def ObjectModifiedEventHandler(obj, event):
             reference_versions[obj.UID()] = version_id + 1
             target.reference_versions = reference_versions
 
+    elif obj.portal_type == 'AnalysisRequest':
+        mp = obj.manage_permission
+        # Manage Analyses / Attachment Removal
+        # https://github.com/senaite/senaite.core/issues/780
+        mp(permissions.DeleteObjects, ['Manager', 'LabManager', 'Owner'], 0)
+
     elif obj.portal_type == 'Client':
         mp = obj.manage_permission
         mp(permissions.ListFolderContents, ['Manager', 'LabManager', 'LabClerk', 'Analyst', 'Sampler', 'Preserver', 'Owner'], 0)

--- a/bika/lims/subscribers/objectmodified.py
+++ b/bika/lims/subscribers/objectmodified.py
@@ -5,10 +5,10 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
+from bika.lims.permissions import ManageLoginDetails
+from bika.lims.permissions import ManageSupplyOrders
 from Products.CMFCore import permissions
 from Products.CMFCore.utils import getToolByName
-from bika.lims.permissions import ManageSupplyOrders, ManageLoginDetails
-from bika.lims.interfaces import IAnalysisRequest
 
 
 def ObjectModifiedEventHandler(obj, event):

--- a/bika/lims/subscribers/objectmodified.py
+++ b/bika/lims/subscribers/objectmodified.py
@@ -32,11 +32,14 @@ def ObjectModifiedEventHandler(obj, event):
             reference_versions[obj.UID()] = version_id + 1
             target.reference_versions = reference_versions
 
-    elif obj.portal_type == 'AnalysisRequest':
+    # Note: obj can be also a reference!
+    # <Folder at .../client-1/4d1dd3f77b76b3427a005e1f339e7bd4/at_references>
+    elif obj.meta_type == obj.portal_type == 'AnalysisRequest':
         mp = obj.manage_permission
-        # Manage Analyses / Attachment Removal
+        # Allow to remove Analyses / Attachments
         # https://github.com/senaite/senaite.core/issues/780
-        mp(permissions.DeleteObjects, ['Manager', 'LabManager', 'Owner'], 0)
+        can_delete = ["Manager", "LabManager", "Owner"]
+        mp(permissions.DeleteObjects, can_delete, 0)
 
     elif obj.portal_type == 'Client':
         mp = obj.manage_permission

--- a/bika/lims/upgrade/v01_02_005.py
+++ b/bika/lims/upgrade/v01_02_005.py
@@ -10,6 +10,7 @@ from bika.lims.catalog.analysisrequest_catalog import CATALOG_ANALYSIS_REQUEST_L
 from bika.lims.config import PROJECTNAME as product
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
+from Products.CMFCore import permissions
 
 version = '1.2.5'  # Remember version number in metadata.xml and setup.py
 profile = 'profile-{0}:default'.format(product)
@@ -30,6 +31,9 @@ def upgrade(tool):
 
     # -------- ADD YOUR STUFF HERE --------
 
+    # Lab Managers can not remove Analyses in "Manage Analyses" form
+    fix_permission_on_analysisrequests()
+
     # Traceback when submitting duplicate when Duplicate Variation is not set
     # Walkthrough all analyses and analyses services and set 0.00 value for
     # DuplicateVariation if returns None
@@ -42,6 +46,18 @@ def upgrade(tool):
     logger.info("{0} upgraded to version {1}".format(product, version))
 
     return True
+
+
+def fix_permission_on_analysisrequests():
+    catalog = api.get_tool(CATALOG_ANALYSIS_REQUEST_LISTING)
+    brains = catalog(portal_type='AnalysisRequest')
+    for brain in brains:
+        obj = api.get_object(brain)
+        mp = obj.manage_permission
+        mp(permissions.DeleteObjects, ['Manager', 'LabManager', 'Owner'], 0)
+        logger.info("Fixed '{}' permission on '{}'".format(
+            permissions.DeleteObjects, obj.Title()))
+
 
 def fix_duplicate_variation_nonfloatable_values():
     # Update Analysis Services

--- a/bika/lims/upgrade/v01_02_005.py
+++ b/bika/lims/upgrade/v01_02_005.py
@@ -50,7 +50,9 @@ def upgrade(tool):
 
 def fix_permission_on_analysisrequests():
     catalog = api.get_tool(CATALOG_ANALYSIS_REQUEST_LISTING)
-    brains = catalog(portal_type='AnalysisRequest')
+    valid_states = ['sample_due', 'sample_received', 'sampled',
+                    'to_be_sampled', 'to_be_preserved']
+    brains = catalog(cancellation_state='active', review_state=valid_states)
     for brain in brains:
         obj = api.get_object(brain)
         mp = obj.manage_permission

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -13,6 +13,7 @@ versions = versions
 develop = .
 
 find-links =
+    https://pypi.python.org/simple
     http://dist.plone.org/release/4.3.15
     http://dist.plone.org/thirdparty
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -135,5 +135,5 @@ scripts = ipython=ipzope
 
 [versions]
 setuptools=
-zc.buildout=2.11.2
+zc.buildout=
 five.pt=2.2.4

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -13,7 +13,6 @@ versions = versions
 develop = .
 
 find-links =
-    https://pypi.python.org/simple
     http://dist.plone.org/release/4.3.15
     http://dist.plone.org/thirdparty
 
@@ -136,5 +135,5 @@ scripts = ipython=ipzope
 
 [versions]
 setuptools=
-zc.buildout=
+zc.buildout=2.11.2
 five.pt=2.2.4


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/780

## Current behavior before PR

Users with the role `LabManager` can not remove Analyses of ARs via the "Manage Analyses" Tab

## Desired behavior after PR is merged

Users with the role `LabManager` can remove Analyses of ARs via the "Manage Analyses" Tab

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
