### PR TITLE
Use list of columns keys in review_states configuration

### DIFF
--- a/bika/lims/controlpanel/bika_analysisprofiles.py
+++ b/bika/lims/controlpanel/bika_analysisprofiles.py
@@ -76,18 +76,18 @@ class AnalysisProfilesView(BikaListingView):
                 "title": _("Active"),
                 "contentFilter": {"inactive_state": "active"},
                 "transitions": [{"id": "deactivate"}, ],
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }, {
                 "id": "inactive",
                 "title": _("Dormant"),
                 "contentFilter": {"inactive_state": "inactive"},
                 "transitions": [{"id": "activate"}, ],
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }, {
                 "id": "all",
                 "title": _("All"),
                 "contentFilter": {},
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             },
         ]
 

--- a/bika/lims/controlpanel/bika_analysisservices.py
+++ b/bika/lims/controlpanel/bika_analysisservices.py
@@ -251,19 +251,19 @@ class AnalysisServicesView(BikaListingView):
                 "id": "default",
                 "title": _("Active"),
                 "contentFilter": {"inactive_state": "active"},
-                "columns": self.columns,
+                "columns": self.columns.keys(),
                 "custom_transitions": [copy_transition]
             }, {
                 "id": "inactive",
                 "title": _("Dormant"),
                 "contentFilter": {"inactive_state": "inactive"},
-                "columns": self.columns,
+                "columns": self.columns.keys(),
                 "custom_transitions": [copy_transition]
             }, {
                 "id": "all",
                 "title": _("All"),
                 "contentFilter": {},
-                "columns": self.columns,
+                "columns": self.columns.keys(),
                 "custom_transitions": [copy_transition]
             },
         ]

--- a/bika/lims/controlpanel/bika_analysisspecs.py
+++ b/bika/lims/controlpanel/bika_analysisspecs.py
@@ -77,18 +77,18 @@ class AnalysisSpecsView(BikaListingView):
                 "title": _("Active"),
                 "contentFilter": {"inactive_state": "active"},
                 "transitions": [{"id": "deactivate"}, ],
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }, {
                 "id": "inactive",
                 "title": _("Dormant"),
                 "contentFilter": {"inactive_state": "inactive"},
                 "transitions": [{"id": "activate"}, ],
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }, {
                 "id": "all",
                 "title": _("All"),
                 "contentFilter": {},
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             },
         ]
 

--- a/bika/lims/controlpanel/bika_artemplates.py
+++ b/bika/lims/controlpanel/bika_artemplates.py
@@ -71,17 +71,17 @@ class TemplatesView(BikaListingView):
                 "id": "default",
                 "title": _("Active"),
                 "contentFilter": {"inactive_state": "active"},
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }, {
                 "id": "inactive",
                 "title": _("Dormant"),
                 "contentFilter": {"inactive_state": "inactive"},
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }, {
                 "id": "all",
                 "title": _("All"),
                 "contentFilter": {},
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             },
         ]
 

--- a/bika/lims/controlpanel/bika_calculations.py
+++ b/bika/lims/controlpanel/bika_calculations.py
@@ -74,18 +74,18 @@ class CalculationsView(BikaListingView):
                 "title": _("Active"),
                 "contentFilter": {"inactive_state": "active"},
                 "transitions": [{"id": "deactivate"}, ],
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }, {
                 "id": "inactive",
                 "title": _("Dormant"),
                 "contentFilter": {"inactive_state": "inactive"},
                 "transitions": [{"id": "activate"}, ],
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }, {
                 "id": "all",
                 "title": _("All"),
                 "contentFilter": {},
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }
         ]
 

--- a/bika/lims/controlpanel/bika_instruments.py
+++ b/bika/lims/controlpanel/bika_instruments.py
@@ -93,18 +93,18 @@ class InstrumentsView(BikaListingView):
                 "title": _("Active"),
                 "contentFilter": {"inactive_state": "active"},
                 "transitions": [{"id": "deactivate"}, ],
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }, {
                 "id": "inactive",
                 "title": _("Dormant"),
                 "contentFilter": {"inactive_state": "inactive"},
                 "transitions": [{"id": "activate"}, ],
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }, {
                 "id": "all",
                 "title": _("All"),
                 "contentFilter": {},
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             },
         ]
 

--- a/bika/lims/controlpanel/bika_sampleconditions.py
+++ b/bika/lims/controlpanel/bika_sampleconditions.py
@@ -70,19 +70,19 @@ class SampleConditionsView(BikaListingView):
                 'title': _('All'),
                 'contentFilter': {},
                 'transitions': [{'id': 'empty'}, ],
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }, {
                 'id': 'active',
                 'title': _('Active'),
                 'contentFilter': {'inactive_state': 'active'},
                 'transitions': [{'id': 'deactivate'}, ],
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }, {
                 'id': 'inactive',
                 'title': _('Dormant'),
                 'contentFilter': {'inactive_state': 'inactive'},
                 'transitions': [{'id': 'activate'}, ],
-                "columns": self.columns,
+                "columns": self.columns.keys(),
 
              }
         ]

--- a/bika/lims/controlpanel/bika_samplepoints.py
+++ b/bika/lims/controlpanel/bika_samplepoints.py
@@ -88,18 +88,18 @@ class SamplePointsView(BikaListingView):
                 "title": _("Active"),
                 "contentFilter": {"inactive_state": "active"},
                 "transitions": [{"id": "deactivate"}, ],
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }, {
                 "id": "inactive",
                 "title": _("Dormant"),
                 "contentFilter": {"inactive_state": "inactive"},
                 "transitions": [{"id": "activate"}, ],
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }, {
                 "id": "all",
                 "title": _("All"),
                 "contentFilter": {},
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }
         ]
 

--- a/bika/lims/controlpanel/bika_sampletypes.py
+++ b/bika/lims/controlpanel/bika_sampletypes.py
@@ -99,18 +99,18 @@ class SampleTypesView(BikaListingView):
                 "title": _("Active"),
                 "contentFilter": {"inactive_state": "active"},
                 "transitions": [{"id": "deactivate"}, ],
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }, {
                 "id": "inactive",
                 "title": _("Dormant"),
                 "contentFilter": {"inactive_state": "inactive"},
                 "transitions": [{"id": "activate"}, ],
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }, {
                 "id": "all",
                 "title": _("All"),
                 "contentFilter": {},
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }
         ]
 

--- a/bika/lims/controlpanel/bika_samplingdeviations.py
+++ b/bika/lims/controlpanel/bika_samplingdeviations.py
@@ -67,19 +67,19 @@ class SamplingDeviationsView(BikaListingView):
                 "title": _("All"),
                 "contentFilter": {},
                 "transitions": [{"id": "empty"}, ],
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }, {
                 "id": "active",
                 "title": _("Active"),
                 "contentFilter": {"inactive_state": "active"},
                 "transitions": [{"id": "deactivate"}, ],
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }, {
                 "id": "inactive",
                 "title": _("Dormant"),
                 "contentFilter": {"inactive_state": "inactive"},
                 "transitions": [{"id": "activate"}, ],
-                "columns": self.columns,
+                "columns": self.columns.keys(),
             }
         ]
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The new listings use an `OrderedDict` as the `columns` config.
The keys of this config can be used in the display config of the review_states

## Current behavior before PR

`self.columns` used in `review_states` config

## Desired behavior after PR is merged

`self.columns.keys()` used in `review_states` config

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
