### PR TITLE
Localization of date and time strings in listings

### DIFF
--- a/bika/lims/browser/__init__.py
+++ b/bika/lims/browser/__init__.py
@@ -26,7 +26,7 @@ def strptime(context, value):
     """
     val = ""
     for fmt in ['date_format_long', 'date_format_short']:
-        fmtstr = context.translate(fmt, domain='bika', mapping={})
+        fmtstr = context.translate(fmt, domain='senaite.core', mapping={})
         fmtstr = fmtstr.replace(r"${", '%').replace('}', '')
         try:
             val = _strptime(value, fmtstr)
@@ -85,7 +85,7 @@ def ulocalized_time(time, long_format=None, time_only=None, context=None,
     if time.second() + time.minute() + time.hour() == 0:
         long_format = False
     try:
-        time_str = _ut(time, long_format, time_only, context, 'bika', request)
+        time_str = _ut(time, long_format, time_only, context, 'senaite.core', request)
     except ValueError:
         err_msg = traceback.format_exc() + '\n'
         logger.warn(
@@ -214,8 +214,9 @@ class BrowserView(BaseBrowserView):
         if time_only:
             msgid = 'time_format'
         # get the formatstring
-        formatstring = translate(msgid, domain='bika', mapping={},
-                                 context=self.request)
+        request = self.request
+        formatstring = translate(msgid, domain="senaite.core", context=request)
+
         if formatstring is None or formatstring.startswith(
                 'date_') or formatstring.startswith('time_'):
             self.logger.error("bika/%s/%s could not be translated" %


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the date and time format strings in the base class of the listings

## Current behavior before PR

Date and Time not localized in listings

## Desired behavior after PR is merged

Date and Time localized in listings

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
