### PR TITLE
Fix message factory

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Changelog
 
 **Fixed**
 
+- #880 Fix message factory
 - #878 Fix AR Header Table Styles and Ajax Failures
 - #857 "other" reasons are not listed on AR rejection notifications (e-mail and attached pdf)
 - #875 Fix Batch AR View

--- a/bika/lims/__init__.py
+++ b/bika/lims/__init__.py
@@ -22,7 +22,7 @@ from Products.Archetypes import PloneMessageFactory as PMF
 
 # import this to log messages
 import logging
-logger = logging.getLogger('Bika')
+logger = logging.getLogger('senaite.core')
 
 from bika.lims.validators import *
 from bika.lims.config import *

--- a/bika/lims/__init__.py
+++ b/bika/lims/__init__.py
@@ -16,8 +16,8 @@ except TypeError:
 
 # import this to create messages in the bika domain.
 from zope.i18nmessageid import MessageFactory
-bikaMessageFactory = MessageFactory('bika')
-_ = MessageFactory('bika.lims')
+bikaMessageFactory = MessageFactory('senaite.core')
+_ = MessageFactory('senaite.core')
 from Products.Archetypes import PloneMessageFactory as PMF
 
 # import this to log messages

--- a/bika/lims/__init__.py
+++ b/bika/lims/__init__.py
@@ -12,13 +12,14 @@ import pkg_resources
 
 import App
 from AccessControl import allow_module
-from bika.lims.config import PROJECTNAME
 from bika.lims.permissions import ADD_CONTENT_PERMISSION
 from bika.lims.permissions import ADD_CONTENT_PERMISSIONS
 from Products.Archetypes.atapi import listTypes
 from Products.Archetypes.atapi import process_types
 from Products.CMFCore.utils import ContentInit
 from zope.i18nmessageid import MessageFactory
+
+PROJECTNAME = "bika.lims"
 
 try:
     __version__ = pkg_resources.get_distribution("senaite.core").version
@@ -33,6 +34,7 @@ _ = MessageFactory("senaite.core")
 # import this to log messages
 logger = logging.getLogger("senaite.core")
 
+# XXX: Do we really need all of these in templates?
 allow_module("AccessControl")
 allow_module("bika.lims")
 allow_module("bika.lims.config")
@@ -46,6 +48,14 @@ allow_module("plone.registry.interfaces")
 debug_mode = App.config.getConfiguration().debug_mode
 if debug_mode:
     allow_module("pdb")
+
+
+# Implicit module imports used by others
+# XXX Refactor these dependencies to explicit imports!
+from bika.lims.config import *  # noqa
+from bika.lims.permissions import *  # noqa
+from bika.lims.validators import *  # noqa
+from Products.Archetypes import PloneMessageFactory as PMF  # noqa
 
 
 def initialize(context):

--- a/bika/lims/__init__.py
+++ b/bika/lims/__init__.py
@@ -5,165 +5,160 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
+import logging
 import warnings
+
 import pkg_resources
+
+import App
+from AccessControl import allow_module
+from bika.lims.config import PROJECTNAME
+from bika.lims.permissions import ADD_CONTENT_PERMISSION
+from bika.lims.permissions import ADD_CONTENT_PERMISSIONS
+from Products.Archetypes.atapi import listTypes
+from Products.Archetypes.atapi import process_types
+from Products.CMFCore.utils import ContentInit
+from zope.i18nmessageid import MessageFactory
 
 try:
     __version__ = pkg_resources.get_distribution("senaite.core").version
 except TypeError:
     __version__ = pkg_resources.get_distribution("bika.lims").version
-    print 'Using old distribution name: bika.lims'
+    print "Using old distribution name: bika.lims"
 
 # import this to create messages in the bika domain.
-from zope.i18nmessageid import MessageFactory
-bikaMessageFactory = MessageFactory('senaite.core')
-_ = MessageFactory('senaite.core')
-from Products.Archetypes import PloneMessageFactory as PMF
+bikaMessageFactory = MessageFactory("senaite.core")
+_ = MessageFactory("senaite.core")
 
 # import this to log messages
-import logging
-logger = logging.getLogger('senaite.core')
+logger = logging.getLogger("senaite.core")
 
