### PR TITLE
Fix traceback in upgrade 1.2.7 to 1.2.8

### DIFF
--- a/bika/lims/upgrade/v01_02_008.py
+++ b/bika/lims/upgrade/v01_02_008.py
@@ -120,12 +120,8 @@ def revert_client_permissions_for_batches(portal):
     batch_wf.states.closed.setPermission("View", acquire, grant)
 
     catalog = api.get_tool('portal_catalog')
-    brains = catalog(portal_type='Batch')
+    brains = catalog(portal_type='Batch', allowedRolesAndUsers=["Client"])
     for brain in brains:
-        allowed = brain.allowedRolesAndUsers or []
-        if 'Client' not in allowed:
-            # No need to do rolemapping + reindex if not necessary
-            continue
         obj = api.get_object(brain)
         batch_wf.updateRoleMappingsFor(obj)
         obj.reindexObject(idxs=['allowedRolesAndUsers'])


### PR DESCRIPTION
Version v1.2.8 in PyPI has already been fixed

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.GenericSetup.tool, line 1053, in manage_doUpgrades
  Module Products.GenericSetup.upgrade, line 166, in doStep
  Module bika.lims.upgrade, line 55, in wrap_func_args
  Module bika.lims.upgrade.v01_02_008, line 50, in upgrade
  Module bika.lims.upgrade.v01_02_008, line 125, in revert_client_permissions_for_batches
AttributeError: allowedRolesAndUsers
```


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
