### PR TITLE
Set new Calculation Interims to dependant services

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Changelog
 
 **Fixed**
 
+- #832 Set new calculation Interims to dependant services
+
 
 **Security**
 

--- a/bika/lims/content/calculation.py
+++ b/bika/lims/content/calculation.py
@@ -180,6 +180,25 @@ class Calculation(BaseFolder, HistoryAwareMixin):
                 row['value'] = 0
             new_value.append(row)
 
+        # extract the keywords from the new calculation interims
+        calculation_interim_keys = map(lambda i: i.get("keyword"), value)
+
+        # update all service interims
+        for service in self.getCalculationDependants():
+            # get the interims of the dependant service
+            service_interims = service.getInterimFields()
+            # extract the keywords from the service interims
+            service_interim_keys = map(lambda i: i.get("keyword"),
+                                       service_interims)
+            # sync new interims from the calculation -> service
+            new_interims = set(calculation_interim_keys).difference(
+                set(service_interim_keys))
+            for key in new_interims:
+                new_interim = value[calculation_interim_keys.index(key)]
+                service_interims.append(new_interim)
+            if new_interims:
+                service.setInterimFields(service_interims)
+
         self.getField('InterimFields').set(self, new_value)
 
     def setFormula(self, Formula=None):

--- a/bika/lims/content/calculation.py
+++ b/bika/lims/content/calculation.py
@@ -11,32 +11,28 @@ import math
 import re
 
 import transaction
-
-from zope.interface import implements
-
 from AccessControl import ClassSecurityInfo
-from Products.ATContentTypes.lib.historyaware import HistoryAwareMixin
-from Products.ATExtensions.field import RecordsField
+from bika.lims import bikaMessageFactory as _
+from bika.lims.api import get_object_by_uid
+from bika.lims.browser.fields import InterimFieldsField
+from bika.lims.browser.fields.uidreferencefield import UIDReferenceField
+from bika.lims.browser.fields.uidreferencefield import get_backreferences
+from bika.lims.browser.widgets import RecordsWidget as BikaRecordsWidget
+from bika.lims.config import PROJECTNAME
+from bika.lims.content.bikaschema import BikaSchema
+from bika.lims.interfaces.calculation import ICalculation
 from Products.Archetypes.atapi import BaseFolder
 from Products.Archetypes.atapi import ReferenceWidget
 from Products.Archetypes.atapi import Schema
 from Products.Archetypes.atapi import TextAreaWidget
 from Products.Archetypes.atapi import TextField
 from Products.Archetypes.atapi import registerType
-from Products.CMFCore.WorkflowCore import WorkflowException
+from Products.ATContentTypes.lib.historyaware import HistoryAwareMixin
+from Products.ATExtensions.field import RecordsField
 from Products.CMFCore.utils import getToolByName
+from Products.CMFCore.WorkflowCore import WorkflowException
 from Products.CMFPlone.utils import safe_unicode
-
-from bika.lims import bikaMessageFactory as _
-from bika.lims.api import get_object_by_uid
-from bika.lims.browser.fields import InterimFieldsField
-from bika.lims.browser.fields.uidreferencefield import UIDReferenceField
-from bika.lims.browser.fields.uidreferencefield import get_backreferences
-from bika.lims.browser.widgets import RecordsWidget
-from bika.lims.browser.widgets import RecordsWidget as BikaRecordsWidget
-from bika.lims.config import PROJECTNAME
-from bika.lims.content.bikaschema import BikaSchema
-from bika.lims.interfaces.calculation import ICalculation
+from zope.interface import implements
 
 
 schema = BikaSchema.copy() + Schema((

--- a/bika/lims/content/calculation.py
+++ b/bika/lims/content/calculation.py
@@ -225,7 +225,7 @@ class Calculation(BaseFolder, HistoryAwareMixin):
 
     def getCalculationDependencies(self, flat=False, deps=None):
         """ Recursively calculates all dependencies of this calculation.
-            The return value is dictionary of dictionaries (of dictionaries....)
+            The return value is dictionary of dictionaries (of dictionaries...)
 
             {service_UID1:
                 {service_UID2:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/830

## Current behavior before PR

New Calculation interims were not set to dependant services, which caused an error in the results calculation

## Desired behavior after PR is merged

New calculation interims are set to dependant services automatically

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
