### PR TITLE
Signatures of verifiers instead of dept managers in reports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Changelog
 
 **Changed**
 
+- #826 Display signatures of verifiers instead of dept managers in results report
 - #814 Change naming from Bika LIMS Configuration to LIMS Configuration in the Site Setup page
 - #814 Change naming from Bika Setup to Setup in the LIMS Configuration section found in the Site Setup page
 

--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -26,6 +26,7 @@ from Products.CMFCore.WorkflowCore import WorkflowException
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import _createObjectByType, safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from bika.lims import api
 from bika.lims import POINTS_OF_CAPTURE, bikaMessageFactory as _, t
 from bika.lims import logger
 from bika.lims.api.analysis import is_out_of_range
@@ -44,6 +45,7 @@ from bika.lims.workflow import wasTransitionPerformed
 from plone.api.portal import get_registry_record
 from plone.api.portal import set_registry_record
 from plone.app.blob.interfaces import IBlobField
+from plone.memoize import view as viewcache
 from plone.registry import Record
 from plone.registry import field
 from plone.registry.interfaces import IRegistry
@@ -1436,7 +1438,7 @@ class AnalysisRequestDigester:
     def _managers_data(self, ar):
         managers = {'ids': [], 'dict': {}}
         departments = {}
-        ar_mngrs = ar.getResponsible()
+        ar_mngrs = self._verifiers_data(ar.UID())
         for id in ar_mngrs['ids']:
             new_depts = ar_mngrs['dict'][id]['departments'].split(',')
             if id in managers['ids']:
@@ -1458,6 +1460,53 @@ class AnalysisRequestDigester:
             managers['dict'][mngr]['departments'] = final_depts
 
         return managers
+
+    @viewcache.memoize
+    def _verifiers_data(self, ar_uid):
+        verifiers = dict()
+        for brain in self.get_analyses(ar_uid):
+            an_verifiers = brain.getVerificators or ''
+            an_verifiers = an_verifiers.split(',')
+            for user_id in an_verifiers:
+                user_data = self._user_contact_data(user_id)
+                if not user_data:
+                    continue
+                verifiers[user_id]=user_data
+        return {'ids': verifiers.keys(),
+                'dict': verifiers}
+
+    @viewcache.memoize
+    def get_analyses(self, ar_uid):
+        query = dict(getRequestUID=ar_uid,
+                     portal_type='Analysis',
+                     cancellation_state='active',
+                     review_state=['verified', 'published'])
+        return api.search(query, CATALOG_ANALYSIS_LISTING)
+
+    @viewcache.memoize
+    def _user_contact_data(self, user_id):
+        user = self.get_user_contact(user_id)
+        if not user:
+            return None
+        signature = user.getSignature()
+        if signature:
+            signature = '{}/Signature'.format(user.absolute_url())
+        return dict(salutation=safe_unicode(user.getSalutation()),
+                    name=safe_unicode(user.getFullname()),
+                    email=safe_unicode(user.getEmailAddress()),
+                    phone=safe_unicode(user.getBusinessPhone()),
+                    job_title=safe_unicode(user.getJobTitle()),
+                    signature=signature or '',
+                    departments='')
+
+    @viewcache.memoize
+    def get_user_contact(self, user_id):
+        query = dict(getUsername=user_id,
+                     portal_type=['LabContact', 'Contact'])
+        users = api.search(query, 'portal_catalog')
+        if len(users) == 1:
+            return api.get_object(users[0])
+        return None
 
     def _set_results_interpretation(self, ar, data):
         """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The signatories of a results report must be all those who verified at least one of the processed analyses, rather than the managers of the departments from which at least one analysis was processed.

## Current behavior before PR

Only signatures of department managers are displayed, even if they did not verify the results.

## Desired behavior after PR is merged

All verifiers are displayed as signatories in results reports. 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
