### PR TITLE
Fix AR Header Table Styles and Ajax Failures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Changelog
 
 **Fixed**
 
+- #878 Fix AR Header Table Styles and Ajax Failures
 - #875 Fix Batch AR View
 - #872 Date format appears wrong in Users history administrative report
 - #855 Dashboard is displayed to Lab clerks after login only

--- a/bika/lims/browser/header_table.py
+++ b/bika/lims/browser/header_table.py
@@ -5,31 +5,26 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-"""ARs and Samples use HeaderTable to display object fields in their custom
-view and edit screens.
-"""
-from Products.CMFCore.utils import getToolByName
-
-from bika.lims.browser import BrowserView
-from bika.lims.interfaces import IHeaderTableFieldRenderer
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from Products.CMFPlone import PloneMessageFactory as _p
-from bika.lims.utils import getHiddenAttributesForClass
-from bika.lims.workflow import doActionFor
-from bika.lims.utils import t
-from bika.lims import bikaMessageFactory as _
-from zope.component import getAdapter
 from AccessControl import getSecurityManager
 from AccessControl.Permissions import view
+from bika.lims import bikaMessageFactory as _
+from bika.lims.browser import BrowserView
+from bika.lims.interfaces import IHeaderTableFieldRenderer
+from bika.lims.utils import t
+from Products.CMFPlone import PloneMessageFactory as _p
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from zope.component import getAdapter
 from zope.component.interfaces import ComponentLookupError
 
-class HeaderTableView(BrowserView):
 
-    template = ViewPageTemplateFile('templates/header_table.pt')
+class HeaderTableView(BrowserView):
+    """Table rendered at the top in AR View
+    """
+    template = ViewPageTemplateFile("templates/header_table.pt")
 
     def __call__(self):
         self.errors = {}
-        if 'header_table_submitted' in self.request:
+        if "header_table_submitted" in self.request:
             schema = self.context.Schema()
             fields = schema.fields()
             form = self.request.form
@@ -48,7 +43,7 @@ class HeaderTableView(BrowserView):
                         # other fields
                         field.getMutator(self.context)(form[fieldname])
             message = _p("Changes saved.")
-            self.context.plone_utils.addPortalMessage(message, 'info')
+            self.context.plone_utils.addPortalMessage(message, "info")
         return self.template()
 
     def three_column_list(self, input_list):
@@ -72,11 +67,12 @@ class HeaderTableView(BrowserView):
     def render_field_view(self, field):
         fieldname = field.getName()
         field = self.context.Schema()[fieldname]
-        ret = {'fieldName': fieldname, 'mode': 'view'}
+        ret = {"fieldName": fieldname, "mode": "view"}
         try:
             adapter = getAdapter(self.context,
                                  interface=IHeaderTableFieldRenderer,
                                  name=fieldname)
+
         except ComponentLookupError:
             adapter = None
         if adapter:
@@ -86,15 +82,16 @@ class HeaderTableView(BrowserView):
         else:
             if field.getType().find("ool") > -1:
                 value = field.get(self.context)
