### PR TITLE
Remove "queued_ars" JS call to avoid 404

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Changelog
 
 **Removed**
 
+- #807 Remove "queued_ars" JS call to avoid 404
 - #800 Remove Dry Matter from tests
 - #779 Remove Dry Matter functionality
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/791

Please see commit https://github.com/senaite/senaite.core/commit/d88afaf444eff4ac76f6077ca853c0c579abd324 for the actual code changes

## Current behavior before PR

404 occurs for JS call to queued_ars

## Desired behavior after PR is merged

View "queued_ars" not called anymore in JS

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