-from bika.lims.validators import *
-from bika.lims.config import *
-from bika.lims.permissions import *
+allow_module("AccessControl")
+allow_module("bika.lims")
+allow_module("bika.lims.config")
+allow_module("bika.lims.permissions")
+allow_module("bika.lims.utils")
+allow_module("json")
+allow_module("zope.i18n.locales")
+allow_module("zope.component")
+allow_module("plone.registry.interfaces")
 
-from AccessControl import ModuleSecurityInfo, allow_module
-from Products.Archetypes.atapi import process_types, listTypes
-from Products.CMFCore import utils
-from Products.CMFCore.DirectoryView import registerDirectory
-from Products.CMFCore.utils import ContentInit, ToolInit, getToolByName
-from Products.CMFPlone import PloneMessageFactory
-from Products.CMFPlone.interfaces import IPloneSiteRoot
-from Products.GenericSetup import EXTENSION, profile_registry
-
-allow_module('AccessControl')
-allow_module('bika.lims')
-allow_module('bika.lims.config')
-allow_module('bika.lims.permissions')
-allow_module('bika.lims.utils')
-allow_module('json')
-allow_module('zope.i18n.locales')
-allow_module('zope.component')
-allow_module('plone.registry.interfaces')
-
-import App
 debug_mode = App.config.getConfiguration().debug_mode
 if debug_mode:
-    allow_module('pdb')
-    allow_module('pudb')
+    allow_module("pdb")
+
 
 def initialize(context):
 
