### PR TITLE
Time not displayed for Date Created in Analysis Requests listings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,7 @@ Changelog
 - #909 List of clients cannot sort by Client ID
 - #921 Missing interim fields in worksheet/analyses_transposed view
 - #920 Refactored Remarks and created RemarksField and RemarksWidget
+- #959 Time not displayed for Date Received in Analysis Requests listings
 
 **Security**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,7 @@ Changelog
 
 **Fixed**
 
+- #959 Time not displayed for Date Created in Analysis Requests listings
 - #949 Retain AR Spec if Analyses were added/removed
 - #948 Inactive Sample Types shown in Analysis Specifications
 - #940 Label "Date Received" appears twice in Analysis Request view
@@ -46,7 +47,6 @@ Changelog
 - #909 List of clients cannot sort by Client ID
 - #921 Missing interim fields in worksheet/analyses_transposed view
 - #920 Refactored Remarks and created RemarksField and RemarksWidget
-- #959 Time not displayed for Date Received in Analysis Requests listings
 
 **Security**
 

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -772,7 +772,7 @@ class AnalysisRequestsView(BikaListingView):
         if after_icons:
             item['after']['getId'] = after_icons
 
-        item['Created'] = self.ulocalized_time(obj.created)
+        item['Created'] = self.ulocalized_time(obj.created, long_format=1)
         if obj.getContactUID:
             item['ClientContact'] = obj.getContactFullName
             item['replace']['ClientContact'] = "<a href='%s'>%s</a>" % \

--- a/bika/lims/browser/batch/batchbook.py
+++ b/bika/lims/browser/batch/batchbook.py
@@ -184,7 +184,7 @@ class BatchBookView(BikaListingView):
                 'url': ar.absolute_url(),
                 'relative_url': ar.absolute_url(),
                 'view_url': ar.absolute_url(),
-                'created': self.ulocalized_time(ar.created()),
+                'created': self.ulocalized_time(ar.created(), long_format=1),
                 'sort_key': ar.created(),
                 'replace': {
                     'Batch': batchlink,

--- a/bika/lims/browser/sample/view.py
+++ b/bika/lims/browser/sample/view.py
@@ -424,7 +424,7 @@ class SamplesView(BikaListingView):
         item['getStorageLocation'] = obj.getStorageLocation() and obj.getStorageLocation().Title() or ''
         item['AdHoc'] = obj.getAdHoc() and True or ''
 
-        item['Created'] = self.ulocalized_time(obj.created())
+        item['Created'] = self.ulocalized_time(obj.created(), long_format=1)
 
         sd = obj.getSamplingDate()
         item['SamplingDate'] = \

--- a/bika/lims/browser/worksheet/views/analysisrequests.py
+++ b/bika/lims/browser/worksheet/views/analysisrequests.py
@@ -71,7 +71,7 @@ class AnalysisRequestsView(BikaListingView):
                 'Position': pos,
                 'RequestID': ar.id,
                 'Client': ar.aq_parent.Title(),
-                'created': self.ulocalized_time(ar.created()),
+                'created': self.ulocalized_time(ar.created(), long_format=1),
                 'replace': {},
                 'before': {},
                 'after': {},


### PR DESCRIPTION
Fixed the main Sample listing too.

## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/922

## Current behavior before PR

Listings of ARs show DateReceived without the time (long_format=False).

## Desired behavior after PR is merged

- Time is show in DateReceived wherever ARs are listed.

- Also fixed this column up in the sample listing view. 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
