### PR TITLE
Fix Duplication Action for Analysis Services

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Changelog
 
 **Fixed**
 
+- #834 Fix Duplication Action for Analysis Services
+
 
 **Security**
 

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -838,7 +838,7 @@
     }
 
     on_workflow_button_click(event) {
-      var $el, e, el, focus, form, form_id, transition;
+      var $el, e, el, focus, form, form_id, transition, url;
       /*
        * Eventhandler for the workflow buttons
        */
@@ -872,9 +872,10 @@
       }
       // If a custom_transitions action with a URL is clicked the form will be
       // submitted there
-      if ($el.attr("url") !== "") {
+      url = $el.attr("url");
+      if (url !== "") {
         form = $el.parents("form");
-        $(form).attr("action", $(this).attr("url"));
+        $(form).attr("action", url);
         return $(form).submit();
       }
     }

--- a/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
@@ -890,9 +890,10 @@ class window.BikaListingTableView
 
     # If a custom_transitions action with a URL is clicked the form will be
     # submitted there
-    if $el.attr("url") != ""
+    url = $el.attr "url"
+    if url != ""
       form = $el.parents("form")
-      $(form).attr "action", $(this).attr("url")
+      $(form).attr "action", url
       $(form).submit()
 
 

--- a/bika/lims/controlpanel/bika_analysisservices.py
+++ b/bika/lims/controlpanel/bika_analysisservices.py
@@ -5,12 +5,6 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from Products.ATContentTypes.content.schemata import finalizeATCTSchema
-from Products.Archetypes import atapi
-from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.utils import _createObjectByType, safe_unicode
-from Products.Five.browser import BrowserView
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.config import PROJECTNAME
@@ -19,21 +13,29 @@ from bika.lims.interfaces import IAnalysisServices
 from bika.lims.utils import tmpID
 from bika.lims.validators import ServiceKeywordValidator
 from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.folder.folder import ATFolder, ATFolderSchema
+from plone.app.folder.folder import ATFolder
+from plone.app.folder.folder import ATFolderSchema
 from plone.app.layout.globals.interfaces import IViewView
+from Products.Archetypes import atapi
+from Products.ATContentTypes.content.schemata import finalizeATCTSchema
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import _createObjectByType
+from Products.CMFPlone.utils import safe_unicode
+from Products.Five.browser import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from transaction import savepoint
 from zope.interface.declarations import implements
 
 
 class AnalysisServiceCopy(BrowserView):
-    template = ViewPageTemplateFile('templates/analysisservice_copy.pt')
+    template = ViewPageTemplateFile("templates/analysisservice_copy.pt")
     # should never be copied between services
     skip_fieldnames = [
-        'UID',
-        'id',
-        'title',
-        'ShortTitle',
-        'Keyword',
+        "UID",
+        "id",
+        "title",
+        "ShortTitle",
+        "Keyword",
     ]
     created = []
 
@@ -56,25 +58,28 @@ class AnalysisServiceCopy(BrowserView):
         if res is not True:
             self.savepoint.rollback()
             self.created = []
-            self.context.plone_utils.addPortalMessage(safe_unicode(res), 'info')
+            self.context.plone_utils.addPortalMessage(
+                safe_unicode(res), "info")
             return False
         return True
 
     def copy_service(self, src_uid, dst_title, dst_keyword):
-        uc = getToolByName(self.context, 'uid_catalog')
+        uc = getToolByName(self.context, "uid_catalog")
         src_service = uc(UID=src_uid)[0].getObject()
         dst_service = self.create_service(src_uid, dst_title, dst_keyword)
         if self.validate_service(dst_service):
             # copy field values
             for field in src_service.Schema().fields():
                 fieldname = field.getName()
-                if field.getType() == "Products.Archetypes.Field.ComputedField" \
+                fieldtype = field.getType()
+                if fieldtype == "Products.Archetypes.Field.ComputedField" \
                         or fieldname in self.skip_fieldnames:
                     continue
                 value = field.get(src_service)
                 if value:
                     # https://github.com/bikalabs/bika.lims/issues/2015
