### PR TITLE
Earliness of analysis is not expressed in minutes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Changelog
 
 **Fixed**
 
+- #1030 Earliness of analysis is not expressed as minutes
 - #1022 Date Received saved as UTC time
 - #1018 Fix AR Add cleanup after template removal
 - #1014 ReferenceWidget does not handle searches with null/None

--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -641,9 +641,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         maxtime_delta = int(maxtime.get('days', 0)) * 24 * 60
         maxtime_delta += int(maxtime.get('hours', 0)) * 60
         maxtime_delta += int(maxtime.get('minutes', 0))
-        duration = self.getDuration()
-        earliness = maxtime_delta - duration
-        return earliness
+        return maxtime_delta - self.getDuration()
 
     def isLateAnalysis(self):
         """Returns true if the analysis is late in accordance with the maximum

--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -638,8 +638,8 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         if not maxtime:
             # No Turnaround time is set for this analysis
             return 0
-        maxtime_delta = int(maxtime.get('days', 0)) * 86400
-        maxtime_delta += int(maxtime.get('hours', 0)) * 3600
+        maxtime_delta = int(maxtime.get('days', 0)) * 24 * 60
+        maxtime_delta += int(maxtime.get('hours', 0)) * 60
         maxtime_delta += int(maxtime.get('minutes', 0))
         duration = self.getDuration()
         earliness = maxtime_delta - duration


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Erliness is the remaining time *in minutes* for an analysis to be completed based on its maximum turn around time. The function was not returning the value in minutes.

## Current behavior before PR

The returned value is not expressed in minutes and thus, values are displayed wrong in those places where the function is used (e.g. Analysis Turnaround report)

![captura de pantalla de 2018-09-25 17-06-11](https://user-images.githubusercontent.com/832627/46023756-a26e9500-c0e5-11e8-8935-d9aa7d9a73f4.png)

## Desired behavior after PR is merged

The returned value is expressed in minutes, so values are displayed right in those places where the function is used (e.g. Analysis Turnaround report)

![captura de pantalla de 2018-09-25 17-04-34](https://user-images.githubusercontent.com/832627/46023752-9f73a480-c0e5-11e8-85e0-da3c0fc6b6de.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
