### PR TITLE
Users created through LabContact's Login Details view are added to "Clients" group

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 **Fixed**
 
 - #898 Cannot view/edit Supplier.  Tabs for different views now visible.
+- Do not automatically add LabContact users to the 'Clients' group
 
 **Security**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@ Changelog
 **Fixed**
 
 - #898 Cannot view/edit Supplier.  Tabs for different views now visible.
-- Do not automatically add LabContact users to the 'Clients' group
+- #905 Users created through LabContact's Login Details view are added to "Clients" group
 
 **Security**
 

--- a/bika/lims/content/contact.py
+++ b/bika/lims/content/contact.py
@@ -24,7 +24,7 @@ from plone import api
 from zope.interface import implements
 
 from bika.lims.utils import isActive
-from bika.lims.interfaces import IContact
+from bika.lims.interfaces import IContact, IClient
 from bika.lims.content.person import Person
 from bika.lims.config import PROJECTNAME
 from bika.lims.config import ManageClients
@@ -252,11 +252,11 @@ class Contact(Person):
         # Update the Email address from the user
         self.setEmailAddress(user.getProperty("email"))
 
-        # Grant local Owner role
-        self._addLocalOwnerRole(username)
-
-        # Add user to "Clients" group
-        self._addUserToGroup(username, group="Clients")
+        if IClient.providedBy(self.aq_parent):
+            # Grant local Owner role
+            self._addLocalOwnerRole(username)
+            # Add user to "Clients" group
+            self._addUserToGroup(username, group="Clients")
 
         # somehow the `getUsername` index gets out of sync
         self.reindexObject()

--- a/bika/lims/tests/doctests/ContactUser.rst
+++ b/bika/lims/tests/doctests/ContactUser.rst
@@ -205,6 +205,33 @@ The user can not access the `client` anymore::
     ...
     Unauthorized: ...
 
+LabContact users
+================
+
+All non-client lab users should be created as Lab Contacts in site-setup:
+
+.. code ::
+
+    >>> labcontact = create(portal.bika_setup.bika_labcontacts, "LabContact")
+
+And a new user for the labcontact:
+
+.. code ::
+
+    >>> user3 = ploneapi.user.create(email="labmanager@example.com", username="labmanager1", password="secret", properties=dict(fullname="Lab Manager 1"))
+
+Link the user to the labcontact:
+
+.. code ::
+
+    >>> labcontact.setUser(user3)
+    True
+
+Linking a user to a LabContact does not give any client group membership:
+
+    >>> 'Client' in sorted(ploneapi.user.get_roles(user=user3)) and "Labcontact should not have the Client role!" or False
+    False
+
 
 Login Details View
 ------------------


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/582

## Current behavior before PR

LabContacts are added to Clients group, and given the role of Client.

## Desired behavior after PR is merged

LabContacts will not have Client role immediately after creation.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
