### PR TITLE
Label "Date Received" appears twice in Analysis Request view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,7 @@ Changelog
 
 **Fixed**
 
+- #940 Label "Date Received" appears twice in Analysis Request view
 - #917 Localization of date and time strings in listings
 - #902 Attribute error when updating QC results using an import interface
 - #456 Date Published appears two times on the header table of AR view

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -1434,6 +1434,7 @@ schema = BikaSchema.copy() + Schema((
         widget=DateTimeWidget(
             label=_("Date Received"),
             description=_("The date when the sample was received"),
+            render_own_label=True,
             visible={
                 'edit': 'visible',
                 'view': 'visible',


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The label for Date Received only gets rendered once.

## Current behavior before PR

![imatge](https://user-images.githubusercontent.com/832627/43357681-bfd67b6e-9285-11e8-8e93-24655750e80d.png)


## Desired behavior after PR is merged

![imatge](https://user-images.githubusercontent.com/832627/43357686-d289700e-9285-11e8-8c53-3bce40e3af00.png)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
