### PR TITLE
Fixed i18n message handling in listings

### DIFF
--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -246,10 +246,10 @@
           }
         });
       }
-      if (col_id === _('Default')) {
+      if (col_id === this._('Default')) {
         console.debug("*** Set DEFAULT toggle columns ***");
         delete cookie[cookie_key];
-      } else if (col_id === _('All')) {
+      } else if (col_id === this._('All')) {
         console.debug("*** Set ALL toggle columns ***");
         all_cols = [];
         $.each(toggle_cols, function(name, record) {
@@ -612,7 +612,7 @@
       /*
        * Build context menu HTML
        */
-      var form, form_id, menu, portal_url, sorted_toggle_cols, toggle_cols, toggleable_columns;
+      var form, form_id, me, menu, portal_url, sorted_toggle_cols, toggle_cols, toggleable_columns;
       console.debug("°°° ListingTableView::make_context_menu °°°");
       $(".tooltip").remove();
       form = $(table).parents("form");
@@ -624,9 +624,10 @@
         return false;
       }
       sorted_toggle_cols = [];
+      me = this;
       $.each($.parseJSON(toggle_cols.val()), function(column, record) {
         record.id = column;
-        record.title = _(record.title) || _(record.id);
+        record.title = me._(record.title) || me._(record.id);
         sorted_toggle_cols.push(record);
       });
       sorted_toggle_cols.sort(function(a, b) {
@@ -652,7 +653,7 @@
         }
         return toggleable_columns += col;
       });
-      menu = "<div class=\"tooltip bottom\">\n  <div class=\"tooltip-inner\">\n    <table class=\"contextmenu\" cellpadding=\"0\" cellspacing=\"0\">\n      <tr>\n        <th colspan=\"2\">" + (_("Display columns")) + "</th>\n      </tr>\n      " + toggleable_columns + "\n      <tr col_id=\"" + (_("All")) + "\" form_id=\"" + form_id + "\">\n        <td style=\"border-top:1px solid #ddd;\">&nbsp;</td>\n        <td style=\"border-top:1px solid #ddd;\">" + (_("All")) + "</td>\n      </tr>\n      <tr col_id=\"" + (_("Default")) + "\" form_id=\"" + form_id + "\">\n        <td>&nbsp;</td>\n        <td>" + (_("Default")) + "</td>\n      </tr>\n    </table>\n  </div>\n  <div class=\"tooltip-arrow\"></div>\n</div>";
+      menu = "<div class=\"tooltip bottom\">\n  <div class=\"tooltip-inner\">\n    <table class=\"contextmenu\" cellpadding=\"0\" cellspacing=\"0\">\n      <tr>\n        <th colspan=\"2\">" + (this._("Display Columns")) + "</th>\n      </tr>\n      " + toggleable_columns + "\n      <tr col_id=\"" + (this._("All")) + "\" form_id=\"" + form_id + "\">\n        <td style=\"border-top:1px solid #ddd;\">&nbsp;</td>\n        <td style=\"border-top:1px solid #ddd;\">" + (this._("All")) + "</td>\n      </tr>\n      <tr col_id=\"" + (this._("Default")) + "\" form_id=\"" + form_id + "\">\n        <td>&nbsp;</td>\n        <td>" + (this._("Default")) + "</td>\n      </tr>\n    </table>\n  </div>\n  <div class=\"tooltip-arrow\"></div>\n</div>";
       return menu;
     };
 

--- a/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
@@ -13,7 +13,7 @@ class window.BikaListingTableView
 
     # load translations
     jarn.i18n.loadCatalog "senaite.core"
-    @_ = window.jarn.i18n.MessageFactory("senaite.core")
+    @_ = window.jarn.i18n.MessageFactory "senaite.core"
 
     # bind the event handler to the elements
     @bind_eventhandler()

--- a/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
@@ -12,7 +12,7 @@ class window.BikaListingTableView
     console.debug "ListingTableView::load"
 
     # load translations
-    jarn.i18n.loadCatalog 'bika'
+    jarn.i18n.loadCatalog "senaite.core"
     @_ = window.jarn.i18n.MessageFactory("senaite.core")
 
     # bind the event handler to the elements
@@ -222,13 +222,13 @@ class window.BikaListingTableView
           columns.push name
 
     # Set default toggle columns
-    if col_id == _('Default')
+    if col_id == @_('Default')
       console.debug "*** Set DEFAULT toggle columns ***"
       # delete the settings for this page
       delete cookie[cookie_key]
 
     # Set all toggle columns
-    else if col_id == _('All')
+    else if col_id == @_('All')
       console.debug "*** Set ALL toggle columns ***"
       # add all possible columns which have the toggle state
       all_cols = []
@@ -667,9 +667,10 @@ class window.BikaListingTableView
 
     sorted_toggle_cols = []
 
+    me = this
     $.each $.parseJSON(toggle_cols.val()), (column, record) ->
       record.id = column
-      record.title = _(record.title) or _(record.id)
+      record.title = me._(record.title) or me._(record.id)
       sorted_toggle_cols.push record
       return
 
@@ -706,16 +707,16 @@ class window.BikaListingTableView
       <div class="tooltip-inner">
         <table class="contextmenu" cellpadding="0" cellspacing="0">
           <tr>
-            <th colspan="2">#{_("Display columns")}</th>
+            <th colspan="2">#{@_("Display Columns")}</th>
           </tr>
           #{toggleable_columns}
-          <tr col_id="#{_("All")}" form_id="#{form_id}">
+          <tr col_id="#{@_("All")}" form_id="#{form_id}">
             <td style="border-top:1px solid #ddd;">&nbsp;</td>
-            <td style="border-top:1px solid #ddd;">#{_("All")}</td>
+            <td style="border-top:1px solid #ddd;">#{@_("All")}</td>
           </tr>
-          <tr col_id="#{_("Default")}" form_id="#{form_id}">
+          <tr col_id="#{@_("Default")}" form_id="#{form_id}">
             <td>&nbsp;</td>
-            <td>#{_("Default")}</td>
+            <td>#{@_("Default")}</td>
           </tr>
         </table>
       </div>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR complements the changes of https://github.com/senaite/senaite.core/pull/881

## Current behavior before PR

- wrong message catalog loaded in listings
- context menu header not correctly translated

## Desired behavior after PR is merged

- correct message catalog loaded
- context menu translates correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
