### PR TITLE
Removed auto-digest of results reports on verify transitions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Removed**
 
+- #1026 Removed auto-digest of results reports on verify transitions
 - #1005 Removed databasesanitize package
 - #992 Removed "Attach" report option for Attachments
 

--- a/bika/lims/browser/analysisrequest/configure.zcml
+++ b/bika/lims/browser/analysisrequest/configure.zcml
@@ -226,27 +226,4 @@
       layer="bika.lims.interfaces.IBikaLIMS"
   />
 
-  <!-- Verifying any Analysis will cause a digestion of the parent AR to
-  be triggered at the end of the request -->
-  <subscriber
-      for="bika.lims.interfaces.IAnalysis
-           Products.DCWorkflow.interfaces.IAfterTransitionEvent"
-      handler="bika.lims.browser.analysisrequest.publish.AnalysisAfterTransitionHandler"
-  />
-
-  <!-- Modifying an AR that has been verified causes a digestion to be
-  triggered at the end of this request. -->
-  <subscriber
-      for="bika.lims.interfaces.IAnalysisRequest
-           zope.lifecycleevent.interfaces.IObjectModifiedEvent"
-      handler="bika.lims.browser.analysisrequest.publish.ARModifiedHandler"
-  />
-
-  <!-- At the end of each request, this will check to see if any ARs are
-  flagged to have their publication data pre-digested. -->
-  <subscriber
-      for="zope.publisher.interfaces.IEndRequestEvent"
-      handler="bika.lims.browser.analysisrequest.publish.EndRequestHandler"
-  />
-
 </configure>

--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -691,15 +691,6 @@ class AnalysisRequestDigester:
     called for all subsequent digestion.  This allows the instance to cache
     data for objects that may be read multiple times for different ARs.
 
-    Passing overwrite=True when calling the instance will cause the
-    ar.Digest field to be overwritten with a new digestion.  This flag
-    is set True by default in the EndRequestHandler that is responsible for
-    automated re-building.
-
-    It should be run once when the AR is verified (or when a verified AR is
-    modified) to pre-digest the data so that AnalysisRequestPublishView will
-    run a little faster.
-
     Note: ProxyFields are not included in the reading of the schema.  If you
     want to access sample fields in the report template, you must refer
     directly to the correct field in the Sample data dictionary.
@@ -717,7 +708,7 @@ class AnalysisRequestDigester:
             'creators', 'effectiveDate', 'expirationDate', 'language', 'rights',
             'relatedItems', 'modification_date', 'immediatelyAddableTypes',
             'locallyAllowedTypes', 'nextPreviousEnabled', 'constrainTypesMode',
-            'RestrictedCategories', 'Digest',
+            'RestrictedCategories',
         ]
 
     def __call__(self, ar, overwrite=False):
@@ -725,38 +716,9 @@ class AnalysisRequestDigester:
         self.context = ar
         self.request = ar.REQUEST
 
-        # if AR was previously digested, use existing data (if exists)
-        verified = wasTransitionPerformed(ar, 'verify')
-        if not overwrite and verified:
-            # Prevent any error related with digest
-            data = ar.getDigest() if hasattr(ar, 'getDigest') else {}
-            if data:
-                # Check if the department managers have changed since
-                # verification:
-                saved_managers = data.get('managers', {})
-                saved_managers_ids = set(saved_managers.get('ids', []))
-                current_managers = self.context.getManagers()
-                current_managers_ids = set([man.getId() for man in
-                                            current_managers])
-                # The symmetric difference of two sets A and B is the set of
-                # elements which are in either of the sets A or B but not
-                # in both.
-                are_different = saved_managers_ids.symmetric_difference(
-                    current_managers_ids)
-                if len(are_different) == 0:
-                    # Seems that sometimes the 'obj' is wrong in the saved
-                    # data.
-                    data['obj'] = ar
-                    # Always set results interpretation
-                    self._set_results_interpretation(ar, data)
-                    return data
-
         logger.info("=========== creating new data for %s" % ar)
-
         # Set data to the AR schema field, and return it.
         data = self._ar_data(ar)
-        if hasattr(ar, 'setDigest'):
-            ar.setDigest(data)
         logger.info("=========== new data for %s created." % ar)
         return data
 
@@ -1531,47 +1493,6 @@ class AnalysisRequestDigester:
         """Returns true if hidden analyses are visible
         """
         return self.request.form.get('hvisible', '0').lower() in ['true', '1']
-
-
-def ARModifiedHandler(instance, event):
-    """After any modification of an AR that has already been verified,
-    re-populate the ar.Digest.
-    """
-    if IAnalysisRequest.providedBy(instance):
-        if wasTransitionPerformed(instance, 'verify'):
-            request = instance.REQUEST
-            ars_to_digest = set(request.get('ars_to_digest', []))
-            ars_to_digest.add(instance)
-            request['ars_to_digest'] = ars_to_digest
-
-
-def AnalysisAfterTransitionHandler(instance, event):
-    """After a 'verify' transition on any analysis, we must set a flag in
-    the request so that the AR is digested before the request terminates.
-    We're doing it here so that the digestion happens only once at the end
-    of the request, regardless of how many children were transitioned.
-    """
-    if event.transition and event.transition.id == 'verify':
-        request = instance.REQUEST
-        ar = instance.aq_parent
-        ars_to_digest = set(request.get('ars_to_digest', []))
-        ars_to_digest.add(ar)
-        request['ars_to_digest'] = ars_to_digest
-
-
-def EndRequestHandler(event):
-    """At the end of the request, we check, to see if any pre-digestion is
-    required, for any ars or analyses that were processed during the request.
-    """
-    request = event.request
-    ars_to_digest = set(request.get('ars_to_digest', []))
-    digester = AnalysisRequestDigester()
-    if ars_to_digest:
-        for ar in ars_to_digest:
-            digester(ar, overwrite=True)
-    # If this commit() is not here, then the data does not appear to be
-    # saved.  IEndRequest happens outside the transaction?
-    transaction.commit()
 
 
 def get_client_address(context):

--- a/bika/lims/browser/analysisrequest/workflow.py
+++ b/bika/lims/browser/analysisrequest/workflow.py
@@ -439,7 +439,7 @@ class AnalysisRequestWorkflowAction(AnalysesWorkflowAction):
         newar.setSample(ar.getSample())
         ignore_fieldnames = ['Analyses', 'DatePublished',
                              'ParentAnalysisRequest', 'ChildAnaysisRequest',
-                             'Digest', 'Sample']
+                             'Sample']
         copy_field_values(ar, newar, ignore_fieldnames=ignore_fieldnames)
 
         # Set the results for each AR analysis

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -1760,12 +1760,6 @@ schema = BikaSchema.copy() + Schema((
                      'edit': 'invisible'},
         ),
     ),
-    # Here is stored pre-digested data used during publication.
-    # It is updated when the object is verified or when changes
-    # are made to verified objects.
-    StringField(
-        'Digest'
-    )
 )
 )
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Each time an analysis or analysis request transitions to "verified" state, the results report digester is called to generate a cached results report for later use in publish preview. This Pull Request removes this behavor due to several tracebacks and because the results report machinery will be replaced by `senaite.impress` soon.

## Current behavior before PR

Each time an analysis request or analysis is verified, the results report digester is called.

## Desired behavior after PR is merged

Digester is no longer called after verify transitions and ARs don't store that pre-digest anymore in "Digest" field. `AnalysisRequestDigester` is only used in the results report preview.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
