### PR TITLE
Manage Analyses: Check permission of the AR to decide if it is frozen

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ Changelog
 
 **Changed**
 
-- #1036 Manage Analyses: Check only the current state of the AR to decide if it is frozen
+- #1036 Manage Analyses: Check permission of the AR to decide if it is frozen
 - #764 Code cleanup and redux of 2-Dimensional-CSV instrument interface
 - #1032 Refactored and fixed inconsistencies with Analysis TAT logic
 - #1027 Refactored relationship between invalidated ARs and retests

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Changelog
 
 **Changed**
 
+- #1036 Manage Analyses: Check only the current state of the AR to decide if it is frozen
 - #764 Code cleanup and redux of 2-Dimensional-CSV instrument interface
 - #1032 Refactored and fixed inconsistencies with Analysis TAT logic
 - #1027 Refactored relationship between invalidated ARs and retests

--- a/bika/lims/browser/fields/aranalysesfield.py
+++ b/bika/lims/browser/fields/aranalysesfield.py
@@ -37,7 +37,7 @@ Run this test from the buildout directory:
     bin/test test_textual_doctests -t ARAnalysesField
 """
 
-FROZEN_STATES = ["verified", "published", "invalid"]
+FROZEN_STATES = ["verified", "published", "retracted"]
 FROZEN_TRANSITIONS = ["verify", "retract"]
 
 
@@ -141,6 +141,11 @@ class ARAnalysesField(ObjectField):
             raise TypeError(
                 "Items parameter must be a tuple or list, got '{}'".format(
                     type(items)))
+
+        # Bail out if the AR is inactive
+        if not api.is_active(instance):
+            raise Unauthorized("Inactive ARs can not be modified"
+                               .format(AddAnalysis))
 
         # Bail out if the user has not the right permission
         sm = getSecurityManager()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the "frozen" check for ARs for the "Manage Analyses" field.

Also refactored and simplified the method `_is_frozen`, which performs the frozen
test for Analyses to check the workflow state first.

## Current behavior before PR

The AR was considered as frozen, if a "verify" or "publish" action was performed at any time 

## Desired behavior after PR is merged

The AR was considered as frozen, if the permission "Add Analysis" is not granted

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
