### PR TITLE
Remarks style in Manage Results/Analyses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Changelog
 
 **Changed**
 
+- #944 Remarks style in Manage Results/Analyses
 - #943 AnalysisRequest View Remarks Field Style
 - #938 Refactored Analysis Profiles Widget
 - #937 Refactored Analysis Specifications Widget

--- a/bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt
@@ -1,143 +1,128 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:tal="http://xml.zope.org/namespaces/tal"
-    xmlns:metal="http://xml.zope.org/namespaces/metal"
-    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-    metal:use-macro="here/main_template/macros/master"
-    i18n:domain="senaite.core">
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="senaite.core">
 
-<body
-    tal:define="
-        form_id view/form_id;
-        table_only python:hasattr(view, 'table_only') and view.table_only or view.request.get('table_only','') == form_id;"
+  <body
+    tal:define="form_id view/form_id;
+                table_only python:hasattr(view, 'table_only') and view.table_only or view.request.get('table_only','') == form_id;"
     tal:omit-tag="python:table_only">
 
-<metal:content-title fill-slot="content-title"
-    tal:define="
-        form_id view/form_id;
-        table_only python:hasattr(view, 'table_only') and view.table_only or view.request.get('table_only','') == form_id;"
-    tal:condition="python:not table_only">
-    <h1>
+    <metal:content-title fill-slot="content-title"
+                         tal:define="form_id view/form_id;
+                                     table_only python:hasattr(view, 'table_only') and view.table_only or view.request.get('table_only','') == form_id;"
+                         tal:condition="python:not table_only">
+      <h1>
         <img tal:condition="view/icon | nothing"
              src="" tal:attributes="src view/icon"/>
         <span style="position:relative;top:-0.2em;" class="documentFirstHeading" tal:content="view/title"/>
         <tal:add_actions repeat="add_item python:view.context_actions.keys()">
-            <a tal:attributes="
-                style python:'background: url(%s) 2px 50%% no-repeat'%(view.context_actions[add_item]['icon']);
-                href python:view.context_actions[add_item]['url'];
-                class python:'context_action_link %s' % (view.context_actions[add_item].get('class',''))">
-                <span tal:replace="python:add_item"/>
-            </a>
-        </tal:add_actions>
-
-    </h1>
-</metal:content-title>
-
-<metal:content-description fill-slot="content-description"
-    tal:define="
-        form_id view/form_id;
-        table_only python:hasattr(view, 'table_only') and view.table_only or view.request.get('table_only','') == form_id;"
-    tal:condition="python:not table_only">
-    <div class="documentDescription"
-        tal:content="structure view/description"
-        tal:condition="view/description"/>
-</metal:content-description>
-
-<metal:content-core fill-slot="content-core">
-
-<span id="bika_setup" style="display:none;"
-    tal:define="bs python: context.bika_setup;"
-    tal:attributes="EnableARSpecs python: 'true' if bs.getEnableARSpecs() else '';
-                    ShowPartitions python: 'true' if bs.getShowPartitions() else '';
-                    SHowPrices python: 'true' if bs.getShowPartitions() else '';">
-</span>
-
-<h3 style="margin-top:1em;" tal:condition="python:context.bika_setup.getShowPartitions()">
-    <img
-        i18n:attributes="title"
-        title="Partitions"
-        tal:attributes="src string:${view/portal_url}/++resource++bika.lims.images/samplepartition.png"/>
-    <span i18n:translate="">Sample Partitions</span>
-    <tal:add_actions repeat="add_item python:view.context_actions.keys()">
-        <a tal:attributes="
-            style python:'background: url(%s) 2px 50%% no-repeat'%(view.context_actions[add_item]['icon']);
-            href python:view.context_actions[add_item]['url'];
-            class python:'context_action_link %s' % (view.context_actions[add_item].get('class',''))">
+          <a tal:attributes="style python:'background: url(%s) 2px 50%% no-repeat'%(view.context_actions[add_item]['icon']);
+                             href python:view.context_actions[add_item]['url'];
+                             class python:'context_action_link %s' % (view.context_actions[add_item].get('class',''))">
             <span tal:replace="python:add_item"/>
-        </a>
-    </tal:add_actions>
-</h3>
+          </a>
+        </tal:add_actions>
+      </h1>
+    </metal:content-title>
 
