### PR TITLE
Fix AR Add cleanup after template removal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Changelog
 
 **Fixed**
 
+- #1018 Fix AR Add cleanup after template removal
 - #1014 ReferenceWidget does not handle searches with null/None
 - #1008 Previous results from same batch are always displayed in reports
 - #1013 ARs and Samples from other clients are listed when logged in as contact

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1499,6 +1499,11 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                     else:
                         service_to_templates[service_uid] = [uid]
 
+                    # remember the service metadata
+                    if service_uid not in service_metadata:
+                        metadata = self.get_service_info(service)
+                        service_metadata[service_uid] = metadata
+
             # PROFILES
             for uid, obj in _profiles.iteritems():
                 # get the profile metadata

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -991,7 +991,7 @@
       /*
        * Eventhandler when an Analysis Template was changed.
        */
-      var $el, arnum, context, dialog, el, field, has_template_selected, me, record, template_metadata, template_services, uid, val;
+      var $el, $parent, arnum, context, dialog, el, existing_uids, field, has_template_selected, item, me, record, remove_index, template_metadata, template_services, title, uid, uids_field, val;
       me = this;
       el = event.currentTarget;
       $el = $(el);
@@ -1031,6 +1031,23 @@
             return $(me).trigger("form:changed");
           });
         }
+        if (template_metadata.analysis_profile_uid) {
+          field = $("#Profiles-" + arnum);
+          uid = template_metadata.analysis_profile_uid;
+          title = template_metadata.analysis_profile_title;
+          $parent = field.closest("div.field");
+          item = $(".reference_multi_item[uid=" + uid + "]", $parent);
+          if (item.length) {
+            item.remove();
+            uids_field = $("input[type=hidden]", $parent);
+            existing_uids = uids_field.val().split(",");
+            remove_index = existing_uids.indexOf(uid);
+            if (remove_index > -1) {
+              existing_uids.splice(remove_index, 1);
+            }
+            uids_field.val(existing_uids.join(","));
+          }
+        }
         if (template_metadata.sample_point_uid) {
           field = $("#SamplePoint-" + arnum);
           this.flush_reference_field(field);
@@ -1038,6 +1055,14 @@
         if (template_metadata.sample_type_uid) {
           field = $("#SampleType-" + arnum);
           this.flush_reference_field(field);
+        }
+        if (template_metadata.remarks) {
+          field = $("#Remarks-" + arnum);
+          field.text("");
+        }
+        if (template_metadata.composite) {
+          field = $("#Composite-" + arnum);
+          field.prop("checked", false);
         }
       }
       return $(me).trigger("form:changed");

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -61,7 +61,7 @@
 
     AnalysisRequestAdd.prototype.load = function() {
       console.debug("AnalysisRequestAdd::load");
-      jarn.i18n.loadCatalog("senaite.core");
+      jarn.i18n.loadCatalog('senaite.core');
       this._ = window.jarn.i18n.MessageFactory("senaite.core");
       $('input[type=text]').prop('autocomplete', 'off');
       this.global_settings = {};
@@ -991,7 +991,7 @@
       /*
        * Eventhandler when an Analysis Template was changed.
        */
-      var $el, arnum, context, dialog, el, has_template_selected, me, record, template_metadata, template_services, uid, val;
+      var $el, arnum, context, dialog, el, field, has_template_selected, me, record, template_metadata, template_services, uid, val;
       me = this;
       el = event.currentTarget;
       $el = $(el);
@@ -1000,6 +1000,11 @@
       arnum = $el.closest("[arnum]").attr("arnum");
       has_template_selected = $el.val();
       console.debug("°°° on_analysis_template_change::UID=" + uid + " Template=" + val + "°°°");
+      if (uid) {
+        $el.attr("previous_uid", uid);
+      } else {
+        uid = $el.attr("previous_uid");
+      }
       if (!has_template_selected && uid) {
         this.applied_templates[arnum] = null;
         $("input[type=hidden]", $el.parent()).val("");
@@ -1011,7 +1016,7 @@
             return template_services.push(record.service_metadata[uid]);
           }
         });
