### PR TITLE
Refactored Analysis Specifications Widget

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Changelog
 
 **Changed**
 
+- #937 Refactored Analysis Specifications Widget
 - #931 Refactored AnalysisSpecs Listing
 - #935 Refactored SamplingDeviations Listing
 - #926 Refactored Analysis Services Listing

--- a/bika/lims/browser/widgets/analysisspecificationwidget.py
+++ b/bika/lims/browser/widgets/analysisspecificationwidget.py
@@ -340,17 +340,15 @@ class AnalysisSpecificationWidget(TypesWidget):
 
         :param field: Contains the schema field with a list of services in it
         """
-
-        # get the view via adapter lookup
-        view = api.get_view("analysis_spec_widget_view")
-
-        context = api.get_object(field.aq_parent)
-        request = api.get_request()
         fieldvalue = getattr(field, field.accessor)()
 
-        # initialize the view with the right parameters
-        view.__init__(context, request,
-                      fieldvalue=fieldvalue, allow_edit=allow_edit)
+        # N.B. we do not want to pass the field as the context to
+        # AnalysisProfileAnalysesView, but rather the holding instance
+        instance = getattr(self, "instance", field.aq_parent)
+        view = AnalysisSpecificationView(instance,
+                                         self.REQUEST,
+                                         fieldvalue=fieldvalue,
+                                         allow_edit=allow_edit)
 
         return view.contents_table(table_only=True)
 

--- a/bika/lims/browser/widgets/analysisspecificationwidget.py
+++ b/bika/lims/browser/widgets/analysisspecificationwidget.py
@@ -131,8 +131,8 @@ class AnalysisSpecificationView(BikaListingView):
         # correct and that no inactive services are displayed.
         query.update({
             "inactive_state": "active",
-            "sort_on": "sortable_title",
-            "sort_order": "ascending",
+            "sort_on": self.sort_on,
+            "sort_order": self.sort_order,
         })
         logger.info("AnalysisSpecificationWidget::query=%r" % query)
         return catalog(query)
@@ -239,8 +239,6 @@ class AnalysisSpecificationView(BikaListingView):
 
     def folderitems(self):
         """Custom folderitems
-
-        N.B. This does *not* call `folderitem` method
 
         :returns: listing items
         """

--- a/bika/lims/browser/widgets/analysisspecificationwidget.py
+++ b/bika/lims/browser/widgets/analysisspecificationwidget.py
@@ -107,7 +107,7 @@ class AnalysisSpecificationView(BikaListingView):
                 "title": _("All"),
                 "contentFilter": {"inactive_state": "active"},
                 "transitions": [],
-                "columns": self.columns
+                "columns": self.columns.keys(),
             },
         ]
 

--- a/bika/lims/browser/widgets/analysisspecificationwidget.py
+++ b/bika/lims/browser/widgets/analysisspecificationwidget.py
@@ -114,6 +114,8 @@ class AnalysisSpecificationView(BikaListingView):
     def get_sorted_categories(self, items):
         """Extracts the categories from the items
         """
+
+        # XXX should be actually following the sortKey as well
         categories = filter(
             None, set(map(lambda item: item.get("category"), items)))
 
@@ -265,7 +267,6 @@ class AnalysisSpecificationView(BikaListingView):
         return items
 
 
-
 class AnalysisSpecificationWidget(TypesWidget):
     _properties = TypesWidget._properties.copy()
     _properties.update({
@@ -345,13 +346,18 @@ class AnalysisSpecificationWidget(TypesWidget):
 
         :param field: Contains the schema field with a list of services in it
         """
+
+        # get the view via adapter lookup
+        view = api.get_view("analysis_spec_widget_view")
+
+        context = api.get_object(field.aq_parent)
+        request = api.get_request()
         fieldvalue = getattr(field, field.accessor)()
