### PR TITLE
Better default styles for listing tables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,9 +11,9 @@ Changelog
 - #844 Missing interface for AR Report added
 - #858 Only Lab Managers sees rejected analysis requests
 
-
 **Changed**
 
+- #891 Better default styles for listing tables
 - #879 Upgrade lxml version from 2.3.6 to 3.6.0 and  Plone from 4.3.15 to 4.3.17
 - #873 Sample Type field editable in AR and Sample edit views before receive
 - #868 AR Add Form: Refactoring and Styling

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -109,7 +109,7 @@ class AnalysisRequestsView(BikaListingView):
             ("getClientOrderNumber", {
                 "title": _("Client Order"),
                 "sortable": True,
-                "toggle": True}),
+                "toggle": False}),
             ("Creator", {
                 "title": PMF("Creator"),
                 "index": "getCreatorFullName",
@@ -124,12 +124,12 @@ class AnalysisRequestsView(BikaListingView):
                 "attr": "getSampleID",
                 "index": "getSampleID",
                 "replace_url": "getSampleURL",
-                "toggle": True, }),
+                "toggle": False}),
             ("BatchID", {
                 "title": _("Batch ID"),
                 "index": "getBatchID",
                 "sortable": True,
-                "toggle": True}),
+                "toggle": False}),
             ("Client", {
                 "title": _("Client"),
                 "index": "getClientTitle",
@@ -141,21 +141,21 @@ class AnalysisRequestsView(BikaListingView):
                 "sortable": True,
                 "index": "getProvince",
                 "attr": "getProvince",
-                "toggle": True}),
+                "toggle": False}),
             ("District", {
                 "title": _("District"),
                 "sortable": True,
                 "index": "getDistrict",
                 "attr": "getDistrict",
-                "toggle": True}),
+                "toggle": False}),
             ("getClientReference", {
                 "title": _("Client Ref"),
                 "sortable": True,
                 "index": "getClientReference",
-                "toggle": True}),
+                "toggle": False}),
             ("getClientSampleID", {
                 "title": _("Client SID"),
-                "toggle": True}),
+                "toggle": False}),
             ("ClientContact", {
                 "title": _("Contact"),
                 "sortable": True,
@@ -191,7 +191,9 @@ class AnalysisRequestsView(BikaListingView):
                 "input_width": "10"}),
             ("getDateVerified", {
                 "title": _("Date Verified"),
-                "input_width": "10"}),
+                "input_width": "10",
+                "toggle": False,
+            }),
             ("getSampler", {
                 "title": _("Sampler"),
                 "toggle": SamplingWorkflowEnabled}),

--- a/bika/lims/browser/analysisrequest/templates/analysisrequests.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequests.pt
@@ -1,87 +1,67 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:tal="http://xml.zope.org/namespaces/tal"
-	xmlns:metal="http://xml.zope.org/namespaces/metal"
-	xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-	metal:use-macro="here/main_template/macros/master"
-	i18n:domain="senaite.core">
-<body
-	tal:define="
-		form_id view/form_id;
-		table_only python:hasattr(view, 'table_only') and view.table_only or view.request.get('table_only','') == form_id;"
-	tal:omit-tag="python:table_only">
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="senaite.core">
 
-<metal:content-title fill-slot="content-title"
-	tal:define="
-		form_id view/form_id;
-		table_only python:hasattr(view, 'table_only') and view.table_only or view.request.get('table_only','') == form_id;"
-	tal:condition="python:not table_only">
-    <h1>
+  <body tal:define="form_id view/form_id;
+                    table_only python:hasattr(view, 'table_only') and view.table_only or view.request.get('table_only','') == form_id;"
+        tal:omit-tag="python:table_only">
+
+    <metal:content-title fill-slot="content-title"
+                         tal:define="form_id view/form_id;
+                                     table_only python:hasattr(view, 'table_only') and view.table_only or view.request.get('table_only','') == form_id;"
+                         tal:condition="python:not table_only">
+      <h1>
         <img tal:condition="view/icon | nothing"
