### PR TITLE
Issue #895 List of clients cannot sort by Client ID

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,7 @@ Changelog
 - #898 Cannot view/edit Supplier.  Tabs for different views now visible.
 - #905 Users created through LabContact's Login Details view are added to "Clients" group
 - #906 DateTime Widget does not display the Time
-- List of clients cannot sort by Client ID
+- #909 List of clients cannot sort by Client ID
 
 **Security**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Changelog
 - #898 Cannot view/edit Supplier.  Tabs for different views now visible.
 - #905 Users created through LabContact's Login Details view are added to "Clients" group
 - #906 DateTime Widget does not display the Time
+- List of clients cannot sort by Client ID
 
 **Security**
 

--- a/bika/lims/browser/clientfolder.py
+++ b/bika/lims/browser/clientfolder.py
@@ -59,7 +59,7 @@ class ClientFolderContentsView(BikaListingView):
             ("title", {
                 "title": _("Name"),
                 "index": "sortable_title"},),
-            ("ClientID", {
+            ("getClientID", {
                 "title": _("Client ID")}),
             ("EmailAddress", {
                 "title": _("Email Address")}),
@@ -148,7 +148,7 @@ class ClientFolderContentsView(BikaListingView):
         # render a link to the defined start page
         link_url = "{}/{}".format(item["url"], self.landing_page)
         item["replace"]["title"] = get_link(link_url, item["title"])
-        item["replace"]["ClientID"] = get_link(link_url, item["ClientID"])
+        item["replace"]["getClientID"] = get_link(link_url, item["getClientID"])
         # render an email link
         item["replace"]["EmailAddress"] = get_email_link(item["EmailAddress"])
         # translate True/FALSE values

--- a/bika/lims/browser/clientfolder.py
+++ b/bika/lims/browser/clientfolder.py
@@ -62,26 +62,34 @@ class ClientFolderContentsView(BikaListingView):
             ("getClientID", {
                 "title": _("Client ID")}),
             ("EmailAddress", {
-                "title": _("Email Address")}),
+                "title": _("Email Address"),
+                "sortable": False}),
             ("getCountry", {
                 "toggle": False,
+                "sortable": False,
                 "title": _("Country")}),
             ("getProvince", {
                 "toggle": False,
+                "sortable": False,
                 "title": _("Province")}),
             ("getDistrict", {
                 "toggle": False,
+                "sortable": False,
                 "title": _("District")}),
             ("Phone", {
-                "title": _("Phone")}),
+                "title": _("Phone"),
+                "sortable": False}),
             ("Fax", {
                 "toggle": False,
+                "sortable": False,
                 "title": _("Fax")}),
             ("BulkDiscount", {
                 "toggle": False,
+                "sortable": False,
                 "title": _("Bulk Discount")}),
             ("MemberDiscountApplies", {
                 "toggle": False,
+                "sortable": False,
                 "title": _("Member Discount")}),
         ))
 

--- a/bika/lims/profiles/default/catalog.xml
+++ b/bika/lims/profiles/default/catalog.xml
@@ -16,4 +16,5 @@
  <column value="SamplingRoundUID"/>
  <column value="review_state"/>
  <index name="Identifiers" meta_type="KeywordIndex"/>
+ <column value="getClientID"/>
 </object>

--- a/bika/lims/upgrade/v01_02_008.py
+++ b/bika/lims/upgrade/v01_02_008.py
@@ -36,7 +36,9 @@ def upgrade(tool):
 
     # -------- ADD YOUR STUFF HERE --------
 
+    setup.runImportStepFromProfile(profile, 'catalog')
     setup.runImportStepFromProfile(profile, 'workflow')
+
     # Revert upgrade actions performed due to #893 (reverted)
     revert_client_permissions_for_batches(portal)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/895

## Current behavior before PR

Clients are sorted by TItle when clicking the header of the ClientID column.  Clicking other column headers like "Email Address" causes the same behaviour.

## Desired behavior after PR is merged

Clients are correctly sorted by ClientID when the ClientID column header is clicked.  Non-sortable columns are flagged as such to prevent the list from incorrectly sorting when they are clicked.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
