### PR TITLE
Attribute error inside function addReferences in content/instrument.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Changelog
 
 **Fixed**
 
+- #902 Attribute error in function addReferences
 - #898 Cannot view/edit Supplier.  Tabs for different views now visible.
 
 **Security**

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ Changelog
 
 **Fixed**
 
-- #902 Attribute error in function addReferences
+- #902 Attribute error when updating QC results using an import interface
 - #898 Cannot view/edit Supplier.  Tabs for different views now visible.
 
 **Security**

--- a/bika/lims/content/instrument.py
+++ b/bika/lims/content/instrument.py
@@ -720,7 +720,7 @@ class Instrument(ATFolder):
                 # This is a reference analysis attached directly to the
                 # Instrument, we apply the assign state
                 wf.doActionFor(ref_analysis, 'assign')
-            ref_analysis.setInstrument(self.context)
+            ref_analysis.setInstrument(self)
             ref_analysis.reindexObject()
             addedanalyses.append(ref_analysis)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
This is probably a typo: calling self.context inside an ATFolder class 
Linked issue: https://github.com/senaite/senaite.core/issues/902

## Current behavior before PR
Attribute error is raised - line 723, in addReferences ref_analysis.setInstrument(self.context)
## Desired behavior after PR is merged
line 723, in addReferences ref_analysis.setInstrument(self.context) should be ref_analysis.setInstrument(self)
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
