### PR TITLE
Refactored Calculation Listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Changelog
 
 **Changed**
 
+- #932 Refactored Calculation Listing
 - #916 Refactored Instruments Listing
 - #919 Refactored Profiles Listing
 - #915 Refactored SamplePoints Listing

--- a/bika/lims/controlpanel/bika_calculations.py
+++ b/bika/lims/controlpanel/bika_calculations.py
@@ -5,93 +5,123 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from AccessControl import ClassSecurityInfo
-from Products.ATContentTypes.content import schemata
-from Products.Archetypes import atapi
-from Products.Archetypes.ArchetypeTool import registerType
-from Products.CMFCore import permissions
-from Products.CMFCore.utils import getToolByName
-from bika.lims.browser import BrowserView
+import collections
+
+from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.config import PROJECTNAME
-from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t
-from plone.app.layout.globals.interfaces import IViewView
-from bika.lims.content.bikaschema import BikaFolderSchema
 from bika.lims.interfaces import ICalculations
+from bika.lims.utils import get_link
 from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.folder.folder import ATFolder, ATFolderSchema
+from plone.app.folder.folder import ATFolder
+from plone.app.folder.folder import ATFolderSchema
+from plone.app.layout.globals.interfaces import IViewView
+from Products.Archetypes import atapi
+from Products.ATContentTypes.content import schemata
 from zope.interface.declarations import implements
+
+
+# TODO: Separate content and view into own modules!
+
 
 class CalculationsView(BikaListingView):
     implements(IFolderContentsView, IViewView)
+
     def __init__(self, context, request):
         super(CalculationsView, self).__init__(context, request)
-        self.catalog = 'bika_setup_catalog'
-        self.contentFilter = {'portal_type': 'Calculation',
-                              'sort_on': 'sortable_title'}
-        self.context_actions = {_('Add'):
-                                {'url':'createObject?type_name=Calculation',
-                                 'icon': '++resource++bika.lims.images/add.png'}}
+
+        self.catalog = "bika_setup_catalog"
+        self.contentFilter = {
+            "portal_type": "Calculation",
+            "sort_on": "sortable_title",
+            "sort_order": "ascending",
+        }
+
+        self.context_actions = {
+            _("Add"): {
+                "url": "createObject?type_name=Calculation",
+                "permission": "Add portal content",
+                "icon": "++resource++bika.lims.images/add.png"}
+        }
+
         self.title = self.context.translate(_("Calculations"))
-        self.icon = self.portal_url + "/++resource++bika.lims.images/calculation_big.png"
-        self.description = ""
+        self.icon = "{}/{}".format(
+            self.portal_url,
+            "/++resource++bika.lims.images/calculation_big.png"
+        )
         self.show_sort_column = False
         self.show_select_row = False
         self.show_select_column = True
         self.pagesize = 25
 
-        self.columns = {
-            'Title': {'title': _('Calculation'),
-                      'index': 'sortable_title'},
-            'Description': {'title': _('Description'),
-                            'index': 'description',
-                            'toggle': True},
-            'Formula': {'title': _('Formula'),
-                        'index': 'getFormula',
-                        'toggle': True},
-        }
+        self.columns = collections.OrderedDict((
+            ("Title", {
+                "title": _("Calculation"),
+                "index": "sortable_title"}),
+            ("Description", {
+                "title": _("Description"),
+                "index": "Description",
+                "toggle": True}),
+            ("Formula", {
+                "title": _("Formula"),
+                "index": "getFormula",
+                "toggle": True}),
+        ))
 
         self.review_states = [
-            {'id':'default',
-             'title': _('Active'),
-             'contentFilter': {'inactive_state': 'active'},
-             'transitions': [{'id':'deactivate'}, ],
-             'columns': ['Title',
-                         'Description',
-                         'Formula']},
-            {'id':'inactive',
-             'title': _('Dormant'),
-             'contentFilter': {'inactive_state': 'inactive'},
-             'transitions': [{'id':'activate'}, ],
-             'columns': ['Title',
-                         'Description',
-                         'Formula']},
-            {'id':'all',
-             'title': _('All'),
-             'contentFilter':{},
-             'columns': ['Title',
-                         'Description',
-                         'Formula']},
+            {
+                "id": "default",
+                "title": _("Active"),
+                "contentFilter": {"inactive_state": "active"},
+                "transitions": [{"id": "deactivate"}, ],
+                "columns": self.columns,
+            }, {
+                "id": "inactive",
+                "title": _("Dormant"),
+                "contentFilter": {"inactive_state": "inactive"},
+                "transitions": [{"id": "activate"}, ],
+                "columns": self.columns,
+            }, {
+                "id": "all",
+                "title": _("All"),
+                "contentFilter": {},
+                "columns": self.columns,
+            }
         ]
 
-    def folderitems(self):
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
-            items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['Title'])
-            items[x]['Description'] = obj.Description()
-            items[x]['Formula'] = obj.getMinifiedFormula()
+    def before_render(self):
+        """Before template render hook
+        """
+        # Don't allow any context actions
+        self.request.set("disable_border", 1)
 
-        return items
+    def folderitem(self, obj, item, index):
+        """Service triggered each time an item is iterated in folderitems.
+        The use of this service prevents the extra-loops in child objects.
+        :obj: the instance of the class to be foldered
+        :item: dict containing the properties of the object to be used by
+            the template
+        :index: current index of the item
+        """
+        title = obj.Title()
+        description = obj.Description()
+        url = obj.absolute_url()
+
+        item["replace"]["Title"] = get_link(url, value=title)
+        item["Description"] = description
+        item["Formula"] = obj.getMinifiedFormula()
+
+        return item
+
 
 schema = ATFolderSchema.copy()
+
+
 class Calculations(ATFolder):
     implements(ICalculations)
     displayContentsTab = False
     schema = schema
 
-schemata.finalizeATCTSchema(schema, folderish = True, moveDiscussion = False)
+
+schemata.finalizeATCTSchema(schema, folderish=True, moveDiscussion=False)
 atapi.registerType(Calculations, PROJECTNAME)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR refactors the Calculations Listing view.

## Current behavior before PR

- Editable border is displayed
- old-style `folderitems` method used
- sort_on and sort_order are missing in filter

## Desired behavior after PR is merged

- Editable border is hidden
- Sort order is *ascending*
- new-style `folderitem` method used
- PEP8 + some minor improvements
- sort_on and sort_order in catalog query

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html