### PR TITLE
Refactored SampleConditions Listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Changelog
 
 **Changed**
 
+- #933 Refactored SampleConditions Listing
 - #916 Refactored Instruments Listing
 - #919 Refactored Profiles Listing
 - #915 Refactored SamplePoints Listing

--- a/bika/lims/controlpanel/bika_sampleconditions.py
+++ b/bika/lims/controlpanel/bika_sampleconditions.py
@@ -5,16 +5,23 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from Products.ATContentTypes.content import schemata
-from Products.Archetypes import atapi
+import collections
+
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.config import PROJECTNAME
 from bika.lims.interfaces import ISampleConditions
+from bika.lims.utils import get_link
 from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.folder.folder import ATFolder, ATFolderSchema
+from plone.app.folder.folder import ATFolder
+from plone.app.folder.folder import ATFolderSchema
 from plone.app.layout.globals.interfaces import IViewView
+from Products.Archetypes import atapi
+from Products.ATContentTypes.content import schemata
 from zope.interface.declarations import implements
+
+
+# TODO: Separate content and view into own modules!
 
 
 class SampleConditionsView(BikaListingView):
@@ -22,55 +29,86 @@ class SampleConditionsView(BikaListingView):
 
     def __init__(self, context, request):
         super(SampleConditionsView, self).__init__(context, request)
-        self.catalog = 'bika_setup_catalog'
-        self.contentFilter = {'portal_type': 'SampleCondition',
-                              'sort_on': 'sortable_title'}
-        self.context_actions = {_('Add'): {
-            'url': 'createObject?type_name=SampleCondition',
-            'icon': '++resource++bika.lims.images/add.png'
-        }}
+
+        self.catalog = "bika_setup_catalog"
+        self.contentFilter = {
+            "portal_type": "SampleCondition",
+            "sort_on": "sortable_title",
+            "sort_order": "ascending",
+        }
+
+        self.context_actions = {
+            _("Add"): {
+                "url": "createObject?type_name=SampleCondition",
+                "permission": "Add portal content",
+                "icon": "++resource++bika.lims.images/add.png"}
+        }
+
         self.title = self.context.translate(_("Sample Conditions"))
-        self.icon = self.portal_url + \
-                    "/++resource++bika.lims.images/samplecondition_big.png"
-        self.description = ""
+        self.icon = "{}/{}".format(
+            self.portal_url,
+            "/++resource++bika.lims.images/samplecondition_big.png"
+        )
         self.show_sort_column = False
         self.show_select_row = False
         self.show_select_column = True
         self.pagesize = 25
 
-        self.columns = {
-            'Title': {'title': _('Sample Condition'),
-                      'index': 'sortable_title'},
-            'Description': {'title': _('Description'),
-                            'index': 'description',
-                            'toggle': True},
-        }
+        self.columns = collections.OrderedDict((
+            ("Title", {
+                "title": _("Sample Condition"),
+                "index": "sortable_title"}),
+            ("Description", {
+                "title": _("Description"),
+                "index": "description",
+                "toggle": True}),
+        ))
 
         self.review_states = [
-            {'id': 'default',
-             'title': _('All'),
-             'contentFilter': {},
-             'transitions': [{'id': 'empty'}, ],
-             'columns': ['Title', 'Description']},
-            {'id': 'active',
-             'title': _('Active'),
-             'contentFilter': {'inactive_state': 'active'},
-             'transitions': [{'id': 'deactivate'}, ],
-             'columns': ['Title', 'Description']},
-            {'id': 'inactive',
-             'title': _('Dormant'),
-             'contentFilter': {'inactive_state': 'inactive'},
-             'transitions': [{'id': 'activate'}, ],
-             'columns': ['Title', 'Description']}]
+            {
+                'id': 'default',
+                'title': _('All'),
+                'contentFilter': {},
+                'transitions': [{'id': 'empty'}, ],
+                "columns": self.columns,
+            }, {
+                'id': 'active',
+                'title': _('Active'),
+                'contentFilter': {'inactive_state': 'active'},
+                'transitions': [{'id': 'deactivate'}, ],
+                "columns": self.columns,
+            }, {
+                'id': 'inactive',
+                'title': _('Dormant'),
+                'contentFilter': {'inactive_state': 'inactive'},
+                'transitions': [{'id': 'activate'}, ],
+                "columns": self.columns,
 
-    def folderitems(self):
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if 'obj' in items[x]:
-                items[x]['replace']['Title'] = \
-                    "<a href='%s'>%s</a>" % (items[x]['url'], items[x]['Title'])
+             }
+        ]
 
-        return items
+    def before_render(self):
+        """Before template render hook
+        """
+        # Don't allow any context actions
+        self.request.set("disable_border", 1)
+
+    def folderitem(self, obj, item, index):
+        """Service triggered each time an item is iterated in folderitems.
+        The use of this service prevents the extra-loops in child objects.
+        :obj: the instance of the class to be foldered
+        :item: dict containing the properties of the object to be used by
+            the template
+        :index: current index of the item
+        """
+        title = obj.Title()
+        description = obj.Description()
+        url = obj.absolute_url()
+
+        item["replace"]["Title"] = get_link(url, value=title)
+        item["Description"] = description
+
+        return item
 
 
 schema = ATFolderSchema.copy()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR refactors the SampleConditions Listing view.

## Current behavior before PR

- Editable border is displayed
- old-style `folderitems` method used
- sort_on and sort_order are missing in filter

## Desired behavior after PR is merged

- Editable border is hidden
- Sort order is *ascending*
- new-style `folderitem` method used
- PEP8 + some minor improvements
- sort_on and sort_order in catalog query

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
