### PR TITLE
Update senaite.core.po

### DIFF
--- a/bika/lims/locales/en/LC_MESSAGES/senaite.core.po
+++ b/bika/lims/locales/en/LC_MESSAGES/senaite.core.po
@@ -1,18 +1,20 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: Senaite LIMS 1.3\n"
 "POT-Creation-Date: 2018-07-02 20:01+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"PO-Revision-Date: 2018-07-20 13:43+0200\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"X-Generator: Poedit 1.8.7.1\n"
+"Language: en_GB\n"
 
 #: bika/lims/content/bikasetup.py:804
 msgid " <p>The Bika LIMS ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client</td><td>{client}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, client, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
@@ -241,8 +243,7 @@ msgstr ""
 msgid "Account Type"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:27
-#: bika/lims/content/laboratory.py:82
+#: bika/lims/browser/accreditation.py:27 bika/lims/content/laboratory.py:82
 msgid "Accreditation"
 msgstr ""
 
@@ -293,8 +294,7 @@ msgid "Active"
 msgstr ""
 
 #: bika/lims/browser/sample/printform.py:346
-#: bika/lims/browser/sample/view.py:129
-#: bika/lims/content/sample.py:591
+#: bika/lims/browser/sample/view.py:129 bika/lims/content/sample.py:591
 msgid "Ad-Hoc"
 msgstr ""
 
@@ -396,8 +396,7 @@ msgstr ""
 msgid "Agency"
 msgstr ""
 
-#: bika/lims/browser/accreditation.py:69
-#: bika/lims/browser/analyses/late.py:61
+#: bika/lims/browser/accreditation.py:69 bika/lims/browser/analyses/late.py:61
 #: bika/lims/browser/analyses/view.py:155
 msgid "All"
 msgstr ""
@@ -424,7 +423,7 @@ msgstr ""
 
 #: bika/lims/content/bikasetup.py:179
 msgid "Allow access to worksheets only to assigned analysts"
-msgstr ""
+msgstr "Worksheets access to assigned analysts only"
 
 #: bika/lims/content/abstractbaseanalysis.py:528
 msgid "Allow manual uncertainty value input"
@@ -540,8 +539,7 @@ msgstr ""
 msgid "Analyses which have been retested"
 msgstr ""
 
-#: bika/lims/browser/analyses/late.py:46
-#: bika/lims/browser/analyses/view.py:89
+#: bika/lims/browser/analyses/late.py:46 bika/lims/browser/analyses/view.py:89
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:67
 msgid "Analysis"
 msgstr ""
@@ -562,8 +560,7 @@ msgstr ""
 msgid "Analysis Keyword"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:467
-#: bika/lims/content/artemplate.py:161
+#: bika/lims/content/analysisrequest.py:467 bika/lims/content/artemplate.py:161
 msgid "Analysis Profile"
 msgstr ""
 
@@ -589,7 +586,7 @@ msgstr ""
 
 #: bika/lims/config.py:66
 msgid "Analysis Request Specifications"
-msgstr ""
+msgstr "Analysis Specifications"
 
 #: bika/lims/content/samplinground.py:200
 msgid "Analysis Request Templates"
@@ -643,8 +640,7 @@ msgstr ""
 msgid "Analysis Service"
 msgstr ""
 
-#: bika/lims/config.py:41
-#: bika/lims/controlpanel/bika_analysisservices.py:158
+#: bika/lims/config.py:41 bika/lims/controlpanel/bika_analysisservices.py:158
 msgid "Analysis Services"
 msgstr ""
 
@@ -684,7 +680,7 @@ msgstr ""
 
 #: bika/lims/content/samplinground.py:156
 msgid "Analysis request templates to be included in the Sampling Round Template"
-msgstr ""
+msgstr "Sampling Round Template to be used for creating this Round"
 
 #: bika/lims/browser/analysisrequest/add.py:549
 #: bika/lims/browser/analysisrequest/add2.py:1860
@@ -733,7 +729,7 @@ msgstr ""
 
 #: bika/lims/browser/client/views/analysisspecs.py:117
 msgid "Analysis specifications reset to lab defaults."
-msgstr ""
+msgstr "Analysis specifications reset to lab defaults"
 
 #: bika/lims/content/bikasetup.py:347
 msgid "Analysis specifications which are edited directly on the Analysis Request."
@@ -780,7 +776,7 @@ msgstr ""
 
 #: bika/lims/browser/fields/interimfieldsfield.py:30
 msgid "Apply wide"
-msgstr ""
+msgstr "Apply Worksheet wide"
 
 #: bika/lims/content/instrumentcertification.py:161
 msgid "Approved by"
@@ -960,8 +956,7 @@ msgstr ""
 msgid "Batch ID"
 msgstr ""
 
-#: bika/lims/content/batch.py:130
-#: bika/lims/controlpanel/bika_batchlabels.py:31
+#: bika/lims/content/batch.py:130 bika/lims/controlpanel/bika_batchlabels.py:31
 msgid "Batch Labels"
 msgstr ""
 
@@ -985,8 +980,7 @@ msgstr ""
 msgid "Biannual"
 msgstr ""
 
-#: bika/lims/config.py:90
-#: bika/lims/content/organisation.py:80
+#: bika/lims/config.py:90 bika/lims/content/organisation.py:80
 msgid "Billing address"
 msgstr ""
 
@@ -1008,8 +1002,7 @@ msgstr ""
 msgid "Bulk Discount"
 msgstr ""
 
-#: bika/lims/content/client.py:43
-#: bika/lims/content/pricelist.py:38
+#: bika/lims/content/client.py:43 bika/lims/content/pricelist.py:38
 msgid "Bulk discount applies"
 msgstr ""
 
@@ -1034,8 +1027,7 @@ msgstr ""
 msgid "CC Contacts"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:187
-#: bika/lims/content/client.py:58
+#: bika/lims/content/analysisrequest.py:187 bika/lims/content/client.py:58
 msgid "CC Emails"
 msgstr ""
 
@@ -1052,8 +1044,7 @@ msgid "Calculate Precision from Uncertainties"
 msgstr ""
 
 #: bika/lims/browser/widgets/serviceswidget.py:72
-#: bika/lims/content/analysisservice.py:355
-#: bika/lims/content/method.py:107
+#: bika/lims/content/analysisservice.py:355 bika/lims/content/method.py:107
 msgid "Calculation"
 msgstr ""
 
@@ -1064,7 +1055,7 @@ msgstr ""
 #: bika/lims/content/abstractanalysis.py:130
 #: bika/lims/content/calculation.py:43
 msgid "Calculation Interim Fields"
-msgstr ""
+msgstr "Interim fields used by the Calculation"
 
 #: bika/lims/content/analysisservice.py:356
 msgid "Calculation to be assigned to this content."
@@ -1093,12 +1084,12 @@ msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:67
 msgid "Calibration report date"
-msgstr ""
+msgstr "Certificate date"
 
 #: bika/lims/browser/instrument.py:204
 #: bika/lims/content/instrumentcalibration.py:94
 msgid "Calibrator"
-msgstr ""
+msgstr "Calibration performed by"
 
 #: bika/lims/browser/analyses/view.py:1008
 msgid "Can verify, but submitted by current user"
@@ -1114,8 +1105,7 @@ msgid "Cancel"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/analysisrequests.py:423
-#: bika/lims/browser/arimports.py:95
-#: bika/lims/browser/batchfolder.py:81
+#: bika/lims/browser/arimports.py:95 bika/lims/browser/batchfolder.py:81
 msgid "Cancelled"
 msgstr ""
 
