### PR TITLE
Refactored AR Templates Listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,8 @@ Changelog
 
 **Changed**
 
+- #936 Refactored AR Templates Listing
 - #926 Refactored Analysis Services Listing
-
 - #916 Refactored Instruments Listing
 - #919 Refactored Profiles Listing
 - #915 Refactored SamplePoints Listing

--- a/bika/lims/controlpanel/bika_artemplates.py
+++ b/bika/lims/controlpanel/bika_artemplates.py
@@ -5,85 +5,117 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from bika.lims.utils import isActive
-from AccessControl.SecurityInfo import ClassSecurityInfo
-from Products.ATContentTypes.content import schemata
-from Products.Archetypes import atapi
-from Products.Archetypes.ArchetypeTool import registerType
-from Products.CMFCore.utils import getToolByName
+import collections
+
+from bika.lims import api
+from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.config import PROJECTNAME
-from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t
-from bika.lims.content.bikaschema import BikaFolderSchema
-from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.folder.folder import ATFolder, ATFolderSchema
-from plone.app.layout.globals.interfaces import IViewView
 from bika.lims.interfaces import IARTemplates
+from bika.lims.utils import get_link
+from plone.app.content.browser.interfaces import IFolderContentsView
+from plone.app.folder.folder import ATFolder
+from plone.app.folder.folder import ATFolderSchema
+from plone.app.layout.globals.interfaces import IViewView
+from Products.Archetypes import atapi
+from Products.ATContentTypes.content import schemata
 from zope.interface.declarations import implements
+
 
 class TemplatesView(BikaListingView):
     implements(IFolderContentsView, IViewView)
+
     def __init__(self, context, request):
         super(TemplatesView, self).__init__(context, request)
+
         self.catalog = "bika_setup_catalog"
         self.contentFilter = {
-            'portal_type': 'ARTemplate',
-            'sort_order': 'sortable_title',
-            'path': {
-                "query": "/".join(self.context.getPhysicalPath()),
-                "level" : 0 },
+            "portal_type": "ARTemplate",
+            "sort_on": "sortable_title",
+            "sort_order": "ascending",
+            "path": {
+                "query": api.get_path(context),
+                "level": 0},
         }
+
+        self.context_actions = {
+            _("Add"): {
+                "url": "createObject?type_name=ARTemplate",
+                "permission": "Add portal content",
+                "icon": "++resource++bika.lims.images/add.png"}
+        }
+
+        self.title = self.context.translate(_("AR Templates"))
+        self.icon = "{}/{}".format(
+            self.portal_url,
+            "/++resource++bika.lims.images/artemplate_big.png"
+        )
+
         self.show_sort_column = False
         self.show_select_row = False
         self.show_select_column = True
-        self.icon = self.portal_url + "/++resource++bika.lims.images/artemplate_big.png"
-        self.title = self.context.translate(_("AR Templates"))
-        self.description = ""
-        self.context_actions = {_('Add Template'):
-                                {'url': 'createObject?type_name=ARTemplate',
-                                 'icon': '++resource++bika.lims.images/add.png'}}
 
-        self.columns = {
-            'Title': {'title': _('Template'),
-                      'index': 'sortable_title'},
-            'Description': {'title': _('Description'),
-                            'index': 'description'},
-        }
+        self.columns = collections.OrderedDict((
+            ("Title", {
+                "title": _("Profile"),
+                "index": "sortable_title"}),
+            ("Description", {
+                "title": _("Description"),
+                "index": "Description",
+                "toggle": True,
+            }),
+        ))
 
         self.review_states = [
-            {'id':'default',
-             'title': _('Active'),
-             'contentFilter': {'inactive_state':'active'},
-             'columns': ['Title',
-                         'Description']},
-            {'id':'inactive',
-             'title': _('Dormant'),
-             'contentFilter': {'inactive_state':'inactive'},
-             'columns': ['Title',
-                         'Description']},
-            {'id':'all',
-             'title': _('All'),
-             'contentFilter':{},
-             'columns': ['Title',
-                         'Description']},
+            {
+                "id": "default",
+                "title": _("Active"),
+                "contentFilter": {"inactive_state": "active"},
+                "columns": self.columns,
+            }, {
+                "id": "inactive",
+                "title": _("Dormant"),
+                "contentFilter": {"inactive_state": "inactive"},
+                "columns": self.columns,
+            }, {
+                "id": "all",
+                "title": _("All"),
+                "contentFilter": {},
+                "columns": self.columns,
+            },
         ]
 
-    def folderitems(self):
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
-            items[x]['Title'] = obj.Title()
-            items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['title'])
-        return items
+    def before_render(self):
+        """Before template render hook
+        """
+        # Don't allow any context actions
+        self.request.set("disable_border", 1)
+
+    def folderitem(self, obj, item, index):
+        """Service triggered each time an item is iterated in folderitems.
+        The use of this service prevents the extra-loops in child objects.
+        :obj: the instance of the class to be foldered
+        :item: dict containing the properties of the object to be used by
+            the template
+        :index: current index of the item
+        """
+        title = obj.Title()
+        description = obj.Description()
+        url = obj.absolute_url()
+
+        item["replace"]["Title"] = get_link(url, value=title)
+        item["Description"] = description
+
+        return item
+
 
 schema = ATFolderSchema.copy()
+
+
 class ARTemplates(ATFolder):
     implements(IARTemplates)
     displayContentsTab = False
     schema = schema
 
-schemata.finalizeATCTSchema(schema, folderish = True, moveDiscussion = False)
+schemata.finalizeATCTSchema(schema, folderish=True, moveDiscussion=False)
 atapi.registerType(ARTemplates, PROJECTNAME)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR refactors the Analysisspecification listing view.

## Current behavior before PR

- Editable border is displayed
- old-style `folderitems` method used
- sort_on and sort_order are missing in filter

## Desired behavior after PR is merged

- Editable border is hidden
- Sort order is *ascending*
- new-style `folderitem` method used
- PEP8 + some minor improvements
- sort_on and sort_order in catalog query

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html