### PR TITLE
Error when exporting Worksheets list with senaite.exporter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Fixed**
 
+- #825 Error when exporting Worksheets list with `senaite.exporter`
 
 **Security**
 

--- a/bika/lims/browser/worksheet/views/folder.py
+++ b/bika/lims/browser/worksheet/views/folder.py
@@ -49,6 +49,10 @@ class FolderView(BikaListingView):
         self.show_select_all_checkbox = True
         self.show_select_column = True
         self.restrict_results = False
+        self.selected_state = ''
+        self.analyst_choices = []
+        self.can_reassign = False
+        self.can_manage = False
         self.wf = getToolByName(self, 'portal_workflow')
         self.rc = getToolByName(self, REFERENCE_CATALOG)
         self.pm = getToolByName(self.context, "portal_membership")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`senaite.exporter` directly calls to filderitems function from the view that implements BikaListing. Thus, if some variables that haven't been initialized before are useed there, a Traceback is rised.

As a good practice, class variables should always be initialized in the class constructor __init__, and this commit does it. As a colateral effect, exporter works without rising any error.

## Current behavior before PR

The following Trace is rised:
```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module senaite.exporter.list_exporters, line 48, in __call__
  Module senaite.exporter.list_exporters, line 131, in export_to_list
  Module senaite.exporter.list_exporters, line 152, in get_items
  Module bika.lims.browser.worksheet.views.folder, line 326, in folderitems
  Module bika.lims.browser.bika_listing, line 932, in folderitems
  Module bika.lims.browser.worksheet.views.folder, line 255, in isItemAllowed
AttributeError: 'FolderView' object has no attribute 'selected_state'
```

## Desired behavior after PR is merged

The list of worksheets gets exported without errors

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