-                ret = {'fieldName': fieldname,
-                       'mode': 'structure',
-                       'html': t(_('Yes')) if value else t(_('No'))
+                ret = {
+                    "fieldName": fieldname,
+                    "mode": "structure",
+                    "html": t(_("Yes")) if value else t(_("No"))
                 }
             elif field.getType().find("Reference") > -1:
-                # Prioritize method retrieval over schema's field
+                # Prioritize method retrieval over schema"s field
                 targets = None
-                if hasattr(self.context, 'get%s' % fieldname):
-                    fieldaccessor = getattr(self.context, 'get%s' % fieldname)
+                if hasattr(self.context, "get%s" % fieldname):
+                    fieldaccessor = getattr(self.context, "get%s" % fieldname)
                     if callable(fieldaccessor):
                         targets = fieldaccessor()
                 if not targets:
@@ -102,47 +99,66 @@ class HeaderTableView(BrowserView):
 
                 if targets:
                     if not type(targets) == list:
-                        targets = [targets,]
+                        targets = [targets, ]
                     sm = getSecurityManager()
                     if all([sm.checkPermission(view, ta) for ta in targets]):
                         a = ["<a href='%s'>%s</a>" % (target.absolute_url(),
                                                       target.Title())
                              for target in targets]
-                        ret = {'fieldName': fieldname,
-                               'mode': 'structure',
-                               'html': ", ".join(a)}
+                        ret = {
+                            "fieldName": fieldname,
+                            "mode": "structure",
+                            "html": ", ".join(a),
+                        }
                     else:
-                        ret = {'fieldName': fieldname,
-                               'mode': 'structure',
-                               'html': ", ".join([ta.Title() for ta in targets])}
+                        ret = {
+                            "fieldName": fieldname,
+                            "mode": "structure",
+                            "html": ", ".join([ta.Title() for ta in targets]),
+                        }
                 else:
-                    ret = {'fieldName': fieldname,
-                           'mode': 'structure',
-                           'html': ''}
-            elif field.getType().lower().find('datetime') > -1:
+                    ret = {
+                        "fieldName": fieldname,
+                        "mode": "structure",
+                        "html": "",
+                    }
+            elif field.getType().lower().find("datetime") > -1:
                 value = field.get(self.context)
-                ret = {'fieldName': fieldname,
-                       'mode': 'structure',
-                       'html': self.ulocalized_time(value, long_format=True)
+                ret = {
+                    "fieldName": fieldname,
+                    "mode": "structure",
+                    "html": self.ulocalized_time(value, long_format=True)
                 }
         return ret
 
     def sublists(self):
         ret = []
         prominent = []
-        for field in self.context.Schema().fields():
+        context = self.context
+
+        for field in context.Schema().fields():
             fieldname = field.getName()
-            state = field.widget.isVisible(self.context, 'header_table', default='invisible', field=field)
-            if state == 'invisible':
+            widget = field.widget
+            state = widget.isVisible(
+                context, "header_table", default="invisible", field=field)
+            if state == "invisible":
                 continue
-            elif state == 'prominent':
-                if field.widget.isVisible(self.context, 'edit', default='invisible', field=field) == 'visible':
-                    prominent.append({'fieldName': fieldname, 'mode': 'edit'})
-                elif field.widget.isVisible(self.context, 'view', default='invisible', field=field) == 'visible':
+            elif state == "prominent":
+                if widget.isVisible(
+                        context,
+                        "edit", default="invisible", field=field) == "visible":
+                    prominent.append({"fieldName": fieldname, "mode": "edit"})
+                elif widget.isVisible(
+                        context,
+                        "view", default="invisible", field=field) == "visible":
                     prominent.append(self.render_field_view(field))
-            elif state == 'visible':
-                if field.widget.isVisible(self.context, 'edit', default='invisible', field=field) == 'visible':
-                    ret.append({'fieldName': fieldname, 'mode': 'edit'})
-                elif field.widget.isVisible(self.context, 'view', default='invisible', field=field) == 'visible':
+            elif state == "visible":
+                if widget.isVisible(
+                        context,
+                        "edit", default="invisible", field=field) == "visible":
+                    ret.append({"fieldName": fieldname, "mode": "edit"})
+                elif widget.isVisible(
+                        context,
+                        "view", default="invisible", field=field) == "visible":
                     ret.append(self.render_field_view(field))
         return prominent, self.three_column_list(ret)

--- a/bika/lims/browser/header_table.py
+++ b/bika/lims/browser/header_table.py
@@ -80,7 +80,7 @@ class HeaderTableView(BrowserView):
                    'mode': 'structure',
                    'html': adapter(field)}
         else:
-            if field.getType().find("ool") > -1:
+            if field.getWidgetName() == "BooleanWidget":
                 value = field.get(self.context)
                 ret = {
                     "fieldName": fieldname,

--- a/bika/lims/browser/header_table.py
+++ b/bika/lims/browser/header_table.py
@@ -102,13 +102,22 @@ class HeaderTableView(BrowserView):
                         targets = [targets, ]
                     sm = getSecurityManager()
                     if all([sm.checkPermission(view, ta) for ta in targets]):
-                        a = ["<a href='%s'>%s</a>" % (target.absolute_url(),
-                                                      target.Title())
-                             for target in targets]
+                        elements = [
+                            "<div id='{id}' class='field reference'>"
+                            "  <a class='link' uid='{uid}' href='{url}'>"
+                            "    {title}"
+                            "  </a>"
+                            "</div>"
+                            .format(id=target.getId(),
+                                    uid=target.UID(),
+                                    url=target.absolute_url(),
+                                    title=target.Title())
+                            for target in targets]
+
                         ret = {
                             "fieldName": fieldname,
                             "mode": "structure",
-                            "html": ", ".join(a),
+                            "html": "".join(elements),
                         }
                     else:
                         ret = {

--- a/bika/lims/browser/templates/header_table.pt
+++ b/bika/lims/browser/templates/header_table.pt
@@ -24,7 +24,7 @@
     <form method="post" name="header_form">
       <input type="hidden" name="header_table_submitted" value="1" />
 
-      <table class="header_table">
+      <table class="header_table table table-condensed table-bordered table-sm">
 
         <tr tal:repeat="action prominent">
           <tal:def define="mode python:action['mode'];
@@ -34,8 +34,8 @@
                            widget python:field.widget;
                            accessor python:field.getAccessor(context);
                            errors python:{};">
-            <td>
-              <span tal:replace="python:widget.label"/>&nbsp;
+            <td class="active">
+              <span tal:replace="python:widget.label"/>
               <span class="fieldRequired"
                     tal:condition="python:field.required and mode == 'edit'"
                     title="Required"
@@ -43,8 +43,7 @@
             </td>
             <td colspan="5">
               <tal:x condition="python:mode!='structure'">
-                <metal:field
-                  use-macro="python:context.widget(fieldName, mode=mode)"/>
+                <metal:field use-macro="python:context.widget(fieldName, mode=mode)"/>
               </tal:x>
               <span
                 tal:condition="python:mode=='structure' and action['html']"
@@ -56,8 +55,8 @@
         <tr tal:repeat="row_nr python:range(len(sublists[0]))">
           <tal:repeat repeat="col_nr python:range(3)">
             <tal:print_blanks condition="python:len(sublists[col_nr]) <= row_nr">
-              <td tal:attributes="class python:row_nr%2 and 'key odd' or 'key even'">&nbsp;</td>
-              <td tal:attributes="class python:row_nr%2 and 'value odd' or 'value even'">&nbsp;</td>
+              <td tal:attributes="class python:row_nr%2 and 'key odd' or 'key even'"></td>
+              <td tal:attributes="class python:row_nr%2 and 'value odd' or 'value even'"></td>
             </tal:print_blanks>
             <tal:skip_blanks condition="python:len(sublists[col_nr]) > row_nr">
               <tal:def define="action python:sublists[col_nr][row_nr];
@@ -68,8 +67,8 @@
                                widget python:field.widget;
                                accessor python:field.getAccessor(context);
                                errors python:{};">
-                <td tal:attributes="class python:row_nr%2 and 'key odd' or 'key even'">
-                  <span tal:replace="python:widget.label"/>&nbsp;
+                <td tal:attributes="class python:row_nr%2 and 'key odd active' or 'key even active'">
+                  <span tal:replace="python:widget.label"/>
                   <span class="fieldRequired"
                         tal:condition="python:field.required and mode == 'edit'"
                         title="Required"
@@ -89,7 +88,7 @@
           </tal:repeat>
         </tr>
       </table>
-      <input class="context"
+      <input class="context btn btn-sm btn-primary"
              type="submit"
              name="form.button.save"
              value="Save"

--- a/bika/lims/jsonapi/__init__.py
+++ b/bika/lims/jsonapi/__init__.py
@@ -183,7 +183,9 @@ def set_fields_from_request(obj, request):
     for fieldname, value in request.items():
         if fieldname not in schema:
             continue
-        if schema[fieldname].type in ('reference', 'proxy'):
+        field = schema[fieldname]
+        widget = field.getWidgetName()
+        if widget in ["ReferenceWidget"]:
             brains = []
             if value:
                 brains = resolve_request_lookup(obj, request, fieldname)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds several fixtures for AR Header Table

## Current behavior before PR

- No Bootstrap styles
- Profiles rendered as comma-separated links
- Composite field failed to set via Ajax
- Boolean values displayed as `True/False` instead of `Yes/No`

## Desired behavior after PR is merged

- Bootstrap styles for `senaite.lims`
- Profiles rendered as `<div>` boxes with proper styles
- Composite field can be set via Ajax
- Boolean values display as `Yes/No`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
