### PR TITLE
Fix inactive services listed in AR "Manage Analyses" forms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #786 Fix inactive services listed in AR "Manage Analyses" forms
 - #775 Analyses on Analysis Requests are hyperlinked to their Worksheets
 - #769 Traceback when submitting duplicate when Duplicate Variation is not set
 - #771 Slow Searches in Listing Views

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -111,7 +111,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
         self.review_states = [
             {'id': 'default',
              'title': _('All'),
-             'contentFilter': {},
+             'contentFilter': {"inactive_state": "active"},
              'columns': columns,
              'transitions': [{'id': 'empty'}, ],  # none
              'custom_transitions': [{'id': 'save_analyses_button',


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/785

## Current behavior before PR

Inactive services listed in AR Manage Analyses

## Desired behavior after PR is merged

Only active Analyses listed in AR Manage Analyses

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
