### PR TITLE
Fix Batch AR View

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Changelog
 
 **Fixed**
 
+- #875 Fix Batch AR View
 - #872 Date format appears wrong in Users history administrative report
 - #855 Dashboard is displayed to Lab clerks after login only
 - #871 Fix OpenTagError for i18ndude

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -76,15 +76,10 @@ class AnalysisRequestAddView(BrowserView):
         self.fieldvalues = self.generate_fieldvalues(self.ar_count)
         self.specifications = self.generate_specifications(self.ar_count)
         self.ShowPrices = self.bika_setup.getShowPrices()
+        self.icon = self.portal_url + \
+            "/++resource++bika.lims.images/analysisrequest_big.png"
         logger.info("*** Prepared data for {} ARs ***".format(self.ar_count))
         return self.template()
-
-    @property
-    def icon(self):
-        icon = "{}/{}".format(
-            self.portal_url,
-            "/++resource++bika.lims.images/analysisrequest_big.png")
-        return icon
 
     def get_view_url(self):
         """Return the current view url including request parameters


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a side-effect coming from https://github.com/senaite/senaite.core/pull/868

The introduced `icon` `@property` from the PR above made this attribute read-only for subclasses.
The Batch AR view subclasses the `AnalysisRequestAddView` and `AnalysisRequestsView`, and because the  latter one set `self.icon` it failed.

## Current behavior before PR

The `analysisrequests` view for Batches failed and returned a 404

## Desired behavior after PR is merged

The `analysisrequests` view for Batches works again

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
