### PR TITLE
Added profiling and timing decorators

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1031 Added profiling and timing decorators
 - #1001 Option to show Interim fields on results reports
 - #1024 Function to get the Verifiers from an Analysis Request
 - #1019 Support for min and max warns in range charts

--- a/bika/lims/decorators.py
+++ b/bika/lims/decorators.py
@@ -5,7 +5,10 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
+import cProfile
 import json
+import os
+from functools import wraps
 
 
 def returns_json(func):
@@ -18,3 +21,26 @@ def returns_json(func):
         result = func(*args, **kwargs)
         return json.dumps(result)
     return decorator
+
+
+def profileit(path=None):
+    """cProfile decorator to profile a function
+
+    :param path: output file path
+    :type path: str
+    :return: Function
+    """
+
+    def inner(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            prof = cProfile.Profile()
+            retval = prof.runcall(func, *args, **kwargs)
+            if path is not None:
+                print prof.print_stats()
+                prof.dump_stats(os.path.expanduser(path))
+            else:
+                print prof.print_stats()
+            return retval
+        return wrapper
+    return inner

--- a/bika/lims/decorators.py
+++ b/bika/lims/decorators.py
@@ -8,7 +8,10 @@
 import cProfile
 import json
 import os
+import time
 from functools import wraps
+
+from bika.lims import logger
 
 
 def returns_json(func):
@@ -42,5 +45,24 @@ def profileit(path=None):
             else:
                 print prof.print_stats()
             return retval
+        return wrapper
+    return inner
+
+
+def timeit(threshold=0):
+    """Decorator to log the execution time of a function
+    """
+
+    def inner(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            start = time.time()
+            return_value = func(*args, **kwargs)
+            end = time.time()
+            duration = float(end-start)
+            if duration > threshold:
+                logger.info("Execution of '{}{}' took {:2f}s".format(
+                    func.__name__, args, duration))
+            return return_value
         return wrapper
     return inner


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds profiling decorators to senaite.core

## Current behavior before PR

No profiling decorators available

## Desired behavior after PR is merged

Profiling and Timing decorators available

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
