### PR TITLE
Fix worksheet verification with retracted results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #851 Fix worksheet verification with retracted results
 
 **Security**
 

--- a/bika/lims/workflow/worksheet/guards.py
+++ b/bika/lims/workflow/worksheet/guards.py
@@ -14,25 +14,34 @@ from bika.lims.workflow import wasTransitionPerformed
 def _children_are_ready(obj, transition_id, dettached_states=None):
     """Returns true if the children of the object passed in (worksheet) have
     been all transitioned in accordance with the 'transition_id' passed in. If
-    dettached_states is provided, children with those states are dismissed, so
+    detached_states is provided, children with those states are dismissed, so
     they will not be taken into account in the evaluation. Nevertheless, at
     least one child with for which the transition_id performed is required for
-    this function to return true (if all children are in dettached states, it
+    this function to return true (if all children are in detached states, it
     always return False).
     """
     query = dict(getWorksheetUID=api.get_uid(obj))
     brains = api.search(query, CATALOG_ANALYSIS_LISTING)
     if not brains:
         return False
+    detached_count = 0
 
     for brain in brains:
         if dettached_states and brain.review_state in dettached_states:
-            return False
+            detached_count += 1
+            # dismiss the brain and skip the rest of the checks
+            continue
         if not api.is_active(brain):
             return False
         analysis = api.get_object(brain)
         if not wasTransitionPerformed(analysis, transition_id):
             return False
+
+    if detached_count == len(brains):
+        # If all brains are in a detached state, it means that the
+        # condition of at least having one child for which the
+        # transition is performed is not satisfied so return False
+        return False
     return True
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: #850 

## Current behavior before PR

When verifying previously retracted services, the services do transition to verified, but the worksheet itself remains "to be verified".

## Desired behavior after PR is merged

When verifying previously retracted services the worksheet also transitions to verified.

## Screenshot (optional)

![seleccio_034](https://user-images.githubusercontent.com/9968427/41283547-2bf09fbe-6e37-11e8-8051-9202f2bb030e.png)

![seleccio_035](https://user-images.githubusercontent.com/9968427/41283552-2f38ea6e-6e37-11e8-900f-9af8690c125b.png)



--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
