### PR TITLE
Calculated results not marked for submission if zero

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,7 @@ Changelog
 - #920 Refactored Remarks and created RemarksField and RemarksWidget
 - #958 Traceback on batch book view
 - #960 Traceback on AnalysisSpec Log
+- #962 Calculated results not marked for submission if zero
 
 **Security**
 

--- a/bika/lims/browser/js/bika.lims.utils.calcs.js
+++ b/bika/lims/browser/js/bika.lims.utils.calcs.js
@@ -201,7 +201,7 @@ function CalculationUtils() {
                         $("span[uid='"+result.uid+"']").filter("span[field='formatted_result']").empty().append(result.formatted_result);
 
                         // check box
-                        if (result.result != '' && result.result != ""){
+                        if (result.result == 0 || (result.result != "")){
                             if ($("[id*='cb_"+result.uid+"']").prop("checked") == false) {
                                 $("[id*='cb_"+result.uid+"']").prop('checked', true);
                             }


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/476

## Current behavior before PR

If calculated result is zero, checkbox of analysis is not selected.

## Desired behavior after PR is merged

Checkbox correctly selected if any result is returned.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