-             src="" tal:attributes="src view/icon"/>
-        <span style="position:relative;top:-0.2em;" class="documentFirstHeading" tal:content="view/title"/>
-        <tal:add_actions repeat="add_item python:view.context_actions.keys()">
-            <a tal:attributes="
-				style python:'background: url(%s) 2px 50%% no-repeat'%(view.context_actions[add_item]['icon']);
-				href python:view.context_actions[add_item]['url'];
-				class python:'context_action_link %s %s' % (view.context_actions[add_item].get('class',''), 'ar_count')">
-                <span tal:replace="python:add_item"/>
-            </a>
-            <input name="ar_count"
-                   class="ar_count context_action_link"
-                   type="number"
-                   style="width:4em;border-radius:0;border:1px solid #ddd;padding:2px;"
-                   tal:condition="python:len(view.context_actions) > 0"
-                   tal:attributes="
-                      value python: view.getDefaultAddCount()"
-            />
-            <a tal:attributes="
-				href python:view.context_actions[add_item]['url'];
-				class python:'context_action_link %s %s' % (view.context_actions[add_item].get('class',''), 'ar_count')"
-               style="padding:5px 1px 3px 1px;"
-               tal:condition="python:len(view.context_actions) > 0">ARs
-            </a>
-        </tal:add_actions>
-    </h1>
-    <script type="text/javascript">
-	(function( $ ) {
-	$(document).ready(function(){
-		$('input.ar_count').change(function(){
-			url = $("a.ar_count.context_action_link")
-                .attr('href').split("?")[0];
-			$("a.ar_count.context_action_link")
-                .attr('href', url + "?ar_count="+$(this).val());
-		});
-		$('input.ar_count').click(function(e){e.preventDefault();})
-		$('input.ar_count').change();
-	});
-	}(jQuery));
-    </script>
-</metal:content-title>
+             tal:attributes="src view/icon"
+             style="height:32px;width:auto;"/>
+        <span tal:content="python:view.context.translate(view.title)"/>
+        <span style="padding-left:0.5em;display:inline-block;">
+          <form method="GET" class="form-inline" action="ar_add">
+            <input type="number"
+                   name="ar_count"
+                   min="1"
+                   style="width:4em;vertical-align:middle;"
+                   class="form-control input-sm"
+                   tal:attributes="value view/getDefaultAddCount|1"/>
+            <button type="submit"
+                    class="btn btn-link">
+              <img src="#"
+                   style="height:16px;width:auto;"
+                   tal:attributes="src string:${context/absolute_url}/++resource++bika.lims.images/add.png"/>
+              <span i18n:translate="">Add</span>
+            </button>
+          </form>
+        </span>
+      </h1>
+    </metal:content-title>
 
-<metal:content-description fill-slot="content-description"
-	tal:define="
-		form_id view/form_id;
-		table_only python:hasattr(view, 'table_only') and view.table_only or view.request.get('table_only','') == form_id;"
-	tal:condition="python:not table_only">
-	<div class="documentDescription"
-		tal:content="structure view/description"
-		tal:condition="view/description"/>
-</metal:content-description>
+    <metal:content-description fill-slot="content-description"
+                               tal:define="form_id view/form_id;
+                                           table_only python:hasattr(view, 'table_only') and view.table_only or view.request.get('table_only','') == form_id;"
+                               tal:condition="python:not table_only">
+      <div class="documentDescription"
+                  tal:content="structure view/description"
+		              tal:condition="view/description"/>
+    </metal:content-description>
 
-<metal:content-core fill-slot="content-core">
-	<div id="folderlisting-main-table"
-		tal:content="structure view/contents_table"/>
+    <metal:content-core fill-slot="content-core">
 
-	<tal:hasremarks tal:condition="python:hasattr(context, 'Remarks')">
-		<tal:remarks define="
-			field python:context.Schema()['Remarks'];
-			errors python:{};">
-			<p style="margin-top:2em;"/>
-			 <metal:widget use-macro="python:context.widget('Remarks', mode='edit')" />
-		</tal:remarks>
-	</tal:hasremarks>
+      <!-- Listing Table -->
+	    <div id="folderlisting-main-table"
+           tal:content="structure view/contents_table"/>
 
-</metal:content-core>
+      <!-- Remarks -->
+	    <tal:hasremarks tal:condition="python:hasattr(context, 'Remarks')">
+		    <tal:remarks define="field python:context.Schema()['Remarks'];
+			                       errors python:{};">
+			    <metal:widget use-macro="python:context.widget('Remarks', mode='edit')" />
+		    </tal:remarks>
+	    </tal:hasremarks>
 
-</body>
+    </metal:content-core>
+
+  </body>
 </html>

--- a/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -247,7 +247,9 @@
             <button type="submit"
                     class="btn btn-link">
               <img src="#"
+                   style="height:16px;width:auto;"
                    tal:attributes="src string:${context/absolute_url}/++resource++bika.lims.images/add.png"/>
+              <span i18n:translate="">Add</span>
             </button>
           </form>
         </span>

--- a/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -234,7 +234,7 @@
       <h1 id="ar-header">
         <img tal:condition="view/icon | nothing" tal:attributes="src view/icon"/>
         <span i18n:translate="">Request new analyses</span>
