### PR TITLE
Remove explicit permission settings for clients

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Changelog
 
 **Removed**
 
+- #901 Remove explicit permission settings for clients
 
 **Fixed**
 

--- a/bika/lims/api/__init__.py
+++ b/bika/lims/api/__init__.py
@@ -815,12 +815,20 @@ def get_cancellation_status(brain_or_object, default="active"):
     :returns: Value of the review_status variable
     :rtype: String
     """
+
     if is_brain(brain_or_object):
-        return getattr(brain_or_object, "cancellation_state", default)
+        state = getattr(brain_or_object, "cancellation_state", None)
+        if state is not None:
+            return state
+
     workflows = get_workflows_for(brain_or_object)
-    if 'bika_cancellation_workflow' not in workflows:
+    if "bika_cancellation_workflow" in workflows:
+        return get_workflow_status_of(brain_or_object, "cancellation_state")
+
+    state = get_workflow_status_of(brain_or_object)
+    if state not in ("active", "inactive"):
         return default
-    return get_workflow_status_of(brain_or_object, 'cancellation_state')
+    return state
 
 
 def get_inactive_status(brain_or_object, default="active"):
@@ -831,12 +839,20 @@ def get_inactive_status(brain_or_object, default="active"):
     :returns: Value of the review_status variable
     :rtype: String
     """
+
     if is_brain(brain_or_object):
-        return getattr(brain_or_object, "inactive_state", default)
+        state = getattr(brain_or_object, "inactive_state", None)
+        if state is not None:
+            return state
+
     workflows = get_workflows_for(brain_or_object)
-    if 'bika_inactive_workflow' not in workflows:
+    if "bika_inactive_workflow" in workflows:
+        return get_workflow_status_of(brain_or_object, "inactive_state")
+
+    state = get_workflow_status_of(brain_or_object)
+    if state not in ("active", "inactive"):
         return default
-    return get_workflow_status_of(brain_or_object, 'inactive_state')
+    return state
 
 
 def is_active(brain_or_object):

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -556,6 +556,7 @@ class AnalysisRequestsView(BikaListingView):
                 (self.mtool.checkPermission(AddAnalysisRequest, self.context)):
             self.context_actions[_("Add")] = \
                 {"url": "ar_add?ar_count=1",
+                 'permission': 'Add portal content',
                  "icon": "++resource++bika.lims.images/add.png"}
 
         self.editresults = -1

--- a/bika/lims/browser/analysisrequest/templates/analysisrequests.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequests.pt
@@ -11,6 +11,7 @@
 
     <metal:content-title fill-slot="content-title"
                          tal:define="form_id view/form_id;
+                                     checkPermission nocall: context/portal_membership/checkPermission;
                                      table_only python:hasattr(view, 'table_only') and view.table_only or view.request.get('table_only','') == form_id;"
                          tal:condition="python:not table_only">
       <h1>
@@ -18,7 +19,8 @@
              tal:attributes="src view/icon"
              style="height:32px;width:auto;"/>
         <span tal:content="python:view.context.translate(view.title)"/>
-        <span style="padding-left:0.5em;display:inline-block;">
+          <span tal:condition="python:checkPermission('Add portal content', context)"
+                style="padding-left:0.5em;display:inline-block;">
           <form method="GET" class="form-inline" action="ar_add">
             <input type="number"
                    name="ar_count"

--- a/bika/lims/browser/client/views/analysisprofiles.py
+++ b/bika/lims/browser/client/views/analysisprofiles.py
@@ -69,5 +69,6 @@ class ClientAnalysisProfilesView(BikaListingView):
         if checkPermission(AddAnalysisProfile, self.context):
             self.context_actions[_('Add')] = \
                 {'url': 'createObject?type_name=AnalysisProfile',
+                 'permission': 'Add portal content',
                  'icon': '++resource++bika.lims.images/add.png'}
         return super(ClientAnalysisProfilesView, self).__call__()

--- a/bika/lims/browser/client/views/analysisrequests.py
+++ b/bika/lims/browser/client/views/analysisrequests.py
@@ -45,6 +45,7 @@ class ClientAnalysisRequestsView(AnalysisRequestsView):
                 if mtool.checkPermission(AddAnalysisRequest, self.context):
                     self.context_actions[_('Add')] = {
                         'url': self.context.absolute_url() + "/ar_add",
+                        'permission': 'Add portal content',
                         'icon': '++resource++bika.lims.images/add.png'}
 
         return super(ClientAnalysisRequestsView, self).__call__()