@@ -1188,7 +1178,7 @@ msgstr ""
 #: bika/lims/browser/worksheet/views/results.py:48
 #: bika/lims/skins/bika/validate_integrity.cpy:24
 msgid "Changes saved."
-msgstr ""
+msgstr "Changes saved"
 
 #: bika/lims/content/method.py:121
 msgid "Check if the method has been accredited"
@@ -1200,7 +1190,7 @@ msgstr ""
 
 #: bika/lims/content/samplepoint.py:95
 msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
-msgstr ""
+msgstr "Check this box if the sample is composed from sub-samples, e.g. several surface samples taken at different points on a dam, and poured into the same container, homogenised and analysed. As opposed to a 'Grab' sample which is the standard way most Samples are taken"
 
 #: bika/lims/content/container.py:50
 msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
@@ -1265,8 +1255,7 @@ msgid "Client Batch ID"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:81
-#: bika/lims/browser/clientfolder.py:63
-#: bika/lims/content/arimport.py:91
+#: bika/lims/browser/clientfolder.py:63 bika/lims/content/arimport.py:91
 msgid "Client ID"
 msgstr ""
 
@@ -1283,8 +1272,7 @@ msgid "Client Order"
 msgstr ""
 
 #: bika/lims/browser/batch/batchbook.py:65
-#: bika/lims/content/analysisrequest.py:924
-#: bika/lims/content/arimport.py:99
+#: bika/lims/content/analysisrequest.py:924 bika/lims/content/arimport.py:99
 msgid "Client Order Number"
 msgstr ""
 
@@ -1293,15 +1281,13 @@ msgstr ""
 msgid "Client Ref"
 msgstr ""
 
-#: bika/lims/browser/sample/printform.py:343
-#: bika/lims/config.py:78
+#: bika/lims/browser/sample/printform.py:343 bika/lims/config.py:78
 #: bika/lims/content/analysisrequest.py:959
 msgid "Client Reference"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/analysisrequests.py:157
-#: bika/lims/browser/sample/view.py:110
-#: bika/lims/config.py:79
+#: bika/lims/browser/sample/view.py:110 bika/lims/config.py:79
 msgid "Client SID"
 msgstr ""
 
@@ -1316,7 +1302,7 @@ msgstr ""
 
 #: bika/lims/content/samplinground.py:213
 msgid "Client contact in charge at sampling time"
-msgstr ""
+msgstr "Client Sampling supervisor"
 
 #: bika/lims/browser/client/views/analysisrequests.py:41
 msgid "Client contact required before request may be submitted"
@@ -1324,7 +1310,7 @@ msgstr ""
 
 #: bika/lims/content/samplinground.py:207
 msgid "Client contact who coordinates with the lab"
-msgstr ""
+msgstr "Client contact for the Round"
 
 #: bika/lims/browser/clientfolder.py:35
 msgid "Clients"
@@ -1377,10 +1363,9 @@ msgid "Complete"
 msgstr ""
 
 #: bika/lims/browser/sample/printform.py:345
-#: bika/lims/content/analysisrequest.py:1261
-#: bika/lims/content/artemplate.py:90
+#: bika/lims/content/analysisrequest.py:1261 bika/lims/content/artemplate.py:90
 msgid "Composite"
-msgstr ""
+msgstr "Composite Sample"
 
 #: bika/lims/browser/srtemplate/artemplates.py:55
 msgid "Composite Y/N"
@@ -1434,8 +1419,7 @@ msgstr ""
 msgid "Container Title"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:89
-#: bika/lims/content/container.py:34
+#: bika/lims/content/analysisservice.py:89 bika/lims/content/container.py:34
 #: bika/lims/controlpanel/bika_containers.py:50
 msgid "Container Type"
 msgstr ""
@@ -1490,8 +1474,7 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:68
-#: bika/lims/content/bikasetup.py:231
+#: bika/lims/browser/clientfolder.py:68 bika/lims/content/bikasetup.py:231
 #: bika/lims/skins/bika/bika_widgets/addresswidget.pt:33
 msgid "Country"
 msgstr ""
@@ -1500,13 +1483,11 @@ msgstr ""
 msgid "Create a new User"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:677
-#: bika/lims/content/artemplate.py:72
+#: bika/lims/content/analysisrequest.py:677 bika/lims/content/artemplate.py:72
 msgid "Create a new sample of this type"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:54
-#: bika/lims/browser/instrument.py:386
+#: bika/lims/browser/batchfolder.py:54 bika/lims/browser/instrument.py:386
 #: bika/lims/browser/reports/__init__.py:152
 msgid "Created"
 msgstr ""
@@ -1567,7 +1548,7 @@ msgstr ""
 
 #: bika/lims/content/instrument.py:184
 msgid "Data Interface"
-msgstr ""
+msgstr "Export Interface"
 
 #: bika/lims/content/instrument.py:237
 msgid "Data Interface Options"
@@ -1579,14 +1560,12 @@ msgstr ""
 msgid "Data entry day book"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:50
-#: bika/lims/browser/instrument.py:620
+#: bika/lims/browser/batchfolder.py:50 bika/lims/browser/instrument.py:620
 #: bika/lims/browser/log.py:53
 msgid "Date"
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:86
-#: bika/lims/browser/arimports.py:65
+#: bika/lims/browser/analyses/view.py:86 bika/lims/browser/arimports.py:65
 #: bika/lims/browser/reports/productivity_dataentrydaybook.py:40
 msgid "Date Created"
 msgstr ""
@@ -1596,13 +1575,11 @@ msgstr ""
 msgid "Date Dispatched"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:135
-#: bika/lims/content/sample.py:567
+#: bika/lims/content/referencesample.py:135 bika/lims/content/sample.py:567
 msgid "Date Disposed"
 msgstr ""
 
-#: bika/lims/content/referencesample.py:128
-#: bika/lims/content/sample.py:524
+#: bika/lims/content/referencesample.py:128 bika/lims/content/sample.py:524
 msgid "Date Expired"
 msgstr ""
 
@@ -1672,7 +1649,7 @@ msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:77
 msgid "Date from which the instrument is under calibration"
-msgstr ""
+msgstr "Calibration start date, the instrument will be unavailable until completed"
 
 #: bika/lims/content/instrumentmaintenancetask.py:53
 msgid "Date from which the instrument is under maintenance"
@@ -1680,7 +1657,7 @@ msgstr ""
 
 #: bika/lims/content/instrumentvalidation.py:58
 msgid "Date from which the instrument is under validation"
-msgstr ""
+msgstr "Validation start date. The instrument is disabled hereafter"
 
 #: bika/lims/browser/analysisrequest/analysisrequests_filter_bar.py:44
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:105
@@ -1700,7 +1677,7 @@ msgstr ""
 #: bika/lims/content/instrumentmaintenancetask.py:63
 #: bika/lims/content/instrumentvalidation.py:68
 msgid "Date until the instrument will not be available"
-msgstr ""
+msgstr "Calibration completion date"
 
 #: bika/lims/content/instrumentcertification.py:92
 msgid "Date when the calibration certificate was granted"
@@ -1712,7 +1689,7 @@ msgstr ""
 
 #: bika/lims/content/instrument.py:148
 msgid "De-activate until next calibration test"
-msgstr ""
+msgstr "Deactivate after failing QC"
 
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
 msgid "Deactivate"
