### PR TITLE
Missing "workflow" import step in upgradestep (required by #901)

### DIFF
--- a/bika/lims/upgrade/v01_02_008.py
+++ b/bika/lims/upgrade/v01_02_008.py
@@ -36,6 +36,7 @@ def upgrade(tool):
 
     # -------- ADD YOUR STUFF HERE --------
 
+    setup.runImportStepFromProfile(profile, 'workflow')
     # Revert upgrade actions performed due to #893 (reverted)
     revert_client_permissions_for_batches(portal)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

"workflow" import step is required by #901 , but was removed in #897 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
