### PR TITLE
Users without privileges can create reports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,7 @@ Changelog
 - #962 Calculated results not marked for submission if zero
 - #964 Dormant Analysis Services displayed in AR Templates
 - #967 Avoid deepcopy, "Can't pickle acquisition wrappers".
+- #911 Users without privileges can create reports
 
 **Security**
 

--- a/bika/lims/profiles/default/actions.xml
+++ b/bika/lims/profiles/default/actions.xml
@@ -153,7 +153,7 @@
 			<property name="icon_expr"/>
 			<property name="available_expr"/>
 			<property name="permissions">
-				<element value="List portal members"/>
+				<element value="Modify portal content"/>
 			</property>
 			<property name="visible">True</property>
 		</object>

--- a/bika/lims/profiles/default/workflows.xml
+++ b/bika/lims/profiles/default/workflows.xml
@@ -17,6 +17,7 @@
   <object name="bika_referenceanalysis_workflow" meta_type="Workflow"/>
   <object name="bika_referencesample_workflow" meta_type="Workflow"/>
   <object name="bika_reject_analysis_workflow" meta_type="Workflow"/>
+  <object name="bika_report_workflow" meta_type="Workflow"/>
   <object name="bika_sample_workflow" meta_type="Workflow"/>
   <object name="bika_samplinground_workflow" meta_type="Workflow"/>
   <object name="bika_worksheet_workflow" meta_type="Workflow"/>
@@ -411,6 +412,11 @@
     <!-- Reject Analysis -->
     <type type_id="RejectAnalysis">
       <bound-workflow workflow_id="bika_reject_analysis_workflow"/>
+    </type>
+
+    <!-- Reports -->
+    <type type_id="Report">
+      <bound-workflow workflow_id="bika_report_workflow"/>
     </type>
 
     <!-- Samples -->

--- a/bika/lims/profiles/default/workflows/bika_report_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_report_workflow/definition.xml
@@ -40,6 +40,5 @@
       <permission-role>LabManager</permission-role>
     </permission-map>
   </state>
-  <!-- /State: active -->
 
 </dc-workflow>

--- a/bika/lims/profiles/default/workflows/bika_report_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_report_workflow/definition.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<dc-workflow xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+             workflow_id="bika_report_workflow"
+             title="Bika Report Workflow"
+             description=""
+             state_variable="review_state"
+             initial_state="registered"
+             manager_bypass="False"
+             i18n:domain="senaite.core">
+
+  <permission>Delete objects</permission>
+  <permission>Modify portal content</permission>
+  <permission>Add portal content</permission>
+  <permission>View</permission>
+  <permission>Access contents information</permission>
+  <permission>List folder contents</permission>
+
+  <state state_id="registered" title="Registered" i18n:attributes="title">
+    <permission-map name="Delete objects" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify portal content" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+    </permission-map>
+    <permission-map name="Add portal content" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+    </permission-map>
+    <permission-map name="View" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+    </permission-map>
+    <permission-map name="Access contents information" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+    </permission-map>
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+    </permission-map>
+  </state>
+  <!-- /State: active -->
+
+</dc-workflow>

--- a/bika/lims/upgrade/v01_02_008.py
+++ b/bika/lims/upgrade/v01_02_008.py
@@ -43,6 +43,7 @@ def upgrade(tool):
 
     # -------- ADD YOUR STUFF HERE --------
 
+    setup.runImportStepFromProfile(profile, 'actions')
     setup.runImportStepFromProfile(profile, 'catalog')
     setup.runImportStepFromProfile(profile, 'workflow')
 

--- a/bika/lims/upgrade/v01_02_008.py
+++ b/bika/lims/upgrade/v01_02_008.py
@@ -55,6 +55,9 @@ def upgrade(tool):
     # re-apply the permissions from the client workflow + reindex
     fix_client_permissions(portal)
 
+    # Apply restricted perms from bika_report_workflow
+    fix_report_permissions(portal)
+
     fix_items_stuck_in_sample_prep_states(portal, ut)
 
     logger.info("{0} upgraded to version {1}".format(product, version))
@@ -225,3 +228,17 @@ def fix_items_stuck_in_sample_prep_states(portal, ut):
                 fix_ar_sample_workflow(instance)
         logger.info("Removed sample_prep state from {} items in {}."
                     .format(len(brains), catalog_id))
+
+
+def fix_report_permissions(portal):
+    wfs = get_workflows()
+    start = time.time()
+    reports = portal.reports.objectValues()
+    total = len(reports)
+    for num, report in enumerate(reports):
+        logger.info("Fixing permission for report {}/{} ({})"
+                    .format(num, total, report.id))
+        update_role_mappings(report, wfs=wfs)
+    end = time.time()
+    logger.info("Fixing report permissions took %.2fs" % float(end-start))
+    transaction.commit()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/896

## Current behavior before PR

Reports tab is visible and permissions on folder are granted to Member and/or Owner roles.

## Desired behavior after PR is merged

Only Manager and LabManager have access.

A user without permission to any of the top-bar actions, doesn't see a top-bar at all - I think it's nice

I tried to use an expression in the view instead of adding another permission just for this,
but in the end this way just seemed less hacky for something so silly as this.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
