### PR TITLE
Function to get all verifiers from Analysis Request

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1024 Function to get the Verifiers from an Analysis Request
 - #1019 Support for min and max warns in range charts
 - #1003 Alphanumeric numbering in sequential IDs generator
 

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2333,7 +2333,9 @@ class AnalysisRequest(BaseFolder):
 
     security.declarePublic('getVerifier')
 
+    @deprecated("Use getVerifiers instead")
     def getVerifier(self):
+        """Returns the """
         wtool = getToolByName(self, 'portal_workflow')
         mtool = getToolByName(self, 'portal_membership')
 
@@ -2356,6 +2358,30 @@ class AnalysisRequest(BaseFolder):
             if verifier is None or verifier == '':
                 verifier = actor
         return verifier
+
+    @security.public
+    def getVerifiersIDs(self):
+        """Returns the ids from users that have verified at least one analysis
+        from this Analysis Request
+        """
+        verifiers_ids = list()
+        for brain in self.getAnalyses():
+            verifiers = brain.getVerificators or ""
+            verifiers_ids += verifiers.split(",")
+        return list(set(verifiers_ids))
+
+    @security.public
+    def getVerifiers(self):
+        """Returns the list of lab contacts that have verified at least one
+        analysis from this Analysis Request
+        """
+        contacts = list()
+        for verifier in self.getVerifiersIDs():
+            user = api.get_user(verifier)
+            contact = api.get_user_contact(user, ["LabContact"])
+            if contact:
+                contacts.append(contact)
+        return contacts
 
     security.declarePublic('getContactUIDForUser')
 

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2335,7 +2335,11 @@ class AnalysisRequest(BaseFolder):
 
     @deprecated("Use getVerifiers instead")
     def getVerifier(self):
-        """Returns the """
+        """Returns the user that verified the whole Analysis Request. Since the
+        verification is done automatically as soon as all the analyses it
+        contains are verified, this function returns the user that verified the
+        last analysis pending.
+        """
         wtool = getToolByName(self, 'portal_workflow')
         mtool = getToolByName(self, 'portal_membership')
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Is very common to display the verifiers of an Analysis Request instead of department managers in results reports. Verifiers of an Analysis Request are the lab contacts that at least verified one of the analyses from that Analysis Request. This Pull Request comes with a function to get them easily.

## Current behavior before PR

No easy way to get the verifiers of an Analysis Request.

## Desired behavior after PR is merged

Easy to get the verifiers of an Analysis Request.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
