### PR TITLE
Attachments assigned to Analyses break and get orphaned when the referenced Analysis was removed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Changelog
 
 **Fixed**
 
+- #1034 Attachments assigned to Analyses break and get orphaned when the referenced Analysis was removed
 - #1022 Date Received saved as UTC time
 - #1018 Fix AR Add cleanup after template removal
 - #1014 ReferenceWidget does not handle searches with null/None

--- a/bika/lims/browser/attachment.py
+++ b/bika/lims/browser/attachment.py
@@ -548,20 +548,20 @@ class ajaxAttachmentsView(AttachmentsView):
         return result
 
     def ajax_delete_analysis_attachment(self):
+        """Endpoint for attachment delete in WS
+        """
         form = self.request.form
-        attachment_uid = form.get('attachment_uid', None)
+        attachment_uid = form.get("attachment_uid", None)
+
         if not attachment_uid:
             return "error"
-        uc = api.get_tool('uid_catalog')
-        attachment = uc(UID=attachment_uid)
-        if not attachment:
-            return "%s does not exist" % attachment_uid
-        attachment = attachment[0].getObject()
-        for analysis in attachment.getBackReferences("AnalysisAttachment"):
-            analysis.setAttachment([r for r in analysis.getAttachment()
-                                    if r.UID() != attachment.UID()])
-        for analysis in attachment.getBackReferences("DuplicateAnalysisAttachment"):
-            analysis.setAttachment([r for r in analysis.getAttachment()
-                                    if r.UID() != attachment.UID()])
-        attachment.aq_parent.manage_delObjects(ids=[attachment.getId(), ])
+
+        attachment = api.get_object_by_uid(attachment_uid, None)
+        if attachment is None:
+            return "Could not resolve attachment UID {}".format(attachment_uid)
+
+        # handle delete via the AttachmentsView
+        view = self.context.restrictedTraverse("@@attachments_view")
+        view.delete_attachment(attachment)
+
         return "success"

--- a/bika/lims/browser/attachment.py
+++ b/bika/lims/browser/attachment.py
@@ -5,22 +5,20 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from zope.interface import implements
-from zope.annotation.interfaces import IAnnotations
-from zope.publisher.interfaces import IPublishTraverse
-
-from plone import protect
-
-from BTrees.OOBTree import OOBTree
-from Products.Five.browser import BrowserView
-
 from bika.lims import api
 from bika.lims import logger
 from bika.lims.config import ATTACHMENT_REPORT_OPTIONS
 from bika.lims.decorators import returns_json
 from bika.lims.permissions import AddAttachment
-from bika.lims.permissions import EditResults
 from bika.lims.permissions import EditFieldResults
+from bika.lims.permissions import EditResults
+from BTrees.OOBTree import OOBTree
+from plone import protect
+from Products.Five.browser import BrowserView
+from zope.annotation.interfaces import IAnnotations
+from zope.interface import implements
+from zope.publisher.interfaces import IPublishTraverse
+
 
 ATTACHMENTS_STORAGE = "bika.lims.browser.attachment"
 

--- a/bika/lims/browser/attachment.py
+++ b/bika/lims/browser/attachment.py
@@ -206,7 +206,7 @@ class AttachmentsView(BrowserView):
         attachment_file = form.get('AttachmentFile_file', None)
         AttachmentType = form.get('AttachmentType', '')
         AttachmentKeys = form.get('AttachmentKeys', '')
-        ReportOption = form.get('ReportOption', 'a')
+        ReportOption = form.get('ReportOption', 'r')
 
         # nothing to do if the attachment file is missing
         if attachment_file is None:

--- a/bika/lims/browser/attachment.py
+++ b/bika/lims/browser/attachment.py
@@ -227,8 +227,7 @@ class AttachmentsView(BrowserView):
         # handle analysis attachment
         analysis_uid = form.get("Analysis", None)
         if analysis_uid:
-            rc = api.get_tool("reference_catalog")
-            analysis = rc.lookupObject(analysis_uid)
+            analysis = api.get_object_by_uid(analysis_uid)
             others = analysis.getAttachment()
             attachments = []
             for other in others:

--- a/bika/lims/browser/fields/uidreferencefield.py
+++ b/bika/lims/browser/fields/uidreferencefield.py
@@ -41,6 +41,49 @@ class UIDReferenceField(StringField):
 
     security = ClassSecurityInfo()
 
