### PR TITLE
Shorter 'listing_searchable_text' methods.

### DIFF
--- a/bika/lims/catalog/indexers/analysisrequest.py
+++ b/bika/lims/catalog/indexers/analysisrequest.py
@@ -42,14 +42,7 @@ def listing_searchable_text(instance):
     columns = catalog.schema()
 
     for column in columns:
-        try:
-            value = api.safe_getattr(instance, column)
-        except:
-            logger.error("{} has no attribute called '{}' ".format(
-                            repr(instance), column))
-            continue
-        if not value:
-            continue
+        value = api.safe_getattr(instance, column, None)
         parsed = api.to_searchable_text_metadata(value)
         entries.append(parsed)
 


### PR DESCRIPTION
## Current behavior before 
While getting an attribute of an object, default value can be set. It is useful for 'listing_searchable_text' setter where we can remove a few lines of code.
## Desired behavior after PR is merged
Shorter 'listing_searchable_text' method.

---
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
