### PR TITLE
Added ExtProxyField for its use in SchemaExtender

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #924 Added ExtProxyField for its use in SchemaExtender
 
 **Changed**
 

--- a/bika/lims/browser/fields/proxyfield.py
+++ b/bika/lims/browser/fields/proxyfield.py
@@ -14,6 +14,7 @@ from AccessControl import ClassSecurityInfo
 from Products.Archetypes.Field import ObjectField
 from Products.Archetypes.Registry import registerField
 
+from bika.lims.fields import ExtensionField
 from bika.lims.interfaces import IProxyField
 from bika.lims import logger
 
@@ -122,3 +123,7 @@ registerField(
     title='Proxy',
     description=('Used to proxy a value to a similar field on another object.')
 )
+
+
+class ExtProxyField(ExtensionField, ProxyField):
+    """An Extended Proxy Field for its use in SchemaExtender"""


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

ProxyField does not work properly when used in SchemaExtender.

## Current behavior before PR

Cannot use ProxyField in SchemaExtender

## Desired behavior after PR is merged

Can use ProxyField in SchemaExtender

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