@@ -1726,10 +1703,9 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: bika/lims/content/bikasetup.py:358
-#: bika/lims/content/client.py:110
+#: bika/lims/content/bikasetup.py:358 bika/lims/content/client.py:110
 msgid "Default AR Specifications"
-msgstr ""
+msgstr "Default Analysis Specifications"
 
 #: bika/lims/profiles/default/registry.xml
 msgid "Default ARReport Template"
@@ -1779,10 +1755,9 @@ msgstr ""
 
 #: bika/lims/content/bikasetup.py:960
 msgid "Default count of AR to add."
-msgstr ""
+msgstr "Default number of analysis requests to add on the AR create form"
 
-#: bika/lims/content/bikasetup.py:265
-#: bika/lims/content/client.py:119
+#: bika/lims/content/bikasetup.py:265 bika/lims/content/client.py:119
 msgid "Default decimal mark"
 msgstr ""
 
@@ -1808,7 +1783,7 @@ msgstr ""
 
 #: bika/lims/content/bikasetup.py:276
 msgid "Default scientific notation format for reports"
-msgstr ""
+msgstr "Scientific notation report format"
 
 #: bika/lims/content/bikasetup.py:494
 msgid "Default scientific notation format for results"
@@ -1828,11 +1803,11 @@ msgstr ""
 
 #: bika/lims/content/bikasetup.py:961
 msgid "Default value of the 'AR count' when users click 'ADD' button to create new Analysis Requests"
-msgstr ""
+msgstr "Default for 'AR count' on the 'Add' button"
 
 #: bika/lims/content/client.py:111
 msgid "DefaultARSpecs_description"
-msgstr ""
+msgstr "Default AR Specifications"
 
 #: bika/lims/browser/sample/templates/print_form.pt:72
 msgid "Define a date range"
@@ -1854,8 +1829,7 @@ msgstr ""
 msgid "Define the precision when converting values to exponent notation.  The default is 7."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:601
-#: bika/lims/content/sample.py:288
+#: bika/lims/content/analysisrequest.py:601 bika/lims/content/sample.py:288
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
 
@@ -1894,15 +1868,14 @@ msgstr ""
 msgid "Describes the method in layman terms. This information is made available to lab clients"
 msgstr ""
 
-#: bika/lims/adapters/identifiers.py:45
-#: bika/lims/browser/batchfolder.py:49
+#: bika/lims/adapters/identifiers.py:45 bika/lims/browser/batchfolder.py:49
 #: bika/lims/browser/client/views/analysisprofiles.py:44
 msgid "Description"
 msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:117
 msgid "Description of the actions made during the calibration"
-msgstr ""
+msgstr "Further information with regards to the tasks carried out to complete the calibration"
 
 #: bika/lims/content/instrumentmaintenancetask.py:91
 msgid "Description of the actions made during the maintenance process"
@@ -1983,7 +1956,7 @@ msgstr ""
 
 #: bika/lims/content/bikasetup.py:593
 msgid "Display individual sample partitions "
-msgstr ""
+msgstr "Sample partitions"
 
 #: bika/lims/browser/sample/partitions.py:63
 msgid "Disposal Date"
@@ -2010,28 +1983,23 @@ msgstr ""
 msgid "Division by zero"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:623
-#: bika/lims/content/multifile.py:33
+#: bika/lims/browser/instrument.py:623 bika/lims/content/multifile.py:33
 msgid "Document"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:767
-#: bika/lims/content/multifile.py:25
+#: bika/lims/browser/instrument.py:767 bika/lims/content/multifile.py:25
 msgid "Document ID"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:771
-#: bika/lims/content/multifile.py:48
+#: bika/lims/browser/instrument.py:771 bika/lims/content/multifile.py:48
 msgid "Document Location"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:773
-#: bika/lims/content/multifile.py:57
+#: bika/lims/browser/instrument.py:773 bika/lims/content/multifile.py:57
 msgid "Document Type"
 msgstr ""
 
-#: bika/lims/browser/instrument.py:769
-#: bika/lims/content/multifile.py:41
+#: bika/lims/browser/instrument.py:769 bika/lims/content/multifile.py:41
 msgid "Document Version"
 msgstr ""
 
@@ -2063,8 +2031,7 @@ msgstr ""
 msgid "Due"
 msgstr ""
 
-#: bika/lims/browser/analyses/late.py:54
-#: bika/lims/browser/analyses/view.py:142
+#: bika/lims/browser/analyses/late.py:54 bika/lims/browser/analyses/view.py:142
 #: bika/lims/browser/referencesample.py:126
 msgid "Due Date"
 msgstr ""
@@ -2074,8 +2041,7 @@ msgid "Dup Var"
 msgstr ""
 
 #: bika/lims/browser/widgets/reflexrulewidget.py:434
-#: bika/lims/browser/worksheet/views/analyses.py:378
-#: bika/lims/config.py:49
+#: bika/lims/browser/worksheet/views/analyses.py:378 bika/lims/config.py:49
 msgid "Duplicate"
 msgstr ""
 
@@ -2125,11 +2091,11 @@ msgstr ""
 
 #: bika/lims/content/bikasetup.py:659
 msgid "Email notification on AR invalidation"
-msgstr ""
+msgstr "AR invalidation notification email"
 
 #: bika/lims/content/bikasetup.py:895
 msgid "Email notification on rejection"
-msgstr ""
+msgstr "Rejection notification email"
 
 #: bika/lims/content/client.py:73
 msgid "Email subject line"
@@ -2157,7 +2123,7 @@ msgstr ""
 
 #: bika/lims/content/bikasetup.py:906
 msgid "Enable filtering by department"
-msgstr ""
+msgstr "Filter by Laboratory Department"
 
 #: bika/lims/content/bikasetup.py:636
 msgid "Enable sampling rejection"
@@ -2165,14 +2131,13 @@ msgstr ""
 
 #: bika/lims/content/bikasetup.py:560
 msgid "Enable the Results Report Printing workflow"
-msgstr ""
+msgstr "Select to allow users an additional 'Printed' states to Published Analysis Requests. Disabled by default"
 
 #: bika/lims/content/bikasetup.py:883
 msgid "Enable the rejection workflow"
-msgstr ""
+msgstr "Sample rejection"
 
-#: bika/lims/browser/invoicebatch.py:64
-#: bika/lims/browser/invoicefolder.py:38
+#: bika/lims/browser/invoicebatch.py:64 bika/lims/browser/invoicefolder.py:38
 #: bika/lims/browser/pricelist.py:48
 msgid "End Date"
 msgstr ""
@@ -2201,7 +2166,7 @@ msgstr ""
 
 #: bika/lims/content/analysisprofile.py:109
 msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
-msgstr ""
+msgstr " This VAT % percentage is applied on the Analysis Profile only, overriding the system default"
 
 #: bika/lims/content/bikasetup.py:254
 msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
@@ -2250,19 +2215,19 @@ msgstr ""
 
 #: bika/lims/browser/dashboard/dashboard.py:591
 msgid "Evolution of Analyses"
-msgstr ""
+msgstr "Analysis Progress"
 
 #: bika/lims/browser/dashboard/dashboard.py:467
 msgid "Evolution of Analysis Requests"
-msgstr ""
+msgstr "Analysis Request Progress"
 
 #: bika/lims/browser/dashboard/dashboard.py:675
 msgid "Evolution of Samples"
-msgstr ""
+msgstr "Sample progress"
 
 #: bika/lims/browser/dashboard/dashboard.py:522
 msgid "Evolution of Worksheets"
