### PR TITLE
Support for warn min and max values in range charts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1019 Support for min and max warns in range charts
 - #1003 Alphanumeric numbering in sequential IDs generator
 
 **Changed**

--- a/bika/lims/browser/analysisrequest/templates/reports/example_1.pt
+++ b/bika/lims/browser/analysisrequest/templates/reports/example_1.pt
@@ -33,7 +33,8 @@
                         hasqcanalyses   python:len(qcanalyses) &gt; 0;
                         hasprevresults  analysisrequest/haspreviousresults;
                         showqcanalyses  python:view.isQCAnalysesVisible();
-                        remarksenabled  python:view.context.bika_setup.getEnableAnalysisRemarks();">
+                        remarksenabled  python:view.context.bika_setup.getEnableAnalysisRemarks();
+                        json modules/json">
 
   <!--
        Page Header
@@ -260,22 +261,11 @@
                   <td class="outofrange">
                     <span tal:replace="python:'*' if analysis['outofrange']==True else ''"></span>
                   </td>
-                  <td class="specs-graphs"
-                      tal:define="rr analysis/specs;
-                             min python: str(rr.get('min',0)).replace(',','.');
-                             min python: min if min else 0;
-                             max python: str(rr.get('max',0)).replace(',','.');
-                             max python: max if max else 0;
-                             warn_min python: str(rr.get('warn_min',0)).replace(',','.');
-                             warn_min python: warn_min if warn_min else 0;
-                             warn_max python: str(rr.get('warn_max',0)).replace(',','.');
-                             warn_max python: warn_max if warn_max else 0;
-                             res python: str(analysis.get('result',0)).replace(',','.');
-                             res python: res if res else 0;
-                             dataspecs python: '[%s,%s,%s,%s,%s]' % (res,min,max,warn_min,warn_max);"
-                      tal:condition="rr">
+                  <td class="specs-graphs">
                     <div class="range-chart"
-                         tal:attributes="data-specs python:dataspecs"></div>
+                         style="width:150px;"
+                         tal:attributes="data-range python: json.dumps(analysis.getResultsRange());
+                                         data-result python: analysis.getResult();"></div>
                   </td>
                 </tr>
                 <tr tal:condition="python:remarksenabled==True and analysis['remarks']">

--- a/bika/lims/browser/analysisrequest/templates/reports/example_1.pt
+++ b/bika/lims/browser/analysisrequest/templates/reports/example_1.pt
@@ -266,11 +266,13 @@
                              min python: min if min else 0;
                              max python: str(rr.get('max',0)).replace(',','.');
                              max python: max if max else 0;
-                             err python: str(rr.get('error',0)).replace(',','.');
-                             err python: err if err else 0;
+                             warn_min python: str(rr.get('warn_min',0)).replace(',','.');
+                             warn_min python: warn_min if warn_min else 0;
+                             warn_max python: str(rr.get('warn_max',0)).replace(',','.');
+                             warn_max python: warn_max if warn_max else 0;
                              res python: str(analysis.get('result',0)).replace(',','.');
                              res python: res if res else 0;
-                             dataspecs python: '[%s,%s,%s,%s]' % (res,min,max,err);"
+                             dataspecs python: '[%s,%s,%s,%s,%s]' % (res,min,max,warn_min,warn_max);"
                       tal:condition="rr">
                     <div class="range-chart"
                          tal:attributes="data-specs python:dataspecs"></div>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

With this PR, the range charts support now `warn_min` and `warn_max` instead of relying on the old percentage of `error`.

## Current behavior before PR

Range graph omit warn min and max values from specifications

## Desired behavior after PR is merged

Range graph uses warn min and max values from specifications

![imatge](https://user-images.githubusercontent.com/832627/45266882-aaca9d00-b462-11e8-84cb-18a1866c47fe.png)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
