### PR TITLE
Allow Client contact to access to batches

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #893 Allow Client contact to access to batches
 
 **Changed**
 

--- a/bika/lims/browser/batchfolder.py
+++ b/bika/lims/browser/batchfolder.py
@@ -9,13 +9,15 @@ import json
 from operator import itemgetter
 
 import plone
+from plone.app.content.browser.interfaces import IFolderContentsView
+from zope.interface import implements
+
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser import BrowserView
 from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.interfaces import IClient, ILabContact
 from bika.lims.permissions import AddBatch
-from plone.app.content.browser.interfaces import IFolderContentsView
-from zope.interface import implements
 
 
 class BatchFolderContentsView(BikaListingView):
@@ -109,6 +111,7 @@ class BatchFolderContentsView(BikaListingView):
             self.context_actions[_('Add')] = \
                 {'url': 'createObject?type_name=Batch',
                  'icon': self.portal.absolute_url() + '/++resource++bika.lims.images/add.png'}
+        self._apply_filter_by_client()
         return super(BatchFolderContentsView, self).__call__()
 
     def isItemAllowed(self, obj):
@@ -175,6 +178,39 @@ class BatchFolderContentsView(BikaListingView):
         item['BatchDate'] = date
         item['replace']['BatchDate'] = self.ulocalized_time(date)
         return item
+
+    def _apply_filter_by_client(self):
+        """
+        If the user has the role Client, the user can not see batches
+        from client objects he/she does not belong to.
+        """
+        # If the current context is a Client, filter Batches by Client UID
+        if IClient.providedBy(self.context):
+            client_uid = api.get_uid(self.context)
+            self.contentFilter['getClientUID'] = client_uid
+            return
+
+        # If the current user is a Client contact, filter the Batches in
+        # accordance. For the rest of users (LabContacts), the visibility of
+        # the Batches depend on their permissions
+        user = api.get_current_user()
+        roles = user.getRoles()
+        if 'Client' not in roles:
+            return
+
+        # Are we sure this a ClientContact?
+        # May happen that this is a Plone member, w/o having a ClientContact
+        # assigned or having a LabContact assigned... weird
+        contact = api.get_user_contact(user)
+        if not contact or ILabContact.providedBy(contact):
+            return
+
+        # Is the parent from the Contact a Client?
+        client = api.get_parent(contact)
+        if not client or not IClient.providedBy(client):
+            return
+        client_uid = api.get_uid(client)
+        self.contentFilter['getClientUID'] = client_uid
 
 
 class ajaxGetBatches(BrowserView):

--- a/bika/lims/browser/client/views/batches.py
+++ b/bika/lims/browser/client/views/batches.py
@@ -12,7 +12,3 @@ class ClientBatchesView(BatchFolderContentsView):
     def __init__(self, context, request):
         super(ClientBatchesView, self).__init__(context, request)
         self.view_url = self.context.absolute_url() + "/batches"
-
-    def __call__(self):
-        self.contentFilter['getClientUID'] = self.context.UID()
-        return BatchFolderContentsView.__call__(self)

--- a/bika/lims/permissions.py
+++ b/bika/lims/permissions.py
@@ -346,7 +346,7 @@ def setup_permissions(portal):
     mp(CancelAndReinstate, ['Manager', 'LabManager', 'LabClerk'], 0)
     mp(permissions.ListFolderContents, ['Authenticated'], 0)
     mp(permissions.AddPortalContent, ['Manager', 'LabManager', 'LabClerk', 'Analyst'], 0)
-    mp(permissions.View, ['Manager', 'LabManager', 'LabClerk', 'Analyst', 'RegulatoryInspector'], 0)
+    mp(permissions.View, ['Manager', 'LabManager', 'LabClerk', 'Analyst', 'RegulatoryInspector', 'Client'], 0)
     mp('Access contents information', ['Authenticated'], 0)
     mp(permissions.DeleteObjects, ['Manager', 'LabManager', 'Owner'], 0)
     portal.batches.reindexObject()

--- a/bika/lims/profiles/default/workflows/bika_batch_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_batch_workflow/definition.xml
@@ -36,6 +36,7 @@
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>RegulatoryInspector</permission-role>
+      <permission-role>Client</permission-role>
     </permission-map>
   </state>
 
@@ -71,6 +72,7 @@
       <permission-role>Manager</permission-role>
       <permission-role>RegulatoryInspector</permission-role>
       <permission-role>Verifier</permission-role>
+      <permission-role>Client</permission-role>
     </permission-map>
   </state>
 

--- a/bika/lims/upgrade/v01_02_008.py
+++ b/bika/lims/upgrade/v01_02_008.py
@@ -10,6 +10,7 @@ from bika.lims import api
 from bika.lims.config import PROJECTNAME as product
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
+from bika.lims import permissions
 
 version = '1.2.8'  # Remember version number in metadata.xml and setup.py
 profile = 'profile-{0}:default'.format(product)
@@ -28,8 +29,20 @@ def upgrade(tool):
         return True
 
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
+    client_contact_permissions_on_batches_folder(portal)
 
     # -------- ADD YOUR STUFF HERE --------
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
+
+
+def client_contact_permissions_on_batches_folder(portal):
+    """
+    Grants view permissions on batches folder in navtree
+    :param portal: portal object
+    :return: None
+    """
+    mp = portal.batches.manage_permission
+    mp(permissions.View, ['Manager', 'LabManager', 'LabClerk', 'Analyst', 'RegulatoryInspector', 'Client'], 0)
+    portal.batches.reindexObject()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR will allow Client users to visualize Batches related with the client that the user belongs to.

Not yet done:

- [ ] Client contact should not be able to see batches from other clients in the general Batch Folder

## Current behavior before PR

Client contact do no see Batches folder in navtree neither can see batches in client's batches tab.

## Desired behavior after PR is merged

Client contact has access to batches

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
