### PR TITLE
Refactored SamplingDeviations Listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Changelog
 
 **Changed**
 
+- #935 Refactored SamplingDeviations Listing
 - #916 Refactored Instruments Listing
 - #919 Refactored Profiles Listing
 - #915 Refactored SamplePoints Listing

--- a/bika/lims/controlpanel/bika_samplingdeviations.py
+++ b/bika/lims/controlpanel/bika_samplingdeviations.py
@@ -5,11 +5,14 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
+import collections
+
 from Products.ATContentTypes.content import schemata
 from Products.Archetypes import atapi
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.config import PROJECTNAME
+from bika.lims.utils import get_link
 from bika.lims.interfaces import ISamplingDeviations
 from plone.app.content.browser.interfaces import IFolderContentsView
 from plone.app.folder.folder import ATFolder, ATFolderSchema
@@ -22,57 +25,86 @@ class SamplingDeviationsView(BikaListingView):
 
     def __init__(self, context, request):
         super(SamplingDeviationsView, self).__init__(context, request)
-        self.catalog = 'bika_setup_catalog'
-        self.contentFilter = {'portal_type': 'SamplingDeviation',
-                              'sort_on': 'sortable_title'}
-        self.context_actions = {_('Add'): {
-            'url': 'createObject?type_name=SamplingDeviation',
-            'icon': '++resource++bika.lims.images/add.png'
-        }}
+
+        self.catalog = "bika_setup_catalog"
+        self.contentFilter = {
+            "portal_type": "SamplingDeviation",
+            "sort_on": "sortable_title",
+            "sort_order": "ascending",
+        }
+
+        self.context_actions = {
+            _("Add"): {
+                "url": "createObject?type_name=SamplingDeviation",
+                "permission": "Add portal content",
+                "icon": "++resource++bika.lims.images/add.png"}
+        }
+
         self.title = self.context.translate(_("Sampling Deviations"))
-        self.icon = self.portal_url + \
-                    "/++resource++bika.lims.images/samplingdeviation_big.png"
-        self.description = ""
+        self.icon = "{}/{}".format(
+            self.portal_url,
+            "/++resource++bika.lims.images/samplingdeviation_big.png"
+        )
         self.show_sort_column = False
         self.show_select_row = False
         self.pagesize = 25
         self.show_select_column = True
 
-        self.columns = {
-            'Title': {'title': _('Sampling Deviation'),
-                      'index': 'sortable_title'},
-            'Description': {'title': _('Description'),
-                            'index': 'description',
-                            'toggle': True},
-        }
+        self.columns = collections.OrderedDict((
+            ("Title", {
+                "title": _("Sampling Deviationn"),
+                "index": "sortable_title"}),
+            ("Description", {
+                "title": _("Description"),
+                "index": "Description",
+                "toggle": True,
+            }),
+        ))
 
         self.review_states = [
-            {'id': 'default',
-             'title': _('All'),
-             'contentFilter': {},
-             'transitions': [{'id': 'empty'}, ],
-             'columns': ['Title', 'Description']},
-            {'id': 'active',
-             'title': _('Active'),
-             'contentFilter': {'inactive_state': 'active'},
-             'transitions': [{'id': 'deactivate'}, ],
-             'columns': ['Title', 'Description']},
-            {'id': 'inactive',
-             'title': _('Dormant'),
-             'contentFilter': {'inactive_state': 'inactive'},
-             'transitions': [{'id': 'activate'}, ],
-             'columns': ['Title', 'Description']}
+            {
+                "id": "default",
+                "title": _("All"),
+                "contentFilter": {},
+                "transitions": [{"id": "empty"}, ],
+                "columns": self.columns,
+            }, {
+                "id": "active",
+                "title": _("Active"),
+                "contentFilter": {"inactive_state": "active"},
+                "transitions": [{"id": "deactivate"}, ],
+                "columns": self.columns,
+            }, {
+                "id": "inactive",
+                "title": _("Dormant"),
+                "contentFilter": {"inactive_state": "inactive"},
+                "transitions": [{"id": "activate"}, ],
+                "columns": self.columns,
+            }
         ]
 
-    def folderitems(self):
+    def before_render(self):
+        """Before template render hook
+        """
+        # Don't allow any context actions
+        self.request.set("disable_border", 1)
 
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'):
-                continue
-            items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
-                                           (items[x]['url'], items[x]['Title'])
-        return items
+    def folderitem(self, obj, item, index):
+        """Service triggered each time an item is iterated in folderitems.
+        The use of this service prevents the extra-loops in child objects.
+        :obj: the instance of the class to be foldered
+        :item: dict containing the properties of the object to be used by
+            the template
+        :index: current index of the item
+        """
+        title = obj.Title()
+        description = obj.Description()
+        url = obj.absolute_url()
+
+        item["replace"]["Title"] = get_link(url, value=title)
+        item["Description"] = description
+
+        return item
 
 
 schema = ATFolderSchema.copy()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR refactors the SamplingDeviations Listing view.

## Current behavior before PR

- Editable border is displayed
- old-style `folderitems` method used
- sort_on and sort_order are missing in filter

## Desired behavior after PR is merged

- Editable border is hidden
- Sort order is *ascending*
- new-style `folderitem` method used
- PEP8 + some minor improvements
- sort_on and sort_order in catalog query

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
