### PR TITLE
Remove dry matter test

### DIFF
--- a/bika/lims/tests/test_ARImport.py
+++ b/bika/lims/tests/test_ARImport.py
@@ -201,8 +201,6 @@ Total price excl Tax,,,,,,,,,,,,,,
             self.fail("Should be two empty SamplePoints, and two with values")
         if len(re.findall('<.*selected.*Liquids', content)) != 2:
             self.fail("Should be two empty Matrix fields, and two with values")
-        if len(re.findall('<.*checked.*ReportDry', content)) != 2:
-            self.fail("Should be two False DryMatters, and two True")
 
     def test_LIMS_2081_post_edit_fails_validation_gracefully(self):
         client = self.portal.clients.objectValues()[0]


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Travis is failing due to AR Import dry matter test failing. As per #779 dry matter functionality has been removed so the tests making use or testing the functionality (`test_ARImport.py`) should also be removed.

## Current behavior before PR

AR Import test includes Dry Matter testing

## Desired behavior after PR is merged

AR Import test doesn't include Dry Matter testing

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
