### PR TITLE
Remove senaite.api import

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Changelog
 
 **Changed**
 
+- #811 api import in printform
 
 **Removed**
 
@@ -19,7 +20,7 @@ Changelog
 
 
 **Fixed**
-
+ 
 - #799 On AR Listing, inline edit for Date Sampled not working when Sampler has a value
 - #776 Analyses submission in Worksheet is slow
 - #726 404 Error raised when clicking Print Samples Sheets from within a client

--- a/bika/lims/browser/sample/printform.py
+++ b/bika/lims/browser/sample/printform.py
@@ -12,7 +12,7 @@ from Products.CMFPlone.utils import safe_unicode
 
 from plone.resource.utils import iterDirectoriesOfType
 
-from senaite import api
+from bika.lims import api
 from bika.lims.browser import BrowserView
 from bika.lims.utils import createPdf
 from bika.lims import logger


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #810 

## Current behavior before PR

Travis fails when trying to import senaite api with the following traceback:

 ```
 File "/home/travis/build/senaite/senaite.core/bika/lims/browser/sample/__init__.py", line 13, in <module>
    from .printform import SamplesPrint
  File "/home/travis/build/senaite/senaite.core/bika/lims/browser/sample/printform.py", line 15, in <module>
    from senaite import api
ZopeXMLConfigurationError: File "/home/travis/build/senaite/senaite.core/bika/lims/configure.zcml", line 29.2-29.32
    ZopeXMLConfigurationError: File "/home/travis/build/senaite/senaite.core/bika/lims/browser/configure.zcml", line 41.2-41.42
    ImportError: No module named senaite
```

## Desired behavior after PR is merged

Travis is happy again (Travis is hard to please)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
