### PR TITLE
Lab Clerks cannot see Contacts tab of Clients'

### DIFF
--- a/bika/lims/permissions.py
+++ b/bika/lims/permissions.py
@@ -327,7 +327,7 @@ def setup_permissions(portal):
         obj = contact.getObject()
         mp = contact.manage_permission
         mp(permissions.View, ['Manager', 'LabManager', 'LabClerk', 'Owner', 'Analyst', 'Sampler', 'Preserver', 'SamplingCoordinator'], 0)
-        mp(permissions.ModifyPortalContent, ['Manager', 'LabManager', 'Owner', 'SamplingCoordinator'], 0)
+        mp(permissions.ModifyPortalContent, ['Manager', 'LabManager', 'LabClerk','Owner', 'SamplingCoordinator'], 0)
 
     # /Clients
 

--- a/bika/lims/subscribers/objectmodified.py
+++ b/bika/lims/subscribers/objectmodified.py
@@ -36,7 +36,7 @@ def ObjectModifiedEventHandler(obj, event):
         mp = obj.manage_permission
         mp(permissions.ListFolderContents, ['Manager', 'LabManager', 'LabClerk', 'Analyst', 'Sampler', 'Preserver', 'Owner'], 0)
         mp(permissions.View, ['Manager', 'LabManager', 'LabClerk',  'Analyst', 'Sampler', 'Preserver', 'Owner'], 0)
-        mp(permissions.ModifyPortalContent, ['Manager', 'LabManager', 'Owner'], 0)
+        mp(permissions.ModifyPortalContent, ['Manager', 'LabClerk', 'LabManager', 'Owner'], 0)
         mp(ManageSupplyOrders, ['Manager', 'LabManager', 'Owner', 'LabClerk'], 0)
         mp('Access contents information', ['Manager', 'LabManager', 'Member', 'LabClerk', 'Analyst', 'Sampler', 'Preserver', 'Owner'], 0)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/787

## Current behavior before PR
Lab Clerks do not have Modify Portal Content permission on Clients to see 'Contacts' tab.
 
## Desired behavior after PR is merged
Give necessary permission to Lab Clerks.
----
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
