### PR TITLE
Date Received saved as UTC time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Changelog
 
 **Fixed**
 
+- #1022 Date Received saved as UTC time
 - #1018 Fix AR Add cleanup after template removal
 - #1014 ReferenceWidget does not handle searches with null/None
 - #1008 Previous results from same batch are always displayed in reports

--- a/bika/lims/browser/widgets/datetimewidget.py
+++ b/bika/lims/browser/widgets/datetimewidget.py
@@ -5,15 +5,11 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-import datetime
-from time import strptime
-
 from AccessControl import ClassSecurityInfo
 from Products.Archetypes.Registry import registerPropertyType
 from Products.Archetypes.Registry import registerWidget
 from Products.Archetypes.Widget import TypesWidget
-from bika.lims import logger
-from Products.ATContentTypes.utils import dt2DT
+from bika.lims.browser import get_date
 from bika.lims.browser import ulocalized_time as ut
 
 
@@ -29,46 +25,21 @@ class DateTimeWidget(TypesWidget):
     security = ClassSecurityInfo()
 
     def ulocalized_time(self, time, context, request):
-        if not time:
-            return ""
-        if isinstance(time, basestring):
-            dtime = self.get_datetime_from_locale_format(context, time)
-            return self.ulocalized_time(dt2DT(dtime), context, request)
-
-        # DateTime is stored with TimeZone, but widget omits TZ!
-        dtime = time.toZone("GMT+0")
-        return ut(dtime,
-                 long_format=self.show_time,
-                 time_only=False,
-                 context=context,
-                 request=request)
-
-    def get_datetime_from_locale_format(self, instance, date_string):
-        """Converts a date string to a datetime object
+        """Returns the localized time in string format
         """
-        default_format = "%Y-%m-%d"
-        locale_key = "date_format_short"
-        if self.show_time:
-            locale_key = "date_format_long"
-            default_format += " %H:%M"
+        value = ut(time, long_format=self.show_time, time_only=False,
+                   context=context, request=request)
+        return value or ""
 
-        locale_format = instance.translate(locale_key, domain="senaite.core",
-                                           mapping={})
-        if locale_format != locale_key:
-            # Custom format set. Try to convert
-            # e.g: locale format is "%b %d, %Y %I:$M %p" and the date_string
-            # passed in is "Sep 12, 2018 12:46 PM"
-            try:
-                struct_time = strptime(date_string, locale_format)
-                return datetime.datetime(*struct_time[:6])
-            except ValueError:
-                logger.warn("Unable to convert to DateTime {} using format {}".
-                            format(date_string, locale_format))
-
-        # Try with default format used by DateTimeWidget
-        struct_time = strptime(date_string, default_format)
-        return datetime.datetime(*struct_time[:6])
-
+    def ulocalized_gmt0_time(self, time, context, request):
+        """Returns the localized time in string format, but in GMT+0
+        """
+        value = get_date(context, time)
+        if not value:
+            return ""
+        # DateTime is stored with TimeZone, but DateTimeWidget omits TZ
+        value = value.toZone("GMT+0")
+        return self.ulocalized_time(value, context, request)
 
     security.declarePublic('process_form')
     def process_form(self, instance, field, form, empty_marker=None,

--- a/bika/lims/browser/widgets/datetimewidget.py
+++ b/bika/lims/browser/widgets/datetimewidget.py
@@ -41,17 +41,6 @@ class DateTimeWidget(TypesWidget):
         value = value.toZone("GMT+0")
         return self.ulocalized_time(value, context, request)
 
-    security.declarePublic('process_form')
-    def process_form(self, instance, field, form, empty_marker=None,
-                     emptyReturnsMarker=False, validating=True):
-        """Basic impl for form processing in a widget"""
-        value = form.get(field.getName(), empty_marker)
-        if value is empty_marker:
-            return empty_marker
-        if emptyReturnsMarker and value == '':
-            return empty_marker
-        return value, {}
-
 
 registerWidget(
     DateTimeWidget,

--- a/bika/lims/browser/widgets/datetimewidget.py
+++ b/bika/lims/browser/widgets/datetimewidget.py
@@ -5,10 +5,15 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
+import datetime
+from time import strptime
+
 from AccessControl import ClassSecurityInfo
-from Products.Archetypes.Widget import TypesWidget
-from Products.Archetypes.Registry import registerWidget
 from Products.Archetypes.Registry import registerPropertyType
+from Products.Archetypes.Registry import registerWidget
+from Products.Archetypes.Widget import TypesWidget
+from bika.lims import logger
+from Products.ATContentTypes.utils import dt2DT
 from bika.lims.browser import ulocalized_time as ut
 
 
@@ -24,12 +29,57 @@ class DateTimeWidget(TypesWidget):
     security = ClassSecurityInfo()
 
     def ulocalized_time(self, time, context, request):
-        val = ut(time,
+        if not time:
+            return ""
+        if isinstance(time, basestring):
+            dtime = self.get_datetime_from_locale_format(context, time)
+            return self.ulocalized_time(dt2DT(dtime), context, request)
+
+        # DateTime is stored with TimeZone, but widget omits TZ!
+        dtime = time.toZone("GMT+0")
+        return ut(dtime,
                  long_format=self.show_time,
                  time_only=False,
                  context=context,
                  request=request)
-        return val
+
+    def get_datetime_from_locale_format(self, instance, date_string):
+        """Converts a date string to a datetime object
+        """
+        default_format = "%Y-%m-%d"
+        locale_key = "date_format_short"
+        if self.show_time:
+            locale_key = "date_format_long"
+            default_format += " %H:%M"
+
+        locale_format = instance.translate(locale_key, domain="senaite.core",
+                                           mapping={})
+        if locale_format != locale_key:
+            # Custom format set. Try to convert
+            # e.g: locale format is "%b %d, %Y %I:$M %p" and the date_string
+            # passed in is "Sep 12, 2018 12:46 PM"
+            try:
+                struct_time = strptime(date_string, locale_format)
+                return datetime.datetime(*struct_time[:6])
+            except ValueError:
+                logger.warn("Unable to convert to DateTime {} using format {}".
+                            format(date_string, locale_format))
+
+        # Try with default format used by DateTimeWidget
+        struct_time = strptime(date_string, default_format)
+        return datetime.datetime(*struct_time[:6])
+
+
+    security.declarePublic('process_form')
+    def process_form(self, instance, field, form, empty_marker=None,
+                     emptyReturnsMarker=False, validating=True):
+        """Basic impl for form processing in a widget"""
+        value = form.get(field.getName(), empty_marker)
+        if value is empty_marker:
+            return empty_marker
+        if emptyReturnsMarker and value == '':
+            return empty_marker
+        return value, {}
 
 
 registerWidget(

--- a/bika/lims/skins/bika/bika_widgets/datetimewidget.pt
+++ b/bika/lims/skins/bika/bika_widgets/datetimewidget.pt
@@ -38,7 +38,7 @@
            size="30"
            tal:attributes="name fieldName;
                            id fieldName;
-                           value python: widget.ulocalized_time(value, context=context, request=request) if value else '';
+                           value python: widget.ulocalized_gmt0_time(value, context=context, request=request) if value else '';
                            size widget/size|nothing;
                            datepicker python:1 if not widget.show_time else 0;
                            datetimepicker python:1 if widget.show_time else 0;


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Although dates are stored with timezone in database, calendar widgets omit timezone info when displaying dates. Thus, all dates are displayed with a timezone offset.

Linked issue: https://github.com/senaite/senaite.core/issues/1011

## Current behavior before PR

Dates are not displayed for the current timezone.

## Desired behavior after PR is merged

Dates are displayed and stored in accordance with the server's timezone.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
