### PR TITLE
Hide checkbox labels on category expansion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Changelog
 
 
 **Fixed**
+- #996 Hide checkbox labels on category expansion
 
 
 **Security**

--- a/bika/lims/browser/templates/bika_listing_table_items.pt
+++ b/bika/lims/browser/templates/bika_listing_table_items.pt
@@ -98,7 +98,7 @@
                      name string:${view/bika_listing/form_id}_selected_obj_uids:list" />
         <label tal:content="item/title"
                tal:attributes="for string:${view/bika_listing/form_id}_cb_${item/uid}"
-               class="hiddenStructure"/>
+               class="hiddenStructure hidden"/>
       </tal:noreplace>
     </td>
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When bikalisting table has categories that are expanded with an async request, the bootstrap-integration is not executed against those elements.  This results in labels for checkboxes being visible in the column containing the checkboxes.

## Current behavior before PR

labels visible alongside checkboxes in expanded categories.

## Desired behavior after PR is merged

Checkbox column contains only checkboxes.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
