### PR TITLE
Refactored Analysis Profiles Widget

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Changelog
 
 **Changed**
 
+- #938 Refactored Analysis Profiles Widget
 - #936 Refactored AR Templates Listing
 - #933 Refactored SampleConditions Listing
 - #932 Refactored Calculation Listing


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Added Keyword and Methods columns.

## Current behavior before PR

- Keyword and methods columns not in listing

## Desired behavior after PR is merged

- Keyword and methods columns in listing
- Better formatted price

- Keyword, methods and unit columns in listing
- Only active services displayed on category expansion
- listing view called with AnalysisSpecification context

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