-msgstr ""
+msgstr "Worksheet Progress"
 
 #: bika/lims/browser/analysisrequest/analysisrequests.py:763
 msgid "Exclude from invoice"
@@ -2278,8 +2243,7 @@ msgid "Expected Result"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/analysisrequests.py:184
-#: bika/lims/content/analysisrequest.py:632
-#: bika/lims/content/sample.py:314
+#: bika/lims/content/analysisrequest.py:632 bika/lims/content/sample.py:314
 msgid "Expected Sampling Date"
 msgstr ""
 
@@ -2316,8 +2280,7 @@ msgstr ""
 msgid "Exponential format threshold"
 msgstr ""
 
-#: bika/lims/browser/clientfolder.py:79
-#: bika/lims/browser/supplier.py:70
+#: bika/lims/browser/clientfolder.py:79 bika/lims/browser/supplier.py:70
 #: bika/lims/content/organisation.py:43
 msgid "Fax"
 msgstr ""
@@ -2330,8 +2293,7 @@ msgstr ""
 msgid "Female"
 msgstr ""
 
-#: bika/lims/browser/worksheet/templates/results.pt:114
-#: bika/lims/config.py:31
+#: bika/lims/browser/worksheet/templates/results.pt:114 bika/lims/config.py:31
 msgid "Field"
 msgstr ""
 
@@ -2409,11 +2371,11 @@ msgstr ""
 
 #: bika/lims/content/instrument.py:210
 msgid "Folder that results will be saved"
-msgstr ""
+msgstr "Results Folder"
 
 #: bika/lims/content/instrument.py:215
 msgid "For each interface of this instrument,                       you can define a folder where                       the system should look for the results files while                       automatically importing results. Having a folder                       for each Instrument and inside that folder creating                       different folders for each of its Interfaces                       can be a good approach. You can use Interface codes                       to be sure that folder names are unique."
-msgstr ""
+msgstr "Provide a folder from where the LIMS will automatically import the Instrument's results"
 
 #: bika/lims/content/bikasetup.py:802
 msgid "Formatting Configuration"
@@ -2529,8 +2491,7 @@ msgstr ""
 msgid "ID Server Values"
 msgstr ""
 
-#: bika/lims/controlpanel/bika_idserver.py:65
-#: bika/lims/idserver.py:54
+#: bika/lims/controlpanel/bika_idserver.py:65 bika/lims/idserver.py:54
 msgid "ID Server unavailable"
 msgstr ""
 
@@ -2564,7 +2525,7 @@ msgstr ""
 
 #: bika/lims/content/instrument.py:149
 msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
-msgstr ""
+msgstr "With this feature enabled, the Instrument is taken off-line until its QC results meet reference specifications. All routine Analyses included on the same Worksheet are quarantined and cannot be verified or edited after retraction. I left unchecked, The LIMS QC procedures leave the Instrument available and the routine results in the failed Worksheet manageable"
 
 #: bika/lims/content/bikasetup.py:387
 msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
@@ -2576,11 +2537,11 @@ msgstr ""
 
 #: bika/lims/content/bikasetup.py:399
 msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-msgstr ""
+msgstr "By default, for ISO 17025 compliance, the same user is not allowed to capture and verify results. Small labs, and skeleton staff on night shift, work around this by enabling self-verification, if not temporarily. Only available for users normally authorised to verify results. Full audit trail remains"
 
 #: bika/lims/content/bikasetup.py:947
 msgid "If enabled, the Analyses Lists will display an additional filter bar which allows the user to filter the listed items by some several criteria.Warning: This may affect the listing performance."
-msgstr ""
+msgstr "If enabled, the Analyses Lists will display an additional filter bar which allows the user to filter the listed items by some several criteria. Warning: This may affect the listing performance."
 
 #: bika/lims/content/bikasetup.py:921
 msgid "If enabled, the Analysis Requests Lists will display an additional filter bar which allows the user to filter the listed items by some several criteria.Warning: This may affect the listing performance."
@@ -2596,7 +2557,7 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:571
 msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Analysis Request"
-msgstr ""
+msgstr "If enabled, this analysis and its result will not be displayed in COA reports by default. This setting can be overwritten on Analysis Profiles and Analysis Requests"
 
 #: bika/lims/content/batch.py:221
 msgid "If no Title value is entered, the Batch ID will be used."
@@ -2612,7 +2573,7 @@ msgstr ""
 
 #: bika/lims/content/method.py:108
 msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
-msgstr ""
+msgstr "If required, select a calculation for the the Analysis Services linked to this method. Calculations are configured in the LIMS set-up"
 
 #: bika/lims/content/abstractbaseanalysis.py:38
 msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
@@ -2636,11 +2597,11 @@ msgstr ""
 
 #: bika/lims/content/bikasetup.py:189
 msgid "If unchecked, analysts and lab clerks will be able to manage Worksheets, too. If the users have restricted access only to those worksheets for which they are assigned, this option will be checked and readonly."
-msgstr ""
+msgstr "Alternatively, analysts and lab clerks will be able to manage Worksheets too. This option will be checked and read-only if worksheets access is restricted the assigned analysts only"
 
 #: bika/lims/content/bikasetup.py:180
 msgid "If unchecked, analysts will have access to all worksheets."
-msgstr ""
+msgstr "If unchecked, analysts have access to all worksheets"
 
 #: bika/lims/content/calculation.py:84
 msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
@@ -2675,7 +2636,7 @@ msgstr ""
 
 #: bika/lims/content/instrument.py:162
 msgid "In-lab calibration procedure"
-msgstr ""
+msgstr "Inhouse calibration procedure"
 
 #: bika/lims/controlpanel/bika_subgroups.py:63
 #: bika/lims/profiles/default/workflows/bika_inactive_workflow/definition.xml
@@ -2740,20 +2701,19 @@ msgstr ""
 
 #: bika/lims/content/instrument.py:329
 msgid "InstallationDate"
-msgstr ""
+msgstr "Installation Date"
 
-#: bika/lims/content/samplinground.py:195
-#: bika/lims/content/srtemplate.py:73
+#: bika/lims/content/samplinground.py:195 bika/lims/content/srtemplate.py:73
 msgid "Instructions"
 msgstr ""
 
 #: bika/lims/content/instrument.py:163
 msgid "Instructions for in-lab regular calibration routines intended for analysts"
-msgstr ""
+msgstr "Calibration Instructions for analysts"
 
 #: bika/lims/content/instrument.py:175
 msgid "Instructions for regular preventive and maintenance routines intended for analysts"
-msgstr ""
+msgstr "Regular preventive maintenance procedure instructions for analysts"
 
 #: bika/lims/browser/analyses/view.py:102
 #: bika/lims/browser/referencesample.py:117
@@ -2767,7 +2727,7 @@ msgstr ""
 
 #: bika/lims/browser/instrument.py:749
 msgid "Instrument Files"
-msgstr ""
+msgstr "Additional Instrument Documentation"
 
 #: bika/lims/exportimport/import.pt:30
 msgid "Instrument Import"
@@ -2817,7 +2777,7 @@ msgstr ""
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:45
 msgid "Instrument disposed until new calibration tests being done:"
-msgstr ""
+msgstr "Instrument(s) decommissioned for recalibration after failing QC"
 
 #: bika/lims/browser/worksheet/views/export.py:42
 msgid "Instrument exporter not found"
@@ -2847,8 +2807,7 @@ msgstr ""
 msgid "Instrument's calibration certificate expired:"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:322
