### PR TITLE
Traceback when removing a retracted analysis from an AR

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Fixed**
 
+- #828 Traceback when removing a retracted analysis through Manage Analyses view
 
 **Security**
 

--- a/bika/lims/browser/fields/aranalysesfield.py
+++ b/bika/lims/browser/fields/aranalysesfield.py
@@ -13,7 +13,7 @@ from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
 from bika.lims.interfaces import IAnalysis, IAnalysisService, IARAnalysesField
 from bika.lims.permissions import ViewRetractedAnalyses
 from bika.lims.utils.analysis import create_analysis
-from bika.lims.workflow import wasTransitionPerformed
+from bika.lims.workflow import getReviewHistoryActionsList
 from Products.Archetypes.public import Field, ObjectField
 from Products.Archetypes.Registry import registerField
 from Products.Archetypes.utils import shasattr
@@ -182,8 +182,9 @@ class ARAnalysesField(ObjectField):
                 continue
 
             # Skip Analyses in frozen states
-            if self._is_frozen(analysis):
-                logger.warn("Inactive/verified Analyses can not be removed.")
+            if self._is_frozen(analysis, additional_frozen_actions=['retract']):
+                logger.warn("Inactive/verified/retracted Analyses can not be "
+                            "removed.")
                 continue
 
             # If it is assigned to a worksheet, unassign it before deletion.
@@ -193,7 +194,14 @@ class ARAnalysesField(ObjectField):
                 ws.removeAnalysis(analysis)
 
             # Unset the partition reference
-            analysis.edit(SamplePartition=None)
+            part = analysis.getSamplePartition()
+            an_uid = api.get_uid(analysis)
+            part_ans = part.getAnalyses() or []
+            part_ans = filter(lambda an: api.get_uid(an) != an_uid, part_ans)
+            # Unset the Partition-to-Analysis reference
+            part.setAnalyses(part_ans)
+            # Unset the Analysis-to-Partition reference
+            analysis.setSamplePartition(None)
             delete_ids.append(analysis.getId())
 
         if delete_ids:
@@ -243,16 +251,23 @@ class ARAnalysesField(ObjectField):
         logger.warn(msg)
         return None
 
-    def _is_frozen(self, brain_or_object):
-        """Check if the passed in object is frozen
-
-        :param obj: Analysis or AR Brain/Object
+    def _is_frozen(self, brain_or_object, additional_frozen_actions=None):
+        """Check if the passed in object is frozen: the objectt is cancelled,
+        inactive or has been verified at some point
+        :param brain_or_object: Analysis or AR Brain/Object
+        :param additional_frozen_actions: additional actions to check against
         :returns: True if the object is frozen
         """
-        obj = api.get_object(brain_or_object)
-        active = api.is_active(obj)
-        verified = wasTransitionPerformed(obj, 'verify')
-        return not active or verified
+        if not api.is_active(brain_or_object):
+            return True
+        actions = getReviewHistoryActionsList(api.get_object(brain_or_object))
+        if 'verify' in actions:
+            return True
+        additional = additional_frozen_actions or list()
+        for action in additional:
+            if action in actions:
+                return True
+        return False
 
     def _get_assigned_worksheets(self, analysis):
         """Return the assigned worksheets of this Analysis

--- a/bika/lims/browser/fields/aranalysesfield.py
+++ b/bika/lims/browser/fields/aranalysesfield.py
@@ -182,7 +182,7 @@ class ARAnalysesField(ObjectField):
                 continue
 
             # Skip Analyses in frozen states
-            if self._is_frozen(analysis, additional_frozen_actions=['retract']):
+            if self._is_frozen(analysis, "retract"):
                 logger.warn("Inactive/verified/retracted Analyses can not be "
                             "removed.")
                 continue
@@ -251,22 +251,21 @@ class ARAnalysesField(ObjectField):
         logger.warn(msg)
         return None
 
-    def _is_frozen(self, brain_or_object, additional_frozen_actions=None):
-        """Check if the passed in object is frozen: the objectt is cancelled,
+    def _is_frozen(self, brain_or_object, *frozen_transitions):
+        """Check if the passed in object is frozen: the object is cancelled,
         inactive or has been verified at some point
         :param brain_or_object: Analysis or AR Brain/Object
-        :param additional_frozen_actions: additional actions to check against
+        :param frozen_transitions: additional transitions that freeze the object
         :returns: True if the object is frozen
         """
         if not api.is_active(brain_or_object):
             return True
-        actions = getReviewHistoryActionsList(api.get_object(brain_or_object))
-        if 'verify' in actions:
+        object = api.get_object(brain_or_object)
+        frozen_trans = set(frozen_transitions)
+        frozen_trans.add('verify')
+        performed_transitions = set(getReviewHistoryActionsList(object))
+        if frozen_trans.intersection(performed_transitions):
             return True
-        additional = additional_frozen_actions or list()
-        for action in additional:
-            if action in actions:
-                return True
         return False
 
     def _get_assigned_worksheets(self, analysis):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/827

## Current behavior before PR

Cannot remove an analysis from an AR if it was retracted

## Desired behavior after PR is merged

The retracted analysis is kept, but the analysis that was created automatically due to retraction is removed, along with the addition of the new selected analysis.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
