### PR TITLE
Increased max length of Results options to 255 chars

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Changelog
 
 **Changed**
 
+- #1010 Increased max length of Results options to 255 chars (was 40)
 
 **Removed**
 

--- a/bika/lims/content/abstractbaseanalysis.py
+++ b/bika/lims/content/abstractbaseanalysis.py
@@ -547,8 +547,9 @@ ResultOptions = RecordsField(
     subfield_validators={'ResultValue': 'resultoptionsvalidator',
                          'ResultText': 'resultoptionsvalidator'},
     subfield_sizes={'ResultValue': 5,
-                    'ResultText': 25,
-                    },
+                    'ResultText': 25,},
+    subfield_maxlength={'ResultValue': 5,
+                        'ResultText': 255,},
     widget=RecordsWidget(
         label=_("Result Options"),
         description=_(


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

ATExtensions' RecordField has max length set to 40 by default: https://github.com/raphael-ritz/Products.ATExtensions/blob/master/Products/ATExtensions/field/record.py#L95

Although a max length of 40 chars for Results options is fine in most cases, there are few situations where longer strings are required (e.g. use of full-categorized names for micro strains, such as "Salmonella sandiego 4,[5],12:e,h:e,n,z15").

Also, neither from a functional nor technical perspective there isn't any reason to have this limitation of 40 chars.

## Current behavior before PR

Display values subfield of Analysis Services' Result Options are truncated to 40 chars.

## Desired behavior after PR is merged

Display values subfield of Analysis Services' Results Options are truncated to 255 chars.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