-#: bika/lims/content/method.py:57
+#: bika/lims/content/analysisservice.py:322 bika/lims/content/method.py:57
 #: bika/lims/controlpanel/bika_instruments.py:37
 msgid "Instruments"
 msgstr ""
@@ -2883,7 +2842,7 @@ msgstr ""
 
 #: bika/lims/browser/instrument.py:474
 msgid "Internal Calibration Tests"
-msgstr ""
+msgstr "Inhouse QC results"
 
 #: bika/lims/content/instrumentcertification.py:75
 msgid "Internal Certificate"
@@ -2961,7 +2920,7 @@ msgstr ""
 
 #: bika/lims/content/artemplate.py:91
 msgid "It's a composite sample"
-msgstr ""
+msgstr "Check this box if the sample is composed from sub-samples, e.g. several surface samples taken at different points on a dam, and poured into the same container"
 
 #: bika/lims/browser/analyses/workflow.py:41
 #: bika/lims/browser/analysisrequest/workflow.py:369
@@ -3006,8 +2965,7 @@ msgstr ""
 msgid "LIMS Configuration"
 msgstr ""
 
-#: bika/lims/browser/analysisrequest/view.py:262
-#: bika/lims/config.py:32
+#: bika/lims/browser/analysisrequest/view.py:262 bika/lims/config.py:32
 #: bika/lims/content/analysisspec.py:145
 msgid "Lab"
 msgstr ""
@@ -3029,8 +2987,7 @@ msgstr ""
 msgid "Lab Preservation"
 msgstr ""
 
-#: bika/lims/config.py:42
-#: bika/lims/controlpanel/bika_labproducts.py:37
+#: bika/lims/config.py:42 bika/lims/controlpanel/bika_labproducts.py:37
 msgid "Lab Products"
 msgstr ""
 
@@ -3143,7 +3100,7 @@ msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:178
 msgid "Load the certificate document here"
-msgstr ""
+msgstr "Load certificate document here"
 
 #: bika/lims/browser/reports/productivity_analysesattachments.py:62
 msgid "Loaded"
@@ -3165,19 +3122,17 @@ msgstr ""
 msgid "Location Type"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:887
-#: bika/lims/content/sample.py:207
+#: bika/lims/content/analysisrequest.py:887 bika/lims/content/sample.py:207
 msgid "Location where sample is kept"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:845
-#: bika/lims/content/artemplate.py:47
+#: bika/lims/content/analysisrequest.py:845 bika/lims/content/artemplate.py:47
 msgid "Location where sample was taken"
-msgstr ""
+msgstr "Location sampled"
 
 #: bika/lims/content/multifile.py:49
 msgid "Location where the document set is shelved"
-msgstr ""
+msgstr "Document shelf position"
 
 #: bika/lims/browser/log.py:48
 #: bika/lims/browser/templates/analysisservice_popup.pt:246
@@ -3287,7 +3242,7 @@ msgstr ""
 
 #: bika/lims/content/method.py:81
 msgid "Manual entry of results"
-msgstr ""
+msgstr "Manual Results Capture"
 
 #: bika/lims/utils/analysis.py:459
 msgid "Manual entry of results for method %s is not allowed and no valid instruments found: %s"
@@ -3348,8 +3303,7 @@ msgstr ""
 msgid "Member Discount"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1495
-#: bika/lims/content/bikasetup.py:241
+#: bika/lims/content/analysisrequest.py:1495 bika/lims/content/bikasetup.py:241
 msgid "Member discount %"
 msgstr ""
 
@@ -3361,8 +3315,7 @@ msgstr ""
 msgid "Member registered and linked to the current Contact."
 msgstr ""
 
-#: bika/lims/browser/analyses/view.py:98
-#: bika/lims/browser/batch/publish.py:98
+#: bika/lims/browser/analyses/view.py:98 bika/lims/browser/batch/publish.py:98
 #: bika/lims/browser/referencesample.py:113
 msgid "Method"
 msgstr ""
@@ -3389,8 +3342,7 @@ msgstr ""
 msgid "Method: None"
 msgstr ""
 
-#: bika/lims/content/analysisservice.py:295
-#: bika/lims/content/instrument.py:140
+#: bika/lims/content/analysisservice.py:295 bika/lims/content/instrument.py:140
 #: bika/lims/content/methods.py:36
 msgid "Methods"
 msgstr ""
@@ -3507,8 +3459,7 @@ msgid "New"
 msgstr ""
 
 #: bika/lims/browser/analysisservice.py:106
-#: bika/lims/browser/clientfolder.py:155
-#: bika/lims/browser/header_table.py:88
+#: bika/lims/browser/clientfolder.py:155 bika/lims/browser/header_table.py:88
 msgid "No"
 msgstr ""
 
@@ -3645,8 +3596,7 @@ msgid "No valid instruments available: %s "
 msgstr ""
 
 #: bika/lims/browser/analyses/view.py:318
-#: bika/lims/content/analysisservice.py:517
-#: bika/lims/content/bikasetup.py:137
+#: bika/lims/content/analysisservice.py:517 bika/lims/content/bikasetup.py:137
 msgid "None"
 msgstr ""
 
@@ -3758,11 +3708,11 @@ msgstr ""
 #: bika/lims/content/abstractbaseanalysis.py:605
 #: bika/lims/content/bikasetup.py:415
 msgid "Number of required verifications"
-msgstr ""
+msgstr "Number of verifications required"
 
 #: bika/lims/content/bikasetup.py:416
 msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-msgstr ""
+msgstr "Number of verifications before a given result is verified. Some labs require more than one verifiers for verification. The setting can be configured further per individual Analysis Service"
 
 #: bika/lims/content/abstractbaseanalysis.py:606
 msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
@@ -3798,14 +3748,13 @@ msgstr ""
 
 #: bika/lims/content/bikasetup.py:188
 msgid "Only lab managers can create and manage worksheets"
-msgstr ""
+msgstr "Only lab managers may create and manage worksheets"
 
 #: bika/lims/browser/worksheet/templates/results.pt:130
 msgid "Only to empty or zero fields"
 msgstr ""
 
-#: bika/lims/browser/batchfolder.py:60
-#: bika/lims/browser/instrument.py:79
+#: bika/lims/browser/batchfolder.py:60 bika/lims/browser/instrument.py:79
 #: bika/lims/browser/worksheet/views/folder.py:133
 msgid "Open"
 msgstr ""
@@ -3909,8 +3858,7 @@ msgstr ""
 msgid "Password lifetime"
 msgstr ""
 
-#: bika/lims/browser/arimports.py:73
-#: bika/lims/browser/supplyorderfolder.py:58
+#: bika/lims/browser/arimports.py:73 bika/lims/browser/supplyorderfolder.py:58
 #: bika/lims/profiles/default/workflows/bika_order_workflow/definition.xml
 msgid "Pending"
 msgstr ""
@@ -3927,7 +3875,7 @@ msgstr ""
 #: bika/lims/content/instrumentcalibration.py:128
 #: bika/lims/content/instrumentvalidation.py:109
 msgid "Performed by"
-msgstr ""
+msgstr "Supervised by"
 
 #: bika/lims/browser/reports/selection_macros/select_period.pt:5
 #: bika/lims/browser/reports/templates/productivity_analysesperdepartment.pt:93
@@ -3964,15 +3912,14 @@ msgstr ""
 
 #: bika/lims/content/instrument.py:320
 msgid "Photo image file"
