### PR TITLE
Fix upgrade step for sample preparation workflow

### DIFF
--- a/bika/lims/upgrade/v01_02_008.py
+++ b/bika/lims/upgrade/v01_02_008.py
@@ -212,9 +212,10 @@ def fix_items_stuck_in_sample_prep_states(portal, ut):
             changeWorkflowState(instance, wfid, state_id)
             # fire transition handler for the action that originally was fired.
             old_sdef = new_sdef = wf.states[state_id]
-            tdef = wf.transitions[action_id]
-            notify(AfterTransitionEvent(
-                instance, wf, old_sdef, new_sdef, tdef, event, {}))
+            if action_id is not None:
+                tdef = wf.transitions[action_id]
+                notify(AfterTransitionEvent(
+                    instance, wf, old_sdef, new_sdef, tdef, event, {}))
             # check AR state matches the analyses
             if IAnalysisRequest.providedBy(instance):
                 fix_ar_sample_workflow(instance)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1020

This PR fixes a `KeyError` when migrating registered samples in sample
preparation Workflow.

NOTE: This PR should be backported to the latest 1.2.8.x branch and a new release
should be released.

## Current behavior before PR

KeyError occurs when running the upgrade step 1.2.8 is run and registered samples exist in the system. 

## Desired behavior after PR is merged

Upgrade step 1.2.8 migrates registered samples sucessful when the sample preparation workflow was active.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
