### PR TITLE
Changed price value to make the check more robust

### DIFF
--- a/bika/lims/tests/doctests/ShowPrices.rst
+++ b/bika/lims/tests/doctests/ShowPrices.rst
@@ -64,7 +64,7 @@ Now we need to create some basic content for our tests:
     >>> labcontact = api.create(portal.bika_setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
     >>> department = api.create(portal.bika_setup.bika_departments, "Department", title="Chemistry", Manager=labcontact)
     >>> category = api.create(portal.bika_setup.bika_analysiscategories, "AnalysisCategory", title="Metals", Department=department)
-    >>> Cu = api.create(portal.bika_setup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="409", Category=category.UID(), Accredited=True)
+    >>> Cu = api.create(portal.bika_setup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="409.17", Category=category.UID(), Accredited=True)
     >>> Fe = api.create(portal.bika_setup.bika_analysisservices, "AnalysisService", title="Iron", Keyword="Fe", Price="208.20", Category=category.UID())
     >>> profile = api.create(portal.bika_setup.bika_analysisprofiles, "AnalysisProfile", title="Profile", Service=[Fe.UID(), Cu.UID()])
     >>> template = api.create(portal.bika_setup.bika_artemplates, "ARTemplate", title="Template", AnalysisProfile=[profile.UID()])
@@ -162,12 +162,12 @@ Accredited services view shows a list of services, with prices.
 
     >>> enableShowPrices()
     >>> browser.open(portal.absolute_url() + "/accreditation")
-    >>> True if "409" in browser.contents else "Accreditation listing should have Price column, but it is not visible."
+    >>> True if "409.17" in browser.contents else "Accreditation listing should have Price column, but it is not visible."
     True
 
     >>> disableShowPrices()
     >>> browser.open(portal.absolute_url() + "/accreditation")
-    >>> True if "409" not in browser.contents else "Accreditation listing should not have Price column, but it is visible."
+    >>> True if "409.17" not in browser.contents else "Accreditation listing should not have Price column, but it is visible."
     True
 
 
@@ -178,12 +178,12 @@ Analysis Profiles contain prices in the list of available analyses.
 
     >>> enableShowPrices()
     >>> browser.open(profile.absolute_url())
-    >>> True if "409" in browser.contents else "Profile Analyses should be showing Price."
+    >>> True if "409.17" in browser.contents else "Profile Analyses should be showing Price."
     True
 
     >>> disableShowPrices()
     >>> browser.open(profile.absolute_url())
-    >>> True if "409" not in browser.contents else "Profile Analyses should NOT be showing Price."
+    >>> True if "409.17" not in browser.contents else "Profile Analyses should NOT be showing Price."
     True
 
 
@@ -194,12 +194,12 @@ Analysis Request Templates contain prices in the list of available analyses.
 
     >>> enableShowPrices()
     >>> browser.open(template.absolute_url())
-    >>> True if "409"  in browser.contents else "AR Templates should be showing Price."
+    >>> True if "409.17"  in browser.contents else "AR Templates should be showing Price."
     True
 
     >>> disableShowPrices()
     >>> browser.open(template.absolute_url())
-    >>> True if "409"  not in browser.contents else "AR Templates should NOT be showing Price."
+    >>> True if "409.17"  not in browser.contents else "AR Templates should NOT be showing Price."
     True
 
 Client discount fields show/hide


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Traceback

```
Failure in test /home/travis/build/senaite/senaite.core/bika/lims/tests/doctests/ShowPrices.rst
Failed doctest test for ShowPrices.rst
  File "/home/travis/build/senaite/senaite.core/bika/lims/tests/doctests/ShowPrices.rst", line 0
----------------------------------------------------------------------
File "/home/travis/build/senaite/senaite.core/bika/lims/tests/doctests/ShowPrices.rst", line 170, in ShowPrices.rst
Failed example:
    True if "409" not in browser.contents else "Accreditation listing should not have Price column, but it is visible."
Differences (ndiff with -expected +actual):
    - True
    + 'Accreditation listing should not have Price column, but it is visible.'
----------------------------------------------------------------------
File "/home/travis/build/senaite/senaite.core/bika/lims/tests/doctests/ShowPrices.rst", line 186, in ShowPrices.rst
Failed example:
    True if "409" not in browser.contents else "Profile Analyses should NOT be showing Price."
Differences (ndiff with -expected +actual):
    - True
    + 'Profile Analyses should NOT be showing Price.'
----------------------------------------------------------------------
File "/home/travis/build/senaite/senaite.core/bika/lims/tests/doctests/ShowPrices.rst", line 202, in ShowPrices.rst
Failed example:
    True if "409"  not in browser.contents else "AR Templates should NOT be showing Price."
Differences (ndiff with -expected +actual):
    - True
    + 'AR Templates should NOT be showing Price.'
```

## Current behavior before PR

The check in `ShowPrices.rst`is failing on Travis

## Desired behavior after PR is merged

The check in `ShowPrices.rst`is not failing on Travis

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