-        # get the context of this field, otherwise the listing view might fail
-        # when getting the widget as the context
-        view = AnalysisSpecificationView(field.aq_parent,
-                                         self.REQUEST,
-                                         fieldvalue=fieldvalue,
-                                         allow_edit=allow_edit)
+
+        # initialize the view with the right parameters
+        view.__init__(context, request,
+                      fieldvalue=fieldvalue, allow_edit=allow_edit)
+
         return view.contents_table(table_only=True)
 
 

--- a/bika/lims/browser/widgets/analysisspecificationwidget.py
+++ b/bika/lims/browser/widgets/analysisspecificationwidget.py
@@ -219,11 +219,6 @@ class AnalysisSpecificationView(BikaListingView):
             "table_row_class": "even",
         }
 
-        # Title
-        item["replace"]["service"] = get_link(
-            service.absolute_url(),
-            value=service.Title())
-
         # Add methods
         methods = service.getMethods()
         if methods:
@@ -285,6 +280,7 @@ class AnalysisSpecificationWidget(TypesWidget):
         hidemin and/or hidemax specified, results might contain empty min
         and/or max fields.
         """
+
         values = []
         if "service" not in form:
             return values, {}

--- a/bika/lims/browser/widgets/analysisspecificationwidget.py
+++ b/bika/lims/browser/widgets/analysisspecificationwidget.py
@@ -4,25 +4,40 @@
 #
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
+
 import collections
+
 from AccessControl import ClassSecurityInfo
-from Products.Archetypes.Registry import registerWidget
-from Products.Archetypes.Widget import TypesWidget
-from Products.CMFCore.utils import getToolByName
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
+from bika.lims import logger
 from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.utils import get_image
+from bika.lims.utils import get_link
+from Products.Archetypes.Registry import registerWidget
+from Products.Archetypes.Widget import TypesWidget
+
+ALLOW_EDIT = ["LabManager", "Manager"]
+
+
+# TODO: Separate widget and view into own modules!
+
 
 class AnalysisSpecificationView(BikaListingView):
-    """ bika listing to display Analysis Services (AS) table for an
-        Analysis Specification.
+    """Renders a listing to display an Analysis Services (AS) table for an
+       Analysis Specification.
     """
 
     def __init__(self, context, request, fieldvalue=[], allow_edit=True):
         BikaListingView.__init__(self, context, request)
-        self.context_actions = {}
-        self.contentFilter = {'inactive_state': 'active',
-                              'sort_on': 'sortable_title'}
+
+        self.contentFilter = {
+            "portal_type": "AnalysisService",
+            "inactive_state": "active",
+            "sort_on": "sortable_title",
+            "sort_order": "ascending",
+        }
+
         self.context_actions = {}
         self.base_url = self.context.absolute_url()
         self.view_url = self.base_url
@@ -35,151 +50,221 @@ class AnalysisSpecificationView(BikaListingView):
         self.show_categories = True
         # self.expand_all_categories = False
         self.ajax_categories = True
-        self.ajax_categories_url = self.context.absolute_url() + "/analysis_spec_widget_view"
-        self.category_index = 'getCategoryTitle'
+        self.ajax_categories_url = "{}/{}".format(
+            self.context.absolute_url(),
+            "/analysis_spec_widget_view"
+        )
+        self.category_index = "getCategoryTitle"
 
         self.specsresults = {}
         for specresults in fieldvalue:
