### PR TITLE
Fix override order of message catalogs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Changelog
 
 **Fixed**
 
+- #889 Fix override order of message catalogs
 - #864 Sort order in setup of analysis services wrong
 - #881 Fixed JS i18n catalog names
 - #880 Fix message factory

--- a/bika/lims/browser/jsi18n.py
+++ b/bika/lims/browser/jsi18n.py
@@ -30,8 +30,12 @@ class i18njs(BaseView):
         if td is None or language not in td._catalogs:
             return
 
+        # N.B. Multiple PO files might be registered for one language, where
+        # usually the one at position 0 is the custom catalog with the
+        # overriding terms in it. Therefore, we need to reverse the order, so
+        # that the custom catalog wins.
         _catalog = {}
-        for mo_path in td._catalogs[language]:
+        for mo_path in reversed(td._catalogs[language]):
             catalog = td._data[mo_path]._catalog
             if catalog is None:
                 td._data[mo_path].reload()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

We use `jarn.jsi18n` for translation strings in JavaScript.
Currently, we override the `i18njs` view in `senaite.core.browser.jsi18n` and use instead of always the first catalog for a translation domain, _all_ catalogs and merge them to one big dict.

- https://github.com/collective/jarn.jsi18n/issues/1
-  https://github.com/collective/jarn.jsi18n/pull/2

However, this overrides happen in the wrong order, because custom translations are usually first in the list.

## Current behavior before PR

Custom translations were not used in JavaScript

## Desired behavior after PR is merged

Custom translations are used in JavaScript

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