-    from content.analysis import Analysis
-    from content.analysiscategory import AnalysisCategory
-    from content.analysisrequest import AnalysisRequest
-    from content.analysisrequestsfolder import AnalysisRequestsFolder
-    from content.analysisservice import AnalysisService
-    from content.analysisspec import AnalysisSpec
-    from content.arimport import ARImport
-    from content.analysisprofile import AnalysisProfile
-    from content.arreport import ARReport
-    from content.artemplate import ARTemplate
-    from content.attachment import Attachment
-    from content.attachmenttype import AttachmentType
-    from content.batch import Batch
-    from content.batchfolder import BatchFolder
-    from content.batchlabel import BatchLabel
-    from content.bikacache import BikaCache
-    from content.bikaschema import BikaSchema
-    from content.bikasetup import BikaSetup
-    from content.calculation import Calculation
-    from content.client import Client
-    from content.clientfolder import ClientFolder
-    from content.contact import Contact
-    from content.container import Container
-    from content.containertype import ContainerType
-    from content.department import Department
-    from content.duplicateanalysis import DuplicateAnalysis
-    from content.identifiertype import IdentifierType
-    from content.instrument import Instrument
-    from content.instrumentcalibration import InstrumentCalibration
-    from content.instrumentcertification import InstrumentCertification
-    from content.instrumentmaintenancetask import InstrumentMaintenanceTask
-    from content.instrumentscheduledtask import InstrumentScheduledTask
-    from content.instrumentvalidation import InstrumentValidation
-    from content.instrumenttype import InstrumentType
-    from content.instrumentlocation import InstrumentLocation
-    from content.invoice import Invoice
-    from content.invoicebatch import InvoiceBatch
-    from content.invoicefolder import InvoiceFolder
-    from content.labcontact import LabContact
-    from content.laboratory import Laboratory
-    from content.labproduct import LabProduct
-    from content.manufacturer import Manufacturer
-    from content.method import Method
-    from content.methods import Methods
-    from content.multifile import Multifile
-    from content.organisation import Organisation
-    from content.person import Person
-    from content.preservation import Preservation
-    from content.pricelist import Pricelist
-    from content.pricelistfolder import PricelistFolder
-    from content.referenceanalysis import ReferenceAnalysis
-    from content.referencedefinition import ReferenceDefinition
-    from content.referencesample import ReferenceSample
-    from content.referencesamplesfolder import ReferenceSamplesFolder
-    from content.rejectanalysis import RejectAnalysis
-    from content.report import Report
-    from content.reportfolder import ReportFolder
-    from content.sample import Sample
-    from content.samplecondition import SampleCondition
-    from content.samplematrix import SampleMatrix
-    from content.samplepartition import SamplePartition
-    from content.samplepoint import SamplePoint
-    from content.storagelocation import StorageLocation
-    from content.samplesfolder import SamplesFolder
-    from content.sampletype import SampleType
-    from content.samplingdeviation import SamplingDeviation
-    from content.srtemplate import SRTemplate
-    from content.subgroup import SubGroup
-    from content.supplier import Supplier
-    from content.suppliercontact import SupplierContact
-    from content.supplyorderfolder import SupplyOrderFolder
-    from content.supplyorder import SupplyOrder
-    from content.worksheet import Worksheet
-    from content.worksheetfolder import WorksheetFolder
-    from content.worksheettemplate import WorksheetTemplate
-    from content.reflexrule import ReflexRule
-    from content.autoimportlog import AutoImportLog
+    from content.analysis import Analysis  # noqa
+    from content.analysiscategory import AnalysisCategory  # noqa
+    from content.analysisprofile import AnalysisProfile  # noqa
+    from content.analysisrequest import AnalysisRequest  # noqa
+    from content.analysisrequestsfolder import AnalysisRequestsFolder  # noqa
+    from content.analysisservice import AnalysisService  # noqa
+    from content.analysisspec import AnalysisSpec  # noqa
+    from content.arimport import ARImport  # noqa
+    from content.arreport import ARReport  # noqa
+    from content.artemplate import ARTemplate  # noqa
+    from content.attachment import Attachment  # noqa
+    from content.attachmenttype import AttachmentType  # noqa
+    from content.autoimportlog import AutoImportLog  # noqa
+    from content.batch import Batch  # noqa
+    from content.batchfolder import BatchFolder  # noqa
+    from content.batchlabel import BatchLabel  # noqa
+    from content.bikacache import BikaCache  # noqa
+    from content.bikaschema import BikaSchema  # noqa
+    from content.bikasetup import BikaSetup  # noqa
+    from content.calculation import Calculation  # noqa
+    from content.client import Client  # noqa
+    from content.clientfolder import ClientFolder  # noqa
+    from content.contact import Contact  # noqa
+    from content.container import Container  # noqa
+    from content.containertype import ContainerType  # noqa
+    from content.department import Department  # noqa
+    from content.duplicateanalysis import DuplicateAnalysis  # noqa
+    from content.identifiertype import IdentifierType  # noqa
+    from content.instrument import Instrument  # noqa
+    from content.instrumentcalibration import InstrumentCalibration  # noqa
+    from content.instrumentcertification import InstrumentCertification  # noqa
+    from content.instrumentlocation import InstrumentLocation  # noqa
+    from content.instrumentmaintenancetask import InstrumentMaintenanceTask  # noqa
+    from content.instrumentscheduledtask import InstrumentScheduledTask  # noqa
+    from content.instrumenttype import InstrumentType  # noqa
+    from content.instrumentvalidation import InstrumentValidation  # noqa
+    from content.invoice import Invoice  # noqa
+    from content.invoicebatch import InvoiceBatch  # noqa
+    from content.invoicefolder import InvoiceFolder  # noqa
+    from content.labcontact import LabContact  # noqa
+    from content.laboratory import Laboratory  # noqa
+    from content.labproduct import LabProduct  # noqa
+    from content.manufacturer import Manufacturer  # noqa
+    from content.method import Method  # noqa
+    from content.methods import Methods  # noqa
+    from content.multifile import Multifile  # noqa
+    from content.organisation import Organisation  # noqa
+    from content.person import Person  # noqa
+    from content.preservation import Preservation  # noqa
+    from content.pricelist import Pricelist  # noqa
+    from content.pricelistfolder import PricelistFolder  # noqa
+    from content.referenceanalysis import ReferenceAnalysis  # noqa
+    from content.referencedefinition import ReferenceDefinition  # noqa
+    from content.referencesample import ReferenceSample  # noqa
+    from content.referencesamplesfolder import ReferenceSamplesFolder  # noqa
+    from content.reflexrule import ReflexRule  # noqa
+    from content.rejectanalysis import RejectAnalysis  # noqa
+    from content.report import Report  # noqa
+    from content.reportfolder import ReportFolder  # noqa
+    from content.sample import Sample  # noqa
+    from content.samplecondition import SampleCondition  # noqa
+    from content.samplematrix import SampleMatrix  # noqa
+    from content.samplepartition import SamplePartition  # noqa
+    from content.samplepoint import SamplePoint  # noqa
+    from content.samplesfolder import SamplesFolder  # noqa
+    from content.sampletype import SampleType  # noqa
+    from content.samplingdeviation import SamplingDeviation  # noqa
+    from content.srtemplate import SRTemplate  # noqa
+    from content.storagelocation import StorageLocation  # noqa
+    from content.subgroup import SubGroup  # noqa
+    from content.supplier import Supplier  # noqa
+    from content.suppliercontact import SupplierContact  # noqa
+    from content.supplyorder import SupplyOrder  # noqa
+    from content.supplyorderfolder import SupplyOrderFolder  # noqa
+    from content.worksheet import Worksheet  # noqa
+    from content.worksheetfolder import WorksheetFolder  # noqa
+    from content.worksheettemplate import WorksheetTemplate  # noqa
 
