### PR TITLE
Refactored AnalysisSpecs Listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Changelog
 
 **Changed**
 
+- #931 Refactored AnalysisSpecs Listing
 - #919 Refactored Profiles Listing
 - #915 Refactored SamplePoints Listing
 - #914 Refactored Sampletypes Listing

--- a/bika/lims/controlpanel/bika_analysisspecs.py
+++ b/bika/lims/controlpanel/bika_analysisspecs.py
@@ -68,9 +68,7 @@ class AnalysisSpecsView(BikaListingView):
                 "index": "sortable_title"}),
             ("SampleType", {
                 "title": _("Sample Type"),
-                "index": "getSampleTypeTitle",
-                "attr": "getSampleType.Title",
-                "replace_url": "getSampleType.absolute_url"}),
+                "index": "getSampleTypeTitle"}),
         ))
 
         self.review_states = [

--- a/bika/lims/controlpanel/bika_analysisspecs.py
+++ b/bika/lims/controlpanel/bika_analysisspecs.py
@@ -5,76 +5,131 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from AccessControl import ClassSecurityInfo
-from Products.ATContentTypes.content import schemata
-from Products.Archetypes import atapi
-from Products.CMFCore import permissions
-from Products.CMFCore.utils import getToolByName
+import collections
+
+from bika.lims import api
+from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.config import PROJECTNAME
-from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t
-from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.folder.folder import ATFolder, ATFolderSchema
 from bika.lims.interfaces import IAnalysisSpecs
-from zope.interface.declarations import implements
+from bika.lims.utils import get_link
+from plone.app.content.browser.interfaces import IFolderContentsView
+from plone.app.folder.folder import ATFolder
+from plone.app.folder.folder import ATFolderSchema
 from plone.app.layout.globals.interfaces import IViewView
+from Products.Archetypes import atapi
+from Products.ATContentTypes.content import schemata
+from zope.interface.declarations import implements
+
+
+# TODO: Separate content and view into own modules!
+
 
 class AnalysisSpecsView(BikaListingView):
     implements(IFolderContentsView, IViewView)
 
     def __init__(self, context, request):
         super(AnalysisSpecsView, self).__init__(context, request)
-        self.catalog = 'bika_setup_catalog'
-        self.contentFilter = {'portal_type': 'AnalysisSpec',
-                              'path': {'query':"/".join(self.context.getPhysicalPath()),
-                                       'level':0}}
-        self.sort_on = 'Title'
-        self.context_actions = {_('Add'):
-                                {'url': 'createObject?type_name=AnalysisSpec',
-                                 'icon': '++resource++bika.lims.images/add.png'}}
-        self.icon = self.portal_url + "/++resource++bika.lims.images/analysisspec_big.png"
+
+        self.catalog = "bika_setup_catalog"
+
+        self.contentFilter = {
+            "portal_type": "AnalysisSpec",
+            "sort_on": "sortable_title",
+            "sort_order": "ascending",
+            "path": {
+                "query": api.get_path(context),
+                "level": 0}
+        }
+
+        self.context_actions = {
+            _("Add"): {
+                "url": "createObject?type_name=AnalysisSpec",
+                "permission": "Add portal content",
+                "icon": "++resource++bika.lims.images/add.png"}
+        }
+
         self.title = self.context.translate(_("Analysis Specifications"))
         self.description = self.context.translate(_(
             "Set up the laboratory analysis service results specifications"))
+        self.icon = "{}/{}".format(
+            self.portal_url,
+            "/++resource++bika.lims.images/analysisspec_big.png"
+        )
+
         self.show_sort_column = False
         self.show_select_row = False
         self.show_select_column = True
         self.pagesize = 25
 
-        self.columns = {
-            'Title': {'title': _('Title'),
-                      'index': 'title',
-                      'replace_url': 'absolute_url'},
-            'SampleType': {'title': _('Sample Type'),
-                           'index': 'getSampleTypeTitle',
-                           'attr': 'getSampleType.Title',
-                           'replace_url': 'getSampleType.absolute_url'},
-        }
+        self.columns = collections.OrderedDict((
+            ("Title", {
+                "title": _("Analysis Specification"),
+                "index": "sortable_title"}),
+            ("SampleType", {
+                "title": _("Sample Type"),
+                "index": "getSampleTypeTitle",
+                "attr": "getSampleType.Title",
+                "replace_url": "getSampleType.absolute_url"}),
+        ))
 
         self.review_states = [
-            {'id':'default',
-             'title': _('Active'),
-             'contentFilter': {'inactive_state': 'active'},
-             'transitions': [{'id':'deactivate'}, ],
-             'columns': ['Title', 'SampleType']},
-            {'id':'inactive',
-             'title': _('Dormant'),
-             'contentFilter': {'inactive_state': 'inactive'},
-             'transitions': [{'id':'activate'}, ],
-             'columns': ['Title', 'SampleType']},
-            {'id':'all',
-             'title': _('All'),
-             'contentFilter':{},
-             'columns': ['Title', 'SampleType']},
+            {
+                "id": "default",
+                "title": _("Active"),
+                "contentFilter": {"inactive_state": "active"},
+                "transitions": [{"id": "deactivate"}, ],
+                "columns": self.columns,
+            }, {
+                "id": "inactive",
+                "title": _("Dormant"),
+                "contentFilter": {"inactive_state": "inactive"},
+                "transitions": [{"id": "activate"}, ],
+                "columns": self.columns,
+            }, {
+                "id": "all",
+                "title": _("All"),
+                "contentFilter": {},
+                "columns": self.columns,
+            },
         ]
+
+    def before_render(self):
+        """Before template render hook
+        """
+        # Don't allow any context actions
+        self.request.set("disable_border", 1)
+
+    def folderitem(self, obj, item, index):
+        """Service triggered each time an item is iterated in folderitems.
+        The use of this service prevents the extra-loops in child objects.
+        :obj: the instance of the class to be foldered
+        :item: dict containing the properties of the object to be used by
+            the template
+        :index: current index of the item
+        """
+        title = obj.Title()
+        url = obj.absolute_url()
+
+        item["replace"]["Title"] = get_link(url, value=title)
+
+        sampletype = obj.getSampleType()
+        if sampletype:
+            title = sampletype.Title()
+            url = sampletype.absolute_url()
+            item["replace"]["SampleType"] = get_link(url, value=title)
+
+        return item
 
 
 schema = ATFolderSchema.copy()
+
+
 class AnalysisSpecs(ATFolder):
     implements(IAnalysisSpecs)
     displayContentsTab = False
     schema = schema
 
-schemata.finalizeATCTSchema(schema, folderish = True, moveDiscussion = False)
+
+schemata.finalizeATCTSchema(schema, folderish=True, moveDiscussion=False)
 atapi.registerType(AnalysisSpecs, PROJECTNAME)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR refactors the Analysisspecification listing view.

## Current behavior before PR

- Editable border is displayed
- old-style `folderitems` method used
- sort_on and sort_order are missing in filter

## Desired behavior after PR is merged

- Editable border is hidden
- Sort order is *ascending*
- new-style `folderitem` method used
- PEP8 + some minor improvements
- sort_on and sort_order in catalog query

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
