### PR TITLE
Fix JS i18n catalog names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Changelog
 
 **Fixed**
 
+- #881 Fixed JS i18n catalog names
 - #878 Fix AR Header Table Styles and Ajax Failures
 - #857 "other" reasons are not listed on AR rejection notifications (e-mail and attached pdf)
 - #875 Fix Batch AR View

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -61,8 +61,8 @@
 
     AnalysisRequestAdd.prototype.load = function() {
       console.debug("AnalysisRequestAdd::load");
-      jarn.i18n.loadCatalog('bika');
-      this._ = window.jarn.i18n.MessageFactory('bika');
+      jarn.i18n.loadCatalog("senaite.core");
+      this._ = window.jarn.i18n.MessageFactory("senaite.core");
       $('input[type=text]').prop('autocomplete', 'off');
       this.global_settings = {};
       this.records_snapshot = {};

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -1984,8 +1984,8 @@ function AnalysisRequestAddByCol() {
          * initiator - the service or control that initiated this check.
          *             used for a more pretty dialog box header.
          */
-        jarn.i18n.loadCatalog('bika')
-        var _ = window.jarn.i18n.MessageFactory("bika")
+        jarn.i18n.loadCatalog("senaite.core")
+        var _ = window.jarn.i18n.MessageFactory("senaite.core")
 
         var Dep
         var i, cb, dep_element

--- a/bika/lims/browser/js/bika.lims.analysisrequest.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.js
@@ -592,8 +592,8 @@
       /*jshint validthis:true */
       var Dependants, Dependencies, _, cb, dep, dep_services, dep_titles, element, elements_i, html, i, lims, service_uid;
       auto_yes = auto_yes || false;
-      jarn.i18n.loadCatalog('bika');
-      _ = window.jarn.i18n.MessageFactory('bika');
+      jarn.i18n.loadCatalog("senaite.core");
+      _ = window.jarn.i18n.MessageFactory("senaite.core");
       dep = void 0;
       i = void 0;
       cb = void 0;

--- a/bika/lims/browser/js/bika.lims.analysisservice.js
+++ b/bika/lims/browser/js/bika.lims.analysisservice.js
@@ -77,8 +77,8 @@
     AnalysisServiceEditView.prototype.load = function() {
       var d1, d2;
       console.debug("AnalysisServiceEditView::load");
-      jarn.i18n.loadCatalog("bika");
-      this._ = window.jarn.i18n.MessageFactory("bika");
+      jarn.i18n.loadCatalog("senaite.core");
+      this._ = window.jarn.i18n.MessageFactory("senaite.core");
       this.all_instruments = {};
       this.invalid_instruments = {};
       d1 = this.load_available_instruments().done(function(instruments) {

--- a/bika/lims/browser/js/bika.lims.artemplate.js
+++ b/bika/lims/browser/js/bika.lims.artemplate.js
@@ -3,8 +3,8 @@
  */
 function ARTemplateEditView() {
 
-    window.jarn.i18n.loadCatalog("bika");
-    var _ = window.jarn.i18n.MessageFactory("bika");
+    window.jarn.i18n.loadCatalog("senaite.core");
+    var _ = window.jarn.i18n.MessageFactory("senaite.core");
 
     var that = this;
     var samplepoint = $('#archetypes-fieldname-SamplePoint #SamplePoint');

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -51,8 +51,8 @@
 
     BikaListingTableView.prototype.load = function() {
       console.debug("ListingTableView::load");
-      jarn.i18n.loadCatalog('bika');
-      this._ = window.jarn.i18n.MessageFactory('bika');
+      jarn.i18n.loadCatalog("senaite.core");
+      this._ = window.jarn.i18n.MessageFactory("senaite.core");
       this.bind_eventhandler();
       this.loading_transitions = false;
       this.toggle_cols_cookie = "toggle_cols";

--- a/bika/lims/browser/js/bika.lims.loader.js
+++ b/bika/lims/browser/js/bika.lims.loader.js
@@ -261,9 +261,9 @@ window.bika.lims.initialize = function() {
     return window.bika.lims.initview();
 };
 
-window.jarn.i18n.loadCatalog("bika");
+window.jarn.i18n.loadCatalog("senaite.core");
 window.jarn.i18n.loadCatalog("plone");
-var _ = window.jarn.i18n.MessageFactory("bika");
+var _ = window.jarn.i18n.MessageFactory("senaite.core");
 var PMF = jarn.i18n.MessageFactory('plone');
 
 

--- a/bika/lims/browser/js/bika.lims.site.js
+++ b/bika/lims/browser/js/bika.lims.site.js
@@ -50,8 +50,8 @@
 
     SiteView.prototype.load = function() {
       console.debug("SiteView::load");
-      jarn.i18n.loadCatalog('bika');
-      this._ = window.jarn.i18n.MessageFactory('bika');
+      jarn.i18n.loadCatalog("senaite.core");
+      this._ = window.jarn.i18n.MessageFactory("senaite.core");
       this.init_spinner();
       this.init_client_add_overlay();
       this.init_client_combogrid();

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -621,8 +621,8 @@
 
     WorksheetManageResultsView.prototype.load = function() {
       console.debug("WorksheetManageResultsView::load");
-      jarn.i18n.loadCatalog('bika');
-      this._ = window.jarn.i18n.MessageFactory('bika');
+      jarn.i18n.loadCatalog("senaite.core");
+      this._ = window.jarn.i18n.MessageFactory("senaite.core");
       this._pmf = window.jarn.i18n.MessageFactory('plone');
       this.bind_eventhandler();
       this.constraints = null;

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -10,7 +10,7 @@ class window.AnalysisRequestAdd
 
     # load translations
     jarn.i18n.loadCatalog 'bika'
-    @_ = window.jarn.i18n.MessageFactory('bika')
+    @_ = window.jarn.i18n.MessageFactory("senaite.core")
 
     # disable browser autocomplete
     $('input[type=text]').prop 'autocomplete', 'off'

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.coffee
@@ -590,7 +590,7 @@ window.AnalysisRequestAnalysesView = ->
 
     auto_yes = auto_yes or false
     jarn.i18n.loadCatalog 'bika'
-    _ = window.jarn.i18n.MessageFactory('bika')
+    _ = window.jarn.i18n.MessageFactory("senaite.core")
     dep = undefined
     i = undefined
     cb = undefined

--- a/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
@@ -13,7 +13,7 @@ class window.BikaListingTableView
 
     # load translations
     jarn.i18n.loadCatalog 'bika'
-    @_ = window.jarn.i18n.MessageFactory('bika')
+    @_ = window.jarn.i18n.MessageFactory("senaite.core")
 
     # bind the event handler to the elements
     @bind_eventhandler()

--- a/bika/lims/browser/js/coffee/bika.lims.site.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.site.coffee
@@ -10,7 +10,7 @@ class window.SiteView
 
     # load translations
     jarn.i18n.loadCatalog 'bika'
-    @_ = window.jarn.i18n.MessageFactory('bika')
+    @_ = window.jarn.i18n.MessageFactory("senaite.core")
 
     # initialze the loading spinner
     @init_spinner()

--- a/bika/lims/browser/js/coffee/bika.lims.worksheet.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.worksheet.coffee
@@ -528,7 +528,7 @@ class window.WorksheetManageResultsView
 
     # load translations
     jarn.i18n.loadCatalog 'bika'
-    @_ = window.jarn.i18n.MessageFactory('bika')
+    @_ = window.jarn.i18n.MessageFactory("senaite.core")
     @_pmf = window.jarn.i18n.MessageFactory('plone')
 
     # bind the event handler to the elements

--- a/bika/lims/skins/bika/bika_widgets/analysisprofileanalyseswidget.js
+++ b/bika/lims/skins/bika/bika_widgets/analysisprofileanalyseswidget.js
@@ -44,8 +44,8 @@ function add_No(dlg, element){
 function calcdependencies(elements, auto_yes) {
 	/*jshint validthis:true */
 	auto_yes = auto_yes || false;
-    window.jarn.i18n.loadCatalog("bika");
-	var _ = window.jarn.i18n.MessageFactory("bika");
+    window.jarn.i18n.loadCatalog("senaite.core");
+	var _ = window.jarn.i18n.MessageFactory("senaite.core");
 
 	var dep;
 	var i, cb;

--- a/bika/lims/skins/bika/bika_widgets/artemplateanalyseswidget.js
+++ b/bika/lims/skins/bika/bika_widgets/artemplateanalyseswidget.js
@@ -78,8 +78,8 @@ function add_No(dlg, element){
 function calcdependencies(elements, auto_yes) {
 	/*jshint validthis:true */
 	auto_yes = auto_yes || false;
-    window.jarn.i18n.loadCatalog("bika");
-	var _ = window.jarn.i18n.MessageFactory("bika");
+    window.jarn.i18n.loadCatalog("senaite.core");
+	var _ = window.jarn.i18n.MessageFactory("senaite.core");
 
 	var dep;
 	var i, cb;

--- a/bika/lims/skins/bika/bika_widgets/datetimewidget.js
+++ b/bika/lims/skins/bika/bika_widgets/datetimewidget.js
@@ -1,8 +1,8 @@
 jQuery( function($) {
 $(document).ready(function(){
 
-    window.jarn.i18n.loadCatalog("bika");
-    _ = jarn.i18n.MessageFactory('bika');
+    window.jarn.i18n.loadCatalog("senaite.core");
+    _ = jarn.i18n.MessageFactory("senaite.core");
     window.jarn.i18n.loadCatalog("plone");
     PMF = jarn.i18n.MessageFactory('plone');
 	dateFormat = _('date_format_short_datepicker');

--- a/bika/lims/skins/bika/bika_widgets/recordswidget.js
+++ b/bika/lims/skins/bika/bika_widgets/recordswidget.js
@@ -2,8 +2,8 @@ jQuery(function($){
     $(document).ready(function(){
         window.jarn.i18n.loadCatalog("plone");
         _p = jarn.i18n.MessageFactory('plone');
-        window.jarn.i18n.loadCatalog("bika");
-        _ = jarn.i18n.MessageFactory('bika');
+        window.jarn.i18n.loadCatalog("senaite.core");
+        _ = jarn.i18n.MessageFactory("senaite.core");
 
         recordswidget_lookups();
         recordswidget_loadEventHandlers();

--- a/bika/lims/skins/bika/bika_widgets/reflexrulewidget.js
+++ b/bika/lims/skins/bika/bika_widgets/reflexrulewidget.js
@@ -113,7 +113,7 @@ jQuery(function($){
         var as_uid = $(as).find(":selected").attr('value');
         var as_info = setupdata[method].analysisservices[as_uid];
         if (as_info === undefined){
-            var _ = window.jarn.i18n.MessageFactory("bika");
+            var _ = window.jarn.i18n.MessageFactory("senaite.core");
             window.bika.lims.portalMessage(_('An analysis service must be selected'));
         }
         else{
@@ -756,7 +756,7 @@ jQuery(function($){
         var setupdata = $.parseJSON($('#rules-setup-data').html());
         var as_info = setupdata[method].analysisservices[as_uid];
         if (as_info === undefined){
-            var _ = window.jarn.i18n.MessageFactory("bika");
+            var _ = window.jarn.i18n.MessageFactory("senaite.core");
             window.bika.lims.portalMessage(_('An analysis service must be selected'));
         }
         var resultoptions = as_info.resultoptions;

--- a/bika/lims/skins/bika/bika_widgets/scheduleinputwidget.js
+++ b/bika/lims/skins/bika/bika_widgets/scheduleinputwidget.js
@@ -1,8 +1,8 @@
 jQuery( function($) {
 $(document).ready(function(){
 
-    window.jarn.i18n.loadCatalog("bika");
-    _ = jarn.i18n.MessageFactory('bika');
+    window.jarn.i18n.loadCatalog("senaite.core");
+    _ = jarn.i18n.MessageFactory("senaite.core");
     window.jarn.i18n.loadCatalog("plone");
     PMF = jarn.i18n.MessageFactory('plone');
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is complementing https://github.com/senaite/senaite.core/pull/846, so that the right i18n catalog is loaded in JS

## Current behavior before PR

JS files used 'bika' catalog 

## Desired behavior after PR is merged

JS files used 'senaite.core' catalog 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
