### PR TITLE
#366 Traceback on batch book view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,7 @@ Changelog
 - #909 List of clients cannot sort by Client ID
 - #921 Missing interim fields in worksheet/analyses_transposed view
 - #920 Refactored Remarks and created RemarksField and RemarksWidget
+- #958 Traceback on batch book view
 
 **Security**
 

--- a/bika/lims/browser/batch/batchbook.py
+++ b/bika/lims/browser/batch/batchbook.py
@@ -211,8 +211,10 @@ class BatchBookView(BikaListingView):
         # Insert columns for analyses
         for d_a in distinct:
             keyword = d_a.getKeyword()
+            short = d_a.getShortTitle()
+            title = d_a.Title()
             self.columns[keyword] = {
-                'title': d_a.ShortTitle if d_a.ShortTitle else d_a.Title,
+                'title':  short if short else title,
                 'sortable': True
             }
             self.review_states[0]['columns'].insert(


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/366

I can't reproduce this, but I'm certain this will fix it.

## Current behavior before PR

BatchBook throws a traceback

## Desired behavior after PR is merged

BatchBook does not throw traceback!

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
