### PR TITLE
Regenerated translations

### DIFF
--- a/bika/lims/locales/af/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/af/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Afrikaans (https://www.transifex.com/senaite/teams/87045/af/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr "Fakture"
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr "Lab kontakpersoon"
@@ -757,6 +753,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
 msgstr "Klein plakkertjie"
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml
 #: bika/lims/profiles/default/types/ReferenceSample.xml

--- a/bika/lims/locales/af/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/af/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Afrikaans (https://www.transifex.com/senaite/teams/87045/af/)\n"

--- a/bika/lims/locales/ar/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/ar/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Arabic (https://www.transifex.com/senaite/teams/87045/ar/)\n"
@@ -380,10 +380,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -754,6 +750,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/ar/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/ar/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Arabic (https://www.transifex.com/senaite/teams/87045/ar/)\n"

--- a/bika/lims/locales/bg_BG/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/bg_BG/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Bulgarian (Bulgaria) (https://www.transifex.com/senaite/teams/87045/bg_BG/)\n"
@@ -380,10 +380,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -754,6 +750,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/bg_BG/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/bg_BG/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Bulgarian (Bulgaria) (https://www.transifex.com/senaite/teams/87045/bg_BG/)\n"

--- a/bika/lims/locales/bn/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/bn/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Bengali (https://www.transifex.com/senaite/teams/87045/bn/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -756,6 +752,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/bn/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/bn/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Bengali (https://www.transifex.com/senaite/teams/87045/bn/)\n"

--- a/bika/lims/locales/ca/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/ca/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2018\n"
 "Language-Team: Catalan (https://www.transifex.com/senaite/teams/87045/ca/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr "Factura"
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr "Contacte del laboratori"
@@ -757,6 +753,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
 msgstr "Etiqueta petita"
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml
 #: bika/lims/profiles/default/types/ReferenceSample.xml

--- a/bika/lims/locales/ca/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/ca/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Catalan (https://www.transifex.com/senaite/teams/87045/ca/)\n"

--- a/bika/lims/locales/cs/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/cs/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Czech (https://www.transifex.com/senaite/teams/87045/cs/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -756,6 +752,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/cs/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/cs/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Czech (https://www.transifex.com/senaite/teams/87045/cs/)\n"

--- a/bika/lims/locales/da_DK/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/da_DK/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Danish (Denmark) (https://www.transifex.com/senaite/teams/87045/da_DK/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr "Faktura"
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr "Lab Kontakt"
@@ -757,6 +753,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
 msgstr "Lille mærkat"
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml
 #: bika/lims/profiles/default/types/ReferenceSample.xml

--- a/bika/lims/locales/da_DK/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/da_DK/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Danish (Denmark) (https://www.transifex.com/senaite/teams/87045/da_DK/)\n"

--- a/bika/lims/locales/de/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/de/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: German (https://www.transifex.com/senaite/teams/87045/de/)\n"
@@ -382,10 +382,6 @@ msgstr "Annullieren"
 msgid "Invoice"
 msgstr "Rechnung"
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr "Rechnungen"
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr "Laborkontakt"
@@ -757,6 +753,10 @@ msgstr "Zugriff"
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
 msgstr "Kleiner Aufkleber"
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml
 #: bika/lims/profiles/default/types/ReferenceSample.xml

--- a/bika/lims/locales/de/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/de/LC_MESSAGES/senaite.core.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: German (https://www.transifex.com/senaite/teams/87045/de/)\n"

--- a/bika/lims/locales/el/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/el/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Greek (https://www.transifex.com/senaite/teams/87045/el/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr "Επαφή Εργαστηρίου"
@@ -757,6 +753,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
 msgstr "Μικρό Αυτοκόλλητο"
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml
 #: bika/lims/profiles/default/types/ReferenceSample.xml

--- a/bika/lims/locales/el/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/el/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Greek (https://www.transifex.com/senaite/teams/87045/el/)\n"

--- a/bika/lims/locales/en/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/en/LC_MESSAGES/plone.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -376,10 +376,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -750,6 +746,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/en/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/en/LC_MESSAGES/senaite.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/bika/lims/locales/en_ES/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/en_ES/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: English (Spain) (https://www.transifex.com/senaite/teams/87045/en_ES/)\n"
@@ -380,10 +380,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -754,6 +750,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/en_ES/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/en_ES/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: English (Spain) (https://www.transifex.com/senaite/teams/87045/en_ES/)\n"

--- a/bika/lims/locales/en_US/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/en_US/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: English (United States) (https://www.transifex.com/senaite/teams/87045/en_US/)\n"
@@ -380,10 +380,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -754,6 +750,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/en_US/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/en_US/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: English (United States) (https://www.transifex.com/senaite/teams/87045/en_US/)\n"

--- a/bika/lims/locales/eo/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/eo/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Esperanto (https://www.transifex.com/senaite/teams/87045/eo/)\n"
@@ -380,10 +380,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -754,6 +750,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/eo/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/eo/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Esperanto (https://www.transifex.com/senaite/teams/87045/eo/)\n"

--- a/bika/lims/locales/es/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/es/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2018\n"
 "Language-Team: Spanish (https://www.transifex.com/senaite/teams/87045/es/)\n"
@@ -382,10 +382,6 @@ msgstr "Invalidado"
 msgid "Invoice"
 msgstr "Factura"
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr "Contacto del laboratorio"
@@ -757,6 +753,10 @@ msgstr "Compartir"
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
 msgstr "Etiqueta pequeña"
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml
 #: bika/lims/profiles/default/types/ReferenceSample.xml

--- a/bika/lims/locales/es/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/es/LC_MESSAGES/senaite.core.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Jordi Puiggené <jpuiggene@naralabs.com>, 2018\n"
 "Language-Team: Spanish (https://www.transifex.com/senaite/teams/87045/es/)\n"

--- a/bika/lims/locales/es_419/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/es_419/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish (Latin America) (https://www.transifex.com/senaite/teams/87045/es_419/)\n"
@@ -380,10 +380,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -754,6 +750,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/es_419/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/es_419/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Spanish (Latin America) (https://www.transifex.com/senaite/teams/87045/es_419/)\n"

--- a/bika/lims/locales/es_AR/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/es_AR/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish (Argentina) (https://www.transifex.com/senaite/teams/87045/es_AR/)\n"
@@ -380,10 +380,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -754,6 +750,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/es_AR/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/es_AR/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish (Argentina) (https://www.transifex.com/senaite/teams/87045/es_AR/)\n"

--- a/bika/lims/locales/es_MX/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/es_MX/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish (Mexico) (https://www.transifex.com/senaite/teams/87045/es_MX/)\n"
@@ -380,10 +380,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -754,6 +750,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/es_MX/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/es_MX/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish (Mexico) (https://www.transifex.com/senaite/teams/87045/es_MX/)\n"

--- a/bika/lims/locales/es_PE/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/es_PE/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Spanish (Peru) (https://www.transifex.com/senaite/teams/87045/es_PE/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr "Factura"
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr "Contacto del laboratorio"
@@ -757,6 +753,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
 msgstr "Etiqueta pequeña"
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml
 #: bika/lims/profiles/default/types/ReferenceSample.xml

--- a/bika/lims/locales/es_PE/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/es_PE/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Spanish (Peru) (https://www.transifex.com/senaite/teams/87045/es_PE/)\n"

--- a/bika/lims/locales/es_UY/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/es_UY/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish (Uruguay) (https://www.transifex.com/senaite/teams/87045/es_UY/)\n"
@@ -380,10 +380,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -754,6 +750,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/es_UY/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/es_UY/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Spanish (Uruguay) (https://www.transifex.com/senaite/teams/87045/es_UY/)\n"

--- a/bika/lims/locales/fa/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/fa/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Persian (https://www.transifex.com/senaite/teams/87045/fa/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -756,6 +752,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/fa/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/fa/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Persian (https://www.transifex.com/senaite/teams/87045/fa/)\n"

--- a/bika/lims/locales/fa_IR/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/fa_IR/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Persian (Iran) (https://www.transifex.com/senaite/teams/87045/fa_IR/)\n"
@@ -380,10 +380,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -754,6 +750,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/fa_IR/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/fa_IR/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Persian (Iran) (https://www.transifex.com/senaite/teams/87045/fa_IR/)\n"

--- a/bika/lims/locales/fi/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/fi/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Finnish (https://www.transifex.com/senaite/teams/87045/fi/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -756,6 +752,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/fi/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/fi/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Finnish (https://www.transifex.com/senaite/teams/87045/fi/)\n"

--- a/bika/lims/locales/fr/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/fr/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: French (https://www.transifex.com/senaite/teams/87045/fr/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr "Facture"
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr "Contact du laboratoire"
@@ -757,6 +753,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
 msgstr "Petite étiquette"
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml
 #: bika/lims/profiles/default/types/ReferenceSample.xml

--- a/bika/lims/locales/fr/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/fr/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: French (https://www.transifex.com/senaite/teams/87045/fr/)\n"

--- a/bika/lims/locales/hi/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/hi/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Hindi (https://www.transifex.com/senaite/teams/87045/hi/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -756,6 +752,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/hi/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/hi/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Hindi (https://www.transifex.com/senaite/teams/87045/hi/)\n"

--- a/bika/lims/locales/hu/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/hu/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Hungarian (https://www.transifex.com/senaite/teams/87045/hu/)\n"
@@ -382,10 +382,6 @@ msgstr "Érvénytelenít"
 msgid "Invoice"
 msgstr "Számla"
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr "Labor kapcsolat"
@@ -757,6 +753,10 @@ msgstr "Megosztás"
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
 msgstr "Kis címke"
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml
 #: bika/lims/profiles/default/types/ReferenceSample.xml

--- a/bika/lims/locales/hu/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/hu/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Hungarian (https://www.transifex.com/senaite/teams/87045/hu/)\n"

--- a/bika/lims/locales/hu_HU/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/hu_HU/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Hungarian (Hungary) (https://www.transifex.com/senaite/teams/87045/hu_HU/)\n"
@@ -380,10 +380,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -754,6 +750,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/hu_HU/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/hu_HU/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Hungarian (Hungary) (https://www.transifex.com/senaite/teams/87045/hu_HU/)\n"

--- a/bika/lims/locales/id/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/id/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Indonesian (https://www.transifex.com/senaite/teams/87045/id/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -756,6 +752,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/id/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/id/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Indonesian (https://www.transifex.com/senaite/teams/87045/id/)\n"

--- a/bika/lims/locales/it/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/it/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Italian (https://www.transifex.com/senaite/teams/87045/it/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr "Fattura"
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr "Contatto Laboratorio"
@@ -757,6 +753,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
 msgstr "Etichetta Piccola"
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml
 #: bika/lims/profiles/default/types/ReferenceSample.xml

--- a/bika/lims/locales/it/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/it/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Italian (https://www.transifex.com/senaite/teams/87045/it/)\n"

--- a/bika/lims/locales/ja/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/ja/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Japanese (https://www.transifex.com/senaite/teams/87045/ja/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -756,6 +752,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/ja/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/ja/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Japanese (https://www.transifex.com/senaite/teams/87045/ja/)\n"

--- a/bika/lims/locales/ka_GE/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/ka_GE/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Georgian (Georgia) (https://www.transifex.com/senaite/teams/87045/ka_GE/)\n"
@@ -380,10 +380,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -754,6 +750,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/ka_GE/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/ka_GE/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Georgian (Georgia) (https://www.transifex.com/senaite/teams/87045/ka_GE/)\n"

--- a/bika/lims/locales/kn/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/kn/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Kannada (https://www.transifex.com/senaite/teams/87045/kn/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -756,6 +752,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/kn/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/kn/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Kannada (https://www.transifex.com/senaite/teams/87045/kn/)\n"

--- a/bika/lims/locales/lt/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/lt/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Lithuanian (https://www.transifex.com/senaite/teams/87045/lt/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -756,6 +752,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/lt/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/lt/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Lithuanian (https://www.transifex.com/senaite/teams/87045/lt/)\n"

--- a/bika/lims/locales/mn/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/mn/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Mongolian (https://www.transifex.com/senaite/teams/87045/mn/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -756,6 +752,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/mn/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/mn/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Mongolian (https://www.transifex.com/senaite/teams/87045/mn/)\n"

--- a/bika/lims/locales/nl/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/nl/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Dutch (https://www.transifex.com/senaite/teams/87045/nl/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -756,6 +752,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/nl/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/nl/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Dutch (https://www.transifex.com/senaite/teams/87045/nl/)\n"

--- a/bika/lims/locales/pl/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/pl/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Polish (https://www.transifex.com/senaite/teams/87045/pl/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr "Faktura"
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr "Kontakt z laboratorium"
@@ -757,6 +753,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
 msgstr "Mała naklejka"
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml
 #: bika/lims/profiles/default/types/ReferenceSample.xml

--- a/bika/lims/locales/pl/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/pl/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Polish (https://www.transifex.com/senaite/teams/87045/pl/)\n"

--- a/bika/lims/locales/plone.pot
+++ b/bika/lims/locales/plone.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -379,10 +379,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -753,6 +749,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/pt/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/pt/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Portuguese (https://www.transifex.com/senaite/teams/87045/pt/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -756,6 +752,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/pt/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/pt/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Portuguese (https://www.transifex.com/senaite/teams/87045/pt/)\n"

--- a/bika/lims/locales/pt_BR/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/pt_BR/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/senaite/teams/87045/pt_BR/)\n"
@@ -382,10 +382,6 @@ msgstr "Invalidar"
 msgid "Invoice"
 msgstr "Faturas"
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr "Contato do laboratório"
@@ -757,6 +753,10 @@ msgstr "Compartilhamento"
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
 msgstr "Etiqueta pequena"
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml
 #: bika/lims/profiles/default/types/ReferenceSample.xml

--- a/bika/lims/locales/pt_BR/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/pt_BR/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/senaite/teams/87045/pt_BR/)\n"

--- a/bika/lims/locales/ro_RO/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/ro_RO/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Romanian (Romania) (https://www.transifex.com/senaite/teams/87045/ro_RO/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr "Factură"
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -756,6 +752,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/ro_RO/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/ro_RO/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Romanian (Romania) (https://www.transifex.com/senaite/teams/87045/ro_RO/)\n"

--- a/bika/lims/locales/ru/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/ru/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Russian (https://www.transifex.com/senaite/teams/87045/ru/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr "Счет"
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr "Контакт лаборатории"
@@ -757,6 +753,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
 msgstr "Мелкий стикер"
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml
 #: bika/lims/profiles/default/types/ReferenceSample.xml

--- a/bika/lims/locales/ru/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/ru/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Russian (https://www.transifex.com/senaite/teams/87045/ru/)\n"

--- a/bika/lims/locales/senaite.core.pot
+++ b/bika/lims/locales/senaite.core.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/bika/lims/locales/sv/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/sv/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Swedish (https://www.transifex.com/senaite/teams/87045/sv/)\n"
@@ -380,10 +380,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -754,6 +750,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/sv/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/sv/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Swedish (https://www.transifex.com/senaite/teams/87045/sv/)\n"

--- a/bika/lims/locales/ta/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/ta/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Tamil (https://www.transifex.com/senaite/teams/87045/ta/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -756,6 +752,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/ta/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/ta/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Tamil (https://www.transifex.com/senaite/teams/87045/ta/)\n"

--- a/bika/lims/locales/te_IN/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/te_IN/LC_MESSAGES/plone.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Telugu (India) (https://www.transifex.com/senaite/teams/87045/te_IN/)\n"
@@ -380,10 +380,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -754,6 +750,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/te_IN/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/te_IN/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Telugu (India) (https://www.transifex.com/senaite/teams/87045/te_IN/)\n"

--- a/bika/lims/locales/tr_TR/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/tr_TR/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Turkish (Turkey) (https://www.transifex.com/senaite/teams/87045/tr_TR/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr "Fatura"
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr "Lab Yetkilisi"
@@ -757,6 +753,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
 msgstr "Küçük Etiket"
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml
 #: bika/lims/profiles/default/types/ReferenceSample.xml

--- a/bika/lims/locales/tr_TR/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/tr_TR/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Turkish (Turkey) (https://www.transifex.com/senaite/teams/87045/tr_TR/)\n"

--- a/bika/lims/locales/uk_UA/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/uk_UA/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Ukrainian (Ukraine) (https://www.transifex.com/senaite/teams/87045/uk_UA/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr "Рахунок"
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr "Контакт лабораторії"
@@ -757,6 +753,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
 msgstr "Маленький стікер"
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml
 #: bika/lims/profiles/default/types/ReferenceSample.xml

--- a/bika/lims/locales/uk_UA/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/uk_UA/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Ukrainian (Ukraine) (https://www.transifex.com/senaite/teams/87045/uk_UA/)\n"

--- a/bika/lims/locales/ur/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/ur/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Urdu (https://www.transifex.com/senaite/teams/87045/ur/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -756,6 +752,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/ur/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/ur/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Urdu (https://www.transifex.com/senaite/teams/87045/ur/)\n"

--- a/bika/lims/locales/vi/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/vi/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Vietnamese (https://www.transifex.com/senaite/teams/87045/vi/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -756,6 +752,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/vi/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/vi/LC_MESSAGES/senaite.core.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Vietnamese (https://www.transifex.com/senaite/teams/87045/vi/)\n"

--- a/bika/lims/locales/zh/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/zh/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Chinese (https://www.transifex.com/senaite/teams/87045/zh/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr ""
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -756,6 +752,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/zh/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/zh/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Chinese (https://www.transifex.com/senaite/teams/87045/zh/)\n"

--- a/bika/lims/locales/zh_CN/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/zh_CN/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Chinese (China) (https://www.transifex.com/senaite/teams/87045/zh_CN/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr "发票"
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr "实验室联系人"
@@ -757,6 +753,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
 msgstr "小贴纸"
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
+msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml
 #: bika/lims/profiles/default/types/ReferenceSample.xml

--- a/bika/lims/locales/zh_CN/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/zh_CN/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Chinese (China) (https://www.transifex.com/senaite/teams/87045/zh_CN/)\n"

--- a/bika/lims/locales/zh_TW/LC_MESSAGES/plone.po
+++ b/bika/lims/locales/zh_TW/LC_MESSAGES/plone.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Chinese (Taiwan) (https://www.transifex.com/senaite/teams/87045/zh_TW/)\n"
@@ -382,10 +382,6 @@ msgstr ""
 msgid "Invoice"
 msgstr "發票"
 
-#: bika/lims/profiles/default/types/InvoiceFolder.xml
-msgid "Invoices"
-msgstr ""
-
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
 msgstr ""
@@ -756,6 +752,10 @@ msgstr ""
 #: bika/lims/profiles/default/types/Sample.xml
 #: bika/lims/profiles/default/types/SamplePartition.xml
 msgid "Small Sticker"
+msgstr ""
+
+#: bika/lims/profiles/default/types/InvoiceFolder.xml
+msgid "Statements"
 msgstr ""
 
 #: bika/lims/profiles/default/types/Batch.xml

--- a/bika/lims/locales/zh_TW/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/zh_TW/LC_MESSAGES/senaite.core.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-02 16:51+0000\n"
+"POT-Creation-Date: 2018-07-02 20:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2018\n"
 "Language-Team: Chinese (Taiwan) (https://www.transifex.com/senaite/teams/87045/zh_TW/)\n"

--- a/bika/lims/profiles/default/types/InvoiceFolder.xml
+++ b/bika/lims/profiles/default/types/InvoiceFolder.xml
@@ -4,7 +4,7 @@
         xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         i18n:domain="plone"
         purge="True">
- <property name="title" i18n:translate="">Invoices</property>
+ <property name="title" i18n:translate="">Statements</property>
  <property name="description"></property>
  <property name="content_icon">++resource++bika.lims.images/invoice.png</property>
  <property name="content_meta_type">InvoiceFolder</property>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR reverts the prior renaming of Statements -> Invoices and regenerated the translations

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