-msgstr ""
+msgstr "Photo"
 
 #: bika/lims/content/instrument.py:321
 msgid "Photo of the instrument"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt:85
-#: bika/lims/config.py:88
-#: bika/lims/content/organisation.py:56
+#: bika/lims/config.py:88 bika/lims/content/organisation.py:56
 msgid "Physical address"
 msgstr ""
 
@@ -4018,8 +3965,7 @@ msgstr ""
 msgid "Position"
 msgstr ""
 
-#: bika/lims/content/organisation.py:68
-#: bika/lims/content/person.py:148
+#: bika/lims/content/organisation.py:68 bika/lims/content/person.py:148
 msgid "Postal address"
 msgstr ""
 
@@ -4072,8 +4018,7 @@ msgstr ""
 msgid "Prefixes can not contain spaces."
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:1729
-#: bika/lims/content/sample.py:342
+#: bika/lims/content/analysisrequest.py:1729 bika/lims/content/sample.py:342
 msgid "Preparation Workflow"
 msgstr ""
 
@@ -4257,8 +4202,7 @@ msgstr ""
 msgid "Publication Specification"
 msgstr ""
 
-#: bika/lims/content/contact.py:42
-#: bika/lims/content/labcontact.py:39
+#: bika/lims/content/contact.py:42 bika/lims/content/labcontact.py:39
 msgid "Publication preference"
 msgstr ""
 
@@ -4295,11 +4239,10 @@ msgstr ""
 msgid "QC Analyses"
 msgstr ""
 
-#: bika/lims/browser/analyses/qc.py:28
-#: bika/lims/browser/instrument.py:523
+#: bika/lims/browser/analyses/qc.py:28 bika/lims/browser/instrument.py:523
 #: bika/lims/browser/referencesample.py:108
 msgid "QC Sample ID"
-msgstr ""
+msgstr "QC Analysis ID"
 
 #: bika/lims/browser/reports/templates/qualitycontrol.pt:9
 msgid "Quality Control Reports"
@@ -4491,7 +4434,7 @@ msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:106
 msgid "Remarks to take into account before calibration"
-msgstr ""
+msgstr "Before staring the procedure, please consider these"
 
 #: bika/lims/content/instrumentscheduledtask.py:67
 msgid "Remarks to take into account before performing the task"
@@ -4539,12 +4482,12 @@ msgstr ""
 #: bika/lims/content/instrumentcalibration.py:66
 #: bika/lims/content/instrumentvalidation.py:47
 msgid "Report Date"
-msgstr ""
+msgstr "Certificate date"
 
 #: bika/lims/content/instrumentcalibration.py:144
 #: bika/lims/content/instrumentvalidation.py:126
 msgid "Report ID"
-msgstr ""
+msgstr "Calibration Certificate ID"
 
 #: bika/lims/browser/viewlets/templates/attachments.pt:62
 msgid "Report Option"
@@ -4561,7 +4504,7 @@ msgstr ""
 #: bika/lims/content/instrumentcalibration.py:145
 #: bika/lims/content/instrumentvalidation.py:127
 msgid "Report identification number"
-msgstr ""
+msgstr "Calibration Certificate ID supplied by calibration agency, or from inhouse indexing"
 
 #: bika/lims/browser/reports/templates/administration.pt:97
 msgid "Report of published analysis requests which have not been invoiced"
@@ -4585,7 +4528,7 @@ msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:177
 msgid "Report upload"
-msgstr ""
+msgstr "Certificate upload"
 
 #: bika/lims/browser/reports/__init__.py:134
 msgid "Reports"
@@ -4627,8 +4570,7 @@ msgstr ""
 msgid "Requests"
 msgstr ""
 
-#: bika/lims/browser/templates/login_details.pt:232
-#: bika/lims/config.py:56
+#: bika/lims/browser/templates/login_details.pt:232 bika/lims/config.py:56
 msgid "Required"
 msgstr ""
 
@@ -4650,7 +4592,7 @@ msgstr ""
 
 #: bika/lims/content/worksheettemplate.py:77
 msgid "Restrict the available analysis services and instrumentsto those with the selected method. In order to apply this change to the services list, you should save the change first."
-msgstr ""
+msgstr "Restrict the available analyses and instruments to those for the selected method. NB, to apply this change on this WS' Analyses tab, save the new method first."
 
 #: bika/lims/browser/analyses/view.py:117
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses_not_requested.pt:69
@@ -4672,7 +4614,7 @@ msgstr ""
 
 #: bika/lims/content/instrument.py:214
 msgid "Result files folders"
-msgstr ""
+msgstr "Result files folder"
 
 #: bika/lims/browser/analyses/view.py:942
 msgid "Result in shoulder range"
@@ -4724,8 +4666,7 @@ msgstr ""
 msgid "Results per samplepoint and analysis service"
 msgstr ""
 
-#: bika/lims/content/preservation.py:36
-#: bika/lims/content/sampletype.py:53
+#: bika/lims/content/preservation.py:36 bika/lims/content/sampletype.py:53
 #: bika/lims/controlpanel/bika_sampletypes.py:61
 msgid "Retention Period"
 msgstr ""
@@ -4845,8 +4786,7 @@ msgstr ""
 msgid "Sample Points"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:710
-#: bika/lims/content/sample.py:624
+#: bika/lims/content/analysisrequest.py:710 bika/lims/content/sample.py:624
 msgid "Sample Rejection"
 msgstr ""
 
@@ -4942,7 +4882,7 @@ msgstr ""
 
 #: bika/lims/content/analysisrequest.py:1223
 msgid "Sampled AdHoc"
-msgstr ""
+msgstr "Ad Hoc Sample"
 
 #: bika/lims/browser/analysisrequest/analysisrequests.py:196
 #: bika/lims/browser/sample/view.py:145
@@ -4951,8 +4891,7 @@ msgid "Sampler"
 msgstr ""
 
 #: bika/lims/browser/sample/view.py:148
-#: bika/lims/content/analysisrequest.py:604
-#: bika/lims/content/sample.py:291
+#: bika/lims/content/analysisrequest.py:604 bika/lims/content/sample.py:291
 msgid "Sampler for scheduled sampling"
 msgstr ""
 
@@ -4967,8 +4906,7 @@ msgid "Samples"
 msgstr ""
 
 #: bika/lims/content/referencedefinition.py:57
-#: bika/lims/content/referencesample.py:61
-#: bika/lims/content/sampletype.py:63
+#: bika/lims/content/referencesample.py:61 bika/lims/content/sampletype.py:63
 msgid "Samples of this type should be treated as hazardous"
 msgstr ""
 
@@ -5029,8 +4967,7 @@ msgstr ""
 msgid "Sampling Deviations"
 msgstr ""
 
-#: bika/lims/content/samplepoint.py:70
-#: bika/lims/content/srtemplate.py:61
+#: bika/lims/content/samplepoint.py:70 bika/lims/content/srtemplate.py:61
 msgid "Sampling Frequency"
 msgstr ""
 
@@ -5057,7 +4994,7 @@ msgstr ""
 
 #: bika/lims/content/samplinground.py:155
 msgid "Sampling Rounds Template"
-msgstr ""
+msgstr "Sampling Round Template"
 
 #: bika/lims/content/samplinground.py:183
 msgid "Sampling date"
@@ -5165,11 +5102,11 @@ msgstr ""
 
 #: bika/lims/content/instrument.py:185
 msgid "Select an Export interface for this instrument."
