### PR TITLE
Dormant Analysis Services displayed in AR Templates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,7 +50,7 @@ Changelog
 - #958 Traceback on batch book view
 - #960 Traceback on AnalysisSpec Log
 - #962 Calculated results not marked for submission if zero
-- Dormant Analysis Services displayed in AR Templates
+- #964 Dormant Analysis Services displayed in AR Templates
 
 **Security**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,7 @@ Changelog
 - #958 Traceback on batch book view
 - #960 Traceback on AnalysisSpec Log
 - #962 Calculated results not marked for submission if zero
+- Dormant Analysis Services displayed in AR Templates
 
 **Security**
 

--- a/bika/lims/browser/widgets/artemplateanalyseswidget.py
+++ b/bika/lims/browser/widgets/artemplateanalyseswidget.py
@@ -63,7 +63,7 @@ class ARTemplateAnalysesView(BikaListingView):
         self.review_states = [
             {'id':'default',
              'title': _('All'),
-             'contentFilter':{},
+             'contentFilter': {'inactive_state': 'active'},
              'columns': ['Title',
                          'Price',
                          'Partition',


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/524

## Current behavior before PR

ARTemplate/Analyses includes inactive services.

## Desired behavior after PR is merged

ARTemplate/Analyses excludes inactive services.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
