### PR TITLE
Added operators for max and min values in Specifications

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Changelog
 
 **Changed**
 
+- #965 Specifications Max values are exclusive while Min values remain inclusive
 - #944 Remarks style in Manage Results/Analyses
 - #943 AnalysisRequest View Remarks Field Style
 - #938 Refactored Analysis Profiles Widget

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,12 +6,12 @@ Changelog
 
 **Added**
 
+- #965 Added operators for max and min values in Specifications
 - #947 Instrument import interface: Cobas Integra 400plus
 - #924 Added ExtProxyField for its use in SchemaExtender
 
 **Changed**
 
-- #965 Specifications Max values are exclusive while Min values remain inclusive
 - #953 Refactored Analysis Categories Listing
 - #956 Refactored LabContacts Listing
 - #955 Refactored Departments Listing

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -1,6 +1,17 @@
 Release notes
 =============
 
+Update from 1.2.7 to 1.2.8
+--------------------------
+
+- Specification maximum values (`max`, `warn_max` and `hide_max`) become
+  exclusive, while min values (`min`, `warn_min` and `hide_min`) remain
+  inclusive: A result is in range if the value equals or is above min, and
+  below max: [min] <= [result] < [max]). Same rule applies for `min_warn`,
+  `max_warn`, `hide_min` and `hide_max` fields.
+  https://github.com/senaite/senaite.core/pull/965
+
+
 Update from 1.2.4 to 1.2.5
 --------------------------
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,11 +4,9 @@ Release notes
 Update from 1.2.7 to 1.2.8
 --------------------------
 
-- Specification maximum values (`max`, `warn_max` and `hide_max`) become
-  exclusive, while min values (`min`, `warn_min` and `hide_min`) remain
-  inclusive: A result is in range if the value equals or is above min, and
-  below max: [min] <= [result] < [max]). Same rule applies for `min_warn`,
-  `max_warn`, `hide_min` and `hide_max` fields.
+- Operators for min and max values have been added. For specifications already
+  present in the system, the result ranges are considered as bounded and closed:
+  `[min,max] = {result | min <= result <= max}`.
   https://github.com/senaite/senaite.core/pull/965
 
 

--- a/bika/lims/api/analysis.py
+++ b/bika/lims/api/analysis.py
@@ -75,6 +75,10 @@ def is_out_of_range(brain_or_object, result=_marker):
     # the result will be in range also if no min/max values are defined
     specs_min = api.to_float(result_range.get('min', result), result)
     specs_max = api.to_float(result_range.get('max', result), result)
+    if specs_min == result == specs_max:
+        # There is no range (a specific value instead)
+        return False, False
+
     if specs_min <= result < specs_max:
         # In range, no need to check shoulders
         return False, False
@@ -84,5 +88,9 @@ def is_out_of_range(brain_or_object, result=_marker):
     # specs' min and max as default fallback values
     warn_min = api.to_float(result_range.get('warn_min', specs_min), specs_min)
     warn_max = api.to_float(result_range.get('warn_max', specs_max), specs_max)
+    if warn_min == result == warn_max:
+        # There is no range (a specific value instead)
+        return True, False
+
     in_shoulder = warn_min <= result < warn_max
     return True, not in_shoulder

--- a/bika/lims/api/analysis.py
+++ b/bika/lims/api/analysis.py
@@ -133,7 +133,5 @@ def get_formatted_interval(results_range, default=_marker):
     # Both values set. Return an interval
     min_bracket = min_operator == 'geq' and '[' or '('
     max_bracket = max_operator == 'leq' and ']' or ')'
-    decimal_mark = api.get_bika_setup().getResultsDecimalMark()
-    sep = decimal_mark == "." and "," or ";"
 
-    return "{}{}{}{}{}".format(min_bracket, min_str, sep, max_str, max_bracket)
+    return "{}{};{}{}".format(min_bracket, min_str, max_str, max_bracket)

