### PR TITLE
Do not retract the whole AR when new analysis is added

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Fixed**
 
+- #821 Cannot retract single analysis services
 
 **Security**
 

--- a/bika/lims/subscribers/analysis.py
+++ b/bika/lims/subscribers/analysis.py
@@ -38,11 +38,7 @@ def ObjectInitializedEventHandler(instance, event):
         changeWorkflowState(instance, "bika_analysis_workflow", ar_state)
     elif ar_state in ('to_be_verified'):
         # Apply to AR only; we don't want this transition to cascade.
-        if 'workflow_skiplist' not in ar.REQUEST:
-            ar.REQUEST['workflow_skiplist'] = []
-        ar.REQUEST['workflow_skiplist'].append("retract all analyses")
-        wf_tool.doActionFor(ar, 'retract')
-        ar.REQUEST['workflow_skiplist'].remove("retract all analyses")
+        changeWorkflowState(ar, "bika_ar_workflow", "sample_received")
 
     return
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/821

## Current behavior before PR

The addition of a new analysis to an Analysis Request in `to_be_verified` state causes the retraction of all analyses it contains.

## Desired behavior after PR is merged

When a new Analysis is added to an AR that is in 'to_be_verified' state, the AR is rolled-back to `sample_received`, but without cascading the `retract` action to all analyses it contains.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
