### PR TITLE
TypeError when Saving AR results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Changelog
 
 **Fixed**
 
+- #813 Saving AR results gives TypeError: can only compare to a set
 - #799 On AR Listing, inline edit for Date Sampled not working when Sampler has a value
 - #776 Analyses submission in Worksheet is slow
 - #726 404 Error raised when clicking Print Samples Sheets from within a client

--- a/bika/lims/browser/analyses/workflow.py
+++ b/bika/lims/browser/analyses/workflow.py
@@ -215,7 +215,7 @@ class AnalysesWorkflowAction(WorkflowAction):
         # AR Catalog contains some metadata that that rely on the Analyses an
         # Analysis Request contains.
         if affected_ars:
-            query = dict(UID=affected_ars, portal_type="AnalysisRequest")
+            query = dict(UID=list(affected_ars), portal_type="AnalysisRequest")
             for ar_brain in api.search(query, CATALOG_ANALYSIS_REQUEST_LISTING):
                 if ar_brain.review_state == 'to_be_verified':
                     continue
@@ -226,7 +226,7 @@ class AnalysesWorkflowAction(WorkflowAction):
                     ar.reindexObject()
 
         if affected_ws:
-            query = dict(UID=affected_ws, portal_type="Worksheet")
+            query = dict(UID=list(affected_ws), portal_type="Worksheet")
             for ws_brain in api.search(query, CATALOG_WORKSHEET_LISTING):
                 if ws_brain.review_state == 'to_be_verified':
                     continue


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

In some instances (maybe with outdated dependencies?), the exception `TypeError: can only compare to a set` (see below) is thrown when the a `set` type is used instead of `list` on catalog searches.

Linked issue: https://github.com/senaite/senaite.core/issues/812

## Current behavior before PR

```
Traceback (innermost last):
Module ZPublisher.Publish, line 138, in publish
Module ZPublisher.mapply, line 77, in mapply
Module ZPublisher.Publish, line 48, in call_object
Module bika.lims.browser.analysisrequest.workflow, line 64, in _call_
Module bika.lims.browser.analysisrequest.workflow, line 342, in workflow_action_submit
Module bika.lims.browser.analyses.workflow, line 219, in workflow_action_submit
Module bika.lims.api, line 655, in search
Module Products.CMFPlone.CatalogTool, line 389, in searchResults
Module Products.ZCatalog.ZCatalog, line 604, in searchResults
Module Products.ZCatalog.Catalog, line 925, in searchResults
Module Products.ZCatalog.Catalog, line 545, in search
Module Products.PluginIndexes.common.UnIndex, line 403, in _apply_index
TypeError: can only compare to a set
```

## Desired behavior after PR is merged

Search is performed correctly without complains

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
