### PR TITLE
Fix workflow state filter not kept when expanding categories in AS listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #784 Fix workflow state filter not kept when expanding categories in AS listing
 - #775 Analyses on Analysis Requests are hyperlinked to their Worksheets
 - #769 Traceback when submitting duplicate when Duplicate Variation is not set
 - #771 Slow Searches in Listing Views

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -363,7 +363,7 @@
       base_url = this.get_base_url();
       url = cat_url || base_url;
       // prepare a new form data
-      form_data = new FormData();
+      form_data = new FormData(form[0]);
       form_data.set("cat", cat_id);
       form_data.set("form_id", form_id);
       form_data.set("ajax_category_expand", 1);

--- a/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
@@ -342,7 +342,7 @@ class window.BikaListingTableView
     url = cat_url or base_url
 
     # prepare a new form data
-    form_data = new FormData()
+    form_data = new FormData form[0]
     form_data.set "cat", cat_id
     form_data.set "form_id", form_id
     form_data.set "ajax_category_expand", 1


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/783

## Current behavior before PR

Active Analyses Services shown when expanding a category in the Setup AS Listing after the "inactive" filter was selected

## Desired behavior after PR is merged

Inactive Analyses Services shown when expanding a category in the Setup AS Listing after the "inactive" filter was selected

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