-msgstr ""
+msgstr "Select a LIMS export interface to be used to format Worksheet exports for the instrument before analysis starts"
 
 #: bika/lims/content/instrument.py:198
 msgid "Select an Import interface for this instrument."
-msgstr ""
+msgstr "Select the interface to use for importing analysis results from the instrument"
 
 #: bika/lims/content/artemplate.py:180
 msgid "Select analyses to include in this template"
@@ -5259,11 +5196,11 @@ msgstr ""
 
 #: bika/lims/content/bikasetup.py:660
 msgid "Select this to activate automatic notifications via email to the Client and Lab Managers when an Analysis Request is invalidated."
-msgstr ""
+msgstr "Automatic notifications by email to lab managers and client contacts when an analysis request is invalidated"
 
 #: bika/lims/content/bikasetup.py:649
 msgid "Select this to activate automatic notifications via email to the Client when a Sample or Analysis Request is rejected."
-msgstr ""
+msgstr "Activate automatic notifications by email to the Client when a Sample or Analysis Request is rejected"
 
 #: bika/lims/content/bikasetup.py:533
 msgid "Select this to activate the dashboard as a default front page."
@@ -5271,7 +5208,7 @@ msgstr ""
 
 #: bika/lims/content/bikasetup.py:637
 msgid "Select this to activate the rejection workflow for Samples and Analysis Requests. A 'Reject' option will be displayed in the actions menu for these objects."
-msgstr ""
+msgstr "Select to activate the sample rejection workflow. A 'Reject' option is displayed in the actions menu for samples and analysis requests"
 
 #: bika/lims/content/bikasetup.py:573
 msgid "Select this to activate the sample collection workflow steps."
@@ -5283,7 +5220,7 @@ msgstr ""
 
 #: bika/lims/content/bikasetup.py:561
 msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests tha have been Published. Disabled by default."
-msgstr ""
+msgstr "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default"
 
 #: bika/lims/content/worksheettemplate.py:60
 msgid "Select which Analyses should be included on the Worksheet"
@@ -5348,8 +5285,7 @@ msgstr ""
 msgid "Set result"
 msgstr ""
 
-#: bika/lims/content/analysisrequest.py:711
-#: bika/lims/content/sample.py:625
+#: bika/lims/content/analysisrequest.py:711 bika/lims/content/sample.py:625
 msgid "Set the Sample Rejection workflow and the reasons"
 msgstr ""
 
@@ -5419,7 +5355,7 @@ msgstr ""
 
 #: bika/lims/browser/dashboard/templates/dashboard.pt:545
 msgid "Show/hide timeline summary"
-msgstr ""
+msgstr "Show/hide timeline"
 
 #: bika/lims/content/labcontact.py:44
 msgid "Signature"
@@ -5450,11 +5386,10 @@ msgstr ""
 #: bika/lims/browser/analysisrequest/manage_results.py:86
 #: bika/lims/browser/worksheet/views/results.py:151
 msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
-msgstr ""
+msgstr "Some results were captured on an Instrument that failed QC on the same worksheet, and cannot be verified. Please retract after the Instrument was restored, and retest"
 
 #: bika/lims/content/abstractbaseanalysis.py:51
-#: bika/lims/content/analysiscategory.py:51
-#: bika/lims/content/subgroup.py:22
+#: bika/lims/content/analysiscategory.py:51 bika/lims/content/subgroup.py:22
 msgid "Sort Key"
 msgstr ""
 
@@ -5474,8 +5409,7 @@ msgstr ""
 msgid "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 +- 0.5. You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2% - a result of 100 will be reported as 100 +- 2. Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30 .00 etc."
 msgstr ""
 
-#: bika/lims/browser/invoicebatch.py:60
-#: bika/lims/browser/invoicefolder.py:37
+#: bika/lims/browser/invoicebatch.py:60 bika/lims/browser/invoicefolder.py:37
 #: bika/lims/browser/pricelist.py:45
 msgid "Start Date"
 msgstr ""
@@ -5485,8 +5419,7 @@ msgid "Start date must be before End Date"
 msgstr ""
 
 #: bika/lims/browser/analysisrequest/analysisrequests.py:235
-#: bika/lims/browser/arimports.py:69
-#: bika/lims/browser/batch/batchbook.py:74
+#: bika/lims/browser/arimports.py:69 bika/lims/browser/batch/batchbook.py:74
 msgid "State"
 msgstr ""
 
@@ -5526,8 +5459,7 @@ msgstr ""
 msgid "Subgroups are sorted with this key in group views"
 msgstr ""
 
-#: bika/lims/browser/batch/batchbook.py:251
-#: bika/lims/exportimport/import.pt:66
+#: bika/lims/browser/batch/batchbook.py:251 bika/lims/exportimport/import.pt:66
 #: bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
 msgid "Submit"
 msgstr ""
@@ -5558,8 +5490,7 @@ msgstr ""
 msgid "Supervisor of the Lab"
 msgstr ""
 
-#: bika/lims/browser/referencesample.py:293
-#: bika/lims/content/instrument.py:98
+#: bika/lims/browser/referencesample.py:293 bika/lims/content/instrument.py:98
 msgid "Supplier"
 msgstr ""
 
@@ -5649,11 +5580,11 @@ msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:119
 msgid "The Lower Detection Limit is the lowest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are less than this value will be reported as < LDL"
-msgstr ""
+msgstr "The Lower Detection Limit is the lowest value to which the result can be measured using the specified method. Results captured smaller than this value are reported as < LDL"
 
 #: bika/lims/content/abstractbaseanalysis.py:137
 msgid "The Upper Detection Limit is the highest value to which the measured parameter can be measured using the specified testing methodology. Results entered which are greater than this value will be reported as > UDL"
-msgstr ""
+msgstr "Ditto results captured greater than this value, reported as > UDL"
 
 #: bika/lims/content/laboratory.py:83
 msgid "The accreditation standard that applies, e.g. ISO 17025"
@@ -5665,7 +5596,7 @@ msgstr ""
 
 #: bika/lims/content/instrumentcalibration.py:95
 msgid "The analyst or agent responsible of the calibration"
-msgstr ""
+msgstr "The analyst or calibration agency responsible"
 
 #: bika/lims/content/instrumentmaintenancetask.py:71
 msgid "The analyst or agent responsible of the maintenance"
@@ -5726,7 +5657,7 @@ msgstr ""
 
 #: bika/lims/content/samplinground.py:184
 msgid "The date to do the sampling process"
-msgstr ""
+msgstr "Proposed date for Sampling"
 
 #: bika/lims/content/analysisrequest.py:1440
 msgid "The date when the request was published"
@@ -5799,17 +5730,16 @@ msgstr ""
 
 #: bika/lims/content/samplinground.py:170
 msgid "The lab department responsible for the sampling round"
-msgstr ""
+msgstr "Responsible laboratory department"
 
 #: bika/lims/browser/accreditation.py:57
 msgid "The lab is not accredited, or accreditation has not been configured. "
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:451
-#: bika/lims/content/analysiscategory.py:44
-#: bika/lims/content/srtemplate.py:50
+#: bika/lims/content/analysiscategory.py:44 bika/lims/content/srtemplate.py:50
 msgid "The laboratory department"
-msgstr ""
+msgstr "The laboratory department responsible for this Analysis Service"
 
 #: bika/lims/content/labcontact.py:61
 msgid "The laboratory departments"
@@ -5855,8 +5785,7 @@ msgstr ""
 msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
 msgstr ""
 