-                    if fieldname in ["UpperDetectionLimit", "LowerDetectionLimit"]:
+                    if fieldname in ["UpperDetectionLimit",
+                                     "LowerDetectionLimit"]:
                         value = str(value)
                     mutator_name = dst_service.getField(fieldname).mutator
                     mutator = getattr(dst_service, mutator_name)
@@ -85,9 +90,9 @@ class AnalysisServiceCopy(BrowserView):
             return False
 
     def __call__(self):
-        uc = getToolByName(self.context, 'uid_catalog')
-        if 'copy_form_submitted' not in self.request:
-            uids = self.request.form.get('uids', [])
+        uc = getToolByName(self.context, "uid_catalog")
+        if "copy_form_submitted" not in self.request:
+            uids = self.request.form.get("uids", [])
             self.services = []
             for uid in uids:
                 proxies = uc(UID=uid)
@@ -96,22 +101,22 @@ class AnalysisServiceCopy(BrowserView):
             return self.template()
         else:
             self.savepoint = savepoint()
-            sources = self.request.form.get('uids', [])
-            titles = self.request.form.get('dst_title', [])
-            keywords = self.request.form.get('dst_keyword', [])
+            sources = self.request.form.get("uids", [])
+            titles = self.request.form.get("dst_title", [])
+            keywords = self.request.form.get("dst_keyword", [])
             self.created = []
             for i, s in enumerate(sources):
                 if not titles[i]:
-                    message = _('Validation failed: title is required')
+                    message = _("Validation failed: title is required")
                     message = safe_unicode(message)
-                    self.context.plone_utils.addPortalMessage(message, 'info')
+                    self.context.plone_utils.addPortalMessage(message, "info")
                     self.savepoint.rollback()
                     self.created = []
                     break
                 if not keywords[i]:
-                    message = _('Validation failed: keyword is required')
+                    message = _("Validation failed: keyword is required")
                     message = safe_unicode(message)
-                    self.context.plone_utils.addPortalMessage(message, 'info')
+                    self.context.plone_utils.addPortalMessage(message, "info")
                     self.savepoint.rollback()
                     self.created = []
                     break
@@ -119,16 +124,17 @@ class AnalysisServiceCopy(BrowserView):
                 if title:
                     self.created.append(title)
             if len(self.created) > 1:
-                message = _('${items} were successfully created.',
+                message = _("${items} were successfully created.",
                             mapping={
-                                'items': safe_unicode(', '.join(self.created))})
+                                "items": safe_unicode(
+                                    ", ".join(self.created))})
             elif len(self.created) == 1:
-                message = _('${item} was successfully created.',
+                message = _("${item} was successfully created.",
                             mapping={
-                                'item': safe_unicode(self.created[0])})
+                                "item": safe_unicode(self.created[0])})
             else:
-                message = _('No new items were created.')
-            self.context.plone_utils.addPortalMessage(message, 'info')
+                message = _("No new items were created.")
+            self.context.plone_utils.addPortalMessage(message, "info")
             self.request.response.redirect(self.context.absolute_url())
 
 
@@ -141,12 +147,12 @@ class AnalysisServicesView(BikaListingView):
         super(AnalysisServicesView, self).__init__(context, request)
         self.an_cats = None
         self.an_cats_order = None
-        self.catalog = 'bika_setup_catalog'
-        self.contentFilter = {'portal_type': 'AnalysisService'}
+        self.catalog = "bika_setup_catalog"
+        self.contentFilter = {"portal_type": "AnalysisService"}
         self.context_actions = {
-            _('Add'):
-                {'url': 'createObject?type_name=AnalysisService',
-                 'icon': '++resource++bika.lims.images/add.png'}}
+            _("Add"):
+                {"url": "createObject?type_name=AnalysisService",
+                 "icon": "++resource++bika.lims.images/add.png"}}
         self.icon = self.portal_url + \
             "/++resource++bika.lims.images/analysisservice_big.png"
         self.title = self.context.translate(_("Analysis Services"))
@@ -156,7 +162,7 @@ class AnalysisServicesView(BikaListingView):
         self.show_select_column = True
         self.show_select_all_checkbox = False
         self.pagesize = 25
-        self.sort_on = 'sortable_title'
+        self.sort_on = "sortable_title"
         self.categories = []
         self.do_cats = self.context.bika_setup.getCategoriseAnalysisServices()
         if self.do_cats:
@@ -164,153 +170,157 @@ class AnalysisServicesView(BikaListingView):
             self.show_categories = True
             self.expand_all_categories = False
             self.ajax_categories = True
-            self.category_index = 'getCategoryTitle'
+            self.category_index = "getCategoryTitle"
 
         self.columns = {
-            'Title': {
-                'title': _('Service'),
-                'index': 'sortable_title',
-                'replace_url': 'absolute_url',
-                'sortable': not self.do_cats,
+            "Title": {
+                "title": _("Service"),
+                "index": "sortable_title",
+                "replace_url": "absolute_url",
+                "sortable": not self.do_cats,
             },
-            'Keyword': {
-                'title': _('Keyword'),
-                'index': 'getKeyword',
-                'attr': 'getKeyword',
-                'sortable': not self.do_cats,
+            "Keyword": {
+                "title": _("Keyword"),
+                "index": "getKeyword",
+                "attr": "getKeyword",
+                "sortable": not self.do_cats,
             },
-            'Category': {
-                'title': _('Category'),
-                'attr': 'getCategoryTitle',
-                'sortable': not self.do_cats,
+            "Category": {
+                "title": _("Category"),
+                "attr": "getCategoryTitle",
+                "sortable": not self.do_cats,
             },
-            'Methods': {
-                'title': _('Methods'),
-                'sortable': not self.do_cats,
+            "Methods": {
+                "title": _("Methods"),
+                "sortable": not self.do_cats,
             },
-            'Department': {
-                'title': _('Department'),
-                'toggle': False,
-                'attr': 'getDepartment.Title',
-                'sortable': not self.do_cats,
+            "Department": {
+                "title": _("Department"),
+                "toggle": False,
+                "attr": "getDepartment.Title",
+                "sortable": not self.do_cats,
             },
-            'Unit': {
-                'title': _('Unit'),
-                'attr': 'getUnit',
-                'sortable': False,
+            "Unit": {
+                "title": _("Unit"),
+                "attr": "getUnit",
+                "sortable": False,
             },
-            'Price': {
-                'title': _('Price'),
-                'sortable': not self.do_cats,
+            "Price": {
+                "title": _("Price"),
+                "sortable": not self.do_cats,
             },
-            'MaxTimeAllowed': {
-                'title': _('Max Time'),
-                'toggle': False,
-                'sortable': not self.do_cats,
+            "MaxTimeAllowed": {
+                "title": _("Max Time"),
+                "toggle": False,
+                "sortable": not self.do_cats,
             },
-            'DuplicateVariation': {
-                'title': _('Dup Var'),
-                'toggle': False,
-                'sortable': False,
+            "DuplicateVariation": {
+                "title": _("Dup Var"),
+                "toggle": False,
+                "sortable": False,
              },
-            'Calculation': {
-                'title': _('Calculation'),
-                'sortable': False,
+            "Calculation": {
+                "title": _("Calculation"),
+                "sortable": False,
             },
-            'CommercialID': {
-                'title': _('Commercial ID'),
-                'attr': 'getCommercialID',
-                'toggle': False,
-                'sortable': not self.do_cats,
+            "CommercialID": {
+                "title": _("Commercial ID"),
+                "attr": "getCommercialID",
+                "toggle": False,
+                "sortable": not self.do_cats,
             },
-            'ProtocolID': {
-                'title': _('Protocol ID'),
-                'attr': 'getProtocolID',
-                'toggle': False,
-                'sortable': not self.do_cats,
+            "ProtocolID": {
+                "title": _("Protocol ID"),
+                "attr": "getProtocolID",
+                "toggle": False,
+                "sortable": not self.do_cats,
             },
-            'SortKey': {
-                'title': _('Sort Key'),
-                'attr': 'getSortKey',
-                'sortable': False,
+            "SortKey": {
+                "title": _("Sort Key"),
+                "attr": "getSortKey",
+                "sortable": False,
             },
         }
 
+        copy_transition = {
+            "id": "duplicate",
+            "title": _("Duplicate"),
+            "url": "copy"
+        }
+
         self.review_states = [
-            {'id': 'default',
-             'title': _('Active'),
-             'contentFilter': {'inactive_state': 'active'},
-             'columns': ['Title',
-                         'Category',
-                         'Keyword',
-                         'Methods',
-                         'Department',
-                         'CommercialID',
-                         'ProtocolID',
-                         'Unit',
-                         'Price',
-                         'MaxTimeAllowed',
-                         'DuplicateVariation',
-                         'Calculation',
-                         'SortKey',
-                         ],
-             'custom_transitions': [{'id': 'duplicate',
-                                 'title': _('Duplicate'),
-                                 'url': 'copy'}, ]
-             },
-            {'id': 'inactive',
-             'title': _('Dormant'),
-             'contentFilter': {'inactive_state': 'inactive'},
-             'columns': ['Title',
-                         'Category',
-                         'Keyword',
-                         'Methods',
-                         'Department',
-                         'CommercialID',
-                         'ProtocolID',
-                         'Unit',
-                         'Price',
-                         'MaxTimeAllowed',
-                         'DuplicateVariation',
-                         'Calculation',
-                         'SortKey',
-                         ],
-             'custom_transitions': [{'id': 'duplicate',
-                                 'title': _('Duplicate'),
-                                 'url': 'copy'}, ]
-             },
-            {'id': 'all',
-             'title': _('All'),
-             'contentFilter': {},
-             'columns': ['Title',
-                         'Keyword',
-                         'Category',
-                         'Methods',
-                         'Department',
-                         'CommercialID',
-                         'ProtocolID',
-                         'Unit',
-                         'Price',
-                         'MaxTimeAllowed',
-                         'DuplicateVariation',
-                         'Calculation',
-                         'SortKey',
-                         ],
-             'custom_transitions': [{'id': 'duplicate',
-                                 'title': _('Duplicate'),
-                                 'url': 'copy'}, ]
-             },
+            {
+                "id": "default",
+                "title": _("Active"),
+                "contentFilter": {"inactive_state": "active"},
+                "columns": [
+                    "Title",
+                    "Category",
+                    "Keyword",
+                    "Methods",
+                    "Department",
+                    "CommercialID",
+                    "ProtocolID",
+                    "Unit",
+                    "Price",
+                    "MaxTimeAllowed",
+                    "DuplicateVariation",
+                    "Calculation",
+                    "SortKey",
+                ],
+                "custom_transitions": [copy_transition]
+            }, {
+                "id": "inactive",
+                "title": _("Dormant"),
+                "contentFilter": {"inactive_state": "inactive"},
+                "columns": [
+                    "Title",
+                    "Category",
+                    "Keyword",
+                    "Methods",
+                    "Department",
+                    "CommercialID",
+                    "ProtocolID",
+                    "Unit",
+                    "Price",
+                    "MaxTimeAllowed",
+                    "DuplicateVariation",
+                    "Calculation",
+                    "SortKey",
+                ],
+                "custom_transitions": [copy_transition]
+            }, {
+                "id": "all",
+                "title": _("All"),
+                "contentFilter": {},
+                "columns": [
+                    "Title",
+                    "Keyword",
+                    "Category",
+                    "Methods",
+                    "Department",
+                    "CommercialID",
+                    "ProtocolID",
+                    "Unit",
+                    "Price",
+                    "MaxTimeAllowed",
+                    "DuplicateVariation",
+                    "Calculation",
+                    "SortKey",
+                ],
+                "custom_transitions": [copy_transition]
+            },
         ]
 
         if not self.context.bika_setup.getShowPrices():
             for i in range(len(self.review_states)):
-                self.review_states[i]['columns'].remove('Price')
+                self.review_states[i]["columns"].remove("Price")
 
     def isItemAllowed(self, obj):
-        """
-        It checks if the item can be added to the list depending on the
-        department filter. If the analysis service is not assigned to a
-        department, show it.
+        """It checks if the item can be added to the list depending on the
+        department filter.
+
+        If the analysis service is not assigned to a department, show it.
         If department filtering is disabled in bika_setup, will return True.
         """
         if not self.context.bika_setup.getAllowDepartmentFiltering():
@@ -320,10 +330,11 @@ class AnalysisServicesView(BikaListingView):
         result = True
         if obj_dep:
             # Getting the cookie value
-            cookie_dep_uid = self.request.get('filter_by_department_info', 'no')
-            # Comparing departments' UIDs
+            cookie_dep_uid = self.request.get(
+                "filter_by_department_info", "no")
+            # Comparing departments" UIDs
             result = True if obj_dep.UID() in\
-                cookie_dep_uid.split(',') else False
+                cookie_dep_uid.split(",") else False
             return result
         return result
 
@@ -332,14 +343,14 @@ class AnalysisServicesView(BikaListingView):
         cat_order = self.an_cats_order.get(cat)
         if self.do_cats:
             # category is for bika_listing to groups entries
-            item['category'] = cat
+            item["category"] = cat
             if (cat, cat_order) not in self.categories:
                 self.categories.append((cat, cat_order))
 
         calculation = obj.getCalculation()
-        item['Calculation'] = calculation.Title() if calculation else ''
+        item["Calculation"] = calculation.Title() if calculation else ""
         if calculation:
-            item['replace']['Calculation'] = "<a href='%s'>%s</a>" % (
+            item["replace"]["Calculation"] = "<a href='%s'>%s</a>" % (
                 calculation.absolute_url() + "/edit", calculation.Title())
 
         item['Price'] = "%s.%02d" % obj.Price
@@ -351,45 +362,45 @@ class AnalysisServicesView(BikaListingView):
         m_anchors = []
         for title in m_titles:
             url = m_dict[title]
-            anchor = '<a href="{}">{}</a>'.format(url, title)
+            anchor = "<a href='{}'>{}</a>".format(url, title)
             m_anchors.append(anchor)
-        item['Methods'] = ', '.join(m_titles)
-        item['replace']['Methods'] = ', '.join(m_anchors)
+        item["Methods"] = ", ".join(m_titles)
+        item["replace"]["Methods"] = ", ".join(m_anchors)
 
         maxtime = obj.MaxTimeAllowed
         maxtime_string = ""
-        for field in ('days', 'hours', 'minutes'):
+        for field in ("days", "hours", "minutes"):
             if field in maxtime:
                 try:
                     val = int(maxtime[field])
                     if val > 0:
                         maxtime_string += "%s%s " % (val, _(field[0]))
-                except:
+                except:  # noqa FIXME remove blind except
                     pass
-        item['MaxTimeAllowed'] = maxtime_string
+        item["MaxTimeAllowed"] = maxtime_string
 
         if obj.DuplicateVariation:
-            item['DuplicateVariation'] = "%s.%02d" % obj.DuplicateVariation
+            item["DuplicateVariation"] = "%s.%02d" % obj.DuplicateVariation
         else:
-            item['DuplicateVariation'] = ""
+            item["DuplicateVariation"] = ""
 
-        after_icons = ''
+        after_icons = ""
         ipath = "++resource++bika.lims.images"
         if obj.getAccredited():
             after_icons += "<img src='%s/accredited.png' title='%s'>" % (
                 ipath, _("Accredited"))
-        if obj.getAttachmentOption() == 'r':
+        if obj.getAttachmentOption() == "r":
             after_icons += "<img src='%s/attach_reqd.png' title='%s'>" % (
                 ipath, _("Attachment required"))
-        if obj.getAttachmentOption() == 'n':
+        if obj.getAttachmentOption() == "n":
             after_icons += "<img src='%s/attach_no.png' title='%s'>" % (
-                ipath, _('Attachment not permitted'))
+                ipath, _("Attachment not permitted"))
         if after_icons:
-            item['after']['Title'] = after_icons
+            item["after"]["Title"] = after_icons
         return item
 
     def folderitems(self, full_objects=False, classic=True):
-        bsc = getToolByName(self.context, 'bika_setup_catalog')
+        bsc = getToolByName(self.context, "bika_setup_catalog")
         self.an_cats = bsc(
             portal_type="AnalysisCategory",
             sort_on="sortable_title")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/819

## Current behavior before PR

Clicking the "Duplicate" Button on Analysis Services listing resulted in a page reload

## Desired behavior after PR is merged

Clicking the "Duplicate" Button on Analysis Services listing navigates to the `/copy` View

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