-            self.specsresults[specresults['keyword']] = specresults
+            self.specsresults[specresults["keyword"]] = specresults
 
         self.columns = collections.OrderedDict((
-            ('service', {
-                'title': _('Service'),
-                'index': 'sortable_title',
-                'sortable': False}),
-            ('warn_min', {
-                'title': _('Min warn'),
-                'sortable': False}),
-            ('min', {
-                'title': _('Min'),
-                'sortable': False}),
-            ('max', {
-                'title': _('Max'),
-                'sortable': False}),
-            ('warn_max', {
-                'title': _('Max warn'),
-                'sortable': False}),
-            ('hidemin', {
-                'title': _('< Min'),
-                'sortable': False}),
-            ('hidemax', {
-                'title': _('> Max'),
-                'sortable': False}),
-            ('rangecomment', {
-                'title': _('Range comment'),
-                'sortable': False,
-                'toggle': False}),
+            ("service", {
+                "title": _("Service"),
+                "index": "sortable_title",
+                "sortable": False}),
+            ("keyword", {
+                "title": _("Keyword"),
+                "sortable": False}),
+            ("methods", {
+                "title": _("Methods"),
+                "sortable": False}),
+            ("unit", {
+                "title": _("Unit"),
+                "sortable": False}),
+            ("service", {
+                "title": _("Service"),
+                "sortable": False}),
+            ("warn_min", {
+                "title": _("Min warn"),
+                "sortable": False}),
+            ("min", {
+                "title": _("Min"),
+                "sortable": False}),
+            ("max", {
+                "title": _("Max"),
+                "sortable": False}),
+            ("warn_max", {
+                "title": _("Max warn"),
+                "sortable": False}),
+            ("hidemin", {
+                "title": _("< Min"),
+                "sortable": False}),
+            ("hidemax", {
+                "title": _("> Max"),
+                "sortable": False}),
+            ("rangecomment", {
+                "title": _("Range comment"),
+                "sortable": False,
+                "toggle": False}),
         ))
 
         self.review_states = [
-            {'id':'default',
-             'title': _('All'),
-             'contentFilter':{},
-             'transitions': [],
-             'columns': self.columns.keys(),
-             },
+            {
+                "id": "default",
+                "title": _("All"),
+                "contentFilter": {"inactive_state": "active"},
+                "transitions": [],
+                "columns": self.columns
+            },
         ]
 
+    def get_sorted_categories(self, items):
+        """Extracts the categories from the items
+        """
+        categories = filter(
+            None, set(map(lambda item: item.get("category"), items)))
+
+        return sorted(categories)
+
+    def get_services(self):
+        """returns all services
+        """
+        catalog = api.get_tool("bika_setup_catalog")
+        query = self.contentFilter.copy()
+        # The contentFilter query get changed by the listing view to show only
+        # services in a category. This update ensures that the sorting is kept
+        # correct and that no inactive services are displayed.
+        query.update({
+            "inactive_state": "active",
+            "sort_on": "sortable_title",
+            "sort_order": "ascending",
+        })
+        logger.info("AnalysisSpecificationWidget::query=%r" % query)
+        return catalog(query)
+
+    def folderitem(self, obj, item, index):
+        """Service triggered each time an item is iterated in folderitems.
+
+        The use of this service prevents the extra-loops in child objects.
+
+        :obj: the instance of the class to be foldered
+        :item: dict containing the properties of the object to be used by
+            the template
+        :index: current index of the item
+        """
+        service = api.get_object(obj)
+
+        if service.getKeyword() in self.specsresults:
+            specresults = self.specsresults[service.getKeyword()]
+        else:
+            specresults = {
+                "keyword": service.getKeyword(),
+                "min": "",
+                "max": "",
+                "warn_min": "",
+                "warn_max": "",
+                "hidemin": "",
+                "hidemax": "",
+                "rangecomment": "",
+            }
+
+        # Icons
+        after_icons = ""
+        if service.getAccredited():
+            after_icons += get_image(
+                "accredited.png", title=_("Accredited"))
+        if service.getAttachmentOption() == "r":
+            after_icons += get_image(
+                "attach_reqd.png", title=_("Attachment required"))
+        if service.getAttachmentOption() == "n":
+            after_icons += get_image(
+                "attach_no.png", title=_("Attachment not permitted"))
+
+        # TRICK for AS keyword retrieval on form POST
+        keyword_input_field = "<input type='hidden' " \
+                              "name='keyword.{}:records' " \
+                              "value='{}'/>".format(
+                                  service.UID(), service.getKeyword())
+        after_icons += keyword_input_field
+
+        state = api.get_workflow_status_of(service, state_var="inactive_state")
+        unit = service.getUnit()
+
+        item = {
+            "obj": service,
+            "id": service.getId(),
+            "uid": service.UID(),
+            "keyword": service.getKeyword(),
+            "title": service.Title(),
+            "unit": unit,
+            "category": service.getCategoryTitle(),
+            "selected": service.getKeyword() in self.specsresults.keys(),
+            "type_class": "contenttype-ReferenceResult",
+            "url": service.absolute_url(),
+            "relative_url": service.absolute_url(),
+            "view_url": service.absolute_url(),
+            "service": service.Title(),
+            "min": specresults.get("min", ""),
+            "max": specresults.get("max", ""),
+            "warn_min": specresults.get("warn_min", ""),
+            "warn_max": specresults.get("warn_max", ""),
+            "hidemin": specresults.get("hidemin", ""),
+            "hidemax": specresults.get("hidemax", ""),
+            "rangecomment": specresults.get("rangecomment", ""),
+            "replace": {},
+            "before": {},
+            "after": {
+                "service": after_icons,
+            },
+            "choices": {},
+            "class": "state-%s" % (state),
+            "state_class": "state-%s" % (state),
+            "allow_edit": ["min", "max", "warn_min", "warn_max", "hidemin",
+                           "hidemax", "rangecomment"],
+            "table_row_class": "even",
+        }
+
+        # Title
+        item["replace"]["service"] = get_link(
+            service.absolute_url(),
+            value=service.Title())
+
+        # Add methods
+        methods = service.getMethods()
+        if methods:
+            links = map(
+                lambda m: get_link(
+                    m.absolute_url(), value=m.Title(), css_class="link"),
+                methods)
+            item["replace"]["methods"] = ", ".join(links)
+        else:
+            item["methods"] = ""
+
+        return item
 
     def folderitems(self):
