### PR TITLE
Revert client batches permission (#893)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,6 @@ Changelog
 
 **Added**
 
-- #893 Allow Client contact to access to batches
 
 **Changed**
 

--- a/bika/lims/browser/client/views/batches.py
+++ b/bika/lims/browser/client/views/batches.py
@@ -12,3 +12,7 @@ class ClientBatchesView(BatchFolderContentsView):
     def __init__(self, context, request):
         super(ClientBatchesView, self).__init__(context, request)
         self.view_url = self.context.absolute_url() + "/batches"
+
+    def __call__(self):
+        self.contentFilter['getClientUID'] = self.context.UID()
+        return BatchFolderContentsView.__call__(self)

--- a/bika/lims/permissions.py
+++ b/bika/lims/permissions.py
@@ -346,7 +346,7 @@ def setup_permissions(portal):
     mp(CancelAndReinstate, ['Manager', 'LabManager', 'LabClerk'], 0)
     mp(permissions.ListFolderContents, ['Authenticated'], 0)
     mp(permissions.AddPortalContent, ['Manager', 'LabManager', 'LabClerk', 'Analyst'], 0)
-    mp(permissions.View, ['Manager', 'LabManager', 'LabClerk', 'Analyst', 'RegulatoryInspector', 'Client'], 0)
+    mp(permissions.View, ['Manager', 'LabManager', 'LabClerk', 'Analyst', 'RegulatoryInspector'], 0)
     mp('Access contents information', ['Authenticated'], 0)
     mp(permissions.DeleteObjects, ['Manager', 'LabManager', 'Owner'], 0)
     portal.batches.reindexObject()

--- a/bika/lims/profiles/default/workflows/bika_batch_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_batch_workflow/definition.xml
@@ -36,7 +36,6 @@
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>RegulatoryInspector</permission-role>
-      <permission-role>Client</permission-role>
     </permission-map>
   </state>
 
@@ -72,7 +71,6 @@
       <permission-role>Manager</permission-role>
       <permission-role>RegulatoryInspector</permission-role>
       <permission-role>Verifier</permission-role>
-      <permission-role>Client</permission-role>
     </permission-map>
   </state>
 

--- a/bika/lims/upgrade/v01_02_008.py
+++ b/bika/lims/upgrade/v01_02_008.py
@@ -5,14 +5,12 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from Products.AdvancedQuery import Eq
-
-from bika.lims import api
 from bika.lims import logger
-from bika.lims import permissions
+from bika.lims import api
 from bika.lims.config import PROJECTNAME as product
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
+from bika.lims import permissions
 
 version = '1.2.8'  # Remember version number in metadata.xml and setup.py
 profile = 'profile-{0}:default'.format(product)
@@ -57,16 +55,18 @@ def client_contact_permissions_on_batches(portal, ut):
     catalog = api.get_tool('portal_catalog')
 
     # Update permissions programmatically
-    query = Eq('portal_type', 'Batch') & ~ Eq('allowedRolesAndUsers', 'Client')
-    brains = catalog.evalAdvancedQuery(query)
+
+    brains = catalog(portal_type='Batch')
     counter = 0
     total = len(brains)
     logger.info(
         "Changing permissions for Batch objects: {0}".format(total))
     for brain in brains:
-        obj = api.get_object(brain)
-        workflow.updateRoleMappingsFor(obj)
-        obj.reindexObject()
+        allowed = brain.allowedRolesAndUsers or []
+        if 'Client' not in allowed:
+            obj = api.get_object(brain)
+            workflow.updateRoleMappingsFor(obj)
+            obj.reindexObject()
         counter += 1
         if counter % 100 == 0:
             logger.info(

--- a/bika/lims/upgrade/v01_02_008.py
+++ b/bika/lims/upgrade/v01_02_008.py
@@ -47,13 +47,13 @@ def revert_client_permissions_for_batches(portal):
     # and review state is 'open'
     remopen = del_permissions_for_role_in_workflow('bika_batch_workflow',
                                                    'open', ['Client'],
-                                                   permissions.View)
+                                                   [permissions.View])
 
     # Remove permission View for role Client in workflow bika_batch_workflow
     # and review state is 'open'
     remclos = del_permissions_for_role_in_workflow('bika_batch_workflow',
                                                    'closed', ['Client'],
-                                                   permissions.View)
+                                                   [permissions.View])
     if remopen or remclos:
         # Update rolemappings for batches, but only if necessary
         wtool = api.get_tool("portal_workflow")