-    from controlpanel.bika_analysiscategories import AnalysisCategories
-    from controlpanel.bika_analysisservices import AnalysisServices
-    from controlpanel.bika_analysisspecs import AnalysisSpecs
-    from controlpanel.bika_analysisprofiles import AnalysisProfiles
-    from controlpanel.bika_artemplates import ARTemplates
-    from controlpanel.bika_attachmenttypes import AttachmentTypes
-    from controlpanel.bika_batchlabels import BatchLabels
-    from controlpanel.bika_calculations import Calculations
-    from controlpanel.bika_containers import Containers
-    from controlpanel.bika_containertypes import ContainerTypes
-    from controlpanel.bika_departments import Departments
-    from controlpanel.bika_identifiertypes import IdentifierTypes
-    from controlpanel.bika_instruments import Instruments
-    from controlpanel.bika_instrumenttypes import InstrumentTypes
-    from controlpanel.bika_instrumentlocations import InstrumentLocations
-    from controlpanel.bika_labcontacts import LabContacts
-    from controlpanel.bika_labproducts import LabProducts
-    from controlpanel.bika_manufacturers import Manufacturers
-    from controlpanel.bika_preservations import Preservations
-    from controlpanel.bika_referencedefinitions import ReferenceDefinitions
-    from controlpanel.bika_sampleconditions import SampleConditions
-    from controlpanel.bika_samplematrices import SampleMatrices
-    from controlpanel.bika_samplepoints import SamplePoints
-    from controlpanel.bika_storagelocations import StorageLocations
-    from controlpanel.bika_sampletypes import SampleTypes
-    from controlpanel.bika_samplingdeviations import SamplingDeviations
-    from controlpanel.bika_srtemplates import SRTemplates
-    from controlpanel.bika_subgroups import SubGroups
-    from controlpanel.bika_suppliers import Suppliers
-    from controlpanel.bika_worksheettemplates import WorksheetTemplates
-    from controlpanel.bika_reflexrulefolder import ReflexRuleFolder
+    from controlpanel.bika_analysiscategories import AnalysisCategories  # noqa
+    from controlpanel.bika_analysisprofiles import AnalysisProfiles  # noqa
+    from controlpanel.bika_analysisservices import AnalysisServices  # noqa
+    from controlpanel.bika_analysisspecs import AnalysisSpecs  # noqa
+    from controlpanel.bika_artemplates import ARTemplates  # noqa
+    from controlpanel.bika_attachmenttypes import AttachmentTypes  # noqa
+    from controlpanel.bika_batchlabels import BatchLabels  # noqa
+    from controlpanel.bika_calculations import Calculations  # noqa
+    from controlpanel.bika_containers import Containers  # noqa
+    from controlpanel.bika_containertypes import ContainerTypes  # noqa
+    from controlpanel.bika_departments import Departments  # noqa
+    from controlpanel.bika_identifiertypes import IdentifierTypes  # noqa
+    from controlpanel.bika_instrumentlocations import InstrumentLocations  # noqa
+    from controlpanel.bika_instruments import Instruments  # noqa
+    from controlpanel.bika_instrumenttypes import InstrumentTypes  # noqa
+    from controlpanel.bika_labcontacts import LabContacts  # noqa
+    from controlpanel.bika_labproducts import LabProducts  # noqa
+    from controlpanel.bika_manufacturers import Manufacturers  # noqa
+    from controlpanel.bika_preservations import Preservations  # noqa
+    from controlpanel.bika_referencedefinitions import ReferenceDefinitions  # noqa
+    from controlpanel.bika_reflexrulefolder import ReflexRuleFolder  # noqa
+    from controlpanel.bika_sampleconditions import SampleConditions  # noqa
+    from controlpanel.bika_samplematrices import SampleMatrices  # noqa
+    from controlpanel.bika_samplepoints import SamplePoints  # noqa
+    from controlpanel.bika_sampletypes import SampleTypes  # noqa
+    from controlpanel.bika_samplingdeviations import SamplingDeviations  # noqa
+    from controlpanel.bika_srtemplates import SRTemplates  # noqa
+    from controlpanel.bika_storagelocations import StorageLocations  # noqa
+    from controlpanel.bika_subgroups import SubGroups  # noqa
+    from controlpanel.bika_suppliers import Suppliers  # noqa
+    from controlpanel.bika_worksheettemplates import WorksheetTemplates  # noqa
 
     content_types, constructors, ftis = process_types(
         listTypes(PROJECTNAME),
@@ -173,20 +168,20 @@ def initialize(context):
     # use ADD_CONTENT_PERMISSION as default
     allTypes = zip(content_types, constructors)
     for atype, constructor in allTypes:
-        kind = "%s: Add %s" % (config.PROJECTNAME, atype.portal_type)
+        kind = "%s: Add %s" % (PROJECTNAME, atype.portal_type)
         perm = ADD_CONTENT_PERMISSIONS.get(atype.portal_type,
                                            ADD_CONTENT_PERMISSION)
         ContentInit(kind,
-                    content_types      = (atype,),
-                    permission         = perm,
-                    extra_constructors = (constructor,),
-                    fti                = ftis,
+                    content_types=(atype,),
+                    permission=perm,
+                    extra_constructors=(constructor, ),
+                    fti=ftis,
                     ).initialize(context)
 
 
 def deprecated(comment=None, replacement=None):
-    """
-    Flags a function as deprecated. A warning will be emitted.
+    """Flags a function as deprecated. A warning will be emitted.
+
     :param comment: A human-friendly string, such as 'This  function
                     will be removed soon'
     :type comment: string
@@ -215,9 +210,10 @@ def deprecated(comment=None, replacement=None):
 
 
 class _DeprecatedClassDecorator(object):
-    """ A decorator which can be used to mark symbols as deprecated.
-        Emits a DeprecationWarning showing the symbol being flagged as
-        deprecated. For add comments, use deprecated() instead of it
+    """A decorator which can be used to mark symbols as deprecated.
+
+    Emits a DeprecationWarning showing the symbol being flagged as deprecated.
+    For add comments, use deprecated() instead of it
     """
     def __call__(self, symbol):
         message = "Deprecated: '%s.%s'" % \
@@ -226,9 +222,10 @@ class _DeprecatedClassDecorator(object):
         warnings.warn(message, category=DeprecationWarning, stacklevel=2)
         return symbol
 
+
 deprecatedsymbol = _DeprecatedClassDecorator()
 del _DeprecatedClassDecorator
 
 
 def enum(**enums):
-    return type('Enum', (), enums)
+    return type("Enum", (), enums)

--- a/bika/lims/config.py
+++ b/bika/lims/config.py
@@ -5,11 +5,15 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from Products.Archetypes.public import DisplayList
 from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t
-from bika.lims.permissions import *
+from Products.Archetypes.public import DisplayList
 from zope.i18n.locales import locales
+
+# Implicit module imports used by others
+# XXX Refactor these dependencies to explicit imports!
+from bika.lims.utils import t  # noqa
+from bika.lims.permissions import *  # noqa
+
 
 PROJECTNAME = "bika.lims"
 
@@ -66,7 +70,7 @@ DEFAULT_AR_SPECS = DisplayList((
 ARIMPORT_OPTIONS = DisplayList((
     ('c', _('Classic')),
     ('p', _('Profiles')),
-#    ('s', _('Special')),
+    # ('s', _('Special')),
 ))
 EMAIL_SUBJECT_OPTIONS = DisplayList((
     ('ar', _('Analysis Request ID')),
@@ -94,7 +98,7 @@ QCANALYSIS_TYPES = DisplayList((
 ))
 
 currencies = locales.getLocale('en').numbers.currencies.values()
-currencies.sort(lambda x,y:cmp(x.displayName, y.displayName))
+currencies.sort(lambda x, y: cmp(x.displayName, y.displayName))
 
 CURRENCIES = DisplayList(
     [(c.type, "%s (%s)" % (c.displayName, c.symbol))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is part of the changes in https://github.com/senaite/senaite.core/pull/846 and fixes the missing `MessageFactory` identifier.

This PR also applies PEP8 to the `__init__.py` and `config.py` files.

## Current behavior before PR

Missing translation strings from code

## Desired behavior after PR is merged

i18n strings coming from code are correctly translated

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
