### PR TITLE
Filter ar clientcontacts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Changelog
 
 **Fixed**
 
+- #1012 ARs and Samples from other clients are listed when logged in as contact
 - #991 New client contacts do not have access to their own AR Templates
 - #996 Hide checkbox labels on category expansion
 - #990 Fix client analysisspecs view


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Although Client contacts cannot access to Analysis Requests or Sampels from other clients (Unauthorized traceback is rised), they could still see them in lists. This commit enforces to never list Analysis Requests and Samples from clients other than the contact.

## Current behavior before PR

Analysis Requests and Samples from clients other than current contact are displayed in listings.

## Desired behavior after PR is merged

Analysis Requests and Samples from clients other than current contact are not displayed in listings.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
