### PR TITLE
Join min/max specification value with semicolon in listing

### DIFF
--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -927,7 +927,8 @@ class AnalysesView(BikaListingView):
         max_str = results_range.get('max', '')
         min_str = api.is_floatable(min_str) and "{0}".format(min_str) or ""
         max_str = api.is_floatable(max_str) and "{0}".format(max_str) or ""
-        specs = ", ".join([val for val in [min_str, max_str] if val])
+        # Join with semi-colon to avoid confusion with commas as decimal mark
+        specs = "; ".join([val for val in [min_str, max_str] if val])
         if not specs:
             return
         item["Specification"] = "[{}]".format(specs)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR joins the min/max values with `;` instead of `,` to avoid confusion when using comma as decimal mark


## Current behavior before PR

min/max values separated with `,` in AR view

## Desired behavior after PR is merged

min/max values separated with `;` in AR view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
