### PR TITLE
Traceback on instance start

### DIFF
--- a/bika/lims/content/calculation.py
+++ b/bika/lims/content/calculation.py
@@ -79,7 +79,7 @@ schema = BikaSchema.copy() + Schema((
         subfield_validators={
             'module': 'importvalidator',
         },
-        widget=RecordsWidget(
+        widget=BikaRecordsWidget(
             label=_("Additional Python Libraries"),
             description=_(
                 "If your formula needs a special function from an external "
@@ -123,7 +123,7 @@ schema = BikaSchema.copy() + Schema((
         subfield_readonly={'keyword': True, 'value': False},
         subfield_types={'keyword': 'string', 'value': 'float'},
         default=[{'keyword': '', 'value': 0}],
-        widget=RecordsWidget(
+        widget=BikaRecordsWidget(
             label=_("Test Parameters"),
             description=_("To test the calculation, enter values here for all "
                           "calculation parameters.  This includes Interim "


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fixes a traceback due to PEP8 refactoring done here https://github.com/senaite/senaite.core/pull/832.

## Current behavior before PR

Instance does not start. The following error appears:

```
Traceback (most recent call last):
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/OFS/Application.py", line 723, in install_package
    init_func(newContext)
  File "/home/xispa/zinstance/src/senaite.core/bika/lims/__init__.py", line 76, in initialize
    from content.calculation import Calculation
  File "/home/xispa/zinstance/src/senaite.core/bika/lims/content/calculation.py", line 82, in <module>
    widget=RecordsWidget(
NameError: name 'RecordsWidget' is not defined
Traceback (most recent call last):
  File "/home/xispa/zinstance/parts/instance/bin/interpreter", line 328, in <module>
    exec(compile(__file__f.read(), __file__, "exec"))
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/Zope2/Startup/run.py", line 76, in <module>
    run()
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/Zope2/Startup/run.py", line 22, in run
    starter.prepare()
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/Zope2/Startup/__init__.py", line 92, in prepare
    self.startZope()
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/Zope2/Startup/__init__.py", line 268, in startZope
    Zope2.startup()
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/Zope2/__init__.py", line 47, in startup
    _startup()
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/Zope2/App/startup.py", line 131, in startup
    OFS.Application.initialize(application)
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/OFS/Application.py", line 251, in initialize
    initializer.initialize()
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/OFS/Application.py", line 277, in initialize
    self.install_products()
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/OFS/Application.py", line 504, in install_products
    return install_products(app)
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/OFS/Application.py", line 539, in install_products
    install_package(app, module, init_func, raise_exc=debug_mode)
  File "/home/xispa/buildout-cache/eggs/Zope2-2.13.26-py2.7.egg/OFS/Application.py", line 723, in install_package
    init_func(newContext)
  File "/home/xispa/zinstance/src/senaite.core/bika/lims/__init__.py", line 76, in initialize
    from content.calculation import Calculation
  File "/home/xispa/zinstance/src/senaite.core/bika/lims/content/calculation.py", line 82, in <module>
    widget=RecordsWidget(
NameError: name 'RecordsWidget' is not defined
``` 

## Desired behavior after PR is merged

Instance starts without problems

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
