### PR TITLE
Inactive Sample Types shown in Analysis Specifications

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,7 @@ Changelog
 
 **Fixed**
 
+- #948 Inactive Sample Types shown in Analysis Specifications
 - #940 Label "Date Received" appears twice in Analysis Request view
 - #917 Localization of date and time strings in listings
 - #902 Attribute error when updating QC results using an import interface

--- a/bika/lims/content/analysisspec.py
+++ b/bika/lims/content/analysisspec.py
@@ -13,10 +13,11 @@ from bika.lims.config import PROJECTNAME
 from bika.lims.content.bikaschema import BikaSchema
 from bika.lims.interfaces import IAnalysisSpec
 from Products.Archetypes import atapi
-from Products.Archetypes.config import REFERENCE_CATALOG
-from Products.Archetypes.public import (BaseFolder, ComputedField,
-                                        ComputedWidget, ReferenceWidget,
-                                        Schema)
+from Products.Archetypes.public import BaseFolder
+from Products.Archetypes.public import ComputedField
+from Products.Archetypes.public import ComputedWidget
+from Products.Archetypes.public import ReferenceWidget
+from Products.Archetypes.public import Schema
 from Products.Archetypes.utils import DisplayList
 from Products.ATContentTypes.lib.historyaware import HistoryAwareMixin
 from Products.ATExtensions.field.records import RecordsField


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the issue that inactive Sample Types are offered for selection in new Analysis Specifications.

## Current behavior before PR

Inactive Sample Types are displayed in Analysis Specs selection

## Desired behavior after PR is merged

Only active Sample Types are displayed in Analysis Specs selection

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