--- a/bika/lims/browser/client/views/analysisspecs.py
+++ b/bika/lims/browser/client/views/analysisspecs.py
@@ -76,6 +76,7 @@ class ClientAnalysisSpecsView(BikaListingView):
             if checkPermission(AddAnalysisSpec, self.context):
                 self.context_actions[_('Add')] = \
                     {'url': 'createObject?type_name=AnalysisSpec',
+                     'permission': 'Add portal content',
                      'icon': '++resource++bika.lims.images/add.png'}
                 #
                 # @lemoene with the changes made in AR-specs, I dont know how much

--- a/bika/lims/browser/client/views/artemplates.py
+++ b/bika/lims/browser/client/views/artemplates.py
@@ -66,5 +66,6 @@ class ClientARTemplatesView(BikaListingView):
         if checkPermission(AddARTemplate, self.context):
             self.context_actions[_('Add')] = \
                 {'url': 'createObject?type_name=ARTemplate',
+                 'permission': 'Add portal content',
                  'icon': '++resource++bika.lims.images/add.png'}
         return super(ClientARTemplatesView, self).__call__()

--- a/bika/lims/browser/client/views/contacts.py
+++ b/bika/lims/browser/client/views/contacts.py
@@ -30,6 +30,7 @@ class ClientContactsView(BikaListingView):
         self.context_actions = {
             _('Add'):
                 {'url': 'createObject?type_name=Contact',
+                 'permission': 'Add portal content',
                  'icon': '++resource++bika.lims.images/add.png'}}
         self.show_sort_column = False
         self.show_select_row = False

--- a/bika/lims/browser/client/views/orders.py
+++ b/bika/lims/browser/client/views/orders.py
@@ -28,6 +28,7 @@ class ClientOrdersView(SupplyOrderFolderView):
         self.context_actions = {
             _('Add'): {
                 'url': 'createObject?type_name=SupplyOrder',
+                'permission': 'Add portal content',
                 'icon': '++resource++bika.lims.images/add.png'
             }
         }

--- a/bika/lims/browser/client/views/samplepoints.py
+++ b/bika/lims/browser/client/views/samplepoints.py
@@ -65,5 +65,6 @@ class ClientSamplePointsView(BikaListingView):
         if checkPermission(AddSamplePoint, self.context):
             self.context_actions[_('Add')] = \
                 {'url': 'createObject?type_name=SamplePoint',
+                 'permission': 'Add portal content',
                  'icon': '++resource++bika.lims.images/add.png'}
         return super(ClientSamplePointsView, self).__call__()

--- a/bika/lims/browser/client/views/samplingrounds.py
+++ b/bika/lims/browser/client/views/samplingrounds.py
@@ -27,6 +27,7 @@ class ClientSamplingRoundsView(SamplingRoundsView):
         self.title = self.context.translate(_("Client Sampling Rounds"))
         self.context_actions = {
             _('Add'): {'url': '++add++SamplingRound',  # To work with dexterity
+                       'permission': 'Add portal content',
                        'icon': '++resource++bika.lims.images/add.png'}}
 
     def __call__(self):

