### PR TITLE
Fix date range filter for "Data entry day book" report

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Changelog
 
 **Fixed**
 
+- #840 Fix date range filter for "Data entry day book" report
 - #828 Traceback when removing a retracted analysis through Manage Analyses view
 - #832 Set new calculation Interims to dependant services
 - #833 Fix sort order of interims in Calculations and Analysis Services

--- a/bika/lims/browser/reports/productivity_dataentrydaybook.py
+++ b/bika/lims/browser/reports/productivity_dataentrydaybook.py
@@ -15,6 +15,7 @@ from plone.app.layout.globals.interfaces import IViewView
 from zope.interface import implements
 from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 from Products.CMFCore.utils import getToolByName
+from bika.lims import logger
 
 
 class Report(BrowserView):
@@ -35,16 +36,20 @@ class Report(BrowserView):
         # Apply filters
         self.contentFilter = {'portal_type': 'AnalysisRequest'}
         val = self.selection_macros.parse_daterange(self.request,
-                                                    'created',
+                                                    'getDateCreated',
                                                     _('Date Created'))
         if val:
-            self.contentFilter[val['contentFilter'][0]] = val['contentFilter'][1]
+            self.contentFilter["created"] = val['contentFilter'][1]
             parms.append(val['parms'])
             titles.append(val['titles'])
 
         # Query the catalog and store results in a dictionary
         catalog = getToolByName(self.context, CATALOG_ANALYSIS_REQUEST_LISTING)
         ars = catalog(self.contentFilter)
+
+        logger.info("Catalog Query '{}' returned {} results".format(
+            self.contentFilter, len(ars)))
+
         if not ars:
             message = _("No Analysis Requests matched your query")
             self.context.plone_utils.addPortalMessage(message, "error")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/839

## Current behavior before PR

Date range filter ignored

## Desired behavior after PR is merged

Date range filter correctly parsed and passed to catalog query

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
