### PR TITLE
Missing interim fields in worksheet/analyses_transposed view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Changelog
 - #905 Users created through LabContact's Login Details view are added to "Clients" group
 - #906 DateTime Widget does not display the Time
 - #909 List of clients cannot sort by Client ID
+- #921 Missing interim fields in worksheet/analyses_transposed view
 
 **Security**
 

--- a/bika/lims/browser/worksheet/templates/analyses_transposed_cell.pt
+++ b/bika/lims/browser/worksheet/templates/analyses_transposed_cell.pt
@@ -101,8 +101,8 @@
 
             <!-- Calculated result -->
             <tal:calculated_result
-                condition="python:item.get('interim_fields', {})">
-                <tal:interim repeat="interim python:item.get('interim_fields',{})">
+                condition="python:item.get('interimfields', {})">
+                <tal:interim repeat="interim python:item.get('interimfields',{})">
                 <div class='interim'>
                     <div tal:content="interim/title" class='interim-title'></div>
                     <tal:edit condition="python:allow_edit">
@@ -149,7 +149,7 @@
                         uid item/uid;
                         objectId string:${item/id};
                         size input_width;"
-                    tal:content="structure python:item['formatted_result']"/>
+                    tal:content="structure python:item.get('formatted_result', '')"/>
                 <input
                     type="hidden"
                     tal:attributes="
@@ -165,7 +165,7 @@
 
             <!-- Regular result -->
             <tal:regular_result
-                condition="python:not item.get('interim_fields', {})">
+                condition="python:not item.get('interimfields', {})">
                 <tal:edit condition="python:allow_edit">
                     <!-- String result -->
                     <input


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Interim fields from calculations are not appearing in worksheet/analsyes_transposed view, and so the worksheet can't complete.

## Desired behavior after PR is merged

Fixed a typo in the template; now interim fields are displayed and results are calculated.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
