### PR TITLE
Fix client analysisspecs view

### DIFF
--- a/bika/lims/browser/templates/bika_listing_table_items.pt
+++ b/bika/lims/browser/templates/bika_listing_table_items.pt
@@ -412,7 +412,7 @@
 
     <!-- Row Range comments field (for Analysis Specifications) -->
     <tal:rangecomments
-      condition="python:view.form_id=='analysisspecs'"
+      condition="python:view.form_id=='analysisspec'"
       define="column string:rangecomment;
               allow_edit python:view.bika_listing.allow_edit \
               and item.get('edit_condition', {}).get(column, True)">

--- a/bika/lims/browser/widgets/analysisspecificationwidget.py
+++ b/bika/lims/browser/widgets/analysisspecificationwidget.py
@@ -49,6 +49,7 @@ class AnalysisSpecificationView(BikaListingView):
         self.pagesize = 999999
         self.allow_edit = allow_edit
         self.show_categories = True
+        self.form_id = "analysisspec"
         # self.expand_all_categories = False
         self.ajax_categories = True
         self.ajax_categories_url = "{}/{}".format(

--- a/bika/lims/skins/bika/bika_listing.css.dtml
+++ b/bika/lims/skins/bika/bika_listing.css.dtml
@@ -84,6 +84,7 @@ table.bika-listing-table {
   color:#444;
   width:99%;
   margin:2px 0px;
+  height:4em;
 }
 
 .bika-listing-table thead {


### PR DESCRIPTION

## Description of the issue/feature this PR addresses

Apply tal:rangecomments only in analysisspec widget.  This special case in bika_listing_table_items.pt was applying directly to the analysisspecs listing (only the Client one).

## Current behavior before PR

Client AnalysisSpecs listing view fails to load, rangecomments are not visible in widget.

## Desired behavior after PR is merged

Client AnalysisSpecs listing view loads, rangecomments are visible in widget.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
