### PR TITLE
Handle back-references of single valued fields

### DIFF
--- a/bika/lims/browser/fields/uidreferencefield.py
+++ b/bika/lims/browser/fields/uidreferencefield.py
@@ -194,7 +194,11 @@ class UIDReferenceField(StringField):
         # UID of the current object
         uid = api.get_uid(context)
         # current set UIDs
-        cur = set(self.getRaw(context) or [])
+        raw = self.getRaw(context) or []
+        # handle single reference fields
+        if isinstance(raw, basestring):
+            raw = [raw, ]
+        cur = set(raw)
         # UIDs to be set
         new = set(map(api.get_uid, items))
         # removed UIDs


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This allows to set/unset the backreferences of single valued reference fields.

This is actually part of https://github.com/senaite/senaite.core/pull/1034

## Current behavior before PR

back-references of single valued fields not handled correctly

## Desired behavior after PR is merged

back-references of single valued fields handled correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
