### PR TITLE
Fix Profile VAT Amount on when adding an AR

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Changelog
 
 **Fixed**
 
+- #865 AR VAT Amount when using Profiles is not calculated correctly
 - #851 Fix worksheet verification with retracted results
 
 **Security**

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1633,9 +1633,8 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                     continue
 
                 profile_price = float(profile.getAnalysisProfilePrice())
-                profile_vat = float(profile.getAnalysisProfileVAT())
                 arprofiles_price += profile_price
-                arprofiles_vat_amount += profile_vat
+                arprofiles_vat_amount += profile.getVATAmount()
                 profile_services = profile.getService()
                 services_from_priced_profile.extend(profile_services)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/865

## Current behavior before PR

VAT Amount is used as the VAT value

## Desired behavior after PR is merged

VAT amount (in currency) should be calculated using the Profile Price and VAT percentage

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
