### PR TITLE
Fix Department for labcontacts listing

### DIFF
--- a/bika/lims/controlpanel/bika_labcontacts.py
+++ b/bika/lims/controlpanel/bika_labcontacts.py
@@ -61,8 +61,11 @@ class LabContactsView(BikaListingView):
             ("Fullname", {
                 "title": _("Name"),
                 "index": "getFullname"}),
-            ("Department", {
-                "title": _("Department"),
+            ("DefaultDepartment", {
+                "title": _("Default Department"),
+                "toggle": False}),
+            ("Departments", {
+                "title": _("Departments"),
                 "toggle": True}),
             ("BusinessPhone", {
                 "title": _("Phone"),
@@ -122,6 +125,12 @@ class LabContactsView(BikaListingView):
         else:
             item["Fullname"] = ""
 
+        default_department = obj.getDefaultDepartment()
+        if default_department:
+            item["replace"]["DefaultDepartment"] = get_link(
+                default_department.absolute_url(),
+                value=default_department.Title())
+
         departments = obj.getDepartments()
         if departments:
             links = map(
@@ -129,7 +138,7 @@ class LabContactsView(BikaListingView):
                                    value=o.Title(),
                                    css_class="link"),
                 departments)
-            item["replace"]["Department"] = ", ".join(links)
+            item["replace"]["Departments"] = ", ".join(links)
 
         email = obj.getEmailAddress()
         if email:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This issue was introduced by https://github.com/senaite/senaite.core/pull/956

## Current behavior before PR

Department shows UID in listing

## Desired behavior after PR is merged

Removed `Departmet` column (coming from person.py) and added `DefaultDepartment` and `Departments` columns (coming from labcontact.py).

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