+    def get_relationship_key(self, context):
+        """Return the configured relationship key or generate a new one
+        """
+        if not self.relationship:
+            return context.portal_type + self.getName()
+        return self.relationship
+
+    def link_reference(self, source, target):
+        """Link the target to the source
+        """
+        target_uid = api.get_uid(target)
+        # get the annotation storage key
+        key = self.get_relationship_key(target)
+        # get all backreferences from the source
+        # N.B. only like this we get the persistent mapping!
+        backrefs = get_backreferences(source, relationship=None)
+        if key not in backrefs:
+            backrefs[key] = PersistentList()
+        if target_uid not in backrefs[key]:
+            backrefs[key].append(target_uid)
+        return True
+
+    def unlink_reference(self, source, target):
+        """Unlink the target from the source
+        """
+        target_uid = api.get_uid(target)
+        # get the storage key
+        key = self.get_relationship_key(target)
+        # get all backreferences from the source
+        # N.B. only like this we get the persistent mapping!
+        backrefs = get_backreferences(source, relationship=None)
+        if key not in backrefs:
+            logger.warn(
+                "Referenced object {} has no backreferences for the key {}"
+                .format(repr(source), key))
+            return False
+        if target_uid not in backrefs[key]:
+            logger.warn("Target {} was not linked by {}"
+                        .format(repr(target), repr(source)))
+            return False
+        backrefs[key].remove(target_uid)
+        return True
+
     @security.public
     def get_object(self, context, value):
         """Resolve a UID to an object.
@@ -135,21 +178,40 @@ class UIDReferenceField(StringField):
                 ret = [ret]
         return ret
 
-    def _set_backreferences(self, context, items):
-        if items:
-            if self.relationship:
-                key = self.relationship
-            else:
-                key = context.portal_type + self.getName()
-            uid = context.UID()
-            for item in items:
-                # Because no relationship is passed to get_backreferences,
-                # the entire set of backrefs is returned by reference.
-                backrefs = get_backreferences(item, relationship=None)
-                if key not in backrefs:
-                    backrefs[key] = PersistentList()
-                if uid not in backrefs[key]:
-                    backrefs[key].append(uid)
+    def _set_backreferences(self, context, items, **kwargs):
+        """Set the back references on the linked items
+
+        This will set an annotation storage on the referenced items which point
+        to the current context.
+        """
+
+        # Don't set any references during initialization.
+        # This might cause a recursion error when calling `getRaw` to fetch the
+        # current set UIDs!
+        initializing = kwargs.get('_initializing_', False)
+        if initializing:
+            return
+
+        # UID of the current object
+        uid = api.get_uid(context)
+        # current set UIDs
+        cur = set(self.getRaw(context) or [])
+        # UIDs to be set
+        new = set(map(api.get_uid, items))
+        # removed UIDs
+        removed = cur.difference(new)
+
+        # Unlink removed UIDs from the source
+        for uid in removed:
+            source = api.get_object_by_uid(uid, None)
+            if source is None:
+                logger.warn("UID {} does not exist anymore".format(uid))
+                continue
+            self.unlink_reference(source, context)
+
+        # Link backrefs
+        for item in items:
+            self.link_reference(item, context)
 
     @security.public
     def set(self, context, value, **kwargs):
@@ -170,7 +232,7 @@ class UIDReferenceField(StringField):
             if type(value) not in (list, tuple):
                 value = [value, ]
             ret = [self.get_object(context, val) for val in value if val]
-            self._set_backreferences(context, ret)
+            self._set_backreferences(context, ret, **kwargs)
             uids = [self.get_uid(context, r) for r in ret if r]
             StringField.set(self, context, uids, **kwargs)
         else:
@@ -186,7 +248,7 @@ class UIDReferenceField(StringField):
                 value = value[0]
             ret = self.get_object(context, value)
             if ret:
-                self._set_backreferences(context, [ret, ])
+                self._set_backreferences(context, [ret, ], **kwargs)
                 uid = self.get_uid(context, ret)
                 StringField.set(self, context, uid, **kwargs)
             else:

--- a/bika/lims/browser/fields/uidreferencefield.py
+++ b/bika/lims/browser/fields/uidreferencefield.py
@@ -6,7 +6,6 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 from AccessControl import ClassSecurityInfo
-from Products.Archetypes.BaseContent import BaseContent
 from Products.Archetypes.Field import Field, StringField
 from bika.lims import logger
 from bika.lims import api

--- a/bika/lims/browser/fields/uidreferencefield.py
+++ b/bika/lims/browser/fields/uidreferencefield.py
@@ -274,7 +274,11 @@ def _get_object(context, value):
     if api.is_uid(value):
         uc = api.get_tool('uid_catalog', context=context)
         brains = uc(UID=value)
-        assert len(brains) == 1
+        if len(brains) == 0:
+            # Broken Reference!
+            logger.warn("Reference on {} with UID {} is broken!"
+                        .format(repr(context), value))
+            return None
         return brains[0].getObject()
     return None
 

--- a/bika/lims/content/attachment.py
+++ b/bika/lims/content/attachment.py
@@ -5,39 +5,33 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from DateTime import DateTime
-
 from AccessControl import ClassSecurityInfo
-
-from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.utils import safe_unicode
-
-from Products.Archetypes.atapi import Schema
+from bika.lims import api
+from bika.lims import bikaMessageFactory as _
+from bika.lims import logger
+from bika.lims.browser.fields.uidreferencefield import get_backreferences
+from bika.lims.browser.widgets import DateTimeWidget
+from bika.lims.config import ATTACHMENT_REPORT_OPTIONS
+from bika.lims.config import PROJECTNAME
+from bika.lims.content.bikaschema import BikaSchema
+from bika.lims.interfaces.analysis import IRequestAnalysis
+from DateTime import DateTime
+from plone.app.blob.field import FileField
 from Products.Archetypes.atapi import BaseFolder
-from Products.Archetypes.atapi import registerType
 from Products.Archetypes.atapi import ComputedField
 from Products.Archetypes.atapi import ComputedWidget
+from Products.Archetypes.atapi import DateTimeField
 from Products.Archetypes.atapi import FileWidget
 from Products.Archetypes.atapi import ReferenceField
 from Products.Archetypes.atapi import ReferenceWidget
+from Products.Archetypes.atapi import Schema
+from Products.Archetypes.atapi import SelectionWidget
 from Products.Archetypes.atapi import StringField
 from Products.Archetypes.atapi import StringWidget
-from Products.Archetypes.atapi import DateTimeField
-from Products.Archetypes.atapi import SelectionWidget
+from Products.Archetypes.atapi import registerType
 from Products.Archetypes.config import REFERENCE_CATALOG
-from bika.lims.browser.fields.uidreferencefield import get_backreferences
-from bika.lims.interfaces.analysis import IRequestAnalysis
-from bika.lims.workflow import getCurrentState
-
-from plone.app.blob.field import FileField
-
-from bika.lims import api
-from bika.lims import logger
-from bika.lims.config import PROJECTNAME
-from bika.lims.config import ATTACHMENT_REPORT_OPTIONS
-from bika.lims import bikaMessageFactory as _
-from bika.lims.content.bikaschema import BikaSchema
-from bika.lims.browser.widgets import DateTimeWidget
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import safe_unicode
 
 
 schema = BikaSchema.copy() + Schema((

--- a/bika/lims/content/attachment.py
+++ b/bika/lims/content/attachment.py
@@ -191,7 +191,7 @@ class Attachment(BaseFolder):
             # This might happen when the AR was invalidated
             ar_ids = ", ".join(map(api.get_id, ars))
             logger.info("Attachment assigned to more than one AR: [{}]. "
-                        "The last AR will be returned".format(ar_ids))
+                        "The first AR will be returned".format(ar_ids))
 
         # return the first AR
         if len(ars) >= 1:
@@ -217,7 +217,7 @@ class Attachment(BaseFolder):
             # happen when the AR was invalidated
             an_ids = ", ".join(map(api.get_id, ans))
             logger.info("Attachment assigned to more than one Analysis: [{}]. "
-                        "The last Analysis will be returned".format(an_ids))
+                        "The first Analysis will be returned".format(an_ids))
 
         if len(ans) >= 1:
             analysis = ans[0]

--- a/bika/lims/content/attachment.py
+++ b/bika/lims/content/attachment.py
@@ -136,7 +136,7 @@ class Attachment(BaseFolder):
     def getLinkedRequests(self):
         """Lookup linked Analysis Requests
 
