### PR TITLE
Cannot view/edit Supplier.  Tabs for different views now visible.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Changelog
 
 **Fixed**
 
+- #898 Cannot view/edit Supplier.  Tabs for different views now visible.
 
 **Security**
 

--- a/bika/lims/browser/referencesample.py
+++ b/bika/lims/browser/referencesample.py
@@ -279,7 +279,6 @@ class ReferenceSamplesView(BikaListingView):
                               'path': {"query": ["/"], "level": 0}, }
         self.context_actions = {}
         self.show_select_column = True
-        request.set('disable_border', 1)
 
         self.columns = {
             'ID': {

--- a/bika/lims/browser/supplier.py
+++ b/bika/lims/browser/supplier.py
@@ -23,7 +23,7 @@ class SupplierInstrumentsView(InstrumentsView):
 
     def isItemAllowed(self, obj):
         supp = obj.getRawSupplier() if obj else None
-        return supp.UID() == self.context.UID() if supp else False
+        return supp == self.context.UID() if supp else False
 
 
 class SupplierReferenceSamplesView(ReferenceSamplesView):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The referencesamples view is used for /referencesamples and also inherited by <supplier>/referencesamples. In the suppliers view which subclasses the ReferenceSamplesView, we do want to see the edit_border tabs.

Linked issue: https://github.com/senaite/senaite.core/issues/860

## Current behavior before PR

Visiting a supplier shows only the list of that supplier's referencesamples, but does not show UI for editing the supplier's details or supplier instruments.

## Desired behavior after PR is merged

Tabs are shown when viewing the supplier to permit accessing the different views.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