@@ -130,7 +130,7 @@ def del_permissions_for_role_in_workflow(wfid, wfstate, roles, permissions):
         st_roles = permission_info['roles']
         ef_roles = filter(lambda role: role not in roles, st_roles)
         if len(ef_roles) == len(st_roles):
-            return False
+            continue
 
         logger.info("Removing roles {} from permission {} in {} with state {}"
                     .format(repr(roles), repr(permission), wfid, wfstate))

--- a/bika/lims/upgrade/v01_02_008.py
+++ b/bika/lims/upgrade/v01_02_008.py
@@ -10,7 +10,6 @@ from bika.lims import api
 from bika.lims.config import PROJECTNAME as product
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
-from bika.lims import permissions
 
 version = '1.2.8'  # Remember version number in metadata.xml and setup.py
 profile = 'profile-{0}:default'.format(product)
@@ -29,49 +28,8 @@ def upgrade(tool):
         return True
 
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
-    setup.runImportStepFromProfile(profile, 'workflow')
-
-    client_contact_permissions_on_batches(portal, ut)
 
     # -------- ADD YOUR STUFF HERE --------
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
-
-
-def client_contact_permissions_on_batches(portal, ut):
-    """
-    Grants view permissions on batches folder in navtree
-    :param portal: portal object
-    :return: None
-    """
-    mp = portal.batches.manage_permission
-    mp(permissions.View, ['Manager', 'LabManager', 'LabClerk', 'Analyst', 'RegulatoryInspector', 'Client'], 0)
-    portal.batches.reindexObject()
-
-    # Update batch object permissions
-    workflow_tool = api.get_tool("portal_workflow")
-    workflow = workflow_tool.getWorkflowById('bika_batch_workflow')
-    catalog = api.get_tool('portal_catalog')
-
-    # Update permissions programmatically
-
-    brains = catalog(portal_type='Batch')
-    counter = 0
-    total = len(brains)
-    logger.info(
-        "Changing permissions for Batch objects: {0}".format(total))
-    for brain in brains:
-        allowed = brain.allowedRolesAndUsers or []
-        if 'Client' not in allowed:
-            obj = api.get_object(brain)
-            workflow.updateRoleMappingsFor(obj)
-            obj.reindexObject()
-        counter += 1
-        if counter % 100 == 0:
-            logger.info(
-                "Changing permissions for Batch objects: " +
-                "{0}/{1}".format(counter, total))
-    logger.info(
-        "Changed permissions for Batch objects: " +
-        "{0}/{1}".format(counter, total))

--- a/bika/lims/upgrade/v01_02_008.py
+++ b/bika/lims/upgrade/v01_02_008.py
@@ -10,6 +10,7 @@ from bika.lims import api
 from bika.lims.config import PROJECTNAME as product
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
+from Products.CMFCore import permissions
 
 version = '1.2.8'  # Remember version number in metadata.xml and setup.py
 profile = 'profile-{0}:default'.format(product)
@@ -31,5 +32,108 @@ def upgrade(tool):
 
     # -------- ADD YOUR STUFF HERE --------
 