-<form id="list" action="workflow_action" method="post" name="bika_listing_form">
-    <input tal:replace="structure context/@@authenticator/authenticator"/>
-    <input type="hidden"
-        name="logged_in_client"
-        tal:define="groups_tool python:context.portal_groups;
-                    membership_tool python:context.portal_membership;
-                    member python:membership_tool.getAuthenticatedMember();
-                    member_groups python:[groups_tool.getGroupById(group.id).getGroupName() for group in groups_tool.getGroupsByUserId(member.id)];
-                    logged_in_client python:'Clients' in member_groups;"
-         tal:condition="logged_in_client"
-         value="1"
-    />
-    <input type="hidden" value="1" name="submitted">
-    <input type="hidden" value="list" name="form_id">
-    <input type="hidden" tal:attributes="value view/view_url" name="view_url">
-    <input type="hidden" tal:attributes="value context/portal_type" name="portal_type">
-    <input type="hidden" value="id" name="list_sort_on">
-    <input type="hidden" value="ascending" name="list_sort_order">
-    <input type="hidden" value="default" name="list_review_state">
-    <input type="hidden" value="1000" name="list_pagesize">
-    <input type="hidden" value="1" name="list_pagenumber">
-    <input type="hidden" value="[]" name="specs">
-    <input id="item_data" type="hidden" value="[]" name="item_data">
-    <input type="hidden" id="ResultsRange" name="ResultsRange"
-            tal:attributes="value view/getResultsRange"/>
+    <metal:content-description fill-slot="content-description"
+                               tal:define="form_id view/form_id;
+                                           table_only python:hasattr(view, 'table_only') and view.table_only or view.request.get('table_only','') == form_id;"
+                               tal:condition="python:not table_only">
+      <div class="documentDescription"
+           tal:content="structure view/description"
+           tal:condition="view/description"/>
+    </metal:content-description>
 
-    <span style="display:none"
-        id="st_title"
-        tal:attributes="st_title python:context.getSample().getSampleType().Title()">
-    </span>
+    <metal:content-core fill-slot="content-core">
 
-    <span id="partitions" tal:condition="python:context.bika_setup.getShowPartitions()">
-        <tal:parts replace="structure view/parts"/>
-    </span>
+      <span id="bika_setup" style="display:none;"
+            tal:define="bs python: context.bika_setup;"
+            tal:attributes="EnableARSpecs python: 'true' if bs.getEnableARSpecs() else '';
+                            ShowPartitions python: 'true' if bs.getShowPartitions() else '';
+                            SHowPrices python: 'true' if bs.getShowPartitions() else '';">
+      </span>
 
-    <h3 style="margin-top:1em;">
+      <h3 style="margin-top:1em;" tal:condition="python:context.bika_setup.getShowPartitions()">
         <img
+          i18n:attributes="title"
+          title="Partitions"
+          tal:attributes="src string:${view/portal_url}/++resource++bika.lims.images/samplepartition.png"/>
+        <span i18n:translate="">Sample Partitions</span>
+        <tal:add_actions repeat="add_item python:view.context_actions.keys()">
+          <a tal:attributes="style python:'background: url(%s) 2px 50%% no-repeat'%(view.context_actions[add_item]['icon']);
+                             href python:view.context_actions[add_item]['url'];
+                             class python:'context_action_link %s' % (view.context_actions[add_item].get('class',''))">
+            <span tal:replace="python:add_item"/>
+          </a>
+        </tal:add_actions>
+      </h3>
+
+      <form id="list" action="workflow_action" method="post" name="bika_listing_form">
+        <input tal:replace="structure context/@@authenticator/authenticator"/>
+        <input type="hidden"
+               name="logged_in_client"
+               tal:define="groups_tool python:context.portal_groups;
+                           membership_tool python:context.portal_membership;
+                           member python:membership_tool.getAuthenticatedMember();
+                           member_groups python:[groups_tool.getGroupById(group.id).getGroupName() for group in groups_tool.getGroupsByUserId(member.id)];
+                           logged_in_client python:'Clients' in member_groups;"
+               tal:condition="logged_in_client"
+               value="1" />
+
+        <input type="hidden" value="1" name="submitted">
+        <input type="hidden" value="list" name="form_id">
+        <input type="hidden" tal:attributes="value view/view_url" name="view_url">
+        <input type="hidden" tal:attributes="value context/portal_type" name="portal_type">
+        <input type="hidden" value="id" name="list_sort_on">
+        <input type="hidden" value="ascending" name="list_sort_order">
+        <input type="hidden" value="default" name="list_review_state">
+        <input type="hidden" value="1000" name="list_pagesize">
+        <input type="hidden" value="1" name="list_pagenumber">
+        <input type="hidden" value="[]" name="specs">
+        <input id="item_data" type="hidden" value="[]" name="item_data">
+        <input type="hidden" id="ResultsRange" name="ResultsRange"
+               tal:attributes="value view/getResultsRange"/>
+
+        <span style="display:none"
+              id="st_title"
+              tal:attributes="st_title python:context.getSample().getSampleType().Title()">
+        </span>
+
+        <span id="partitions" tal:condition="python:context.bika_setup.getShowPartitions()">
+          <tal:parts replace="structure view/parts"/>
+        </span>
+
+        <h3 style="margin-top:1em;">
+          <img
             i18n:attributes="title"
             title="Analyses"
             tal:attributes="src string:${view/portal_url}/++resource++bika.lims.images/analysisservice.png"/>