-        bsc = getToolByName(self.context, 'bika_setup_catalog')
-        self.categories = []
+        """Custom folderitems
 
-        # Check edition permissions
-        mtool = getToolByName(self.context, 'portal_membership')
-        member = mtool.getAuthenticatedMember()
+        N.B. This does *not* call `folderitem` method
+
+        :returns: listing items
+        """
+
+        # XXX: Should be done via the Worflow
+        # Check edit permissions
+        self.allow_edit = False
+        member = api.get_current_user()
         roles = member.getRoles()
-        self.allow_edit = 'LabManager' in roles or 'Manager' in roles
+        if set(roles).intersection(ALLOW_EDIT):
+            self.allow_edit = True
 
         # Analysis Services retrieval and custom item creation
         items = []
-        workflow = getToolByName(self.context, 'portal_workflow')
-        self.contentFilter['portal_type'] = 'AnalysisService'
-        services = bsc(self.contentFilter)
-        for service in services:
-            service = service.getObject()
-            cat = service.getCategoryTitle()
-            if cat not in self.categories:
-                self.categories.append(cat)
-            if service.getKeyword() in self.specsresults:
-                specresults = self.specsresults[service.getKeyword()]
-            else:
-                specresults = {'keyword': service.getKeyword(),
-                        'min': '',
-                        'max': '',
-                        'warn_min': '',
-                        'warn_max': '',
-                        'hidemin': '',
-                        'hidemax': '',
-                        'rangecomment': ''}
 
-            after_icons = ' <span class="discreet">(%s)</span>&nbsp;&nbsp;' % service.getKeyword()
-            if service.getAccredited():
-                after_icons += "<img\
-                src='%s/++resource++bika.lims.images/accredited.png'\
-                title='%s'>"%(self.context.absolute_url(),
-                              _("Accredited"))
-            if service.getAttachmentOption() == 'r':
-                after_icons += "<img\
-                src='%s/++resource++bika.lims.images/attach_reqd.png'\
-                title='%s'>"%(self.context.absolute_url(),
-                              _("Attachment required"))
-            if service.getAttachmentOption() == 'n':
-                after_icons += "<img\
-                src='%s/++resource++bika.lims.images/attach_no.png'\
-                title='%s'>"%(self.context.absolute_url(),
-                              _('Attachment not permitted'))
+        services = self.get_services()
+        for num, service in enumerate(services):
+            item = self.folderitem(service, {}, num)
+            if item:
+                items.append(item)
 
