### PR TITLE
Missing interface for AR Report added

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog
 
 **Added**
 
+- #844 Missing interface for AR Report added
+
 
 **Changed**
 

--- a/bika/lims/content/arreport.py
+++ b/bika/lims/content/arreport.py
@@ -5,47 +5,53 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-""" An AnalysisRequest report, containing the report itself in pdf and html
-    format. Also, includes information about the date when was published, from
-    who, the report recipients (and their emails) and the publication mode
-"""
 from AccessControl import ClassSecurityInfo
-from Products.ATExtensions.ateapi import RecordsField
+from bika.lims import bikaMessageFactory as _
+from bika.lims.browser.fields import DateTimeField
+from bika.lims.browser.fields import UIDReferenceField
+from bika.lims.browser.widgets import DateTimeWidget
+from bika.lims.config import PROJECTNAME
+from bika.lims.content.bikaschema import BikaSchema
+from plone.app.blob.field import BlobField
 from Products.Archetypes import atapi
 from Products.Archetypes.public import BaseFolder
 from Products.Archetypes.public import Schema
 from Products.Archetypes.public import StringField
 from Products.Archetypes.references import HoldingReference
-from bika.lims import bikaMessageFactory as _
-from bika.lims.browser.fields import DateTimeField, UIDReferenceField
-from bika.lims.browser.widgets import DateTimeWidget
-from bika.lims.config import PROJECTNAME
-from bika.lims.content.bikaschema import BikaSchema
-from plone.app.blob.field import BlobField
+from Products.ATExtensions.ateapi import RecordsField
+
 
 schema = BikaSchema.copy() + Schema((
-    UIDReferenceField('AnalysisRequest',
-       allowed_types=('AnalysisRequest',),
-       referenceClass=HoldingReference,
-       required=1,
+    UIDReferenceField(
+        "AnalysisRequest",
+        allowed_types=("AnalysisRequest",),
+        referenceClass=HoldingReference,
+        required=1,
     ),
-    BlobField('Pdf',
-    ),
-    StringField('SMS',
-    ),
-    RecordsField('Recipients',
-        type='recipients',
-        subfields=('UID', 'Username', 'Fullname', 'EmailAddress',
-                   'PublicationModes'),
+    BlobField(
+        "Pdf",),
+    StringField(
+        "SMS",),
+    RecordsField(
+        "Recipients",
+        type="recipients",
+        subfields=(
+            "UID",
+            "Username",
+            "Fullname",
+            "EmailAddress",
+            "PublicationModes"
+        ),
     ),
     DateTimeField(
-        'DatePrinted',
+        "DatePrinted",
         mode="rw",
         widget=DateTimeWidget(
-            label = _("Date Printed"),
-            visible={'edit': 'visible',
-                     'view': 'visible'
-                     }
+            label=_("Date Printed"),
+            visible={
+                "edit": "visible",
+                "view": "visible",
+            }
         ),
     ),
 ))
@@ -55,13 +61,19 @@ schema['title'].required = False
 
 
 class ARReport(BaseFolder):
+    """An AnalysisRequest report, containing the report itself in pdf and html
+       format. It includes information about the date when was published, from
+       whom, the report recipients (and their emails) and the publication mode
+    """
     security = ClassSecurityInfo()
     displayContentsTab = False
     schema = schema
 
     _at_rename_after_creation = True
+
     def _renameAfterCreation(self, check_auto_id=False):
         from bika.lims.idserver import renameAfterCreation
         renameAfterCreation(self)
+
 
 atapi.registerType(ARReport, PROJECTNAME)

--- a/bika/lims/content/arreport.py
+++ b/bika/lims/content/arreport.py
@@ -12,6 +12,7 @@ from bika.lims.browser.fields import UIDReferenceField
 from bika.lims.browser.widgets import DateTimeWidget
 from bika.lims.config import PROJECTNAME
 from bika.lims.content.bikaschema import BikaSchema
+from bika.lims.interfaces import IARReport
 from plone.app.blob.field import BlobField
 from Products.Archetypes import atapi
 from Products.Archetypes.public import BaseFolder
@@ -19,6 +20,7 @@ from Products.Archetypes.public import Schema
 from Products.Archetypes.public import StringField
 from Products.Archetypes.references import HoldingReference
 from Products.ATExtensions.ateapi import RecordsField
+from zope.interface import implements
 
 
 schema = BikaSchema.copy() + Schema((
@@ -65,6 +67,8 @@ class ARReport(BaseFolder):
        format. It includes information about the date when was published, from
        whom, the report recipients (and their emails) and the publication mode
     """
+    implements(IARReport)
+
     security = ClassSecurityInfo()
     displayContentsTab = False
     schema = schema

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -838,3 +838,7 @@ class IGetStickerTemplates(Interface):
     :return: [{'id': <template_id>,
              'title': <template_title>}, ...]
     """
+
+class IARReport(Interface):
+    """Marker interface for published AR Reports
+    """

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -9,66 +9,71 @@ from zope.interface import Interface
 
 
 class IBikaLIMS(Interface):
-
     """Marker interface that defines a Zope 3 browser layer.
        If you need to register a viewlet only for the
        "bika" theme, this interface must be its layer
     """
 
+
 class IGenerateID(Interface):
     """Marker Interface to generate an ID
     """
 
-class IHaveNoBreadCrumbs(Interface):
 
-    """Items which do not display breadcrumbs"""
+class IHaveNoBreadCrumbs(Interface):
+    """Items which do not display breadcrumbs
+    """
 
 
 class IClientFolder(Interface):
-
-    """Client folder"""
+    """Client folder
+    """
 
 
 class IClient(Interface):
-
-    """Client"""
+    """Client
+    """
 
 
 class IBatchFolder(Interface):
-
-    """Batch folder"""
+    """Batch folder
+    """
 
 
 class IBatch(Interface):
-
-    """Batch"""
+    """Batch
+    """
 
 
 class IBatchLabels(Interface):
-
-    """Batch label"""
+    """Batch label
+    """
 
 
 class IAnalysisRequest(Interface):
-
-    """Analysis Request"""
+    """Analysis Request
+    """
 
 
 class IAnalysisRequestAddView(Interface):
-
-    """ AR Add view """
+    """AR Add view
+    """
 
 
 class IAnalysisRequestsFolder(Interface):
+    """AnalysisRequests Folder
+    """
 
-    """AnalysisRequests Folder"""
 
 class IInvoiceView(Interface):
-    """Invoice View"""
+    """Invoice View
+    """
+
 
 class IAnalysis(Interface):
+    """Analysis
+    """
 
-    """Analysis"""
 
 class IRoutineAnalysis(Interface):
     """This adapter distinguishes normal analyses from Duplicates, References,
@@ -77,18 +82,18 @@ class IRoutineAnalysis(Interface):
 
 
 class IAnalysisSpec(Interface):
-
-    """Analysis Specs"""
+    """Analysis Specs
+    """
 
 
 class IDuplicateAnalysis(Interface):
-
-    """DuplicateAnalysis"""
+    """DuplicateAnalysis
+    """
 
 
 class IReferenceAnalysis(Interface):
-
-    """Reference Analyses """
+    """Reference Analyses
+    """
 
 
 class IRejectAnalysis(Interface):
@@ -97,171 +102,169 @@ class IRejectAnalysis(Interface):
     """
 
 
-class IAnalysisSpec(Interface):
-
-    """Analysis Specs"""
-
-
 class IReportFolder(Interface):
-
-    """Report folder"""
+    """Report folder
+    """
 
 
 class ISample(Interface):
-
-    """Sample"""
+    """Sample
+    """
 
 
 class ISampleCondition(Interface):
-
-    """Sample Condition"""
+    """Sample Condition
+    """
 
 
 class ISampleConditions(Interface):
-
-    """Sample Conditions"""
+    """Sample Conditions
+    """
 
 
 class ISampleMatrix(Interface):
-
-    """Sample Matrix"""
+    """Sample Matrix
+    """
 
 
 class ISampleMatrices(Interface):
-
-    """Sample Matrices"""
+    """Sample Matrices
+    """
 
 
 class ISamplePartition(Interface):
-
-    """Sample"""
+    """Sample
+    """
 
 
 class ISamplesFolder(Interface):
-
-    """Samples Folder"""
+    """Samples Folder
+    """
 
 
 class ISamplingDeviation(Interface):
-
-    """Sampling Deviation"""
+    """Sampling Deviation
+    """
 
 
 class ISamplingDeviations(Interface):
-
-    """Sampling Deviations"""
+    """Sampling Deviations
+    """
 
 
 class IWorksheetFolder(Interface):
-
-    """WorksheetFolder"""
+    """WorksheetFolder
+    """
 
 
 class IWorksheet(Interface):
-
-    """Worksheet"""
+    """Worksheet
+    """
 
 
 class IReferenceSample(Interface):
-
-    """Reference Sample"""
+    """Reference Sample
+    """
 
 
 class IReferenceSamplesFolder(Interface):
-
-    """Reference Samples Folder"""
+    """Reference Samples Folder
+    """
 
 
 class IReportsFolder(Interface):
-
-    """Reports Folder"""
+    """Reports Folder
+    """
 
 
 class IInvoice(Interface):
-
-    """Invoice"""
+    """Invoice
+    """
 
 
 class IInvoiceBatch(Interface):
-
-    """Invoice Batch"""
+    """Invoice Batch
+    """
 
 
 class IInvoiceFolder(Interface):
-
-    """Invoices Folder"""
+    """Invoices Folder
+    """
 
 
 class IBikaSetup(Interface):
-
-    ""
+    """Marker interface for the LIMS Setup
+    """
 
 
 class IAnalysisCategory(Interface):
-
-    ""
+    """Marker interface for an Analysis Category
+    """
 
 
 class IAnalysisCategories(Interface):
+    """Marker interface for Analysis Categories
+    """
 
-    ""
 
 class IBaseAnalysis(Interface):
-    ""
+    """Marker interface for base Analysis
+    """
 
 
 class IAnalysisService(Interface):
-
-    ""
+    """Marker interface for Analysis Service
+    """
 
 
 class IAnalysisServices(Interface):
-
-    ""
+    """Marker interface for Analysis Services
+    """
 
 
 class IAttachmentTypes(Interface):
-
-    ""
+    """Marker interface for Attachment types
+    """
 
 
 class ICalculation(Interface):
-
-    ""
+    """Marker interface for a Calculation
+    """
 
 
 class ICalculations(Interface):
-
-    ""
+    """Marker interface for Calculations
+    """
 
 
 class IContacts(Interface):
-
-    ""
+    """Marker interface for Contacts
+    """
 
 
 class IContact(Interface):
-
-    ""
+    """Marker interface for a single Contact
+    """
 
 
 class IDepartments(Interface):
-
-    ""
+    """Marker interface for a Departments
+    """
 
 
 class IContainers(Interface):
-
-    ""
+    """Marker interface for Containers
+    """
 
 
 class IContainerTypes(Interface):
-
-    ""
+    """Marker interface for Container types
+    """
 
 
 class IIdentifierTypes(Interface):
-    ""
+    """Marker interface for identifier types
+    """
 
 
 class IHaveIdentifiers(Interface):
@@ -272,257 +275,275 @@ class IHaveIdentifiers(Interface):
 
 
 class IInstrument(Interface):
-
-    ""
+    """Marker interface for an Instrument
+    """
 
 
 class IInstruments(Interface):
-
-    ""
+    """Marker interface for Instruments
+    """
 
 
 class IInstrumentType(Interface):
-
-    ""
+    """Marker interface for an instrument type
+    """
 
 
 class IInstrumentTypes(Interface):
+    """Marker interface for instrument types
+    """
 
-    ""
 
 class IInstrumentLocation(Interface):
     """A physical place, where instruments can be located
     """
 
+
 class IInstrumentLocations(Interface):
     """Physical places, where instruments can be located
     """
+
 
 class IInstrumentCalibration(Interface):
     """Instrument Calibration
     """
 
-class IInstrumentCertification(Interface):
-    """Instrument Certification
-    """
-
-class IInstrumentValidation(Interface):
-    """Instrument Validation
-    """
 
 class IInstrumentCertification(Interface):
     """Instrument Certification
     """
 
+
 class IInstrumentValidation(Interface):
     """Instrument Validation
     """
+
 
 class IAnalysisSpecs(Interface):
-    ""
+    """Marker interface for Analysis Specs
+    """
 
 
 class IAnalysisProfile(Interface):
-    ""
-
-
-class IAnalysisProfile(Interface):
-
-    ""
+    """Marker interface for an Analysis Profile
+    """
 
 
 class IAnalysisProfiles(Interface):
-    ""
+    """Marker interface for analysis profiles
+    """
 
 
 class IARTemplate(Interface):
-    ""
-
-
-class IARTemplate(Interface):
-
-    ""
+    """Marker interface for an AR Template
+    """
 
 
 class IARTemplates(Interface):
-    ""
+    """Marker interface for AR templates
+    """
 
 
 class ILabContacts(Interface):
-
-    ""
+    """Marker interface for Lab contacts
+    """
 
 
 class ILabContact(Interface):
-
-    ""
+    """Marker interface for a lab contact
+    """
 
 
 class IManufacturer(Interface):
-
-    ""
+    """Marker interface for Manufacturer
+    """
 
 
 class IManufacturers(Interface):
-
-    ""
+    """Marker interface for Manufacturers
+    """
 
 
 class IMethods(Interface):
+    """Marker interface for Methods
+    """
 
-    ""
 
 class IMethod(Interface):
+    """Marker interface for Method
+    """
 
-    ""
 
 class IMultifile(Interface):
+    """Marker interface for a Multifile
+    """
 
-    ""
 
 class ILabProducts(Interface):
-
-    ""
+    """Marker interface for Lab Products
+    """
 
 
 class ISamplePoint(Interface):
-
-    ""
+    """Marker interface for a Sample Point
+    """
 
 
 class ISamplePoints(Interface):
+    """Marker interface for Sample Points
+    """
 
-    ""
 
 class IStorageLocation(Interface):
+    """Marker interface for a Storage Location
+    """
 
-    ""
 
 class IStorageLocations(Interface):
-
-    ""
+    """Marker interface for Storage Location
+    """
 
 
 class ISampleType(Interface):
-
-    ""
+    """Marker interface for a Sample Type
+    """
 
 
 class ISampleTypes(Interface):
-
-    ""
+    """Marker interface for Sample Types
+    """
 
 
 class ISamplingRoundTemplates(Interface):
+    """Marker interface for Sampling Round Templates
+    """
 
-    ""
 
 class ISamplingRoundTemplate(Interface):
-    ""
+    """Marker interface for a Sampling Round Template
+    """
+
 
 class ISupplier(Interface):
-
-    ""
+    """Marker interface for a Supplier
+    """
 
 
 class ISuppliers(Interface):
-    ""
+    """Marker interface for Suplliers
+    """
+
 
 class ISupplyOrder(Interface):
-    ""
+    """Marker interface for a Supplier Order
+    """
+
 
 class ISupplyOrderFolder(Interface):
-    ""
+    """Marker interface for Supply Order Folder
+    """
 
 
 class ISubGroups(Interface):
-    """Sub-groups configuration folder"""
+    """Sub-groups configuration folder
+    """
 
 
 class ISubGroup(Interface):
-    """Sub-Group"""
+    """Sub-Group
+    """
 
 
 class IPreservations(Interface):
-
-    ""
+    """Marker interface for Preservations
+    """
 
 
 class IReferenceDefinitions(Interface):
-
-    ""
+    """Marker interface for Reference Definitions
+    """
 
 
 class IWorksheetTemplates(Interface):
-
-    ""
+    """Marker interface for Worksheet Templates
+    """
 
 
 class IBikaCatalog(Interface):
-
-    """Marker interface for custom catalog"""
+    """Marker interface for bika_catalog
+    """
 
 
 class IBikaAnalysisCatalog(Interface):
-
-    """Marker interface for custom catalog"""
+    """Marker interface for bika_analysis_catalog
+    """
 
 
 class IBikaSetupCatalog(Interface):
-
-    """Marker interface for custom catalog"""
+    """Marker interface for bika_setup_catalog
+    """
 
 
 class IBikaCatalogAnalysisRequestListing(Interface):
-    """Marker interface for custom catalog"""
+    """Marker interface for bika_catalog_analysisrequest_listing
+    """
 
 
 class IBikaCatalogAutoImportLogsListing(Interface):
-    """Marker interface for custom catalog"""
+    """Marker interface for bika_catalog_autoimportlogs_listing
+    """
 
 
 class IBikaCatalogWorksheetListing(Interface):
-    """Marker interface for custom catalog"""
+    """Marker interface for bika_catalog_worksheet_listing
+    """
 
 
 class IBikaCatalogReport(Interface):
-    """Marker interface for custom catalog"""
+    """Marker interface for bika_catalog_report
+    """
+
 
 class IIdServer(Interface):
-
-    """ Interface for ID server """
+    """Marker Interface for ID server
+    """
 
     def generate_id(self, portal_type, batch_size=None):
-        """ Generate a new id for 'portal_type' """
+        """Generate a new id for 'portal_type'
+        """
+
 
 class IBatchSearchableText(Interface):
-
-    """ Interface for BatchSearchableText """
+    """Marker Interface for BatchSearchableText
+    """
 
     def get_plain_text_fields(self):
-        """ Returns field names as a list of strings"""
+        """Returns field names as a list of strings
+        """
+
 
 class IReferenceWidgetVocabulary(Interface):
     """Return values for reference widgets in AR contexts
     """
+
     def __call__(**kwargs):
-        """
+        """Call method
         """
 
 
 class IDisplayListVocabulary(Interface):
-
     """Make vocabulary from catalog query.
+
     Return a DisplayList.
     kwargs are added to contentFilter.
     """
+
     def __call__(**kwargs):
-        """
+        """Call method
         """
 
 
 class IFieldIcons(Interface):
-
     """Used to signal an analysis result out of range alert
     """
 
@@ -537,17 +558,17 @@ class IFieldIcons(Interface):
         w/ 'min', 'max', and 'error' keys.
         """
 
-class IResultOutOfRange(Interface):
 
+class IResultOutOfRange(Interface):
     """Any code which wants to check some condition and flag an Analysis as
     out of range, uses this interface
     """
-    def __call(result = None):
+    def __call(result=None):
         """The adapter must return a dictionary to indicate range out of bounds:
         {
          out_of_range: boolean - the result is out of bounds,
          acceptable: boolean - the result is in acceptable error margin,
-         spec_values: dict - the min/max/error values for the failed specification
+         spec_values: dict - the min/max/error values for the failed spec
         }
 
         If the adapter returns a value that resolves to boolean False, the
@@ -560,20 +581,19 @@ class IResultOutOfRange(Interface):
 
 
 class IATWidgetVisibility(Interface):
-
     """Adapter to modify the default list of fields to show on each view.
 
-    Archetypes uses a widget attribute called 'visible' to decide which
-    fields are editable or viewable in different contexts (view and edit).
+    Archetypes uses a widget attribute called 'visible' to decide which fields
+    are editable or viewable in different contexts (view and edit).
 
     This adapter lets you create/use arbitrary keys in the field.widget.visible
     attribute, or or any other condition to decide if a particular field is
     displayed or not.
 
-    an attribute named 'sort', if present, is an integer.  It is used
-    to allow some adapters to take preference over others.  It's default is '1000',
-    other lower values will take preference over higher values.
-
+    an attribute named 'sort', if present, is an integer.
+    It is used to allow some adapters to take preference over others.
+    It's default is '1000', other lower values will take preference over higher
+    values.
     """
 
     def __call__(widget, instance, mode, vis_dict, default=None, field=None):
@@ -583,10 +603,10 @@ class IATWidgetVisibility(Interface):
         :arg field: the AT schema field object
         :arg mode: 'edit', 'view', or some custom mode, eg 'add', 'secondary'
         :arg vis_dict: the original schema value of field.widget.visible
-        :arg default: the value returned by the base Archetypes.Widget.isVisible
+        :arg default: value returned by the base Archetypes.Widget.isVisible
 
-        In default Archetypes the value for the attribute on the field may either
-        be a dict with a mapping for edit and view::
+        In default Archetypes the value for the attribute on the field may
+        either be a dict with a mapping for edit and view::
 
             visible = { 'edit' :'hidden', 'view': 'invisible' }
 
@@ -597,25 +617,25 @@ class IATWidgetVisibility(Interface):
             -1:      'hidden'
 
         visible: The field is shown in the view/edit screen
-        invisible: The field is skipped when rendering the visVisibleiew/edit screen
+        invisible: The field is skipped when rendering the visVisibleiew/edit
+                   screen
         hidden: The field is added as <input type="hidden" />
         The default state is 'visible'.
 
-        The default rules are always applied, but any IATWidgetVisibility adapters
-        found are called and permitted to modify the value.
-
+        The default rules are always applied, but any IATWidgetVisibility
+        adapters found are called and permitted to modify the value.
         """
 
 
 class ISetupDataSetList(Interface):
-
     """Allow products to register distributed setup datasets (xlsx files).
+
     Each ISetupDataSetList adapter returns a list of values to be included in
     the load_setup_data view
     """
 
-class IJSONReadExtender(Interface):
 
+class IJSONReadExtender(Interface):
     """This interface allows an adapter to modify an object's data before
     it is sent to the HTTP response.
     """
@@ -625,30 +645,34 @@ class IJSONReadExtender(Interface):
         it should be modified in place, there is no need to return a value.
         """
 
-class ISetupDataImporter(Interface):
 
+class ISetupDataImporter(Interface):
     """ISetupDataImporter adapters are responsible for importing sections of
     the load_setup_data xlsx workbooks.
     """
 
-class IARImportFolder(Interface):
 
+class IARImportFolder(Interface):
     """Marker interface for a folder that contains ARImports
     """
 
-class IARImport(Interface):
 
+class IARImport(Interface):
     """Marker interface for an ARImport
     """
 
+
 class IPricelist(Interface):
-    "Folder view marker for Pricelist"
+    """Folder view marker for Pricelist
+    """
+
 
 class IPricelistFolder(Interface):
-    "Folder view marker for PricelistFolder instance"
+    """Folder view marker for PricelistFolder instance
+    """
+
 
 class IProductivityReport(Interface):
-
     """Reports are enumerated manually in reports/*.pt - but addional reports
     can be added to this list by extension packages using this adapter.
 
@@ -666,7 +690,6 @@ class IProductivityReport(Interface):
 
 
 class IQualityControlReport(Interface):
-
     """Reports are enumerated manually in reports/*.pt - but addional reports
     can be added to this list by extension packages using this adapter.
 
@@ -684,7 +707,6 @@ class IQualityControlReport(Interface):
 
 
 class IAdministrationReport(Interface):
-
     """Reports are enumerated manually in reports/*.pt - but addional reports
     can be added to this list by extension packages using this adapter.
 
@@ -699,6 +721,7 @@ class IAdministrationReport(Interface):
              an instance of this class will be used to create the report
     }
     """
+
 
 class IHeaderTableFieldRenderer(Interface):
     """
@@ -737,6 +760,7 @@ class IHeaderTableFieldRenderer(Interface):
         Accepts an Archetypes Field, returns HTML.
         """
 
+
 class ISamplePrepWorkflow(Interface):
     """This flag enables the sample_prep workflow transitions to be inserted
     into an object's workflow chain.
@@ -744,17 +768,24 @@ class ISamplePrepWorkflow(Interface):
 
 
 class ICustomPubPref(Interface):
-    ""
+    """Marker interface for CustomPubPref
+    """
+
 
 class IReflexRule(Interface):
+    """Marker interface for a Reflex Rule
+    """
 
-    ""
 
 class IReflexRuleFolder(Interface):
-    ""
+    """Marker interface for the Reflex Rule Folder
+    """
+
 
 class IDepartment(Interface):
-    ""
+    """Marker interface for a Department
+    """
+
 
 class IAcquireFieldDefaults(Interface):
     """Register this adapter to define if and how the value for a field is
@@ -778,59 +809,61 @@ class IAcquireFieldDefaults(Interface):
 
     No attempt is made to type check the fields - the value of the parent
     field is simply injected into getDefaults().
-
     """
 
     def __call__(context, field):
         """This function must return the surrogate (source) value directly.
         """
 
+
 class IProxyField(Interface):
     """A field that proxies transparently to the field of another object.
-    Mainly needed for AnalysisRequest fields that are actually stored on the Sample.
+    Mainly needed for AnalysisRequest fields that are actually stored on the
+    Sample.
     """
+
 
 class IARAnalysesField(Interface):
     """A field that manages AR Analyses
     """
 
-class IFrontPageAdapter(Interface):
 
-    """ Bika Front Page Url Finder Adapter's Interface"""
+class IFrontPageAdapter(Interface):
+    """Front Page Url Finder Adapter's Interface
+    """
 
     def get_front_page_url(self):
-        """ Get url of necessary front-page """
+        """Get url of necessary front-page
+        """
+
 
 class INumberGenerator(Interface):
     """A utility to generates unique numbers by key
     """
 
-class IGenerateID(Interface):
-    """Marker Interface to generate an ID
-    """
 
 class ITopRightHTMLComponentsHook(Interface):
+    """Marker interface to hook html components in bikalisting
     """
-    Marker interface to hook html components in bikalisting
-    """
+
 
 class ITopLeftHTMLComponentsHook(Interface):
-    """
-    Marker interface to hook html components in bikalisting
+    """Marker interface to hook html components in bikalisting
     """
 
+
 class ITopWideHTMLComponentsHook(Interface):
+    """Marker interface to hook html components in bikalisting
     """
-    Marker interface to hook html components in bikalisting
-    """
+
 
 class IGetDefaultFieldValueARAddHook(Interface):
     """Marker interface to hook default
     """
 
+
 class IGetStickerTemplates(Interface):
-    """
-    Marker interface to get stickers for a specific content type.
+    """Marker interface to get stickers for a specific content type.
 
     An IGetStickerTemplates adapter should return a result with the
     following format:
@@ -838,6 +871,7 @@ class IGetStickerTemplates(Interface):
     :return: [{'id': <template_id>,
              'title': <template_title>}, ...]
     """
+
 
 class IARReport(Interface):
     """Marker interface for published AR Reports


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

AR Reports hold the published PDF of an AR.

## Current behavior before PR

AR Reports did not implement any interface

## Desired behavior after PR is merged

AR Reports  implement `IARReport` interface

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