-        <span i18n:translate="">Analyses</span>
-    </h3>
+          <span i18n:translate="">Analyses</span>
+        </h3>
 
-    <div id="folderlisting-main-table"
-        tal:content="structure view/contents_table"/>
+        <div id="folderlisting-main-table"
+             tal:content="structure view/contents_table"/>
 
-    </form>
+      </form>
 
-    <tal:remarks tal:condition="python:hasattr(context.aq_inner, 'schema') and 'Remarks' in context.schema"
-                 define="checkPermission nocall: context/portal_membership/checkPermission;
-                         mode python:'edit' if checkPermission('Modify portal content', context) else 'view';
-                         field python:context.Schema()['Remarks'];
-                         errors python:{};">
-        <metal:widget use-macro="python:context.widget('Remarks', mode=mode)"/>
-    </tal:remarks>
-
-    <tal:rejection define="
-        field python:context.Schema()['RejectionReasons'];
-        widget python:field.widget;
-        errors python:{};">
+      <tal:rejection define="field python:context.Schema()['RejectionReasons'];
+                             widget python:field.widget;
+                             errors python:{};">
         <table style="display: none;">
-            <td>
-                <span tal:replace="python:widget.label"/>
-            </td>
-            <td>
-                <metal:widget use-macro="python:context.widget('RejectionReasons', mode='edit')" />
-            </td>
+          <td>
+            <span tal:replace="python:widget.label"/>
+          </td>
+          <td>
+            <metal:widget use-macro="python:context.widget('RejectionReasons', mode='edit')" />
+          </td>
         </table>
-    </tal:rejection>
+      </tal:rejection>
 
-</metal:content-core>
+    </metal:content-core>
 
-</body>
+  </body>
 </html>

--- a/bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt
@@ -1,74 +1,102 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:tal="http://xml.zope.org/namespaces/tal"
-    xmlns:metal="http://xml.zope.org/namespaces/metal"
-    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-    metal:use-macro="here/main_template/macros/master"
-    i18n:domain="senaite.core">
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="senaite.core">
 
-<body tal:define="
-    portal context/@@plone_portal_state/portal;
-    global out_of_range python:0;
-    global late python:0;
-    tabindex view/tabindex;
-    now view/now">
+  <head>
+    <title></title>
+    <metal:block fill-slot="javascript_head_slot"
+                 tal:define="portal context/@@plone_portal_state/portal;">
 
-<metal:content-title fill-slot="content-title">
-    <h1>
-    <img tal:condition="view/icon | nothing"
-         src="" tal:attributes="src view/icon"/>
-    <span class="documentFirstHeading" tal:content="context/title_or_id"></span>
-	<img tal:condition="python:context.getSample().getSampleType().getHazardous()"
-		title="Hazardous"
-		i18n:attributes="value"
-		tal:attributes="src string:${view/portal_url}/++resource++bika.lims.images/hazardous_big.png"/>
-	<img tal:condition="python:context.getInvoiceExclude()"
-		title="Exclude from invoice"
-		i18n:attributes="value"
-		tal:attributes="src string:${view/portal_url}/++resource++bika.lims.images/invoice_exclude_big.png"/>
-    </h1>
-</metal:content-title>
+      <!-- TODO move to senaite.lims bootstrap css -->
+      <style type="text/css">
+       #remarks-widget {
+         padding-top: 2em;
+       }
+       #archetypes-fieldname-Remarks {
+         padding: 0!important;
+       }
+       #remarks-widget fieldset legend {
+         display: none;
+       }
+       #remarks-widget input.saveRemarks {
+         margin-top: 1em;
+       }
+      </style>
+    </metal:block>
+  </head>
 
-<metal:content-description fill-slot="content-description">
-</metal:content-description>
+  <body tal:define="ortal context/@@plone_portal_state/portal;
+                    global out_of_range python:0;
+                    global late python:0;
+                    tabindex view/tabindex;
+                    now view/now">
 
