### PR TITLE
Display only active Analyses for new Profiles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ Changelog
 
 **Fixed**
 
+- #892 Display only active Analyses for new Profiles
 - #889 Fix override order of message catalogs
 - #864 Sort order in setup of analysis services wrong
 - #881 Fixed JS i18n catalog names

--- a/bika/lims/browser/widgets/analysisprofileanalyseswidget.py
+++ b/bika/lims/browser/widgets/analysisprofileanalyseswidget.py
@@ -72,7 +72,7 @@ class AnalysisProfileAnalysesView(BikaListingView):
             {
                 "id": "default",
                 "title": _("All"),
-                "contentFilter": {},
+                "contentFilter": {"inactive_state": "active"},
                 "columns": [
                     "Title",
                     "Unit",


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the Analyses listing in Profiles.

## Current behavior before PR

Inactive Analyses are shown in the Profiles Analyses Listing

## Desired behavior after PR is merged

Only active Analyses are shown in the Profiles Analyses Listing

## Screenshot

<img width="1590" alt="add analysis profile senaite 2018-07-10 10-59-44" src="https://user-images.githubusercontent.com/713193/42500015-7cfb38a6-8430-11e8-8f24-7ae5c5501590.png">

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
