### PR TITLE
Refactored and fixed inconsistencies with Analysis Turnaround Time logic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,9 @@ Changelog
 **Fixed**
 
 - #1030 Earliness of analysis is not expressed as minutes
+- #1029 TAT in Analysis TAT over time report does not display days
+- #1029 TAT in Analysis TAT over time report with decimals
+- #1029 Need to always choose an analyst in productivity reports
 - #1022 Date Received saved as UTC time
 - #1018 Fix AR Add cleanup after template removal
 - #1014 ReferenceWidget does not handle searches with null/None

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Changelog
 
 **Changed**
 
+- #1032 Refactored and fixed inconsistencies with Analysis TAT logic
 - #1027 Refactored relationship between invalidated ARs and retests
 - #1027 Rename `retract_ar` transition to `invalidate`
 - #1012 Refactored Contacts listing

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Changelog
 
 **Fixed**
 
+- #1030 Earliness of analysis is not expressed as minutes
 - #1022 Date Received saved as UTC time
 - #1018 Fix AR Add cleanup after template removal
 - #1014 ReferenceWidget does not handle searches with null/None

--- a/bika/lims/api/__init__.py
+++ b/bika/lims/api/__init__.py
@@ -1265,6 +1265,15 @@ def to_date(value, default=None):
         return to_date(default)
 
 
+def to_minutes(days=0, hours=0, minutes=0, seconds=0, milliseconds=0,
+               to_int=True):
+    """Returns the computed total number of minutes
+    """
+    total = float(days)*24*60 + float(hours)*60 + float(minutes) + \
+            float(seconds)/60 + float(milliseconds)/1000/60
+    return int(round(total)) if to_int else total
+
+
 def to_int(value, default=_marker):
     """Tries to convert the value to int.
     Truncates at the decimal point if the value is a float

--- a/bika/lims/api/__init__.py
+++ b/bika/lims/api/__init__.py
@@ -1280,7 +1280,7 @@ def to_dhm_format(days=0, hours=0, minutes=0, seconds=0, milliseconds=0):
     """
     minutes = to_minutes(days=days, hours=hours, minutes=minutes,
                          seconds=seconds, milliseconds=milliseconds)
-    delta = timedelta(minutes= int(round(minutes)))
+    delta = timedelta(minutes=int(round(minutes)))
     d = delta.days
     h = delta.seconds // 3600
     m = (delta.seconds // 60) % 60

--- a/bika/lims/api/__init__.py
+++ b/bika/lims/api/__init__.py
@@ -1267,12 +1267,12 @@ def to_date(value, default=None):
 
 
 def to_minutes(days=0, hours=0, minutes=0, seconds=0, milliseconds=0,
-               to_int=True):
+               round_to_int=True):
     """Returns the computed total number of minutes
     """
     total = float(days)*24*60 + float(hours)*60 + float(minutes) + \
             float(seconds)/60 + float(milliseconds)/1000/60
-    return int(round(total)) if to_int else total
+    return int(round(total)) if round_to_int else total
 
 
 def to_dhm_format(days=0, hours=0, minutes=0, seconds=0, milliseconds=0):

--- a/bika/lims/api/__init__.py
+++ b/bika/lims/api/__init__.py
@@ -12,6 +12,7 @@ from Acquisition import aq_base
 from AccessControl.PermissionRole import rolesForPermissionOn
 
 from datetime import datetime
+from datetime import timedelta
 from DateTime import DateTime
 
 from Products.CMFPlone.utils import base_hasattr, safe_unicode