-            # TRICK for AS keyword retrieval on form POST
-            after_icons += '<input type="hidden" name="keyword.%s:records"\
-            value="%s"></input>' % (service.UID(), service.getKeyword())
-
-            state = workflow.getInfoFor(service, 'inactive_state', '')
-            unit = service.getUnit()
-            unitspan = unit and \
-                "<span class='discreet'>%s</span>" % service.getUnit() or ''
-            percspan = "<span class='discreet'>%</span>"
-
-            item = {
-                'obj': service,
-                'id': service.getId(),
-                'uid': service.UID(),
-                'keyword': service.getKeyword(),
-                'title': service.Title(),
-                'category': cat,
-                'selected': service.getKeyword() in self.specsresults.keys(),
-                'type_class': 'contenttype-ReferenceResult',
-                'url': service.absolute_url(),
-                'relative_url': service.absolute_url(),
-                'view_url': service.absolute_url(),
-                'service': service.Title(),
-                'min': specresults.get('min', ''),
-                'max': specresults.get('max', ''),
-                'warn_min': specresults.get('warn_min', ''),
-                'warn_max': specresults.get('warn_max', ''),
-                'hidemin': specresults.get('hidemin',''),
-                'hidemax': specresults.get('hidemax',''),
-                'rangecomment': specresults.get('rangecomment', ''),
-                'replace': {},
-                'before': {},
-                'after': {'service':after_icons,
-                          'min':unitspan,
-                          'max':unitspan,
-                          'warn_min':unitspan,
-                          'warn_max':unitspan},
-                'choices':{},
-                'class': "state-%s" % (state),
-                'state_class': "state-%s" % (state),
-                'allow_edit': ['min', 'max', 'warn_min', 'warn_max', 'hidemin',
-                               'hidemax', 'rangecomment'],
-            }
-            items.append(item)
-
-        self.categories.sort()
-        for i in range(len(items)):
-            items[i]['table_row_class'] = "even"
+        self.categories = self.get_sorted_categories(items)
 
         return items
+
+
 
 class AnalysisSpecificationWidget(TypesWidget):
     _properties = TypesWidget._properties.copy()
@@ -189,21 +274,25 @@ class AnalysisSpecificationWidget(TypesWidget):
 
     security = ClassSecurityInfo()
 
