### PR TITLE
Removed remarks.zcml

### DIFF
--- a/bika/lims/browser/configure.zcml
+++ b/bika/lims/browser/configure.zcml
@@ -27,7 +27,6 @@
   <include file="manufacturer.zcml"/>
   <include file="menu.zcml"/>
   <include file="methodfolder.zcml"/>
-  <include file="remarks.zcml"/>
   <include file="referenceanalysis.zcml"/>
   <include file="referencesample.zcml"/>
   <include file="pricelist.zcml"/>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This line was removed as of #920 and came accidently in again as of #913.

No changelog for this needed.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
