### PR TITLE
List only published ARs when "Published" Filter is active

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Changelog
 
 **Fixed**
 
+- #835 List only published ARs when "Published" Filter is active
+
 
 **Security**
 

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -377,7 +377,7 @@ class AnalysisRequestsView(BikaListingView):
                 "id": "published",
                 "title": _("Published"),
                 "contentFilter": {
-                    "review_state": ("published", "invalid"),
+                    "review_state": ("published"),
                     "sort_on": "created",
                     "sort_order": "descending",
                 },


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/818

## Current behavior before PR

Invalid ARs are listed in "Published" Filter

## Desired behavior after PR is merged

Only published ARs are listed in "Published" Filter

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
