### PR TITLE
ReferenceWidget does not handle searches with null/None

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,8 +21,9 @@ Changelog
 
 **Fixed**
 
+- #1014 ReferenceWidget does not handle searches with null/None
 - #1008 Previous results from same batch are always displayed in reports
-- #1012 ARs and Samples from other clients are listed when logged in as contact
+- #1013 ARs and Samples from other clients are listed when logged in as contact
 - #991 New client contacts do not have access to their own AR Templates
 - #996 Hide checkbox labels on category expansion
 - #990 Fix client analysisspecs view


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`ast.literal_eval` does not convert javascript's `null` to python's `None` and the following Traceback is thrown:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.widgets.referencewidget, line 204, in __call__
  Module bika.lims.browser.client.ajax, line 31, in __call__
  Module bika.lims.adapters.referencewidgetvocabulary, line 44, in __call__
  Module ast, line 80, in literal_eval
  Module ast, line 63, in _convert
  Module ast, line 62, in <genexpr>
  Module ast, line 60, in _convert
  Module ast, line 79, in _convert
ValueError: malformed string
```
`ast.literal_eval` has been replaced by built-in `json.loads`, and to overcome the [issue about unicodes](https://github.com/senaite/senaite.core/issues/443), a function that converts unicodes to strings recursively has been added, as suggested in the same issue above.

Sometimes, searching catalog for a content type with a field that has either a value or `None` is highly desirable. E.g (in health):

```python
client_uid = "01f004a407da40bebd9f63c2669abf9f"
query = dict(portal_type="Doctor", getPrimaryReferrerUID=[client_uid, None])
doctors = api.search(query, "portal_catalog")
results = map(lambda doctor: api.get_object(res).getPrimaryReferrerUID(), doctors)
list(set(results))
# This will return ["01f004a407da40bebd9f63c2669abf9f", None]
```
This search will include all Doctors that belong to the client `client_uid` and those that are not assigned to any client.


## Current behavior before PR

ReferenceWidget does not supports searches with "null" values.

## Desired behavior after PR is merged

ReferenceWidget does not supports searches with "null" values.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
