### PR TITLE
Only Lab Managers see rejected analysis requests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changelog
 **Added**
 
 - #844 Missing interface for AR Report added
+- #858 Only Lab Managers sees rejected analysis requests
 
 
 **Changed**

--- a/bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
@@ -1029,8 +1029,12 @@
     <permission-map name="Modify portal content" acquired="False">
     </permission-map>
     <permission-map name="View" acquired="False">
+      <permission-role>Client</permission-role>
+      <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>RegulatoryInspector</permission-role>
     </permission-map>
   </state>
 

--- a/bika/lims/upgrade/v01_02_007.py
+++ b/bika/lims/upgrade/v01_02_007.py
@@ -6,6 +6,8 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 from bika.lims import logger
+from bika.lims import api
+from bika.lims.catalog.analysisrequest_catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.config import PROJECTNAME as product
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
@@ -19,6 +21,7 @@ def upgrade(tool):
     portal = tool.aq_inner.aq_parent
     ut = UpgradeUtils(portal)
     ver_from = ut.getInstalledVersion(product)
+    setup = portal.portal_setup
 
     if ut.isOlderVersion(product, version):
         logger.info("Skipping upgrade of {0}: {1} > {2}".format(
@@ -28,6 +31,39 @@ def upgrade(tool):
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
     # -------- ADD YOUR STUFF HERE --------
+    setup.runImportStepFromProfile(profile, 'workflow')
+    update_permissions_rejected_analysis_requests()
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
+
+
+def update_permissions_rejected_analysis_requests():
+    """
+    Maps and updates the permissions for rejected analysis requests so lab clerks, clients, owners and
+    RegulatoryInspector can see rejected analysis requests on lists.
+
+    :return: None
+    """
+    workflow_tool = api.get_tool("portal_workflow")
+    workflow = workflow_tool.getWorkflowById('bika_ar_workflow')
+    catalog = api.get_tool(CATALOG_ANALYSIS_REQUEST_LISTING)
+    brains = catalog(review_state='rejected')
+    counter = 0
+    total = len(brains)
+    logger.info(
+        "Changing permissions for rejected analysis requests. " +
+        "Number of rejected analysis requests: {0}".format(total))
+    for brain in brains:
+        if 'LabClerk' not in brain.allowedRolesAndUsers:
+            if counter % 100 == 0:
+                logger.info(
+                    "Changing permissions for rejected analysis requests: " +
+                    "{0}/{1}".format(counter, total))
+            obj = api.get_object(brain)
+            workflow.updateRoleMappingsFor(obj)
+            obj.reindexObject()
+        counter += 1
+    logger.info(
+        "Changed permissions for rejected analysis requests: " +
+        "{0}/{1}".format(counter, total))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/858

## Current behavior before PR

Only Lab Managers see rejected analysis requests

## Desired behavior after PR is merged

Lab clerk, client, and RegulatoryInspector see rejected analysis requests in lists.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