+    # Revert upgrade actions performed due to #893 (reverted)
+    revert_client_permissions_for_batches(portal)
+
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
+
+
+def revert_client_permissions_for_batches(portal):
+    # Disallow client contacts to see the list of batches
+    del_permission_for_role(portal.batches, permissions.View, 'Client')
+
+    # Remove permission View for role Client in workflow bika_batch_workflow
+    # and review state is 'open'
+    remopen = del_permissions_for_role_in_workflow('bika_batch_workflow',
+                                                   'open', ['Client'],
+                                                   permissions.View)
+
+    # Remove permission View for role Client in workflow bika_batch_workflow
+    # and review state is 'open'
+    remclos = del_permissions_for_role_in_workflow('bika_batch_workflow',
+                                                   'closed', ['Client'],
+                                                   permissions.View)
+    if remopen or remclos:
+        # Update rolemappings for batches, but only if necessary
+        wtool = api.get_tool("portal_workflow")
+        workflow = wtool.getWorkflowById('bika_batch_workflow')
+        catalog = api.get_tool('bika_catalog')
+        brains = catalog(portal_type='Batch')
+        counter = 0
+        total = len(brains)
+        logger.info(
+            "Changing permissions for Batch objects: {0}".format(total))
+        for brain in brains:
+            obj = api.get_object(brain)
+            workflow.updateRoleMappingsFor(obj)
+            obj.reindexObject()
+            counter += 1
+            if counter % 100 == 0:
+                logger.info(
+                    "Changing permissions for Batch objects: " +
+                    "{0}/{1}".format(counter, total))
+        logger.info(
+            "Changed permissions for Batch objects: " +
+            "{0}/{1}".format(counter, total))
+
+
+def del_permission_for_role(folder, permission, role):
+    """Removes a permission from the given role and given folder
+    :param folder: folder from which the permission for the role has to be removed
+    :param permission: the permission to be removed
+    :param role: role from which the permission must be removed
+    :return True if succeed, otherwise, False
+    """
+    roles = filter(lambda perm: perm.get('selected') == 'SELECTED',
+                   folder.rolesOfPermission(permission))
+    roles = map(lambda perm_role: perm_role['name'], roles)
+    if role not in roles:
+        # Nothing to do, the role has not the permission
+        logger.info(
+            "Role '{}' has not the permission {} assigned for {}"
+                .format(role, repr(permission), repr(folder)))
+        return False
+    roles.remove(role)
+    acquire = folder.acquiredRolesAreUsedBy(
+        permission) == 'CHECKED' and 1 or 0
+    folder.manage_permission(permission, roles=roles, acquire=acquire)
+    folder.reindexObject()
+    logger.info(
+        "Removed permission {} from role '{}' for {}"
+            .format(repr(permission), role, repr(folder)))
+    return True
+
+
+def del_permissions_for_role_in_workflow(wfid, wfstate, roles, permissions):
+    """Removes the permissions passed in for the given roles and for the
+    specified workflow and its state
+    :param wfid: workflow id
+    :param wfstate: workflow state
+    :param roles: roles the permissions must be removed from
+    :param permissions: permissions to be removed
+    :return True if succeed, otherwise, False
+    """
+    wtool = api.get_tool("portal_workflow")
+    workflow = wtool.getWorkflowById(wfid)
+    if not workflow:
+        return False
+    state = workflow.states.get(wfstate, None)
+    if not state:
+        return False
+    # Get the permission-roles that apply to this state
+    removed = False
+    for permission in permissions:
+        # Get the roles that apply for this permission
+        permission_info = state.getPermissionInfo(permission)
+        acquired = permission_info['acquired']
+        st_roles = permission_info['roles']
+        ef_roles = filter(lambda role: role not in roles, st_roles)
+        if len(ef_roles) == len(st_roles):
+            return False
+
+        logger.info("Removing roles {} from permission {} in {} with state {}"
+                    .format(repr(roles), repr(permission), wfid, wfstate))
+        state.setPermission(permission, acquired, ef_roles)
+        removed = True
+    return removed


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR reverts #893 . Batches are meant to be used by lab to group ARs. Also, Analysis Requests from different Clients can be added in the same Batch, and Batches can be assigned to a client or not. Thus, making client contacts able to see the list of Batches can cause a lot of secondary effects.

The use of Batches in `senaite.health` is different. In `senaite.health`, Batches represent Clinical cases binded to Patients, and client contacts need to create them as part of the specimen+analyses submission workflow. Hence, this functionality has been moved, along with add/edition capabilities to `senaite.health`: https://github.com/senaite/senaite.health/pull/86

## Current behavior before PR

Client contacts can see the main list of Batches

## Desired behavior after PR is merged

Client contacts cannot see the main list of Batches.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
