### PR TITLE
Turnaround Time with decimals in "Productivity > Analysis TAT over time" report

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ Changelog
 
 **Fixed**
 
+- #1029 TAT in Analysis TAT over time report does not display days
+- #1029 TAT in Analysis TAT over time report with decimals
+- #1029 Need to always choose an analyst in productivity reports
 - #1022 Date Received saved as UTC time
 - #1018 Fix AR Add cleanup after template removal
 - #1014 ReferenceWidget does not handle searches with null/None

--- a/bika/lims/browser/reports/productivity_analysestats.py
+++ b/bika/lims/browser/reports/productivity_analysestats.py
@@ -122,16 +122,14 @@ class Report(BrowserView):
                 services[service_uid]['ave_early'] = ''
             else:
                 avemins = (mins_early) / count_early
-                services[service_uid]['ave_early'] = formatDuration(self.context,
-                                                                    avemins)
+                services[service_uid]['ave_early'] = formatDuration(avemins)
             count_late = services[service_uid]['count_late']
             mins_late = services[service_uid]['mins_late']
             if count_late == 0:
                 services[service_uid]['ave_late'] = ''
             else:
                 avemins = mins_late / count_late
-                services[service_uid]['ave_late'] = formatDuration(self.context,
-                                                                   avemins)
+                services[service_uid]['ave_late'] = formatDuration(avemins)
 
         # and now lets do the actual report lines
         formats = {'columns': 7,
@@ -265,7 +263,7 @@ class Report(BrowserView):
 
         if total_count_late:
             ave_mins = total_mins_late / total_count_late
-            footline.append({'value': formatDuration(self.context, ave_mins),
+            footline.append({'value': formatDuration(ave_mins),
                              'class': 'total number'})
         else:
             footline.append({'value': ''})
@@ -275,7 +273,7 @@ class Report(BrowserView):
 
         if total_count_early:
             ave_mins = total_mins_early / total_count_early
-            footline.append({'value': formatDuration(self.context, ave_mins),
+            footline.append({'value': formatDuration(ave_mins),
                              'class': 'total number'})
         else:
             footline.append({'value': '',

--- a/bika/lims/browser/reports/productivity_analysestats_overtime.py
+++ b/bika/lims/browser/reports/productivity_analysestats_overtime.py
@@ -122,8 +122,7 @@ class Report(BrowserView):
             count = periods[datekey]['count']
             duration = periods[datekey]['duration']
             ave_duration = (duration) / count
-            periods[datekey]['duration'] = \
-                formatDuration(self.context, ave_duration)
+            periods[datekey]['duration'] = formatDuration(ave_duration)
 
         # and now lets do the actual report lines
         formats = {'columns': 2,
@@ -147,7 +146,7 @@ class Report(BrowserView):
             ave_total_duration = total_duration / total_count
         else:
             ave_total_duration = 0
-        ave_total_duration = formatDuration(self.context, ave_total_duration)
+        ave_total_duration = formatDuration(ave_total_duration)
 
         # footer data
         footlines = []

--- a/bika/lims/browser/reports/productivity_analysestats_overtime.py
+++ b/bika/lims/browser/reports/productivity_analysestats_overtime.py
@@ -5,12 +5,17 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from Products.CMFCore.utils import getToolByName
-from bika.lims.browser import BrowserView
+import StringIO
+import csv
+import datetime
+
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from bika.lims import api
 from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t
+from bika.lims.browser import BrowserView
+from bika.lims.catalog.analysis_catalog import CATALOG_ANALYSIS_LISTING
 from bika.lims.utils import formatDateQuery, formatDateParms, formatDuration
+from bika.lims.utils import t
 from plone.app.layout.globals.interfaces import IViewView
 from zope.interface import implements
 
@@ -20,184 +25,176 @@ class Report(BrowserView):
     template = ViewPageTemplateFile("templates/report_out.pt")
 
     def __init__(self, context, request, report=None):
-        self.report = report
         BrowserView.__init__(self, context, request)
-
-    def __call__(self):
-        # get all the data into datalines
-
-        bc = getToolByName(self.context, 'bika_analysis_catalog')
-        rc = getToolByName(self.context, 'reference_catalog')
-        self.report_content = {}
-        parms = []
-        headings = {}
-        headings['header'] = _("Analysis turnaround times over time")
-        headings['subheader'] = \
-            _("The turnaround time of analyses plotted over time")
-
-        query = {'portal_type': 'Analysis'}
-
-        if 'ServiceUID' in self.request.form:
-            service_uid = self.request.form['ServiceUID']
-            query['ServiceUID'] = service_uid
-            service = rc.lookupObject(service_uid)
-            service_title = service.Title()
-            parms.append(
-                {'title': _('Analysis Service'),
-                 'value': service_title,
-                 'type': 'text'})
-
-        if 'Analyst' in self.request.form:
-            analyst = self.request.form['Analyst']
-            query['getAnalyst'] = analyst
-            analyst_title = self.user_fullname(analyst)
-            parms.append(
-                {'title': _('Analyst'),
-                 'value': analyst_title,
-                 'type': 'text'})
-
-        if 'getInstrumentUID' in self.request.form:
-            instrument_uid = self.request.form['getInstrumentUID']
-            query['getInstrument'] = instrument_uid
-            instrument = rc.lookupObject(instrument_uid)
-            instrument_title = instrument.Title()
-            parms.append(
-                {'title': _('Instrument'),
-                 'value': instrument_title,
-                 'type': 'text'})
-
-        if 'Period' in self.request.form:
-            period = self.request.form['Period']
-        else:
-            period = 'Day'
-
-        date_query = formatDateQuery(self.context, 'tats_DateReceived')
-        if date_query:
-            query['created'] = date_query
-            received = formatDateParms(self.context, 'tats_DateReceived')
-            parms.append(
-                {'title': _('Received'),
-                 'value': received,
-                 'type': 'text'})
-
-        query['review_state'] = 'published'
-
-        # query all the analyses and increment the counts
-
-        periods = {}
-        total_count = 0
-        total_duration = 0
-
-        analyses = bc(query)
-        for a in analyses:
-            analysis = a.getObject()
-            received = analysis.created()
-            if period == 'Day':
-                datekey = received.strftime('%d %b %Y')
-            elif period == 'Week':
-                # key period on Monday
-                dayofweek = received.strftime('%w')  # Sunday = 0
-                if dayofweek == 0:
-                    firstday = received - 6
-                else:
-                    firstday = received - (int(dayofweek) - 1)
-                datekey = firstday.strftime(self.date_format_short)
-            elif period == 'Month':
-                datekey = received.strftime('%m-%d')
-            if datekey not in periods:
-                periods[datekey] = {'count': 0,
-                                    'duration': 0,
-                }
-            count = periods[datekey]['count']
-            duration = periods[datekey]['duration']
-            count += 1
-            duration += analysis.getDuration()
-            periods[datekey]['duration'] = duration
-            periods[datekey]['count'] = count
-            total_count += 1
-            total_duration += duration
-
-        # calculate averages
-        for datekey in periods.keys():
-            count = periods[datekey]['count']
-            duration = periods[datekey]['duration']
-            ave_duration = (duration) / count
-            periods[datekey]['duration'] = formatDuration(ave_duration)
-
-        # and now lets do the actual report lines
-        formats = {'columns': 2,
-                   'col_heads': [_('Date'),
-                                 _('Turnaround time (h)'),
-                   ],
-                   'class': '',
+        self.report = report
+        self.headings = {
+            'header': _("Analysis turnaround times over time"),
+            'subheader': _("The turnaround time of analyses plotted over time")
+        }
+        self.formats = {
+            'columns': 2,
+            'col_heads': [
+                _('Date'),
+                 _('Turnaround time (h)')],
+            'class': ''
         }
 
-        datalines = []
+    def __call__(self):
+        parms = []
+        query = dict(portal_type="Analysis", sort_on="getDateReceived",
+                     sort_order="ascending")
 
-        period_keys = periods.keys()
-        for period in period_keys:
-            dataline = [{'value': period,
-                         'class': ''}, ]
-            dataline.append({'value': periods[period]['duration'],
-                             'class': 'number'})
-            datalines.append(dataline)
+        # Filter by Service UID
+        self.add_filter_by_service(query=query, out_params=parms)
 
-        if total_count > 0:
-            ave_total_duration = total_duration / total_count
-        else:
-            ave_total_duration = 0
-        ave_total_duration = formatDuration(ave_total_duration)
+        # Filter by Analyst
+        self.add_filter_by_analyst(query=query, out_params=parms)
 
-        # footer data
-        footlines = []
-        footline = []
-        footline = [{'value': _('Total data points'),
-                     'class': 'total'}, ]
+        # Filter by date range
+        self.add_filter_by_date_range(query=query, out_params=parms)
 
-        footline.append({'value': total_count,
-                         'class': 'total number'})
-        footlines.append(footline)
+        # Period
+        period = self.request.form.get("Period", "Day")
+        parms.append(
+            {"title": _("Period"),
+             "value": period,
+             "type": "text"}
+        )
 
-        footline = [{'value': _('Average TAT'),
-                     'class': 'total'}, ]
+        # Fetch the data
+        data_lines = []
+        prev_date_key = None
+        count = 0
+        duration = 0
+        total_count = 0
+        total_duration = 0
+        analyses = api.search(query, CATALOG_ANALYSIS_LISTING)
+        for analysis in analyses:
+            analysis = api.get_object(analysis)
+            date_key = self.get_period_key(analysis.getDateReceived(),
+                                           self.date_format_short)
+            if date_key and date_key != prev_date_key:
+                if prev_date_key:
+                    # Calculate averages
+                    data_lines.append(
+                        [{"value": prev_date_key, 'class': ''},
+                         {"value": formatDuration(duration / count),
+                          "class": "number"}]
+                    )
+                count = 0
+                duration = 0
 
-        footline.append({'value': ave_total_duration,
-                         'class': 'total number'})
-        footlines.append(footline)
+            analysis_duration = analysis.getDuration()
+            count += 1
+            total_count += 1
+            duration += analysis_duration
+            total_duration += analysis_duration
+            prev_date_key = date_key
+
+        if prev_date_key:
+            # Calculate averages
+            data_lines.append(
+                [{"value": prev_date_key, 'class': ''},
+                 {"value": formatDuration(duration / count),
+                  "class": "number"}]
+            )
+
+        # Totals
+        total_duration = total_count and total_duration / total_count or 0
+        total_duration = formatDuration(total_duration)
+
+        if self.request.get("output_format", "") == "CSV":
+            return self.generate_csv(data_lines)
 
         self.report_content = {
-            'headings': headings,
+            'headings': self.headings,
             'parms': parms,
-            'formats': formats,
-            'datalines': datalines,
-            'footings': footlines}
+            'formats': self.formats,
+            'datalines': data_lines,
+            'footings': [
+                [{'value': _('Total data points'), 'class': 'total'},
+                 {'value': total_count, 'class': 'total number'}],
 
-        if self.request.get('output_format', '') == 'CSV':
-            import csv
-            import StringIO
-            import datetime
+                [{'value': _('Average TAT'), 'class': 'total'},
+                 {'value': total_duration, 'class': 'total number'}]
+        ]}
+        return {'report_title': t(self.headings['header']),
+                'report_data': self.template()}
 
-            fieldnames = [
-                'Date',
-                'Turnaround time (h)',
-            ]
-            output = StringIO.StringIO()
-            dw = csv.DictWriter(output, extrasaction='ignore',
-                                fieldnames=fieldnames)
-            dw.writerow(dict((fn, fn) for fn in fieldnames))
-            for row in datalines:
-                dw.writerow({
-                    'Date': row[0]['value'],
-                    'Turnaround time (h)': row[1]['value'],
-                })
-            report_data = output.getvalue()
-            output.close()
-            date = datetime.datetime.now().strftime("%Y%m%d%H%M")
-            setheader = self.request.RESPONSE.setHeader
-            setheader('Content-Type', 'text/csv')
-            setheader("Content-Disposition",
-                      "attachment;filename=\"analysesperservice_%s.csv\"" % date)
-            self.request.RESPONSE.write(report_data)
-        else:
-            return {'report_title': t(headings['header']),
-                    'report_data': self.template()}
+    def add_filter_by_service(self, query, out_params):
+        if not self.request.form.get("ServiceUID", ""):
+            return
+        query["getServiceUID"] = self.request.form["ServiceUID"]
+        service = api.get_object_by_uid(query["getServiceUID"])
+        out_params.append({
+            "title": _("Analysis Service"),
+            "value": service.Title(),
+            "type": "text"})
+
+    def add_filter_by_analyst(self, query, out_params):
+        if not self.request.form.get("Analyst", ""):
+            return
+        query["getAnalyst"] = self.request.form["Analyst"]
+        out_params.append({
+            "title": _("Analyst"),
+            "value": self.user_fullname(query["getAnalyst"]),
+            "type": "text"})
+
+    def add_filter_by_instrument(self, query, out_params):
+        if not self.request.form.get("getInstrumentUID", ""):
+            return
+        query["getInstrumentUID"] = self.request.form["getInstrumentUID"]
+        instrument = api.get_object_by_uid(query["getInstrumentUID"])
+        out_params.append({
+            "title": _("Instrument"),
+            "value": instrument.Title(),
+            "type": "text"})
+
+    def add_filter_by_date_range(self, query, out_params):
+        date_query = formatDateQuery(self.context, "tats_DateReceived")
+        if not date_query:
+            return
+        query["getDateReceived"] = date_query
+        out_params.append(
+            {"title": _("Received"),
+             "value": formatDateParms(self.context, "Tats_DateReceived"),
+             "type": "text"}
+        )
+
+    def get_period_key(self, date_time, date_format):
+        period = self.request.form.get("Period", "Day")
+        if period == "Day":
+            return date_time.strftime('%d %b %Y')
+        elif period == "Week":
+            day_of_week = date_time.strftime("%w")
+            first_day = date_time - (int(day_of_week) - 1)
+            # Sunday = 0
+            if not day_of_week:
+                first_day = date_time - 6
+            return first_day.strftime(date_format)
+        elif period == "Month":
+            return date_time.strftime("%b %Y")
+        return "unknown"
+
+    def generate_csv(self, data_lines):
+        fieldnames = [
+            'Date',
+            'Turnaround time (h)',
+        ]
+        output = StringIO.StringIO()
+        dw = csv.DictWriter(output, extrasaction='ignore',
+                            fieldnames=fieldnames)
+        dw.writerow(dict((fn, fn) for fn in fieldnames))
+        for row in data_lines:
+            dw.writerow({
+                'Date': row[0]['value'],
+                'Turnaround time (h)': row[1]['value'],
+            })
+        report_data = output.getvalue()
+        output.close()
+        date = datetime.datetime.now().strftime("%Y%m%d%H%M")
+        setheader = self.request.RESPONSE.setHeader
+        setheader('Content-Type', 'text/csv')
+        setheader("Content-Disposition",
+                  "attachment;filename=\"analysesperservice_%s.csv\"" % date)
+        self.request.RESPONSE.write(report_data)

--- a/bika/lims/browser/reports/selection_macros/select_analyst.pt
+++ b/bika/lims/browser/reports/selection_macros/select_analyst.pt
@@ -8,12 +8,10 @@
             id="Analyst"
             tal:attributes="style string:font-family:${here/base_properties/fontFamily};;font-size:100%;">
 
+        <option value=""/>
         <tal:analysts tal:repeat="analyst analysts">
-            <option
-                    value=""
-                    tal:attributes="
-                            value python:analyst;
-                            selected python:request.get('Analyst', '') == analyst and 'selected' or ''"
+            <option tal:attributes="value python:analyst;
+                                    selected python:request.get('Analyst', '') == analyst and 'selected' or ''"
                     tal:content="python:analysts.getValue(analyst)">
             </option>
         </tal:analysts>

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -185,23 +185,20 @@ def formatDateParms(context, date_id):
     return date_parms
 
 
-def formatDuration(context, totminutes):
-    """ Format a time period in a usable manner: eg. 3h24m
+def formatDuration(total_minutes):
+    """ Format a time period in a usable manner: eg. 2d 3h 24m
     """
-    mins = totminutes % 60
-    hours = (totminutes - mins) / 60
+    minutes = int(round(total_minutes))
+    hours = minutes / 60
+    days = hours / 24
 
-    if mins:
-        mins_str = '%sm' % mins
-    else:
-        mins_str = ''
+    minutes = minutes % 60
+    hours = hours % 24
 
-    if hours:
-        hours_str = '%sh' % hours
-    else:
-        hours_str = ''
-
-    return '%s%s' % (hours_str, mins_str)
+    days = days and "{}d ".format(str(days)) or ""
+    hours = hours and "{}h ".format(str(hours)) or ""
+    minutes = minutes and "{}m ".format(str(minutes)) or ""
+    return "".join([days, hours, minutes])
 
 
 def formatDecimalMark(value, decimalmark='.'):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request addresses the following issues:
- Turnaround Time is displayed with decimals in "Productivity > Analysis TAT over time"
- Turnaround Time without days in "Productivity > Analysis TAT over time"
- System forces the user to always select an Analyst to generate the report

## Current behavior before PR

![captura de pantalla de 2018-09-25 13-17-47](https://user-images.githubusercontent.com/832627/46011201-73e0c200-c0c5-11e8-8899-4d32e4c4c326.png)

## Desired behavior after PR is merged

![captura de pantalla de 2018-09-25 13-17-35](https://user-images.githubusercontent.com/832627/46011211-793e0c80-c0c5-11e8-9fb3-b84a50ec7d12.png)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