--- a/bika/lims/browser/clientfolder.py
+++ b/bika/lims/browser/clientfolder.py
@@ -88,14 +88,14 @@ class ClientFolderContentsView(BikaListingView):
         self.review_states = [
             {
                 "id": "default",
-                "contentFilter": {"inactive_state": "active"},
+                "contentFilter": {"review_state": "active"},
                 "title": _("Active"),
                 "transitions": [{"id": "deactivate"}, ],
                 "columns": self.columns,
             }, {
                 "id": "inactive",
                 "title": _("Dormant"),
-                "contentFilter": {"inactive_state": "inactive"},
+                "contentFilter": {"review_state": "inactive"},
                 "transitions": [{"id": "activate"}, ],
                 "columns": self.columns,
             }, {

--- a/bika/lims/browser/templates/bika_listing.pt
+++ b/bika/lims/browser/templates/bika_listing.pt
@@ -23,10 +23,13 @@
         <tal:contextactions repeat="key python:view.context_actions.keys()">
           <!-- Context Actions -->
           <tal:contextaction define="url python:view.context_actions[key]['url'];
+                                     checkPermission nocall: context/portal_membership/checkPermission;
                                      icon python:view.context_actions[key]['icon'];
+                                     permission python:view.context_actions[key].get('permission', 'View');
                                      css_class python:view.context_actions[key].get('class', '');">
-            <a tal:attributes="href url;
-                               class python:'context_action_link %s btn btn-link' % css_class">
+            <a tal:condition="python:checkPermission(permission, context)"
+               tal:attributes="href url;
+                              class python:'context_action_link %s btn btn-link' % css_class">
               <img tal:condition="icon|nothing"
                    tal:attributes="src icon"
                    style="height:16px;width:auto;"/>

--- a/bika/lims/browser/templates/bika_listing.pt
+++ b/bika/lims/browser/templates/bika_listing.pt
@@ -19,11 +19,11 @@
              tal:attributes="src view/icon"
              style="height:32px;width:auto;"/>
         <span class="documentFirstHeading"
+              tal:define="checkPermission nocall: context/portal_membership/checkPermission;"
               tal:content="python:view.context.translate(view.title)"/>
         <tal:contextactions repeat="key python:view.context_actions.keys()">
           <!-- Context Actions -->
           <tal:contextaction define="url python:view.context_actions[key]['url'];
-                                     checkPermission nocall: context/portal_membership/checkPermission;
                                      icon python:view.context_actions[key]['icon'];
                                      permission python:view.context_actions[key].get('permission', 'View');
                                      css_class python:view.context_actions[key].get('class', '');">

--- a/bika/lims/profiles/default/types/Client.xml
+++ b/bika/lims/profiles/default/types/Client.xml
@@ -72,7 +72,7 @@
          url_expr="string:${object_url}/samples"
          i18n:attributes="title"
          visible="True">
-  <permission value="BIKA: Manage Samples"/>
+  <permission value="View"/>
  </action>
 
  <action title="Imports"
@@ -84,7 +84,7 @@
          url_expr="string:${object_url}/arimports"
          i18n:attributes="title"
          visible="True">
-  <permission value="BIKA: Manage ARImport"/>
+  <permission value="View"/>
  </action>
 
  <action title="SamplePoints"
@@ -96,7 +96,7 @@
          url_expr="string:${object_url}/samplepoints"
          i18n:attributes="title"
          visible="True">
-  <permission value="BIKA: Manage Samples"/>
+  <permission value="View"/>
  </action>
 
  <action title="Analysis Profiles"
@@ -180,7 +180,7 @@
          url_expr="string:${object_url}/orders"
          i18n:attributes="title"
          visible="True">
-    <permission value="BIKA: Manage Supply Orders"/>
+    <permission value="View"/>
  </action>
 
  <action title="Edit"
@@ -190,7 +190,7 @@
          i18n:attributes="title"
          i18n:domain="plone"
          visible="True">
-    <permission value="BIKA: Edit Client"/>
+   <permission value="Modify portal content"/>
  </action>
 
  <action title="Contacts"
@@ -200,7 +200,7 @@
          url_expr="string:${object_url}/contacts"
          i18n:attributes="title"
          visible="True">
-    <permission value="Modify portal content"/>
+    <permission value="View"/>
  </action>
 
 </object>

--- a/bika/lims/profiles/default/workflows.xml
+++ b/bika/lims/profiles/default/workflows.xml
@@ -168,7 +168,6 @@
     </type>
     <type type_id="Client">
       <bound-workflow workflow_id="bika_client_workflow"/>
-      <bound-workflow workflow_id="bika_inactive_workflow"/>
     </type>
 
     <!-- Client Types -->

--- a/bika/lims/profiles/default/workflows/bika_client_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_client_workflow/definition.xml
@@ -105,19 +105,14 @@
 
     <!-- Delete objects -->
     <permission-map name="Delete objects" acquired="False">
-      <permission-role>Manager</permission-role>
     </permission-map>
 
     <!-- Modify portal content -->
     <permission-map name="Modify portal content" acquired="False">
-      <permission-role>Manager</permission-role>
-      <permission-role>LabManager</permission-role>
     </permission-map>
 
     <!-- Add portal content -->
     <permission-map name="Add portal content" acquired="False">
-      <permission-role>Manager</permission-role>
-      <permission-role>LabManager</permission-role>
     </permission-map>
 
     <!-- View -->

--- a/bika/lims/profiles/default/workflows/bika_client_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_client_workflow/definition.xml
@@ -12,6 +12,8 @@
   <permission>Delete objects</permission>
   <!-- This governs whether you are allowed to modify some content. -->
   <permission>Modify portal content</permission>
+  <!-- This governs whether you are allowed to add some content. -->
+  <permission>Add portal content</permission>
   <!-- This governs whether you are allowed to view some content. -->
   <permission>View</permission>
   <!-- This permission allows access to an object, without necessarily viewing
@@ -23,9 +25,19 @@
        it doesn't check whether you have the right to view the objects listed. -->
   <permission>List folder contents</permission>
 
+  <!-- Transitions Permissions -->
+  <permission>Activate client</permission>
+  <permission>Deactivate client</permission>
+
   <!-- State: active -->
   <state state_id="active" title="Active" i18n:attributes="title">
     <exit-transition transition_id="deactivate" />
+
+    <!-- Deactivate client -->
+    <permission-map name="Deactivate client" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+    </permission-map>
 
     <!-- Delete objects -->
     <permission-map name="Delete objects" acquired="False">
@@ -34,9 +46,17 @@
 
     <!-- Modify portal content -->
     <permission-map name="Modify portal content" acquired="False">
-      <permission-role>LabClerk</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+
+    <!-- Add portal content -->
+    <permission-map name="Add portal content" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
       <permission-role>Owner</permission-role>
     </permission-map>
 
@@ -77,6 +97,12 @@
   <state state_id="inactive" title="Inactive" i18n:attributes="title">
     <exit-transition transition_id="activate" />
 
+    <!-- Activate client -->
+    <permission-map name="Activate client" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+    </permission-map>
+
     <!-- Delete objects -->
     <permission-map name="Delete objects" acquired="False">
       <permission-role>Manager</permission-role>
@@ -88,22 +114,31 @@
       <permission-role>LabManager</permission-role>
     </permission-map>
 
+    <!-- Add portal content -->
+    <permission-map name="Add portal content" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+    </permission-map>
+
     <!-- View -->
     <permission-map name="View" acquired="False">
       <permission-role>Manager</permission-role>
       <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
     </permission-map>
 
     <!-- Access contents information -->
     <permission-map name="Access contents information" acquired="False">
       <permission-role>Manager</permission-role>
       <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
     </permission-map>
 
     <!-- List folder contents -->
     <permission-map name="List folder contents" acquired="False">
       <permission-role>Manager</permission-role>
       <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
     </permission-map>
   </state>
   <!-- /State: inactive -->
@@ -113,7 +148,7 @@
     <action url="" category="workflow" icon="">Activate</action>
     <guard>
       <guard-expression>python:here.guard_activate_transition()</guard-expression>
-      <guard-permission>Modify portal content</guard-permission>
+      <guard-permission>Activate client</guard-permission>
     </guard>
   </transition>
   <!-- /Transition: activate -->
@@ -123,7 +158,7 @@
     <action url="" category="workflow" icon="">Deactivate</action>
     <guard>
       <guard-expression>python:here.guard_deactivate_transition()</guard-expression>
-      <guard-permission>Modify portal content</guard-permission>
+      <guard-permission>Deactivate client</guard-permission>
     </guard>
   </transition>
   <!-- /Transition: deactivate -->

--- a/bika/lims/profiles/default/workflows/bika_client_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_client_workflow/definition.xml
@@ -8,76 +8,28 @@
              manager_bypass="False"
              i18n:domain="senaite.core">
 
-  <!-- This governs whether you are allowed to view some content. -->
-  <permission>View</permission>
-  <!-- This permission allows access to an object, without necessarily viewing the -->
-  <!-- object. For example, a user may want to see the object's title in a list of -->
-  <!-- results, even though the user can't view the contents of that file. -->
-  <permission>Access contents information</permission>
-  <!-- This governs whether you can get a listing of the contents of a folder; it -->
-  <!-- doesn't check whether you have the right to view the objects listed. -->
-  <permission>List folder contents</permission>
+  <!-- This governs whether you are allowed to delete objects *inside* this folder. -->
+  <permission>Delete objects</permission>
   <!-- This governs whether you are allowed to modify some content. -->
   <permission>Modify portal content</permission>
-  <!-- This governs whether you are allowed to see the Edit tab of a client. -->
-  <permission>BIKA: Edit Client</permission>
-  <!-- This governs whether you are allowed to add a Supply Order. -->
-  <permission>BIKA: Add SupplyOrder</permission>
-  <!-- This governs whether you are allowed to see the Supply Order tab (see: types/Client.xml) -->
-  <permission>BIKA: Manage Supply Orders</permission>
+  <!-- This governs whether you are allowed to view some content. -->
+  <permission>View</permission>
+  <!-- This permission allows access to an object, without necessarily viewing
+       the object. For example, a user may want to see the object's title in a
+       list of results, even though the user can't view the contents of that
+       file. -->
+  <permission>Access contents information</permission>
+  <!-- This governs whether you can get a listing of the contents of a folder;
+       it doesn't check whether you have the right to view the objects listed. -->
+  <permission>List folder contents</permission>
 
-  <!-- State: active
-       N.B. All permissions need to be in sync with bika.lims.subscribers.objectmodified.py
-  -->
+  <!-- State: active -->
   <state state_id="active" title="Active" i18n:attributes="title">
-    <exit-transition transition_id="" />
+    <exit-transition transition_id="deactivate" />
 
-    <!-- View -->
-    <permission-map name="View" acquired="False">
+    <!-- Delete objects -->
+    <permission-map name="Delete objects" acquired="False">
       <permission-role>Manager</permission-role>
-      <permission-role>LabManager</permission-role>
-      <permission-role>LabClerk</permission-role>
-      <permission-role>Analyst</permission-role>
-      <permission-role>Sampler</permission-role>
-      <permission-role>Preserver</permission-role>
-      <permission-role>Owner</permission-role>
-      <permission-role>SamplingCoordinator</permission-role>
-    </permission-map>
-
-    <!-- Access contents information -->
-    <permission-map name="Access contents information" acquired="False">
-      <permission-role>Manager</permission-role>
-      <permission-role>LabManager</permission-role>
-      <permission-role>LabClerk</permission-role>
-      <permission-role>Analyst</permission-role>
-      <permission-role>Sampler</permission-role>
-      <permission-role>Preserver</permission-role>
-      <permission-role>Owner</permission-role>
-      <permission-role>SamplingCoordinator</permission-role>
-    </permission-map>
-
-    <!-- List folder contents -->
-    <permission-map name="List folder contents" acquired="False">
-      <permission-role>Manager</permission-role>
-      <permission-role>LabManager</permission-role>
-      <permission-role>LabClerk</permission-role>
-      <permission-role>Analyst</permission-role>
-      <permission-role>Sampler</permission-role>
-      <permission-role>Preserver</permission-role>
-      <permission-role>Owner</permission-role>
-      <permission-role>SamplingCoordinator</permission-role>
-    </permission-map>
-
-    <!-- BIKA: Edit Client
-         Please see types/Client.xml
-         -> The edit tab is secured with that permission and thus, need to be
-            aligned with the `Modify portal content` permission below.
-    -->
-    <permission-map name="BIKA: Edit Client" acquired="False">
-      <permission-role>LabClerk</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>LabManager</permission-role>
-      <permission-role>Owner</permission-role>
     </permission-map>
 
     <!-- Modify portal content -->
@@ -88,23 +40,93 @@
       <permission-role>Owner</permission-role>
     </permission-map>
 
-    <!-- Add Supply Order -->
-    <permission-map name="BIKA: Add SupplyOrder" acquired="False">
-      <permission-role>LabClerk</permission-role>
+    <!-- View -->
+    <permission-map name="View" acquired="False">
       <permission-role>Manager</permission-role>
       <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>Analyst</permission-role>
+      <permission-role>Sampler</permission-role>
       <permission-role>Owner</permission-role>
     </permission-map>
 
-    <!-- Manage Supply Orders -->
-    <permission-map name="BIKA: Manage Supply Orders" acquired="False">
-      <permission-role>LabClerk</permission-role>
+    <!-- Access contents information -->
+    <permission-map name="Access contents information" acquired="False">
       <permission-role>Manager</permission-role>
       <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>Analyst</permission-role>
+      <permission-role>Sampler</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+
+    <!-- List folder contents -->
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>Analyst</permission-role>
+      <permission-role>Sampler</permission-role>
       <permission-role>Owner</permission-role>
     </permission-map>
 
   </state>
+  <!-- /State: active -->
+
+  <!-- State: inactive -->
+  <state state_id="inactive" title="Inactive" i18n:attributes="title">
+    <exit-transition transition_id="activate" />
+
+    <!-- Delete objects -->
+    <permission-map name="Delete objects" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+
+    <!-- Modify portal content -->
+    <permission-map name="Modify portal content" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+    </permission-map>
+
+    <!-- View -->
+    <permission-map name="View" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+    </permission-map>
+
+    <!-- Access contents information -->
+    <permission-map name="Access contents information" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+    </permission-map>
+
+    <!-- List folder contents -->
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+    </permission-map>
+  </state>
+  <!-- /State: inactive -->
+
+  <!-- Transition: activate -->
+  <transition transition_id="activate" title="Activate" new_state="active" trigger="USER" before_script="" after_script="" i18n:attributes="title">
+    <action url="" category="workflow" icon="">Activate</action>
+    <guard>
+      <guard-expression>python:here.guard_activate_transition()</guard-expression>
+      <guard-permission>Modify portal content</guard-permission>
+    </guard>
+  </transition>
+  <!-- /Transition: activate -->
+
+  <!-- Transition: deactivate -->
+  <transition transition_id="deactivate" title="Deactivate" new_state="inactive" trigger="USER" before_script="" after_script="" i18n:attributes="title">
+    <action url="" category="workflow" icon="">Deactivate</action>
+    <guard>
+      <guard-expression>python:here.guard_deactivate_transition()</guard-expression>
+      <guard-permission>Modify portal content</guard-permission>
+    </guard>
+  </transition>
+  <!-- /Transition: deactivate -->
 
   <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
     <description>Previous transition</description>

--- a/bika/lims/subscribers/objectmodified.py
+++ b/bika/lims/subscribers/objectmodified.py
@@ -6,7 +6,6 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 from bika.lims.permissions import ManageLoginDetails
-from bika.lims.permissions import ManageSupplyOrders
 from Products.CMFCore import permissions
 from Products.CMFCore.utils import getToolByName
 
@@ -40,14 +39,6 @@ def ObjectModifiedEventHandler(obj, event):
         # https://github.com/senaite/senaite.core/issues/780
         can_delete = ["Manager", "LabManager", "Owner"]
         mp(permissions.DeleteObjects, can_delete, 0)
-
-    elif obj.portal_type == 'Client':
-        mp = obj.manage_permission
-        mp(permissions.ListFolderContents, ['Manager', 'LabManager', 'LabClerk', 'Analyst', 'Sampler', 'Preserver', 'Owner'], 0)
-        mp(permissions.View, ['Manager', 'LabManager', 'LabClerk',  'Analyst', 'Sampler', 'Preserver', 'Owner'], 0)
-        mp(permissions.ModifyPortalContent, ['Manager', 'LabManager', 'Owner'], 0)
-        mp(ManageSupplyOrders, ['Manager', 'LabManager', 'Owner', 'LabClerk'], 0)
-        mp('Access contents information', ['Manager', 'LabManager', 'Member', 'LabClerk', 'Analyst', 'Sampler', 'Preserver', 'Owner'], 0)
 
     elif obj.portal_type == 'Contact':
         # Contacts need to be given "Owner" local-role on their Client.

--- a/bika/lims/tests/doctests/API.rst
+++ b/bika/lims/tests/doctests/API.rst
@@ -646,12 +646,12 @@ This function returns all assigned workflows for a given object::
     ('bika_one_state_workflow',)
 
     >>> api.get_workflows_for(client)
-    ('bika_client_workflow', 'bika_inactive_workflow')
+    ('bika_client_workflow',)
 
 This function also supports the portal_type as parameter::
 
     >>> api.get_workflows_for(api.get_portal_type(client))
-    ('bika_client_workflow', 'bika_inactive_workflow')
+    ('bika_client_workflow',)
 
 
 Getting the Workflow Status of an Object
@@ -664,7 +664,7 @@ This function returns the state of a given object::
 
 It is also capable to get the state of another state variable::
 
-    >>> api.get_workflow_status_of(client, "inactive_state")
+    >>> api.get_workflow_status_of(client, "review_state")
     'active'
 
 Deactivate the client::
@@ -672,18 +672,15 @@ Deactivate the client::
     >>> api.do_transition_for(client, "deactivate")
     <Client at /plone/clients/client-1>
 
-    >>> api.get_workflow_status_of(client, "inactive_state")
-    'inactive'
-
     >>> api.get_workflow_status_of(client)
-    'active'
+    'inactive'
 
 Reactivate the client::
 
     >>> api.do_transition_for(client, "activate")
     <Client at /plone/clients/client-1>
 
-    >>> api.get_workflow_status_of(client, "inactive_state")
+    >>> api.get_workflow_status_of(client)
     'active'
 
 

--- a/bika/lims/tests/doctests/IDServer.rst
+++ b/bika/lims/tests/doctests/IDServer.rst
@@ -149,7 +149,7 @@ Set up `ID Server` configuration:
     ...             'portal_type': 'SamplePartition',
     ...             'sequence_type': 'counter',
     ...             'value': ''},
-    ...            {'form': 'BÖ-{year}-{seq:04d}',
+    ...            {'form': 'BA-{year}-{seq:04d}',
     ...             'portal_type': 'Batch',
     ...             'prefix': 'batch',
     ...             'sequence_type': 'generated',
@@ -207,6 +207,7 @@ Create a third `AnalysisRequest` with existing sample:
     True
 
 Create a forth `Batch`::
+
     >>> batches = self.portal.batches
     >>> batch = api.create(batches, "Batch", ClientID="RB")
     >>> batch.getId() == "BA-{}-0001".format(year)
@@ -234,7 +235,7 @@ Change ID formats and create new `AnalysisRequest`::
     ...             'portal_type': 'SamplePartition',
     ...             'sequence_type': 'counter',
     ...             'value': ''},
-    ...            {'form': 'BÖ-{year}-{seq:04d}',
+    ...            {'form': 'BA-{year}-{seq:04d}',
     ...             'portal_type': 'Batch',
     ...             'prefix': 'batch',
     ...             'sequence_type': 'generated',

--- a/bika/lims/tests/doctests/Permissions.rst
+++ b/bika/lims/tests/doctests/Permissions.rst
@@ -353,11 +353,11 @@ The `clients` folder follows **no** workflow::
     >>> get_workflows_for(clients)
     ()
 
-A `client` follows the `bika_one_state_workflow` and the
+A `client` follows the `bika_client_workflow` and the
 `bika_inactive_workflow` and has an initial state of `active`::
 
     >>> get_workflows_for(client)
-    ('bika_client_workflow', 'bika_inactive_workflow')
+    ('bika_client_workflow',)
 
     >>> get_workflow_status_of(client)
     'active'
@@ -380,7 +380,7 @@ Exactly these roles have should have a `View` permission::
     ['Authenticated']
 
     >>> get_roles_for_permission("View", client)
-    ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Owner', 'Preserver', 'Sampler']
+    ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Owner', 'Sampler']
 
     >>> get_roles_for_permission("View", contact)
     ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Owner', 'Preserver', 'Sampler']
@@ -391,10 +391,10 @@ Exactly these roles have should have the `Access contents information` permissio
     ['Authenticated']
 
     >>> get_roles_for_permission("Access contents information", client)
-    ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Member', 'Owner', 'Preserver', 'Sampler']
+    ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Owner', 'Sampler']
 
     >>> get_roles_for_permission("Access contents information", contact)
-    ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Member', 'Owner', 'Preserver', 'Sampler']
+    ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Owner', 'Sampler']
 
 Exactly these roles have should have the `List folder contents` permission::
 
@@ -402,10 +402,10 @@ Exactly these roles have should have the `List folder contents` permission::
     ['Authenticated']
 
     >>> get_roles_for_permission("List folder contents", client)
-    ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Owner', 'Preserver', 'Sampler']
+    ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Owner', 'Sampler']
 
     >>> get_roles_for_permission("List folder contents", contact)
-    ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Owner', 'Preserver', 'Sampler']
+    ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Owner', 'Sampler']
 
 Exactly these roles have should have the `Modify portal content` permission::
 
@@ -413,7 +413,7 @@ Exactly these roles have should have the `Modify portal content` permission::
     ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
     >>> get_roles_for_permission("Modify portal content", client)
-    ['LabManager', 'Manager', 'Owner']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
 Exactly these roles have should have the `Delete objects` permission::
 

--- a/bika/lims/upgrade/v01_02_008.py
+++ b/bika/lims/upgrade/v01_02_008.py
@@ -5,14 +5,17 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from Products.AdvancedQuery import Eq
+import time
 
+import transaction
+from Acquisition import aq_base
 from bika.lims import api
 from bika.lims import logger
 from bika.lims import permissions
 from bika.lims.config import PROJECTNAME as product
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
+from Products.AdvancedQuery import Eq
 
 version = '1.2.8'  # Remember version number in metadata.xml and setup.py
 profile = 'profile-{0}:default'.format(product)
@@ -31,14 +34,62 @@ def upgrade(tool):
         return True
 
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
-    setup.runImportStepFromProfile(profile, 'workflow')
-
-    client_contact_permissions_on_batches(portal, ut)
 
     # -------- ADD YOUR STUFF HERE --------
+    setup.runImportStepFromProfile(profile, 'workflow')
+    client_contact_permissions_on_batches(portal, ut)
+
+    # re-apply the permission for the view tabs on clients
+    setup.runImportStepFromProfile(profile, 'typeinfo')
+    # re-apply the permissions from the client workflow + reindex
+    fix_client_permissions(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
+
+
+def get_workflows():
+    """Returns a mapping of id->workflow
+    """
+    wftool = api.get_tool("portal_workflow")
+    wfs = {}
+    for wfid in wftool.objectIds():
+        wf = wftool.getWorkflowById(wfid)
+        if hasattr(aq_base(wf), "updateRoleMappingsFor"):
+            wfs[wfid] = wf
+    return wfs
+
+
+def update_role_mappings(obj, wfs=None, reindex=True):
+    """Update the role mappings of the given object
+    """
+    wftool = api.get_tool("portal_workflow")
+    if wfs is None:
+        wfs = get_workflows()
+    chain = wftool.getChainFor(obj)
+    for wfid in chain:
+        wf = wfs[wfid]
+        wf.updateRoleMappingsFor(obj)
+    if reindex is True:
+        obj.reindexObject(idxs=["allowedRolesAndUsers"])
+    return obj
+
+
+def fix_client_permissions(portal):
+    """Fix client permissions
+    """
+    wfs = get_workflows()
+
+    start = time.time()
+    clients = portal.clients.objectValues()
+    total = len(clients)
+    for num, client in enumerate(clients):
+        logger.info("Fixing permission for client {}/{} ({})"
+                    .format(num, total, client.getName()))
+        update_role_mappings(client, wfs=wfs)
+    end = time.time()
+    logger.info("Fixing client permissions took %.2fs" % float(end-start))
+    transaction.commit()
 
 
 def client_contact_permissions_on_batches(portal, ut):

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -23,7 +23,7 @@ from Products.Archetypes.public import DisplayList
 from Products.Archetypes.interfaces.field import IComputedField
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
-from bika.lims import api as api
+from bika.lims import api
 from bika.lims import logger
 from bika.lims.browser import BrowserView
 from email.MIMEBase import MIMEBase
@@ -143,10 +143,7 @@ def getUsers(context, roles, allow_empty=True):
 def isActive(obj):
     """ Check if obj is inactive or cancelled.
     """
-    # The import is performed here because if placed
-    # at the beginning of the file we get circular imports
-    from bika.lims.workflow import isActive as is_active
-    return is_active(obj)
+    return api.is_active(obj)
 
 
 def formatDateQuery(context, date_id):

--- a/bika/lims/workflow/__init__.py
+++ b/bika/lims/workflow/__init__.py
@@ -329,13 +329,7 @@ def wasTransitionPerformed(instance, transition_id):
 def isActive(instance):
     """Returns True if the object is neither in a cancelled nor inactive state
     """
-    state = getCurrentState(instance, 'cancellation_state')
-    if state == 'cancelled':
-        return False
-    state = getCurrentState(instance, 'inactive_state')
-    if state == 'inactive':
-        return False
-    return True
+    return api.is_active(instance)
 
 
 def getReviewHistoryActionsList(instance):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the explicit permission settings for `Client` objects on modified.
The settings are already set by the Client Workflow here:
https://github.com/senaite/senaite.core/blob/master/bika/lims/profiles/default/workflows/bika_client_workflow/definition.xml

## Current behavior before PR

Permissions set by the handler did not match the managed permissions of the workflow

## Desired behavior after PR is merged

No more explicit permission setting in the modified subscriber.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
