### PR TITLE
Only the first analysis get saved in Analysis Specifications

### DIFF
--- a/bika/lims/browser/widgets/analysisspecificationwidget.py
+++ b/bika/lims/browser/widgets/analysisspecificationwidget.py
@@ -175,13 +175,6 @@ class AnalysisSpecificationView(BikaListingView):
             after_icons += get_image(
                 "attach_no.png", title=_("Attachment not permitted"))
 
-        # TRICK for AS keyword retrieval on form POST
-        keyword_input_field = "<input type='hidden' " \
-                              "name='keyword.{}:records' " \
-                              "value='{}'/>".format(
-                                  service.UID(), service.getKeyword())
-        after_icons += keyword_input_field
-
         state = api.get_workflow_status_of(service, state_var="inactive_state")
         unit = service.getUnit()
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Only the ranges for the first Analysis Service from the list are stored in Analysis Specifications edit view.

## Current behavior before PR

Only the ranges for the first Analysis Service from the list are stored in Analysis Specifications edit view.

## Desired behavior after PR is merged

Values for all Analysis Services are stored when submitting an Analysis Specification.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
