### PR TITLE
#942: Traceback on AnalysisSpec Log

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,7 @@ Changelog
 - #909 List of clients cannot sort by Client ID
 - #921 Missing interim fields in worksheet/analyses_transposed view
 - #920 Refactored Remarks and created RemarksField and RemarksWidget
+- #960 Traceback on AnalysisSpec Log
 
 **Security**
 

--- a/bika/lims/browser/templates/bika_listing_table_items.pt
+++ b/bika/lims/browser/templates/bika_listing_table_items.pt
@@ -412,7 +412,7 @@
 
     <!-- Row Range comments field (for Analysis Specifications) -->
     <tal:rangecomments
-      condition="python:view.context.portal_type=='AnalysisSpec'"
+      condition="python:view.form_id=='analysisspecs'"
       define="column string:rangecomment;
               allow_edit python:view.bika_listing.allow_edit \
               and item.get('edit_condition', {}).get(column, True)">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/942

## Current behavior before PR

Log tab of AnalysisSpec throws traceback

## Desired behavior after PR is merged

Log tab does not throw traceback!

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