--- a/bika/lims/api/analysis.py
+++ b/bika/lims/api/analysis.py
@@ -22,6 +22,8 @@ def is_out_of_range(brain_or_object, result=_marker):
     ----- out-of-range -----><----- in-range ------><----- out-of-range -----
              <-- shoulder --><----- in-range ------><-- shoulder -->
 
+    NOTE: min values are inclusive (<=) and max values are exclusive (>)
+
     :param brain_or_object: A single catalog brain or content object
     :param result: Tentative result. If None, use the analysis result
     :type brain_or_object: ATContentType/DexterityContentType/CatalogBrain
@@ -73,7 +75,7 @@ def is_out_of_range(brain_or_object, result=_marker):
     # the result will be in range also if no min/max values are defined
     specs_min = api.to_float(result_range.get('min', result), result)
     specs_max = api.to_float(result_range.get('max', result), result)
-    if specs_min <= result <= specs_max:
+    if specs_min <= result < specs_max:
         # In range, no need to check shoulders
         return False, False
 
@@ -82,5 +84,5 @@ def is_out_of_range(brain_or_object, result=_marker):
     # specs' min and max as default fallback values
     warn_min = api.to_float(result_range.get('warn_min', specs_min), specs_min)
     warn_max = api.to_float(result_range.get('warn_max', specs_max), specs_max)
-    in_shoulder = warn_min <= result <= warn_max
+    in_shoulder = warn_min <= result < warn_max
     return True, not in_shoulder

--- a/bika/lims/api/analysis.py
+++ b/bika/lims/api/analysis.py
@@ -5,6 +5,7 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
+from collections import Mapping
 from bika.lims import api
 from bika.lims.api import _marker
 from bika.lims.config import MIN_OPERATORS, MAX_OPERATORS
@@ -106,16 +107,14 @@ def is_out_of_range(brain_or_object, result=_marker):
 def get_formatted_interval(results_range, default=_marker):
     """Returns a string representation of the interval defined by the results
     range passed in
+    :param results_range: a dict or a ResultsRangeDict
     """
-    if type(results_range) is dict:
-        return get_formatted_interval(ResultsRangeDict(results_range),
-                                      default=default)
-
-    if not results_range or type(results_range) is not ResultsRangeDict:
+    if not isinstance(results_range, Mapping):
         if default is not _marker:
             return default
-        api.fail("Empty results range or type not supported")
+        api.fail("Type not supported")
 
+    results_range = ResultsRangeDict(results_range)
     min_str = api.is_floatable(results_range.min) and results_range.min or ""
     max_str = api.is_floatable(results_range.max) and results_range.max or ""
     if not min_str and not max_str:

--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -13,9 +13,10 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from bika.lims import api, logger
 from bika.lims import bikaMessageFactory as _