-<metal:content-core fill-slot="content-core" tal:define="
-	tabindex view/tabindex;
-	portal context/@@plone_portal_state/portal;">
+    <metal:content-title fill-slot="content-title">
+      <h1>
+        <img tal:condition="view/icon | nothing"
+             src="" tal:attributes="src view/icon"/>
+        <span class="documentFirstHeading" tal:content="context/title_or_id"></span>
+        <img tal:condition="python:context.getSample().getSampleType().getHazardous()"
+                            title="Hazardous"
+                            i18n:attributes="value"
+                            tal:attributes="src string:${view/portal_url}/++resource++bika.lims.images/hazardous_big.png"/>
+        <img tal:condition="python:context.getInvoiceExclude()"
+                            title="Exclude from invoice"
+                            i18n:attributes="value"
+                            tal:attributes="src string:${view/portal_url}/++resource++bika.lims.images/invoice_exclude_big.png"/>
+      </h1>
+    </metal:content-title>
 
-    <tal:tables tal:repeat="table python:view.tables.items()" tal:condition="python:hasattr(view, 'tables')">
+    <metal:content-description fill-slot="content-description">
+    </metal:content-description>
+
+    <metal:content-core fill-slot="content-core" tal:define="
+                                   tabindex view/tabindex;
+                                   portal context/@@plone_portal_state/portal;">
+
+      <tal:tables tal:repeat="table python:view.tables.items()" tal:condition="python:hasattr(view, 'tables')">
         <h3>
-            <img
-				i18n:attributes="title"
-				title="Analyses"
-				tal:attributes="src string:${view/portal_url}/++resource++bika.lims.images/analysisservice.png"/>
-            <span tal:content="python: table[0]"/>
+          <img
+            i18n:attributes="title"
+                             title="Analyses"
+                             tal:attributes="src string:${view/portal_url}/++resource++bika.lims.images/analysisservice.png"/>
+          <span tal:content="python: table[0]"/>
         </h3>
         <span tal:replace="structure python: table[1]"/>
-    </tal:tables>
+      </tal:tables>
 
-	<tal:remarks tal:condition="python:hasattr(context.aq_inner, 'schema') and 'Remarks' in context.schema"
-               tal:define="checkPermission nocall: context/portal_membership/checkPermission;
-                           mode python:'edit' if checkPermission('Modify portal content', context) else 'view';
-                           field python:context.Schema()['Remarks'];
-                           errors python:{};">
-		<metal:widget use-macro="python:context.widget('Remarks', mode=mode)"/>
-	</tal:remarks>
+      <!-- Refactored Remarks Widget
+           https://github.com/senaite/senaite.core/pull/920 -->
+      <div id="remarks-widget" tal:define="checkPermission nocall: context/portal_membership/checkPermission;
+               mode python:'edit' if checkPermission('Modify portal content', context) else 'view';
+               field python:context.Schema()['Remarks'];
+               errors python:{};">
+        <h3>
+          <img i18n:attributes="title" title="Remarks" src="++resource++bika.lims.images/remarks.png"/>
+          <span i18n:translate="">Remarks</span>
+        </h3>
+        <div class="well">
+          <metal:widget use-macro="python:context.widget('Remarks', mode=mode)"/>
+        </div>
+      </div>
 
-    <tal:rejection define="
-        field python:context.Schema()['RejectionReasons'];
-        widget python:field.widget;
-        errors python:{};">
+      <tal:rejection define="field python:context.Schema()['RejectionReasons'];
+                             widget python:field.widget;
+                             errors python:{};">
         <table style="display: none;">
-            <td>
-                <span tal:replace="python:widget.label"/>
-            </td>
-            <td>
-                <metal:widget use-macro="python:context.widget('RejectionReasons', mode='edit')" />
-            </td>
+          <td>
+            <span tal:replace="python:widget.label"/>
+          </td>
+          <td>
+            <metal:widget use-macro="python:context.widget('RejectionReasons', mode='edit')" />
+          </td>
         </table>
-    </tal:rejection>
+      </tal:rejection>
 
-</metal:content-core>
+    </metal:content-core>
 
-</body>
+  </body>
 </html>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR applies the same style of the Remarks style to the Manage Results View.
The Remarks widget from the Manage Analyses View is removed

## Current behavior before PR

- old Remarks style in Manage Results View
- Remarks widget visible on the bottom of the Manage Analyses View

## Desired behavior after PR is merged

- new Remarks style in Manage Results View
- Remarks widget removed from the bottom of the Manage Analyses View


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
