### PR TITLE
Upgrade lxml version to fulfill requirements of Plone 4.3.17 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Changelog
 
 **Changed**
 
+- #879 Upgrade lxml version from 2.3.6 to 3.6.0 forbeing compatible with Plone 4.3.17
 - #873 Sample Type field editable in AR and Sample edit views before receive
 - #868 AR Add Form: Refactoring and Styling
 - #817 Make warn message clearer if transition rejection is due to missing sampler

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ Changelog
 
 **Changed**
 
-- #879 Upgrade lxml version from 2.3.6 to 3.6.0 forbeing compatible with Plone 4.3.17
+- #879 Upgrade lxml version from 2.3.6 to 3.6.0 and  Plone from 4.3.15 to 4.3.17
 - #873 Sample Type field editable in AR and Sample edit views before receive
 - #868 AR Add Form: Refactoring and Styling
 - #817 Make warn message clearer if transition rejection is due to missing sampler

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -8,14 +8,14 @@
 #
 
 [buildout]
-extends = http://dist.plone.org/release/4.3.15/versions.cfg
+extends = http://dist.plone.org/release/4.3.17/versions.cfg
 versions = versions
 develop = .
 
 index = https://pypi.python.org/simple/
 
 find-links =
-    http://dist.plone.org/release/4.3.15
+    http://dist.plone.org/release/4.3.17
     http://dist.plone.org/thirdparty
 
 parts =

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -35,7 +35,6 @@ eggs =
     plone.reload
     i18ndude
     lxml
-    Products.PloneHotfix20171128
 zcml =
 
 [instance]

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -97,7 +97,7 @@ return-status-codes = False
 
 [lxml]
 recipe = z3c.recipe.staticlxml
-egg = lxml==2.3.6
+egg = lxml==3.6.0
 force = false
 static-build = true
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.ansible-playbook/issues/2
Related PR: https://github.com/senaite/senaite.ansible-playbook/pull/3

Since Plone's 4.3.15 `buildout-cache.tar.bz2`  (http://dist.plone.org/release/4.3.15/) is no longer available SENAITE's ansible playbook will have to work now with Plone 4.3.17. 

Plone 4.3.17 requires `lxml=3.6.0` so our custom buildout configs have to be updated.

## Current behavior before PR

The version of `lxml` used in our custom buildout configs is version `2.3.6`.

## Desired behavior after PR is merged

The version of `lxml` used in our custom buildout configs is version `3.6.0`.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
