### PR TITLE
Re-compiled Coffee-Scripts with version 1.12.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Changelog
 
 **Fixed**
 
+- #842 Re-compiled Coffee-Scripts with version 1.12.7 
 - #824 Instrument Listing Views Fixes and Refactoring
 - #840 Fix date range filter for "Data entry day book" report
 - #828 Traceback when removing a retracted analysis through Manage Analyses view

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -1,95 +1,84 @@
-(function() {
-  /* Please use this command to compile this file into the parent `js` directory:
-      coffee --no-header -w -o ../ -c bika.lims.analysisrequest.add.coffee
-  */
-  var hasProp = {}.hasOwnProperty,
-    indexOf = [].indexOf;
 
-  window.AnalysisRequestAdd = class AnalysisRequestAdd {
-    constructor() {
-      this.load = this.load.bind(this);
-      /* METHODS */
-      this.bind_eventhandler = this.bind_eventhandler.bind(this);
-      this.debounce = this.debounce.bind(this);
-      this.template_dialog = this.template_dialog.bind(this);
-      this.render_template = this.render_template.bind(this);
-      this.get_global_settings = this.get_global_settings.bind(this);
-      this.recalculate_records = this.recalculate_records.bind(this);
-      this.recalculate_prices = this.recalculate_prices.bind(this);
-      this.update_form = this.update_form.bind(this);
-      this.get_portal_url = this.get_portal_url.bind(this);
-      this.get_base_url = this.get_base_url.bind(this);
-      this.get_authenticator = this.get_authenticator.bind(this);
-      this.get_form = this.get_form.bind(this);
-      this.get_fields = this.get_fields.bind(this);
-      this.get_field_by_id = this.get_field_by_id.bind(this);
-      this.set_reference_field_query = this.set_reference_field_query.bind(this);
-      this.set_reference_field = this.set_reference_field.bind(this);
-      this.set_client = this.set_client.bind(this);
-      this.set_contact = this.set_contact.bind(this);
-      this.set_sample = this.set_sample.bind(this);
-      this.set_sampletype = this.set_sampletype.bind(this);
-      this.set_template = this.set_template.bind(this);
-      this.set_service = this.set_service.bind(this);
-      this.set_service_spec = this.set_service_spec.bind(this);
-      this.get_service = this.get_service.bind(this);
-      this.hide_all_service_info = this.hide_all_service_info.bind(this);
-      /* EVENT HANDLER */
-      this.on_client_changed = this.on_client_changed.bind(this);
-      this.on_contact_changed = this.on_contact_changed.bind(this);
-      this.on_analysis_specification_changed = this.on_analysis_specification_changed.bind(this);
-      this.on_analysis_details_click = this.on_analysis_details_click.bind(this);
-      this.on_analysis_lock_button_click = this.on_analysis_lock_button_click.bind(this);
-      this.on_sample_changed = this.on_sample_changed.bind(this);
-      this.on_sampletype_changed = this.on_sampletype_changed.bind(this);
-      this.on_specification_changed = this.on_specification_changed.bind(this);
-      this.on_analysis_template_changed = this.on_analysis_template_changed.bind(this);
-      this.on_analysis_profile_selected = this.on_analysis_profile_selected.bind(this);
-      // Note: Context of callback bound to this object
-      this.on_analysis_profile_removed = this.on_analysis_profile_removed.bind(this);
-      this.on_analysis_checkbox_click = this.on_analysis_checkbox_click.bind(this);
-      this.on_service_listing_header_click = this.on_service_listing_header_click.bind(this);
-      this.on_service_category_click = this.on_service_category_click.bind(this);
-      this.on_copy_button_click = this.on_copy_button_click.bind(this);
-      // Note: Context of callback bound to this object
-      this.ajax_post_form = this.ajax_post_form.bind(this);
-      this.on_ajax_start = this.on_ajax_start.bind(this);
-      this.on_ajax_end = this.on_ajax_end.bind(this);
-      // Note: Context of callback bound to this object
-      this.on_form_submit = this.on_form_submit.bind(this);
-      this.init_file_fields = this.init_file_fields.bind(this);
+/* Please use this command to compile this file into the parent `js` directory:
+    coffee --no-header -w -o ../ -c bika.lims.analysisrequest.add.coffee
+ */
+
+(function() {
+  var bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
+    slice = [].slice,
+    hasProp = {}.hasOwnProperty,
+    indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
+
+  window.AnalysisRequestAdd = (function() {
+    function AnalysisRequestAdd() {
+      this.init_file_fields = bind(this.init_file_fields, this);
+      this.on_form_submit = bind(this.on_form_submit, this);
+      this.on_ajax_end = bind(this.on_ajax_end, this);
+      this.on_ajax_start = bind(this.on_ajax_start, this);
+      this.ajax_post_form = bind(this.ajax_post_form, this);
+      this.on_copy_button_click = bind(this.on_copy_button_click, this);
+      this.on_service_category_click = bind(this.on_service_category_click, this);
+      this.on_service_listing_header_click = bind(this.on_service_listing_header_click, this);
+      this.on_analysis_checkbox_click = bind(this.on_analysis_checkbox_click, this);
+      this.on_analysis_profile_removed = bind(this.on_analysis_profile_removed, this);
+      this.on_analysis_profile_selected = bind(this.on_analysis_profile_selected, this);
+      this.on_analysis_template_changed = bind(this.on_analysis_template_changed, this);
+      this.on_specification_changed = bind(this.on_specification_changed, this);
+      this.on_sampletype_changed = bind(this.on_sampletype_changed, this);
+      this.on_sample_changed = bind(this.on_sample_changed, this);
+      this.on_analysis_lock_button_click = bind(this.on_analysis_lock_button_click, this);
+      this.on_analysis_details_click = bind(this.on_analysis_details_click, this);
+      this.on_analysis_specification_changed = bind(this.on_analysis_specification_changed, this);
+      this.on_contact_changed = bind(this.on_contact_changed, this);
+      this.on_client_changed = bind(this.on_client_changed, this);
+      this.hide_all_service_info = bind(this.hide_all_service_info, this);
+      this.get_service = bind(this.get_service, this);
+      this.set_service_spec = bind(this.set_service_spec, this);
+      this.set_service = bind(this.set_service, this);
+      this.set_template = bind(this.set_template, this);
+      this.set_sampletype = bind(this.set_sampletype, this);
+      this.set_sample = bind(this.set_sample, this);
+      this.set_contact = bind(this.set_contact, this);
+      this.set_client = bind(this.set_client, this);
+      this.set_reference_field = bind(this.set_reference_field, this);
+      this.set_reference_field_query = bind(this.set_reference_field_query, this);
+      this.get_field_by_id = bind(this.get_field_by_id, this);
+      this.get_fields = bind(this.get_fields, this);
+      this.get_form = bind(this.get_form, this);
+      this.get_authenticator = bind(this.get_authenticator, this);
+      this.get_base_url = bind(this.get_base_url, this);
+      this.get_portal_url = bind(this.get_portal_url, this);
+      this.update_form = bind(this.update_form, this);
+      this.recalculate_prices = bind(this.recalculate_prices, this);
+      this.recalculate_records = bind(this.recalculate_records, this);
+      this.get_global_settings = bind(this.get_global_settings, this);
+      this.render_template = bind(this.render_template, this);
+      this.template_dialog = bind(this.template_dialog, this);
+      this.debounce = bind(this.debounce, this);
+      this.bind_eventhandler = bind(this.bind_eventhandler, this);
+      this.load = bind(this.load, this);
     }
 
-    load() {
+    AnalysisRequestAdd.prototype.load = function() {
       console.debug("AnalysisRequestAdd::load");
-      // load translations
       jarn.i18n.loadCatalog('bika');
       this._ = window.jarn.i18n.MessageFactory('bika');
-      // disable browser autocomplete
       $('input[type=text]').prop('autocomplete', 'off');
-      // storage for global Bika settings
       this.global_settings = {};
-      // services data snapshot from recalculate_records
-      // returns a mapping of arnum -> services data
       this.records_snapshot = {};
-      // brain for already applied templates
       this.applied_templates = {};
-      // Remove the '.blurrable' class to avoid inline field validation
       $(".blurrable").removeClass("blurrable");
-      // bind the event handler to the elements
       this.bind_eventhandler();
-      // N.B.: The new AR Add form handles File fields like this:
-      // - File fields can carry more than one field (see init_file_fields)
-      // - All uploaded files are extracted and added as attachments to the new created AR
-      // - The file field itself (Plone) will stay empty therefore
       this.init_file_fields();
-      // get the global settings on load
       this.get_global_settings();
-      // recalculate records on load (needed for AR copies)
       return this.recalculate_records();
-    }
+    };
 
-    bind_eventhandler() {
+
+    /* METHODS */
+
+    AnalysisRequestAdd.prototype.bind_eventhandler = function() {
+
       /*
        * Binds callbacks on elements
        *
@@ -98,70 +87,49 @@
        *
        */
       console.debug("AnalysisRequestAdd::bind_eventhandler");
-      // Categories header clicked
       $("body").on("click", ".service-listing-header", this.on_service_listing_header_click);
-      // Category toggle button clicked
       $("body").on("click", "tr.category", this.on_service_category_click);
-      // Save button clicked
       $("body").on("click", "[name='save_button']", this.on_form_submit);
-      // AdHoc Checkbox clicked
       $("body").on("click", "tr[fieldname=AdHoc] input[type='checkbox']", this.recalculate_records);
-      // Composite Checkbox clicked
       $("body").on("click", "tr[fieldname=Composite] input[type='checkbox']", this.recalculate_records);
-      // InvoiceExclude Checkbox clicked
       $("body").on("click", "tr[fieldname=InvoiceExclude] input[type='checkbox']", this.recalculate_records);
-      // Analysis Checkbox clicked
       $("body").on("click", "tr[fieldname=Analyses] input[type='checkbox']", this.on_analysis_checkbox_click);
-      // Client changed
       $("body").on("selected change", "tr[fieldname=Client] input[type='text']", this.on_client_changed);
-      // Contact changed
       $("body").on("selected change", "tr[fieldname=Contact] input[type='text']", this.on_contact_changed);
-      // Analysis Specification changed
       $("body").on("change", "input.min", this.on_analysis_specification_changed);
       $("body").on("change", "input.max", this.on_analysis_specification_changed);
       $("body").on("change", "input.warn_min", this.on_analysis_specification_changed);
       $("body").on("change", "input.warn_max", this.on_analysis_specification_changed);
-      // Analysis lock button clicked
       $("body").on("click", ".service-lockbtn", this.on_analysis_lock_button_click);
-      // Analysis info button clicked
       $("body").on("click", ".service-infobtn", this.on_analysis_details_click);
-      // Sample changed
       $("body").on("selected change", "tr[fieldname=Sample] input[type='text']", this.on_sample_changed);
-      // SampleType changed
       $("body").on("selected change", "tr[fieldname=SampleType] input[type='text']", this.on_sampletype_changed);
-      // Specification changed
       $("body").on("selected change", "tr[fieldname=Specification] input[type='text']", this.on_specification_changed);
-      // Analysis Template changed
       $("body").on("selected change", "tr[fieldname=Template] input[type='text']", this.on_analysis_template_changed);
-      // Analysis Profile selected
       $("body").on("selected", "tr[fieldname=Profiles] input[type='text']", this.on_analysis_profile_selected);
-      // Analysis Profile deselected
       $("body").on("click", "tr[fieldname=Profiles] img.deletebtn", this.on_analysis_profile_removed);
-      // Copy button clicked
       $("body").on("click", "img.copybutton", this.on_copy_button_click);
+
       /* internal events */
-      // handle value changes in the form
       $(this).on("form:changed", this.debounce(this.recalculate_records, 500));
-      // recalculate prices after data changed
       $(this).on("data:updated", this.debounce(this.recalculate_prices, 3000));
-      // update form from records after the data changed
       $(this).on("data:updated", this.debounce(this.update_form, 300));
-      // hide open service info after data changed
       $(this).on("data:updated", this.debounce(this.hide_all_service_info, 300));
-      // handle Ajax events
       $(this).on("ajax:start", this.on_ajax_start);
       return $(this).on("ajax:end", this.on_ajax_end);
-    }
+    };
 
-    debounce(func, threshold, execAsap) {
+    AnalysisRequestAdd.prototype.debounce = function(func, threshold, execAsap) {
+
       /*
        * Debounce a function call
        * See: https://coffeescript-cookbook.github.io/chapters/functions/debounce
        */
       var timeout;
       timeout = null;
-      return function(...args) {
-        var delayed, obj;
+      return function() {
+        var args, delayed, obj;
+        args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
         obj = this;
         delayed = function() {
           if (!execAsap) {
@@ -176,88 +144,80 @@
         }
         return timeout = setTimeout(delayed, threshold || 100);
       };
-    }
+    };
 
-    template_dialog(template_id, context, buttons) {
-      var content;
+    AnalysisRequestAdd.prototype.template_dialog = function(template_id, context, buttons) {
+
       /*
        * Render the content of a Handlebars template in a jQuery UID dialog
          [1] http://handlebarsjs.com/
          [2] https://jqueryui.com/dialog/
        */
-      // prepare the buttons
+      var content;
       if (buttons == null) {
         buttons = {};
         buttons[this._("Yes")] = function() {
-          // trigger 'yes' event
           $(this).trigger("yes");
           return $(this).dialog("close");
         };
         buttons[this._("No")] = function() {
-          // trigger 'no' event
           $(this).trigger("no");
           return $(this).dialog("close");
         };
       }
-      // render the Handlebars template
       content = this.render_template(template_id, context);
-      // render the dialog box
       return $(content).dialog({
         width: 450,
         resizable: false,
         closeOnEscape: false,
         buttons: buttons,
         open: function(event, ui) {
-          // Hide the X button on the top right border
           return $(".ui-dialog-titlebar-close").hide();
         }
       });
-    }
+    };
 
-    render_template(template_id, context) {
-      var content, source, template;
+    AnalysisRequestAdd.prototype.render_template = function(template_id, context) {
+
       /*
        * Render Handlebars JS template
        */
-      // get the template by ID
-      source = $(`#${template_id}`).html();
+      var content, source, template;
+      source = $("#" + template_id).html();
       if (!source) {
         return;
       }
-      // Compile the handlebars template
       template = Handlebars.compile(source);
-      // Render the template with the given context
       content = template(context);
       return content;
-    }
+    };
 
-    get_global_settings() {
+    AnalysisRequestAdd.prototype.get_global_settings = function() {
+
       /*
        * Submit all form values to the server to recalculate the records
        */
       return this.ajax_post_form("get_global_settings").done(function(settings) {
         console.debug("Global Settings:", settings);
-        // remember the global settings
         this.global_settings = settings;
-        // trigger event for whom it might concern
         return $(this).trigger("settings:updated", settings);
       });
-    }
+    };
 
-    recalculate_records() {
+    AnalysisRequestAdd.prototype.recalculate_records = function() {
+
       /*
        * Submit all form values to the server to recalculate the records
        */
       return this.ajax_post_form("recalculate_records").done(function(records) {
         console.debug("Recalculate Analyses: Records=", records);
-        // remember a services snapshot
         this.records_snapshot = records;
-        // trigger event for whom it might concern
         return $(this).trigger("data:updated", records);
       });
-    }
+    };
 
-    recalculate_prices() {
+    AnalysisRequestAdd.prototype.recalculate_prices = function() {
+
       /*
        * Submit all form values to the server to recalculate the prices of all columns
        */
@@ -271,70 +231,53 @@
         for (arnum in data) {
           if (!hasProp.call(data, arnum)) continue;
           prices = data[arnum];
-          $(`#discount-${arnum}`).text(prices.discount);
-          $(`#subtotal-${arnum}`).text(prices.subtotal);
-          $(`#vat-${arnum}`).text(prices.vat);
-          $(`#total-${arnum}`).text(prices.total);
+          $("#discount-" + arnum).text(prices.discount);
+          $("#subtotal-" + arnum).text(prices.subtotal);
+          $("#vat-" + arnum).text(prices.vat);
+          $("#total-" + arnum).text(prices.total);
         }
-        // trigger event for whom it might concern
         return $(this).trigger("prices:updated", data);
       });
-    }
+    };
 
-    update_form(event, records) {
-      var me;
+    AnalysisRequestAdd.prototype.update_form = function(event, records) {
+
       /*
        * Update form according to the server data
        */
+      var me;
       console.debug("*** update_form ***");
       me = this;
-      // initially hide all lock icons
       $(".service-lockbtn").hide();
-      // set all values for one record (a single column in the AR Add form)
       return $.each(records, function(arnum, record) {
-        // set client
         $.each(record.client_metadata, function(uid, client) {
           return me.set_client(arnum, client);
         });
-        // set contact
         $.each(record.contact_metadata, function(uid, contact) {
           return me.set_contact(arnum, contact);
         });
-        // set services
         $.each(record.service_metadata, function(uid, metadata) {
           var lock;
-          // lock icon (to be displayed when the service cannot be deselected)
-          lock = $(`#${uid}-${arnum}-lockbtn`);
-          // service is included in a profile
+          lock = $("#" + uid + "-" + arnum + "-lockbtn");
           if (uid in record.service_to_profiles) {
             lock.show();
           }
-          // service is part of the template
-          // if uid of record.service_to_templates
-          //   lock.show()
-
-          // select the service
           return me.set_service(arnum, uid, true);
         });
-        // set template
         $.each(record.template_metadata, function(uid, template) {
           return me.set_template(arnum, template);
         });
-        // set specification
         $.each(record.specification_metadata, function(uid, spec) {
           return $.each(spec.specifications, function(uid, service_spec) {
             return me.set_service_spec(arnum, uid, service_spec);
           });
         });
-        // set sample
         $.each(record.sample_metadata, function(uid, sample) {
           return me.set_sample(arnum, sample);
         });
-        // set sampletype
         $.each(record.sampletype_metadata, function(uid, sampletype) {
           return me.set_sampletype(arnum, sampletype);
         });
-        // handle unmet dependencies, one at a time
         return $.each(record.unmet_dependencies, function(uid, dependencies) {
           var context, dialog, service;
           service = record.service_metadata[uid];
@@ -344,35 +287,32 @@
           };
           dialog = me.template_dialog("dependency-add-template", context);
           dialog.on("yes", function() {
-            // select the services
             $.each(dependencies, function(index, service) {
               return me.set_service(arnum, service.uid, true);
             });
-            // trigger form:changed event
             return $(me).trigger("form:changed");
           });
           dialog.on("no", function() {
-            // deselect the dependant service
             me.set_service(arnum, uid, false);
-            // trigger form:changed event
             return $(me).trigger("form:changed");
           });
-          // break the iteration after the first loop to avoid multiple dialogs.
           return false;
         });
       });
-    }
+    };
 
-    get_portal_url() {
+    AnalysisRequestAdd.prototype.get_portal_url = function() {
+
       /*
        * Return the portal url (calculated in code)
        */
       var url;
       url = $("input[name=portal_url]").val();
       return url;
-    }
+    };
 
-    get_base_url() {
+    AnalysisRequestAdd.prototype.get_base_url = function() {
+
       /*
        * Return the current (relative) base url
        */
@@ -382,23 +322,26 @@
         return base_url.split("/portal_factory")[0];
       }
       return base_url.split("/ar_add")[0];
-    }
+    };
 
-    get_authenticator() {
+    AnalysisRequestAdd.prototype.get_authenticator = function() {
+
       /*
        * Get the authenticator value
        */
       return $("input[name='_authenticator']").val();
-    }
+    };
 
-    get_form() {
+    AnalysisRequestAdd.prototype.get_form = function() {
+
       /*
        * Return the form element
        */
       return $("#analysisrequest_add_form");
-    }
+    };
 
-    get_fields(arnum) {
+    AnalysisRequestAdd.prototype.get_fields = function(arnum) {
+
       /*
        * Get all fields of the form
        */
@@ -406,35 +349,32 @@
       form = this.get_form();
       fields_selector = "tr[fieldname] td[arnum] input";
       if (arnum != null) {
-        fields_selector = `tr[fieldname] td[arnum=${arnum}] input`;
+        fields_selector = "tr[fieldname] td[arnum=" + arnum + "] input";
       }
       fields = $(fields_selector, form);
       return fields;
-    }
+    };
 
-    get_field_by_id(id, arnum) {
-      var field_id, name, suffix;
+    AnalysisRequestAdd.prototype.get_field_by_id = function(id, arnum) {
+
       /*
        * Query the field by id
        */
-      // split the fieldname from the suffix
-      [name, suffix] = id.split("_");
-      // append the arnum
-      field_id = `${name}-${arnum}`;
-      // append the suffix if it is there
+      var field_id, name, ref, suffix;
+      ref = id.split("_"), name = ref[0], suffix = ref[1];
+      field_id = name + "-" + arnum;
       if (suffix != null) {
-        field_id = `${field_id}_${suffix}`;
+        field_id = field_id + "_" + suffix;
       }
-      // prepend a hash if it is not there
       if (!id.startsWith("#")) {
-        field_id = `#${field_id}`;
+        field_id = "#" + field_id;
       }
-      console.debug(`get_field_by_id: $(${field_id})`);
-      // query the field
+      console.debug("get_field_by_id: $(" + field_id + ")");
       return $(field_id);
-    }
+    };
 
-    flush_reference_field(field) {
+    AnalysisRequestAdd.prototype.flush_reference_field = function(field) {
+
       /*
        * Empty the reference field
        */
@@ -443,52 +383,52 @@
       if (!catalog_name) {
         return;
       }
-      // flush values
       field.val("");
       $("input[type=hidden]", field.parent()).val("");
       return $(".multiValued-listing", field.parent()).empty();
-    }
+    };
 
-    set_reference_field_query(field, query, type = "base_query") {
+    AnalysisRequestAdd.prototype.set_reference_field_query = function(field, query, type) {
+      var catalog_name, catalog_query, new_query, options, url;
+      if (type == null) {
+        type = "base_query";
+      }
+
       /*
        * Set the catalog search query for the given reference field
        * XXX This is lame! The field should provide a proper API.
        */
-      var catalog_name, catalog_query, new_query, options, url;
       catalog_name = field.attr("catalog_name");
       if (!catalog_name) {
         return;
       }
-      // get the combogrid options
       options = $.parseJSON(field.attr("combogrid_options"));
-      // prepare the new query url
       url = this.get_base_url();
-      url += `/${options.url}`;
-      url += `?_authenticator=${this.get_authenticator()}`;
-      url += `&catalog_name=${catalog_name}`;
-      url += `&colModel=${$.toJSON(options.colModel)}`;
-      url += `&search_fields=${$.toJSON(options.search_fields)}`;
-      url += `&discard_empty=${$.toJSON(options.discard_empty)}`;
-      // get the current query (either "base_query" or "search_query" attribute)
+      url += "/" + options.url;
+      url += "?_authenticator=" + (this.get_authenticator());
+      url += "&catalog_name=" + catalog_name;
+      url += "&colModel=" + ($.toJSON(options.colModel));
+      url += "&search_fields=" + ($.toJSON(options.search_fields));
+      url += "&discard_empty=" + ($.toJSON(options.discard_empty));
       catalog_query = $.parseJSON(field.attr(type));
-      // update this query with the passed in query
       $.extend(catalog_query, query);
       new_query = $.toJSON(catalog_query);
-      console.debug(`set_reference_field_query: query=${new_query}`);
+      console.debug("set_reference_field_query: query=" + new_query);
       if (type === 'base_query') {
-        url += `&base_query=${new_query}`;
-        url += `&search_query=${field.attr('search_query')}`;
+        url += "&base_query=" + new_query;
+        url += "&search_query=" + (field.attr('search_query'));
       } else {
-        url += `&base_query=${field.attr('base_query')}`;
-        url += `&search_query=${new_query}`;
+        url += "&base_query=" + (field.attr('base_query'));
+        url += "&search_query=" + new_query;
       }
       options.url = url;
       options.force_all = "false";
       field.combogrid(options);
       return field.attr("search_query", "{}");
-    }
+    };
 
-    set_reference_field(field, uid, title) {
+    AnalysisRequestAdd.prototype.set_reference_field = function(field, uid, title) {
+
       /*
        * Set the value and the uid of a reference field
        * XXX This is lame! The field should handle this on data change.
@@ -497,34 +437,29 @@
       me = this;
       $field = $(field);
       if (!$field.length) {
-        console.debug(`field ${field} does not exist, skip set_reference_field`);
+        console.debug("field " + field + " does not exist, skip set_reference_field");
         return;
       }
       $parent = field.closest("div.field");
       fieldname = field.attr("name");
-      console.debug(`set_reference_field:: field=${fieldname} uid=${uid} title=${title}`);
+      console.debug("set_reference_field:: field=" + fieldname + " uid=" + uid + " title=" + title);
       uids_field = $("input[type=hidden]", $parent);
       existing_uids = uids_field.val();
-      // uid is already selected
       if (existing_uids.indexOf(uid) >= 0) {
         return;
       }
-      // nothing in the field -> uid is the first entry
       if (existing_uids.length === 0) {
         uids_field.val(uid);
       } else {
-        // append to the list
         uids = uids_field.val().split(",");
         uids.push(uid);
         uids_field.val(uids.join(","));
       }
-      // set the title as the value
       $field.val(title);
-      // handle multivalued reference fields
       mvl = $(".multiValued-listing", $parent);
       if (mvl.length > 0) {
         portal_url = this.get_portal_url();
-        src = `${portal_url}/++resource++bika.lims.images/delete.png`;
+        src = portal_url + "/++resource++bika.lims.images/delete.png";
         img = $("<img class='deletebtn'/>");
         img.attr("src", src);
         img.attr("data-contact-title", title);
@@ -537,10 +472,10 @@
         mvl.append(div);
         return $field.val("");
       }
-    }
+    };
 
-    set_client(arnum, client) {
-      var contact_title, contact_uid, field, query;
+    AnalysisRequestAdd.prototype.set_client = function(arnum, client) {
+
       /*
        * Filter Contacts
        * Filter CCContacts
@@ -550,12 +485,10 @@
        * Filter Specification
        * Filter SamplingRound
        */
-      // filter Contacts
-      field = $(`#Contact-${arnum}`);
+      var contact_title, contact_uid, field, query;
+      field = $("#Contact-" + arnum);
       query = client.filter_queries.contact;
       this.set_reference_field_query(field, query);
-      // handle default contact for /analysisrequests listing
-      // https://github.com/senaite/senaite.core/issues/705
       if (document.URL.indexOf("analysisrequests") > -1) {
         contact_title = client.default_contact.title;
         contact_uid = client.default_contact.uid;
@@ -563,146 +496,124 @@
           this.set_reference_field(field, contact_uid, contact_title);
         }
       }
-      // filter CCContacts
-      field = $(`#CCContact-${arnum}`);
+      field = $("#CCContact-" + arnum);
       query = client.filter_queries.cc_contact;
       this.set_reference_field_query(field, query);
-      // filter InvoiceContact
-      // XXX Where is this field?
-      field = $(`#InvoiceContact-${arnum}`);
+      field = $("#InvoiceContact-" + arnum);
       query = client.filter_queries.invoice_contact;
       this.set_reference_field_query(field, query);
-      // filter Sample Points
-      field = $(`#SamplePoint-${arnum}`);
+      field = $("#SamplePoint-" + arnum);
       query = client.filter_queries.samplepoint;
       this.set_reference_field_query(field, query);
-      // filter AR Templates
-      field = $(`#Template-${arnum}`);
+      field = $("#Template-" + arnum);
       query = client.filter_queries.artemplates;
       this.set_reference_field_query(field, query);
-      // filter Analysis Profiles
-      field = $(`#Profiles-${arnum}`);
+      field = $("#Profiles-" + arnum);
       query = client.filter_queries.analysisprofiles;
       this.set_reference_field_query(field, query);
-      // filter Analysis Specs
-      field = $(`#Specification-${arnum}`);
+      field = $("#Specification-" + arnum);
       query = client.filter_queries.analysisspecs;
       this.set_reference_field_query(field, query);
-      // filter Samplinground
-      field = $(`#SamplingRound-${arnum}`);
+      field = $("#SamplingRound-" + arnum);
       query = client.filter_queries.samplinground;
       this.set_reference_field_query(field, query);
-      // filter Sample
-      field = $(`#Sample-${arnum}`);
+      field = $("#Sample-" + arnum);
       query = client.filter_queries.sample;
       return this.set_reference_field_query(field, query);
-    }
+    };
 
-    set_contact(arnum, contact) {
+    AnalysisRequestAdd.prototype.set_contact = function(arnum, contact) {
+
       /*
        * Set CC Contacts
        */
       var field, me;
       me = this;
-      field = $(`#CCContact-${arnum}`);
+      field = $("#CCContact-" + arnum);
       return $.each(contact.cccontacts, function(uid, cccontact) {
         var fullname;
         fullname = cccontact.fullname;
         return me.set_reference_field(field, uid, fullname);
       });
-    }
+    };
 
-    set_sample(arnum, sample) {
-      var field, title, uid, value;
+    AnalysisRequestAdd.prototype.set_sample = function(arnum, sample) {
+
       /*
        * Apply the sample data to all fields of arnum
        */
-      // set the sampling date
-      field = $(`#SamplingDate-${arnum}`);
+      var field, title, uid, value;
+      field = $("#SamplingDate-" + arnum);
       value = sample.sampling_date;
       field.val(value);
-      // set the date sampeld
-      field = $(`#DateSampled-${arnum}`);
+      field = $("#DateSampled-" + arnum);
       value = sample.date_sampled;
       field.val(value);
-      // set the sample type (required)
-      field = $(`#SampleType-${arnum}`);
+      field = $("#SampleType-" + arnum);
       uid = sample.sample_type_uid;
       title = sample.sample_type_title;
       this.set_reference_field(field, uid, title);
-      // set environmental conditions
-      field = $(`#EnvironmentalConditions-${arnum}`);
+      field = $("#EnvironmentalConditions-" + arnum);
       value = sample.environmental_conditions;
       field.val(value);
-      // set client sample ID
-      field = $(`#ClientSampleID-${arnum}`);
+      field = $("#ClientSampleID-" + arnum);
       value = sample.client_sample_id;
       field.val(value);
-      // set client reference
-      field = $(`#ClientReference-${arnum}`);
+      field = $("#ClientReference-" + arnum);
       value = sample.client_reference;
       field.val(value);
-      // set adhoc
-      field = $(`#AdHoc-${arnum}`);
+      field = $("#AdHoc-" + arnum);
       field.prop("checked", sample.adhoc);
-      // set composite
-      field = $(`#Composite-${arnum}`);
+      field = $("#Composite-" + arnum);
       field.prop("checked", sample.composite);
-      // set the sample condition
-      field = $(`#SampleCondition-${arnum}`);
+      field = $("#SampleCondition-" + arnum);
       uid = sample.sample_condition_uid;
       title = sample.sample_condition_title;
       this.set_reference_field(field, uid, title);
-      // set the sample point
-      field = $(`#SamplePoint-${arnum}`);
+      field = $("#SamplePoint-" + arnum);
       uid = sample.sample_point_uid;
       title = sample.sample_point_title;
       this.set_reference_field(field, uid, title);
-      // set the storage location
-      field = $(`#StorageLocation-${arnum}`);
+      field = $("#StorageLocation-" + arnum);
       uid = sample.storage_location_uid;
       title = sample.storage_location_title;
       this.set_reference_field(field, uid, title);
-      // set the default container type
-      field = $(`#DefaultContainerType-${arnum}`);
+      field = $("#DefaultContainerType-" + arnum);
       uid = sample.container_type_uid;
       title = sample.container_type_title;
       return this.set_reference_field(field, uid, title);
-    }
+    };
 
-    set_sampletype(arnum, sampletype) {
-      var field, query, title, uid;
+    AnalysisRequestAdd.prototype.set_sampletype = function(arnum, sampletype) {
+
       /*
        * Recalculate partitions
        * Filter Sample Points
        */
-      // restrict the sample points
-      field = $(`#SamplePoint-${arnum}`);
+      var field, query, title, uid;
+      field = $("#SamplePoint-" + arnum);
       query = sampletype.filter_queries.samplepoint;
       this.set_reference_field_query(field, query);
-      // set the default container
-      field = $(`#DefaultContainerType-${arnum}`);
-      // apply default container if the field is empty
+      field = $("#DefaultContainerType-" + arnum);
       if (!field.val()) {
         uid = sampletype.container_type_uid;
         title = sampletype.container_type_title;
         this.flush_reference_field(field);
         this.set_reference_field(field, uid, title);
       }
-      // restrict the specifications
-      field = $(`#Specification-${arnum}`);
+      field = $("#Specification-" + arnum);
       query = sampletype.filter_queries.specification;
       return this.set_reference_field_query(field, query);
-    }
+    };
 
-    set_template(arnum, template) {
+    AnalysisRequestAdd.prototype.set_template = function(arnum, template) {
+
       /*
        * Apply the template data to all fields of arnum
        */
       var field, me, part_selectors, template_uid, title, uid;
       me = this;
-      // apply template only once
-      field = $(`#Template-${arnum}`);
+      field = $("#Template-" + arnum);
       uid = field.attr("uid");
       template_uid = template.uid;
       if (arnum in this.applied_templates) {
@@ -711,56 +622,41 @@
           return;
         }
       }
-      // remember the template for this ar
       this.applied_templates[arnum] = template_uid;
-      // set the sample type
-      field = $(`#SampleType-${arnum}`);
+      field = $("#SampleType-" + arnum);
       uid = template.sample_type_uid;
       title = template.sample_type_title;
       this.flush_reference_field(field);
       this.set_reference_field(field, uid, title);
-      // set the sample point
-      field = $(`#SamplePoint-${arnum}`);
+      field = $("#SamplePoint-" + arnum);
       uid = template.sample_point_uid;
       title = template.sample_point_title;
       this.flush_reference_field(field);
       this.set_reference_field(field, uid, title);
-      // set the analysis profile
-      field = $(`#Profiles-${arnum}`);
+      field = $("#Profiles-" + arnum);
       uid = template.analysis_profile_uid;
       title = template.analysis_profile_title;
       this.flush_reference_field(field);
       this.set_reference_field(field, uid, title);
-      // set the remarks
-      field = $(`#Remarks-${arnum}`);
+      field = $("#Remarks-" + arnum);
       field.text(template.remarks);
-      // set the composite checkbox
-      field = $(`#Composite-${arnum}`);
+      field = $("#Composite-" + arnum);
       field.prop("checked", template.composite);
-      // set the services
       $.each(template.service_uids, function(index, uid) {
-        // select the service
         return me.set_service(arnum, uid, true);
       });
-      // PARTITIONS
       me = this;
-      part_selectors = $(`.part-select-${arnum}`);
+      part_selectors = $(".part-select-" + arnum);
       return $.each(part_selectors, function(index, part_selector) {
         var $el, context, partitions, parts, selected_part;
-        // the selection widget of a service
         $el = $(part_selector);
-        // make the selector visible
         $el.parent().show();
-        // flush existing options (usually part-1)
         $el.empty();
-        // service uid
         uid = $el.attr("uid");
-        // lookup which part is selected for this service
         selected_part = "part-1";
         if (uid in template.analyses_partitions) {
           selected_part = template.analyses_partitions[uid];
         }
-        // prepare the context for the template
         partitions = [];
         $.each(template.partitions, function(index, part) {
           var part_id;
@@ -776,34 +672,31 @@
         parts = me.render_template("part-select-template", context);
         return $el.append(parts);
       });
-    }
+    };
 
-    set_service(arnum, uid, checked) {
-      var el, poc;
+    AnalysisRequestAdd.prototype.set_service = function(arnum, uid, checked) {
+
       /*
        * Select the checkbox of a service by UID
        */
-      console.debug(`*** set_service::AR=${arnum} UID=${uid} checked=${checked}`);
-      // get the service checkbox element
-      el = $(`td[fieldname='Analyses-${arnum}'] #cb_${uid}`);
-      // select the checkbox
+      var el, poc;
+      console.debug("*** set_service::AR=" + arnum + " UID=" + uid + " checked=" + checked);
+      el = $("td[fieldname='Analyses-" + arnum + "'] #cb_" + uid);
       el.prop("checked", checked);
-      // get the point of capture of this element
       poc = el.closest("tr[poc]").attr("poc");
-      // make the element visible if the categories are visible
       if (this.is_poc_expanded(poc)) {
         return el.closest("tr").addClass("visible");
       }
-    }
+    };
 
-    set_service_spec(arnum, uid, spec) {
-      var el, max, min, warn_max, warn_min;
+    AnalysisRequestAdd.prototype.set_service_spec = function(arnum, uid, spec) {
+
       /*
        * Set the specification of the service
        */
-      console.debug(`*** set_service_spec::AR=${arnum} UID=${uid} spec=`, spec);
-      // get the service specifications
-      el = $(`div#${uid}-${arnum}-specifications`);
+      var el, max, min, warn_max, warn_min;
+      console.debug("*** set_service_spec::AR=" + arnum + " UID=" + uid + " spec=", spec);
+      el = $("div#" + uid + "-" + arnum + "-specifications");
       min = $(".min", el);
       max = $(".max", el);
       warn_min = $(".warn_min", el);
@@ -812,9 +705,10 @@
       max.val(spec.max);
       warn_min.val(spec.warn_min);
       return warn_max.val(spec.warn_max);
-    }
+    };
 
-    get_service(uid) {
+    AnalysisRequestAdd.prototype.get_service = function(uid) {
+
       /*
        * Fetch the service data from server by UID
        */
@@ -829,43 +723,42 @@
       return this.ajax_post_form("get_service", options).done(function(data) {
         return console.debug("get_service::data=", data);
       });
-    }
+    };
 
-    hide_all_service_info() {
+    AnalysisRequestAdd.prototype.hide_all_service_info = function() {
+
       /*
        * hide all open service info boxes
        */
       var info;
       info = $("div.service-info");
       return info.hide();
-    }
+    };
 
-    is_poc_expanded(poc) {
+    AnalysisRequestAdd.prototype.is_poc_expanded = function(poc) {
+
       /*
        * Checks if the point of captures are visible
        */
       var el;
-      el = $(`tr.service-listing-header[poc=${poc}]`);
+      el = $("tr.service-listing-header[poc=" + poc + "]");
       return el.hasClass("visible");
-    }
+    };
 
-    toggle_poc_categories(poc, toggle) {
-      var categories, el, services, services_checked, toggle_buttons;
+    AnalysisRequestAdd.prototype.toggle_poc_categories = function(poc, toggle) {
+
       /*
        * Toggle all categories within a point of capture (lab/service)
        * :param poc: the point of capture (lab/field)
        * :param toggle: services visible if true
        */
+      var categories, el, services, services_checked, toggle_buttons;
       if (toggle == null) {
         toggle = !this.is_poc_expanded(poc);
       }
-      // get the element
-      el = $(`tr[data-poc=${poc}]`);
-      // all categories of this poc
-      categories = $(`tr.category.${poc}`);
-      // all services of this poc
-      services = $(`tr.service.${poc}`);
-      // all checked services
+      el = $("tr[data-poc=" + poc + "]");
+      categories = $("tr.category." + poc);
+      services = $("tr.service." + poc);
       services_checked = $("input[type=checkbox]:checked", services);
       toggle_buttons = $(".service-category-toggle");
       if (toggle) {
@@ -880,9 +773,13 @@
         services.removeClass("expanded");
         return toggle_buttons.text("+");
       }
-    }
+    };
 
-    on_client_changed(event) {
+
+    /* EVENT HANDLER */
+
+    AnalysisRequestAdd.prototype.on_client_changed = function(event) {
+
       /*
        * Eventhandler when the client changed (happens on Batches)
        */
@@ -892,19 +789,18 @@
       $el = $(el);
       uid = $el.attr("uid");
       arnum = $el.closest("[arnum]").attr("arnum");
-      console.debug(`°°° on_client_changed: arnum=${arnum} °°°`);
-      // Flush client depending fields
+      console.debug("°°° on_client_changed: arnum=" + arnum + " °°°");
       field_ids = ["Contact", "CCContact", "InvoiceContact", "SamplePoint", "Template", "Profiles", "Specification"];
       $.each(field_ids, function(index, id) {
         var field;
         field = me.get_field_by_id(id, arnum);
         return me.flush_reference_field(field);
       });
-      // trigger form:changed event
       return $(me).trigger("form:changed");
-    }
+    };
 
-    on_contact_changed(event) {
+    AnalysisRequestAdd.prototype.on_contact_changed = function(event) {
+
       /*
        * Eventhandler when the contact changed
        */
@@ -914,30 +810,29 @@
       $el = $(el);
       uid = $el.attr("uid");
       arnum = $el.closest("[arnum]").attr("arnum");
-      console.debug(`°°° on_contact_changed: arnum=${arnum} °°°`);
-      // Flush client depending fields
+      console.debug("°°° on_contact_changed: arnum=" + arnum + " °°°");
       field_ids = ["CCContact"];
       $.each(field_ids, function(index, id) {
         var field;
         field = me.get_field_by_id(id, arnum);
         return me.flush_reference_field(field);
       });
-      // trigger form:changed event
       return $(me).trigger("form:changed");
-    }
+    };
 
-    on_analysis_specification_changed(event) {
-      var me;
+    AnalysisRequestAdd.prototype.on_analysis_specification_changed = function(event) {
+
       /*
        * Eventhandler when the specification of an analysis service changed
        */
+      var me;
       console.debug("°°° on_analysis_specification_changed °°°");
       me = this;
-      // trigger form:changed event
       return $(me).trigger("form:changed");
-    }
+    };
 
-    on_analysis_details_click(event) {
+    AnalysisRequestAdd.prototype.on_analysis_details_click = function(event) {
+
       /*
        * Eventhandler when the user clicked on the info icon of a service.
        */
@@ -946,33 +841,28 @@
       $el = $(el);
       uid = $el.attr("uid");
       arnum = $el.closest("[arnum]").attr("arnum");
-      console.debug(`°°° on_analysis_column::UID=${uid}°°°`);
+      console.debug("°°° on_analysis_column::UID=" + uid + "°°°");
       info = $("div.service-info", $el.parent());
       info.empty();
       data = info.data("data");
-      // extra data to extend to the template context
       extra = {
         profiles: [],
         templates: [],
         specifications: []
       };
-      // get the current snapshot record for this column
       record = this.records_snapshot[arnum];
-      // inject profile info
       if (uid in record.service_to_profiles) {
         profiles = record.service_to_profiles[uid];
         $.each(profiles, function(index, uid) {
           return extra["profiles"].push(record.profile_metadata[uid]);
         });
       }
-      // inject template info
       if (uid in record.service_to_templates) {
         templates = record.service_to_templates[uid];
         $.each(templates, function(index, uid) {
           return extra["templates"].push(record.template_metadata[uid]);
         });
       }
-      // inject specification info
       if (uid in record.service_to_specifications) {
         specifications = record.service_to_specifications[uid];
         $.each(specifications, function(index, uid) {
@@ -994,13 +884,14 @@
         info.append(template);
         return info.fadeToggle();
       }
-    }
+    };
 
-    on_analysis_lock_button_click(event) {
-      var $el, arnum, buttons, context, dialog, el, me, profile_uid, record, template_uid, uid;
+    AnalysisRequestAdd.prototype.on_analysis_lock_button_click = function(event) {
+
       /*
        * Eventhandler when an Analysis Profile was removed.
        */
+      var $el, arnum, buttons, context, dialog, el, me, profile_uid, record, template_uid, uid;
       console.debug("°°° on_analysis_lock_button_click °°°");
       me = this;
       el = event.currentTarget;
@@ -1012,12 +903,10 @@
       context["service"] = record.service_metadata[uid];
       context["profiles"] = [];
       context["templates"] = [];
-      // collect profiles
       if (uid in record.service_to_profiles) {
         profile_uid = record.service_to_profiles[uid];
         context["profiles"].push(record.profile_metadata[profile_uid]);
       }
-      // collect templates
       if (uid in record.service_to_templates) {
         template_uid = record.service_to_templates[uid];
         context["templates"].push(record.template_metadata[template_uid]);
@@ -1028,9 +917,10 @@
         }
       };
       return dialog = this.template_dialog("service-dependant-template", context, buttons);
-    }
+    };
 
-    on_sample_changed(event) {
+    AnalysisRequestAdd.prototype.on_sample_changed = function(event) {
+
       /*
        * Eventhandler when the Sample was changed.
        */
@@ -1042,17 +932,15 @@
       val = $el.val();
       arnum = $el.closest("[arnum]").attr("arnum");
       has_sample_selected = $el.val();
-      console.debug(`°°° on_sample_change::UID=${uid} Sample=${val}°°°`);
-      // deselect the sample if the field is empty
+      console.debug("°°° on_sample_change::UID=" + uid + " Sample=" + val + "°°°");
       if (!has_sample_selected) {
-        // XXX manually flush UID field
         $("input[type=hidden]", $el.parent()).val("");
       }
-      // trigger form:changed event
       return $(me).trigger("form:changed");
-    }
+    };
 
-    on_sampletype_changed(event) {
+    AnalysisRequestAdd.prototype.on_sampletype_changed = function(event) {
+
       /*
        * Eventhandler when the SampleType was changed.
        * Fires form:changed event
@@ -1065,24 +953,21 @@
       val = $el.val();
       arnum = $el.closest("[arnum]").attr("arnum");
       has_sampletype_selected = $el.val();
-      console.debug(`°°° on_sampletype_change::UID=${uid} SampleType=${val}°°°`);
-      // deselect the sampletype if the field is empty
+      console.debug("°°° on_sampletype_change::UID=" + uid + " SampleType=" + val + "°°°");
       if (!has_sampletype_selected) {
-        // XXX manually flush UID field
         $("input[type=hidden]", $el.parent()).val("");
       }
-      // Flush sampletype depending fields
       field_ids = ["SamplePoint", "Specification"];
       $.each(field_ids, function(index, id) {
         var field;
         field = me.get_field_by_id(id, arnum);
         return me.flush_reference_field(field);
       });
-      // trigger form:changed event
       return $(me).trigger("form:changed");
-    }
+    };
 
-    on_specification_changed(event) {
+    AnalysisRequestAdd.prototype.on_specification_changed = function(event) {
+
       /*
        * Eventhandler when the Specification was changed.
        */
@@ -1094,17 +979,15 @@
       val = $el.val();
       arnum = $el.closest("[arnum]").attr("arnum");
       has_specification_selected = $el.val();
-      console.debug(`°°° on_specification_change::UID=${uid} Specification=${val}°°°`);
-      // deselect the specification if the field is empty
+      console.debug("°°° on_specification_change::UID=" + uid + " Specification=" + val + "°°°");
       if (!has_specification_selected) {
-        // XXX manually flush UID field
         $("input[type=hidden]", $el.parent()).val("");
       }
-      // trigger form:changed event
       return $(me).trigger("form:changed");
-    }
+    };
 
-    on_analysis_template_changed(event) {
+    AnalysisRequestAdd.prototype.on_analysis_template_changed = function(event) {
+
       /*
        * Eventhandler when an Analysis Template was changed.
        */
@@ -1116,19 +999,14 @@
       val = $el.val();
       arnum = $el.closest("[arnum]").attr("arnum");
       has_template_selected = $el.val();
-      console.debug(`°°° on_analysis_template_change::UID=${uid} Template=${val}°°°`);
-      // deselect the template if the field is empty
+      console.debug("°°° on_analysis_template_change::UID=" + uid + " Template=" + val + "°°°");
       if (!has_template_selected && uid) {
-        // forget the applied template
         this.applied_templates[arnum] = null;
-        // XXX manually flush UID field
         $("input[type=hidden]", $el.parent()).val("");
         record = this.records_snapshot[arnum];
         template_metadata = record.template_metadata[uid];
         template_services = [];
-        // prepare a list of services used by the template with the given UID
         $.each(record.template_to_services[uid], function(index, uid) {
-          // service might be deselected before and thus, absent
           if (uid in record.service_metadata) {
             return template_services.push(record.service_metadata[uid]);
           }
@@ -1139,42 +1017,39 @@
           context["services"] = template_services;
           dialog = this.template_dialog("template-remove-template", context);
           dialog.on("yes", function() {
-            // deselect the services
             $.each(template_services, function(index, service) {
               return me.set_service(arnum, service.uid, false);
             });
-            // trigger form:changed event
             return $(me).trigger("form:changed");
           });
           dialog.on("no", function() {
-            // trigger form:changed event
             return $(me).trigger("form:changed");
           });
         }
       }
-      // trigger form:changed event
       return $(me).trigger("form:changed");
-    }
+    };
 
-    on_analysis_profile_selected(event) {
-      var $el, el, me, uid;
+    AnalysisRequestAdd.prototype.on_analysis_profile_selected = function(event) {
+
       /*
        * Eventhandler when an Analysis Profile was selected.
        */
+      var $el, el, me, uid;
       console.debug("°°° on_analysis_profile_selected °°°");
       me = this;
       el = event.currentTarget;
       $el = $(el);
       uid = $(el).attr("uid");
-      // trigger form:changed event
       return $(me).trigger("form:changed");
-    }
+    };
 
-    on_analysis_profile_removed(event) {
-      var $el, arnum, context, dialog, el, me, profile_metadata, profile_services, record, uid;
+    AnalysisRequestAdd.prototype.on_analysis_profile_removed = function(event) {
+
       /*
        * Eventhandler when an Analysis Profile was removed.
        */
+      var $el, arnum, context, dialog, el, me, profile_metadata, profile_services, record, uid;
       console.debug("°°° on_analysis_profile_removed °°°");
       me = this;
       el = event.currentTarget;
@@ -1184,7 +1059,6 @@
       record = this.records_snapshot[arnum];
       profile_metadata = record.profile_metadata[uid];
       profile_services = [];
-      // prepare a list of services used by the profile with the given UID
       $.each(record.profile_to_services[uid], function(index, uid) {
         return profile_services.push(record.service_metadata[uid]);
       });
@@ -1194,20 +1068,18 @@
       me = this;
       dialog = this.template_dialog("profile-remove-template", context);
       dialog.on("yes", function() {
-        // deselect the services
         $.each(profile_services, function(index, service) {
           return me.set_service(arnum, service.uid, false);
         });
-        // trigger form:changed event
         return $(me).trigger("form:changed");
       });
       return dialog.on("no", function() {
-        // trigger form:changed event
         return $(me).trigger("form:changed");
       });
-    }
+    };
 
-    on_analysis_checkbox_click(event) {
+    AnalysisRequestAdd.prototype.on_analysis_checkbox_click = function(event) {
+
       /*
        * Eventhandler for Analysis Service Checkboxes.
        */
@@ -1217,12 +1089,12 @@
       checked = el.checked;
       $el = $(el);
       uid = $el.val();
-      console.debug(`°°° on_analysis_click::UID=${uid} checked=${checked}°°°`);
-      // trigger form:changed event
+      console.debug("°°° on_analysis_click::UID=" + uid + " checked=" + checked + "°°°");
       return $(me).trigger("form:changed");
-    }
+    };
 
-    on_service_listing_header_click(event) {
+    AnalysisRequestAdd.prototype.on_service_listing_header_click = function(event) {
+
       /*
        * Eventhandler for analysis service category header rows.
        * Toggles the visibility of all categories within this poc.
@@ -1233,24 +1105,25 @@
       visible = $el.hasClass("visible");
       toggle = !visible;
       return this.toggle_poc_categories(poc, toggle);
-    }
+    };
 
-    on_service_category_click(event) {
-      var $btn, $el, category, expanded, poc, services, services_checked;
+    AnalysisRequestAdd.prototype.on_service_category_click = function(event) {
+
       /*
        * Eventhandler for analysis service category rows.
        * Toggles the visibility of all services within this category.
        * Selected services always stay visible.
        */
+      var $btn, $el, category, expanded, poc, services, services_checked;
       event.preventDefault();
       $el = $(event.currentTarget);
       poc = $el.attr("poc");
       $btn = $(".service-category-toggle", $el);
       expanded = $el.hasClass("expanded");
       category = $el.data("category");
-      services = $(`tr.${poc}.${category}`);
+      services = $("tr." + poc + "." + category);
       services_checked = $("input[type=checkbox]:checked", services);
-      console.debug(`°°° on_service_category_click: category=${category} °°°`);
+      console.debug("°°° on_service_category_click: category=" + category + " °°°");
       if (expanded) {
         $btn.text("+");
         $el.removeClass("expanded");
@@ -1263,15 +1136,16 @@
         services.addClass("visible");
         return services.addClass("expanded");
       }
-    }
+    };
 
-    on_copy_button_click(event) {
-      var $el, $td1, $tr, ar_count, el, field, me, mvl, record_one, td1, tr, uid, value;
+    AnalysisRequestAdd.prototype.on_copy_button_click = function(event) {
+
       /*
        * Eventhandler for the field copy button per row.
        * Copies the value of the first field in this row to the remaining.
        * XXX Refactor
        */
+      var $el, $td1, $tr, ar_count, el, field, i, me, mvl, record_one, results, td1, tr, uid, value;
       console.debug("°°° on_copy_button_click °°°");
       me = this;
       el = event.target;
@@ -1284,10 +1158,7 @@
       if (!(ar_count > 1)) {
         return;
       }
-      // the record data of the first AR
       record_one = this.records_snapshot[0];
-      // ReferenceWidget cannot be simply copied, the combogrid dropdown widgets
-      // don't cooperate and the multiValued div must be copied.
       if ($(td1).find('.ArchetypesReferenceWidget').length > 0) {
         console.debug("-> Copy reference field");
         el = $(td1).find(".ArchetypesReferenceWidget");
@@ -1296,207 +1167,187 @@
         value = field.val();
         mvl = el.find(".multiValued-listing");
         $.each((function() {
-          var results = [];
+          results = [];
           for (var i = 1; 1 <= ar_count ? i <= ar_count : i >= ar_count; 1 <= ar_count ? i++ : i--){ results.push(i); }
           return results;
         }).apply(this), function(arnum) {
           var _el, _field, _td;
-          // skip the first column
           if (!(arnum > 0)) {
             return;
           }
-          _td = $tr.find(`td[arnum=${arnum}]`);
+          _td = $tr.find("td[arnum=" + arnum + "]");
           _el = $(_td).find(".ArchetypesReferenceWidget");
           _field = _el.find("input[type=text]");
-          // flush the field completely
           me.flush_reference_field(_field);
           if (mvl.length > 0) {
-            // multi valued reference field
             $.each(mvl.children(), function(idx, item) {
               uid = $(item).attr("uid");
               value = $(item).text();
               return me.set_reference_field(_field, uid, value);
             });
           } else {
-            // single reference field
             me.set_reference_field(_field, uid, value);
           }
-          // notify that the field changed
           return $(_field).trigger("change");
         });
-        // trigger form:changed event
         $(me).trigger("form:changed");
         return;
       }
-      // Copy <input type="checkbox"> fields
       $td1.find("input[type=checkbox]").each(function(index, el) {
-        var checked;
+        var checked, j, results1;
         console.debug("-> Copy checkbox field");
         $el = $(el);
         checked = $el.prop("checked");
-        // iterate over columns, starting from column 2
         return $.each((function() {
-          var results = [];
-          for (var i = 1; 1 <= ar_count ? i <= ar_count : i >= ar_count; 1 <= ar_count ? i++ : i--){ results.push(i); }
-          return results;
+          results1 = [];
+          for (var j = 1; 1 <= ar_count ? j <= ar_count : j >= ar_count; 1 <= ar_count ? j++ : j--){ results1.push(j); }
+          return results1;
         }).apply(this), function(arnum) {
           var _el, _td;
-          // skip the first column
           if (!(arnum > 0)) {
             return;
           }
-          _td = $tr.find(`td[arnum=${arnum}]`);
+          _td = $tr.find("td[arnum=" + arnum + "]");
           _el = $(_td).find("input[type=checkbox]")[index];
           return $(_el).prop("checked", checked);
         });
       });
-      // Copy <select> fields
       $td1.find("select").each(function(index, el) {
+        var j, results1;
         console.debug("-> Copy select field");
         $el = $(el);
         value = $el.val();
         return $.each((function() {
-          var results = [];
-          for (var i = 1; 1 <= ar_count ? i <= ar_count : i >= ar_count; 1 <= ar_count ? i++ : i--){ results.push(i); }
-          return results;
+          results1 = [];
+          for (var j = 1; 1 <= ar_count ? j <= ar_count : j >= ar_count; 1 <= ar_count ? j++ : j--){ results1.push(j); }
+          return results1;
         }).apply(this), function(arnum) {
           var _el, _td;
-          // skip the first column
           if (!(arnum > 0)) {
             return;
           }
-          _td = $tr.find(`td[arnum=${arnum}]`);
+          _td = $tr.find("td[arnum=" + arnum + "]");
           _el = $(_td).find("select")[index];
           return $(_el).val(value);
         });
       });
-      // Copy <input type="text"> fields
       $td1.find("input[type=text]").each(function(index, el) {
+        var j, results1;
         console.debug("-> Copy text field");
         $el = $(el);
         value = $el.val();
         return $.each((function() {
-          var results = [];
-          for (var i = 1; 1 <= ar_count ? i <= ar_count : i >= ar_count; 1 <= ar_count ? i++ : i--){ results.push(i); }
-          return results;
+          results1 = [];
+          for (var j = 1; 1 <= ar_count ? j <= ar_count : j >= ar_count; 1 <= ar_count ? j++ : j--){ results1.push(j); }
+          return results1;
         }).apply(this), function(arnum) {
           var _el, _td;
-          // skip the first column
           if (!(arnum > 0)) {
             return;
           }
-          _td = $tr.find(`td[arnum=${arnum}]`);
+          _td = $tr.find("td[arnum=" + arnum + "]");
           _el = $(_td).find("input[type=text]")[index];
           return $(_el).val(value);
         });
       });
-      // Copy <textarea> fields
       $td1.find("textarea").each(function(index, el) {
+        var j, results1;
         console.debug("-> Copy textarea field");
         $el = $(el);
         value = $el.val();
         return $.each((function() {
-          var results = [];
-          for (var i = 1; 1 <= ar_count ? i <= ar_count : i >= ar_count; 1 <= ar_count ? i++ : i--){ results.push(i); }
-          return results;
+          results1 = [];
+          for (var j = 1; 1 <= ar_count ? j <= ar_count : j >= ar_count; 1 <= ar_count ? j++ : j--){ results1.push(j); }
+          return results1;
         }).apply(this), function(arnum) {
           var _el, _td;
-          // skip the first column
           if (!(arnum > 0)) {
             return;
           }
-          _td = $tr.find(`td[arnum=${arnum}]`);
+          _td = $tr.find("td[arnum=" + arnum + "]");
           _el = $(_td).find("textarea")[index];
           return $(_el).val(value);
         });
       });
-      // trigger form:changed event
       return $(me).trigger("form:changed");
-    }
+    };
 
-    ajax_post_form(endpoint, options = {}) {
+    AnalysisRequestAdd.prototype.ajax_post_form = function(endpoint, options) {
       var ajax_options, base_url, form, form_data, me, url;
+      if (options == null) {
+        options = {};
+      }
+
       /*
        * Ajax POST the form data to the given endpoint
        */
-      console.debug(`°°° ajax_post_form::Endpoint=${endpoint} °°°`);
-      // calculate the right form URL
+      console.debug("°°° ajax_post_form::Endpoint=" + endpoint + " °°°");
       base_url = this.get_base_url();
-      url = `${base_url}/ajax_ar_add/${endpoint}`;
-      console.debug(`Ajax POST to url ${url}`);
-      // extract the form data
+      url = base_url + "/ajax_ar_add/" + endpoint;
+      console.debug("Ajax POST to url " + url);
       form = $("#analysisrequest_add_form");
-      // form.serialize does not include file attachments
-      // form_data = form.serialize()
       form_data = new FormData(form[0]);
-      // jQuery Ajax options
       ajax_options = {
         url: url,
         type: 'POST',
         data: form_data,
         context: this,
         cache: false,
-        dataType: 'json', // data type we expect from the server
+        dataType: 'json',
         processData: false,
         contentType: false
       };
-      // contentType: 'application/x-www-form-urlencoded; charset=UTF-8'
-
-      // Update Options
       $.extend(ajax_options, options);
+
       /* Execute the request */
-      // Notify Ajax start
       me = this;
       $(me).trigger("ajax:start");
       return $.ajax(ajax_options).always(function(data) {
-        // Always notify Ajax end
         return $(me).trigger("ajax:end");
       });
-    }
+    };
 
-    on_ajax_start() {
-      var button;
+    AnalysisRequestAdd.prototype.on_ajax_start = function() {
+
       /*
        * Ajax request started
        */
+      var button;
       console.debug("°°° on_ajax_start °°°");
-      // deactivate the button
       button = $("input[name=save_button]");
       return button.prop({
         "disabled": true
       });
-    }
+    };
 
-    on_ajax_end() {
-      var button;
+    AnalysisRequestAdd.prototype.on_ajax_end = function() {
+
       /*
        * Ajax request finished
        */
+      var button;
       console.debug("°°° on_ajax_end °°°");
-      // reactivate the button
       button = $("input[name=save_button]");
       return button.prop({
         "disabled": false
       });
-    }
+    };
 
-    on_form_submit(event, callback) {
-      var base_url, me;
+    AnalysisRequestAdd.prototype.on_form_submit = function(event, callback) {
+
       /*
        * Eventhandler for the form submit button.
        * Extracts and submits all form data asynchronous.
        */
+      var base_url, me;
       console.debug("°°° on_form_submit °°°");
       event.preventDefault();
       me = this;
-      // get the right base url
       base_url = me.get_base_url();
-      // remove all errors
       $("div.error").removeClass("error");
       $("div.fieldErrorBox").text("");
-      // Ajax POST to the submit endpoint
       return this.ajax_post_form("submit").done(function(data) {
-        var ars, destination, errorbox, field, fieldname, message, msg, parent, q, stickertemplate;
+
         /*
          * data contains the following useful keys:
          * - errors: any errors which prevented the AR from being created
@@ -1505,20 +1356,21 @@
          *   This includes GET params for printing labels, so that we do not
          *   have to care about this here.
          */
+        var ars, destination, errorbox, field, fieldname, message, msg, parent, q, stickertemplate;
         if (data['errors']) {
           msg = data.errors.message;
           if (msg !== "") {
-            msg = `${msg}<br/>`;
+            msg = msg + "<br/>";
           }
           for (fieldname in data.errors.fielderrors) {
-            field = $(`#${fieldname}`);
+            field = $("#" + fieldname);
             parent = field.parent("div.field");
             if (field && parent) {
               parent.toggleClass("error");
               errorbox = parent.children("div.fieldErrorBox");
               message = data.errors.fielderrors[fieldname];
               errorbox.text(message);
-              msg += `${message}<br/>`;
+              msg += message + "<br/>";
             }
           }
           window.bika.lims.portalMessage(msg);
@@ -1533,66 +1385,56 @@
           return window.location.replace(base_url);
         }
       });
-    }
+    };
 
-    init_file_fields() {
+    AnalysisRequestAdd.prototype.init_file_fields = function() {
       var me;
       me = this;
       return $('tr[fieldname] input[type="file"]').each(function(index, element) {
         var add_btn, add_btn_src, file_field, file_field_div;
-        // Wrap the initial field into a div
         file_field = $(element);
         file_field.wrap("<div class='field'/>");
         file_field_div = file_field.parent();
-        // Create and add an ADD Button on the fly
-        add_btn_src = `${window.portal_url}/++resource++bika.lims.images/add.png`;
-        add_btn = $(`<img class='addbtn' style='cursor:pointer;' src='${add_btn_src}' />`);
-        // bind ADD event handler
+        add_btn_src = window.portal_url + "/++resource++bika.lims.images/add.png";
+        add_btn = $("<img class='addbtn' style='cursor:pointer;' src='" + add_btn_src + "' />");
         add_btn.on("click", element, function(event) {
           return me.file_addbtn_click(event, element);
         });
-        // Attach the Button into the same div container
         return file_field_div.append(add_btn);
       });
-    }
+    };
 
-    file_addbtn_click(event, element) {
-      var arnum, counter, del_btn, del_btn_src, existing_file_field_names, existing_file_fields, file_field, file_field_div, holding_div, name, newfieldname;
-      // Clone the file field and wrap it into a div
+    AnalysisRequestAdd.prototype.file_addbtn_click = function(event, element) {
+      var arnum, counter, del_btn, del_btn_src, existing_file_field_names, existing_file_fields, file_field, file_field_div, holding_div, name, newfieldname, ref;
       file_field = $(element).clone();
       file_field.val("");
       file_field.wrap("<div class='field'/>");
       file_field_div = file_field.parent();
-      [name, arnum] = $(element).attr("name").split("-");
-      // Get all existing input fields and their names
+      ref = $(element).attr("name").split("-"), name = ref[0], arnum = ref[1];
       holding_div = $(element).parent().parent();
       existing_file_fields = holding_div.find("input[type='file']");
       existing_file_field_names = existing_file_fields.map(function(index, element) {
         return $(element).attr("name");
       });
-      // Generate a new name for the field and ensure it is not taken by another field already
       counter = 0;
       newfieldname = $(element).attr("name");
       while (indexOf.call(existing_file_field_names, newfieldname) >= 0) {
-        newfieldname = `${name}_${counter}-${arnum}`;
+        newfieldname = name + "_" + counter + "-" + arnum;
         counter++;
       }
-      // set the new id, name
       file_field.attr("name", newfieldname);
       file_field.attr("id", newfieldname);
-      // Create and add an DELETE Button on the fly
-      del_btn_src = `${window.portal_url}/++resource++bika.lims.images/delete.png`;
-      del_btn = $(`<img class='delbtn' style='cursor:pointer;' src='${del_btn_src}' />`);
-      // Bind an DELETE event handler
+      del_btn_src = window.portal_url + "/++resource++bika.lims.images/delete.png";
+      del_btn = $("<img class='delbtn' style='cursor:pointer;' src='" + del_btn_src + "' />");
       del_btn.on("click", element, function(event) {
         return $(this).parent().remove();
       });
-      // Attach the Button into the same div container
       file_field_div.append(del_btn);
-      // Attach the new field to the outer div of the passed file field
       return $(element).parent().parent().append(file_field_div);
-    }
+    };
 
-  };
+    return AnalysisRequestAdd;
+
+  })();
 
 }).call(this);

--- a/bika/lims/browser/js/bika.lims.analysisrequest.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.js
@@ -1,21 +1,23 @@
+
 /* Please use this command to compile this file into the parent `js` directory:
     coffee --no-header -w -o ../ -c bika.lims.analysisrequest.coffee
  */
+
+
 /**
  * Controller class for Analysis Request View/s
  */
+
 (function() {
   window.AnalysisRequestView = function() {
+    var that, transition_schedule_sampling, transition_with_publication_spec, workflow_transition_sample;
+    that = this;
+
     /**
      * Entry-point method for AnalysisRequestView
      */
-    var that, transition_schedule_sampling, transition_with_publication_spec, workflow_transition_sample;
-    that = this;
     transition_with_publication_spec = function(event) {
       var element, href;
-      // Pass the Publication Spec UID (if present) into the WorkflowAction handler
-      // Force the transition to use the "workflow_action" url instead of content_status_modify.
-      // TODO This should be using content_status_modify!  modifying the href is silly.
       event.preventDefault();
       href = event.currentTarget.href.replace('content_status_modify', 'workflow_action');
       element = $('#PublicationSpecification_uid');
@@ -25,23 +27,23 @@
       window.location.href = href;
     };
     transition_schedule_sampling = function() {
+
       /* Force the transition to use the "workflow_action" url instead of content_status_modify. workflow_action triggers a class from
       analysisrequest/workflow/AnalysisRequestWorkflowAction which manage
       workflow_actions from analysisrequest/sample/samplepartition objects.
       It is not possible to abort a transition using "workflow_script_*".
       The recommended way is to set a guard instead.
-
+      
       The guard expression should be able to look up a view to facilitate more complex guard code, but when a guard returns False the transition isn't even listed as available. It is listed after saving the fields.
-
+      
       TODO This should be using content_status_modify!  modifying the href
       is silly.
-      */
+       */
       var new_url, url;
       url = $('#workflow-transition-schedule_sampling').attr('href');
       if (url) {
         new_url = url.replace('content_status_modify', 'workflow_action');
         $('#workflow-transition-schedule_sampling').attr('href', new_url);
-        // When user clicks on the transition
         $('#workflow-transition-schedule_sampling').click(function() {
           var date, message, sampler;
           date = $('#SamplingDate').val();
@@ -78,7 +80,6 @@
         sampler = $('#Sampler').val();
         if (date && sampler) {
           form = $('form[name=\'header_form\']');
-          // this 'transition' key is scanned for in header_table.py/__call__
           form.append('<input type=\'hidden\' name=\'transition\' value=\'sample\'/>');
           form.submit();
         } else {
@@ -103,24 +104,24 @@
       });
     };
     that.load = function() {
-      // fires for all AR workflow transitions fired using the plone contentmenu workflow actions
       $('a[id^=\'workflow-transition\']').not('#workflow-transition-schedule_sampling').not('#workflow-transition-sample').click(transition_with_publication_spec);
-      // fires AR workflow transitions when using the schedule samplign transition
       transition_schedule_sampling();
     };
   };
 
+
   /**
    * Controller class for Analysis Request View View
    */
+
   window.AnalysisRequestViewView = function() {
+    var build_typical_save_request, filter_CCContacts, filter_by_client, getClientUID, parse_CCClist, resultsinterpretation_move_below, save_elements, set_autosave_input, that;
+    that = this;
+
     /**
      * Entry-point method for AnalysisRequestView
      */
-    var build_typical_save_request, filter_CCContacts, filter_by_client, getClientUID, parse_CCClist, resultsinterpretation_move_below, save_elements, set_autosave_input, that;
-    that = this;
     resultsinterpretation_move_below = function() {
-      // By default show only the Results Interpretation for the whole AR, not Dept specific
       $('a.department-tab').click(function(e) {
         var uid;
         e.preventDefault();
@@ -131,7 +132,6 @@
         $(this).addClass('selected');
       });
       $('a.department-tab[data-uid="ResultsInterpretationDepts-general"]').click();
-      //Remove buttons from TinyMCE
       setTimeout((function() {
         $('div.arresultsinterpretation-container .fieldTextFormat').remove();
         $('table.mceToolbar a.mce_image').remove();
@@ -140,10 +140,11 @@
       }), 1500);
     };
     filter_CCContacts = function() {
-      var clientUID, element;
+
       /**
        * Filter the CCContacts dropdown list by the current client.
        */
+      var clientUID, element;
       if ($('#CCContact').length > 0) {
         element = $('#CCContact');
         clientUID = getClientUID();
@@ -151,12 +152,12 @@
       }
     };
     getClientUID = function() {
+
       /**
        * Return the AR client's UID.
        */
       var clientid, clientuid;
       clientid = window.location.href.split('clients')[1].split('/')[1];
-      // ajax petition to obtain the current client info
       clientuid = '';
       $.ajax({
         url: window.portal_url + '/clients/' + clientid + '/getClientInfo',
@@ -175,11 +176,11 @@
       return clientuid;
     };
     filter_by_client = function(element, filterkey, filtervalue) {
-      var base_query, options;
+
       /**
        * Filter the dropdown's results (called element) by current client contacts.
        */
-      // Get the base_query data in array format
+      var base_query, options;
       base_query = $.parseJSON($(element).attr('base_query'));
       base_query[filterkey] = filtervalue;
       $(element).attr('base_query', $.toJSON(base_query));
@@ -189,12 +190,12 @@
       referencewidget_lookups($(element));
     };
     set_autosave_input = function() {
+
       /**
        * Set an event for each input field in the AR header. After write something in the input field and
        * focus out it, the event automatically saves the change.
        */
       $('table.header_table input').not('[attr="referencewidget"]').not('[type="hidden"]').not('.rejectionwidget-field').each(function(i) {
-        // Save input fields
         $(this).change(function() {
           var pointer;
           pointer = this;
@@ -202,7 +203,6 @@
         });
       });
       $('table.header_table select').not('[type="hidden"]').not('.rejectionwidget-field').each(function(i) {
-        // Save select fields
         $(this).change(function() {
           var pointer;
           pointer = this;
@@ -210,7 +210,6 @@
         });
       });
       $('table.header_table input.referencewidget').not('[type="hidden"]').not('[id="CCContact"]').each(function(i) {
-        // Save referencewidget inputs.
         $(this).bind('selected', function() {
           var fieldname, fieldvalue, pointer, requestdata;
           requestdata = {};
@@ -220,16 +219,12 @@
           setTimeout((function() {
             fieldname = $(pointer).closest('div[id^="archetypes-fieldname-"]').attr('data-fieldname');
             fieldvalue = $(pointer).attr('uid');
-            // To search by uid, we should follow this array template:
-            // { SamplePoint = "uid:TheValueOfuid1|uid:TheValueOfuid2..." }
-            // This is the way how jsonapi/__init__.py/resolve_request_lookup() works.
             requestdata[fieldname] = 'uid:' + fieldvalue;
             save_elements(requestdata);
           }), 500);
         });
       });
       $('table.header_table input#CCContact.referencewidget').not('[type="hidden"]').each(function(i) {
-        // CCContact works different.
         $(this).bind('selected', function() {
           var fieldname, fieldvalue, pointer, requestdata;
           pointer = this;
@@ -237,9 +232,6 @@
           fieldname = void 0;
           requestdata = {};
           setTimeout((function() {
-            // To search by uid, we should follow this array template:
-            // { SamplePoint = "uid:TheValueOfuid1|uid:TheValueOfuid2..." }
-            // This is the way how jsonapi/__init__.py/resolve_request_lookup() works.
             fieldname = $(pointer).closest('div[id^="archetypes-fieldname-"]').attr('data-fieldname');
             fieldvalue = parse_CCClist();
             requestdata[fieldname] = fieldvalue;
@@ -249,7 +241,6 @@
       });
       $('img[fieldname="CCContact"]').each(function() {
         var fieldname, fieldvalue, requestdata;
-        // If a delete cross is clicked on CCContact-listing, we should update the saved list.
         fieldvalue = void 0;
         requestdata = {};
         fieldname = void 0;
@@ -264,6 +255,7 @@
       });
     };
     build_typical_save_request = function(pointer) {
+
       /**
        * Build an array with the data to be saved for the typical data fields.
        * @pointer is the object which has been modified and we want to save its new data.
@@ -272,9 +264,7 @@
       fieldvalue = void 0;
       fieldname = void 0;
       requestdata = {};
-      // Checkbox
       if ($(pointer).attr('type') === 'checkbox') {
-        // Checkboxes name is located in its parent div, but its value is located inside the input.
         fieldvalue = $(pointer).prop('checked');
         fieldname = $(pointer).closest('div[id^="archetypes-fieldname-"]').attr('data-fieldname');
       } else {
@@ -285,6 +275,7 @@
       save_elements(requestdata);
     };
     save_elements = function(requestdata) {
+
       /**
        * Given a dict with a fieldname and a fieldvalue, save this data via ajax petition.
        * @requestdata should has the format  {fieldname=fieldvalue}
@@ -292,7 +283,6 @@
       var anch, ar, element, name, obj_path, url;
       url = window.location.href.replace('/base_view', '');
       obj_path = url.replace(window.portal_url, '');
-      // Staff for the notification
       element = void 0;
       name = $.map(requestdata, function(element, index) {
         element;
@@ -301,7 +291,6 @@
       name = $.trim($('[data-fieldname="' + name + '"]').closest('td').prev().text());
       ar = $.trim($('.documentFirstHeading').text());
       anch = '<a href=\'' + url + '\'>' + ar + '</a>';
-      // Needed fot the ajax petition
       requestdata['obj_path'] = obj_path;
       $.ajax({
         type: 'POST',
@@ -310,7 +299,6 @@
       }).done(function(data) {
         var msg;
         var msg;
-        //success alert
         if (data !== null && data['success'] === true) {
           bika.lims.SiteView.notificationPanel(anch + ': ' + name + ' updated successfully', 'succeed');
         } else if (data === null) {
@@ -326,7 +314,6 @@
         }
       }).fail(function(xhr, textStatus, errorThrown) {
         var msg;
-        //error
         bika.lims.SiteView.notificationPanel('Error while updating ' + name + ' for ' + anch, 'error');
         msg = '[bika.lims.analysisrequest.js] Error in AJAX call' + 'while updating ' + name + ' for ' + ar + '. Error: ' + xhr.responseText;
         console.warn(msg);
@@ -334,6 +321,7 @@
       });
     };
     parse_CCClist = function() {
+
       /**
        * It parses the CCContact-listing, where are located the CCContacts, and build the fieldvalue list.
        * @return: the builed field value -> "uid:TheValueOfuid1|uid:TheValueOfuid2..."
@@ -372,14 +360,6 @@
               base_query['getClientUID'] = [data['ClientUID'], setup_uid];
               $(spelement).attr('base_query', $.toJSON(base_query));
               options = $.parseJSON($(spelement).attr('combogrid_options'));
-              // Getting the url like that will return the query
-              // part of it:
-              // http://localhost:8080/Plone/clients/client17-14/..
-              //    ..OA17-0030-R01
-              // In order to create a correct ajax call
-              // we only need until the pathname of that url:
-              // http://localhost:8080/Plone/clients/client17-14/..
-              //    ..OA17-0030-R01
               simple_url = window.location.href.split('/ar')[0];
               simple_url = simple_url.split('?')[0];
               options.url = simple_url + '/' + options.url;
@@ -401,17 +381,19 @@
     };
   };
 
+
   /**
    * Controller class for Analysis Request Manage Results view
    */
+
   window.AnalysisRequestManageResultsView = function() {
     var that;
     that = this;
+
     /**
      * Entry-point method for AnalysisRequestManageResultsView
      */
     that.load = function() {
-      // Set the analyst automatically when selected in the picklist
       $('.portaltype-analysisrequest .bika-listing-table td.Analyst select').change(function() {
         var analyst, key, obj_path, obj_path_split;
         analyst = $(this).val();
@@ -436,50 +418,23 @@
     };
   };
 
+
   /**
    * Controller class for Analysis Request Analyses view
    */
+
   window.AnalysisRequestAnalysesView = function() {
-    /**
-    * Given a selected service, this function selects the dependencies for
-    * the selected service.
-    * @param {String} dlg: The dialog to display (Not working!)
-    * @param {DOM object} element: The checkbox object.
-    * @param {Object} dep_services: A list of UIDs.
-    * @return {None} nothing.
-     */
-    /**
-    * Once a checkbox has been selected, this functions finds out which are
-    * the dependencies and dependants related to it.
-    * @param {elements} The selected element, a checkbox.
-    * @param {auto_yes} A boolean. If 'true', the dependants and dependencies
-    * will be automatically selected/unselected.
-     */
-    /**
-    * This functions runs the logic needed after setting the checkbox of a
-    * service.
-    * @param {service_uid} the service uid checked.
-     */
-    /**
-    * Given an analysis service UID, this function expands the category for
-    * that service and selects it.
-    * @param {String} serv_uid: uid of the analysis service.
-    * @return {None} nothing.
-     */
-    /**
-    * This functions runs the logic needed after unsetting the checkbox of a
-    * service.
-    * @param {service_uid} the service uid unchecked.
-     */
+    var add_No, add_Yes, calcdependencies, check_service, expand_category_for_service, that, uncheck_service, validate_spec_field_entry;
+    that = this;
+
     /**
      * Entry-point method for AnalysisRequestAnalysesView
      */
+
     /**
     * This function validates specification inputs
     * @param {element} The input field from specifications (min, max, err)
      */
-    var add_No, add_Yes, calcdependencies, check_service, expand_category_for_service, that, uncheck_service, validate_spec_field_entry;
-    that = this;
     validate_spec_field_entry = function(element) {
       var error, error_element, max, max_element, min, min_element, uid;
       uid = $(element).attr('uid');
@@ -507,25 +462,31 @@
         }
       }
     };
-    check_service = function(service_uid) {
-      /* Check if this row is disabled. row_data has the attribute "disabled"
-      as true if the analysis service has been submitted. So, in this case
-      no further action will take place.
 
-      "allow_edit" attribute in bika_listing displays the editable fields.
-      Since the object keeps this attr even if the row is disabled; price,
-      partition, min,max and error will be displayed (but disabled).
-      */
+    /**
+    * This functions runs the logic needed after setting the checkbox of a
+    * service.
+    * @param {service_uid} the service uid checked.
+     */
+    check_service = function(service_uid) {
       var element, i, logged_in_client, new_element, row_data, specfields;
       new_element = void 0;
       element = void 0;
+
+      /* Check if this row is disabled. row_data has the attribute "disabled"
+      as true if the analysis service has been submitted. So, in this case
+      no further action will take place.
+      
+      "allow_edit" attribute in bika_listing displays the editable fields.
+      Since the object keeps this attr even if the row is disabled; price,
+      partition, min,max and error will be displayed (but disabled).
+       */
       row_data = $.parseJSON($('#' + service_uid + '_row_data').val());
       if (row_data !== '' && row_data !== void 0 && row_data !== null) {
         if ('disabled' in row_data && row_data.disabled === true) {
           return;
         }
       }
-      // Add partition dropdown
       element = $('[name=\'Partition.' + service_uid + ':records\']');
       new_element = '' + '<select class=\'listing_select_entry\' ' + 'name=\'Partition.' + service_uid + ':records\' ' + 'field=\'Partition\' uid=\'' + service_uid + '\' ' + 'style=\'font-size: 100%\'>';
       $.each($('td.PartTitle'), function(i, v) {
@@ -535,7 +496,6 @@
       });
       new_element = new_element + '</select>';
       $(element).replaceWith(new_element);
-      // Add price field
       logged_in_client = $('input[name=\'logged_in_client\']').val();
       if (logged_in_client !== '1') {
         element = $('[name=\'Price.' + service_uid + ':records\']');
@@ -543,7 +503,6 @@
         $($(element).siblings()[1]).remove();
         $(element).replaceWith(new_element);
       }
-      // spec fields
       specfields = ['min', 'max', 'error'];
       for (i in specfields) {
         element = $('[name=\'' + specfields[i] + '.' + service_uid + ':records\']');
@@ -551,6 +510,12 @@
         $(element).replaceWith(new_element);
       }
     };
+
+    /**
+    * This functions runs the logic needed after unsetting the checkbox of a
+    * service.
+    * @param {service_uid} the service uid unchecked.
+     */
     uncheck_service = function(service_uid) {
       var element, i, logged_in_client, new_element, specfields;
       new_element = void 0;
@@ -572,6 +537,15 @@
         $(element).replaceWith(new_element);
       }
     };
+
+    /**
+    * Given a selected service, this function selects the dependencies for
+    * the selected service.
+    * @param {String} dlg: The dialog to display (Not working!)
+    * @param {DOM object} element: The checkbox object.
+    * @param {Object} dep_services: A list of UIDs.
+    * @return {None} nothing.
+     */
     add_Yes = function(dlg, element, dep_services) {
       var dep_cb, i, service_uid;
       service_uid = void 0;
@@ -605,7 +579,17 @@
         $('#messagebox').remove();
       }
     };
+
+    /**
+    * Once a checkbox has been selected, this functions finds out which are
+    * the dependencies and dependants related to it.
+    * @param {elements} The selected element, a checkbox.
+    * @param {auto_yes} A boolean. If 'true', the dependants and dependencies
+    * will be automatically selected/unselected.
+     */
     calcdependencies = function(elements, auto_yes) {
+
+      /*jshint validthis:true */
       var Dependants, Dependencies, _, cb, dep, dep_services, dep_titles, element, elements_i, html, i, lims, service_uid;
       auto_yes = auto_yes || false;
       jarn.i18n.loadCatalog('bika');
@@ -617,11 +601,9 @@
       elements_i = 0;
       while (elements_i < elements.length) {
         dep_services = [];
-        // actionable services
         dep_titles = [];
         element = elements[elements_i];
         service_uid = $(element).attr('value');
-        // selecting a service; discover dependencies
         if ($(element).prop('checked')) {
           Dependencies = lims.AnalysisService.Dependencies(service_uid);
           i = 0;
@@ -631,7 +613,6 @@
               i++;
               continue;
             }
-            // skip if checked already
             dep_services.push(dep);
             dep_titles.push(dep.Service);
             i++;
@@ -723,9 +704,15 @@
         elements_i++;
       }
     };
+
+    /**
+    * Given an analysis service UID, this function expands the category for
+    * that service and selects it.
+    * @param {String} serv_uid: uid of the analysis service.
+    * @return {None} nothing.
+     */
     expand_category_for_service = function(serv_uid) {
       var request_data;
-      // Ajax getting the category from uid
       request_data = {
         catalog_name: 'uid_catalog',
         UID: serv_uid,
@@ -739,9 +726,7 @@
           window.bika.lims.warning(msg);
         } else {
           cat_title = data.objects[0].getCategoryTitle;
-          // Expand category by uid and select the service
           element = $('th[cat=\'' + cat_title + '\']');
-          //category_header_expand_handler(element, arnum, serv_uid);
           window.bika.lims.BikaListingTableView.category_header_expand_handler(element).done(function() {
             check_service(serv_uid);
             $('#list_cb_' + serv_uid).prop('checked', true);
@@ -753,15 +738,11 @@
       $('[name^=\'min\\.\'], [name^=\'max\\.\'], [name^=\'error\\.\']').live('change', function() {
         validate_spec_field_entry(this);
       });
-      ////////////////////////////////////////
-      // disable checkboxes for eg verified analyses.
       $.each($('[name=\'uids:list\']'), function(x, cb) {
         var cbid, cbname, el, element, elname, elval, i, new_element, row_data, service_uid, specfields;
         service_uid = $(cb).val();
         row_data = $.parseJSON($('#' + service_uid + '_row_data').val());
         if (row_data.disabled === true) {
-          // disabled fields must be shadowed by hidden fields,
-          // or they don't appear in the submitted form.
           $(cb).prop('disabled', true);
           cbname = $(cb).attr('name');
           cbid = $(cb).attr('id');
@@ -785,8 +766,6 @@
           }
         }
       });
-      ////////////////////////////////////////
-      // checkboxes in services list
       $('[name=\'uids:list\']').live('click', function() {
         var service_uid;
         calcdependencies([this], true);

--- a/bika/lims/browser/js/bika.lims.analysisservice.js
+++ b/bika/lims/browser/js/bika.lims.analysisservice.js
@@ -1,137 +1,120 @@
-(function() {
-  /* Please use this command to compile this file into the parent `js` directory:
-      coffee --no-header -w -o ../ -c bika.lims.analysisservice.coffee
-  */
-  var indexOf = [].indexOf;
 
-  window.AnalysisServiceEditView = class AnalysisServiceEditView {
-    constructor() {
-      this.load = this.load.bind(this);
-      /* INITIALIZERS */
-      this.bind_eventhandler = this.bind_eventhandler.bind(this);
-      this.init = this.init.bind(this);
-      /* FIELD GETTERS/SETTERS/SELECTORS */
-      this.is_manual_entry_of_results_allowed = this.is_manual_entry_of_results_allowed.bind(this);
-      this.toggle_manual_entry_of_results_allowed = this.toggle_manual_entry_of_results_allowed.bind(this);
-      this.get_methods = this.get_methods.bind(this);
-      this.set_methods = this.set_methods.bind(this);
-      this.select_methods = this.select_methods.bind(this);
-      this.is_instrument_assignment_allowed = this.is_instrument_assignment_allowed.bind(this);
-      this.toggle_instrument_assignment_allowed = this.toggle_instrument_assignment_allowed.bind(this);
-      this.get_instruments = this.get_instruments.bind(this);
-      this.set_instruments = this.set_instruments.bind(this);
-      this.select_instruments = this.select_instruments.bind(this);
-      this.get_default_method = this.get_default_method.bind(this);
-      this.set_default_method = this.set_default_method.bind(this);
-      this.select_default_method = this.select_default_method.bind(this);
-      this.get_default_instrument = this.get_default_instrument.bind(this);
-      this.set_default_instrument = this.set_default_instrument.bind(this);
-      this.select_default_instrument = this.select_default_instrument.bind(this);
-      this.use_default_calculation_of_method = this.use_default_calculation_of_method.bind(this);
-      this.toggle_use_default_calculation_of_method = this.toggle_use_default_calculation_of_method.bind(this);
-      this.get_calculation = this.get_calculation.bind(this);
-      this.set_calculation = this.set_calculation.bind(this);
-      this.select_calculation = this.select_calculation.bind(this);
-      this.get_interims = this.get_interims.bind(this);
-      this.set_interims = this.set_interims.bind(this);
-      this.flush_interims = this.flush_interims.bind(this);
-      this.set_method_calculation = this.set_method_calculation.bind(this);
-      this.set_instrument_methods = this.set_instrument_methods.bind(this);
-      this.display_detection_limit_selector = this.display_detection_limit_selector.bind(this);
-      this.toggle_display_detection_limit_selector = this.toggle_display_detection_limit_selector.bind(this);
-      this.show_alert = this.show_alert.bind(this);
-      /* ASYNC DATA LOADERS */
-      this.load_available_instruments = this.load_available_instruments.bind(this);
-      this.load_instrument_methods = this.load_instrument_methods.bind(this);
-      this.load_method_calculation = this.load_method_calculation.bind(this);
-      this.load_calculation = this.load_calculation.bind(this);
-      this.load_manual_interims = this.load_manual_interims.bind(this);
-      this.load_object_by_uid = this.load_object_by_uid.bind(this);
-      /* HELPERS */
-      this.ajax_submit = this.ajax_submit.bind(this);
-      this.get_url = this.get_url.bind(this);
-      this.get_portal_url = this.get_portal_url.bind(this);
-      this.is_uid = this.is_uid.bind(this);
-      this.add_select_option = this.add_select_option.bind(this);
-      this.parse_select_options = this.parse_select_options.bind(this);
-      this.parse_select_option = this.parse_select_option.bind(this);
-      this.select_options = this.select_options.bind(this);
-      this.toggle_checkbox = this.toggle_checkbox.bind(this);
-      /* EVENT HANDLER */
-      this.on_manual_entry_of_results_change = this.on_manual_entry_of_results_change.bind(this);
-      this.on_methods_change = this.on_methods_change.bind(this);
-      this.on_instrument_assignment_allowed_change = this.on_instrument_assignment_allowed_change.bind(this);
-      this.on_instruments_change = this.on_instruments_change.bind(this);
-      this.on_default_instrument_change = this.on_default_instrument_change.bind(this);
-      this.on_default_method_change = this.on_default_method_change.bind(this);
-      this.on_use_default_calculation_change = this.on_use_default_calculation_change.bind(this);
-      this.on_calculation_change = this.on_calculation_change.bind(this);
-      this.on_display_detection_limit_selector_change = this.on_display_detection_limit_selector_change.bind(this);
-      this.on_separate_container_change = this.on_separate_container_change.bind(this);
-      this.on_default_preservation_change = this.on_default_preservation_change.bind(this);
-      this.on_default_container_change = this.on_default_container_change.bind(this);
-      this.on_partition_sampletype_change = this.on_partition_sampletype_change.bind(this);
-      this.on_partition_separate_container_change = this.on_partition_separate_container_change.bind(this);
-      this.on_partition_container_change = this.on_partition_container_change.bind(this);
-      this.on_partition_required_volume_change = this.on_partition_required_volume_change.bind(this);
+/* Please use this command to compile this file into the parent `js` directory:
+    coffee --no-header -w -o ../ -c bika.lims.analysisservice.coffee
+ */
+
+(function() {
+  var bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
+    indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
+
+  window.AnalysisServiceEditView = (function() {
+    function AnalysisServiceEditView() {
+      this.on_partition_required_volume_change = bind(this.on_partition_required_volume_change, this);
+      this.on_partition_container_change = bind(this.on_partition_container_change, this);
+      this.on_partition_separate_container_change = bind(this.on_partition_separate_container_change, this);
+      this.on_partition_sampletype_change = bind(this.on_partition_sampletype_change, this);
+      this.on_default_container_change = bind(this.on_default_container_change, this);
+      this.on_default_preservation_change = bind(this.on_default_preservation_change, this);
+      this.on_separate_container_change = bind(this.on_separate_container_change, this);
+      this.on_display_detection_limit_selector_change = bind(this.on_display_detection_limit_selector_change, this);
+      this.on_calculation_change = bind(this.on_calculation_change, this);
+      this.on_use_default_calculation_change = bind(this.on_use_default_calculation_change, this);
+      this.on_default_method_change = bind(this.on_default_method_change, this);
+      this.on_default_instrument_change = bind(this.on_default_instrument_change, this);
+      this.on_instruments_change = bind(this.on_instruments_change, this);
+      this.on_instrument_assignment_allowed_change = bind(this.on_instrument_assignment_allowed_change, this);
+      this.on_methods_change = bind(this.on_methods_change, this);
+      this.on_manual_entry_of_results_change = bind(this.on_manual_entry_of_results_change, this);
+      this.toggle_checkbox = bind(this.toggle_checkbox, this);
+      this.select_options = bind(this.select_options, this);
+      this.parse_select_option = bind(this.parse_select_option, this);
+      this.parse_select_options = bind(this.parse_select_options, this);
+      this.add_select_option = bind(this.add_select_option, this);
+      this.is_uid = bind(this.is_uid, this);
+      this.get_portal_url = bind(this.get_portal_url, this);
+      this.get_url = bind(this.get_url, this);
+      this.ajax_submit = bind(this.ajax_submit, this);
+      this.load_object_by_uid = bind(this.load_object_by_uid, this);
+      this.load_manual_interims = bind(this.load_manual_interims, this);
+      this.load_calculation = bind(this.load_calculation, this);
+      this.load_method_calculation = bind(this.load_method_calculation, this);
+      this.load_instrument_methods = bind(this.load_instrument_methods, this);
+      this.load_available_instruments = bind(this.load_available_instruments, this);
+      this.show_alert = bind(this.show_alert, this);
+      this.toggle_display_detection_limit_selector = bind(this.toggle_display_detection_limit_selector, this);
+      this.display_detection_limit_selector = bind(this.display_detection_limit_selector, this);
+      this.set_instrument_methods = bind(this.set_instrument_methods, this);
+      this.set_method_calculation = bind(this.set_method_calculation, this);
+      this.flush_interims = bind(this.flush_interims, this);
+      this.set_interims = bind(this.set_interims, this);
+      this.get_interims = bind(this.get_interims, this);
+      this.select_calculation = bind(this.select_calculation, this);
+      this.set_calculation = bind(this.set_calculation, this);
+      this.get_calculation = bind(this.get_calculation, this);
+      this.toggle_use_default_calculation_of_method = bind(this.toggle_use_default_calculation_of_method, this);
+      this.use_default_calculation_of_method = bind(this.use_default_calculation_of_method, this);
+      this.select_default_instrument = bind(this.select_default_instrument, this);
+      this.set_default_instrument = bind(this.set_default_instrument, this);
+      this.get_default_instrument = bind(this.get_default_instrument, this);
+      this.select_default_method = bind(this.select_default_method, this);
+      this.set_default_method = bind(this.set_default_method, this);
+      this.get_default_method = bind(this.get_default_method, this);
+      this.select_instruments = bind(this.select_instruments, this);
+      this.set_instruments = bind(this.set_instruments, this);
+      this.get_instruments = bind(this.get_instruments, this);
+      this.toggle_instrument_assignment_allowed = bind(this.toggle_instrument_assignment_allowed, this);
+      this.is_instrument_assignment_allowed = bind(this.is_instrument_assignment_allowed, this);
+      this.select_methods = bind(this.select_methods, this);
+      this.set_methods = bind(this.set_methods, this);
+      this.get_methods = bind(this.get_methods, this);
+      this.toggle_manual_entry_of_results_allowed = bind(this.toggle_manual_entry_of_results_allowed, this);
+      this.is_manual_entry_of_results_allowed = bind(this.is_manual_entry_of_results_allowed, this);
+      this.init = bind(this.init, this);
+      this.bind_eventhandler = bind(this.bind_eventhandler, this);
+      this.load = bind(this.load, this);
     }
 
-    load() {
+    AnalysisServiceEditView.prototype.load = function() {
       var d1, d2;
       console.debug("AnalysisServiceEditView::load");
-      // load translations
       jarn.i18n.loadCatalog("bika");
       this._ = window.jarn.i18n.MessageFactory("bika");
-      // All available instruments by UID
       this.all_instruments = {};
-      // All invalid instruments by UID
       this.invalid_instruments = {};
-      // Load available instruments
       d1 = this.load_available_instruments().done(function(instruments) {
         var me;
         me = this;
         return $.each(instruments, function(index, instrument) {
           var uid;
           uid = instrument.UID;
-          // remember the instrument
           me.all_instruments[uid] = instrument;
           if (instrument.Valid !== "1") {
-            // remember invalid instrument
             return me.invalid_instruments[uid] = instrument;
           }
         });
       });
-      // Interim values defined by the user (not part of the current calculation)
       this.manual_interims = [];
-      // Calculate manual set interims
       d2 = this.load_manual_interims().done(function(manual_interims) {
         return this.manual_interims = manual_interims;
       });
-      // UIDs of the initial selected methods
       this.selected_methods = this.get_methods();
-      // UIDs of the initial selected instruments
       this.selected_instruments = this.get_instruments();
-      // UID of the initial selected calculation
       this.selected_calculation = this.get_calculation();
-      // UID of the initial selected default instrument
       this.selected_default_instrument = this.get_default_instrument();
-      // UID of the initial selected default method
       this.selected_default_method = this.get_default_method();
-      // Array of UID/Title objects of the initial options from the methods field
       this.methods = this.parse_select_options($("#archetypes-fieldname-Methods #Methods"));
-      // Array of UID/Title objects of the initial options from the instrument field
       this.instruments = this.parse_select_options($("#archetypes-fieldname-Instruments #Instruments"));
-      // Array of UID/Title objects of the initial options from the calculations field
       this.calculations = this.parse_select_options($("#archetypes-fieldname-Calculation #Calculation"));
-      // bind the event handler to the elements
       this.bind_eventhandler();
-      // initialize the form when all data is loaded
       $.when(d1, d2).then(this.init);
-      // Dev only
       return window.asv = this;
-    }
+    };
 
-    bind_eventhandler() {
+
+    /* INITIALIZERS */
+
+    AnalysisServiceEditView.prototype.bind_eventhandler = function() {
+
       /*
        * Binds callbacks on elements
        *
@@ -139,74 +122,54 @@
        * delegate the event: https://learn.jquery.com/events/event-delegation/
        */
       console.debug("AnalysisServiceEditView::bind_eventhandler");
-      /* METHODS TAB */
-      // The "Instrument assignment is not required" checkbox changed
-      $("body").on("change", "#archetypes-fieldname-ManualEntryOfResults #ManualEntryOfResults", this.on_manual_entry_of_results_change);
-      // The "Methods" multiselect changed
-      $("body").on("change", "#archetypes-fieldname-Methods #Methods", this.on_methods_change);
-      // The "Instrument assignment is allowed" checkbox changed
-      $("body").on("change", "#archetypes-fieldname-InstrumentEntryOfResults #InstrumentEntryOfResults", this.on_instrument_assignment_allowed_change);
-      // The "Instruments" multiselect changed
-      $("body").on("change", "#archetypes-fieldname-Instruments #Instruments", this.on_instruments_change);
-      // The "Default Instrument" selector changed
-      $("body").on("change", "#archetypes-fieldname-Instrument #Instrument", this.on_default_instrument_change);
-      // The "Default Method" select changed
-      $("body").on("change", "#archetypes-fieldname-Method #Method", this.on_default_method_change);
-      // The "Use the Default Calculation of Method" checkbox changed
-      $("body").on("change", "#archetypes-fieldname-UseDefaultCalculation #UseDefaultCalculation", this.on_use_default_calculation_change);
-      // The "Calculation" selector changed
-      $("body").on("change", "#archetypes-fieldname-Calculation #Calculation", this.on_calculation_change);
-      /* ANALYSIS TAB */
-      // The "Display a Detection Limit selector" checkbox changed
-      $("body").on("change", "#archetypes-fieldname-DetectionLimitSelector #DetectionLimitSelector", this.on_display_detection_limit_selector_change);
-      /* CONTAINER AND PRESERVATION TAB */
-      // The "Separate Container" checkbox changed
-      $("body").on("change", "#archetypes-fieldname-Separate #Separate", this.on_separate_container_change);
-      // The "Default Preservation" select changed
-      $("body").on("change", "#archetypes-fieldname-Preservation #Preservation", this.on_default_preservation_change);
-      // The "Default Container" select changed
-      $("body").on("selected", "#archetypes-fieldname-Container #Container", this.on_default_container_change);
-      // The "Sample Type" select changed in the Partition setup
-      $("body").on("change", "#archetypes-fieldname-PartitionSetup [name^='PartitionSetup.sampletype']", this.on_partition_sampletype_change);
-      // The "Separate Container" checkbox changed in the Partition setup
-      $("body").on("change", "#archetypes-fieldname-PartitionSetup [name^='PartitionSetup.separate']", this.on_partition_separate_container_change);
-      // The "Container" checkbox changed in the Partition setup
-      $("body").on("change", "#archetypes-fieldname-PartitionSetup [name^='PartitionSetup.container']", this.on_partition_container_change);
-      // The "Required Volume" value changed in the Partition setup
-      return $("body").on("change", "#archetypes-fieldname-PartitionSetup [name^='PartitionSetup.vol']", this.on_partition_required_volume_change);
-    }
 
-    init() {
+      /* METHODS TAB */
+      $("body").on("change", "#archetypes-fieldname-ManualEntryOfResults #ManualEntryOfResults", this.on_manual_entry_of_results_change);
+      $("body").on("change", "#archetypes-fieldname-Methods #Methods", this.on_methods_change);
+      $("body").on("change", "#archetypes-fieldname-InstrumentEntryOfResults #InstrumentEntryOfResults", this.on_instrument_assignment_allowed_change);
+      $("body").on("change", "#archetypes-fieldname-Instruments #Instruments", this.on_instruments_change);
+      $("body").on("change", "#archetypes-fieldname-Instrument #Instrument", this.on_default_instrument_change);
+      $("body").on("change", "#archetypes-fieldname-Method #Method", this.on_default_method_change);
+      $("body").on("change", "#archetypes-fieldname-UseDefaultCalculation #UseDefaultCalculation", this.on_use_default_calculation_change);
+      $("body").on("change", "#archetypes-fieldname-Calculation #Calculation", this.on_calculation_change);
+
+      /* ANALYSIS TAB */
+      $("body").on("change", "#archetypes-fieldname-DetectionLimitSelector #DetectionLimitSelector", this.on_display_detection_limit_selector_change);
+
+      /* CONTAINER AND PRESERVATION TAB */
+      $("body").on("change", "#archetypes-fieldname-Separate #Separate", this.on_separate_container_change);
+      $("body").on("change", "#archetypes-fieldname-Preservation #Preservation", this.on_default_preservation_change);
+      $("body").on("selected", "#archetypes-fieldname-Container #Container", this.on_default_container_change);
+      $("body").on("change", "#archetypes-fieldname-PartitionSetup [name^='PartitionSetup.sampletype']", this.on_partition_sampletype_change);
+      $("body").on("change", "#archetypes-fieldname-PartitionSetup [name^='PartitionSetup.separate']", this.on_partition_separate_container_change);
+      $("body").on("change", "#archetypes-fieldname-PartitionSetup [name^='PartitionSetup.container']", this.on_partition_container_change);
+      return $("body").on("change", "#archetypes-fieldname-PartitionSetup [name^='PartitionSetup.vol']", this.on_partition_required_volume_change);
+    };
+
+    AnalysisServiceEditView.prototype.init = function() {
+
       /**
        * Initialize Form
        */
-      // Set "Instrument assignment is not required" checkbox
       if (this.is_manual_entry_of_results_allowed()) {
         console.debug("--> Manual Entry of Results is allowed");
-        // restore all initial set methods in the method multi-select
         this.set_methods(this.methods);
       } else {
         console.debug("--> Manual Entry of Results is **not** allowed");
-        // flush all methods and add only the "None" option
         this.set_methods(null);
       }
-      // Set "Instrument assignment is allowed" checkbox
       if (this.is_instrument_assignment_allowed()) {
         console.debug("--> Instrument assignment is allowed");
-        // restore all initial set instruments
         this.set_instruments(this.instruments);
       } else {
         console.debug("--> Instrument assignment is **not** allowed");
-        // flush all instruments and add only the "None" option
         this.set_instruments(null);
       }
-      // Set "Use the Default Calculation of Method" checkbox
       if (this.use_default_calculation_of_method()) {
         console.debug("--> Use default calculation of method");
       } else {
         console.debug("--> Use default calculation of instrument");
       }
-      // Set "Display a Detection Limit selector" checkbox
       if (this.display_detection_limit_selector()) {
         console.debug("--> Allow detection limit selector");
         return this.toggle_display_detection_limit_selector(true);
@@ -214,9 +177,13 @@
         console.debug("--> Disallow detection limit selector");
         return this.toggle_display_detection_limit_selector(false);
       }
-    }
+    };
 
-    is_manual_entry_of_results_allowed() {
+
+    /* FIELD GETTERS/SETTERS/SELECTORS */
+
+    AnalysisServiceEditView.prototype.is_manual_entry_of_results_allowed = function() {
+
       /**
        * Get the value of the checkbox "Instrument assignment is not required"
        *
@@ -225,18 +192,23 @@
       var field;
       field = $("#archetypes-fieldname-ManualEntryOfResults #ManualEntryOfResults");
       return field.is(":checked");
-    }
+    };
 
-    toggle_manual_entry_of_results_allowed(toggle, silent = true) {
+    AnalysisServiceEditView.prototype.toggle_manual_entry_of_results_allowed = function(toggle, silent) {
+      var field;
+      if (silent == null) {
+        silent = true;
+      }
+
       /**
        * Toggle the "Instrument assignment is not required" checkbox
        */
-      var field;
       field = $("#archetypes-fieldname-ManualEntryOfResults #ManualEntryOfResults");
       return this.toggle_checkbox(field, toggle, silent);
-    }
+    };
 
-    get_methods() {
+    AnalysisServiceEditView.prototype.get_methods = function() {
+
       /**
        * Get all selected method UIDs from the multiselect field
        *
@@ -245,9 +217,14 @@
       var field;
       field = $("#archetypes-fieldname-Methods #Methods");
       return $.extend([], field.val());
-    }
+    };
 
-    set_methods(methods, flush = true) {
+    AnalysisServiceEditView.prototype.set_methods = function(methods, flush) {
+      var field, me;
+      if (flush == null) {
+        flush = true;
+      }
+
       /**
        * Set the methods multiselect field with the given methods
        *
@@ -257,11 +234,8 @@
        * @param {boolean} flush
        *    True to empty all instruments first
        */
-      var field, me;
       field = $("#archetypes-fieldname-Methods #Methods");
-      // create a copy of the methods array
       methods = $.extend([], methods);
-      // empty the field if the `flush` flag is set
       if (flush) {
         field.empty();
       }
@@ -271,7 +245,6 @@
         me = this;
         $.each(methods, function(index, method) {
           var title, uid;
-          // ensure only "methods with allow manual entry"
           if (method.ManualEntryOfResults === false) {
             return;
           }
@@ -280,49 +253,43 @@
           return me.add_select_option(field, title, uid);
         });
       }
-      // restore initial selection
       return this.select_methods(this.selected_methods);
-    }
+    };
 
-    select_methods(uids) {
-      var field, me;
+    AnalysisServiceEditView.prototype.select_methods = function(uids) {
+
       /**
        * Select methods by UID
        *
        * @param {Array} uids
        *    UIDs of Methods to select
        */
+      var field, me;
       if (!this.is_manual_entry_of_results_allowed()) {
         console.debug("Manual entry of results is not allowed");
         return;
       }
       field = $("#archetypes-fieldname-Methods #Methods");
-      // set selected attribute to the options
       this.select_options(field, uids);
-      // Set selected value to the default method select box
       me = this;
       $.each(uids, function(index, uid) {
         var flush, method, option;
-        // flush the field for the first element
         flush = index === 0 && true || false;
-        // extract the title and uid from the option element
-        option = field.find(`option[value=${uid}]`);
+        option = field.find("option[value=" + uid + "]");
         method = {
           uid: option.val(),
           title: option.text()
         };
-        // append option to the default method select box
         return me.set_default_method(method, flush = flush);
       });
-      // restore initial selected default method
       this.select_default_method(this.selected_default_method);
       if (this.use_default_calculation_of_method()) {
-        // set the calculation of the default method
         return this.set_method_calculation(this.get_default_method());
       }
-    }
+    };
 
-    is_instrument_assignment_allowed() {
+    AnalysisServiceEditView.prototype.is_instrument_assignment_allowed = function() {
+
       /**
        * Get the value of the checkbox "Instrument assignment is allowed"
        *
@@ -331,18 +298,23 @@
       var field;
       field = $("#archetypes-fieldname-InstrumentEntryOfResults #InstrumentEntryOfResults");
       return field.is(":checked");
-    }
+    };
 
-    toggle_instrument_assignment_allowed(toggle, silent = true) {
+    AnalysisServiceEditView.prototype.toggle_instrument_assignment_allowed = function(toggle, silent) {
+      var field;
+      if (silent == null) {
+        silent = true;
+      }
+
       /**
        * Toggle the "Instrument assignment is allowed" checkbox
        */
-      var field;
       field = $("#archetypes-fieldname-InstrumentEntryOfResults #InstrumentEntryOfResults");
       return this.toggle_checkbox(field, toggle, silent);
-    }
+    };
 
-    get_instruments() {
+    AnalysisServiceEditView.prototype.get_instruments = function() {
+
       /**
        * Get all selected instrument UIDs from the multiselect
        *
@@ -351,9 +323,14 @@
       var field;
       field = $("#archetypes-fieldname-Instruments #Instruments");
       return $.extend([], field.val());
-    }
+    };
 
-    set_instruments(instruments, flush = true) {
+    AnalysisServiceEditView.prototype.set_instruments = function(instruments, flush) {
+      var field, me;
+      if (flush == null) {
+        flush = true;
+      }
+
       /*
        * Set the instruments to the field
        *
@@ -363,18 +340,14 @@
        * @param {boolean} flush
        *    True to empty all instruments first
        */
-      var field, me;
       field = $("#archetypes-fieldname-Instruments #Instruments");
-      // create a copy of the instruments array
       instruments = $.extend([], instruments);
-      // empty the field if the `flush` flag is set
       if (flush) {
         field.empty();
       }
       if (instruments.length === 0) {
         this.add_select_option(field, null);
       } else {
-        // set the instruments
         me = this;
         $.each(instruments, function(index, instrument) {
           var title, uid;
@@ -383,45 +356,41 @@
           return me.add_select_option(field, title, uid);
         });
       }
-      // restore initial selection
       return this.select_instruments(this.selected_instruments);
-    }
+    };
 
-    select_instruments(uids) {
-      var field, invalid_instruments, me, notification, title;
+    AnalysisServiceEditView.prototype.select_instruments = function(uids) {
+
       /**
        * Select instruments by UID
        *
        * @param {Array} uids
        *    UIDs of Instruments to select
        */
+      var field, invalid_instruments, me, notification, title;
       if (!this.is_instrument_assignment_allowed()) {
         console.debug("Instrument assignment not allowed");
         this.set_default_instrument(null);
         return;
       }
       field = $("#archetypes-fieldname-Instruments #Instruments");
-      // set selected attribute to the options
       this.select_options(field, uids);
       invalid_instruments = [];
-      // Set selected instruments to the list of the default instruments
       me = this;
       $.each(uids, function(index, uid) {
         var flush, instrument;
         flush = index === 0 && true || false;
-        // get the instrument
         instrument = me.all_instruments[uid];
         if (uid in me.invalid_instruments) {
-          console.warn(`Instrument '${instrument.Title}' is invalid`);
+          console.warn("Instrument '" + instrument.Title + "' is invalid");
           invalid_instruments.push(instrument);
         }
         return me.set_default_instrument(instrument, flush = flush);
       });
-      // show invalid instruments
       if (invalid_instruments.length > 0) {
         notification = $("<dl/>");
         $.each(invalid_instruments, function(index, instrument) {
-          return notification.append(`<dd>⚠ ${instrument.Title}</dd>`);
+          return notification.append("<dd>⚠ " + instrument.Title + "</dd>");
         });
         title = this._("Some of the selected instruments are out-of-date, with failed calibration tests or under maintenance");
         this.show_alert({
@@ -433,13 +402,12 @@
           message: ""
         });
       }
-      // restore initially selected default instrument
       this.select_default_instrument(this.selected_default_instrument);
-      // set the instrument methods of the default instrument
       return this.set_instrument_methods(this.get_default_instrument());
-    }
+    };
 
-    get_default_method() {
+    AnalysisServiceEditView.prototype.get_default_method = function() {
+
       /**
        * Get the UID of the selected default method
        *
@@ -448,17 +416,19 @@
       var field;
       field = $("#archetypes-fieldname-Method #Method");
       return field.val();
-    }
+    };
 
-    set_default_method(method, flush = true) {
+    AnalysisServiceEditView.prototype.set_default_method = function(method, flush) {
+      var field, title, uid;
+      if (flush == null) {
+        flush = true;
+      }
+
       /**
        * Set options for the default method select
        */
-      var field, title, uid;
       field = $("#archetypes-fieldname-Method #Method");
-      // create a copy of the method
       method = $.extend({}, method);
-      // empty the field first
       if (flush) {
         field.empty();
       }
@@ -469,9 +439,10 @@
       } else {
         return this.add_select_option(field, null);
       }
-    }
+    };
 
-    select_default_method(uid) {
+    AnalysisServiceEditView.prototype.select_default_method = function(uid) {
+
       /**
        * Select method by UID
        *
@@ -481,9 +452,10 @@
       var field;
       field = $("#archetypes-fieldname-Method #Method");
       return this.select_options(field, [uid]);
-    }
+    };
 
-    get_default_instrument() {
+    AnalysisServiceEditView.prototype.get_default_instrument = function() {
+
       /**
        * Get the UID of the selected default instrument
        *
@@ -492,17 +464,19 @@
       var field;
       field = $("#archetypes-fieldname-Instrument #Instrument");
       return field.val();
-    }
+    };
 
-    set_default_instrument(instrument, flush = true) {
+    AnalysisServiceEditView.prototype.set_default_instrument = function(instrument, flush) {
+      var field, title, uid;
+      if (flush == null) {
+        flush = true;
+      }
+
       /*
        * Set options for the default instrument select
        */
-      var field, title, uid;
       field = $("#archetypes-fieldname-Instrument #Instrument");
-      // create a copy of the instrument
       instrument = $.extend({}, instrument);
-      // empty the field first
       if (flush) {
         field.empty();
       }
@@ -513,9 +487,10 @@
       } else {
         return this.add_select_option(field, null);
       }
-    }
+    };
 
-    select_default_instrument(uid) {
+    AnalysisServiceEditView.prototype.select_default_instrument = function(uid) {
+
       /**
        * Select instrument by UID
        *
@@ -525,9 +500,10 @@
       var field;
       field = $("#archetypes-fieldname-Instrument #Instrument");
       return this.select_options(field, [uid]);
-    }
+    };
 
-    use_default_calculation_of_method() {
+    AnalysisServiceEditView.prototype.use_default_calculation_of_method = function() {
+
       /**
        * Get the value of the checkbox "Use the Default Calculation of Method"
        *
@@ -536,18 +512,23 @@
       var field;
       field = $("#archetypes-fieldname-UseDefaultCalculation #UseDefaultCalculation");
       return field.is(":checked");
-    }
+    };
 
-    toggle_use_default_calculation_of_method(toggle, silent = true) {
+    AnalysisServiceEditView.prototype.toggle_use_default_calculation_of_method = function(toggle, silent) {
+      var field;
+      if (silent == null) {
+        silent = true;
+      }
+
       /**
        * Toggle the "Use the Default Calculation of Method" checkbox
        */
-      var field;
       field = $("#archetypes-fieldname-UseDefaultCalculation #UseDefaultCalculation");
       return this.toggle_checkbox(field, toggle, silent);
-    }
+    };
 
-    get_calculation() {
+    AnalysisServiceEditView.prototype.get_calculation = function() {
+
       /**
        * Get the UID of the selected default calculation
        *
@@ -556,15 +537,18 @@
       var field;
       field = $("#archetypes-fieldname-Calculation #Calculation");
       return field.val();
-    }
+    };
 
-    set_calculation(calculation, flush = true) {
+    AnalysisServiceEditView.prototype.set_calculation = function(calculation, flush) {
+      var field, title, uid;
+      if (flush == null) {
+        flush = true;
+      }
+
       /**
        * Set the calculation field with the given calculation data
        */
-      var field, title, uid;
       field = $("#archetypes-fieldname-Calculation #Calculation");
-      // create a copy of the calculation
       calculation = $.extend({}, calculation);
       if (flush) {
         field.empty();
@@ -576,9 +560,10 @@
       } else {
         return this.add_select_option(field, null);
       }
-    }
+    };
 
-    select_calculation(uid) {
+    AnalysisServiceEditView.prototype.select_calculation = function(uid) {
+
       /**
        * Select calculation by UID
        *
@@ -588,13 +573,13 @@
       var field;
       field = $("#archetypes-fieldname-Calculation #Calculation");
       this.select_options(field, [uid]);
-      // load the calculation now, to set the interims
       return this.load_calculation(uid).done(function(calculation) {
         return this.set_interims(calculation.InterimFields);
       });
-    }
+    };
 
-    get_interims() {
+    AnalysisServiceEditView.prototype.get_interims = function() {
+
       /**
        * Extract the interim field values as a list of objects
        *
@@ -609,8 +594,6 @@
         values = {};
         $.each($(row).find("td input"), function(index, input) {
           var key, value;
-          // Extract the key from the element name
-          // InterimFields.keyword:records:ignore_empty
           key = this.name.split(":")[0].split(".")[1];
           value = input.value;
           if (input.type === "checkbox") {
@@ -618,43 +601,39 @@
           }
           return values[key] = value;
         });
-        // Only rows with Keyword set
         if (values.keyword !== "") {
           return interims.push(values);
         }
       });
       return interims;
-    }
+    };
 
-    set_interims(interims, flush = true) {
+    AnalysisServiceEditView.prototype.set_interims = function(interims, flush) {
       var field, interim_keys, more_button;
+      if (flush == null) {
+        flush = true;
+      }
+
       /**
        * Set the interim field values
        *
        * Note: This method takes the same input format as returned from get_interims
        */
-      // create a copy of the calculation interims
       interims = $.extend([], interims);
       field = $("#archetypes-fieldname-InterimFields");
       more_button = field.find("#InterimFields_more");
-      // empty all interims
       if (flush) {
         this.flush_interims();
       }
-      // extract the keys of the calculation interims
       interim_keys = interims.map(function(v) {
         return v.keyword;
       });
-      // always keep manual set interims
       $.each(this.manual_interims, function(index, interim) {
         var i;
-        // the keyword of the manual interim is in the keys of the calculation
-        // interims -> overwrite calculation interim with the manual interim
         i = interim_keys.indexOf(interim.keyword);
         if (i >= 0) {
           return interims[i] = interim;
         } else {
-          // append the manual interim at the end
           return interims.push(interim);
         }
       });
@@ -663,13 +642,11 @@
         last_row = field.find("tr.records_row_InterimFields").last();
         more_button.click();
         inputs = last_row.find("input");
-        // iterate over all inputs of the interim field
         return $.each(inputs, function(index, input) {
           var key, value;
           key = this.name.split(":")[0].split(".")[1];
           value = interim[key];
           if (input.type === "checkbox") {
-            // transform to bool value
             if (value) {
               value = true;
             } else {
@@ -684,9 +661,10 @@
           }
         });
       });
-    }
+    };
 
-    flush_interims() {
+    AnalysisServiceEditView.prototype.flush_interims = function() {
+
       /**
        * Flush interim field
        */
@@ -696,9 +674,10 @@
       more_button.click();
       rows = field.find("tr.records_row_InterimFields");
       return rows.not(":last").remove();
-    }
+    };
 
-    set_method_calculation(method_uid) {
+    AnalysisServiceEditView.prototype.set_method_calculation = function(method_uid) {
+
       /**
        * Loads the calculation of the method and set the interims of it
        *
@@ -706,51 +685,47 @@
        *    The UID of the method to set the calculations from
        */
       if (!this.is_uid(method_uid)) {
-        // remove all calculation interims
         this.set_interims(null);
-        // Set empty calculation
         return this.set_calculation(null);
       } else {
-        // load the assigned calculation of the method
         return this.load_method_calculation(method_uid).done(function(calculation) {
-          // set the default calculation
           this.set_calculation(calculation);
-          // set the interims of the default calculation
           return this.set_interims(calculation.InterimFields);
         });
       }
-    }
+    };
 
-    set_instrument_methods(instrument_uid, flush = true) {
+    AnalysisServiceEditView.prototype.set_instrument_methods = function(instrument_uid, flush) {
+      var me;
+      if (flush == null) {
+        flush = true;
+      }
+
       /**
        * Loads the methods of the instrument
        *
        * @param {string} instrument_uid
        *    The UID of the instrument to set the method from
        */
-      var me;
       me = this;
-      // Leave default method if the "None" instrument was selected
       if (!this.is_uid(instrument_uid)) {
         return;
       }
       return this.load_instrument_methods(instrument_uid).done(function(methods) {
         methods = $.extend([], methods);
-        // Extend the default methods with the instrument methods
         $.each(methods, function(index, method) {
           flush = index === 0 ? true : false;
           return me.set_default_method(method, flush = flush);
         });
-        // restore the initially selected method
         this.select_default_method(this.selected_default_method);
-        // set the calculation of the method
         if (this.use_default_calculation_of_method()) {
           return this.set_method_calculation(this.get_default_method());
         }
       });
-    }
+    };
 
-    display_detection_limit_selector() {
+    AnalysisServiceEditView.prototype.display_detection_limit_selector = function() {
+
       /**
        * Get the value of the checkbox "Display a Detection Limit selector"
        *
@@ -759,18 +734,21 @@
       var field;
       field = $("#archetypes-fieldname-DetectionLimitSelector #DetectionLimitSelector");
       return field.is(":checked");
-    }
+    };
 
-    toggle_display_detection_limit_selector(toggle, silent = true) {
+    AnalysisServiceEditView.prototype.toggle_display_detection_limit_selector = function(toggle, silent) {
+      var field, field2;
+      if (silent == null) {
+        silent = true;
+      }
+
       /**
        * Toggle the "Display detection limit selector" checkbox
        *
        * If it is checked, display the "Allow manual detection limit input" field below
        * If it is unchecked, hide and uncheck the "Allow manual detection limit input" field below
        */
-      var field, field2;
       field = $("#archetypes-fieldname-DetectionLimitSelector #DetectionLimitSelector");
-      // control the visiblity of the dependent field
       field2 = $("#archetypes-fieldname-AllowManualDetectionLimit #AllowManualDetectionLimit");
       if (toggle === true) {
         field2.parent().show();
@@ -779,9 +757,10 @@
         field2.prop("checked", false);
       }
       return this.toggle_checkbox(field, toggle, silent);
-    }
+    };
 
-    show_alert(options) {
+    AnalysisServiceEditView.prototype.show_alert = function(options) {
+
       /*
        * Display a notification box above the content
        */
@@ -801,11 +780,15 @@
       if (message === "") {
         alerts.remove();
       }
-      html = `<div class="alert alert-${level} errorbox" role="alert">\n  <h3>${title}</h3>\n  <div>${message}</div>\n</div>`;
+      html = "<div class=\"alert alert-" + level + " errorbox\" role=\"alert\">\n  <h3>" + title + "</h3>\n  <div>" + message + "</div>\n</div>";
       return alerts.append(html);
-    }
+    };
 
-    load_available_instruments() {
+
+    /* ASYNC DATA LOADERS */
+
+    AnalysisServiceEditView.prototype.load_available_instruments = function() {
+
       /**
        * Load all available and valid instruments
        *
@@ -823,16 +806,15 @@
       };
       this.ajax_submit(options).done(function(data) {
         if (!data.objects) {
-          // resolve with an empty array
           return deferred.resolveWith(this, [[]]);
         }
-        // resolve with data objects
         return deferred.resolveWith(this, [data.objects]);
       });
       return deferred.promise();
-    }
+    };
 
-    load_instrument_methods(instrument_uid) {
+    AnalysisServiceEditView.prototype.load_instrument_methods = function(instrument_uid) {
+
       /**
        * Load assigned methods of the instrument
        *
@@ -842,7 +824,6 @@
        */
       var deferred, options;
       deferred = $.Deferred();
-      // return immediately if we do not have a valid UID
       if (!this.is_uid(instrument_uid)) {
         deferred.resolveWith(this, [[]]);
         return deferred.promise();
@@ -854,18 +835,16 @@
         }
       };
       this.ajax_submit(options).done(function(data) {
-        // {instrument: "51ebff9bf1314d00a7731b2f765dac37", methods: Array(3), title: "My Instrument"}
-        // where `methods` is an array of {uid: "3a85b7bc0430496ba7d0a6bcb9cdc5d5", title: "My Method"}
         if (!data.methods) {
-          // resolve with an empty array
           deferred.resolveWith(this, [[]]);
         }
         return deferred.resolveWith(this, [data.methods]);
       });
       return deferred.promise();
-    }
+    };
 
-    load_method_calculation(method_uid) {
+    AnalysisServiceEditView.prototype.load_method_calculation = function(method_uid) {
+
       /**
        * Load assigned calculation of the given method UID
        *
@@ -875,7 +854,6 @@
        */
       var deferred, options;
       deferred = $.Deferred();
-      // return immediately if we do not have a valid UID
       if (!this.is_uid(method_uid)) {
         deferred.resolveWith(this, [{}]);
         return deferred.promise();
@@ -887,21 +865,18 @@
         }
       };
       this.ajax_submit(options).done(function(data) {
-        // /get_method_calculation returns just this structure:
-        // {uid: "488400e9f5e24a4cbd214056e6b5e2aa", title: "My Calculation"}
         if (!this.is_uid(data.uid)) {
           return deferred.resolveWith(this, [{}]);
         }
-        // load the full calculation object
         return this.load_calculation(data.uid).done(function(calculation) {
-          // resolve with the full calculation object
           return deferred.resolveWith(this, [calculation]);
         });
       });
       return deferred.promise();
-    }
+    };
 
-    load_calculation(calculation_uid) {
+    AnalysisServiceEditView.prototype.load_calculation = function(calculation_uid) {
+
       /*
        * Load calculation object from the JSON API for the given UID
        *
@@ -911,7 +886,6 @@
        */
       var deferred, options;
       deferred = $.Deferred();
-      // return immediately if we do not have a valid UID
       if (!this.is_uid(calculation_uid)) {
         deferred.resolveWith(this, [{}]);
         return deferred.promise();
@@ -929,19 +903,18 @@
       this.ajax_submit(options).done(function(data) {
         var calculation;
         calculation = {};
-        // Parse the calculation object from the response data
         if (data.objects.length === 1) {
           calculation = data.objects[0];
         } else {
-          console.warn(`Invalid data returned for calculation UID ${calculation_uid}: `, data);
+          console.warn("Invalid data returned for calculation UID " + calculation_uid + ": ", data);
         }
-        // Resolve the deferred with the parsed calculation
         return deferred.resolveWith(this, [calculation]);
       });
       return deferred.promise();
-    }
+    };
 
-    load_manual_interims() {
+    AnalysisServiceEditView.prototype.load_manual_interims = function() {
+
       /**
        * 1. Load the default calculation
        * 2. Subtract calculation interims from the current active interims
@@ -954,31 +927,21 @@
       deferred = $.Deferred();
       this.load_calculation(this.get_calculation()).done(function(calculation) {
         var calculation_interim_keys, calculation_interims, manual_interims;
-        // interims of this calculation
         calculation_interims = $.extend([], calculation.InterimFields);
-        // extract the keys of the calculation interims
         calculation_interim_keys = calculation_interims.map(function(v) {
           return v.keyword;
         });
-        // separate manual interims from calculation interims
         manual_interims = [];
         $.each(this.get_interims(), function(index, value) {
           var calculation_interim, i, ref;
-          // manual interim is not part of the calculation interims
           if (ref = value.keyword, indexOf.call(calculation_interim_keys, ref) < 0) {
             return manual_interims.push(value);
           } else {
-            // manual interim is also located in the calculaiton interims
-            // -> check for interim override, e.g. different value, unit etc.
-
-            // get the calculation interim
             i = calculation_interim_keys.indexOf(value.keyword);
             calculation_interim = calculation_interims[i];
-            // check for different values
             return $.each(calculation_interim, function(k, v) {
               if (v !== value[k]) {
                 manual_interims.push(value);
-                // stop iteration
                 return false;
               }
             });
@@ -987,9 +950,10 @@
         return deferred.resolveWith(this, [manual_interims]);
       });
       return deferred.promise();
-    }
+    };
 
-    load_object_by_uid(uid) {
+    AnalysisServiceEditView.prototype.load_object_by_uid = function(uid) {
+
       /*
        * Load object by UID
        *
@@ -1011,14 +975,16 @@
         if (data.objects.length === 1) {
           object = data.objects[0];
         }
-        // Resolve the deferred with the parsed calculation
         return deferred.resolveWith(this, [object]);
       });
       return deferred.promise();
-    }
+    };
 
-    ajax_submit(options) {
-      var base, done;
+
+    /* HELPERS */
+
+    AnalysisServiceEditView.prototype.ajax_submit = function(options) {
+
       /**
        * Ajax Submit with automatic event triggering and some sane defaults
        *
@@ -1026,8 +992,8 @@
        *    jQuery ajax options
        * @returns {Deferred} XHR request
        */
+      var base, done;
       console.debug("°°° ajax_submit °°°");
-      // some sane option defaults
       if (options == null) {
         options = {};
       }
@@ -1055,9 +1021,10 @@
         return $(this).trigger("ajax:submit:end");
       };
       return $.ajax(options).done(done);
-    }
+    };
 
-    get_url() {
+    AnalysisServiceEditView.prototype.get_url = function() {
+
       /**
        * Return the current absolute url
        *
@@ -1068,47 +1035,50 @@
       protocol = location.protocol;
       host = location.host;
       pathname = location.pathname;
-      return `${protocol}//${host}${pathname}`;
-    }
+      return protocol + "//" + host + pathname;
+    };
 
-    get_portal_url() {
+    AnalysisServiceEditView.prototype.get_portal_url = function() {
+
       /**
        * Return the portal url
        *
        * @returns {string} portal url
        */
       return window.portal_url;
-    }
+    };
 
-    is_uid(str) {
-      var match;
+    AnalysisServiceEditView.prototype.is_uid = function(str) {
+
       /**
        * Validate valid UID
        *
        * @returns {boolean} True if the argument is a UID
        */
+      var match;
       if (typeof str !== "string") {
         return false;
       }
       match = str.match(/[a-z0-9]{32}/);
       return match !== null;
-    }
+    };
 
-    add_select_option(select, name, value) {
-      var option;
+    AnalysisServiceEditView.prototype.add_select_option = function(select, name, value) {
+
       /**
        * Adds an option to the select
        */
+      var option;
       if (value) {
-        option = `<option value='${value}'>${this._(name)}</option>`;
+        option = "<option value='" + value + "'>" + (this._(name)) + "</option>";
       } else {
-        // empty option (selected by default)
-        option = `<option selected='selected' value=''>${this._("None")}</option>`;
+        option = "<option selected='selected' value=''>" + (this._("None")) + "</option>";
       }
       return $(select).append(option);
-    }
+    };
 
-    parse_select_options(select) {
+    AnalysisServiceEditView.prototype.parse_select_options = function(select) {
+
       /**
        * Parse UID/Title from the select field
        *
@@ -1129,22 +1099,24 @@
         });
       });
       return options;
-    }
+    };
 
-    parse_select_option(select, value) {
+    AnalysisServiceEditView.prototype.parse_select_option = function(select, value) {
+
       /**
        * Return the option by value
        */
       var data, option;
-      option = field.find(`option[value=${uid}]`);
+      option = field.find("option[value=" + uid + "]");
       data = {
         uid: option.val() || "",
         title: option.text() || ""
       };
       return data;
-    }
+    };
 
-    select_options(select, values) {
+    AnalysisServiceEditView.prototype.select_options = function(select, values) {
+
       /**
        * Select the options of the given select field where the value is in values
        */
@@ -1156,9 +1128,14 @@
         }
         return option.selected = "selected";
       });
-    }
+    };
 
-    toggle_checkbox(checkbox, toggle, silent = true) {
+    AnalysisServiceEditView.prototype.toggle_checkbox = function(checkbox, toggle, silent) {
+      var field;
+      if (silent == null) {
+        silent = true;
+      }
+
       /**
        * Toggle the checkbox
        *
@@ -1171,142 +1148,133 @@
        * @param {boolean} silent
        *    True to trigger a "change" event after set
        */
-      var field;
       field = $(checkbox);
       if (toggle === void 0) {
         toggle = !field.is(":checked");
       }
       field.prop("checked", toggle);
-      // trigger change event
       if (!silent) {
         return field.trigger("change");
       }
-    }
+    };
 
-    on_manual_entry_of_results_change(event) {
+
+    /* EVENT HANDLER */
+
+    AnalysisServiceEditView.prototype.on_manual_entry_of_results_change = function(event) {
+
       /**
        * Eventhandler when the "Instrument assignment is not required" checkbox changed
        */
       console.debug("°°° AnalysisServiceEditView::on_manual_entry_of_results_change °°°");
-      // Results can be set by "hand"
       if (this.is_manual_entry_of_results_allowed()) {
         console.debug("Manual entry of results is allowed");
-        // restore all initial set methods
         return this.set_methods(this.methods);
       } else {
-        // Results can be only set by an instrument
         console.debug("Manual entry of results is **not** allowed");
-        // flush all methods and add only the "None" option
         return this.set_methods(null);
       }
-    }
+    };
 
-    on_methods_change(event) {
-      var method_uids;
+    AnalysisServiceEditView.prototype.on_methods_change = function(event) {
+
       /**
        * Eventhandler when the "Methods" multiselect changed
        */
+      var method_uids;
       console.debug("°°° AnalysisServiceEditView::on_methods_change °°°");
-      // selected method UIDs
       method_uids = this.get_methods();
-      // All methods deselected
       if (method_uids.length === 0) {
         console.warn("All methods deselected");
       }
-      // Select the methods
       return this.select_methods(method_uids);
-    }
+    };
 
-    on_instrument_assignment_allowed_change(event) {
+    AnalysisServiceEditView.prototype.on_instrument_assignment_allowed_change = function(event) {
+
       /**
        * Eventhandler when the "Instrument assignment is allowed" checkbox changed
        */
       console.debug("°°° AnalysisServiceEditView::on_instrument_assignment_allowed_change °°°");
       if (this.is_instrument_assignment_allowed()) {
         console.debug("Instrument assignment is allowed");
-        // restore the instruments multi-select to the initial value
         return this.set_instruments(this.instruments);
       } else {
         console.debug("Instrument assignment is **not** allowed");
         return this.set_instruments(null);
       }
-    }
+    };
 
-    on_instruments_change(event) {
-      var instrument_uids;
+    AnalysisServiceEditView.prototype.on_instruments_change = function(event) {
+
       /**
        * Eventhandler when the "Instruments" multiselect changed
        */
+      var instrument_uids;
       console.debug("°°° AnalysisServiceEditView::on_instruments_change °°°");
-      // selected instrument UIDs
       instrument_uids = this.get_instruments();
       if (instrument_uids.length === 0) {
         console.warn("All instruments deselected");
       }
-      // Select the instruments
       return this.select_instruments(instrument_uids);
-    }
+    };
 
-    on_default_instrument_change(event) {
+    AnalysisServiceEditView.prototype.on_default_instrument_change = function(event) {
+
       /**
        * Eventhandler when the "Default Instrument" selector changed
        */
       console.debug("°°° AnalysisServiceEditView::on_default_instrument_change °°°");
-      // set the instrument methods of the default instrument
       return this.set_instrument_methods(this.get_default_instrument());
-    }
+    };
 
-    on_default_method_change(event) {
+    AnalysisServiceEditView.prototype.on_default_method_change = function(event) {
+
       /**
        * Eventhandler when the "Default Method" selector changed
        */
       console.debug("°°° AnalysisServiceEditView::on_default_method_change °°°");
-      // Load the calculation of the method if the checkbox "Use the Default
-      // Calculation of Method" is checked
       if (this.use_default_calculation_of_method()) {
-        // set the calculation of the method
         return this.set_method_calculation(this.get_default_method());
       }
-    }
+    };
 
-    on_use_default_calculation_change(event) {
-      var me;
+    AnalysisServiceEditView.prototype.on_use_default_calculation_change = function(event) {
+
       /**
        * Eventhandler when the "Use the Default Calculation of Method" checkbox changed
        */
+      var me;
       console.debug("°°° AnalysisServiceEditView::on_use_default_calculation_change °°°");
-      // "Use the Default Calculation of Method" checkbox checked
       if (this.use_default_calculation_of_method()) {
         console.debug("Use default calculation");
-        // set the calculation of the method
         return this.set_method_calculation(this.get_default_method());
       } else {
-        // restore all initial set calculations
         me = this;
         $.each(this.calculations, function(index, calculation) {
           var flush;
           flush = index === 0 ? true : false;
           return me.set_calculation(calculation, flush = flush);
         });
-        // select initial set calculation
         if (this.selected_calculation) {
           return this.select_calculation(this.selected_calculation);
         } else {
-          // select first calculation in list
           return this.select_calculation(this.get_calculation());
         }
       }
-    }
+    };
 
-    on_calculation_change(event) {
+    AnalysisServiceEditView.prototype.on_calculation_change = function(event) {
+
       /**
        * Eventhandler when the "Calculation" selector changed
        */
       console.debug("°°° AnalysisServiceEditView::on_calculation_change °°°");
       return this.select_calculation(this.get_calculation());
-    }
+    };
 
-    on_display_detection_limit_selector_change(event) {
+    AnalysisServiceEditView.prototype.on_display_detection_limit_selector_change = function(event) {
+
       /**
        * Eventhandler when the "Display a Detection Limit selector" checkbox changed
        *
@@ -1320,35 +1288,38 @@
         console.debug("Disallow detection limit selector");
         return this.toggle_display_detection_limit_selector(false);
       }
-    }
+    };
 
-    on_separate_container_change(event) {
-      var value;
+    AnalysisServiceEditView.prototype.on_separate_container_change = function(event) {
+
       /**
        * Eventhandler when the "Separate Container" checkbox changed
        *
        * This checkbox is located on the "Container and Preservation" Tab
        */
+      var value;
       console.debug("°°° AnalysisServiceEditView::on_separate_container_change °°°");
       return value = event.currentTarget.checked;
-    }
+    };
 
-    on_default_preservation_change(event) {
+    AnalysisServiceEditView.prototype.on_default_preservation_change = function(event) {
+
       /**
        * Eventhandler when the "Default Preservation" selection changed
        *
        * This field is located on the "Container and Preservation" Tab
        */
       return console.debug("°°° AnalysisServiceEditView::on_default_preservation_change °°°");
-    }
+    };
 
-    on_default_container_change(event) {
-      var el, field, uid;
+    AnalysisServiceEditView.prototype.on_default_container_change = function(event) {
+
       /**
        * Eventhandler when the "Default Container" selection changed
        *
        * This field is located on the "Container and Preservation" Tab
        */
+      var el, field, uid;
       console.debug("°°° AnalysisServiceEditView::on_default_container_change °°°");
       el = event.currentTarget;
       uid = el.getAttribute("uid");
@@ -1362,42 +1333,44 @@
           return field.prop("disabled", false);
         }
       });
-    }
+    };
 
-    on_partition_sampletype_change(event) {
-      var el, uid;
+    AnalysisServiceEditView.prototype.on_partition_sampletype_change = function(event) {
+
       /**
        * Eventhandler when the "Sample Type" selection changed
        *
        * This field is located on the "Container and Preservation" Tab
        */
+      var el, uid;
       console.debug("°°° AnalysisServiceEditView::on_partition_sampletype_change °°°");
       el = event.currentTarget;
       uid = el.value;
       return this.load_object_by_uid(uid).done(function(sampletype) {
         var minvol;
         minvol = sampletype.MinimumVolume || "";
-        // set the minimum volume to the partition
         return $(el).parents("tr").find("[name^='PartitionSetup.vol']").val(minvol);
       });
-    }
+    };
 
-    on_partition_separate_container_change(event) {
+    AnalysisServiceEditView.prototype.on_partition_separate_container_change = function(event) {
+
       /**
        * Eventhandler when the "Separate Container" checkbox changed
        *
        * This checkbox is located on the "Container and Preservation" Tab
        */
       return console.debug("°°° AnalysisServiceEditView::on_partition_separate_container_change °°°");
-    }
+    };
 
-    on_partition_container_change(event) {
-      var el, field, uid;
+    AnalysisServiceEditView.prototype.on_partition_container_change = function(event) {
+
       /**
        * Eventhandler when the "Container" multi-select changed
        *
        * This multi select is located on the "Container and Preservation" Tab
        */
+      var el, field, uid;
       console.debug("°°° AnalysisServiceEditView::on_partition_container_change °°°");
       el = event.currentTarget;
       uid = el.value;
@@ -1411,17 +1384,20 @@
           return $(field).prop("disabled", false);
         }
       });
-    }
+    };
 
-    on_partition_required_volume_change(event) {
+    AnalysisServiceEditView.prototype.on_partition_required_volume_change = function(event) {
+
       /**
        * Eventhandler when the "Required Volume" value changed
        *
        * This field is located on the "Container and Preservation" Tab
        */
       return console.debug("°°° AnalysisServiceEditView::on_partition_required_volume_change °°°");
-    }
+    };
 
-  };
+    return AnalysisServiceEditView;
+
+  })();
 
 }).call(this);

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -1,69 +1,70 @@
+
+/* Please use this command to compile this file into the parent `js` directory:
+    coffee --no-header -w -o ../ -c bika.lims.bikalisting.coffee
+ */
+
 (function() {
-  /* Please use this command to compile this file into the parent `js` directory:
-      coffee --no-header -w -o ../ -c bika.lims.bikalisting.coffee
-  */
-  window.BikaListingTableView = class BikaListingTableView {
-    constructor() {
-      /*
-      * Controller class for Bika Listing Table view
-       */
-      this.load = this.load.bind(this);
-      /* INITIALIZERS */
-      this.bind_eventhandler = this.bind_eventhandler.bind(this);
-      /* METHODS */
-      this.ajax_submit = this.ajax_submit.bind(this);
-      this.get_portal_url = this.get_portal_url.bind(this);
-      this.get_base_url = this.get_base_url.bind(this);
-      this.get_authenticator = this.get_authenticator.bind(this);
-      this.get_cookie = this.get_cookie.bind(this);
-      this.set_cookie = this.set_cookie.bind(this);
-      this.get_toggle_cookie_key = this.get_toggle_cookie_key.bind(this);
-      this.toggle_sort_order = this.toggle_sort_order.bind(this);
-      this.get_toggle_cols = this.get_toggle_cols.bind(this);
-      this.toggle_column = this.toggle_column.bind(this);
-      this.sort_column = this.sort_column.bind(this);
-      this.toggle_category = this.toggle_category.bind(this);
-      this.filter_state = this.filter_state.bind(this);
-      this.show_more = this.show_more.bind(this);
-      this.parse_int = this.parse_int.bind(this);
-      /* EVENT HANDLER */
-      this.on_click = this.on_click.bind(this);
-      this.on_review_state_filter_click = this.on_review_state_filter_click.bind(this);
-      this.on_listing_entry_change = this.on_listing_entry_change.bind(this);
-      this.on_listing_entry_keypress = this.on_listing_entry_keypress.bind(this);
-      this.on_category_header_click = this.on_category_header_click.bind(this);
-      this.on_autosave_field_change = this.on_autosave_field_change.bind(this);
-      this.on_workflow_button_click = this.on_workflow_button_click.bind(this);
-      this.on_contextmenu = this.on_contextmenu.bind(this);
-      this.on_contextmenu_item_click = this.on_contextmenu_item_click.bind(this);
-      this.on_search_field_keypress = this.on_search_field_keypress.bind(this);
-      this.on_search_button_click = this.on_search_button_click.bind(this);
-      this.on_select_all_click = this.on_select_all_click.bind(this);
-      this.on_checkbox_click = this.on_checkbox_click.bind(this);
-      this.on_ajax_submit_start = this.on_ajax_submit_start.bind(this);
-      this.on_ajax_submit_end = this.on_ajax_submit_end.bind(this);
-      this.on_column_header_click = this.on_column_header_click.bind(this);
-      this.on_show_more_click = this.on_show_more_click.bind(this);
+  var bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
+
+  window.BikaListingTableView = (function() {
+    function BikaListingTableView() {
+      this.on_show_more_click = bind(this.on_show_more_click, this);
+      this.on_column_header_click = bind(this.on_column_header_click, this);
+      this.on_ajax_submit_end = bind(this.on_ajax_submit_end, this);
+      this.on_ajax_submit_start = bind(this.on_ajax_submit_start, this);
+      this.on_checkbox_click = bind(this.on_checkbox_click, this);
+      this.on_select_all_click = bind(this.on_select_all_click, this);
+      this.on_search_button_click = bind(this.on_search_button_click, this);
+      this.on_search_field_keypress = bind(this.on_search_field_keypress, this);
+      this.on_contextmenu_item_click = bind(this.on_contextmenu_item_click, this);
+      this.on_contextmenu = bind(this.on_contextmenu, this);
+      this.on_workflow_button_click = bind(this.on_workflow_button_click, this);
+      this.on_autosave_field_change = bind(this.on_autosave_field_change, this);
+      this.on_category_header_click = bind(this.on_category_header_click, this);
+      this.on_listing_entry_keypress = bind(this.on_listing_entry_keypress, this);
+      this.on_listing_entry_change = bind(this.on_listing_entry_change, this);
+      this.on_review_state_filter_click = bind(this.on_review_state_filter_click, this);
+      this.on_click = bind(this.on_click, this);
+      this.parse_int = bind(this.parse_int, this);
+      this.show_more = bind(this.show_more, this);
+      this.filter_state = bind(this.filter_state, this);
+      this.toggle_category = bind(this.toggle_category, this);
+      this.sort_column = bind(this.sort_column, this);
+      this.toggle_column = bind(this.toggle_column, this);
+      this.get_toggle_cols = bind(this.get_toggle_cols, this);
+      this.toggle_sort_order = bind(this.toggle_sort_order, this);
+      this.get_toggle_cookie_key = bind(this.get_toggle_cookie_key, this);
+      this.set_cookie = bind(this.set_cookie, this);
+      this.get_cookie = bind(this.get_cookie, this);
+      this.get_authenticator = bind(this.get_authenticator, this);
+      this.get_base_url = bind(this.get_base_url, this);
+      this.get_portal_url = bind(this.get_portal_url, this);
+      this.ajax_submit = bind(this.ajax_submit, this);
+      this.bind_eventhandler = bind(this.bind_eventhandler, this);
+      this.load = bind(this.load, this);
     }
 
-    load() {
+
+    /*
+    * Controller class for Bika Listing Table view
+     */
+
+    BikaListingTableView.prototype.load = function() {
       console.debug("ListingTableView::load");
-      // load translations
       jarn.i18n.loadCatalog('bika');
       this._ = window.jarn.i18n.MessageFactory('bika');
-      // bind the event handler to the elements
       this.bind_eventhandler();
-      // flag to signal async wf button loading
       this.loading_transitions = false;
-      // toggle columns cookie name
       this.toggle_cols_cookie = "toggle_cols";
-      // Initially load the transitions
       this.load_transitions();
-      // dev only
       return window.tv = this;
-    }
+    };
 
-    bind_eventhandler() {
+
+    /* INITIALIZERS */
+
+    BikaListingTableView.prototype.bind_eventhandler = function() {
+
       /*
        * Binds callbacks on elements
        *
@@ -72,47 +73,38 @@
        *
        */
       console.debug("ListingTableView::bind_eventhandler");
-      // Table header clicked for sorting
       $("form").on("click", "th.sortable", this.on_column_header_click);
-      // Show More clickd
       $("form").on("click", "a.bika_listing_show_more", this.on_show_more_click);
-      // Single checkbox clicked
       $("form").on("click", "input[type='checkbox'][id*='_cb_']", this.on_checkbox_click);
-      // Check all checkbox clicked
       $("form").on("click", "input[id*='select_all']", this.on_select_all_click);
-      // Enter keypress in search field
       $("form").on("keypress", ".filter-search-input", this.on_search_field_keypress);
-      // Search button clicked (magnifier in search field)
       $("form").on("click", ".filter-search-button", this.on_search_button_click);
-      // Context menu
       $("form").on('contextmenu', "th[id^='foldercontents-']", this.on_contextmenu);
-      // Workflow Button
       $("form").on("click", "input.workflow_action_button", this.on_workflow_button_click);
-      // Autosave – seems to be used by sample and analysis views
       $("form").on("change", "input.autosave, select.autsave", this.on_autosave_field_change);
-      // Category headers
       $("form").on("click", "th.collapsed, th.expanded", this.on_category_header_click);
-      // Results entry
       $("form").on("change", ".listing_string_entry, .listing_select_entry", this.on_listing_entry_change);
       $("form").on("keypress", ".listing_string_entry, .listing_select_entry", this.on_listing_entry_keypress);
-      // Review state filter buttons
       $("form").on("click", "td.review_state_selector a", this.on_review_state_filter_click);
-      // Document click
       $(document).on("click", this.on_click);
-      // bind event handler for contextmenu clicks
       $(document).on("click", ".contextmenu tr", this.on_contextmenu_item_click);
-      // Ajax form submit events
       $(this).on("ajax:submit:start", this.on_ajax_submit_start);
       return $(this).on("ajax:submit:end", this.on_ajax_submit_end);
-    }
+    };
 
-    ajax_submit(options = {}) {
+
+    /* METHODS */
+
+    BikaListingTableView.prototype.ajax_submit = function(options) {
       var done;
+      if (options == null) {
+        options = {};
+      }
+
       /*
        * Ajax Submit with automatic event triggering and some sane defaults
        */
       console.debug("°°° ajax_submit °°°");
-      // some sane option defaults
       if (options.type == null) {
         options.type = "POST";
       }
@@ -124,40 +116,49 @@
       }
       console.debug(">>> ajax_submit::options=", options);
       $(this).trigger("ajax:submit:start");
-      done = () => {
-        return $(this).trigger("ajax:submit:end");
-      };
+      done = (function(_this) {
+        return function() {
+          return $(_this).trigger("ajax:submit:end");
+        };
+      })(this);
       return $.ajax(options).done(done);
-    }
+    };
 
-    get_portal_url() {
+    BikaListingTableView.prototype.get_portal_url = function() {
+
       /*
        * Return the portal url (calculated in code)
        */
       var url;
       url = $("input[name=portal_url]").val();
       return url || window.portal_url;
-    }
+    };
 
-    get_base_url() {
+    BikaListingTableView.prototype.get_base_url = function() {
+
       /*
        * Return the current base url
        */
       var url;
       url = window.location.href;
       return url.split('?')[0];
-    }
+    };
 
-    get_authenticator() {
+    BikaListingTableView.prototype.get_authenticator = function() {
+
       /*
        * Get the authenticator value
        */
       return $("input[name='_authenticator']").val();
-    }
+    };
 
-    get_cookie(name) {
+    BikaListingTableView.prototype.get_cookie = function(name) {
+
+      /*
+       * read the value of the cookie
+       */
       var c, cookies, i;
-      name = `${name}=`;
+      name = name + "=";
       cookies = document.cookie.split(";");
       i = 0;
       while (i < cookies.length) {
@@ -171,13 +172,14 @@
         i = i + 1;
       }
       return null;
-    }
+    };
 
-    set_cookie(name, value, days) {
-      var cookie, date, expires;
+    BikaListingTableView.prototype.set_cookie = function(name, value, days) {
+
       /*
        * set the value of the cookie
        */
+      var cookie, date, expires;
       if (days) {
         date = new Date;
         date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
@@ -185,21 +187,23 @@
       } else {
         expires = "";
       }
-      cookie = `${name}=${escape(value)}; expires=${expires}; path=/;`;
+      cookie = name + "=" + (escape(value)) + "; expires=" + expires + "; path=/;";
       document.cookie = cookie;
       return true;
-    }
+    };
 
-    get_toggle_cookie_key(form_id) {
+    BikaListingTableView.prototype.get_toggle_cookie_key = function(form_id) {
+
       /*
        * Make a unique toggle cookie key for the current listing site
        */
       var portal_type;
-      portal_type = $(`#${form_id} input[name=portal_type]`).val();
-      return `${portal_type}${form_id}`;
-    }
+      portal_type = $("#" + form_id + " input[name=portal_type]").val();
+      return "" + portal_type + form_id;
+    };
 
-    toggle_sort_order(sort_order) {
+    BikaListingTableView.prototype.toggle_sort_order = function(sort_order) {
+
       /*
        * Toggle the sort_order value
        */
@@ -207,95 +211,77 @@
         return "descending";
       }
       return "ascending";
-    }
+    };
 
-    get_toggle_cols(form_id) {
+    BikaListingTableView.prototype.get_toggle_cols = function(form_id) {
+
       /*
        * Get the value of the toggle cols input field
        */
       var toggle_cols;
-      toggle_cols = $(`#${form_id}_toggle_cols`);
+      toggle_cols = $("#" + form_id + "_toggle_cols");
       if (toggle_cols.length === 0) {
         return {};
       }
       return $.parseJSON(toggle_cols.val());
-    }
+    };
 
-    toggle_column(form_id, col_id) {
-      var all_cols, columns, cookie, cookie_key, form, form_data, table, toggle_cols;
+    BikaListingTableView.prototype.toggle_column = function(form_id, col_id) {
+
       /*
        * Toggle column by form and column id
        */
-      // get the form object
-      form = $(`form#${form_id}`);
-      // get the listing table within the form
+      var all_cols, columns, cookie, cookie_key, form, form_data, table, toggle_cols;
+      form = $("form#" + form_id);
       table = $("table.bika-listing-table", form);
-      // get the toggle column settings of this page
       toggle_cols = this.get_toggle_cols(form_id);
-      // read the current value of the toggle cookie
       cookie = $.parseJSON(this.get_cookie(this.toggle_cols_cookie) || "{}");
-      // get the right key for this page
       cookie_key = this.get_toggle_cookie_key(form_id);
-      // current set columns
       columns = cookie[cookie_key];
       if (!columns) {
         columns = [];
         $.each(toggle_cols, function(name, record) {
-          // only append current visible columns
-          if ($(`#foldercontents-${name}-column`).length > 0) {
+          if ($("#foldercontents-" + name + "-column").length > 0) {
             return columns.push(name);
           }
         });
       }
-      // Set default toggle columns
       if (col_id === _('Default')) {
         console.debug("*** Set DEFAULT toggle columns ***");
-        // delete the settings for this page
         delete cookie[cookie_key];
-      // Set all toggle columns
       } else if (col_id === _('All')) {
         console.debug("*** Set ALL toggle columns ***");
-        // add all possible columns which have the toggle state
         all_cols = [];
         $.each(toggle_cols, function(name, record) {
           return all_cols.push(name);
         });
-        // set the cookie with the updated value
         cookie[cookie_key] = all_cols;
       } else {
-        // Toggle individual columns
         if (!(col_id in toggle_cols)) {
-          console.warn(`Invalid column name: '${col_id}'`);
+          console.warn("Invalid column name: '" + col_id + "'");
           return;
         }
         if (columns.indexOf(col_id) > -1) {
-          // toggle off
-          console.debug(`*** Toggle ${col_id} OFF ***`);
+          console.debug("*** Toggle " + col_id + " OFF ***");
           columns.splice(columns.indexOf(col_id), 1);
         } else {
-          // toggle on
-          console.debug(`*** Toggle ${col_id} ON ***`);
+          console.debug("*** Toggle " + col_id + " ON ***");
           columns.push(col_id);
         }
-        // set the cookie with the updated value
         cookie[cookie_key] = columns;
       }
-      // set the toggle config cookie
       this.set_cookie(this.toggle_cols_cookie, $.toJSON(cookie), 365);
-      // prepare the form data
       form_data = new FormData(form[0]);
       form_data.set("table_only", form_id);
-      // send the new data to the server
       return this.ajax_submit({
         data: form_data,
-        processData: false, // do not transform to a query string
-        contentType: false // do not set any content type header
+        processData: false,
+        contentType: false
       }).done(function(data) {
         var menu, style, tooltip;
         $(table).replaceWith(data);
         table = $("table.bika-listing-table", form);
         tooltip = $(".tooltip");
-        // re-render the tooltip
         if (tooltip.length > 0) {
           style = tooltip.attr("style");
           menu = this.make_context_menu(table);
@@ -303,135 +289,117 @@
           return menu.attr("style", style);
         }
       });
-    }
+    };
 
-    sort_column(form_id, sort_index) {
-      var form, form_data, sort_on, sort_on_value, sort_order, sort_order_value, table;
+    BikaListingTableView.prototype.sort_column = function(form_id, sort_index) {
+
       /*
        * Sort column by form and sort index
        */
-      // get the form object
-      form = $(`form#${form_id}`);
-      // get the listing table within the form
+      var form, form_data, sort_on, sort_on_value, sort_order, sort_order_value, table;
+      form = $("form#" + form_id);
       table = $("table.bika-listing-table", form);
-      // hidden input fields which holds the current sort_on value
-      sort_on = $(`[name=${form_id}_sort_on]`);
-      // hidden input field which holds the current sort_order value
-      sort_order = $(`[name=${form_id}_sort_order]`);
-      // current sort_on value
+      sort_on = $("[name=" + form_id + "_sort_on]");
+      sort_order = $("[name=" + form_id + "_sort_order]");
       sort_on_value = sort_on.val();
-      // current sort_order value
       sort_order_value = sort_order.val();
-      // update sort_on value
       sort_on.val(sort_index);
-      // update sort_order value
       sort_order.val(this.toggle_sort_order(sort_order_value));
-      // prepare the form data
       form_data = new FormData(form[0]);
       form_data.set("table_only", form_id);
       return this.ajax_submit({
         data: form_data,
-        processData: false, // do not transform to a query string
-        contentType: false // do not set any content type header
+        processData: false,
+        contentType: false
       }).done(function(data) {
         $(table).replaceWith(data);
         return this.load_transitions();
       });
-    }
+    };
 
-    toggle_category(form_id, cat_id) {
-      var base_url, cat, cat_items, cat_url, expanded, form, form_data, placeholder, url;
+    BikaListingTableView.prototype.toggle_category = function(form_id, cat_id) {
+
       /*
        * Toggle category by form and category id
        */
-      // get the form object
-      form = $(`form#${form_id}`);
-      cat = $(`th.cat_header[cat='${cat_id}']`);
-      placeholder = $(`tr[data-ajax_category='${cat_id}']`);
+      var base_url, cat, cat_items, cat_url, expanded, form, form_data, placeholder, url;
+      form = $("form#" + form_id);
+      cat = $("th.cat_header[cat='" + cat_id + "']");
+      placeholder = $("tr[data-ajax_category='" + cat_id + "']");
       expanded = cat.hasClass("expanded");
-      cat_items = $(`tr[cat='${cat_id}']`);
-      // Toggle expand/collapsed class
+      cat_items = $("tr[cat='" + cat_id + "']");
       cat.toggleClass("expanded collapsed");
-      // Just hide/show if the items are already loaded
       if (cat_items.length > 0) {
-        console.debug(`ListingTableView::toggle_category: Category ${cat_id} is already expanded -> Toggle only`);
+        console.debug("ListingTableView::toggle_category: Category " + cat_id + " is already expanded -> Toggle only");
         cat_items.toggle();
         return;
       }
-      // load the items asynchronous
       cat_url = $("input[name=ajax_categories_url]").val();
       base_url = this.get_base_url();
       url = cat_url || base_url;
-      // prepare a new form data
       form_data = new FormData(form[0]);
       form_data.set("cat", cat_id);
       form_data.set("form_id", form_id);
       form_data.set("ajax_category_expand", 1);
-      // send the new data to the server
       return this.ajax_submit({
         url: url,
         data: form_data,
-        processData: false, // do not transform to a query string
-        contentType: false // do not set any content type header
+        processData: false,
+        contentType: false
       }).done(function(data) {
-        // replace the placeholder with the loaded rows
         placeholder.replaceWith(data);
         return this.load_transitions();
       });
-    }
+    };
 
-    filter_state(form_id, state_id) {
-      var form, form_data, input, input_name, table;
+    BikaListingTableView.prototype.filter_state = function(form_id, state_id) {
+
       /*
        * Filter listing by review_state
        */
-      // get the form object
-      form = $(`form#${form_id}`);
+      var form, form_data, input, input_name, table;
+      form = $("form#" + form_id);
       table = $("table.bika-listing-table", form);
-      input_name = `${form_id}_review_state`;
-      input = $(`input[name=${input_name}]`, form);
+      input_name = form_id + "_review_state";
+      input = $("input[name=" + input_name + "]", form);
       if (input.length === 0) {
-        input = form.append(`<input name='${input_name}' value='${state_id}' type='hidden'/>`);
+        input = form.append("<input name='" + input_name + "' value='" + state_id + "' type='hidden'/>");
       }
       input.val(state_id);
-      // prepare the form data
       form_data = new FormData(form[0]);
       form_data.set("table_only", form_id);
-      form_data.set(`${form_id}_review_state`, state_id);
+      form_data.set(form_id + "_review_state", state_id);
       return this.ajax_submit({
         url: this.get_base_url(),
         data: form_data,
-        processData: false, // do not transform to a query string
-        contentType: false // do not set any content type header
+        processData: false,
+        contentType: false
       }).done(function(data) {
         $(table).replaceWith(data);
         return this.load_transitions();
       });
-    }
+    };
 
-    show_more(form_id, pagesize, limit_from) {
-      var filter_options, filters, filters1, filters2, form, form_data, show_more, table, tbody;
+    BikaListingTableView.prototype.show_more = function(form_id, pagesize, limit_from) {
+
       /*
        * Show more
        */
-      // get the form object
-      form = $(`form#${form_id}`);
+      var filter_options, filters, filters1, filters2, form, form_data, show_more, table, tbody;
+      form = $("form#" + form_id);
       table = $("table.bika-listing-table", form);
       tbody = $("tbody.item-listing-tbody", table);
-      show_more = $(`#${form_id} a.bika_listing_show_more`);
-      // sane defaults
+      show_more = $("#" + form_id + " a.bika_listing_show_more");
       if (pagesize == null) {
         pagesize = 30;
       }
       if (limit_from == null) {
         limit_from = 0;
       }
-      // prepare the form data
       form_data = new FormData(form[0]);
       form_data.set("rows_only", form_id);
-      form_data.set(`${form_id}_pagesize`, pagesize);
-      form_data.set(`${form_id}_limit_from`, limit_from);
-      // Advanced filter bar options
+      form_data.set(form_id + "_pagesize", pagesize);
+      form_data.set(form_id + "_limit_from", limit_from);
       filter_options = [];
       filters1 = $(".bika_listing_filter_bar input[name][value!='']");
       filters2 = $(".bika_listing_filter_bar select option:selected[value!='']");
@@ -445,42 +413,41 @@
       show_more.fadeOut();
       return this.ajax_submit({
         data: form_data,
-        processData: false, // do not transform to a query string
-        contentType: false // do not set any content type header
+        processData: false,
+        contentType: false
       }).done(function(data) {
         var numitems, rows;
-        // filter out all <tr> elements
         rows = $(data).filter("tr");
-        // probably further pages exist when this returns 0
         if (rows.length % pagesize === 0) {
           show_more.fadeIn();
         }
-        // flush the whole table when there is no limit from
         if (limit_from === 0) {
           $(tbody).empty();
         }
         $(tbody).append(rows);
-        // update the counter with the number of rendered rows
-        numitems = $(`table.bika-listing-table[form_id=${form_id}] tbody.item-listing-tbody tr`).length;
-        $(`#${form_id} span.number-items`).html(numitems);
-        // update the show more control
+        numitems = $("table.bika-listing-table[form_id=" + form_id + "] tbody.item-listing-tbody tr").length;
+        $("#" + form_id + " span.number-items").html(numitems);
         show_more.attr("data-limitfrom", numitems);
         show_more.attr("data-pagesize", pagesize);
-        // reload the transitions
         return this.load_transitions();
       });
-    }
+    };
 
-    parse_int(thing, fallback = 0) {
+    BikaListingTableView.prototype.parse_int = function(thing, fallback) {
+      var number;
+      if (fallback == null) {
+        fallback = 0;
+      }
+
       /*
        * Safely parse to an integer
        */
-      var number;
       number = parseInt(thing);
       return number || fallback;
-    }
+    };
 
-    load_transitions(table) {
+    BikaListingTableView.prototype.load_transitions = function(table) {
+
       /*
        * Fetch allowed transitions for all the objects listed in bika_listing and
        * sets the value for the attribute 'data-valid_transitions' for each check
@@ -495,18 +462,14 @@
           return self.load_transitions(this);
         });
       }
-      // The listing table object
       $table = $(table);
       wf_buttons = $(table).find("span.workflow_action_buttons");
       if (this.loading_transitions || $(wf_buttons).length === 0) {
         return;
       }
-      // If show_workflow_action_buttons param is set to False in the
-      // view, or transitions are being loaded already, do nothing
       uids = [];
       checkall = $("input[id*='select_all']", $table);
       $(checkall).hide();
-      // Update valid transitions for elements which have not yet been updated:
       wo_trans = $("input[id*='_cb_'][data-valid_transitions='{}']");
       $(wo_trans).prop("disabled", true);
       $(wo_trans).each(function(e) {
@@ -515,10 +478,9 @@
       if (uids.length === 0) {
         return;
       }
-      // load possible transitions
       this.loading_transitions = true;
       return this.ajax_submit({
-        url: `${this.get_portal_url()}/@@API/allowedTransitionsFor_many`,
+        url: (this.get_portal_url()) + "/@@API/allowedTransitionsFor_many",
         data: {
           _authenticator: this.get_authenticator(),
           uid: $.toJSON(uids)
@@ -526,25 +488,22 @@
       }).done(function(data) {
         this.loading_transitions = false;
         $("input[id*='select_all']").fadeIn();
-        // setting a data attribute on each checkbox
         if ("transitions" in data) {
           $.each(data.transitions, function(index, record) {
             var checkbox, trans, uid;
             uid = record.uid;
             trans = record.transitions;
-            checkbox = $(`input[id*='_cb_'][value='${uid}']`);
+            checkbox = $("input[id*='_cb_'][value='" + uid + "']");
             checkbox.attr("data-valid_transitions", $.toJSON(trans));
             return $(checkbox).prop("disabled", false);
           });
         }
-        // re-render the transition buttons in case the user clicked the back
-        // button of the browser
         return this.render_transition_buttons(table);
       });
-    }
+    };
 
-    render_transition_buttons(table) {
-      var allowed_transitions, checked, custom_transitions, hidden_transitions, restricted_transitions, self, wf_buttons;
+    BikaListingTableView.prototype.render_transition_buttons = function(table) {
+
       /* Render workflow transition buttons to the table
        *
        * Re-generates the workflow action buttons from the bottom of the list in
@@ -552,17 +511,13 @@
        * This is, makes the intersection within all allowed transitions and adds
        * the corresponding buttons to the workflow action bar.
        */
-      // reference to this instance
+      var allowed_transitions, checked, custom_transitions, hidden_transitions, restricted_transitions, self, wf_buttons;
       self = this;
       wf_buttons = $(table).find("span.workflow_action_buttons");
       if ($(wf_buttons).length === 0) {
         return;
       }
-      // If `show_workflow_action_buttons` param is set to False in the view,
-      // do nothing
       allowed_transitions = [];
-      // hidden_transitions and restricted are hidden fields containing comma
-      // separated list of transition IDs.
       hidden_transitions = $(table).find("input[id='hide_transitions']");
       hidden_transitions = $(hidden_transitions).length === 1 ? $(hidden_transitions).val() : '';
       hidden_transitions = hidden_transitions === '' ? [] : hidden_transitions.split(',');
@@ -576,26 +531,22 @@
         if (!transitions.length) {
           return;
         }
-        // Do not want transitions other than those defined in bikalisting
         if (restricted_transitions.length > 0) {
           transitions = transitions.filter(function(el) {
             return restricted_transitions.indexOf(el.id) > -1;
           });
         }
-        // Do not show hidden transitions
         if (hidden_transitions.length > 0) {
           transitions = transitions.filter(function(el) {
             return hidden_transitions.indexOf(el.id) < 0;
           });
         }
-        // We only want the intersection within all selected items
         if (allowed_transitions.length > 0) {
           return transitions = transitions.filter(function(el) {
             return allowed_transitions.indexOf(el) > -1;
           });
         } else {
           allowed_transitions = transitions;
-          // and the inverse of the intersection
           if (transitions.length > 0) {
             return allowed_transitions = allowed_transitions.filter(function(el) {
               return transitions.indexOf(el) > -1;
@@ -603,9 +554,7 @@
           }
         }
       });
-      // Flush existing Workflow buttons
       $(wf_buttons).html("");
-      // Generate the action buttons
       $.each(allowed_transitions, function(index, record) {
         var button, transition, url, value;
         transition = record.id;
@@ -614,8 +563,6 @@
         button = self.make_wf_button(transition, url, value);
         return $(wf_buttons).append(button);
       });
-      // Always add custom transitions
-      // https://github.com/senaite/senaite.core/issues/708
       custom_transitions = $(table).find("input[type='hidden'].custom_transition");
       return $.each(custom_transitions, function(index, element) {
         var button, transition, url, value;
@@ -625,59 +572,55 @@
         button = self.make_wf_button(transition, url, value);
         return $(wf_buttons).append(button);
       });
-    }
+    };
 
-    make_wf_button(transition, url, value) {
+    BikaListingTableView.prototype.make_wf_button = function(transition, url, value) {
+
       /*
        * Make a workflow button
        */
       var button;
-      button = `<input id='${transition}_transition' class='context workflow_action_button action_button allowMultiSubmit' type='submit' url='${url}' value='${value}' transition='${transition}' name='workflow_action_button'/>&nbsp;`;
+      button = "<input id='" + transition + "_transition' class='context workflow_action_button action_button allowMultiSubmit' type='submit' url='" + url + "' value='" + value + "' transition='" + transition + "' name='workflow_action_button'/>&nbsp;";
       return button;
-    }
+    };
 
-    search(form_id, searchterm) {
-      var form, form_data, table;
+    BikaListingTableView.prototype.search = function(form_id, searchterm) {
+
       /*
        * Search in table and expand the rows
        */
-      // get the form object
-      form = $(`form#${form_id}`);
+      var form, form_data, table;
+      form = $("form#" + form_id);
       form_id = form.attr("id");
       table = $("table.bika-listing-table", form);
       form_data = new FormData(form[0]);
       form_data.set("table_only", form_id);
-      form_data.set(`${form_id}_filter`, searchterm);
+      form_data.set(form_id + "_filter", searchterm);
       return this.ajax_submit({
         data: form_data,
-        processData: false, // do not transform to a query string
-        contentType: false // do not set any content type header
+        processData: false,
+        contentType: false
       }).done(function(data) {
-        // replace table with server data
         table = $(table).replaceWith(data);
-        // focus on the search field
         $(".filter-search-input", form).select();
         return this.load_transitions();
       });
-    }
+    };
 
-    make_context_menu(table) {
-      var form, form_id, menu, portal_url, sorted_toggle_cols, toggle_cols, toggleable_columns;
+    BikaListingTableView.prototype.make_context_menu = function(table) {
+
       /*
        * Build context menu HTML
        */
+      var form, form_id, menu, portal_url, sorted_toggle_cols, toggle_cols, toggleable_columns;
       console.debug("°°° ListingTableView::make_context_menu °°°");
-      // remove any existing tooltip
       $(".tooltip").remove();
       form = $(table).parents("form");
       form_id = form.attr("id");
       portal_url = this.get_portal_url();
-      // toggle'able columns are stored in a hidden input field, e.g.
-      // {"getStorageLocation": {"index": "getStorageLocationTitle",
-      //  "toggle": false, "sortable": true, "title": "Storage Location"}, ...}
-      toggle_cols = $(`#${form_id}_toggle_cols`);
+      toggle_cols = $("#" + form_id + "_toggle_cols");
       if (!toggle_cols.val()) {
-        console.warn(`Could not get toggle column info from input field ${toggle_cols}`);
+        console.warn("Could not get toggle column info from input field " + toggle_cols);
         return false;
       }
       sorted_toggle_cols = [];
@@ -701,40 +644,40 @@
       toggleable_columns = "";
       $.each(sorted_toggle_cols, function(index, record) {
         var col, column_exists;
-        column_exists = $(`#foldercontents-${record.id}-column`);
+        column_exists = $("#foldercontents-" + record.id + "-column");
         if (column_exists.length > 0) {
-          col = `<tr class="enabled" col_id="${record.id}" form_id="${form_id}">\n  <td>&#10003;</td>\n  <td>${record.title || record.id}</td>\n</tr>`;
+          col = "<tr class=\"enabled\" col_id=\"" + record.id + "\" form_id=\"" + form_id + "\">\n  <td>&#10003;</td>\n  <td>" + (record.title || record.id) + "</td>\n</tr>";
         } else {
-          col = `<tr col_id=${record.id} form_id="${form_id}">\n  <td>&nbsp;</td>\n  <td>${record.title || record.id}</td>\n</tr>`;
+          col = "<tr col_id=" + record.id + " form_id=\"" + form_id + "\">\n  <td>&nbsp;</td>\n  <td>" + (record.title || record.id) + "</td>\n</tr>";
         }
-        // append row to list
         return toggleable_columns += col;
       });
-      // Note: This markup is bootstrap ready:
-      //       http://getbootstrap.com/docs/3.3/javascript/#tooltips
-      menu = `<div class="tooltip bottom">\n  <div class="tooltip-inner">\n    <table class="contextmenu" cellpadding="0" cellspacing="0">\n      <tr>\n        <th colspan="2">${_("Display columns")}</th>\n      </tr>\n      ${toggleable_columns}\n      <tr col_id="${_("All")}" form_id="${form_id}">\n        <td style="border-top:1px solid #ddd;">&nbsp;</td>\n        <td style="border-top:1px solid #ddd;">${_("All")}</td>\n      </tr>\n      <tr col_id="${_("Default")}" form_id="${form_id}">\n        <td>&nbsp;</td>\n        <td>${_("Default")}</td>\n      </tr>\n    </table>\n  </div>\n  <div class="tooltip-arrow"></div>\n</div>`;
+      menu = "<div class=\"tooltip bottom\">\n  <div class=\"tooltip-inner\">\n    <table class=\"contextmenu\" cellpadding=\"0\" cellspacing=\"0\">\n      <tr>\n        <th colspan=\"2\">" + (_("Display columns")) + "</th>\n      </tr>\n      " + toggleable_columns + "\n      <tr col_id=\"" + (_("All")) + "\" form_id=\"" + form_id + "\">\n        <td style=\"border-top:1px solid #ddd;\">&nbsp;</td>\n        <td style=\"border-top:1px solid #ddd;\">" + (_("All")) + "</td>\n      </tr>\n      <tr col_id=\"" + (_("Default")) + "\" form_id=\"" + form_id + "\">\n        <td>&nbsp;</td>\n        <td>" + (_("Default")) + "</td>\n      </tr>\n    </table>\n  </div>\n  <div class=\"tooltip-arrow\"></div>\n</div>";
       return menu;
-    }
+    };
 
-    on_click(event) {
+
+    /* EVENT HANDLER */
+
+    BikaListingTableView.prototype.on_click = function(event) {
+
       /*
        * Eventhandler for all clicks
        */
       var el;
       el = $(event.target);
-      // dismiss the tooltip
       if (el.parents(".tooltip").length === 0) {
         return $(".tooltip").remove();
       }
-    }
+    };
 
-    on_review_state_filter_click(event) {
-      var $el, el, form, form_id, state_id;
+    BikaListingTableView.prototype.on_review_state_filter_click = function(event) {
+
       /*
        * Eventhandler for review state filter buttons
        */
+      var $el, el, form, form_id, state_id;
       console.debug("°°° ListingTableView::on_review_state_filter_click °°°");
-      // prevent full page reload
       event.preventDefault();
       el = event.currentTarget;
       $el = $(el);
@@ -742,47 +685,48 @@
       form_id = form.attr("id");
       state_id = $el.attr("value");
       return this.filter_state(form_id, state_id);
-    }
+    };
 
-    on_listing_entry_change(event) {
-      var $el, checkbox, el, table, tr, uid;
+    BikaListingTableView.prototype.on_listing_entry_change = function(event) {
+
       /*
        * Eventhandler for listing entries (results capturing)
        */
+      var $el, checkbox, el, table, tr, uid;
       console.debug("°°° ListingTableView::on_listing_entry_change °°°");
       el = event.currentTarget;
       $el = $(el);
       uid = $el.attr("uid");
-      tr = $el.parents(`tr#folder-contents-item-${uid}`);
-      checkbox = tr.find(`input[id$=_cb_${uid}]`);
+      tr = $el.parents("tr#folder-contents-item-" + uid);
+      checkbox = tr.find("input[id$=_cb_" + uid + "]");
       if ($(checkbox).length === 1) {
         table = $(checkbox).parents("table.bika-listing-table");
         $(checkbox).prop('checked', true);
         return this.render_transition_buttons(table);
       }
-    }
+    };
 
-    on_listing_entry_keypress(event) {
+    BikaListingTableView.prototype.on_listing_entry_keypress = function(event) {
+
       /*
        * Eventhandler for listing entries (results capturing)
        */
       console.debug("°°° ListingTableView::on_listing_entry_keypress °°°");
-      // Prevent automatic submissions of manage_results forms when enter is pressed
       if (event.which === 13) {
         console.debug("ListingTableView::on_listing_entry_keypress: capture Enter key");
         return event.preventDefault();
       }
-    }
+    };
 
-    on_category_header_click(event) {
-      var $el, cat_id, el, form, form_id;
+    BikaListingTableView.prototype.on_category_header_click = function(event) {
+
       /*
        * Eventhandler for collapsed/expanded categories
        */
+      var $el, cat_id, el, form, form_id;
       console.debug("°°° ListingTableView::on_category_header_click °°°");
       el = event.currentTarget;
       $el = $(el);
-      // disable category collapse
       if ($el.hasClass("ignore_bikalisting_default_handler")) {
         console.debug("Category toggling disabled by CSS class");
         return;
@@ -791,10 +735,10 @@
       form_id = form.attr("id");
       cat_id = $el.attr("cat");
       return this.toggle_category(form_id, cat_id);
-    }
+    };
 
-    on_autosave_field_change(event) {
-      var $el, el, fieldname, fieldvalue, form_data, rowname, tr, uid, url;
+    BikaListingTableView.prototype.on_autosave_field_change = function(event) {
+
       /*
        * Eventhandler for input fields with `autosave` css class
        *
@@ -804,23 +748,22 @@
        *
        * Used in Analysis Listing when the "Hidden" checkbox is clicked
        */
+      var $el, el, fieldname, fieldvalue, form_data, rowname, tr, uid, url;
       console.debug("°°° ListingTableView::on_autosave_field_change °°°");
       el = event.currentTarget;
       $el = $(el);
-      url = `${this.get_portal_url()}/@@API/update`;
+      url = (this.get_portal_url()) + "/@@API/update";
       tr = $el.closest("tr");
       rowname = tr.attr("title");
       uid = $el.attr("uid");
       fieldname = $el.attr("field");
       fieldvalue = $el.val();
       if ($el.is(":checkbox")) {
-        // note: only the element has the checked property
         fieldvalue = $el[0].checked;
       }
       form_data = {};
       form_data[fieldname] = fieldvalue;
       form_data["obj_uid"] = uid;
-      // send the new data to the server
       return this.ajax_submit({
         url: url,
         data: form_data
@@ -828,74 +771,62 @@
         var level, message, success;
         success = data && data.success === true ? true : false;
         if (success) {
-          message = this._(`${rowname} saved`);
+          message = this._(rowname + " saved");
         } else {
-          message = this._(`Failed to update ${rowname}`);
+          message = this._("Failed to update " + rowname);
         }
         level = success ? "succeed" : "error";
         return bika.lims.SiteView.notify_in_panel(message, level);
       });
-    }
+    };
 
-    on_workflow_button_click(event) {
-      var $el, e, el, focus, form, form_id, transition, url;
+    BikaListingTableView.prototype.on_workflow_button_click = function(event) {
+
       /*
        * Eventhandler for the workflow buttons
        */
+      var $el, e, el, focus, form, form_id, transition, url;
       console.debug("°°° ListingTableView::on_workflow_button_click °°°");
       el = event.currentTarget;
       $el = $(el);
       form = $el.parents("form");
       form_id = $(form).attr("id");
-      // The submit buttons would like to put the translated action title into the
-      // request. Insert the real action name here to prevent the WorkflowAction
-      // handler from having to look it up (painful/slow).
       transition = $el.attr("transition");
-      $(form).append(`<input type='hidden' name='workflow_action_id' value='${transition}' />`);
-      // This submit_transition cheat fixes a bug where hitting submit caused form
-      // to be posted before ajax calculation is returned
+      $(form).append("<input type='hidden' name='workflow_action_id' value='" + transition + "' />");
       if ($el.id === "submit_transition") {
         focus = $(".ajax_calculate_focus");
         if (focus.length > 0) {
           e = $(focus[0]);
           if ($(e).attr("focus_value") === $(e).val()) {
-            // value did not change - transparent blur handler.
             $(e).removeAttr("focus_value");
             $(e).removeClass("ajax_calculate_focus");
           } else {
-            // The calcs.js code is now responsible for submitting
-            // this form when the calculation ajax is complete
             $(e).parents("form").attr("submit_after_calculation", 1);
             event.preventDefault();
           }
         }
       }
-      // If a custom_transitions action with a URL is clicked the form will be
-      // submitted there
       url = $el.attr("url");
       if (url !== "") {
         form = $el.parents("form");
         $(form).attr("action", url);
         return $(form).submit();
       }
-    }
+    };
 
-    on_contextmenu(event) {
-      var $el, el, menu, table;
+    BikaListingTableView.prototype.on_contextmenu = function(event) {
+
       /*
        * Eventhandler for the table contextmenu
        */
+      var $el, el, menu, table;
       console.debug("°°° ListingTableView::on_contextmenu °°°");
-      // prevent the system context menu
       event.preventDefault();
       el = event.currentTarget;
       $el = $(el);
       table = $el.parents("table.bika-listing-table");
-      // create the context menu HTML
       menu = this.make_context_menu(table);
-      // append to the body
       menu = $(menu).appendTo("body");
-      // position the contextmenu where the mouse clicked
       return $(menu).css({
         "border": "1px solid #fff",
         "border-radius": ".25em",
@@ -904,61 +835,55 @@
         "top": event.pageY - 5,
         "left": event.pageX - 5
       });
-    }
+    };
 
-    on_contextmenu_item_click(event) {
-      var $el, col_id, el, form_id;
+    BikaListingTableView.prototype.on_contextmenu_item_click = function(event) {
+
       /*
        * Eventhandler when an item was clicked in the contextmenu
        */
+      var $el, col_id, el, form_id;
       console.debug("°°° ListingTableView::on_contextmenu_item_click °°°");
-      // current event target (table header)
       el = event.currentTarget;
-      // We're getting here the <tr> element from the context menu
       $el = $(el);
-      // get the form and column id from the contextmenu <tr> element
       form_id = $el.attr("form_id");
       col_id = $el.attr("col_id");
-      // toggle the column
       return this.toggle_column(form_id, col_id);
-    }
+    };
 
-    on_search_field_keypress(event) {
-      var $el, el, form, form_id, searchfield, searchterm;
+    BikaListingTableView.prototype.on_search_field_keypress = function(event) {
+
       /*
        * Eventhandler for the search field
        */
+      var $el, el, form, form_id, searchfield, searchterm;
       console.debug("°°° ListingTableView::on_search_field_keypress °°°");
-      // current event target (table header)
       el = event.currentTarget;
       $el = $(el);
-      // only trigger search on enter
       if (event.which === 13) {
-        // prevent form submit on enter
         event.preventDefault();
-        // get the form and column id from the contextmenu <tr> element
         form = $el.parents("form");
         form_id = form.attr("id");
         searchfield = $(".filter-search-input", form);
         searchterm = searchfield.val();
         return this.search(form_id, searchterm);
       }
-    }
+    };
 
-    on_search_button_click(event) {
-      var $el, el;
+    BikaListingTableView.prototype.on_search_button_click = function(event) {
+
       /*
        * Eventhandler for the search field button
        */
+      var $el, el;
       console.debug("°°° ListingTableView::on_search_button_click °°°");
-      // current event target (table header)
       el = event.currentTarget;
       $el = $(el);
       return this.on_search_field_keypress(event);
-    }
+    };
 
-    on_select_all_click(event) {
-      var $el, checkboxes, el, table;
+    BikaListingTableView.prototype.on_select_all_click = function(event) {
+
       /*
        * Eventhandler when the select all checkbox was clicked
        *
@@ -967,19 +892,18 @@
        * re-renders the workflow action buttons from the bottom of the list,
        * based on the allowed transitions for the currently selected items
        */
+      var $el, checkboxes, el, table;
       console.debug("°°° ListingTableView::on_select_all_click °°°");
-      // current event target (table header)
       el = event.currentTarget;
       $el = $(el);
       table = $el.parents("table.bika-listing-table");
       checkboxes = $(table).find("[id*='_cb_']");
       $(checkboxes).prop("checked", $el.prop("checked"));
-      // render transition buttons
       return this.render_transition_buttons(table);
-    }
+    };
 
-    on_checkbox_click(event) {
-      var $el, all, checkall, checked, el, table;
+    BikaListingTableView.prototype.on_checkbox_click = function(event) {
+
       /*
        * Eventhandler when a Checkbox was clicked
        *
@@ -988,70 +912,67 @@
        * re-renders the workflow action buttons from the bottom of the list
        * based on the allowed transitions of the currently selected items
        */
+      var $el, all, checkall, checked, el, table;
       console.debug("°°° ListingTableView::on_checkbox_click °°°");
-      // current event target (table header)
       el = event.currentTarget;
       $el = $(el);
       table = $el.parents("table.bika-listing-table");
-      // Toggle select all checkbox
       checked = $("input[type='checkbox'][id*='_cb_']:checked");
       all = $("input[type='checkbox'][id*='_cb_']");
       checkall = $(table).find("input[id*='select_all']");
       checkall.prop("checked", checked.length === all.length);
-      // render transition buttons
       return this.render_transition_buttons(table);
-    }
+    };
 
-    on_ajax_submit_start(event) {
+    BikaListingTableView.prototype.on_ajax_submit_start = function(event) {
+
       /*
        * Eventhandler for Ajax form submit
        */
       return console.debug("°°° ListingTableView::on_ajax_submit_start °°°");
-    }
+    };
 
-    on_ajax_submit_end(event) {
+    BikaListingTableView.prototype.on_ajax_submit_end = function(event) {
+
       /*
        * Eventhandler for Ajax form submit
        */
       return console.debug("°°° ListingTableView::on_ajax_submit_end °°°");
-    }
+    };
 
-    on_column_header_click(event) {
-      var $el, el, form, form_id, sort_index;
+    BikaListingTableView.prototype.on_column_header_click = function(event) {
+
       /*
        * Eventhandler for Table Column Header
        */
+      var $el, el, form, form_id, sort_index;
       console.debug("°°° ListingTableView::on_column_header_click °°°");
-      // current event target (table header)
       el = event.currentTarget;
       $el = $(el);
       form = $el.parents("form");
       form_id = form.attr("id");
-      // extract the sort on index
-      // XXX add the index directly to the table header
-      // foldercontents-getClientReference-column -> getClientReference
       sort_index = $el.attr("id").split("-")[1];
-      // sort the table
       return this.sort_column(form_id, sort_index);
-    }
+    };
 
-    on_show_more_click(event) {
-      var $el, el, form_id, limit_from, pagesize;
+    BikaListingTableView.prototype.on_show_more_click = function(event) {
+
       /*
        * Eventhandler for the Table "Show More" Button
        */
+      var $el, el, form_id, limit_from, pagesize;
       console.debug("°°° ListingTableView::on_show_more_click °°°");
-      // current event target (Show More button)
       el = event.currentTarget;
       $el = $(el);
-      // prevent form submit on button click
       event.preventDefault();
       form_id = $el.attr("data-form-id");
       pagesize = this.parse_int($el.attr("data-pagesize"));
       limit_from = this.parse_int($el.attr("data-limitfrom"));
       return this.show_more(form_id, pagesize, limit_from);
-    }
+    };
 
-  };
+    return BikaListingTableView;
+
+  })();
 
 }).call(this);

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -1,30 +1,36 @@
+
+/* Please use this command to compile this file into the parent `js` directory:
+    coffee --no-header -w -o ../ -c bika.lims.worksheet.coffee
+ */
+
 (function() {
-  /* Please use this command to compile this file into the parent `js` directory:
-      coffee --no-header -w -o ../ -c bika.lims.worksheet.coffee
-  */
-  window.WorksheetFolderView = class WorksheetFolderView {
-    constructor() {
-      /*
-      * Controller class for Worksheets Folder
-       */
-      this.load = this.load.bind(this);
-      /* INITIALIZERS */
-      this.bind_eventhandler = this.bind_eventhandler.bind(this);
-      /* METHODS */
-      this.get_template_instrument = this.get_template_instrument.bind(this);
-      this.select_instrument = this.select_instrument.bind(this);
-      /* EVENT HANDLER */
-      this.on_template_change = this.on_template_change.bind(this);
-      this.on_instrument_change = this.on_instrument_change.bind(this);
+  var bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
+
+  window.WorksheetFolderView = (function() {
+    function WorksheetFolderView() {
+      this.on_instrument_change = bind(this.on_instrument_change, this);
+      this.on_template_change = bind(this.on_template_change, this);
+      this.select_instrument = bind(this.select_instrument, this);
+      this.get_template_instrument = bind(this.get_template_instrument, this);
+      this.bind_eventhandler = bind(this.bind_eventhandler, this);
+      this.load = bind(this.load, this);
     }
 
-    load() {
+
+    /*
+    * Controller class for Worksheets Folder
+     */
+
+    WorksheetFolderView.prototype.load = function() {
       console.debug("WorksheetFolderView::load");
-      // bind the event handler to the elements
       return this.bind_eventhandler();
-    }
+    };
 
-    bind_eventhandler() {
+
+    /* INITIALIZERS */
+
+    WorksheetFolderView.prototype.bind_eventhandler = function() {
+
       /*
        * Binds callbacks on elements
        *
@@ -33,101 +39,105 @@
        *
        */
       console.debug("WorksheetFolderView::bind_eventhandler");
-      // Template changed
       $("body").on("change", "select.template", this.on_template_change);
-      // Instrument changed
       return $("body").on("change", "select.instrument", this.on_instrument_change);
-    }
+    };
 
-    get_template_instrument() {
-      var input, value;
+
+    /* METHODS */
+
+    WorksheetFolderView.prototype.get_template_instrument = function() {
+
       /*
        * TODO: Refactor to get the data directly from the server
        * Returns the JSON parsed value of the HTML element with the class
          `templateinstruments`
        */
+      var input, value;
       console.debug("WorksheetFolderView::get_template_instruments");
       input = $("input.templateinstruments");
       value = input.val();
       return $.parseJSON(value);
-    }
+    };
 
-    select_instrument(instrument_uid) {
+    WorksheetFolderView.prototype.select_instrument = function(instrument_uid) {
+
       /*
        * Select instrument by UID
        */
       var option, select;
       select = $(".instrument");
-      option = select.find(`option[value='${instrument_uid}']`);
+      option = select.find("option[value='" + instrument_uid + "']");
       if (option) {
         return option.prop("selected", true);
       }
-    }
+    };
 
-    on_template_change(event) {
-      var $el, instrument_uid, template_instrument, template_uid;
+
+    /* EVENT HANDLER */
+
+    WorksheetFolderView.prototype.on_template_change = function(event) {
+
       /*
        * Eventhandler for template change
        */
+      var $el, instrument_uid, template_instrument, template_uid;
       console.debug("°°° WorksheetFolderView::on_template_change °°°");
-      // The select element for WS Template
       $el = $(event.currentTarget);
-      // The option value is the worksheettemplate UID
       template_uid = $el.val();
-      // Assigned instrument of this worksheet
       template_instrument = this.get_template_instrument();
-      // The UID of the assigned instrument in the template
       instrument_uid = template_instrument[template_uid];
-      // Select the instrument from the selection
       return this.select_instrument(instrument_uid);
-    }
+    };
 
-    on_instrument_change(event) {
-      var $el, instrument_uid, message;
+    WorksheetFolderView.prototype.on_instrument_change = function(event) {
+
       /*
        * Eventhandler for instrument change
        */
+      var $el, instrument_uid, message;
       console.debug("°°° WorksheetFolderView::on_instrument_change °°°");
-      // The select element for WS Instrument
       $el = $(event.currentTarget);
-      // The option value is the nstrument UID
       instrument_uid = $el.val();
       if (instrument_uid) {
         message = _("Only the analyses for which the selected instrument is allowed will be added automatically.");
-        // actually just a notification, but lacking a proper css class here
         return bika.lims.SiteView.notify_in_panel(message, "error");
       }
+    };
+
+    return WorksheetFolderView;
+
+  })();
+
+  window.WorksheetAddAnalysesView = (function() {
+    function WorksheetAddAnalysesView() {
+      this.on_search_click = bind(this.on_search_click, this);
+      this.on_category_change = bind(this.on_category_change, this);
+      this.filter_service_selector_by_category_uid = bind(this.filter_service_selector_by_category_uid, this);
+      this.get_listing_form = bind(this.get_listing_form, this);
+      this.get_listing_form_id = bind(this.get_listing_form_id, this);
+      this.get_authenticator = bind(this.get_authenticator, this);
+      this.get_base_url = bind(this.get_base_url, this);
+      this.ajax_submit = bind(this.ajax_submit, this);
+      this.bind_eventhandler = bind(this.bind_eventhandler, this);
+      this.load = bind(this.load, this);
     }
 
-  };
 
-  window.WorksheetAddAnalysesView = class WorksheetAddAnalysesView {
-    constructor() {
-      /*
-       * Controller class for Worksheet's add analyses view
-       */
-      this.load = this.load.bind(this);
-      /* INITIALIZERS */
-      this.bind_eventhandler = this.bind_eventhandler.bind(this);
-      /* METHODS */
-      this.ajax_submit = this.ajax_submit.bind(this);
-      this.get_base_url = this.get_base_url.bind(this);
-      this.get_authenticator = this.get_authenticator.bind(this);
-      this.get_listing_form_id = this.get_listing_form_id.bind(this);
-      this.get_listing_form = this.get_listing_form.bind(this);
-      this.filter_service_selector_by_category_uid = this.filter_service_selector_by_category_uid.bind(this);
-      /* EVENT HANDLER */
-      this.on_category_change = this.on_category_change.bind(this);
-      this.on_search_click = this.on_search_click.bind(this);
-    }
+    /*
+     * Controller class for Worksheet's add analyses view
+     */
 
-    load() {
+    WorksheetAddAnalysesView.prototype.load = function() {
       console.debug("WorksheetAddanalysesview::load");
-      // bind the event handler to the elements
       return this.bind_eventhandler();
-    }
+    };
 
-    bind_eventhandler() {
+
+    /* INITIALIZERS */
+
+    WorksheetAddAnalysesView.prototype.bind_eventhandler = function() {
+
       /*
        * Binds callbacks on elements
        *
@@ -136,19 +146,23 @@
        *
        */
       console.debug("WorksheetAddanalysesview::bind_eventhandler");
-      // Category filter changed
       $("body").on("change", "[name='list_FilterByCategory']", this.on_category_change);
-      // Search button clicked
       return $("body").on("click", ".ws-analyses-search-button", this.on_search_click);
-    }
+    };
 
-    ajax_submit(options = {}) {
+
+    /* METHODS */
+
+    WorksheetAddAnalysesView.prototype.ajax_submit = function(options) {
       var done;
+      if (options == null) {
+        options = {};
+      }
+
       /*
        * Ajax Submit with automatic event triggering and some sane defaults
        */
       console.debug("°°° ajax_submit °°°");
-      // some sane option defaults
       if (options.type == null) {
         options.type = "POST";
       }
@@ -160,53 +174,60 @@
       }
       console.debug(">>> ajax_submit::options=", options);
       $(this).trigger("ajax:submit:start");
-      done = () => {
-        return $(this).trigger("ajax:submit:end");
-      };
+      done = (function(_this) {
+        return function() {
+          return $(_this).trigger("ajax:submit:end");
+        };
+      })(this);
       return $.ajax(options).done(done);
-    }
+    };
 
-    get_base_url() {
+    WorksheetAddAnalysesView.prototype.get_base_url = function() {
+
       /*
        * Return the current base url
        */
       var url;
       url = window.location.href;
       return url.split('?')[0];
-    }
+    };
 
-    get_authenticator() {
+    WorksheetAddAnalysesView.prototype.get_authenticator = function() {
+
       /*
        * Get the authenticator value
        */
       return $("input[name='_authenticator']").val();
-    }
+    };
 
-    get_listing_form_id() {
+    WorksheetAddAnalysesView.prototype.get_listing_form_id = function() {
+
       /*
        * Returns the CSS ID of the analyses listing
        */
       return "list";
-    }
+    };
 
-    get_listing_form() {
+    WorksheetAddAnalysesView.prototype.get_listing_form = function() {
+
       /*
        * Returns the analyses listing form element
        */
       var form_id;
       form_id = this.get_listing_form_id();
-      return $(`form[id='${form_id}']`);
-    }
+      return $("form[id='" + form_id + "']");
+    };
 
-    filter_service_selector_by_category_uid(category_uid) {
-      var $select, base_url, data, form_id, select_name, url;
+    WorksheetAddAnalysesView.prototype.filter_service_selector_by_category_uid = function(category_uid) {
+
       /*
        * Filters the service selector by category
        */
-      console.debug(`WorksheetAddanalysesview::filter_service_selector_by_category_uid:${category_uid}`);
+      var $select, base_url, data, form_id, select_name, url;
+      console.debug("WorksheetAddanalysesview::filter_service_selector_by_category_uid:" + category_uid);
       form_id = this.get_listing_form_id();
-      select_name = `${form_id}_FilterByService`;
-      $select = $(`[name='${select_name}']`);
+      select_name = form_id + "_FilterByService";
+      $select = $("[name='" + select_name + "']");
       base_url = this.get_base_url();
       url = base_url.replace("/add_analyses", "/getServices");
       data = {
@@ -222,114 +243,113 @@
       }).done(function(data) {
         var any_option;
         $select.empty();
-        any_option = `<option value='any'>${_('Any')}</option>`;
+        any_option = "<option value='any'>" + (_('Any')) + "</option>";
         $select.append(any_option);
         return $.each(data, function(index, item) {
           var name, option, uid;
           uid = item[0];
           name = item[1];
-          option = `<option value='${uid}'>${name}</option>`;
+          option = "<option value='" + uid + "'>" + name + "</option>";
           return $select.append(option);
         });
       });
-    }
+    };
 
-    on_category_change(event) {
-      var $el, category_uid;
+
+    /* EVENT HANDLER */
+
+    WorksheetAddAnalysesView.prototype.on_category_change = function(event) {
+
       /*
        * Eventhandler for category change
        */
+      var $el, category_uid;
       console.debug("°°° WorksheetAddanalysesview::on_category_change °°°");
-      // The select element for WS Template
       $el = $(event.currentTarget);
-      // extract the category UID and filter the services box
       category_uid = $el.val();
       return this.filter_service_selector_by_category_uid(category_uid);
-    }
+    };
 
-    on_search_click(event) {
-      var filter_indexes, form, form_data, form_id;
+    WorksheetAddAnalysesView.prototype.on_search_click = function(event) {
+
       /*
        * Eventhandler for the search button
        */
+      var filter_indexes, form, form_data, form_id;
       console.debug("°°° WorksheetAddanalysesview::on_search_click °°°");
-      // Prevent form submit
       event.preventDefault();
       form = this.get_listing_form();
       form_id = this.get_listing_form_id();
       filter_indexes = ["FilterByCategory", "FilterByService", "FilterByClient"];
-      // The filter elements (Category/Service/Client) belong to another form.
-      // Therefore, we need to inject these values into the listing form as hidden
-      // input fields.
       $.each(filter_indexes, function(index, filter) {
         var $el, input, name, value;
-        name = `${form_id}_${filter}`;
-        $el = $(`select[name='${name}']`);
+        name = form_id + "_" + filter;
+        $el = $("select[name='" + name + "']");
         value = $el.val();
-        // get the corresponding input element of the listing form
-        input = $(`input[name='${name}']`, form);
+        input = $("input[name='" + name + "']", form);
         if (input.length === 0) {
-          form.append(`<input name='${name}' value='${value}' type='hidden'/>`);
-          input = $(`input[name='${name}']`, form);
+          form.append("<input name='" + name + "' value='" + value + "' type='hidden'/>");
+          input = $("input[name='" + name + "']", form);
         }
         input.val(value);
-        // omit the field if the value is set to any
         if (value === "any") {
           return input.remove();
         }
       });
-      // extract the data of the listing form and post it to the AddAnalysesView
       form_data = new FormData(form[0]);
       form_data.set("table_only", form_id);
       return this.ajax_submit({
         data: form_data,
-        processData: false, // do not transform to a query string
-        contentType: false // do not set any content type header
+        processData: false,
+        contentType: false
       }).done(function(data) {
         var $container, $data;
         $container = $("div.bika-listing-table-container", form);
         $data = $(data);
         if ($data.find("tbody").length === 0) {
-          return $container.html(`<div class='discreet info'>0 ${_('Results')}</div>`);
+          return $container.html("<div class='discreet info'>0 " + (_('Results')) + "</div>");
         } else {
           $container.html(data);
           return window.bika.lims.BikaListingTableView.load_transitions();
         }
       });
+    };
+
+    return WorksheetAddAnalysesView;
+
+  })();
+
+  window.WorksheetAddQCAnalysesView = (function() {
+    function WorksheetAddQCAnalysesView() {
+      this.on_referencesample_row_click = bind(this.on_referencesample_row_click, this);
+      this.on_service_click = bind(this.on_service_click, this);
+      this.load_controls = bind(this.load_controls, this);
+      this.get_postion = bind(this.get_postion, this);
+      this.get_control_type = bind(this.get_control_type, this);
+      this.get_selected_services = bind(this.get_selected_services, this);
+      this.get_authenticator = bind(this.get_authenticator, this);
+      this.get_base_url = bind(this.get_base_url, this);
+      this.ajax_submit = bind(this.ajax_submit, this);
+      this.bind_eventhandler = bind(this.bind_eventhandler, this);
+      this.load = bind(this.load, this);
     }
 
-  };
 
-  window.WorksheetAddQCAnalysesView = class WorksheetAddQCAnalysesView {
-    constructor() {
-      /*
-       * Controller class for Worksheet's add blank/control views
-       */
-      this.load = this.load.bind(this);
-      /* INITIALIZERS */
-      this.bind_eventhandler = this.bind_eventhandler.bind(this);
-      /* METHODS */
-      this.ajax_submit = this.ajax_submit.bind(this);
-      this.get_base_url = this.get_base_url.bind(this);
-      this.get_authenticator = this.get_authenticator.bind(this);
-      this.get_selected_services = this.get_selected_services.bind(this);
-      this.get_control_type = this.get_control_type.bind(this);
-      this.get_postion = this.get_postion.bind(this);
-      this.load_controls = this.load_controls.bind(this);
-      /* EVENT HANDLER */
-      this.on_service_click = this.on_service_click.bind(this);
-      this.on_referencesample_row_click = this.on_referencesample_row_click.bind(this);
-    }
+    /*
+     * Controller class for Worksheet's add blank/control views
+     */
 
-    load() {
+    WorksheetAddQCAnalysesView.prototype.load = function() {
       console.debug("WorksheetAddQCAnalysesView::load");
-      // bind the event handler to the elements
       this.bind_eventhandler();
-      // initially load the references
       return this.load_controls();
-    }
+    };
 
-    bind_eventhandler() {
+
+    /* INITIALIZERS */
+
+    WorksheetAddQCAnalysesView.prototype.bind_eventhandler = function() {
+
       /*
        * Binds callbacks on elements
        *
@@ -338,19 +358,23 @@
        *
        */
       console.debug("WorksheetAddQCAnalysesView::bind_eventhandler");
-      // Service checkbox clicked
       $("body").on("click", "#worksheet_services input[id*='_cb_']", this.on_service_click);
-      // click a Reference Sample in add_control or add_blank
       return $("body").on("click", "#worksheet_add_references .bika-listing-table tbody.item-listing-tbody tr", this.on_referencesample_row_click);
-    }
+    };
 
-    ajax_submit(options = {}) {
+
+    /* METHODS */
+
+    WorksheetAddQCAnalysesView.prototype.ajax_submit = function(options) {
       var done;
+      if (options == null) {
+        options = {};
+      }
+
       /*
        * Ajax Submit with automatic event triggering and some sane defaults
        */
       console.debug("°°° ajax_submit °°°");
-      // some sane option defaults
       if (options.type == null) {
         options.type = "POST";
       }
@@ -362,29 +386,34 @@
       }
       console.debug(">>> ajax_submit::options=", options);
       $(this).trigger("ajax:submit:start");
-      done = () => {
-        return $(this).trigger("ajax:submit:end");
-      };
+      done = (function(_this) {
+        return function() {
+          return $(_this).trigger("ajax:submit:end");
+        };
+      })(this);
       return $.ajax(options).done(done);
-    }
+    };
 
-    get_base_url() {
+    WorksheetAddQCAnalysesView.prototype.get_base_url = function() {
+
       /*
        * Return the current base url
        */
       var url;
       url = window.location.href;
       return url.split('?')[0];
-    }
+    };
 
-    get_authenticator() {
+    WorksheetAddQCAnalysesView.prototype.get_authenticator = function() {
+
       /*
        * Get the authenticator value
        */
       return $("input[name='_authenticator']").val();
-    }
+    };
 
-    get_selected_services() {
+    WorksheetAddQCAnalysesView.prototype.get_selected_services = function() {
+
       /*
        * Returns a list of selected service uids
        */
@@ -395,9 +424,10 @@
         return services.push(element.value);
       });
       return services;
-    }
+    };
 
-    get_control_type() {
+    WorksheetAddQCAnalysesView.prototype.get_control_type = function() {
+
       /*
        * Returns the control type
        */
@@ -407,25 +437,27 @@
         control_type = "c";
       }
       return control_type;
-    }
+    };
 
-    get_postion() {
+    WorksheetAddQCAnalysesView.prototype.get_postion = function() {
+
       /*
        * Returns the postition
        */
       var position;
       position = $("#position").val();
       return position || "new";
-    }
+    };
 
-    load_controls() {
+    WorksheetAddQCAnalysesView.prototype.load_controls = function() {
+
       /*
        * Load the controls
        */
       var base_url, element, url;
       base_url = this.get_base_url();
       base_url = base_url.replace("/add_blank", "").replace("/add_control", "");
-      url = `${base_url}/getWorksheetReferences`;
+      url = base_url + "/getWorksheetReferences";
       element = $("#worksheet_add_references");
       if (element.length === 0) {
         console.warn("Element with id='#worksheet_add_references' missing!");
@@ -441,29 +473,32 @@
       }).done(function(data) {
         return element.html(data);
       });
-    }
+    };
 
-    on_service_click(event) {
+
+    /* EVENT HANDLER */
+
+    WorksheetAddQCAnalysesView.prototype.on_service_click = function(event) {
+
       /*
        * Eventhandler when a service checkbox was clicked
        */
       console.debug("°°° WorksheetAddQCAnalysesView::on_category_change °°°");
       return this.load_controls();
-    }
+    };
 
-    on_referencesample_row_click(event) {
-      var $el, $form, action, control_type, selected_services, uid;
+    WorksheetAddQCAnalysesView.prototype.on_referencesample_row_click = function(event) {
+
       /*
        * Eventhandler for a click on the loaded referencesample listing
        *
        * A reference sample for the service need to be added via
        * Setup -> Supplier -> Referene Samples
        */
+      var $el, $form, action, control_type, selected_services, uid;
       console.debug("°°° WorksheetAddQCAnalysesView::on_referencesample_row_click °°°");
-      // The clicked element is a row from the referencesample listing
       $el = $(event.currentTarget);
       uid = $el.attr("uid");
-      // we want to submit to the worksheet.py/add_control or add_blank views.
       $form = $el.parents("form");
       control_type = this.get_control_type();
       action = "add_blank";
@@ -472,38 +507,39 @@
       }
       $form.attr("action", action);
       selected_services = this.get_selected_services().join(",");
-      $form.append(`<input type='hidden' value='${selected_services}' name='selected_service_uids'/>`);
-      // tell the form handler which reference UID was clicked
-      $form.append(`<input type='hidden' value='${uid}' name='reference_uid'/>`);
-      // add the position dropdown's value to the form before submitting.
-      $form.append(`<input type='hidden' value='${this.get_postion()}' name='position'/>`);
-      // submit the referencesample listing form
+      $form.append("<input type='hidden' value='" + selected_services + "' name='selected_service_uids'/>");
+      $form.append("<input type='hidden' value='" + uid + "' name='reference_uid'/>");
+      $form.append("<input type='hidden' value='" + (this.get_postion()) + "' name='position'/>");
       return $form.submit();
+    };
+
+    return WorksheetAddQCAnalysesView;
+
+  })();
+
+  window.WorksheetAddDuplicateAnalysesView = (function() {
+    function WorksheetAddDuplicateAnalysesView() {
+      this.on_duplicate_row_click = bind(this.on_duplicate_row_click, this);
+      this.get_postion = bind(this.get_postion, this);
+      this.bind_eventhandler = bind(this.bind_eventhandler, this);
+      this.load = bind(this.load, this);
     }
 
-  };
 
-  window.WorksheetAddDuplicateAnalysesView = class WorksheetAddDuplicateAnalysesView {
-    constructor() {
-      /*
-       * Controller class for Worksheet's add blank/control views
-       */
-      this.load = this.load.bind(this);
-      /* INITIALIZERS */
-      this.bind_eventhandler = this.bind_eventhandler.bind(this);
-      /* METHODS */
-      this.get_postion = this.get_postion.bind(this);
-      /* EVENT HANDLER */
-      this.on_duplicate_row_click = this.on_duplicate_row_click.bind(this);
-    }
+    /*
+     * Controller class for Worksheet's add blank/control views
+     */
 
-    load() {
+    WorksheetAddDuplicateAnalysesView.prototype.load = function() {
       console.debug("WorksheetAddDuplicateAnalysesView::load");
-      // bind the event handler to the elements
       return this.bind_eventhandler();
-    }
+    };
 
-    bind_eventhandler() {
+
+    /* INITIALIZERS */
+
+    WorksheetAddDuplicateAnalysesView.prototype.bind_eventhandler = function() {
+
       /*
        * Binds callbacks on elements
        *
@@ -512,88 +548,93 @@
        *
        */
       console.debug("WorksheetAddDuplicateAnalysesView::bind_eventhandler");
-      // Service checkbox clicked
       return $("body").on("click", "#worksheet_add_duplicate_ars .bika-listing-table tbody.item-listing-tbody tr", this.on_duplicate_row_click);
-    }
+    };
 
-    get_postion() {
+
+    /* METHODS */
+
+    WorksheetAddDuplicateAnalysesView.prototype.get_postion = function() {
+
       /*
        * Returns the postition
        */
       var position;
       position = $("#position").val();
       return position || "new";
-    }
+    };
 
-    on_duplicate_row_click(event) {
-      var $el, $form, uid;
+
+    /* EVENT HANDLER */
+
+    WorksheetAddDuplicateAnalysesView.prototype.on_duplicate_row_click = function(event) {
+
       /*
        * Eventhandler for a click on a row of the loaded dduplicate listing
        */
+      var $el, $form, uid;
       console.debug("°°° WorksheetAddDuplicateAnalysesView::on_duplicate_row_click °°°");
       $el = $(event.currentTarget);
       uid = $el.attr("uid");
-      // we want to submit to the worksheet.py/add_duplicate view.
       $form = $el.parents("form");
       $form.attr("action", "add_duplicate");
-      // add the position dropdown's value to the form before submitting.
-      $form.append(`<input type='hidden' value='${uid}' name='ar_uid'/>`);
-      $form.append(`<input type='hidden' value='${this.get_postion()}' name='position'/>`);
+      $form.append("<input type='hidden' value='" + uid + "' name='ar_uid'/>");
+      $form.append("<input type='hidden' value='" + (this.get_postion()) + "' name='position'/>");
       return $form.submit();
+    };
+
+    return WorksheetAddDuplicateAnalysesView;
+
+  })();
+
+  window.WorksheetManageResultsView = (function() {
+    function WorksheetManageResultsView() {
+      this.on_wideinterims_apply_click = bind(this.on_wideinterims_apply_click, this);
+      this.on_wideiterims_interims_change = bind(this.on_wideiterims_interims_change, this);
+      this.on_wideiterims_analyses_change = bind(this.on_wideiterims_analyses_change, this);
+      this.on_remarks_balloon_clicked = bind(this.on_remarks_balloon_clicked, this);
+      this.on_detection_limit_change = bind(this.on_detection_limit_change, this);
+      this.on_analysis_instrument_change = bind(this.on_analysis_instrument_change, this);
+      this.on_analysis_instrument_focus = bind(this.on_analysis_instrument_focus, this);
+      this.on_method_change = bind(this.on_method_change, this);
+      this.on_instrument_change = bind(this.on_instrument_change, this);
+      this.on_layout_change = bind(this.on_layout_change, this);
+      this.on_analyst_change = bind(this.on_analyst_change, this);
+      this.on_constraints_loaded = bind(this.on_constraints_loaded, this);
+      this.load_analysis_method_constraint = bind(this.load_analysis_method_constraint, this);
+      this.is_instrument_allowed = bind(this.is_instrument_allowed, this);
+      this.get_method_by_analysis_uid = bind(this.get_method_by_analysis_uid, this);
+      this.get_analysis_uids = bind(this.get_analysis_uids, this);
+      this.get_authenticator = bind(this.get_authenticator, this);
+      this.get_base_url = bind(this.get_base_url, this);
+      this.get_portal_url = bind(this.get_portal_url, this);
+      this.ajax_submit = bind(this.ajax_submit, this);
+      this.init_instruments_and_methods = bind(this.init_instruments_and_methods, this);
+      this.bind_eventhandler = bind(this.bind_eventhandler, this);
+      this.load = bind(this.load, this);
     }
 
-  };
 
-  window.WorksheetManageResultsView = class WorksheetManageResultsView {
-    constructor() {
-      /*
-       * Controller class for Worksheet's manage results view
-       */
-      this.load = this.load.bind(this);
-      /* INITIALIZERS */
-      this.bind_eventhandler = this.bind_eventhandler.bind(this);
-      this.init_instruments_and_methods = this.init_instruments_and_methods.bind(this);
-      /* METHODS */
-      this.ajax_submit = this.ajax_submit.bind(this);
-      this.get_portal_url = this.get_portal_url.bind(this);
-      this.get_base_url = this.get_base_url.bind(this);
-      this.get_authenticator = this.get_authenticator.bind(this);
-      this.get_analysis_uids = this.get_analysis_uids.bind(this);
-      this.get_method_by_analysis_uid = this.get_method_by_analysis_uid.bind(this);
-      this.is_instrument_allowed = this.is_instrument_allowed.bind(this);
-      this.load_analysis_method_constraint = this.load_analysis_method_constraint.bind(this);
-      /* EVENT HANDLER */
-      this.on_constraints_loaded = this.on_constraints_loaded.bind(this);
-      this.on_analyst_change = this.on_analyst_change.bind(this);
-      this.on_layout_change = this.on_layout_change.bind(this);
-      this.on_instrument_change = this.on_instrument_change.bind(this);
-      this.on_method_change = this.on_method_change.bind(this);
-      this.on_analysis_instrument_focus = this.on_analysis_instrument_focus.bind(this);
-      this.on_analysis_instrument_change = this.on_analysis_instrument_change.bind(this);
-      this.on_detection_limit_change = this.on_detection_limit_change.bind(this);
-      this.on_remarks_balloon_clicked = this.on_remarks_balloon_clicked.bind(this);
-      this.on_wideiterims_analyses_change = this.on_wideiterims_analyses_change.bind(this);
-      this.on_wideiterims_interims_change = this.on_wideiterims_interims_change.bind(this);
-      this.on_wideinterims_apply_click = this.on_wideinterims_apply_click.bind(this);
-    }
+    /*
+     * Controller class for Worksheet's manage results view
+     */
 
-    load() {
+    WorksheetManageResultsView.prototype.load = function() {
       console.debug("WorksheetManageResultsView::load");
-      // load translations
       jarn.i18n.loadCatalog('bika');
       this._ = window.jarn.i18n.MessageFactory('bika');
       this._pmf = window.jarn.i18n.MessageFactory('plone');
-      // bind the event handler to the elements
       this.bind_eventhandler();
-      // method instrument constraints
       this.constraints = null;
-      // initialize
       this.init_instruments_and_methods();
-      // dev only
       return window.ws = this;
-    }
+    };
 
-    bind_eventhandler() {
+
+    /* INITIALIZERS */
+
+    WorksheetManageResultsView.prototype.bind_eventhandler = function() {
+
       /*
        * Binds callbacks on elements
        *
@@ -602,32 +643,24 @@
        *
        */
       console.debug("WorksheetManageResultsView::bind_eventhandler");
-      // Analyst changed
       $("body").on("change", ".manage_results_header .analyst", this.on_analyst_change);
-      // Layout changed
       $("body").on("change", "#resultslayout_form #resultslayout", this.on_layout_change);
-      // Instrument changed
       $("body").on("change", ".manage_results_header .instrument", this.on_instrument_change);
-      // Method changed
       $("body").on("change", "table.bika-listing-table select.listing_select_entry[field='Method']", this.on_method_change);
-      // Analysis instrument focused
       $("body").on("focus", "table.bika-listing-table select.listing_select_entry[field='Instrument']", this.on_analysis_instrument_focus);
-      // Analysis instrument changed
       $("body").on("change", "table.bika-listing-table select.listing_select_entry[field='Instrument']", this.on_analysis_instrument_change);
-      // Detection limit changed
       $("body").on("change", "select[name^='DetectionLimit.']", this.on_detection_limit_change);
-      // Remarks balloon clicked
       $("body").on("click", "a.add-remark", this.on_remarks_balloon_clicked);
-      // Wide interims changed
       $("body").on("change", "#wideinterims_analyses", this.on_wideiterims_analyses_change);
       $("body").on("change", "#wideinterims_interims", this.on_wideiterims_interims_change);
       $("body").on("click", "#wideinterims_apply", this.on_wideinterims_apply_click);
-      /* internal events */
-      // handle value changes in the form
-      return $(this).on("constraints:loaded", this.on_constraints_loaded);
-    }
 
-    init_instruments_and_methods() {
+      /* internal events */
+      return $(this).on("constraints:loaded", this.on_constraints_loaded);
+    };
+
+    WorksheetManageResultsView.prototype.init_instruments_and_methods = function() {
+
       /*
        * Applies the rules and constraints to each analysis displayed in the
        * manage results view regarding to methods, instruments and results.
@@ -645,7 +678,7 @@
       var analysis_uids;
       analysis_uids = this.get_analysis_uids();
       return this.ajax_submit({
-        url: `${this.get_portal_url()}/get_method_instrument_constraints`,
+        url: (this.get_portal_url()) + "/get_method_instrument_constraints",
         data: {
           _authenticator: this.get_authenticator,
           uids: $.toJSON(analysis_uids)
@@ -655,15 +688,21 @@
         this.constraints = data;
         return $(this).trigger("constraints:loaded", data);
       });
-    }
+    };
 
-    ajax_submit(options = {}) {
+
+    /* METHODS */
+
+    WorksheetManageResultsView.prototype.ajax_submit = function(options) {
       var done;
+      if (options == null) {
+        options = {};
+      }
+
       /*
        * Ajax Submit with automatic event triggering and some sane defaults
        */
       console.debug("°°° ajax_submit °°°");
-      // some sane option defaults
       if (options.type == null) {
         options.type = "POST";
       }
@@ -675,38 +714,44 @@
       }
       console.debug(">>> ajax_submit::options=", options);
       $(this).trigger("ajax:submit:start");
-      done = () => {
-        return $(this).trigger("ajax:submit:end");
-      };
+      done = (function(_this) {
+        return function() {
+          return $(_this).trigger("ajax:submit:end");
+        };
+      })(this);
       return $.ajax(options).done(done);
-    }
+    };
 
-    get_portal_url() {
+    WorksheetManageResultsView.prototype.get_portal_url = function() {
+
       /*
        * Return the portal url (calculated in code)
        */
       var url;
       url = $("input[name=portal_url]").val();
       return url || window.portal_url;
-    }
+    };
 
-    get_base_url() {
+    WorksheetManageResultsView.prototype.get_base_url = function() {
+
       /*
        * Return the current base url
        */
       var url;
       url = window.location.href;
       return url.split('?')[0];
-    }
+    };
 
-    get_authenticator() {
+    WorksheetManageResultsView.prototype.get_authenticator = function() {
+
       /*
        * Get the authenticator value
        */
       return $("input[name='_authenticator']").val();
-    }
+    };
 
-    get_analysis_uids() {
+    WorksheetManageResultsView.prototype.get_analysis_uids = function() {
+
       /*
        * Returns a list of analysis UIDs
        */
@@ -717,19 +762,21 @@
         return analysis_uids.push(uid);
       });
       return analysis_uids;
-    }
+    };
 
-    get_method_by_analysis_uid(analysis_uid) {
+    WorksheetManageResultsView.prototype.get_method_by_analysis_uid = function(analysis_uid) {
+
       /*
        * Return the method UID of the analysis identified by analysis_uid
        */
       var $method_field, method_uid;
-      $method_field = $(`select.listing_select_entry[field='Method'][uid='${analysis_uid}']`);
+      $method_field = $("select.listing_select_entry[field='Method'][uid='" + analysis_uid + "']");
       method_uid = $method_field.val();
       return method_uid || "";
-    }
+    };
 
-    is_instrument_allowed(instrument_uid) {
+    WorksheetManageResultsView.prototype.is_instrument_allowed = function(instrument_uid) {
+
       /*
        * Check if the Instrument is allowed to appear in Instrument list of Analysis.
        *
@@ -750,10 +797,10 @@
         });
       }
       return allowed;
-    }
+    };
 
-    load_analysis_method_constraint(analysis_uid, method_uid) {
-      var analysis_constraints, i_selector, ins_old_val, m_selector, me, method_constraints, method_name;
+    WorksheetManageResultsView.prototype.load_analysis_method_constraint = function(analysis_uid, method_uid) {
+
       /*
        * Applies the constraints and rules to the specified analysis regarding to
        * the method specified.
@@ -773,8 +820,8 @@
        * If `method_uid` is null, uses the method that is currently selected for
        * the specified analysis
        */
-      console.debug(`WorksheetManageResultsView::load_analysis_method_constraint:analysis_uid=${analysis_uid} method_uid=${method_uid}`);
-      // reference to this object for $.each calls
+      var analysis_constraints, i_selector, ins_old_val, m_selector, me, method_constraints, method_name;
+      console.debug("WorksheetManageResultsView::load_analysis_method_constraint:analysis_uid=" + analysis_uid + " method_uid=" + method_uid);
       me = this;
       if (!method_uid) {
         method_uid = this.get_method_by_analysis_uid(analysis_uid);
@@ -790,104 +837,92 @@
       if (method_constraints.length < 7) {
         return;
       }
-      // method selector
-      m_selector = $(`select.listing_select_entry[field='Method'][uid='${analysis_uid}']`);
-      // instrument selector
-      i_selector = $(`select.listing_select_entry[field='Instrument'][uid='${analysis_uid}']`);
-      // Remove None option in method selector
+      m_selector = $("select.listing_select_entry[field='Method'][uid='" + analysis_uid + "']");
+      i_selector = $("select.listing_select_entry[field='Instrument'][uid='" + analysis_uid + "']");
       $(m_selector).find('option[value=""]').remove();
       if (method_constraints[1] === 1) {
-        $(m_selector).prepend(`<option value=''>${_('Not defined')}</option>`);
+        $(m_selector).prepend("<option value=''>" + (_('Not defined')) + "</option>");
       }
-      // Select the method
       $(m_selector).val(method_uid);
-      // Method selector visible?
-      // 0: no, 1: yes, 2: label, 3: readonly
       $(m_selector).prop("disabled", false);
-      $(`.method-label[uid='${analysis_uid}']`).remove();
+      $(".method-label[uid='" + analysis_uid + "']").remove();
       if (method_constraints[0] === 0) {
         $(m_selector).hide();
       } else if (method_constraints[0] === 1) {
         $(m_selector).show();
       } else if (method_constraints[0] === 2) {
-        // XXX length check of an object??
         if (analysis_constraints.length > 1) {
           $(m_selector).hide();
-          method_name = $(m_selector).find(`option[value='${method_uid}']`).innerHtml();
-          $(m_selector).after(`<span class='method-label' uid='${analysis_uid}' href='#'>${method_name}</span>`);
+          method_name = $(m_selector).find("option[value='" + method_uid + "']").innerHtml();
+          $(m_selector).after("<span class='method-label' uid='" + analysis_uid + "' href='#'>" + method_name + "</span>");
         }
       } else if (method_constraints[0] === 3) {
         $(m_selector).show();
       }
-      // We are going to reload the instrument list.
-      // Enable all disabled options from other Instrument lists which has the same
-      // value as old value of this instrument selectbox.
       ins_old_val = $(i_selector).val();
       if (ins_old_val && ins_old_val !== '') {
-        $(`table.bika-listing-table select.listing_select_entry[field='Instrument'][value!='${ins_old_val}'] option[value='${ins_old_val}']`).prop("disabled", false);
+        $("table.bika-listing-table select.listing_select_entry[field='Instrument'][value!='" + ins_old_val + "'] option[value='" + ins_old_val + "']").prop("disabled", false);
       }
-      // Populate instruments list
       $(i_selector).find("option").remove();
       if (method_constraints[7]) {
         $.each(method_constraints[7], function(key, value) {
           if (me.is_instrument_allowed(key)) {
-            return $(i_selector).append(`<option value='${key}'>${value}</option>`);
+            return $(i_selector).append("<option value='" + key + "'>" + value + "</option>");
           } else {
-            return $(i_selector).append(`<option value='${key}' disabled='disabled'>${value}</option>`);
+            return $(i_selector).append("<option value='" + key + "' disabled='disabled'>" + value + "</option>");
           }
         });
       }
-      // None option in instrument selector?
       if (method_constraints[3] === 1) {
-        $(i_selector).prepend(`<option selected='selected' value=''>${_('None')}</option>`);
+        $(i_selector).prepend("<option selected='selected' value=''>" + (_('None')) + "</option>");
       }
-      // Select the default instrument
       if (me.is_instrument_allowed(method_constraints[4])) {
         $(i_selector).val(method_constraints[4]);
-        // Disable this Instrument in the other Instrument SelectBoxes
-        $(`table.bika-listing-table select.listing_select_entry[field='Instrument'][value!='${method_constraints[4]}'] option[value='${method_constraints[4]}']`).prop("disabled", true);
+        $("table.bika-listing-table select.listing_select_entry[field='Instrument'][value!='" + method_constraints[4] + "'] option[value='" + method_constraints[4] + "']").prop("disabled", true);
       }
-      // Instrument selector visible?
       if (method_constraints[2] === 0) {
         $(i_selector).hide();
       } else if (method_constraints[2] === 1) {
         $(i_selector).show();
       }
-      // Allow to edit results?
       if (method_constraints[5] === 0) {
-        $(`.interim input[uid='${analysis_uid}']`).val("");
-        $(`input[field='Result'][uid='${analysis_uid}']`).val("");
-        $(`.interim input[uid='${analysis_uid}']`).prop("disabled", true);
-        $(`input[field='Result'][uid='${analysis_uid}']`).prop("disabled", true);
+        $(".interim input[uid='" + analysis_uid + "']").val("");
+        $("input[field='Result'][uid='" + analysis_uid + "']").val("");
+        $(".interim input[uid='" + analysis_uid + "']").prop("disabled", true);
+        $("input[field='Result'][uid='" + analysis_uid + "']").prop("disabled", true);
       } else if (method_constraints[5] === 1) {
-        $(`.interim input[uid='${analysis_uid}']`).prop("disabled", false);
-        $(`input[field='Result'][uid='${analysis_uid}']`).prop("disabled", false);
+        $(".interim input[uid='" + analysis_uid + "']").prop("disabled", false);
+        $("input[field='Result'][uid='" + analysis_uid + "']").prop("disabled", false);
       }
-      // Info/Warn message?
-      $(`.alert-instruments-invalid[uid='${analysis_uid}']`).remove();
+      $(".alert-instruments-invalid[uid='" + analysis_uid + "']").remove();
       if (method_constraints[6] && method_constraints[6] !== "") {
-        $(i_selector).after(`<img uid='${analysis_uid}' class='alert-instruments-invalid' src='${this.get_portal_url()}/++resource++bika.lims.images/warning.png' title='${method_constraints[6]}'>`);
+        $(i_selector).after("<img uid='" + analysis_uid + "' class='alert-instruments-invalid' src='" + (this.get_portal_url()) + "/++resource++bika.lims.images/warning.png' title='" + method_constraints[6] + "'>");
       }
-      return $(`.amconstr[uid='${analysis_uid}']`).remove();
-    }
+      return $(".amconstr[uid='" + analysis_uid + "']").remove();
+    };
 
-    on_constraints_loaded(event) {
-      var me;
+
+    /* EVENT HANDLER */
+
+    WorksheetManageResultsView.prototype.on_constraints_loaded = function(event) {
+
       /*
        * Eventhandler when the instrument and method constraints were loaded from the server
        */
+      var me;
       console.debug("°°° WorksheetManageResultsView::on_constraints_loaded °°°");
       me = this;
       return $.each(this.get_analysis_uids(), function(index, uid) {
         return me.load_analysis_method_constraint(uid, null);
       });
-    }
+    };
 
-    on_analyst_change(event) {
-      var $el, analyst, base_url, url;
+    WorksheetManageResultsView.prototype.on_analyst_change = function(event) {
+
       /*
        * Eventhandler when the analyst select changed
        */
+      var $el, analyst, base_url, url;
       console.debug("°°° WorksheetManageResultsView::on_analyst_change °°°");
       $el = $(event.currentTarget);
       analyst = $el.val();
@@ -908,22 +943,24 @@
       }).fail(function() {
         return bika.lims.SiteView.notify_in_panel(this._("Could not set the selected analyst"), "error");
       });
-    }
+    };
 
-    on_layout_change(event) {
-      var $el;
+    WorksheetManageResultsView.prototype.on_layout_change = function(event) {
+
       /*
        * Eventhandler when the analyst changed
        */
+      var $el;
       console.debug("°°° WorksheetManageResultsView::on_layout_change °°°");
       return $el = $(event.currentTarget);
-    }
+    };
 
-    on_instrument_change(event) {
-      var $el, base_url, instrument_uid, url;
+    WorksheetManageResultsView.prototype.on_instrument_change = function(event) {
+
       /*
        * Eventhandler when the instrument changed
        */
+      var $el, base_url, instrument_uid, url;
       console.debug("°°° WorksheetManageResultsView::on_instrument_change °°°");
       $el = $(event.currentTarget);
       instrument_uid = $el.val();
@@ -941,45 +978,43 @@
         dataType: "json"
       }).done(function(data) {
         bika.lims.SiteView.notify_in_panel(this._pmf("Changes saved."), "succeed");
-        // Set the selected instrument to all the analyses which that can be done
-        // using that instrument. The rest of of the instrument picklist will not
-        // be changed
-        $(`select.listing_select_entry[field='Instrument'] option[value='${instrument_uid}']`).parent().find(`option[value='${instrument_uid}']`).prop("selected", false);
-        return $(`select.listing_select_entry[field='Instrument'] option[value='${instrument_uid}']`).prop("selected", true);
+        $("select.listing_select_entry[field='Instrument'] option[value='" + instrument_uid + "']").parent().find("option[value='" + instrument_uid + "']").prop("selected", false);
+        return $("select.listing_select_entry[field='Instrument'] option[value='" + instrument_uid + "']").prop("selected", true);
       }).fail(function() {
         return bika.lims.SiteView.notify_in_panel(this._("Unable to apply the selected instrument"), "error");
       });
-    }
+    };
 
-    on_method_change(event) {
-      var $el, analysis_uid, method_uid;
+    WorksheetManageResultsView.prototype.on_method_change = function(event) {
+
       /*
        * Eventhandler when the method changed
        *
        */
+      var $el, analysis_uid, method_uid;
       console.debug("°°° WorksheetManageResultsView::on_method_change °°°");
       $el = $(event.currentTarget);
       analysis_uid = $el.attr("uid");
       method_uid = $el.val();
-      // Change the instruments to be shown for an analysis when the method selected changes
       return this.load_analysis_method_constraint(analysis_uid, method_uid);
-    }
+    };
 
-    on_analysis_instrument_focus(event) {
-      var $el;
+    WorksheetManageResultsView.prototype.on_analysis_instrument_focus = function(event) {
+
       /*
        * Eventhandler when the instrument of an analysis is focused
        *
        * Only needed to remember the last value
        */
+      var $el;
       console.debug("°°° WorksheetManageResultsView::on_analysis_instrument_focus °°°");
       $el = $(event.currentTarget);
       this.previous_instrument = $el.val();
       return console.info(this.previous_instrument);
-    }
+    };
 
-    on_analysis_instrument_change(event) {
-      var $el, analysis_uid, instrument_uid;
+    WorksheetManageResultsView.prototype.on_analysis_instrument_change = function(event) {
+
       /*
        * Eventhandler when the instrument of an analysis changed
        *
@@ -987,23 +1022,22 @@
        * for the other analyses. Also, remove the restriction of previous
        * Instrument of this analysis to be chosen in the other analyses.
        */
+      var $el, analysis_uid, instrument_uid;
       console.debug("°°° WorksheetManageResultsView::on_analysis_instrument_change °°°");
       $el = $(event.currentTarget);
       analysis_uid = $el.attr("uid");
       instrument_uid = $el.val();
-      // Disable New Instrument for rest of the analyses
-      $(`table.bika-listing-table select.listing_select_entry[field='Instrument'][value!='${instrument_uid}'] option[value='${instrument_uid}']`).prop("disabled", true);
-      // Enable previous Instrument everywhere
-      $(`table.bika-listing-table select.listing_select_entry[field='Instrument'] option[value='${this.previous_instrument}']`).prop("disabled", false);
-      // Enable 'None' option as well.
+      $("table.bika-listing-table select.listing_select_entry[field='Instrument'][value!='" + instrument_uid + "'] option[value='" + instrument_uid + "']").prop("disabled", true);
+      $("table.bika-listing-table select.listing_select_entry[field='Instrument'] option[value='" + this.previous_instrument + "']").prop("disabled", false);
       return $("table.bika-listing-table select.listing_select_entry[field='Instrument'] option[value='']").prop("disabled", false);
-    }
+    };
 
-    on_detection_limit_change(event) {
-      var $el, defdls, resfld, uncfld;
+    WorksheetManageResultsView.prototype.on_detection_limit_change = function(event) {
+
       /*
        * Eventhandler when the detection limit changed
        */
+      var $el, defdls, resfld, uncfld;
       console.debug("°°° WorksheetManageResultsView::on_detection_limit_change °°°");
       $el = $(event.currentTarget);
       defdls = $el.closest("td").find("input[id^='DefaultDLS.']").first().val();
@@ -1013,7 +1047,6 @@
       $(resfld).prop("readonly", !defdls.manual);
       if ($el.val() === "<") {
         $(resfld).val(defdls['min']);
-        // Inactivate uncertainty?
         if (uncfld.length > 0) {
           $(uncfld).val("");
           $(uncfld).prop("readonly", true);
@@ -1021,7 +1054,6 @@
         }
       } else if ($el.val() === ">") {
         $(resfld).val(defdls["max"]);
-        // Inactivate uncertainty?
         if (uncfld.length > 0) {
           $(uncfld).val("");
           $(uncfld).prop("readonly", true);
@@ -1030,77 +1062,77 @@
       } else {
         $(resfld).val("");
         $(resfld).prop("readonly", false);
-        // Activate uncertainty?
         if (uncfld.length > 0) {
           $(uncfld).val("");
           $(uncfld).prop("readonly", false);
           $(uncfld).closest("td").children().show();
         }
       }
-      // Maybe the result is used in calculations...
       return $(resfld).change();
-    }
+    };
 
-    on_remarks_balloon_clicked(event) {
-      var $el, remarks;
+    WorksheetManageResultsView.prototype.on_remarks_balloon_clicked = function(event) {
+
       /*
        * Eventhandler when the remarks balloon was clicked
        */
+      var $el, remarks;
       console.debug("°°° WorksheetManageResultsView::on_remarks_balloon_clicked °°°");
       $el = $(event.currentTarget);
       event.preventDefault();
       remarks = $el.closest("tr").next("tr").find("td.remarks");
       return $(remarks).find("div.remarks-placeholder").toggle();
-    }
+    };
 
-    on_wideiterims_analyses_change(event) {
-      var $el, category;
+    WorksheetManageResultsView.prototype.on_wideiterims_analyses_change = function(event) {
+
       /*
        * Eventhandler when the wide interims analysis selector changed
        *
        * Search all interim fields which begin with the selected category and fill
        *  the analyses interim fields to the selection
        */
+      var $el, category;
       console.debug("°°° WorksheetManageResultsView::on_wideiterims_analyses_change °°°");
       $el = $(event.currentTarget);
-      // Empty the wideinterim analysis field
       $("#wideinterims_interims").html("");
       category = $el.val();
-      return $(`input[id^='wideinterim_${category}']`).each(function(index, element) {
+      return $("input[id^='wideinterim_" + category + "']").each(function(index, element) {
         var itemval, keyword, name;
         name = $(element).attr("name");
         keyword = $(element).attr("keyword");
-        itemval = `<option value='${keyword}'>${name}</option>`;
+        itemval = "<option value='" + keyword + "'>" + name + "</option>";
         return $("#wideinterims_interims").append(itemval);
       });
-    }
+    };
 
-    on_wideiterims_interims_change(event) {
-      var $el, analysis, idinter, interim;
+    WorksheetManageResultsView.prototype.on_wideiterims_interims_change = function(event) {
+
       /*
        * Eventhandler when the wide interims selector changed
        */
+      var $el, analysis, idinter, interim;
       console.debug("°°° WorksheetManageResultsView::on_wideiterims_interims_change °°°");
       $el = $(event.currentTarget);
       analysis = $("#wideinterims_analyses").val();
       interim = $el.val();
-      idinter = `#wideinterim_${analysis}_${interim}`;
+      idinter = "#wideinterim_" + analysis + "_" + interim;
       return $("#wideinterims_value").val($(idinter).val());
-    }
+    };
 
-    on_wideinterims_apply_click(event) {
-      var $el, analysis, empty_only, interim;
+    WorksheetManageResultsView.prototype.on_wideinterims_apply_click = function(event) {
+
       /*
        * Eventhandler when the wide interim apply button was clicked
        */
+      var $el, analysis, empty_only, interim;
       console.debug("°°° WorksheetManageResultsView::on_wideinterims_apply_click °°°");
-      // prevent form submission
       event.preventDefault();
       $el = $(event.currentTarget);
       analysis = $("#wideinterims_analyses").val();
       interim = $("#wideinterims_interims").val();
       empty_only = $("#wideinterims_empty").is(":checked");
-      return $(`tr[keyword='${analysis}'] input[field='${interim}']`).each(function(index, element) {
+      return $("tr[keyword='" + analysis + "'] input[field='" + interim + "']").each(function(index, element) {
         if (empty_only) {
           if ($(this).val() === "" || $(this).val().match(/\d+/) === "0") {
             $(this).val($("#wideinterims_value").val());
@@ -1111,8 +1143,10 @@
           return $(this).change();
         }
       });
-    }
+    };
 
-  };
+    return WorksheetManageResultsView;
+
+  })();
 
 }).call(this);


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

We can not use Coffee Script versions >= 2to compile our coffee script files
The reason is that newer CS version compile template strings into ES compatible templatesliterals:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals

But these Template Literals are not cached correctly in Plone's portal_javascripts and it comes to failures with the global jQuery $ variable.

Please see here the differences between compiling code with CoffeeScript version 2.2.3 (the code removed -) and CoffeeScript version
1.12.7 (the code added +)
```
+    AnalysisServiceEditView.prototype.add_select_option = function(select, name, value) {

-    add_select_option(select, name, value) {
-      var option;
       /**
        * Adds an option to the select
        */
+      var option;
       if (value) {
-        option = `<option value='${value}'>${this._(name)}</option>`;
+        option = "<option value='" + value + "'>" + (this._(name)) + "</option>";
       } else {
-        // empty option (selected by default)
-        option = `<option selected='selected' value=''>${this._("None")}</option>`;
+        option = "<option selected='selected' value=''>" + (this._("None")) + "</option>";
       }
       return $(select).append(option);
-    }
+    };
```

Therefore, ensure you have CoffeeScript version 1.12.7 installed on your system
`npm list -g | grep coffeescript`
Install it like this:
`npm install -g "coffeescript@<2"`
Ensure you have it like this:
```
coffee --version
CoffeeScript version 1.12.7
```

## Current behavior before PR

Analysis Category Expansion fails in Production Mode with this Error:
```Uncaught SyntaxError: Unexpected identifier```

## Desired behavior after PR is merged

JS logic works fine in Production Mode

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
