### PR TITLE
Do not display content actions in listings from inside Client

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,7 @@ Changelog
 
 **Fixed**
 
+- #985 Do not display content actions in listings from inside Client
 - #966 Traceback in Analyses listings when analysis unit is a numeric value
 - #959 Time not displayed for Date Created in Analysis Requests listings
 - #949 Retain AR Spec if Analyses were added/removed

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -8,29 +8,27 @@
 import collections
 import json
 import traceback
-from DateTime import DateTime
 
-from bika.lims import bikaMessageFactory as _
+from DateTime import DateTime
+from Products.Archetypes import PloneMessageFactory as PMF
+from Products.CMFCore.permissions import ModifyPortalContent
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims import api
+from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
 from bika.lims.browser.analysisrequest.analysisrequests_filter_bar import \
     AnalysisRequestsBikaListingFilterBar
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.config import PRIORITIES
-from bika.lims.permissions import Verify as VerifyPermission
 from bika.lims.permissions import (AddAnalysisRequest, ManageAnalysisRequests,
                                    SampleSample)
+from bika.lims.permissions import Verify as VerifyPermission
 from bika.lims.utils import getUsers, t
 from collective.taskqueue.interfaces import ITaskQueue
 from plone.api import user
-from plone.app.layout.globals.interfaces import IViewView
 from plone.protect import CheckAuthenticator, PostOnly
-from Products.Archetypes import PloneMessageFactory as PMF
-from Products.CMFCore.permissions import ModifyPortalContent
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import queryUtility
-from zope.interface import implements
 
 
 class AnalysisRequestsView(BikaListingView):

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -36,7 +36,6 @@ from zope.interface import implements
 class AnalysisRequestsView(BikaListingView):
     """Listing View for all Analysis Requests in the System
     """
-    implements(IViewView)
 
     template = ViewPageTemplateFile("templates/analysisrequests.pt")
     ar_add = ViewPageTemplateFile("templates/ar_add.pt")

--- a/bika/lims/browser/batchfolder.py
+++ b/bika/lims/browser/batchfolder.py
@@ -14,8 +14,6 @@ from bika.lims import bikaMessageFactory as _
 from bika.lims.browser import BrowserView
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.permissions import AddBatch
-from plone.app.content.browser.interfaces import IFolderContentsView
-from zope.interface import implements
 
 
 class BatchFolderContentsView(BikaListingView):

--- a/bika/lims/browser/batchfolder.py
+++ b/bika/lims/browser/batchfolder.py
@@ -20,8 +20,6 @@ from zope.interface import implements
 
 class BatchFolderContentsView(BikaListingView):
 
-    implements(IFolderContentsView)
-
     def __init__(self, context, request):
         super(BatchFolderContentsView, self).__init__(context, request)
         self.catalog = 'bika_catalog'

--- a/bika/lims/browser/client/views/contacts.py
+++ b/bika/lims/browser/client/views/contacts.py
@@ -14,7 +14,7 @@ from zope.interface import implements
 
 
 class ClientContactsView(BikaListingView):
-    implements(IViewView, IContacts)
+    implements(IContacts)
 
     def __init__(self, context, request):
         super(ClientContactsView, self).__init__(context, request)

--- a/bika/lims/browser/client/views/contacts.py
+++ b/bika/lims/browser/client/views/contacts.py
@@ -9,7 +9,6 @@ from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.interfaces import IContacts
 from bika.lims.vocabularies import CatalogVocabulary
-from plone.app.layout.globals.interfaces import IViewView
 from zope.interface import implements
 
 

--- a/bika/lims/browser/client/views/samplingrounds.py
+++ b/bika/lims/browser/client/views/samplingrounds.py
@@ -5,9 +5,8 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from bika.lims import bikaMessageFactory as _
-from bika.lims.browser.bika_listing import BikaListingView
 from Products.CMFCore.utils import getToolByName
+from bika.lims import bikaMessageFactory as _
 from bika.lims.controlpanel.bika_samplingrounds import SamplingRoundsView
 
 

