### PR TITLE
Previous results from same batch are always displayed in reports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@ Changelog
 
 **Fixed**
 
-- #1008 Previous Results on COA
+- #1008 Previous results from same batch are always displayed in reports
 - #991 New client contacts do not have access to their own AR Templates
 - #996 Hide checkbox labels on category expansion
 - #990 Fix client analysisspecs view

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Changelog
 
 **Fixed**
 
+- #1008 Previous Results on COA
 - #991 New client contacts do not have access to their own AR Templates
 - #996 Hide checkbox labels on category expansion
 - #990 Fix client analysisspecs view

--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -1278,6 +1278,7 @@ class AnalysisRequestDigester:
         analyses = []
         dm = ar.aq_parent.getDecimalMark()
         batch = ar.getBatch()
+        incl_prev_results = self.context.bika_setup.getIncludePreviousFromBatch()
         workflow = getToolByName(self.context, 'portal_workflow')
         showhidden = self.isHiddenAnalysesVisible()
 
@@ -1297,7 +1298,7 @@ class AnalysisRequestDigester:
             # Are there previous results for the same AS and batch?
             andict['previous'] = []
             andict['previous_results'] = ""
-            if batch:
+            if batch and incl_prev_results:
                 keyword = an.getKeyword()
                 bars = [bar for bar in batch.getAnalysisRequests()
                         if an.aq_parent.UID() != bar.UID() and keyword in bar]

--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -50,7 +50,7 @@ from plone.registry import Record
 from plone.registry import field
 from plone.registry.interfaces import IRegistry
 from plone.resource.utils import queryResourceDirectory
-from zope.component import getAdapters, getUtility
+from zope.component import getUtility
 
 
 class AnalysisRequestPublishView(BrowserView):
@@ -659,8 +659,8 @@ class AnalysisRequestPublishView(BrowserView):
 
     def _lab_address(self, lab):
         lab_address = lab.getPostalAddress() \
-                      or lab.getBillingAddress() \
-                      or lab.getPhysicalAddress()
+            or lab.getBillingAddress() \
+            or lab.getPhysicalAddress()
         return _format_address(lab_address)
 
     def explode_data(self, data, padding=''):
@@ -941,10 +941,10 @@ class AnalysisRequestDigester:
                 'prepublish': False,
                 'child_analysisrequest': None,
                 'parent_analysisrequest': None,
-                'resultsinterpretation':ar.getResultsInterpretation(),
+                'resultsinterpretation': ar.getResultsInterpretation(),
                 'ar_attachments': self._get_ar_attachments(ar),
                 'an_attachments': self._get_an_attachments(ar),
-        }
+                }
 
         # Sub-objects
         excludearuids.append(ar.UID())
@@ -1175,7 +1175,7 @@ class AnalysisRequestDigester:
             physical_address = _format_address(
                 contact.getPhysicalAddress()) if contact else ''
             postal_address =\
-                    _format_address(contact.getPostalAddress())\
+                _format_address(contact.getPostalAddress())\
                 if contact else ''
             data = {'id': member.id,
                     'fullname': to_utf8(cfullname) if cfullname else to_utf8(
@@ -1213,8 +1213,8 @@ class AnalysisRequestDigester:
 
     def _lab_address(self, lab):
         lab_address = lab.getPostalAddress() \
-                      or lab.getBillingAddress() \
-                      or lab.getPhysicalAddress()
+            or lab.getBillingAddress() \
+            or lab.getPhysicalAddress()
         return _format_address(lab_address)
 
     def _lab_data(self):
@@ -1300,8 +1300,7 @@ class AnalysisRequestDigester:
             if batch:
                 keyword = an.getKeyword()
                 bars = [bar for bar in batch.getAnalysisRequests()
-                        if an.aq_parent.UID() != bar.UID()
-                        and keyword in bar]
+                        if an.aq_parent.UID() != bar.UID() and keyword in bar]
                 for bar in bars:
                     pan = bar[keyword]
                     pan_state = workflow.getInfoFor(pan, 'review_state')
@@ -1471,7 +1470,7 @@ class AnalysisRequestDigester:
                 user_data = self._user_contact_data(user_id)
                 if not user_data:
                     continue
-                verifiers[user_id]=user_data
+                verifiers[user_id] = user_data
         return {'ids': verifiers.keys(),
                 'dict': verifiers}
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1008

## Current behavior before PR
When publishing results on a COA 'Previous Results' are shown, even if IncludePreviousFromBatch is toggled off
## Desired behavior after PR is merged
'Previous Results' should not be shown when IncludePreviousFromBatch is toggled off
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