-    security.declarePublic('process_form')
-    def process_form(self, instance, field, form, empty_marker = None, emptyReturnsMarker = False):
-        """ Return a list of dictionaries fit for AnalysisSpecsResultsField
-            consumption. If neither hidemin nor hidemax are specified, only
-            services which have float()able entries in result,min and max field
-            will be included. If hidemin and/or hidemax specified, results
-            might contain empty min and/or max fields.
+    security.declarePublic("process_form")
+
+    def process_form(self, instance, field, form, empty_marker=None,
+                     emptyReturnsMarker=False):
+        """Return a list of dictionaries fit for AnalysisSpecsResultsField
+           consumption.
+
+        If neither hidemin nor hidemax are specified, only services which have
+        float()able entries in result,min and max field will be included. If
+        hidemin and/or hidemax specified, results might contain empty min
+        and/or max fields.
         """
         values = []
-        if 'service' not in form:
+        if "service" not in form:
             return values, {}
 
-        for uid, keyword in form['keyword'][0].items():
-            s_min = self._get_spec_value(form, uid, 'min')
-            s_max = self._get_spec_value(form, uid, 'max')
+        for uid, keyword in form["keyword"][0].items():
+            s_min = self._get_spec_value(form, uid, "min")
+            s_max = self._get_spec_value(form, uid, "max")
             if not s_min and not s_max:
                 # If user has not set value neither for min nor max, omit this
                 # record. Otherwise, since 'min' and 'max' are defined as
@@ -212,24 +301,26 @@ class AnalysisSpecificationWidget(TypesWidget):
                 continue
 
             values.append({
-                'keyword': keyword,
-                'uid': uid,
-                'min': s_min,
-                'max': s_max,
-                'warn_min': self._get_spec_value(form, uid, 'warn_min'),
-                'warn_max': self._get_spec_value(form, uid, 'warn_max'),
-                'hidemin': self._get_spec_value(form, uid, 'hidemin'),
-                'hidemax': self._get_spec_value(form, uid, 'hidemax'),
-                'rangecomment': self._get_spec_value(form, uid, 'rangecomment',
+                "keyword": keyword,
+                "uid": uid,
+                "min": s_min,
+                "max": s_max,
+                "warn_min": self._get_spec_value(form, uid, "warn_min"),
+                "warn_max": self._get_spec_value(form, uid, "warn_max"),
+                "hidemin": self._get_spec_value(form, uid, "hidemin"),
+                "hidemax": self._get_spec_value(form, uid, "hidemax"),
+                "rangecomment": self._get_spec_value(form, uid, "rangecomment",
                                                      check_floatable=False)})
         return values, {}
 
-    def _get_spec_value(self, form, uid, key, check_floatable=True, default=''):
+    def _get_spec_value(self, form, uid, key, check_floatable=True,
+                        default=''):
         """Returns the value assigned to the passed in key for the analysis
         service uid from the passed in form.
 
         If check_floatable is true, will return the passed in default if the
         obtained value is not floatable
+
         :param form: form being submitted
         :param uid: uid of the Analysis Service the specification relates
         :param key: id of the specs param to get (e.g. 'min')
@@ -247,18 +338,23 @@ class AnalysisSpecificationWidget(TypesWidget):
             return value
         return api.is_floatable(value) and value or default
 
-    security.declarePublic('AnalysisSpecificationResults')
-    def AnalysisSpecificationResults(self, field, allow_edit = False):
-        """ Prints a bika listing with categorized services.
-            field contains the archetypes field with a list of services in it
+    security.declarePublic("AnalysisSpecificationResults")
+
+    def AnalysisSpecificationResults(self, field, allow_edit=False):
+        """Render listing with categorized services.
+
+        :param field: Contains the schema field with a list of services in it
         """
         fieldvalue = getattr(field, field.accessor)()
-        view = AnalysisSpecificationView(self,
-                                            self.REQUEST,
-                                            fieldvalue = fieldvalue,
-                                            allow_edit = allow_edit)
-        return view.contents_table(table_only = True)
+        # get the context of this field, otherwise the listing view might fail
+        # when getting the widget as the context
+        view = AnalysisSpecificationView(field.aq_parent,
+                                         self.REQUEST,
+                                         fieldvalue=fieldvalue,
+                                         allow_edit=allow_edit)
+        return view.contents_table(table_only=True)
+
 
 registerWidget(AnalysisSpecificationWidget,
-               title = 'Analysis Specification Results',
-               description = ('Analysis Specification Results'))
+               title="Analysis Specification Results",
+               description=("Analysis Specification Results"))


### PR DESCRIPTION

## Description of the issue/feature this PR addresses

Added Keyword, Methods and Unit columns.
Ensure sorting on Async Category expansion

## Current behavior before PR

- Keyword, methods and unit columns not in listing
- Inactive Services displayed on category expansion
- View called with widget as context instead of the AnalysisSpecification object (Caused sometimes a Traceback in `get_path_query`, because this expects a portal object)

## Desired behavior after PR is merged

- Keyword, methods and unit columns in listing
- Only active services displayed on category expansion
- listing view called with AnalysisSpecification context

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