--- a/bika/lims/browser/sample/view.py
+++ b/bika/lims/browser/sample/view.py
@@ -37,7 +37,6 @@ class SamplesView(BikaListingView):
     """
     A list of samples view (folder view)
     """
-    implements(IViewView)
 
     def __init__(self, context, request):
         super(SamplesView, self).__init__(context, request)

--- a/bika/lims/browser/sample/view.py
+++ b/bika/lims/browser/sample/view.py
@@ -9,19 +9,14 @@ from DateTime import DateTime
 from Products.CMFCore.utils import getToolByName
 from bika.lims import PMF
 from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t
 from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.browser.sample.samples_filter_bar \
+    import SamplesBikaListingFilterBar
 from bika.lims.permissions import *
 from bika.lims.utils import getUsers
-from bika.lims.browser.sample.samples_filter_bar\
-    import SamplesBikaListingFilterBar
-from plone.app.layout.globals.interfaces import IViewView
-from zope.interface import implements
+from bika.lims.utils import t
+
 from . import SampleEdit
-import json
-from datetime import datetime, date
-import plone
-import App
 
 
 class SampleView(SampleEdit):

--- a/bika/lims/controlpanel/bika_samplingrounds.py
+++ b/bika/lims/controlpanel/bika_samplingrounds.py
@@ -5,13 +5,11 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from plone.supermodel import model
-from plone.dexterity.content import Container
-from zope.interface import implements
-from bika.lims.browser.bika_listing import BikaListingView
-from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.layout.globals.interfaces import IViewView
 from bika.lims import bikaMessageFactory as _
+from bika.lims.browser.bika_listing import BikaListingView
+from plone.dexterity.content import Container
+from plone.supermodel import model
+from zope.interface import implements
 
 
 class SamplingRoundsView(BikaListingView):

--- a/bika/lims/controlpanel/bika_samplingrounds.py
+++ b/bika/lims/controlpanel/bika_samplingrounds.py
@@ -17,7 +17,6 @@ from bika.lims import bikaMessageFactory as _
 class SamplingRoundsView(BikaListingView):
     """Displays all system's sampling rounds
     """
-    implements(IFolderContentsView, IViewView)
 
     def __init__(self, context, request):
         super(SamplingRoundsView, self).__init__(context, request)

--- a/bika/lims/controlpanel/bika_srtemplates.py
+++ b/bika/lims/controlpanel/bika_srtemplates.py
@@ -22,7 +22,6 @@ from zope.interface.declarations import implements
 
 
 class SamplingRoundTemplatesView(BikaListingView):
-    implements(IFolderContentsView, IViewView)
     """
     Displays the list of Sampling Round Templates registered in the system.
     For users with 'Bika: Add SRTemplate' permission granted (along with

--- a/bika/lims/controlpanel/bika_srtemplates.py
+++ b/bika/lims/controlpanel/bika_srtemplates.py
@@ -5,19 +5,16 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
+from Products.ATContentTypes.content import schemata
+from Products.Archetypes import atapi
+from Products.CMFCore.permissions import ModifyPortalContent, AddPortalContent
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.config import PROJECTNAME
 from bika.lims.interfaces import ISamplingRoundTemplates
 from bika.lims.permissions import AddSRTemplate
 from bika.lims.utils import checkPermissions
-from plone.app.content.browser.interfaces import IFolderContentsView
 from plone.app.folder.folder import ATFolder, ATFolderSchema
-from plone.app.layout.globals.interfaces import IViewView
-from Products.ATContentTypes.content import schemata
-from Products.Archetypes import atapi
-from Products.CMFCore.utils import getToolByName
-from Products.CMFCore.permissions import ModifyPortalContent, AddPortalContent
 from zope.interface.declarations import implements
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR disables the content actions selection list that are displayed inside listings from Client: AnalysisRequests, Samples, Batches, Sampling Rounds, Sampling Round Templates and Contacts.

## Current behavior before PR

Content actions selection list is displayed in listings from inside Client view

## Desired behavior after PR is merged

Content actions selection list is not displayed in listings from inside Client view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
