### PR TITLE
Traceback in Analyses listings when analysis unit is a numeric value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,7 @@ Changelog
 
 **Fixed**
 
+- #966 Traceback in Analyses listings when analysis unit is a numeric value
 - #959 Time not displayed for Date Created in Analysis Requests listings
 - #949 Retain AR Spec if Analyses were added/removed
 - #948 Inactive Sample Types shown in Analysis Specifications

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -595,7 +595,7 @@ def format_supsub(text):
     subsup = []
     clauses = []
     insubsup = True
-    for c in text:
+    for c in str(text):
         if c == '(':
             if insubsup is False:
                 out.append(c)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Traceback in Analyses listings when analysis unit is a numeric value

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.analysisrequest.manage_results, line 50, in __call__
  Module bika.lims.browser.bika_listing, line 1610, in contents_table
  Module bika.lims.browser.bika_listing, line 1788, in __init__
  Module bika.lims.browser.analyses.view, line 509, in folderitems
  Module bika.lims.browser.bika_listing, line 1011, in folderitems
  Module bika.lims.browser.analyses.view, line 452, in folderitem
  Module bika.lims.utils, line 598, in format_supsub
TypeError: 'int' object is not iterable
```

## Desired behavior after PR is merged

No Traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
