### PR TITLE
Removed "Attach" report option for Attachments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Changelog
 
 **Removed**
 
+- #992 Removed "Attach" report option for Attachments
+
 
 **Fixed**
 

--- a/bika/lims/browser/analysisrequest/templates/reports/bydepartment.pt
+++ b/bika/lims/browser/analysisrequest/templates/reports/bydepartment.pt
@@ -311,15 +311,6 @@
         <tal:render condition="python:attachment['renderoption']=='r'">
           <tal:tag replace="structure attachment/inline"/>
         </tal:render>
-        <tal:attach condition="python:attachment['renderoption'] in ('a', '')">
-          <span tal:content="attachment/keywords">Total Vit D2 + D3</span>
-          <a title="Click to download"
-            tal:attributes="href attachment/download"
-            tal:content="attachment/filename">Filename</a>
-          <span class="file-type" tal:content="attachment/type">Type</span>&nbsp;&nbsp;
-          (<span class="file-mime" tal:content="attachment/mimetype">CSV</span>)&nbsp;&mdash;&nbsp;
-          <span class="file-size" tal:content="attachment/size">145Kb</span>
-        </tal:attach>
       </div>
       </tal:ar_attachments>
 
@@ -329,15 +320,6 @@
         <tal:render condition="python:attachment['renderoption']=='r'">
           <tal:tag replace="structure attachment/inline"/>
         </tal:render>
-        <tal:attach condition="python:attachment['renderoption'] in ('a', '')">
-          <span tal:content="attachment/keywords">Total Vit D2 + D3</span>
-          <a title="Click to download"
-            tal:attributes="href attachment/download"
-            tal:content="attachment/filename">Filename</a>
-          <span class="file-type" tal:content="attachment/type">Type</span>&nbsp;&nbsp;
-          (<span class="file-mime" tal:content="attachment/mimetype">CSV</span>)&nbsp;&mdash;&nbsp;
-          <span class="file-size" tal:content="attachment/size">145Kb</span>
-        </tal:attach>
       </div>
     </tal:attachments>
     <!-- /ATTACHMENTS -->

--- a/bika/lims/browser/analysisrequest/templates/reports/default.pt
+++ b/bika/lims/browser/analysisrequest/templates/reports/default.pt
@@ -373,15 +373,6 @@
       <tal:render condition="python:attachment['renderoption']=='r'">
         <tal:tag replace="structure attachment/inline"/>
       </tal:render>
-      <tal:attach condition="python:attachment['renderoption'] in ('a', '')">
-        <span tal:content="attachment/keywords">Total Vit D2 + D3</span>
-        <a title="Click to download"
-          tal:attributes="href attachment/download"
-          tal:content="attachment/filename">Filename</a>
-        <span class="file-type" tal:content="attachment/type">Type</span>&nbsp;&nbsp;
-        (<span class="file-mime" tal:content="attachment/mimetype">CSV</span>)&nbsp;&mdash;&nbsp;
-        <span class="file-size" tal:content="attachment/size">145Kb</span>
-      </tal:attach>
     </div>
     </tal:ar_attachments>
 
@@ -391,15 +382,6 @@
       <tal:render condition="python:attachment['renderoption']=='r'">
         <tal:tag replace="structure attachment/inline"/>
       </tal:render>
-      <tal:attach condition="python:attachment['renderoption'] in ('a', '')">
-        <span tal:content="attachment/keywords">Total Vit D2 + D3</span>
-        <a title="Click to download"
-          tal:attributes="href attachment/download"
-          tal:content="attachment/filename">Filename</a>
-        <span class="file-type" tal:content="attachment/type">Type</span>&nbsp;&nbsp;
-        (<span class="file-mime" tal:content="attachment/mimetype">CSV</span>)&nbsp;&mdash;&nbsp;
-        <span class="file-size" tal:content="attachment/size">145Kb</span>
-      </tal:attach>
     </div>
   </tal:attachments>
   <!-- /ATTACHMENTS -->

--- a/bika/lims/browser/analysisrequest/templates/reports/example_1.pt
+++ b/bika/lims/browser/analysisrequest/templates/reports/example_1.pt
@@ -367,60 +367,34 @@
     <p tal:content="structure analysisrequest/remarks"></p>
   </div>
 
-  <!-- Attachments section -->
-  <div id="section-attachments"
-       tal:define="ar_attachments analysisrequest/ar_attachments;
-           an_attachments analysisrequest/an_attachments">
+  <!-- ATTACHMENTS -->
+  <tal:attachments
+    define="ar_attachments analysisrequest/ar_attachments;
+            an_attachments analysisrequest/an_attachments">
 
-    <h1 i18n:translate="" tal:condition="python:ar_attachments or an_attachments">Attachments</h1>
+    <tal:attchmentheader condition="python:ar_attachments or an_attachments">
+      <h1 i18n:translate="">Attachments</h1>
+    </tal:attchmentheader>
 
     <!-- AR Attachments -->