-        if (template_services) {
+        if (template_services.length) {
           context = {};
           context["template"] = template_metadata;
           context["services"] = template_services;
@@ -1025,6 +1030,14 @@
           dialog.on("no", function() {
             return $(me).trigger("form:changed");
           });
+        }
+        if (template_metadata.sample_point_uid) {
+          field = $("#SamplePoint-" + arnum);
+          this.flush_reference_field(field);
+        }
+        if (template_metadata.sample_type_uid) {
+          field = $("#SampleType-" + arnum);
+          this.flush_reference_field(field);
         }
       }
       return $(me).trigger("form:changed");

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -1104,6 +1104,12 @@ class window.AnalysisRequestAdd
     has_template_selected = $el.val()
     console.debug "°°° on_analysis_template_change::UID=#{uid} Template=#{val}°°°"
 
+    # remember the set uid to handle later removal
+    if uid
+      $el.attr "previous_uid", uid
+    else
+      uid = $el.attr "previous_uid"
+
     # deselect the template if the field is empty
     if not has_template_selected and uid
       # forget the applied template
@@ -1122,7 +1128,7 @@ class window.AnalysisRequestAdd
         if uid of record.service_metadata
           template_services.push record.service_metadata[uid]
 
-      if template_services
+      if template_services.length
         context = {}
         context["template"] = template_metadata
         context["services"] = template_services
@@ -1137,6 +1143,16 @@ class window.AnalysisRequestAdd
         dialog.on "no", ->
           # trigger form:changed event
           $(me).trigger "form:changed"
+
+      # deselect the samplepoint
+      if template_metadata.sample_point_uid
+        field = $("#SamplePoint-#{arnum}")
+        @flush_reference_field(field)
+
+      # deselect the sampletype
+      if template_metadata.sample_type_uid
+        field = $("#SampleType-#{arnum}")
+        @flush_reference_field(field)
 
     # trigger form:changed event
     $(me).trigger "form:changed"

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -1144,6 +1144,30 @@ class window.AnalysisRequestAdd
           # trigger form:changed event
           $(me).trigger "form:changed"
 
+      # deselect the profile coming from the template
+      # XXX: This is crazy and need to get refactored!
+      if template_metadata.analysis_profile_uid
+        field = $("#Profiles-#{arnum}")
+
+        # uid and title of the selected profile
+        uid = template_metadata.analysis_profile_uid
+        title = template_metadata.analysis_profile_title
+
+        # get the parent field wrapper (field is only the input)
+        $parent = field.closest("div.field")
+
+        # search for the multi item and remove it
+        item = $(".reference_multi_item[uid=#{uid}]", $parent)
+        if item.length
+          item.remove()
+          # remove the uid from the hidden field
+          uids_field = $("input[type=hidden]", $parent)
+          existing_uids = uids_field.val().split(",")
+          remove_index = existing_uids.indexOf(uid)
+          if remove_index > -1
+            existing_uids.splice remove_index, 1
+          uids_field.val existing_uids.join ","
+
       # deselect the samplepoint
       if template_metadata.sample_point_uid
         field = $("#SamplePoint-#{arnum}")
@@ -1153,6 +1177,16 @@ class window.AnalysisRequestAdd
       if template_metadata.sample_type_uid
         field = $("#SampleType-#{arnum}")
         @flush_reference_field(field)
+
+      # flush the remarks field
+      if template_metadata.remarks
+        field = $("#Remarks-#{arnum}")
+        field.text ""
+
+      # reset the composite checkbox
+      if template_metadata.composite
+        field = $("#Composite-#{arnum}")
+        field.prop "checked", no
 
     # trigger form:changed event
     $(me).trigger "form:changed"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the cleanup step after AR Template deselection in AR Add form

## Current behavior before PR

Template Analyses, Sample Type and SamplePoint remained after Template removal

## Desired behavior after PR is merged

Template Analyses, Sample Type and SamplePoint are cleaned up after Template removal


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
