### PR TITLE
Include Client ID when setting up ARReport on the IDServer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #806 Include Client ID when setting up ARReport on the IDServer
 
 **Changed**
 

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -174,6 +174,11 @@ def get_variables(context, **kw):
             'sampleType': sampletype_prefix,
         })
 
+    elif portal_type == "ARReport":
+        variables.update({
+            'clientId': context.aq_parent.getClientID(),
+        })
+
     return variables
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Modified IDServer so that ARReport can have a format like `COA-{clientId}-{year}-{seq:05d}`

## Current behavior before PR

ClientId cannot be included on the ARReport format when setting up the ID Server for ARReport 

## Desired behavior after PR is merged

Be able to include ClientID on the ARReport format when setting up IDServer for ARReport i.e `COA-{clientId}-{year}-{seq:05d}`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
