### PR TITLE
Remove "Bika" naming from Setup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Changelog
 
 **Fixed**
 
+- #799 On AR Listing, inline edit for Date Sampled not working when Sampler has a value
 - #776 Analyses submission in Worksheet is slow
 - #726 404 Error raised when clicking Print Samples Sheets from within a client
 - #802 Remove Dry Matter remainders

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Changelog
 
 **Changed**
 
+- #814 Change naming from Bika LIMS Configuration to LIMS Configuration in the Site Setup page
+- #814 Change naming from Bika Setup to Setup in the LIMS Configuration section found in the Site Setup page
 
 **Removed**
 
@@ -29,8 +31,6 @@ Changelog
 
 **Changed**
 
-- #814 Change naming from Bika LIMS Configuration to LIMS Configuration in the Site Setup page
-- #814 Change naming from Bika Setup to Setup in the LIMS Configuration section found in the Site Setup page
 - #815 Change description and title of the invalidation notification option
 
 **Removed**

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Changelog
 
 **Changed**
 
+- #814 Change naming from Bika LIMS Configuration to LIMS Configuration in the Site Setup page
+- #814 Change naming from Bika Setup to Setup in the LIMS Configuration section found in the Site Setup page
 
 **Removed**
 

--- a/bika/lims/monkey/controlpanel.py
+++ b/bika/lims/monkey/controlpanel.py
@@ -16,6 +16,6 @@ def overview_controlpanel_categories(self):
     """
     return [
         {'id': 'Plone', 'title': PMF(u'Plone Configuration')},
-        {'id': 'bika', 'title': _(u'SENAITE LIMS Configuration')},
+        {'id': 'bika', 'title': _(u'LIMS Configuration')},
         {'id': 'Products', 'title': PMF(u'Add-on Configuration')},
     ]

--- a/bika/lims/monkey/controlpanel.py
+++ b/bika/lims/monkey/controlpanel.py
@@ -16,6 +16,6 @@ def overview_controlpanel_categories(self):
     """
     return [
         {'id': 'Plone', 'title': PMF(u'Plone Configuration')},
-        {'id': 'bika', 'title': _(u'Bika LIMS Configuration')},
+        {'id': 'bika', 'title': _(u'SENAITE LIMS Configuration')},
         {'id': 'Products', 'title': PMF(u'Add-on Configuration')},
     ]

--- a/bika/lims/profiles/default/controlpanel.xml
+++ b/bika/lims/profiles/default/controlpanel.xml
@@ -4,7 +4,7 @@
  xmlns:i18n="http://xml.zope.org/namespaces/i18n"
  i18n:domain="plone">
 
- <configlet title="Bika Setup" action_id="bika_setup"
+ <configlet title="Setup" action_id="bika_setup"
     appId="bika.lims" category="bika" condition_expr=""
     icon_expr="string:++resource++bika.lims.images/bikasetup.png"
     url_expr="string:$portal_url/bika_setup/edit"

--- a/bika/lims/upgrade/v01_02_006.py
+++ b/bika/lims/upgrade/v01_02_006.py
@@ -35,7 +35,13 @@ def upgrade(tool):
 
 
 def rename_bika_setup():
+    """
+    Rename Bika Setup to just Setup to avoid naming confusions for new users
+    """
     logger.info("Renaming Bika Setup...")
     bika_setup = api.get_bika_setup()
     bika_setup.setTitle("Setup")
     bika_setup.reindexObject()
+    setup = api.get_portal().portal_setup
+    setup.runImportStepFromProfile('profile-bika.lims:default', 'controlpanel')
+


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #795 

## Current behavior before PR

When navigating to the control panel users find that the LIMS Configuration section is called "Bika LIMS Configuration". Also, the link to the setup page is called "Bika Setup". This is confusing for new users.

## Desired behavior after PR is merged

The fields specified in the previous section are renamed to "LIMS Configuration" and "Setup". "Bika" naming is removed from Setup.

## Screenshot (optional)

![seleccio_004](https://user-images.githubusercontent.com/9968427/39621432-12a1f4de-4f8f-11e8-974f-af5f31e7ba8c.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
