### PR TITLE
ARReferenceField doctest is failing

### DIFF
--- a/bika/lims/browser/fields/aranalysesfield.py
+++ b/bika/lims/browser/fields/aranalysesfield.py
@@ -195,11 +195,15 @@ class ARAnalysesField(ObjectField):
 
             # Unset the partition reference
             part = analysis.getSamplePartition()
-            an_uid = api.get_uid(analysis)
-            part_ans = part.getAnalyses() or []
-            part_ans = filter(lambda an: api.get_uid(an) != an_uid, part_ans)
-            # Unset the Partition-to-Analysis reference
-            part.setAnalyses(part_ans)
+            if part:
+                # From this partition, remove the reference to the current
+                # analysis that is going to be removed to prevent inconsistent
+                # states (Sample Partitions referencing to Analyses that do not
+                # exist anymore
+                an_uid = api.get_uid(analysis)
+                part_ans = part.getAnalyses() or []
+                part_ans = filter(lambda an: api.get_uid(an) != an_uid, part_ans)
+                part.setAnalyses(part_ans)
             # Unset the Analysis-to-Partition reference
             analysis.setSamplePartition(None)
             delete_ids.append(analysis.getId())


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Makes the `ARAnalysesField.rst` doctest to pass again.

At this point, https://github.com/senaite/senaite.core/blob/5cd022e48601332f8353c7b61935b889da203765/bika/lims/browser/fields/aranalysesfield.py#L197 might happen the analysis to be removed does not have a partition assigned already, precisely because of the inherent recursive behavior caused by lines L202 + L204:

https://github.com/senaite/senaite.core/blob/5cd022e48601332f8353c7b61935b889da203765/bika/lims/browser/fields/aranalysesfield.py#L201-L204

Even though, this is temporary and will only happen during the process of assigning/unassigning analyses here inside this set func.

## Current behavior before PR

Test `ARAnalysesField.rst` fails

## Desired behavior after PR is merged

Test `ARAnalysesField.rst` passes

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
