### PR TITLE
Attach attachments to analysis on a worksheet when doing results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #852 Cannot attach files to analysis on a worksheet when results import is used 
 
 **Security**
 

--- a/bika/lims/exportimport/instruments/resultsimport.py
+++ b/bika/lims/exportimport/instruments/resultsimport.py
@@ -664,7 +664,6 @@ class AnalysisResultsImporter(Logger):
 
     def attach_attachments(self, analysis, attachments):
         # Sometime we get a list and sometimes an object of 1 attachment
-        import pdb; pdb.set_trace()
         if not isinstance(attachments, list):
             attachments = [attachments, ]
         if not attachments:

--- a/bika/lims/exportimport/instruments/resultsimport.py
+++ b/bika/lims/exportimport/instruments/resultsimport.py
@@ -595,7 +595,7 @@ class AnalysisResultsImporter(Logger):
                                 importedars[ar.getId()] = importedar
 
                         if ws:
-                            self.attach_attachment(
+                            self.attach_attachments(
                                 analysis, attachments[ws.getId()])
                         else:
                             self.warn(
@@ -662,21 +662,26 @@ class AnalysisResultsImporter(Logger):
             attachment.reindexObject()
         return attachment
 
-    def attach_attachment(self, analysis, attachment):
-        if attachment:
+    def attach_attachments(self, analysis, attachments):
+        # Sometime we get a list and sometimes an object of 1 attachment
+        import pdb; pdb.set_trace()
+        if not isinstance(attachments, list):
+            attachments = [attachments, ]
+        if not attachments:
+            self.warn("Attachment %s was not linked to analysis %s" %
+                      (attachments, analysis))
+        for attachment in attachments:
             an_atts = analysis.getAttachment()
-            attachments = []
+            attachments_to_be_attached = []
             for an_att in an_atts:
                 if an_att.getAttachmentFile().filename != \
                         attachment.getAttachmentFile().filename:
-                    logger.info(
-                            "Attaching %s to %s" % (an_att.UID(), analysis))
-                    attachments.append(attachment.UID())
-                    analysis.setAttachment(attachments)
-                    break
-            else:
-                self.warn("Attachment %s was not linked to analysis %s" %
-                          (attachment, analysis))
+                    logger.info("Attaching %s to %s" % (an_att.UID(), analysis))
+                    attachments_to_be_attached.append(an_att.UID())
+            logger.info("Attaching %s to %s" % (attachment.UID(), analysis))
+            attachments_to_be_attached.append(attachment.UID())
+            analysis.setAttachment(attachments_to_be_attached)
+            analysis.reindexObject(idxs='Attachment')
 
     def get_attachment_filenames(self, ws):
         fn_attachments = {}

--- a/bika/lims/tests/doctests/InstrumentsImportInterface.rst
+++ b/bika/lims/tests/doctests/InstrumentsImportInterface.rst
@@ -176,6 +176,21 @@ Create an `AnalysisRequest` with this `AnalysisService` and receive it::
     >>> ar.getReceivedBy()
     'test_user_1_'
 
+Create a new `Worksheet` and add the analyses::
+    >>> worksheet = api.create(portal.worksheets, "Worksheet", Analyst='test_user_1_') # doctest: +SKIP
+    >>> worksheet # doctest: +SKIP
+    <Worksheet at /plone/worksheets/WS-001>
+    >>> transaction.commit() # doctest: +SKIP
+    >>> worksheets_url = worksheet.absolute_url() + '/manage_results' # doctest: +SKIP
+    >>> analyses = map(api.get_object, ar.getAnalyses()) # doctest: +SKIP
+    >>> for analysis in analyses: # doctest: +SKIP
+    ...     worksheet.addAnalysis(analysis)
+    >>> transaction.commit() # doctest: +SKIP
+    >>> for analysis in analyses: # doctest: +SKIP
+    ...     if api.get_workflow_status_of(analysis, state_var='worksheetanalysis_review_state') != 'assigned':
+    ...         self.fail('{} not assigned to the worksheet'.format(analysis))
+
+
 
 Instruments files path
 ----------------------


### PR DESCRIPTION
instrument imports

## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/852

## Current behavior before PR
Resutls updated but Attachment column on the worksheet view is empty
## Desired behavior after PR is merged
Attachment column on the worksheet view should have links to the attached files

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