-from bika.lims.api.analysis import is_out_of_range
+from bika.lims.api.analysis import is_out_of_range, get_formatted_interval
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
+from bika.lims.config import MIN_OPERATORS, MAX_OPERATORS
 from bika.lims.interfaces import (IAnalysisRequest, IFieldIcons,
                                   IRoutineAnalysis)
 from bika.lims.permissions import (EditFieldResults, EditResults,
@@ -923,15 +924,9 @@ class AnalysesView(BikaListingView):
         results_range = analysis_brain.getResultsRange
         if not results_range:
             return
-        min_str = results_range.get('min', '')
-        max_str = results_range.get('max', '')
-        min_str = api.is_floatable(min_str) and "{0}".format(min_str) or ""
-        max_str = api.is_floatable(max_str) and "{0}".format(max_str) or ""
-        # Join with semi-colon to avoid confusion with commas as decimal mark
-        specs = "; ".join([val for val in [min_str, max_str] if val])
-        if not specs:
-            return
-        item["Specification"] = "[{}]".format(specs)
+
+        # Display the specification interval
+        item["Specification"] = get_formatted_interval(results_range, "")
 
         # Show an icon if out of range
         out_range, out_shoulders = is_out_of_range(analysis_brain)

--- a/bika/lims/browser/calcs.py
+++ b/bika/lims/browser/calcs.py
@@ -13,7 +13,7 @@ from Products.Archetypes.config import REFERENCE_CATALOG
 from Products.CMFCore.utils import getToolByName
 from Products.PythonScripts.standard import html_quote
 from bika.lims import bikaMessageFactory as _, api
-from bika.lims.api.analysis import is_out_of_range
+from bika.lims.api.analysis import is_out_of_range, get_formatted_interval
 from bika.lims.browser import BrowserView
 from bika.lims.interfaces import IFieldIcons
 from bika.lims.utils import t, isnumber
@@ -281,9 +281,7 @@ class ajaxCalculateAnalysisEntry(BrowserView):
             return
 
         result_range = analysis.getResultsRange()
-        rngstr = "{0} {1}, {2} {3}".format(
-            t(_("min")), result_range.get("min"),
-            t(_("max")), result_range.get("max"))
+        rngstr = get_formatted_interval(result_range, default="")
         message = "Result out of range"
         icon = "exclamation.png"
         if not out_of_shoulder:
@@ -293,7 +291,7 @@ class ajaxCalculateAnalysisEntry(BrowserView):
         uid = api.get_uid(analysis)
         alert = self.alerts.get(uid, [])
         alert.append({'icon': "++resource++bika.lims.images/{}".format(icon),
-                      'msg': "{0} ({1})".format(t(_(message)), rngstr),
+                      'msg': "{0} {1}".format(t(_(message)), rngstr),
                       'field': "Result"})
         self.alerts[uid] = alert
 

--- a/bika/lims/browser/widgets/analysisspecificationwidget.py
+++ b/bika/lims/browser/widgets/analysisspecificationwidget.py
@@ -12,7 +12,8 @@ from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
 from bika.lims.browser.bika_listing import BikaListingView
-from bika.lims.utils import get_image
+from bika.lims.config import MIN_OPERATORS, MAX_OPERATORS
+from bika.lims.utils import get_image, to_choices
 from bika.lims.utils import get_link
 from Products.Archetypes.Registry import registerWidget
 from Products.Archetypes.Widget import TypesWidget
@@ -80,8 +81,16 @@ class AnalysisSpecificationView(BikaListingView):
             ("warn_min", {
                 "title": _("Min warn"),
                 "sortable": False}),
+            ("min_operator", {
+                "title": _("Min operator"),
+                "type": "choices",
+                "sortable": False}),
             ("min", {
                 "title": _("Min"),
+                "sortable": False}),
+            ("max_operator", {
+                "title": _("Max operator"),
+                "type": "choices",
                 "sortable": False}),
             ("max", {
                 "title": _("Max"),
@@ -154,7 +163,9 @@ class AnalysisSpecificationView(BikaListingView):
         else:
             specresults = {
                 "keyword": service.getKeyword(),
+                "min_operator": "",
                 "min": "",
+                "max_operator": "",
                 "max": "",
                 "warn_min": "",
                 "warn_max": "",
@@ -192,7 +203,9 @@ class AnalysisSpecificationView(BikaListingView):
             "relative_url": service.absolute_url(),
             "view_url": service.absolute_url(),
             "service": service.Title(),
+            "min_operator": specresults.get("min_operator", "geq"),
             "min": specresults.get("min", ""),
+            "max_operator": specresults.get("max_operator", "leq"),
             "max": specresults.get("max", ""),
             "warn_min": specresults.get("warn_min", ""),
             "warn_max": specresults.get("warn_max", ""),
@@ -204,12 +217,17 @@ class AnalysisSpecificationView(BikaListingView):
             "after": {
                 "service": after_icons,
             },
-            "choices": {},
+            "choices": {
+                "min_operator": to_choices(MIN_OPERATORS),
+                "max_operator": to_choices(MAX_OPERATORS),
+            },
             "class": "state-%s" % (state),
             "state_class": "state-%s" % (state),
             "allow_edit": ["min", "max", "warn_min", "warn_max", "hidemin",
-                           "hidemax", "rangecomment"],
+                           "hidemax", "rangecomment", "min_operator",
+                           "max_operator"],
             "table_row_class": "even",
+            "required": ["min_operator", "max_operator"]
         }
 
         # Add methods
@@ -287,11 +305,20 @@ class AnalysisSpecificationWidget(TypesWidget):
                 # mandatory subfields, the following message will appear after
                 # submission: "Specifications is required, please correct."
                 continue
+            min_operator = self._get_spec_value(form, uid, "min_operator",
+                                                check_floatable=False)
+            max_operator = self._get_spec_value(form, uid, "max_operator",
+                                                check_floatable=False)
+            if not min_operator and not max_operator:
+                # Values for min operator and max operator are required
+                continue
 
             values.append({
                 "keyword": keyword,
                 "uid": uid,
+                "min_operator": min_operator,
                 "min": s_min,
+                "max_operator": max_operator,
                 "max": s_max,
                 "warn_min": self._get_spec_value(form, uid, "warn_min"),
                 "warn_max": self._get_spec_value(form, uid, "warn_max"),

--- a/bika/lims/config.py
+++ b/bika/lims/config.py
@@ -129,3 +129,11 @@ PRIORITIES = DisplayList((
     ('4', _('Low')),
     ('5', _('Lowest')),
 ))
+MIN_OPERATORS = DisplayList((
+    ('geq', ">="),
+    ('gt', '>')
+))
+MAX_OPERATORS = DisplayList((
+    ('leq', "<="),
+    ('lt', '<')
+))

--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -838,7 +838,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         2. Print ResultText of matching ResultOptions
         3. If the result is not floatable, return it without being formatted
         4. If the analysis specs has hidemin or hidemax enabled and the
-           result is out of range, render result as '<min' or '>=max'
+           result is out of range, render result as '<min' or '>max'
         5. If the result is below Lower Detection Limit, show '<LDL'
         6. If the result is above Upper Detecion Limit, show '>UDL'
         7. Otherwise, render numerical value
@@ -900,7 +900,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         except (TypeError, ValueError):
             belowmin = False
         try:
-            abovemax = hidemax and result >= float(hidemax) or False
+            abovemax = hidemax and result > float(hidemax) or False
         except (TypeError, ValueError):
             abovemax = False
 
@@ -909,10 +909,10 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             fdm = formatDecimalMark('< %s' % hidemin, decimalmark)
             return fdm.replace('< ', '&lt; ', 1) if html else fdm
 
-        # 4.2. If result is above max and hidemax enabled, return '>=max'
+        # 4.2. If result is above max and hidemax enabled, return '>max'
         if abovemax:
-            fdm = formatDecimalMark('>= %s' % hidemax, decimalmark)
-            return fdm.replace('>= ', '&gt; ', 1) if html else fdm
+            fdm = formatDecimalMark('> %s' % hidemax, decimalmark)
+            return fdm.replace('> ', '&gt; ', 1) if html else fdm
 
         # Below Lower Detection Limit (LDL)?
         ldl = self.getLowerDetectionLimit()

--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -838,7 +838,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         2. Print ResultText of matching ResultOptions
         3. If the result is not floatable, return it without being formatted
         4. If the analysis specs has hidemin or hidemax enabled and the
-           result is out of range, render result as '<min' or '>max'
+           result is out of range, render result as '<min' or '>=max'
         5. If the result is below Lower Detection Limit, show '<LDL'
         6. If the result is above Upper Detecion Limit, show '>UDL'
         7. Otherwise, render numerical value
@@ -900,7 +900,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         except (TypeError, ValueError):
             belowmin = False
         try:
-            abovemax = hidemax and result > float(hidemax) or False
+            abovemax = hidemax and result >= float(hidemax) or False
         except (TypeError, ValueError):
             abovemax = False
 
@@ -909,10 +909,10 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             fdm = formatDecimalMark('< %s' % hidemin, decimalmark)
             return fdm.replace('< ', '&lt; ', 1) if html else fdm
 
-        # 4.2. If result is above max and hidemax enabled, return '>max'
+        # 4.2. If result is above max and hidemax enabled, return '>=max'
         if abovemax:
-            fdm = formatDecimalMark('> %s' % hidemax, decimalmark)
-            return fdm.replace('> ', '&gt; ', 1) if html else fdm
+            fdm = formatDecimalMark('>= %s' % hidemax, decimalmark)
+            return fdm.replace('>= ', '&gt; ', 1) if html else fdm
 
         # Below Lower Detection Limit (LDL)?
         ldl = self.getLowerDetectionLimit()

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -31,6 +31,7 @@ from bika.lims.browser.widgets import SelectionWidget as BikaSelectionWidget
 from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
 from bika.lims.config import PRIORITIES
 from bika.lims.config import PROJECTNAME
+from bika.lims.content.analysisspec import ResultsRangeDict
 from bika.lims.content.bikaschema import BikaSchema
 # Bika Interfaces
 from bika.lims.interfaces import IAnalysisRequest
@@ -813,7 +814,7 @@ schema = BikaSchema.copy() + Schema((
         required=0,
         type='resultsrange',
         subfields=('keyword', 'min', 'max', 'warn_min', 'warn_max', 'hidemin',
-                   'hidemax', 'rangecomment'),
+                   'hidemax', 'rangecomment', 'min_operator', 'max_operator'),
         widget=ComputedWidget(visible=False),
     ),
 
@@ -2611,7 +2612,7 @@ class AnalysisRequest(BaseFolder):
         out_specs = [sp for sp in specs_range if sp['keyword'] not in keywords]
         # Add manually set ranges
         out_specs.extend(an_specs)
-        return out_specs
+        return map(lambda spec: ResultsRangeDict(spec), out_specs)
 
     def getDatePublished(self):
         """

--- a/bika/lims/content/analysisspec.py
+++ b/bika/lims/content/analysisspec.py
@@ -64,7 +64,9 @@ schema = Schema((
         type='resultsrange',
         subfields=(
             'keyword',
+            'min_operator',
             'min',
+            'max_operator',
             'max',
             'warn_min',
             'warn_max',
@@ -79,7 +81,9 @@ schema = Schema((
         },
         subfield_labels={
             'keyword': _('Analysis Service'),
+            'min_operator': _('Min operator'),
             'min': _('Min'),
+            'max_operator': _('Max operator'),
             'max': _('Max'),
             'warn_min': _('Min warn'),
             'warn_max': _('Max warn'),
@@ -223,6 +227,14 @@ class ResultsRangeDict(dict):
     def warn_max(self):
         return self.get('warn_max', self.max)
 
+    @property
+    def min_operator(self):
+        return self.get('min_operator', self.min_operator)
+
+    @property
+    def max_operator(self):
+        return self.get('max_operator', self.max_operator)
+
     @min.setter
     def min(self, value):
         self["min"] = value
@@ -238,3 +250,11 @@ class ResultsRangeDict(dict):
     @warn_max.setter
     def warn_max(self, value):
         self['warn_max'] = value
+
+    @min_operator.setter
+    def min_operator(self, value):
+        self['min_operator'] = value
+
+    @max_operator.setter
+    def max_operator(self, value):
+        self['max_operator'] = value

--- a/bika/lims/content/analysisspec.py
+++ b/bika/lims/content/analysisspec.py
@@ -210,6 +210,8 @@ class ResultsRangeDict(dict):
         self["max"] = self.max
         self["warn_min"] = self.warn_min
         self["warn_max"] = self.warn_max
+        self["min_operator"] = self.min_operator
+        self["max_operator"] = self.max_operator
 
     @property
     def min(self):
@@ -229,11 +231,11 @@ class ResultsRangeDict(dict):
 
     @property
     def min_operator(self):
-        return self.get('min_operator', self.min_operator)
+        return self.get('min_operator', 'geq')
 
     @property
     def max_operator(self):
-        return self.get('max_operator', self.max_operator)
+        return self.get('max_operator', 'leq')
 
     @min.setter
     def min(self, value):

--- a/bika/lims/tests/doctests/API_analysis.rst
+++ b/bika/lims/tests/doctests/API_analysis.rst
@@ -17,6 +17,7 @@ Needed Imports:
     >>> import re
     >>> from AccessControl.PermissionRole import rolesForPermissionOn
     >>> from bika.lims import api
+    >>> from bika.lims.api.analysis import get_formatted_interval
     >>> from bika.lims.api.analysis import is_out_of_range
     >>> from bika.lims.content.analysisrequest import AnalysisRequest
     >>> from bika.lims.content.sample import Sample
@@ -529,6 +530,7 @@ Set results for analysis `Au` (min: -5, max: 5, warn_min: -5.5, warn_max: 5.5):
     >>> is_out_of_range(au_analysis)
     (True, False)
 
+
 Check if results are out of range when left-open interval is used
 -----------------------------------------------------------------
 
@@ -556,10 +558,11 @@ Set results for analysis `Au` (min: -5, max: 5, warn_min: -5.5, warn_max: 5.5):
     >>> is_out_of_range(au_analysis)
     (True, False)
 
+
 Check if results are out of range when right-open interval is used
 ------------------------------------------------------------------
 
-Set left-open interval for min and max from water specification
+Set right-open interval for min and max from water specification
 
     >>> ranges = specification.getResultsRange()
     >>> for range in ranges:
@@ -582,3 +585,79 @@ Set results for analysis `Au` (min: -5, max: 5, warn_min: -5.5, warn_max: 5.5):
     >>> au_analysis.setResult(5)
     >>> is_out_of_range(au_analysis)
     (False, False)
+
+
+Check if formatted interval is rendered properly
+------------------------------------------------
+
+Set closed interval for min and max from water specification
+
+    >>> ranges = specification.getResultsRange()
+    >>> for range in ranges:
+    ...     range['min_operator'] = 'geq'
+    ...     range['max_operator'] = 'leq'
+    >>> specification.setResultsRange(ranges)
+
+Get the result range for `Au` (min: -5, max: 5)
+
+    >>> rr = specification.getResultsRange()
+    >>> res_range = filter(lambda item: item.get('keyword') == 'Au', rr)[0]
+    >>> get_formatted_interval(res_range)
+    '[-5,5]'
+
+And test after changing decimal mark
+
+    >>> bikasetup.setResultsDecimalMark(',')
+    >>> get_formatted_interval(res_range)
+    '[-5;5]'
+
+Reset decimal mark
+
+    >>> bikasetup.setResultsDecimalMark('.')
+    >>> get_formatted_interval(res_range)
+    '[-5,5]'
+
+Try now with left-open interval
+
+    >>> ranges = specification.getResultsRange()
+    >>> for range in ranges:
+    ...     range['min_operator'] = 'gt'
+    ...     range['max_operator'] = 'leq'
+    >>> specification.setResultsRange(ranges)
+
+Get the result range for `Au` (min: -5, max: 5)
+
+    >>> rr = specification.getResultsRange()
+    >>> res_range = filter(lambda item: item.get('keyword') == 'Au', rr)[0]
+    >>> get_formatted_interval(res_range)
+    '(-5,5]'
+
+Try now with right-open interval
+
+    >>> ranges = specification.getResultsRange()
+    >>> for range in ranges:
+    ...     range['min_operator'] = 'geq'
+    ...     range['max_operator'] = 'lt'
+    >>> specification.setResultsRange(ranges)
+
+Get the result range for `Au` (min: -5, max: 5)
+
+    >>> rr = specification.getResultsRange()
+    >>> res_range = filter(lambda item: item.get('keyword') == 'Au', rr)[0]
+    >>> get_formatted_interval(res_range)
+    '[-5,5)'
+
+Try now with open interval
+
+    >>> ranges = specification.getResultsRange()
+    >>> for range in ranges:
+    ...     range['min_operator'] = 'gt'
+    ...     range['max_operator'] = 'lt'
+    >>> specification.setResultsRange(ranges)
+
+Get the result range for `Au` (min: -5, max: 5)
+
+    >>> rr = specification.getResultsRange()
+    >>> res_range = filter(lambda item: item.get('keyword') == 'Au', rr)[0]
+    >>> get_formatted_interval(res_range)
+    '(-5,5)'

--- a/bika/lims/tests/doctests/API_analysis.rst
+++ b/bika/lims/tests/doctests/API_analysis.rst
@@ -500,3 +500,85 @@ Now, check for out-of-range results:
     >>> cu_control.setResult("-1.09")
     >>> is_out_of_range(cu_control)
     (True, True)
+
+
+Check if results are out of range when open interval is used
+------------------------------------------------------------
+
+Set open interval for min and max from water specification
+
+    >>> ranges = specification.getResultsRange()
+    >>> for range in ranges:
+    ...     range['min_operator'] = 'gt'
+    ...     range['max_operator'] = 'lt'
+    >>> specification.setResultsRange(ranges)
+
+First, get the analyses from slot 1 and sort them asc:
+
+    >>> analyses = worksheet.get_analyses_at(1)
+    >>> analyses.sort(key=lambda analysis: analysis.getKeyword(), reverse=False)
+
+Set results for analysis `Au` (min: -5, max: 5, warn_min: -5.5, warn_max: 5.5):
+
+    >>> au_analysis = analyses[0]
+    >>> au_analysis.setResult(-5)
+    >>> is_out_of_range(au_analysis)
+    (True, False)
+
+    >>> au_analysis.setResult(5)
+    >>> is_out_of_range(au_analysis)
+    (True, False)
+
+Check if results are out of range when left-open interval is used
+-----------------------------------------------------------------
+
+Set left-open interval for min and max from water specification
+
+    >>> ranges = specification.getResultsRange()
+    >>> for range in ranges:
+    ...     range['min_operator'] = 'geq'
+    ...     range['max_operator'] = 'lt'
+    >>> specification.setResultsRange(ranges)
+
+First, get the analyses from slot 1 and sort them asc:
+
+    >>> analyses = worksheet.get_analyses_at(1)
+    >>> analyses.sort(key=lambda analysis: analysis.getKeyword(), reverse=False)
+
+Set results for analysis `Au` (min: -5, max: 5, warn_min: -5.5, warn_max: 5.5):
+
+    >>> au_analysis = analyses[0]
+    >>> au_analysis.setResult(-5)
+    >>> is_out_of_range(au_analysis)
+    (False, False)
+
+    >>> au_analysis.setResult(5)
+    >>> is_out_of_range(au_analysis)
+    (True, False)
+
+Check if results are out of range when right-open interval is used
+------------------------------------------------------------------
+
+Set left-open interval for min and max from water specification
+
+    >>> ranges = specification.getResultsRange()
+    >>> for range in ranges:
+    ...     range['min_operator'] = 'gt'
+    ...     range['max_operator'] = 'leq'
+    >>> specification.setResultsRange(ranges)
+
+First, get the analyses from slot 1 and sort them asc:
+
+    >>> analyses = worksheet.get_analyses_at(1)
+    >>> analyses.sort(key=lambda analysis: analysis.getKeyword(), reverse=False)
+
+Set results for analysis `Au` (min: -5, max: 5, warn_min: -5.5, warn_max: 5.5):
+
+    >>> au_analysis = analyses[0]
+    >>> au_analysis.setResult(-5)
+    >>> is_out_of_range(au_analysis)
+    (True, False)
+
+    >>> au_analysis.setResult(5)
+    >>> is_out_of_range(au_analysis)
+    (False, False)

--- a/bika/lims/tests/doctests/API_analysis.rst
+++ b/bika/lims/tests/doctests/API_analysis.rst
@@ -603,19 +603,7 @@ Get the result range for `Au` (min: -5, max: 5)
     >>> rr = specification.getResultsRange()
     >>> res_range = filter(lambda item: item.get('keyword') == 'Au', rr)[0]
     >>> get_formatted_interval(res_range)
-    '[-5,5]'
-
-And test after changing decimal mark
-
-    >>> bikasetup.setResultsDecimalMark(',')
-    >>> get_formatted_interval(res_range)
     '[-5;5]'
-
-Reset decimal mark
-
-    >>> bikasetup.setResultsDecimalMark('.')
-    >>> get_formatted_interval(res_range)
-    '[-5,5]'
 
 Try now with left-open interval
 
@@ -630,7 +618,7 @@ Get the result range for `Au` (min: -5, max: 5)
     >>> rr = specification.getResultsRange()
     >>> res_range = filter(lambda item: item.get('keyword') == 'Au', rr)[0]
     >>> get_formatted_interval(res_range)
-    '(-5,5]'
+    '(-5;5]'
 
 Try now with right-open interval
 
@@ -645,7 +633,7 @@ Get the result range for `Au` (min: -5, max: 5)
     >>> rr = specification.getResultsRange()
     >>> res_range = filter(lambda item: item.get('keyword') == 'Au', rr)[0]
     >>> get_formatted_interval(res_range)
-    '[-5,5)'
+    '[-5;5)'
 
 Try now with open interval
 
@@ -660,4 +648,4 @@ Get the result range for `Au` (min: -5, max: 5)
     >>> rr = specification.getResultsRange()
     >>> res_range = filter(lambda item: item.get('keyword') == 'Au', rr)[0]
     >>> get_formatted_interval(res_range)
-    '(-5,5)'
+    '(-5;5)'

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -931,3 +931,16 @@ def get_display_list(brains_or_objects=None, none_item=False):
         items.insert(0, ('', t('Select...')))
 
     return DisplayList(items)
+
+
+def to_choices(display_list):
+    """Converts a display list to a choices list
+    """
+    if not display_list:
+        return []
+
+    return map(
+        lambda item: {
+            "ResultValue": item[0],
+            "ResultText": item[1]},
+        display_list.items())


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

By default, the system considers both min and max values from specifications as inclusive (bounded and closed). Thus, the system considers a result as out of range if the value is below minimum or above maximum. This behavior is prone to inconsistencies, cause there is not possible to create different specifications to cover the whole range of results without gaps within:

 E.g:
1) Specification 1: min=10, max=20

If the result is 20 or 10, the system currently considers the result is in-range. If the following specification is added:

2) Specification 2: min=20, max=30

The system considers a result 20 in-range for any of the two specifications, making difficult to set different specifications to cover the whole range of results within overlap or gaps.

This Pull Requests adds the possibility to define the operators to use for min and max fields when evaluating if the result is out of range or not. For specifications already present in the system, the result ranges are considered as usual, bounded and closed:  `[min,max] = {result | min <= result <= max}`.

## Current behavior before PR

User cannot set the operators for min and max fields (specifications)

## Desired behavior after PR is merged

User can set the operators for min and max fields to use when evaluating if the result is out of range.

![imatge](https://user-images.githubusercontent.com/832627/43803235-9d958840-9a98-11e8-8f56-ddc7f4c4720e.png)

![imatge](https://user-images.githubusercontent.com/832627/43803290-c9263982-9a98-11e8-8970-64a0c053e23c.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
