### PR TITLE
Avoid deepcopy, "Can't pickle acquisition wrappers".

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,7 @@ Changelog
 - #960 Traceback on AnalysisSpec Log
 - #962 Calculated results not marked for submission if zero
 - #964 Dormant Analysis Services displayed in AR Templates
+- #967 Avoid deepcopy, "Can't pickle acquisition wrappers".
 
 **Security**
 

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -55,7 +55,7 @@ def create_analysisrequest(client, request, values, analyses=None,
         are read from the associated analysis service.
     """
     # Don't pollute the dict param passed in
-    values = deepcopy(values)
+    values = dict(values.items())
 
     # Create new sample or locate the existing for secondary AR
     secondary = False


### PR DESCRIPTION
This function fails when used with json api, since the request values are resolved to actual objects before being passed here.

## Description of the issue/feature this PR addresses

Cannot create AR from JSON API with /senaite/@@API/senaite/v1/analysisrequest POST.

## Current behavior before PR

TypeError: Can't pickle objects in acquisition wrappers.

## Desired behavior after PR is merged

inputted values dict is copied without deepcopy().

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