-        :returns: list of AR objects in ascending order, e.g -R1..-Rn
+        :returns: sorted list of ARs, where the latest AR comes first
         """
         rc = api.get_tool("reference_catalog")
         refs = rc.getBackReferences(self, "AnalysisRequestAttachment")
@@ -152,6 +152,8 @@ class Attachment(BaseFolder):
     @security.public
     def getLinkedAnalyses(self):
         """Lookup linked Analyses
+
+        :returns: sorted list of ANs, where the latest AN comes first
         """
         # Fetch the linked Analyses UIDs
         refs = get_backreferences(self, "AnalysisAttachment")

--- a/bika/lims/content/attachment.py
+++ b/bika/lims/content/attachment.py
@@ -64,7 +64,7 @@ schema = BikaSchema.copy() + Schema((
     StringField(
         'ReportOption',
         searchable=True,
-        vocabulary="ATTACHMENT_REPORT_OPTIONS",
+        vocabulary=ATTACHMENT_REPORT_OPTIONS,
         widget=SelectionWidget(
             label=_("Report Options"),
             checkbox_bound=0,

--- a/bika/lims/content/attachment.py
+++ b/bika/lims/content/attachment.py
@@ -140,9 +140,14 @@ class Attachment(BaseFolder):
         """
         rc = api.get_tool("reference_catalog")
         refs = rc.getBackReferences(self, "AnalysisRequestAttachment")