-        <span style="padding-left:0.5em;float:right;">
+        <span style="padding-left:0.5em;display:inline-block;">
           <form method="GET" class="form-inline">
             <input type="hidden"
                    name="copy_from" tal:attributes="value request/copy_from|nothing"/>

--- a/bika/lims/browser/templates/bika_listing.pt
+++ b/bika/lims/browser/templates/bika_listing.pt
@@ -16,15 +16,24 @@
                          tal:condition="python:not table_only">
       <h1>
         <img tal:condition="view/icon | nothing"
-             src="" tal:attributes="src view/icon"/>
-        <span style="position:relative;top:-0.2em;" class="documentFirstHeading" tal:content="python:view.context.translate(view.title)"/>
-        <tal:add_actions repeat="add_item python:view.context_actions.keys()">
-          <a tal:attributes="style python:'background: url(%s) 2px 50%% no-repeat'%(view.context_actions[add_item]['icon']);
-                             href python:view.context_actions[add_item]['url'];
-                             class python:'context_action_link %s' % (view.context_actions[add_item].get('class',''))">
-            <span tal:replace="python:add_item"/>
+             tal:attributes="src view/icon"
+             style="height:32px;width:auto;"/>
+        <span class="documentFirstHeading"
+              tal:content="python:view.context.translate(view.title)"/>
+        <tal:contextactions repeat="key python:view.context_actions.keys()">
+          <!-- Context Actions -->
+          <tal:contextaction define="url python:view.context_actions[key]['url'];
+                                     icon python:view.context_actions[key]['icon'];
+                                     css_class python:view.context_actions[key].get('class', '');">
+            <a tal:attributes="href url;
+                               class python:'context_action_link %s btn btn-link' % css_class">
+              <img tal:condition="icon|nothing"
+                   tal:attributes="src icon"
+                   style="height:16px;width:auto;"/>
+              <span tal:replace="key"/>
           </a>
-        </tal:add_actions>
+          </tal:contextaction>
+        </tal:contextactions>
       </h1>
     </metal:content-title>
 

--- a/bika/lims/browser/templates/bika_listing_table.pt
+++ b/bika/lims/browser/templates/bika_listing_table.pt
@@ -136,7 +136,7 @@
                              view.bika_listing.json_interim_fields or []"/>
       <table summary="Content listing"
              tal:omit-tag="python:rows_only"
-             tal:attributes="class python:'bika-listing-table';
+             tal:attributes="class python:'bika-listing-table table table-condensed table-noborder';
                              form_id view/bika_listing/form_id"
              i18n:attributes="summary summary_content_listing;"
              tal:define="columns view/bika_listing/columns;
@@ -173,7 +173,7 @@
                                          value state_id;
                                          id state/id;
                                          class python:request.get(form_id + '_review_state', 'default') == state_id
-                                         and 'selected' or ''"
+                                         and 'selected btn btn-sm btn-primary' or 'btn btn-sm btn-default'"
                         tal:content="structure state/title"/>
                     </tal:review_states>
                   </td>
@@ -186,7 +186,7 @@
                     <tal:filters_enabled
                       tal:define="term python:request.get(form_id+'_filter', '');">
                       <span class="filter-search-button">&nbsp;</span>
-                      <input class="filter-search-input"
+                      <input class="filter-search-input input-sm"
                              autocomplete="off"
                              tal:attributes="name python:form_id+'_filter';
                                              value python:term;"/>
@@ -325,13 +325,13 @@
                                           next_pagesize   python:pagesize+next_limit_from;
                                           form_id         python:view.bika_listing.form_id;"
                                   condition="python:view.bika_listing.show_more">
-                      &nbsp;&nbsp;
+
                       <a tal:attributes="href           python:view.bika_listing.GET_url(pagesize=next_pagesize,limit_from=limit_from,sort_on=sort_on,sort_order=sort_order);
                                          data-ajax-url  python:'%s&rows_only=%s' % (view.bika_listing.GET_url(pagesize=pagesize),form_id);
                                          data-pagesize  python:pagesize;
                                          data-limitfrom python:next_limit_from;
                                          data-form-id   python:form_id;"
-                         class="bika_listing_show_more"
+                         class="bika_listing_show_more btn btn-default btn-sm"
                          i18n:translate="">Show more</a>
                     </tal:showmore>
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR improves some default styles for listing tables to be usable with the new `senaite.lims` Bootstrap UI

## Current behavior before PR

No Bootstrap improved markup/styles for listings

## Desired behavior after PR is merged

Bootstrap improved markup/styles for listings

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