@@ -1272,6 +1273,24 @@ def to_minutes(days=0, hours=0, minutes=0, seconds=0, milliseconds=0,
     total = float(days)*24*60 + float(hours)*60 + float(minutes) + \
             float(seconds)/60 + float(milliseconds)/1000/60
     return int(round(total)) if to_int else total
+
+
+def to_dhm_format(days=0, hours=0, minutes=0, seconds=0, milliseconds=0):
+    """Returns a representation of time in a string in xd yh zm format
+    """
+    minutes = to_minutes(days=days, hours=hours, minutes=minutes,
+                         seconds=seconds, milliseconds=milliseconds)
+    delta = timedelta(minutes= int(round(minutes)))
+    d = delta.days
+    h = delta.seconds // 3600
+    m = (delta.seconds // 60) % 60
+    m = m and "{}m ".format(str(m)) or ""
+    d = d and "{}d ".format(str(d)) or ""
+    if m and d:
+        h = "{}h ".format(str(h))
+    else:
+        h = h and "{}h ".format(str(h)) or ""
+    return "".join([d, h, m]).strip()
 
 
 def to_int(value, default=_marker):

--- a/bika/lims/browser/analyses/late.py
+++ b/bika/lims/browser/analyses/late.py
@@ -104,19 +104,16 @@ class LateAnalysesView(BikaListingView):
             items[x]['DateReceived'] = self.ulocalized_time(sample.getDateReceived())
             items[x]['DueDate'] = self.ulocalized_time(obj.getDueDate())
 
-            late_str = ""
-            if obj.getDueDate():
-                late = DateTime() - obj.getDueDate()
-                days = int(late / 1)
-                hours = int((late % 1 ) * 24)
-                mins = int((((late % 1) * 24) % 1) * 60)
-                late_str = days and "%s day%s" % (days, days > 1 and 's' or '') or ""
-                if days < 2:
-                    late_str += hours and " %s hour%s" % (hours, hours > 1 and 's' or '') or ""
-                if not days and not hours:
-                    late_str = "%s min%s" % (mins, mins > 1 and 's' or '')
-
-            items[x]['Late'] = late_str
+            minutes = abs(obj.getEarliness())
+            minutes = int(round(minutes))
+            hours = minutes/60
+            days = hours/24
+            minutes = minutes % 60
+            hours = hours % 24
+            days = days and "{}d ".format(str(days)) or ""
+            hours = hours and "{}h ".format(str(hours)) or ""
+            minutes = minutes and "{}m ".format(str(minutes)) or ""
+            items[x]['Late'] = "".join([days, hours, minutes])
         return items
 
     def isItemAllowed(self, obj):

--- a/bika/lims/browser/analyses/late.py
+++ b/bika/lims/browser/analyses/late.py
@@ -8,6 +8,7 @@
 from AccessControl import getSecurityManager
 from DateTime import DateTime
 from Products.CMFCore.utils import getToolByName
+from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims.utils import t
 from bika.lims.browser.bika_listing import BikaListingView
@@ -103,17 +104,7 @@ class LateAnalysesView(BikaListingView):
                                                   contact.getFullname())
             items[x]['DateReceived'] = self.ulocalized_time(sample.getDateReceived())
             items[x]['DueDate'] = self.ulocalized_time(obj.getDueDate())
-
-            minutes = abs(obj.getEarliness())
-            minutes = int(round(minutes))
-            hours = minutes/60
-            days = hours/24
-            minutes = minutes % 60
-            hours = hours % 24
-            days = days and "{}d ".format(str(days)) or ""
-            hours = hours and "{}h ".format(str(hours)) or ""
-            minutes = minutes and "{}m ".format(str(minutes)) or ""
-            items[x]['Late'] = "".join([days, hours, minutes])
+            items[x]['Late'] = api.to_dhm_format(obj.getLateness())
         return items
 
     def isItemAllowed(self, obj):

--- a/bika/lims/browser/analyses/late.py
+++ b/bika/lims/browser/analyses/late.py
@@ -104,15 +104,17 @@ class LateAnalysesView(BikaListingView):
             items[x]['DateReceived'] = self.ulocalized_time(sample.getDateReceived())
             items[x]['DueDate'] = self.ulocalized_time(obj.getDueDate())
 
-            late = DateTime() - obj.getDueDate()
-            days = int(late / 1)
-            hours = int((late % 1 ) * 24)
-            mins = int((((late % 1) * 24) % 1) * 60)
-            late_str = days and "%s day%s" % (days, days > 1 and 's' or '') or ""
-            if days < 2:
-                late_str += hours and " %s hour%s" % (hours, hours > 1 and 's' or '') or ""
-            if not days and not hours:
-                late_str = "%s min%s" % (mins, mins > 1 and 's' or '')
+            late_str = ""
+            if obj.getDueDate():
+                late = DateTime() - obj.getDueDate()
+                days = int(late / 1)
+                hours = int((late % 1 ) * 24)
+                mins = int((((late % 1) * 24) % 1) * 60)
+                late_str = days and "%s day%s" % (days, days > 1 and 's' or '') or ""
+                if days < 2:
+                    late_str += hours and " %s hour%s" % (hours, hours > 1 and 's' or '') or ""
+                if not days and not hours:
+                    late_str = "%s min%s" % (mins, mins > 1 and 's' or '')
 
             items[x]['Late'] = late_str
         return items

--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -591,6 +591,8 @@ class AnalysesView(BikaListingView):
         # returns the date when the ReferenceSample expires. If the analysis is
         # a duplicate, `getDueDate` returns the due date of the source analysis
         due_date = analysis_brain.getDueDate
+        if not due_date:
+            return
         due_date_str = self.ulocalized_time(due_date, long_format=0)
         item['DueDate'] = due_date_str
 

--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -592,7 +592,7 @@ class AnalysesView(BikaListingView):
         # a duplicate, `getDueDate` returns the due date of the source analysis
         due_date = analysis_brain.getDueDate
         if not due_date:
-            return
+            return None
         due_date_str = self.ulocalized_time(due_date, long_format=0)
         item['DueDate'] = due_date_str
 

--- a/bika/lims/browser/reports/productivity_analysestats.py
+++ b/bika/lims/browser/reports/productivity_analysestats.py
@@ -8,9 +8,10 @@
 from Products.CMFCore.utils import getToolByName
 from bika.lims.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims.utils import t
-from bika.lims.utils import formatDateQuery, formatDateParms, formatDuration, \
+from bika.lims.utils import formatDateQuery, formatDateParms, \
     logged_in_client
 from plone.app.layout.globals.interfaces import IViewView
 from zope.interface import implements
@@ -122,14 +123,15 @@ class Report(BrowserView):
                 services[service_uid]['ave_early'] = ''
             else:
                 avemins = (mins_early) / count_early
-                services[service_uid]['ave_early'] = formatDuration(avemins)
+                services[service_uid]['ave_early'] = \
+                    api.to_dhm_format(minutes=avemins)
             count_late = services[service_uid]['count_late']
             mins_late = services[service_uid]['mins_late']
             if count_late == 0:
                 services[service_uid]['ave_late'] = ''
             else:
                 avemins = mins_late / count_late
-                services[service_uid]['ave_late'] = formatDuration(avemins)
+                services[service_uid]['ave_late'] = api.to_dhm_format(avemins)
 
         # and now lets do the actual report lines
         formats = {'columns': 7,
@@ -263,7 +265,7 @@ class Report(BrowserView):
 
         if total_count_late:
             ave_mins = total_mins_late / total_count_late
-            footline.append({'value': formatDuration(ave_mins),
+            footline.append({'value': api.to_dhm_format(minutes=ave_mins),
                              'class': 'total number'})
         else:
             footline.append({'value': ''})
@@ -273,7 +275,7 @@ class Report(BrowserView):
 
         if total_count_early:
             ave_mins = total_mins_early / total_count_early
-            footline.append({'value': formatDuration(ave_mins),
+            footline.append({'value': api.to_dhm_format(minutes=ave_mins),
                              'class': 'total number'})
         else:
             footline.append({'value': '',

--- a/bika/lims/browser/reports/productivity_analysestats.py
+++ b/bika/lims/browser/reports/productivity_analysestats.py
@@ -122,16 +122,14 @@ class Report(BrowserView):
                 services[service_uid]['ave_early'] = ''
             else:
                 avemins = (mins_early) / count_early
-                services[service_uid]['ave_early'] = formatDuration(self.context,
-                                                                    avemins)
+                services[service_uid]['ave_early'] = formatDuration(avemins)
             count_late = services[service_uid]['count_late']
             mins_late = services[service_uid]['mins_late']
             if count_late == 0:
                 services[service_uid]['ave_late'] = ''
             else:
                 avemins = mins_late / count_late
-                services[service_uid]['ave_late'] = formatDuration(self.context,
-                                                                   avemins)
+                services[service_uid]['ave_late'] = formatDuration(avemins)
 
         # and now lets do the actual report lines
         formats = {'columns': 7,
@@ -265,7 +263,7 @@ class Report(BrowserView):
 
         if total_count_late:
             ave_mins = total_mins_late / total_count_late
-            footline.append({'value': formatDuration(self.context, ave_mins),
+            footline.append({'value': formatDuration(ave_mins),
                              'class': 'total number'})
         else:
             footline.append({'value': ''})
@@ -275,7 +273,7 @@ class Report(BrowserView):
 
         if total_count_early:
             ave_mins = total_mins_early / total_count_early
-            footline.append({'value': formatDuration(self.context, ave_mins),
+            footline.append({'value': formatDuration(ave_mins),
                              'class': 'total number'})
         else:
             footline.append({'value': '',

--- a/bika/lims/browser/reports/productivity_analysestats_overtime.py
+++ b/bika/lims/browser/reports/productivity_analysestats_overtime.py
@@ -122,8 +122,7 @@ class Report(BrowserView):
             count = periods[datekey]['count']
             duration = periods[datekey]['duration']
             ave_duration = (duration) / count
-            periods[datekey]['duration'] = \
-                formatDuration(self.context, ave_duration)
+            periods[datekey]['duration'] = formatDuration(ave_duration)
 
         # and now lets do the actual report lines
         formats = {'columns': 2,
@@ -147,7 +146,7 @@ class Report(BrowserView):
             ave_total_duration = total_duration / total_count
         else:
             ave_total_duration = 0
-        ave_total_duration = formatDuration(self.context, ave_total_duration)
+        ave_total_duration = formatDuration(ave_total_duration)
 
         # footer data
         footlines = []

--- a/bika/lims/browser/reports/productivity_analysestats_overtime.py
+++ b/bika/lims/browser/reports/productivity_analysestats_overtime.py
@@ -14,7 +14,7 @@ from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser import BrowserView
 from bika.lims.catalog.analysis_catalog import CATALOG_ANALYSIS_LISTING
-from bika.lims.utils import formatDateQuery, formatDateParms, formatDuration
+from bika.lims.utils import formatDateQuery, formatDateParms
 from bika.lims.utils import t
 from plone.app.layout.globals.interfaces import IViewView
 from zope.interface import implements
@@ -78,7 +78,7 @@ class Report(BrowserView):
                     # Calculate averages
                     data_lines.append(
                         [{"value": prev_date_key, 'class': ''},
-                         {"value": formatDuration(duration / count),
+                         {"value": api.to_dhm_format(minutes=(duration//count)),
                           "class": "number"}]
                     )
                 count = 0
@@ -95,13 +95,13 @@ class Report(BrowserView):
             # Calculate averages
             data_lines.append(
                 [{"value": prev_date_key, 'class': ''},
-                 {"value": formatDuration(duration / count),
+                 {"value": api.to_dhm_format(minutes=(duration//count)),
                   "class": "number"}]
             )
 
         # Totals
         total_duration = total_count and total_duration / total_count or 0
-        total_duration = formatDuration(total_duration)
+        total_duration = api.to_dhm_format(minutes=total_duration)
 
         if self.request.get("output_format", "") == "CSV":
             return self.generate_csv(data_lines)

--- a/bika/lims/browser/reports/productivity_analysestats_overtime.py
+++ b/bika/lims/browser/reports/productivity_analysestats_overtime.py
@@ -5,12 +5,17 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from Products.CMFCore.utils import getToolByName
-from bika.lims.browser import BrowserView
+import StringIO
+import csv
+import datetime
+
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from bika.lims import api
 from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t
+from bika.lims.browser import BrowserView
+from bika.lims.catalog.analysis_catalog import CATALOG_ANALYSIS_LISTING
 from bika.lims.utils import formatDateQuery, formatDateParms, formatDuration
+from bika.lims.utils import t
 from plone.app.layout.globals.interfaces import IViewView
 from zope.interface import implements
 
@@ -20,184 +25,176 @@ class Report(BrowserView):
     template = ViewPageTemplateFile("templates/report_out.pt")
 
     def __init__(self, context, request, report=None):
-        self.report = report
         BrowserView.__init__(self, context, request)
-
-    def __call__(self):
-        # get all the data into datalines
-
-        bc = getToolByName(self.context, 'bika_analysis_catalog')
-        rc = getToolByName(self.context, 'reference_catalog')
-        self.report_content = {}
-        parms = []
-        headings = {}
-        headings['header'] = _("Analysis turnaround times over time")
-        headings['subheader'] = \
-            _("The turnaround time of analyses plotted over time")
-
-        query = {'portal_type': 'Analysis'}
-
-        if 'ServiceUID' in self.request.form:
-            service_uid = self.request.form['ServiceUID']
-            query['ServiceUID'] = service_uid
-            service = rc.lookupObject(service_uid)
-            service_title = service.Title()
-            parms.append(
-                {'title': _('Analysis Service'),
-                 'value': service_title,
-                 'type': 'text'})
-
-        if 'Analyst' in self.request.form:
-            analyst = self.request.form['Analyst']
-            query['getAnalyst'] = analyst
-            analyst_title = self.user_fullname(analyst)
-            parms.append(
-                {'title': _('Analyst'),
-                 'value': analyst_title,
-                 'type': 'text'})
-
-        if 'getInstrumentUID' in self.request.form:
-            instrument_uid = self.request.form['getInstrumentUID']
-            query['getInstrument'] = instrument_uid
-            instrument = rc.lookupObject(instrument_uid)
-            instrument_title = instrument.Title()
-            parms.append(
-                {'title': _('Instrument'),
-                 'value': instrument_title,
-                 'type': 'text'})
-
-        if 'Period' in self.request.form:
-            period = self.request.form['Period']
-        else:
-            period = 'Day'
-
-        date_query = formatDateQuery(self.context, 'tats_DateReceived')
-        if date_query:
-            query['created'] = date_query
-            received = formatDateParms(self.context, 'tats_DateReceived')
-            parms.append(
-                {'title': _('Received'),
-                 'value': received,
-                 'type': 'text'})
-
-        query['review_state'] = 'published'
-
-        # query all the analyses and increment the counts
-
-        periods = {}
-        total_count = 0
-        total_duration = 0
-
-        analyses = bc(query)
-        for a in analyses:
-            analysis = a.getObject()
-            received = analysis.created()
-            if period == 'Day':
-                datekey = received.strftime('%d %b %Y')
-            elif period == 'Week':
-                # key period on Monday
-                dayofweek = received.strftime('%w')  # Sunday = 0
-                if dayofweek == 0:
-                    firstday = received - 6
-                else:
-                    firstday = received - (int(dayofweek) - 1)
-                datekey = firstday.strftime(self.date_format_short)
-            elif period == 'Month':
-                datekey = received.strftime('%m-%d')
-            if datekey not in periods:
-                periods[datekey] = {'count': 0,
-                                    'duration': 0,
-                }
-            count = periods[datekey]['count']
-            duration = periods[datekey]['duration']
-            count += 1
-            duration += analysis.getDuration()
-            periods[datekey]['duration'] = duration
-            periods[datekey]['count'] = count
-            total_count += 1
-            total_duration += duration
-
-        # calculate averages
-        for datekey in periods.keys():
-            count = periods[datekey]['count']
-            duration = periods[datekey]['duration']
-            ave_duration = (duration) / count
-            periods[datekey]['duration'] = formatDuration(ave_duration)
-
-        # and now lets do the actual report lines
-        formats = {'columns': 2,
-                   'col_heads': [_('Date'),
-                                 _('Turnaround time (h)'),
-                   ],
-                   'class': '',
+        self.report = report
+        self.headings = {
+            'header': _("Analysis turnaround times over time"),
+            'subheader': _("The turnaround time of analyses plotted over time")
+        }
+        self.formats = {
+            'columns': 2,
+            'col_heads': [
+                _('Date'),
+                 _('Turnaround time (h)')],
+            'class': ''
         }
 
-        datalines = []
+    def __call__(self):
+        parms = []
+        query = dict(portal_type="Analysis", sort_on="getDateReceived",
+                     sort_order="ascending")
 
-        period_keys = periods.keys()
-        for period in period_keys:
-            dataline = [{'value': period,
-                         'class': ''}, ]
-            dataline.append({'value': periods[period]['duration'],
-                             'class': 'number'})
-            datalines.append(dataline)
+        # Filter by Service UID
+        self.add_filter_by_service(query=query, out_params=parms)
 
-        if total_count > 0:
-            ave_total_duration = total_duration / total_count
-        else:
-            ave_total_duration = 0
-        ave_total_duration = formatDuration(ave_total_duration)
+        # Filter by Analyst
+        self.add_filter_by_analyst(query=query, out_params=parms)
 
-        # footer data
-        footlines = []
-        footline = []
-        footline = [{'value': _('Total data points'),
-                     'class': 'total'}, ]
+        # Filter by date range
+        self.add_filter_by_date_range(query=query, out_params=parms)
 
-        footline.append({'value': total_count,
-                         'class': 'total number'})
-        footlines.append(footline)
+        # Period
+        period = self.request.form.get("Period", "Day")
+        parms.append(
+            {"title": _("Period"),
+             "value": period,
+             "type": "text"}
+        )
 
-        footline = [{'value': _('Average TAT'),
-                     'class': 'total'}, ]
+        # Fetch the data
+        data_lines = []
+        prev_date_key = None
+        count = 0
+        duration = 0
+        total_count = 0
+        total_duration = 0
+        analyses = api.search(query, CATALOG_ANALYSIS_LISTING)
+        for analysis in analyses:
+            analysis = api.get_object(analysis)
+            date_key = self.get_period_key(analysis.getDateReceived(),
+                                           self.date_format_short)
+            if date_key and date_key != prev_date_key:
+                if prev_date_key:
+                    # Calculate averages
+                    data_lines.append(
+                        [{"value": prev_date_key, 'class': ''},
+                         {"value": formatDuration(duration / count),
+                          "class": "number"}]
+                    )
+                count = 0
+                duration = 0
 
-        footline.append({'value': ave_total_duration,
-                         'class': 'total number'})
-        footlines.append(footline)
+            analysis_duration = analysis.getDuration()
+            count += 1
+            total_count += 1
+            duration += analysis_duration
+            total_duration += analysis_duration
+            prev_date_key = date_key
+
+        if prev_date_key:
+            # Calculate averages
+            data_lines.append(
+                [{"value": prev_date_key, 'class': ''},
+                 {"value": formatDuration(duration / count),
+                  "class": "number"}]
+            )
+
+        # Totals
+        total_duration = total_count and total_duration / total_count or 0
+        total_duration = formatDuration(total_duration)
+
+        if self.request.get("output_format", "") == "CSV":
+            return self.generate_csv(data_lines)
 
         self.report_content = {
-            'headings': headings,
+            'headings': self.headings,
             'parms': parms,
-            'formats': formats,
-            'datalines': datalines,
-            'footings': footlines}
+            'formats': self.formats,
+            'datalines': data_lines,
+            'footings': [
+                [{'value': _('Total data points'), 'class': 'total'},
+                 {'value': total_count, 'class': 'total number'}],
 
-        if self.request.get('output_format', '') == 'CSV':
-            import csv
-            import StringIO
-            import datetime
+                [{'value': _('Average TAT'), 'class': 'total'},
+                 {'value': total_duration, 'class': 'total number'}]
+        ]}
+        return {'report_title': t(self.headings['header']),
+                'report_data': self.template()}
 
-            fieldnames = [
-                'Date',
-                'Turnaround time (h)',
-            ]
-            output = StringIO.StringIO()
-            dw = csv.DictWriter(output, extrasaction='ignore',
-                                fieldnames=fieldnames)
-            dw.writerow(dict((fn, fn) for fn in fieldnames))
-            for row in datalines:
-                dw.writerow({
-                    'Date': row[0]['value'],
-                    'Turnaround time (h)': row[1]['value'],
-                })
-            report_data = output.getvalue()
-            output.close()
-            date = datetime.datetime.now().strftime("%Y%m%d%H%M")
-            setheader = self.request.RESPONSE.setHeader
-            setheader('Content-Type', 'text/csv')
-            setheader("Content-Disposition",
-                      "attachment;filename=\"analysesperservice_%s.csv\"" % date)
-            self.request.RESPONSE.write(report_data)
-        else:
-            return {'report_title': t(headings['header']),
-                    'report_data': self.template()}
+    def add_filter_by_service(self, query, out_params):
+        if not self.request.form.get("ServiceUID", ""):
+            return
+        query["getServiceUID"] = self.request.form["ServiceUID"]
+        service = api.get_object_by_uid(query["getServiceUID"])
+        out_params.append({
+            "title": _("Analysis Service"),
+            "value": service.Title(),
+            "type": "text"})
+
+    def add_filter_by_analyst(self, query, out_params):
+        if not self.request.form.get("Analyst", ""):
+            return
+        query["getAnalyst"] = self.request.form["Analyst"]
+        out_params.append({
+            "title": _("Analyst"),
+            "value": self.user_fullname(query["getAnalyst"]),
+            "type": "text"})
+
+    def add_filter_by_instrument(self, query, out_params):
+        if not self.request.form.get("getInstrumentUID", ""):
+            return
+        query["getInstrumentUID"] = self.request.form["getInstrumentUID"]
+        instrument = api.get_object_by_uid(query["getInstrumentUID"])
+        out_params.append({
+            "title": _("Instrument"),
+            "value": instrument.Title(),
+            "type": "text"})
+
+    def add_filter_by_date_range(self, query, out_params):
+        date_query = formatDateQuery(self.context, "tats_DateReceived")
+        if not date_query:
+            return
+        query["getDateReceived"] = date_query
+        out_params.append(
+            {"title": _("Received"),
+             "value": formatDateParms(self.context, "Tats_DateReceived"),
+             "type": "text"}
+        )
+
+    def get_period_key(self, date_time, date_format):
+        period = self.request.form.get("Period", "Day")
+        if period == "Day":
+            return date_time.strftime('%d %b %Y')
+        elif period == "Week":
+            day_of_week = date_time.strftime("%w")
+            first_day = date_time - (int(day_of_week) - 1)
+            # Sunday = 0
+            if not day_of_week:
+                first_day = date_time - 6
+            return first_day.strftime(date_format)
+        elif period == "Month":
+            return date_time.strftime("%b %Y")
+        return "unknown"
+
+    def generate_csv(self, data_lines):
+        fieldnames = [
+            'Date',
+            'Turnaround time (h)',
+        ]
+        output = StringIO.StringIO()
+        dw = csv.DictWriter(output, extrasaction='ignore',
+                            fieldnames=fieldnames)
+        dw.writerow(dict((fn, fn) for fn in fieldnames))
+        for row in data_lines:
+            dw.writerow({
+                'Date': row[0]['value'],
+                'Turnaround time (h)': row[1]['value'],
+            })
+        report_data = output.getvalue()
+        output.close()
+        date = datetime.datetime.now().strftime("%Y%m%d%H%M")
+        setheader = self.request.RESPONSE.setHeader
+        setheader('Content-Type', 'text/csv')
+        setheader("Content-Disposition",
+                  "attachment;filename=\"analysesperservice_%s.csv\"" % date)
+        self.request.RESPONSE.write(report_data)

--- a/bika/lims/browser/reports/selection_macros/select_analyst.pt
+++ b/bika/lims/browser/reports/selection_macros/select_analyst.pt
@@ -8,12 +8,10 @@
             id="Analyst"
             tal:attributes="style string:font-family:${here/base_properties/fontFamily};;font-size:100%;">
 
+        <option value=""/>
         <tal:analysts tal:repeat="analyst analysts">
-            <option
-                    value=""
-                    tal:attributes="
-                            value python:analyst;
-                            selected python:request.get('Analyst', '') == analyst and 'selected' or ''"
+            <option tal:attributes="value python:analyst;
+                                    selected python:request.get('Analyst', '') == analyst and 'selected' or ''"
                     tal:content="python:analysts.getValue(analyst)">
             </option>
         </tal:analysts>

--- a/bika/lims/browser/worksheet/views/add_analyses.py
+++ b/bika/lims/browser/worksheet/views/add_analyses.py
@@ -206,7 +206,7 @@ class AddAnalysesView(BikaListingView):
         item['getDateReceived'] = self.ulocalized_time(obj.getDateReceived)
         DueDate = obj.getDueDate
         item['getDueDate'] = self.ulocalized_time(DueDate)
-        if DueDate < DateTime():
+        if DueDate and DueDate < DateTime():
             item['after']['DueDate'] = '<img width="16" height="16"'
             ' src="%s/++resource++bika.lims.images/late.png" title="%s"/>' % \
                 (self.context.absolute_url(),

--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -621,15 +621,6 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         return duration
 
     @security.public
-    def getMaxTimeAllowed(self):
-        """Returns the maximum turnaround time for this analysis. If no TAT is
-        set for this particular analysis, it returns the value set at setup
-        return: a dictionary with the keys "days", "hours" and "minutes"
-        """
-        tat = self.Schema().getField("MaxTimeAllowed").get(self)
-        return tat or self.bika_setup.getDefaultTurnaroundTime()
-
-    @security.public
     def getEarliness(self):
         """The remaining time in minutes for this analysis to be completed.
         Returns zero if the analysis is neither 'ready to process' nor a

--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -621,6 +621,15 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         return duration
 
     @security.public
+    def getMaxTimeAllowed(self):
+        """Returns the maximum turnaround time for this analysis. If no TAT is
+        set for this particular analysis, it returns the value set at setup
+        return: a dictionary with the keys "days", "hours" and "minutes"
+        """
+        tat = self.Schema().getField("MaxTimeAllowed").get(self)
+        return tat or self.bika_setup.getDefaultTurnaroundTime()
+
+    @security.public
     def getEarliness(self):
         """The remaining time in minutes for this analysis to be completed.
         Returns zero if the analysis is neither 'ready to process' nor a
@@ -636,6 +645,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             return 0
         return api.to_minutes(**maxtime) - self.getDuration()
 
+    @security.public
     def isLateAnalysis(self):
         """Returns true if the analysis is late in accordance with the maximum
         turnaround time. If no maximum turnaround time is set for this analysis
@@ -645,6 +655,17 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         :rtype: bool
         """
         return self.getEarliness() < 0
+
+    @security.public
+    def getLateness(self):
+        """The time in minutes that exceeds the maximum turnaround set for this
+        analysis. If the analysis has no turnaround time set or is not ready
+        for process yet, returns 0. The analysis is not late if the lateness is
+        negative
+        :return: the time in minutes that exceeds the maximum turnaround time
+        :rtype: int
+        """
+        return -self.getEarliness()
 
     @security.public
     def isInstrumentValid(self):

--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -641,9 +641,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         maxtime_delta = int(maxtime.get('days', 0)) * 24 * 60
         maxtime_delta += int(maxtime.get('hours', 0)) * 60
         maxtime_delta += int(maxtime.get('minutes', 0))
-        duration = self.getDuration()
-        earliness = maxtime_delta - duration
-        return earliness
+        return maxtime_delta - self.getDuration()
 
     def isLateAnalysis(self):
         """Returns true if the analysis is late in accordance with the maximum

--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -638,8 +638,8 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         if not maxtime:
             # No Turnaround time is set for this analysis
             return 0
-        maxtime_delta = int(maxtime.get('days', 0)) * 86400
-        maxtime_delta += int(maxtime.get('hours', 0)) * 3600
+        maxtime_delta = int(maxtime.get('days', 0)) * 24 * 60
+        maxtime_delta += int(maxtime.get('hours', 0)) * 60
         maxtime_delta += int(maxtime.get('minutes', 0))
         duration = self.getDuration()
         earliness = maxtime_delta - duration

--- a/bika/lims/content/abstractbaseanalysis.py
+++ b/bika/lims/content/abstractbaseanalysis.py
@@ -15,6 +15,7 @@ from Products.Archetypes.Widget import BooleanWidget, DecimalWidget, \
     IntegerWidget, SelectionWidget, StringWidget
 from Products.Archetypes.utils import DisplayList, IntDisplayList
 from Products.CMFCore.utils import getToolByName
+from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.fields import DurationField, UIDReferenceField
 from bika.lims.browser.widgets.durationwidget import DurationWidget
@@ -956,3 +957,12 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
         department = self.getDepartment()
         if department:
             return department.UID()
+
+    @security.public
+    def getMaxTimeAllowed(self):
+        """Returns the maximum turnaround time for this analysis. If no TAT is
+        set for this particular analysis, it returns the value set at setup
+        return: a dictionary with the keys "days", "hours" and "minutes"
+        """
+        tat = self.Schema().getField("MaxTimeAllowed").get(self)
+        return tat or self.bika_setup.getDefaultTurnaroundTime()

--- a/bika/lims/content/abstractroutineanalysis.py
+++ b/bika/lims/content/abstractroutineanalysis.py
@@ -6,10 +6,11 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 from AccessControl import ClassSecurityInfo
+from datetime import timedelta
 from Products.Archetypes.Field import BooleanField, FixedPointField, \
     StringField
 from Products.Archetypes.Schema import Schema
-from Products.CMFCore.utils import getToolByName
+from Products.ATContentTypes.utils import DT2dt, dt2DT
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.fields import UIDReferenceField
@@ -258,23 +259,14 @@ class AbstractRoutineAnalysis(AbstractAnalysis):
     @security.public
     def getDueDate(self):
         """Used to populate getDueDate index and metadata.
-        This calculates the difference between the time that the sample
-        partition associated with this analysis was recieved, and the
-        maximum turnaround time.
+        This calculates the difference between the time the analysis processing
+        started and the maximum turnaround time.
         """
-        maxtime = self.getMaxTimeAllowed()
-        if not maxtime:
-            maxtime = getToolByName(self, 'bika_setup').getDefaultTurnaroundTime()
-        max_days = float(maxtime.get('days', 0)) + (
-            (float(maxtime.get('hours', 0)) * 3600 +
-             float(maxtime.get('minutes', 0)) * 60)
-            / 86400
-        )
-        part = self.getSamplePartition()
-        if part:
-            starttime = part.getDateReceived()
-            duetime = starttime + max_days if starttime else ''
-            return duetime
+        start = self.getStartProcessDate()
+        if not start:
+            return None
+        minutes = api.to_minutes(**self.getMaxTimeAllowed())
+        return dt2DT(DT2dt(start) + timedelta(minutes=minutes))
 
     @security.public
     def getSampleTypeUID(self):

--- a/bika/lims/content/abstractroutineanalysis.py
+++ b/bika/lims/content/abstractroutineanalysis.py
@@ -260,13 +260,16 @@ class AbstractRoutineAnalysis(AbstractAnalysis):
     def getDueDate(self):
         """Used to populate getDueDate index and metadata.
         This calculates the difference between the time the analysis processing
-        started and the maximum turnaround time.
+        started and the maximum turnaround time. If the analysis has no
+        turnaround time set or is not yet ready for proces, returns None
         """
+        tat = self.getMaxTimeAllowed()
+        if not tat:
+            return None
         start = self.getStartProcessDate()
         if not start:
             return None
-        minutes = api.to_minutes(**self.getMaxTimeAllowed())
-        return dt2DT(DT2dt(start) + timedelta(minutes=minutes))
+        return dt2DT(DT2dt(start) + timedelta(minutes=api.to_minutes(**tat)))
 
     @security.public
     def getSampleTypeUID(self):

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -1987,9 +1987,10 @@ class AnalysisRequest(BaseFolder):
     def getLate(self):
         """Return True if there is at least one late analysis in this Request
         """
-        analyses = self.getAnalyses(full_objects=True, retracted=False)
-        late_ans = filter(lambda an: an.isLateAnalysis(), analyses)
-        return len(late_ans) > 0
+        for analysis in self.getAnalyses(full_objects=True, retracted=False):
+            if analysis.isLateAnalysis():
+                return True
+        return False
 
     def getPrinted(self):
         """ returns "0", "1" or "2" to indicate Printed state.

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -1985,33 +1985,11 @@ class AnalysisRequest(BaseFolder):
     security.declareProtected(View, 'getLate')
 
     def getLate(self):
-        """Return True if any analyses are late
+        """Return True if there is at least one late analysis in this Request
         """
-        workflow = getToolByName(self, 'portal_workflow')
-        review_state = workflow.getInfoFor(self, 'review_state', '')
-        resultdate = 0
-        if review_state in ['to_be_sampled', 'to_be_preserved',
-                            'sample_due', 'published']:
-            return False
-
-        for analysis in self.objectValues('Analysis'):
-            review_state = workflow.getInfoFor(analysis, 'review_state', '')
-            if review_state == 'published':
-                continue
-            # This situation can be met during analysis request creation
-            calculation = analysis.getCalculation()
-            if not calculation or (
-                    calculation and not calculation.getDependentServices()):
-                resultdate = analysis.getResultCaptureDate()
-            duedate = analysis.getDueDate()
-            if not duedate:
-                continue
-
-            # noinspection PyCallingNonCallable
-            if (resultdate and resultdate > duedate) \
-                    or (not resultdate and DateTime() > duedate):
-                return True
-        return False
+        analyses = self.getAnalyses(full_objects=True, retracted=False)
+        late_ans = filter(lambda an: an.isLateAnalysis(), analyses)
+        return len(late_ans) > 0
 
     def getPrinted(self):
         """ returns "0", "1" or "2" to indicate Printed state.

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2004,6 +2004,9 @@ class AnalysisRequest(BaseFolder):
                     calculation and not calculation.getDependentServices()):
                 resultdate = analysis.getResultCaptureDate()
             duedate = analysis.getDueDate()
+            if not duedate:
+                continue
+
             # noinspection PyCallingNonCallable
             if (resultdate and resultdate > duedate) \
                     or (not resultdate and DateTime() > duedate):

--- a/bika/lims/tests/doctests/API.rst
+++ b/bika/lims/tests/doctests/API.rst
@@ -1419,3 +1419,33 @@ With default fallback:
 
     >>> api.to_int("as", "2")
     2
+
+Convert to minutes
+------------------
+
+    >>> api.to_minutes(hours=1)
+    60
+
+    >>> api.to_minutes(hours=1.5, minutes=30)
+    120
+
+    >>> api.to_minutes(hours=0, minutes=0, seconds=0)
+    0
+
+    >>> api.to_minutes(minutes=120)
+    120
+
+    >>> api.to_minutes(hours="1", minutes="120", seconds="120")
+    182
+
+    >>> api.to_minutes(days=3)
+    4320
+
+    >>> api.to_minutes(minutes=122.4567)
+    122
+
+    >>> api.to_minutes(minutes=122.4567, seconds=6)
+    123
+
+    >>> api.to_minutes(minutes=122.4567, seconds=6, to_int=False)
+    122.55669999999999

--- a/bika/lims/tests/doctests/API.rst
+++ b/bika/lims/tests/doctests/API.rst
@@ -1449,3 +1449,37 @@ Convert to minutes
 
     >>> api.to_minutes(minutes=122.4567, seconds=6, to_int=False)
     122.55669999999999
+
+
+Convert to dhm format
+---------------------
+
+    >>> api.to_dhm_format(hours=1)
+    '1h'
+
+    >>> api.to_dhm_format(hours=1.5, minutes=30)
+    '2h'
+
+    >>> api.to_dhm_format(hours=0, minutes=0, seconds=0)
+    ''
+
+    >>> api.to_dhm_format(minutes=120)
+    '2h'
+
+    >>> api.to_dhm_format(hours="1", minutes="120", seconds="120")
+    '3h 2m'
+
+    >>> api.to_dhm_format(days=3)
+    '3d'
+
+    >>> api.to_dhm_format(days=3, minutes=140)
+    '3d 2h 20m'
+
+    >>> api.to_dhm_format(days=3, minutes=20)
+    '3d 0h 20m'
+
+    >>> api.to_dhm_format(minutes=122.4567)
+    '2h 2m'
+
+    >>> api.to_dhm_format(minutes=122.4567, seconds=6)
+    '2h 3m'

--- a/bika/lims/tests/doctests/API.rst
+++ b/bika/lims/tests/doctests/API.rst
@@ -1447,7 +1447,7 @@ Convert to minutes
     >>> api.to_minutes(minutes=122.4567, seconds=6)
     123
 
-    >>> api.to_minutes(minutes=122.4567, seconds=6, to_int=False)
+    >>> api.to_minutes(minutes=122.4567, seconds=6, round_to_int=False)
     122.55669999999999
 
 

--- a/bika/lims/tests/doctests/AnalysisTurnaroundTime.rst
+++ b/bika/lims/tests/doctests/AnalysisTurnaroundTime.rst
@@ -100,12 +100,16 @@ Set different Turnaround Times for every single Analysis Service:
     >>> [maxtime.get("days"), maxtime.get("hours"), maxtime.get("minutes")]
     [3, 0, 0]
 
-And leave Magnesium (Mg) without any Turnaround Time set:
+And leave Magnesium (Mg) without any Turnaround Time set, so it will use the
+default Turnaround time set in setup:
 
-    >>> Mg.setMaxTimeAllowed(dict())
+    >>> maxtime = bikasetup.getDefaultTurnaroundTime()
+    >>> [maxtime.get("days"), maxtime.get("hours"), maxtime.get("minutes")]
+    [5, 0, 0]
+
     >>> maxtime = Mg.getMaxTimeAllowed()
     >>> [maxtime.get("days"), maxtime.get("hours"), maxtime.get("minutes")]
-    [None, None, None]
+    [5, 0, 0]
 
 Create an Analysis Request:
 
@@ -153,9 +157,9 @@ And none of the analyses are late:
 And Earliness (in minutes) matches with the TAT assigned to each analysis:
 
     >>> map(lambda an: api.to_minutes(**an.getMaxTimeAllowed()), analyses)
-    [3390, 1680, 4320, 0]
+    [3390, 1680, 4320, 7200]
     >>> map(lambda an: an.getEarliness(), analyses)
-    [3390, 1680, 4320, 0]
+    [3390, 1680, 4320, 7200]
 
 Receive the Analysis Request:
 
@@ -210,7 +214,12 @@ Earliness in minutes. Note the value for Cu is negative (is late), and the value
 for Mg is 0 (no Turnaround Time) set:
 
     >>> map(lambda an: int(round(an.getEarliness())), analyses)
-    [510, -1200, 1440, 0]
+    [510, -1200, 1440, 4320]
+
+Lateness in minutes. Note that all values are negative except for Cu:
+
+    >>> map(lambda an: int(round(an.getLateness())), analyses)
+    [-510, 1200, -1440, -4320]
 
 Because one of the analyses (Cu) is late, the Analysis Request is late too:
 

--- a/bika/lims/tests/doctests/AnalysisTurnaroundTime.rst
+++ b/bika/lims/tests/doctests/AnalysisTurnaroundTime.rst
@@ -1,0 +1,218 @@
+Analysis Turnaround Time
+========================
+
+Running this test from the buildout directory::
+
+    bin/test test_textual_doctests -t AnalysisTurnaroundTime
+
+
+Test Setup
+----------
+
+Needed Imports:
+
+    >>> import re
+    >>> from AccessControl.PermissionRole import rolesForPermissionOn
+    >>> from bika.lims import api
+    >>> from bika.lims.api.analysis import get_formatted_interval
+    >>> from bika.lims.api.analysis import is_out_of_range
+    >>> from bika.lims.content.analysisrequest import AnalysisRequest
+    >>> from bika.lims.content.sample import Sample
+    >>> from bika.lims.content.samplepartition import SamplePartition
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.utils.sample import create_sample
+    >>> from bika.lims.utils import tmpID
+    >>> from bika.lims.workflow import doActionFor
+    >>> from bika.lims.workflow import getCurrentState
+    >>> from bika.lims.workflow import getAllowedTransitions
+    >>> from bika.lims.workflow import getReviewHistory
+    >>> from DateTime import DateTime
+    >>> from datetime import timedelta
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+    >>> from plone.app.testing import setRoles
+    >>> from Products.ATContentTypes.utils import DT2dt, dt2DT
+
+Functional Helpers:
+
+    >>> def start_server():
+    ...     from Testing.ZopeTestCase.utils import startZServer
+    ...     ip, port = startZServer()
+    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
+
+    >>> def change_receive_date(analysis, days):
+    ...     tool = api.get_tool("portal_workflow")
+    ...     review_history = getReviewHistory(analysis)
+    ...     for event in review_history:
+    ...         if event.get('action') != 'receive':
+    ...             continue
+    ...         event["time"] = event.get('time') + days
+    ...         tool.setStatusOf("bika_analysis_workflow", analysis, event)
+    ...         return
+
+    >>> def compute_due_date(analysis):
+    ...     start = DT2dt(analysis.getStartProcessDate())
+    ...     tat = api.to_minutes(**analysis.getMaxTimeAllowed())
+    ...     due_date = start + timedelta(minutes=tat)
+    ...     return dt2DT(due_date)
+
+    >>> def compute_duration(date_from, date_to):
+    ...     return (date_to - date_from) * 24 * 60
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> bikasetup = portal.bika_setup
+
+We need to create some basic objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
+    >>> date_now = DateTime().strftime("%Y-%m-%d")
+    >>> date_future = (DateTime() + 5).strftime("%Y-%m-%d")
+    >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH", MemberDiscountApplies=True)
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(bikasetup.bika_sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> labcontact = api.create(bikasetup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(bikasetup.bika_departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = api.create(bikasetup.bika_analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> Cu = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID(), DuplicateVariation="0.5")
+    >>> Fe = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Iron", Keyword="Fe", Price="10", Category=category.UID(), DuplicateVariation="0.5")
+    >>> Au = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Gold", Keyword="Au", Price="20", Category=category.UID(), DuplicateVariation="0.5")
+    >>> Mg = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Magnesium", Keyword="Mg", Price="20", Category=category.UID(), DuplicateVariation="0.5")
+    >>> service_uids = [api.get_uid(an) for an in [Cu, Fe, Au, Mg]]
+    >>> sampletype_uid = api.get_uid(sampletype)
+
+Set different Turnaround Times for every single Analysis Service:
+
+    >>> Au.setMaxTimeAllowed(dict(days=2, hours=8, minutes=30))
+    >>> maxtime = Au.getMaxTimeAllowed()
+    >>> [maxtime.get("days"), maxtime.get("hours"), maxtime.get("minutes")]
+    [2, 8, 30]
+
+    >>> Cu.setMaxTimeAllowed(dict(days=1, hours=4, minutes=0))
+    >>> maxtime = Cu.getMaxTimeAllowed()
+    >>> [maxtime.get("days"), maxtime.get("hours"), maxtime.get("minutes")]
+    [1, 4, 0]
+
+    >>> Fe.setMaxTimeAllowed(dict(days=3, hours=0, minutes=0))
+    >>> maxtime = Fe.getMaxTimeAllowed()
+    >>> [maxtime.get("days"), maxtime.get("hours"), maxtime.get("minutes")]
+    [3, 0, 0]
+
+And leave Magnesium (Mg) without any Turnaround Time set:
+
+    >>> Mg.setMaxTimeAllowed(dict())
+    >>> maxtime = Mg.getMaxTimeAllowed()
+    >>> [maxtime.get("days"), maxtime.get("hours"), maxtime.get("minutes")]
+    [None, None, None]
+
+Create an Analysis Request:
+
+    >>> values = {
+    ...     'Client': api.get_uid(client),
+    ...     'Contact': api.get_uid(contact),
+    ...     'DateSampled': date_now,
+    ...     'SampleType': sampletype_uid,
+    ...     'Priority': '1',
+    ... }
+
+    >>> ar = create_analysisrequest(client, request, values, service_uids)
+
+Get the Analyses for further use:
+
+    >>> analyses = ar.getAnalyses(full_objects=True)
+    >>> analyses = sorted(analyses, key=lambda an: an.getKeyword())
+    >>> map(lambda an: an.getKeyword(), analyses)
+    ['Au', 'Cu', 'Fe', 'Mg']
+    >>> analyses_dict = {an.getKeyword(): an for an in analyses}
+
+
+Test basic functions related with TAT
+-------------------------------------
+
+Since we haven't received the Analysis Request yet, the duration (time in
+minutes taken for analyses must be zero):
+
+    >>> map(lambda an: an.getStartProcessDate(), analyses)
+    [None, None, None, None]
+
+    >>> map(lambda an: an.getDuration(), analyses)
+    [0, 0, 0, 0]
+
+So Due Date returns empty:
+
+    >>> map(lambda an: an.getDueDate(), analyses)
+    [None, None, None, None]
+
+And none of the analyses are late:
+
+    >>> map(lambda an: an.isLateAnalysis(), analyses)
+    [False, False, False, False]
+
+And Earliness (in minutes) matches with the TAT assigned to each analysis:
+
+    >>> map(lambda an: api.to_minutes(**an.getMaxTimeAllowed()), analyses)
+    [3390, 1680, 4320, 0]
+    >>> map(lambda an: an.getEarliness(), analyses)
+    [3390, 1680, 4320, 0]
+
+Receive the Analysis Request:
+
+    >>> success = doActionFor(ar, 'receive')
+
+The process date now for analyses is the received date:
+
+    >>> start_process = map(lambda an: an.getStartProcessDate(), analyses)
+    >>> received = map(lambda an: an.getDateReceived(), analyses)
+    >>> received == start_process
+    True
+
+Also, the Analysis Request is not late because none of its analyses is late:
+
+    >>> ar.getLate()
+    False
+
+
+Test TAT with analyses received 2d ago
+--------------------------------------
+
+We manually force a receive date 2d before so we can test:
+
+    >>> new_received = map(lambda rec: rec-2, received)
+    >>> for analysis in analyses:
+    ...     change_receive_date(analysis, -2)
+    >>> received = map(lambda an: an.getDateReceived(), analyses)
+    >>> start_process = map(lambda an: an.getStartProcessDate(), analyses)
+    >>> new_received == received == start_process
+    True
+
+Analyses Au and Fe are not late, but Cu is late:
+
+    >>> map(lambda an: an.isLateAnalysis(), analyses)
+    [False, True, False, False]
+
+Check Due Dates:
+
+    >>> expected_due_dates = map(lambda an: compute_due_date(an), analyses)
+    >>> due_dates = map(lambda an: an.getDueDate(), analyses)
+    >>> due_dates == expected_due_dates
+    True
+
+And duration:
+
+    >>> expected = map(lambda an: int(compute_duration(an.getStartProcessDate(), DateTime())), analyses)
+    >>> durations = map(lambda an: int(an.getDuration()), analyses)
+    >>> expected == durations
+    True
+
+Earliness in minutes. Note the value for Cu is negative (is late), and the value
+for Mg is 0 (no Turnaround Time) set:
+
+    >>> map(lambda an: int(round(an.getEarliness())), analyses)
+    [510, -1200, 1440, 0]
+
+Because one of the analyses (Cu) is late, the Analysis Request is late too:
+
+    >>> ar.getLate()
+    True

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -22,7 +22,7 @@ from Products.Archetypes.interfaces.field import IComputedField
 from Products.Archetypes.public import DisplayList
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
-from bika.lims import api, deprecated
+from bika.lims import api
 from bika.lims import logger
 from bika.lims.browser import BrowserView
 from email.MIMEBase import MIMEBase
@@ -183,13 +183,6 @@ def formatDateParms(context, date_id):
         date_parms = 'to %s' % (to_date)
 
     return date_parms
-
-
-@deprecated("Use api.to_dhm_format function")
-def formatDuration(total_minutes):
-    """ Format a time period in a usable manner: eg. 2d 3h 24m
-    """
-    return api.to_dhm_format(minutes=total_minutes)
 
 
 def formatDecimalMark(value, decimalmark='.'):

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -185,23 +185,20 @@ def formatDateParms(context, date_id):
     return date_parms
 
 
-def formatDuration(context, totminutes):
-    """ Format a time period in a usable manner: eg. 3h24m
+def formatDuration(total_minutes):
+    """ Format a time period in a usable manner: eg. 2d 3h 24m
     """
-    mins = totminutes % 60
-    hours = (totminutes - mins) / 60
+    minutes = int(round(total_minutes))
+    hours = minutes / 60
+    days = hours / 24
 
-    if mins:
-        mins_str = '%sm' % mins
-    else:
-        mins_str = ''
+    minutes = minutes % 60
+    hours = hours % 24
 
-    if hours:
-        hours_str = '%sh' % hours
-    else:
-        hours_str = ''
-
-    return '%s%s' % (hours_str, mins_str)
+    days = days and "{}d ".format(str(days)) or ""
+    hours = hours and "{}h ".format(str(hours)) or ""
+    minutes = minutes and "{}m ".format(str(minutes)) or ""
+    return "".join([days, hours, minutes])
 
 
 def formatDecimalMark(value, decimalmark='.'):

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -22,7 +22,7 @@ from Products.Archetypes.interfaces.field import IComputedField
 from Products.Archetypes.public import DisplayList
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
-from bika.lims import api
+from bika.lims import api, deprecated
 from bika.lims import logger
 from bika.lims.browser import BrowserView
 from email.MIMEBase import MIMEBase
@@ -185,20 +185,11 @@ def formatDateParms(context, date_id):
     return date_parms
 
 
+@deprecated("Use api.to_dhm_format function")
 def formatDuration(total_minutes):
     """ Format a time period in a usable manner: eg. 2d 3h 24m
     """
-    minutes = int(round(total_minutes))
-    hours = minutes / 60
-    days = hours / 24
-
-    minutes = minutes % 60
-    hours = hours % 24
-
-    days = days and "{}d ".format(str(days)) or ""
-    hours = hours and "{}h ".format(str(hours)) or ""
-    minutes = minutes and "{}m ".format(str(minutes)) or ""
-    return "".join([days, hours, minutes])
+    return api.to_dhm_format(minutes=total_minutes)
 
 
 def formatDecimalMark(value, decimalmark='.'):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Superseds the following PRs**:
- [#1029 Turnaround Time with decimals in "Productivity > Analysis TAT over time" report](https://github.com/senaite/senaite.core/pull/1029) 
- [#1030 Earliness of analysis is not expressed in minutes](https://github.com/senaite/senaite.core/pull/1030)

Revisit, fixing and cleanup of functions and logic related with Analysis Turnaround Time.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