+        # fetch the objects by UID and handle nonexisting UIDs gracefully
         ars = map(lambda ref: api.get_object_by_uid(ref.sourceUID, None), refs)
-        # filter None values and ensure an ascending order of the ARs by ID
-        return sorted(filter(None, ars), key=lambda ar: api.get_id(ar))
+        # filter out None values (nonexisting UIDs)
+        ars = filter(None, ars)
+        # sort by physical path, so that attachments coming from an AR with a
+        # higher "-Rn" suffix get sorted correctly.
+        # N.B. the created date is the same, hence we can not use it
+        return sorted(ars, key=api.get_path, reverse=True)
 
     @security.public
     def getLinkedAnalyses(self):
@@ -150,9 +155,14 @@ class Attachment(BaseFolder):
         """
         # Fetch the linked Analyses UIDs
         refs = get_backreferences(self, "AnalysisAttachment")
+        # fetch the objects by UID and handle nonexisting UIDs gracefully
         ans = map(lambda uid: api.get_object_by_uid(uid, None), refs)
-        # filter None values and ensure an ascending order of the ARs by ID
-        return sorted(filter(None, ans), key=lambda an: api.get_id(an))
+        # filter out None values (nonexisting UIDs)
+        ans = filter(None, ans)
+        # sort by physical path, so that attachments coming from an AR with a
+        # higher "-Rn" suffix get sorted correctly.
+        # N.B. the created date is the same, hence we can not use it
+        return sorted(ans, key=api.get_path, reverse=True)
 
     @security.public
     def getTextTitle(self):

--- a/bika/lims/content/attachment.py
+++ b/bika/lims/content/attachment.py
@@ -172,7 +172,7 @@ class Attachment(BaseFolder):
     def getRequest(self):
         """Return the primary AR this attachment is linked
         """
-        ars = self.getLinkedAnalyses()
+        ars = self.getLinkedRequests()
 
         if len(ars) > 1:
             # Attachment is assigned to more than one Analysis Request.

--- a/bika/lims/tests/doctests/ARAnalysesField.rst
+++ b/bika/lims/tests/doctests/ARAnalysesField.rst
@@ -817,7 +817,7 @@ However, this retest AR **references the same Attachments** as the original AR:
     True
 
     >>> att_ar.getLinkedRequests()
-    [<AnalysisRequest at /plone/clients/client-1/water-0003-R01>, <AnalysisRequest at /plone/clients/client-1/water-0003-R02>]
+    [<AnalysisRequest at /plone/clients/client-1/water-0003-R02>, <AnalysisRequest at /plone/clients/client-1/water-0003-R01>]
 
     >>> att_ar.getLinkedAnalyses()
     []
@@ -831,7 +831,7 @@ And all contained Analyses of the retest keep references to the same Attachments
     []
 
     >>> att_an.getLinkedAnalyses()
-    [<Analysis at /plone/clients/client-1/water-0003-R01/NoCalc>, <Analysis at /plone/clients/client-1/water-0003-R02/NoCalc>]
+    [<Analysis at /plone/clients/client-1/water-0003-R02/NoCalc>, <Analysis at /plone/clients/client-1/water-0003-R01/NoCalc>]
 
 This means that removing that attachment from the retest should **not** delete
 the attachment from the original AR:

--- a/bika/lims/tests/doctests/ARAnalysesField.rst
+++ b/bika/lims/tests/doctests/ARAnalysesField.rst
@@ -28,6 +28,8 @@ Imports:
 
     >>> from bika.lims import api
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+
 
 Functional Helpers:
 
@@ -127,6 +129,12 @@ Create Analysis Service for Total Hardness (Keyword: `THCaCO3`):
     >>> analysisservice4 = api.create(analysisservices, "AnalysisService", title="Total Hardness", ShortTitle="Tot. Hard", Category=analysiscategory, Keyword="THCaCO3", Price="40")
     >>> analysisservice4
     <AnalysisService at /plone/bika_setup/bika_analysisservices/analysisservice-4>
+
+Create Analysis Service w/o calculation (Keyword: `NOCALC`):
+
+    >>> analysisservice5 = api.create(analysisservices, "AnalysisService", title="No Calculation", ShortTitle="nocalc", Category=analysiscategory, Keyword="NoCalc", Price="50")
+    >>> analysisservice5
+    <AnalysisService at /plone/bika_setup/bika_analysisservices/analysisservice-5>
 
 Create some Calculations with Formulas referencing existing AS keywords:
 
@@ -626,7 +634,216 @@ Get the dependent services:
 
 We expect that dependent services get automatically set:
 
-    >>> new_analyses = field.set(ar, [analysisservice4], debug=1)
+    >>> new_analyses = field.set(ar, [analysisservice4])
 
     >>> sorted(ar.objectValues("Analysis"), key=methodcaller('getId'))
     [<Analysis at /plone/clients/client-1/water-0001-R01/CA>, <Analysis at /plone/clients/client-1/water-0001-R01/MG>, <Analysis at /plone/clients/client-1/water-0001-R01/THCaCO3>]
+
+
+Attachments
+-----------
+
+Attachments can be assigned to the Analysis Request or to individual Analyses.
+
+If an attachment was assigned to a specific analysis, it must be deleted if the
+Analysis was removed, see https://github.com/senaite/senaite.core/issues/1025.
+
+Hoever, for invalidated/retested ARs the attachments are linked to the original
+AR/Analyses as well as to the retested AR/Analyses. Therefore, it must be
+retained when it is still referenced.
+
+Create a new AR and assign the *PH* analysis:
+
+    >>> service_uids = [analysisservice1.UID()]
+    >>> ar2 = create_analysisrequest(client, request, values, service_uids)
+    >>> ar2
+    <AnalysisRequest at /plone/clients/client-1/water-0002-R01>
+
+Get the analysis:
+
+    >>> an1 = ar2[analysisservice1.getKeyword()]
+    >>> an1
+    <Analysis at /plone/clients/client-1/water-0002-R01/PH>
+
+It should have *no* attachments assigned:
+
+    >>> an1.getAttachment()
+    []
+
+We create a new attachment in the client and assign it to this specific analysis:
+
+    >>> att1 = api.create(ar2.getClient(), "Attachment", title="PH.png")
+    >>> an1.setAttachment(att1)
+    >>> an1.getAttachment()
+    [<Attachment at /plone/clients/client-1/attachment-1>]
+
+Now we remove the *PH* analysis. Since it is prohibited by the field to remove
+all analyses from an AR, we will set here some other analyses instead:
+
+    >>> new_analyses = field.set(ar2, [analysisservice2, analysisservice3])
+
+The attachment should be deleted from the client folder as well:
+
+    >>> att1.getId() in ar2.getClient().objectIds()
+    False
+
+Re-adding the *PH* analysis should start with no attachments:
+
+    >>> new_analyses = field.set(ar2, [analysisservice1, analysisservice2, analysisservice3])
+    >>> an1 = ar2[analysisservice1.getKeyword()]
+    >>> an1.getAttachment()
+    []
+
+This should work as well when multiple attachments are assigned.
+
+    >>> new_analyses = field.set(ar2, [analysisservice1, analysisservice2])
+
+    >>> an1 = ar2[analysisservice1.getKeyword()]
+    >>> an2 = ar2[analysisservice2.getKeyword()]
+
+    >>> att2 = api.create(ar2.getClient(), "Attachment", title="test2.png")
+    >>> att3 = api.create(ar2.getClient(), "Attachment", title="test3.png")
+    >>> att4 = api.create(ar2.getClient(), "Attachment", title="test4.png")
+
+    >>> att5 = api.create(ar2.getClient(), "Attachment", title="test5.png")
+    >>> att6 = api.create(ar2.getClient(), "Attachment", title="test6.png")
+    >>> att7 = api.create(ar2.getClient(), "Attachment", title="test7.png")
+
+Assign the first half of the attachments to the *PH* analysis:
+
+    >>> an1.setAttachment([att2, att3, att4])
+    >>> an1.getAttachment()
+    [<Attachment at /plone/clients/client-1/attachment-2>, <Attachment at /plone/clients/client-1/attachment-3>, <Attachment at /plone/clients/client-1/attachment-4>]
+
+Assign the second half of the attachments to the *Magnesium* analysis:
+
+    >>> an2.setAttachment([att5, att6, att7])
+    >>> an2.getAttachment()
+    [<Attachment at /plone/clients/client-1/attachment-5>, <Attachment at /plone/clients/client-1/attachment-6>, <Attachment at /plone/clients/client-1/attachment-7>]
+
+Removing the *PH* analysis should also remove all the assigned attachments:
+
+    >>> new_analyses = field.set(ar2, [analysisservice2])
+
+    >>> att2.getId() in ar2.getClient().objectIds()
+    False
+
+    >>> att3.getId() in ar2.getClient().objectIds()
+    False
+
+    >>> att4.getId() in ar2.getClient().objectIds()
+    False
+
+The attachments of *Magnesium* should be still there:
+
+    >>> att5.getId() in ar2.getClient().objectIds()
+    True
+
+    >>> att6.getId() in ar2.getClient().objectIds()
+    True
+
+    >>> att7.getId() in ar2.getClient().objectIds()
+    True
+
+
+Attachments linked to multiple ARs/ANs
+......................................
+
+When an AR is invalidated, a copy of it get created for retesting with the
+suffix "-R2 ... -Rn". This copy holds also the Attachments as references.
+
+Create a new AR for that and assign a service w/o caclucation:
+
+    >>> service_uids = [analysisservice5.UID()]
+    >>> ar3 = create_analysisrequest(client, request, values, service_uids)
+    >>> ar3
+    <AnalysisRequest at /plone/clients/client-1/water-0003-R01>
+
+Receive the AR:
+
+    >>> transitioned = do_action_for(ar3, "receive")
+    >>> transitioned[0]
+    True
+
+    >>> ar3.portal_workflow.getInfoFor(ar3, "review_state")
+    'sample_received'
+
+Assign an attachment to the AR:
+
+    >>> att_ar = api.create(ar3.getClient(), "Attachment", title="ar.png")
+    >>> ar3.setAttachment(att_ar)
+    >>> ar3.getAttachment()
+    [<Attachment at /plone/clients/client-1/attachment-8>]
+
+Assign an attachment to the Analysis:
+
+    >>> an = ar3[analysisservice5.getKeyword()]
+    >>> att_an = api.create(ar3.getClient(), "Attachment", title="an.png")
+    >>> an.setAttachment(att_an)
+    >>> an.getAttachment()
+    [<Attachment at /plone/clients/client-1/attachment-9>]
+
+Set the results of the Analysis and submit and verify them directly.
+Therefore, self-verification must be allowed in the setup:
+
+    >>> setup.setSelfVerificationEnabled(True)
+
+    >>> for analysis in ar3.getAnalyses(full_objects=True):
+    ...     analysis.setResult("12")
+    ...     transitioned = do_action_for(analysis, "submit")
+    ...     transitioned = do_action_for(analysis, "verify")
+
+Finally we can publish the AR:
+
+    >>> transitioned = do_action_for(ar3, "publish")
+
+And invalidate it directly:
+
+    >>> transitioned = do_action_for(ar3, "invalidate")
+
+A new AR is automatically created for retesting with the suffix "-R2":
+
+    >>> ar_retest = ar3.getRetest()
+    >>> ar_retest
+    <AnalysisRequest at /plone/clients/client-1/water-0003-R02>
+
+    >>> an_retest = ar3.getRetest()[analysisservice5.getKeyword()]
+    >>> an_retest
+    <Analysis at /plone/clients/client-1/water-0003-R02/NoCalc>
+
+However, this retest AR **references the same Attachments** as the original AR:
+
+    >>> ar_retest.getAttachment() == ar3.getAttachment()
+    True
+
+    >>> att_ar.getLinkedRequests()
+    [<AnalysisRequest at /plone/clients/client-1/water-0003-R01>, <AnalysisRequest at /plone/clients/client-1/water-0003-R02>]
+
+    >>> att_ar.getLinkedAnalyses()
+    []
+
+And all contained Analyses of the retest keep references to the same Attachments:
+
+    >>> an_retest.getAttachment() == an.getAttachment()
+    True
+
+    >>> att_an.getLinkedRequests()
+    []
+
+    >>> att_an.getLinkedAnalyses()
+    [<Analysis at /plone/clients/client-1/water-0003-R01/NoCalc>, <Analysis at /plone/clients/client-1/water-0003-R02/NoCalc>]
+
+This means that removing that attachment from the retest should **not** delete
+the attachment from the original AR:
+
+    >>> new_analyses = field.set(ar_retest, [analysisservice1])
+    >>> an.getAttachment()
+    [<Attachment at /plone/clients/client-1/attachment-9>]
+
+    >>> att_an.getId() in ar3.getClient().objectIds()
+    True
+
+And the attachment is now only linked to the attachment of the original analysis:
+
+    >>> att_an.getLinkedAnalyses()
+    [<Analysis at /plone/clients/client-1/water-0003-R01/NoCalc>]

--- a/bika/lims/upgrade/v01_02_009.py
+++ b/bika/lims/upgrade/v01_02_009.py
@@ -34,6 +34,12 @@ def upgrade(tool):
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
     # -------- ADD YOUR STUFF HERE --------
+
+    # Delete orphaned Attachments
+    # https://github.com/senaite/senaite.core/issues/1025
+    delete_orphaned_attachments(portal)
+
+    # Migrate report option from attach (a) -> ignore (i)
     migrate_attachment_report_options(portal)
 
     # Reindex object security for client contents (see #991)
@@ -47,6 +53,26 @@ def upgrade(tool):
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
+
+
+def delete_orphaned_attachments(portal):
+    """Delete attachments where the Analysis was removed
+       https://github.com/senaite/senaite.core/issues/1025
+    """
+    attachments = api.search({"portal_type": "Attachment"})
+    total = len(attachments)
+    logger.info("Integrity checking %d attachments" % total)
+    for num, attachment in enumerate(attachments):
+        obj = api.get_object(attachment)
+        # The method `getRequest` from the attachment tries to get the AR
+        # either directly or from one of the linked Analyses. If it returns
+        # `None`, we can be sure that the attachment is neither assigned
+        # directly to an AR nor to an Analysis.
+        ar = obj.getRequest()
+        if ar is None:
+            obj_id = api.get_id(obj)
+            api.get_parent(obj).manage_delObjects(obj_id)
+            logger.info("Deleted orphaned Attachment {}".format(obj_id))
 
 
 def reindex_client_local_owner_permissions(portal):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1025

This PR in general handles the case when an Attachment was assigned to an Analysis, which is later removed via the "Manage Analysis" tab.

## Current behavior before PR

- Attachments linked to specific Analyses got orphan when the Analysis was removed via AR Manage Analysis View
- Attachments could be deleted in retested ARs, although they were still referenced by the original AR or by Analyses of the original AR
- Attachments could be removed in WS w/o taking handling multiple references
- UIDReference field was not able to unset once added References
- UIDReference field failed with an `AssertionError` when a broken UID reference was found

## Desired behavior after PR is merged

- Attachments will be only deleted if no further reference is held from another object
- UIDRefeference field supports "unsetting" existing references
- UIDReference field handles non-existing UIDs gracefully
- Migration step removes orphaned Attachments in the system

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
