### PR TITLE
AR 'listing_searchable_text' indexer optimization.

### DIFF
--- a/bika/lims/catalog/indexers/analysisrequest.py
+++ b/bika/lims/catalog/indexers/analysisrequest.py
@@ -40,10 +40,10 @@ def listing_searchable_text(instance):
     entries = set()
     catalog = api.get_tool(CATALOG_ANALYSIS_REQUEST_LISTING)
     columns = catalog.schema()
+    brains = catalog({"UID": api.get_uid(instance)})
 
     for column in columns:
         brain_value = None
-        brains = catalog({"UID": api.get_uid(instance)})
         if brains:
             brain_value = api.safe_getattr(brains[0], column, None)
         instance_value = api.safe_getattr(instance, column, None)

--- a/bika/lims/catalog/indexers/analysisrequest.py
+++ b/bika/lims/catalog/indexers/analysisrequest.py
@@ -41,11 +41,9 @@ def listing_searchable_text(instance):
     catalog = api.get_tool(CATALOG_ANALYSIS_REQUEST_LISTING)
     columns = catalog.schema()
     brains = catalog({"UID": api.get_uid(instance)})
-
+    brain = brains[0] if brains else None
     for column in columns:
-        brain_value = None
-        if brains:
-            brain_value = api.safe_getattr(brains[0], column, None)
+        brain_value = api.safe_getattr(brain, column, None)
         instance_value = api.safe_getattr(instance, column, None)
         parsed = api.to_searchable_text_metadata(brain_value or instance_value)
         entries.add(parsed)

--- a/bika/lims/catalog/indexers/analysisrequest.py
+++ b/bika/lims/catalog/indexers/analysisrequest.py
@@ -5,11 +5,11 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
+from plone.indexer import indexer
+
 from bika.lims import api
-from bika.lims import logger
 from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.interfaces import IAnalysisRequest
-from plone.indexer import indexer
 
 
 @indexer(IAnalysisRequest)
@@ -42,10 +42,13 @@ def listing_searchable_text(instance):
     columns = catalog.schema()
 
     for column in columns:
-        value = api.safe_getattr(instance, column, None)
-        parsed = api.to_searchable_text_metadata(value)
-        if parsed:
-            entries.add(parsed)
+        brain_value = None
+        brains = catalog({"UID": api.get_uid(instance)})
+        if brains:
+            brain_value = api.safe_getattr(brains[0], column, None)
+        instance_value = api.safe_getattr(instance, column, None)
+        parsed = api.to_searchable_text_metadata(brain_value or instance_value)
+        entries.add(parsed)
 
     # Concatenate all strings to one text blob
     return " ".join(entries)


### PR DESCRIPTION
## Current behavior before PR
While indexing AR's, attributes are called directly from instance.

## Desired behavior after PR is merged
Try to get the attributes from object's brain instead. It will help with not-overridding that method in other Add-ons which Extend AR Schema.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
