### PR TITLE
load 'senaite.core' i18n catalog instead of 'bika'

### DIFF
--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -9,7 +9,7 @@ class window.AnalysisRequestAdd
     console.debug "AnalysisRequestAdd::load"
 
     # load translations
-    jarn.i18n.loadCatalog 'bika'
+    jarn.i18n.loadCatalog 'senaite.core'
     @_ = window.jarn.i18n.MessageFactory("senaite.core")
 
     # disable browser autocomplete

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.coffee
@@ -589,7 +589,7 @@ window.AnalysisRequestAnalysesView = ->
     ###jshint validthis:true ###
 
     auto_yes = auto_yes or false
-    jarn.i18n.loadCatalog 'bika'
+    jarn.i18n.loadCatalog 'senaite.core'
     _ = window.jarn.i18n.MessageFactory("senaite.core")
     dep = undefined
     i = undefined

--- a/bika/lims/browser/js/coffee/bika.lims.site.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.site.coffee
@@ -9,7 +9,7 @@ class window.SiteView
     console.debug "SiteView::load"
 
     # load translations
-    jarn.i18n.loadCatalog 'bika'
+    jarn.i18n.loadCatalog 'senaite.core'
     @_ = window.jarn.i18n.MessageFactory("senaite.core")
 
     # initialze the loading spinner


### PR DESCRIPTION
A tiny handful of i18n catalog loads were still using 'bika' domain.