-    <div id="analysisrequest-attachments" tal:condition="ar_attachments">
-      <h2 i18n:translate="">Analysis request attachments</h2>
-      <ul>
-        <tal:attachment tal:repeat="attachment ar_attachments">
-          <li>
-            <tal:inline condition="python:attachment['renderoption']=='r'">
-              <div class="inline-attachment">
-                <tal:tag replace="structure attachment/inline"/>
-              </div>
-            </tal:inline>
-            <a title="Click to download"
-               tal:attributes="href attachment/download"
-               tal:content="attachment/filename">Filename</a>
-            <span class="file-type" tal:content="attachment/type">Type</span>&nbsp;&nbsp;
-            (<span class="file-mime" tal:content="attachment/mimetype">CSV</span>)&nbsp;&mdash;&nbsp;
-            <span class="file-size" tal:content="attachment/size">145Kb</span>
-          </li>
-        </tal:attachment>
-      </ul>
+    <tal:ar_attachments>
+    <h2 i18n:translate="" tal:condition="ar_attachments">Analysis services attachments</h2>
+    <div class="attachment" tal:repeat="attachment ar_attachments">
+      <tal:render condition="python:attachment['renderoption']=='r'">
+        <tal:tag replace="structure attachment/inline"/>
+      </tal:render>
     </div>
+    </tal:ar_attachments>
 
-    <!-- Analyses Attachments -->
-    <div id="analyses-attachments" tal:condition="an_attachments">
-      <h2 i18n:translate="">Analysis services attachments</h2>
-      <table id="analysis-attachments">
-        <tal:attachment tal:repeat="attachment an_attachments">
-          <tr>
-            <td tal:content="attachment/keywords">Total Vit D2 + D3</td>
-            <td>
-              <tal:inline condition="python:attachment['renderoption']=='r'">
-                <div class="inline-attachment">
-                  <tal:tag replace="structure attachment/inline"/>
-                </div>
-              </tal:inline>
-              <a title="Click to download"
-                 tal:attributes="href attachment/download"
-                 tal:content="attachment/filename">Filename</a>
-              <span class="file-type" tal:content="attachment/type">Type</span>&nbsp;&nbsp;
-              (<span class="file-mime" tal:content="attachment/mimetype">CSV</span>)&nbsp;&mdash;&nbsp;
-              <span class="file-size" tal:content="attachment/size">145Kb</span>
-            </td>
-          </tr>
-        </tal:attachment>
-      </table>
+    <!-- AN Attachments -->
+    <h2 i18n:translate="" tal:condition="an_attachments">Analysis services attachments</h2>
+    <div class="attachment"  tal:repeat="attachment an_attachments">
+      <tal:render condition="python:attachment['renderoption']=='r'">
+        <tal:tag replace="structure attachment/inline"/>
+      </tal:render>
     </div>
-  </div>
+  </tal:attachments>
+  <!-- /ATTACHMENTS -->
 
   <!-- Signatures section -->
   <div id="section-signatures">

--- a/bika/lims/browser/attachment.py
+++ b/bika/lims/browser/attachment.py
@@ -124,7 +124,7 @@ class AttachmentsView(BrowserView):
         service_uid = self.request.get('Service', None)
         AttachmentType = form.get('AttachmentType', '')
         AttachmentKeys = form.get('AttachmentKeys', '')
-        ReportOption = form.get('ReportOption', 'a')
+        ReportOption = form.get('ReportOption', 'i')
 
         # nothing to do if the attachment file is missing
         if attachment_file is None:

--- a/bika/lims/browser/viewlets/templates/attachments.pt
+++ b/bika/lims/browser/viewlets/templates/attachments.pt
@@ -117,8 +117,7 @@
                 </td>
                 <td class="attachment-report-option">
                   <!-- Attachment Report Option
-                       a=Attach to Report (default)
-                       i=Ignore in Report
+                       i=Ignore in Report (default)
                        r=Render in Report
                     -->
                   <select name="ReportOption"

--- a/bika/lims/config.py
+++ b/bika/lims/config.py
@@ -59,7 +59,6 @@ ATTACHMENT_OPTIONS = DisplayList((
 ))
 ATTACHMENT_REPORT_OPTIONS = DisplayList((
     ('r', _('Render in Report')),
-    ('a', _('Attach to Report')),
     ('i', _('Ignore in Report')),
 ))
 ARIMPORT_OPTIONS = DisplayList((

--- a/bika/lims/upgrade/v01_02_009.py
+++ b/bika/lims/upgrade/v01_02_009.py
@@ -5,6 +5,7 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
+from bika.lims import api
 from bika.lims import logger
 from bika.lims.config import PROJECTNAME as product
 from bika.lims.upgrade import upgradestep
@@ -28,6 +29,24 @@ def upgrade(tool):
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
     # -------- ADD YOUR STUFF HERE --------
+    migrate_attachment_report_options(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
+
+
+def migrate_attachment_report_options(portal):
+    """Migrate Attachments with the report option "a" (attach in report)
+       to the option to "i" (ignore in report)
+    """
+    attachments = api.search({"portal_type": "Attachment"})
+    total = len(attachments)
+    logger.info("Migrating 'Attach to Report' -> 'Ingore in Report' "
+                "for %d attachments" % total)
+    for num, attachment in enumerate(attachments):
+        obj = api.get_object(attachment)
+
+        if obj.getReportOption() in ["a", ""]:
+            obj.setReportOption("i")
+            obj.reindexObject()
+            logger.info("Migrated Attachment %s" % obj.getTextTitle())


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Attachments with the "Attach to Report" option set, render only a link inside the report.
However, the user would assume that these attachments are attached to the report email sent out.
Therefore, providing this option is confusing and also does not work in cases where the LIMS is accessible in the intranet only.

A better approach would be to allow the user before sending the report to select additional Attachments to be attached in the final email.

Since this feature will be provided in the future by `senaite.impress` (will be probably moved to `senaite.core`), there is no need anymore to provide this option here. 

## Current behavior before PR

Attach option provided

## Desired behavior after PR is merged

Attach option removed. Only "Render in report" and "Ignore in Report" stay.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