-#: bika/lims/content/samplinground.py:177
-#: bika/lims/content/srtemplate.py:62
+#: bika/lims/content/samplinground.py:177 bika/lims/content/srtemplate.py:62
 msgid "The number of days between recurring field trips"
 msgstr ""
 
@@ -5883,7 +5812,7 @@ msgstr ""
 #: bika/lims/content/instrumentcalibration.py:129
 #: bika/lims/content/instrumentvalidation.py:110
 msgid "The person at the supplier who performed the task"
-msgstr ""
+msgstr "The lab manager supervising and approving the calibration"
 
 #: bika/lims/content/instrumentcertification.py:142
 msgid "The person at the supplier who prepared the certificate"
@@ -5923,7 +5852,7 @@ msgstr ""
 
 #: bika/lims/content/method.py:82
 msgid "The results for the Analysis Services that use this method can be set manually"
-msgstr ""
+msgstr "Analysis Results may be captured manually for this Method"
 
 #: bika/lims/content/abstractbaseanalysis.py:380
 msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
@@ -6031,7 +5960,7 @@ msgstr ""
 
 #: bika/lims/content/samplinground.py:150
 msgid "This text is also displayed upon a mouse-over of the Title field"
-msgstr ""
+msgstr "The Description is displayed upon a mouse-over of the Sampling Round title"
 
 #: bika/lims/content/bikasetup.py:328
 msgid "This text will be appended to results reports."
@@ -6057,8 +5986,7 @@ msgstr ""
 msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
 msgstr ""
 
-#: bika/lims/browser/arimports.py:62
-#: bika/lims/browser/batchfolder.py:45
+#: bika/lims/browser/arimports.py:62 bika/lims/browser/batchfolder.py:45
 #: bika/lims/browser/bika_listing.py:451
 msgid "Title"
 msgstr ""
@@ -6152,8 +6080,7 @@ msgstr ""
 msgid "Total data points"
 msgstr ""
 
-#: bika/lims/content/analysisprofile.py:128
-#: bika/lims/content/labproduct.py:52
+#: bika/lims/content/analysisprofile.py:128 bika/lims/content/labproduct.py:52
 msgid "Total price"
 msgstr ""
 
@@ -6175,7 +6102,7 @@ msgstr ""
 
 #: bika/lims/content/bikasetup.py:594
 msgid "Turn this on if you want to work with sample partitions"
-msgstr ""
+msgstr "Enable sample partition functionality"
 
 #: bika/lims/browser/reports/productivity_analysestats_overtime.py:131
 msgid "Turnaround time (h)"
@@ -6193,7 +6120,7 @@ msgstr ""
 
 #: bika/lims/content/multifile.py:58
 msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
-msgstr ""
+msgstr "Document type,  Manual, Specifications, Image, etc."
 
 #: bika/lims/content/storagelocation.py:67
 msgid "Type of location"
@@ -6345,8 +6272,7 @@ msgid "VAT"
 msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:435
-#: bika/lims/content/analysisprofile.py:108
-#: bika/lims/content/bikasetup.py:253
+#: bika/lims/content/analysisprofile.py:108 bika/lims/content/bikasetup.py:253
 msgid "VAT %"
 msgstr ""
 
@@ -6550,7 +6476,7 @@ msgstr ""
 
 #: bika/lims/content/instrumentvalidation.py:48
 msgid "Validation report date"
-msgstr ""
+msgstr "Certificate date"
 
 #: bika/lims/browser/instrument.py:300
 #: bika/lims/content/instrumentvalidation.py:75
@@ -6558,8 +6484,7 @@ msgid "Validator"
 msgstr ""
 
 #: bika/lims/browser/worksheet/templates/results.pt:125
-#: bika/lims/content/calculation.py:122
-#: bika/lims/content/instrument.py:234
+#: bika/lims/content/calculation.py:122 bika/lims/content/instrument.py:234
 msgid "Value"
 msgstr ""
 
@@ -6608,7 +6533,7 @@ msgstr ""
 
 #: bika/lims/content/supplier.py:37
 msgid "Website."
-msgstr ""
+msgstr "Website"
 
 #: bika/lims/browser/dashboard/templates/dashboard.pt:559
 msgid "Weekly"
@@ -6620,11 +6545,11 @@ msgstr ""
 
 #: bika/lims/content/bikasetup.py:907
 msgid "When enabled, only those items belonging to the same department as the logged user will be displayed. Since a user can belong to more than one department, a department filtering portlet will be displayed too. By default, disabled."
-msgstr ""
+msgstr "Display data objects belonging to the user's laboratory department only. Users belonging to more than one, may select departments from an on-screen portlet"
 
 #: bika/lims/content/analysisprofile.py:88
 msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
-msgstr ""
+msgstr "When set, the system uses the Profile price and default VAT % may be edited"
 
 #: bika/lims/content/abstractbaseanalysis.py:346
 msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
@@ -6638,15 +6563,14 @@ msgstr ""
 #: bika/lims/content/instrumentmaintenancetask.py:90
 #: bika/lims/content/instrumentvalidation.py:97
 msgid "Work Performed"
-msgstr ""
+msgstr "Tasks performed"
 
 #: bika/lims/browser/reports/templates/administration_usershistory.pt:73
 msgid "Workflow"
 msgstr ""
 
 #: bika/lims/browser/aggregatedanalyses/aggregatedanalyses.py:56
-#: bika/lims/browser/analyses/qc.py:30
-#: bika/lims/browser/referencesample.py:111
+#: bika/lims/browser/analyses/qc.py:30 bika/lims/browser/referencesample.py:111
 msgid "Worksheet"
 msgstr ""
 
@@ -6673,8 +6597,7 @@ msgid "Yearly"
 msgstr ""
 
 #: bika/lims/browser/analysisservice.py:106
-#: bika/lims/browser/clientfolder.py:155
-#: bika/lims/browser/header_table.py:88
+#: bika/lims/browser/clientfolder.py:155 bika/lims/browser/header_table.py:88
 msgid "Yes"
 msgstr ""
 
@@ -6742,7 +6665,7 @@ msgstr ""
 #. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
 #. In english speaking countries default is:
 #. ${b} ${d}, ${Y} ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
+#: TranslationServiceTool.py
 msgid "date_format_long"
 msgstr ""
 
@@ -6753,7 +6676,7 @@ msgstr ""
 #. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
 #. In english speaking countries default is:
 #. ${b} ${d}, ${Y}
-#: ./TranslationServiceTool.py
+#: TranslationServiceTool.py
 msgid "date_format_short"
 msgstr ""
 
@@ -6832,7 +6755,7 @@ msgstr ""
 #. For example: "${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}"
 #. In english speaking countries default is:
 #. ${I}:${M} ${p}
-#: ./TranslationServiceTool.py
+#: TranslationServiceTool.py
 msgid "time_format"
 msgstr ""
 


### PR DESCRIPTION
Capitilisation was kept to be the same as the text's context. We could define a standard, will cause many changes, left too late already.

Speccing tags and descriptions for coders beforehand can also reduce  changes

## Description of the issue/feature this PR addresses

Linked issue/discussion: https://community.senaite.org/t/improving-english-strings-and-its-consequences-to-translations/36/8

## Current behavior before PR

Many field tags and descriptions are somewhat confusing or sub pro

## Desired behavior after PR is merged

The strings updated herewith to display

--
I did not  test this PR according to [PEP8][1], and [Plone's Python styleguide][2] standards, assumed the file complied already

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
