### PR TITLE
Make the descritpion for invalidation notification easier to understand

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Changelog
 
 **Changed**
 
+- #815 Change description and title of the invalidation notification option so that it is easier to understand
 
 **Removed**
 

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -656,10 +656,10 @@ schema = BikaFolderSchema.copy() + Schema((
         schemata="Notifications",
         default=True,
         widget=BooleanWidget(
-            label=_("Email notification on AR retract"),
+            label=_("Email notification on AR invalidation"),
             description=_("Select this to activate automatic notifications "
                           "via email to the Client and Lab Managers when an Analysis "
-                          "Request is retracted.")
+                          "Request is invalidated.")
         ),
     ),
     TextField(


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #697 

## Current behavior before PR

Navigate to: Site Setup -> Bika Setup -> Notifications

The wording used both for the title and description of the invalidation notification option is very confusing.

## Desired behavior after PR is merged

The wording used both for the title and description of the invalidation notification option results in the functionality expressed being easier to understand.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
