### PR TITLE
DateTime Widget does not display the Time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Changelog
 - #456 Date Published appears two times on the header table of AR view
 - #898 Cannot view/edit Supplier.  Tabs for different views now visible.
 - #905 Users created through LabContact's Login Details view are added to "Clients" group
+- DateTime Widget does not display the Time
 
 **Security**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ Changelog
 - #456 Date Published appears two times on the header table of AR view
 - #898 Cannot view/edit Supplier.  Tabs for different views now visible.
 - #905 Users created through LabContact's Login Details view are added to "Clients" group
-- DateTime Widget does not display the Time
+- #906 DateTime Widget does not display the Time
 
 **Security**
 

--- a/bika/lims/browser/widgets/datetimewidget.py
+++ b/bika/lims/browser/widgets/datetimewidget.py
@@ -25,7 +25,7 @@ class DateTimeWidget(TypesWidget):
 
     def ulocalized_time(self, time, context, request):
         val = ut(time,
-                 long_format=self._properties['show_time'],
+                 long_format=self.show_time,
                  time_only=False,
                  context=context,
                  request=request)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/471

## Current behavior before PR

Time is now shown in any DateTimeWidget, regardless of widget setting show_time=True.

## Desired behavior after PR is merged

Time is shown when schema field sets widget.show_time=True

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
