### PR TITLE
Formatted interval not displayed correctly if min/max == 0

### DIFF
--- a/bika/lims/api/analysis.py
+++ b/bika/lims/api/analysis.py
@@ -115,21 +115,20 @@ def get_formatted_interval(results_range, default=_marker):
         if default is not _marker:
             return default
         api.fail("Type not supported")
-
     results_range = ResultsRangeDict(results_range)
-    min_str = api.is_floatable(results_range.min) and results_range.min or ""
-    max_str = api.is_floatable(results_range.max) and results_range.max or ""
-    if not min_str and not max_str:
+    min_str = results_range.min if api.is_floatable(results_range.min) else None
+    max_str = results_range.max if api.is_floatable(results_range.max) else None
+    if min_str is None and max_str is None:
         if default is not _marker:
             return default
         api.fail("Min and max values are not floatable or not defined")
 
     min_operator = results_range.min_operator
     max_operator = results_range.max_operator
-    if min_str and not max_str:
-        return "{}{}".format(MIN_OPERATORS.getKey(min_operator), min_str)
-    if not min_str and max_str:
-        return "{}{}".format(MAX_OPERATORS.getKey(max_operator), max_str)
+    if max_str is None:
+        return "{}{}".format(MIN_OPERATORS.getValue(min_operator), min_str)
+    if min_str is None:
+        return "{}{}".format(MAX_OPERATORS.getValue(max_operator), max_str)
 
     # Both values set. Return an interval
     min_bracket = min_operator == 'geq' and '[' or '('

--- a/bika/lims/tests/doctests/API_analysis.rst
+++ b/bika/lims/tests/doctests/API_analysis.rst
@@ -649,3 +649,41 @@ Get the result range for `Au` (min: -5, max: 5)
     >>> res_range = filter(lambda item: item.get('keyword') == 'Au', rr)[0]
     >>> get_formatted_interval(res_range)
     '(-5;5)'
+
+And if we set a 0 value as min or max?
+
+    >>> res_range['min'] = 0
+    >>> get_formatted_interval(res_range)
+    '(0;5)'
+
+    >>> res_range['max'] = 0
+    >>> res_range['min'] = -5
+    >>> get_formatted_interval(res_range)
+    '(-5;0)'
+
+And now, set no value for min and/or max
+
+    >>> res_range['min'] = ''
+    >>> res_range['max'] = 5
+    >>> get_formatted_interval(res_range)
+    '<5'
+
+    >>> res_range['max'] = ''
+    >>> res_range['min'] = -5
+    >>> get_formatted_interval(res_range)
+    '>-5'
+
+And change the operators
+
+    >>> res_range['min'] = ''
+    >>> res_range['max'] = 5
+    >>> res_range['max_operator'] = 'leq'
+    >>> get_formatted_interval(res_range)
+    '<=5'
+
+    >>> res_range['max'] = ''
+    >>> res_range['min'] = -5
+    >>> res_range['max_operator'] = 'lt'
+    >>> res_range['min_operator'] = 'geq'
+    >>> get_formatted_interval(res_range)
+    '>=-5'


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This issue has been introduced because of https://github.com/senaite/senaite.core/pull/965

When min or max from specifications have a value of 0 (zero), the formatted interval is not displayed correctly.

## Current behavior before PR

Formatted interval is not displayed correctly if min or max value equals zero

## Desired behavior after PR is merged

Formatted interval is always displayed correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
