### PR TITLE
Display supplier view instead of reference samples per default

### DIFF
--- a/bika/lims/browser/supplier.py
+++ b/bika/lims/browser/supplier.py
@@ -22,6 +22,24 @@ class SupplierInstrumentsView(InstrumentsView):
     def __init__(self, context, request):
         super(SupplierInstrumentsView, self).__init__(context, request)
 
+        portal = api.get_portal()
+        portal_url = portal.absolute_url()
+
+        add_url = "{}/{}/{}/createObject?type_name={}".format(
+            portal_url, "bika_setup", "bika_instruments", "Instrument")
+
+        self.context_actions = {
+            _("Add"): {
+                "url": add_url,
+                "permisison": "Add portal content",
+                "icon": "++resource++bika.lims.images/add.png"}
+        }
+
+    def before_render(self):
+        """Before template render hook
+        """
+        pass
+
     def isItemAllowed(self, obj):
         supp = obj.getRawSupplier() if obj else None
         return supp == self.context.UID() if supp else False

--- a/bika/lims/browser/supplier.py
+++ b/bika/lims/browser/supplier.py
@@ -5,18 +5,19 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from bika.lims.browser.bika_listing import BikaListingView
-from bika.lims.controlpanel.bika_instruments import InstrumentsView
-from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t
-from Products.CMFCore.utils import getToolByName
-from bika.lims.utils import to_utf8
-from Products.ATContentTypes.utils import DT2dt
-from datetime import datetime
+import collections
 
+from bika.lims import api
+from bika.lims import bikaMessageFactory as _
+from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.browser.referencesample import ReferenceSamplesView
+from bika.lims.controlpanel.bika_instruments import InstrumentsView
+from bika.lims.utils import get_link
+
 
 class SupplierInstrumentsView(InstrumentsView):
+    """Supplier Instruments
+    """
 
     def __init__(self, context, request):
         super(SupplierInstrumentsView, self).__init__(context, request)
@@ -27,65 +28,100 @@ class SupplierInstrumentsView(InstrumentsView):
 
 
 class SupplierReferenceSamplesView(ReferenceSamplesView):
+    """Supplier Reference Samples
+    """
 
     def __init__(self, context, request):
         super(SupplierReferenceSamplesView, self).__init__(context, request)
-        self.contentFilter['path']['query'] = '/'.join(context.getPhysicalPath())
-        self.context_actions = {_('Add'):
-                                {'url': 'createObject?type_name=ReferenceSample',
-                                 'icon': '++resource++bika.lims.images/add.png'}}
+
+        self.contentFilter["path"]["query"] = api.get_path(context)
+
+        self.context_actions = {
+            _("Add"): {
+                "url": "createObject?type_name=ReferenceSample",
+                "permission": "Add portal content",
+                "icon": "++resource++bika.lims.images/add.png"}
+        }
+
         # Remove the Supplier column from the list
-        del self.columns['Supplier']
+        del self.columns["Supplier"]
         for rs in self.review_states:
-            rs['columns'] = [col for col in rs['columns'] if col != 'Supplier']
+            rs["columns"] = [col for col in rs["columns"] if col != "Supplier"]
 
 
 class ContactsView(BikaListingView):
+    """Supplier Contacts
+    """
 
     def __init__(self, context, request):
         super(ContactsView, self).__init__(context, request)
+
         self.catalog = "portal_catalog"
+
         self.contentFilter = {
-            'portal_type': 'SupplierContact',
-            'path': {"query": "/".join(context.getPhysicalPath()),
-                     "level": 0}
+            "portal_type": "SupplierContact",
+            "sort_on": "sortable_title",
+            "sort_order": "ascending",
+            "path": {
+                "query": "/".join(context.getPhysicalPath()),
+                "level": 0}
         }
-        self.context_actions = {_('Add'):
-            {'url': 'createObject?type_name=SupplierContact',
-             'icon': '++resource++bika.lims.images/add.png'}
+
+        self.context_actions = {
+            _("Add"): {
+                "url": "createObject?type_name=SupplierContact",
+                "permission": "Add portal content",
+                "icon": "++resource++bika.lims.images/add.png"}
         }
+
+        self.title = self.context.translate(_("Contacts"))
+        self.icon = "{}/{}".format(
+            self.portal_url,
+            "/++resource++bika.lims.images/contact_big.png"
+        )
+
         self.show_table_only = False
         self.show_sort_column = False
         self.show_select_row = False
         self.show_select_column = True
         self.pagesize = 25
-        self.icon = self.portal_url + "/++resource++bika.lims.images/contact_big.png"
-        self.title = self.context.translate(_("Contacts"))
 
-        self.columns = {
-            'getFullname': {'title': _('Full Name')},
-            'getEmailAddress': {'title': _('Email Address')},
-            'getBusinessPhone': {'title': _('Business Phone')},
-            'getMobilePhone': {'title': _('Mobile Phone')},
-            'getFax': {'title': _('Fax')},
-        }
+        self.columns = collections.OrderedDict((
+            ("getFullname", {
+                "title": _("FullName")}),
+            ("getEmailAddress", {
+                "title": _("Email Address")}),
+            ("getBusinessPhone", {
+                "title": _("Business Phone")}),
+            ("getMobilePhone", {
+                "title": _("Mobile Phone")}),
+            ("getFax", {
+                "title": _("Fax")}),
+        ))
 
         self.review_states = [
-            {'id':'default',
-             'title': _('All'),
-             'contentFilter':{},
-             'columns': ['getFullname',
-                         'getEmailAddress',
-                         'getBusinessPhone',
-                         'getMobilePhone',
-                         'getFax']},
+            {
+                "id": "default",
+                "title": _("All"),
+                "contentFilter": {},
+                "columns": self.columns.keys(),
+            },
         ]
 
-    def folderitems(self):
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-            items[x]['replace']['getFullname'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['obj'].getFullname())
+    def folderitem(self, obj, item, index):
+        """Service triggered each time an item is iterated in folderitems.
 
-        return items
+        The use of this service prevents the extra-loops in child objects.
+
+        :obj: the instance of the class to be foldered
+        :item: dict containing the properties of the object to be used by
+            the template
+        :index: current index of the item
+        """
+
+        name = obj.getFullname()
+        url = obj.absolute_url()
+
+        item["replace"]["getFullname"] = get_link(url, value=name)
+
+        return item

--- a/bika/lims/browser/supplier.py
+++ b/bika/lims/browser/supplier.py
@@ -21,19 +21,8 @@ class SupplierInstrumentsView(InstrumentsView):
 
     def __init__(self, context, request):
         super(SupplierInstrumentsView, self).__init__(context, request)
-
-        portal = api.get_portal()
-        portal_url = portal.absolute_url()
-
-        add_url = "{}/{}/{}/createObject?type_name={}".format(
-            portal_url, "bika_setup", "bika_instruments", "Instrument")
-
-        self.context_actions = {
-            _("Add"): {
-                "url": add_url,
-                "permisison": "Add portal content",
-                "icon": "++resource++bika.lims.images/add.png"}
-        }
+        # Don't allow to add instruments here
+        self.context_actions = {}
 
     def before_render(self):
         """Before template render hook

--- a/bika/lims/browser/supplier.zcml
+++ b/bika/lims/browser/supplier.zcml
@@ -14,7 +14,7 @@
 
     <browser:page
       for="bika.lims.interfaces.ISupplier"
-      name="base_view"
+      name="reference_samples"
       class="bika.lims.browser.supplier.SupplierReferenceSamplesView"
       permission="bika.lims.ManageSuppliers"
       layer="bika.lims.interfaces.IBikaLIMS"

--- a/bika/lims/controlpanel/bika_suppliers.py
+++ b/bika/lims/controlpanel/bika_suppliers.py
@@ -5,88 +5,132 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from AccessControl import ClassSecurityInfo
-from Products.ATContentTypes.content import schemata
-from Products.Archetypes import atapi
-from Products.Archetypes.ArchetypeTool import registerType
-from Products.CMFCore import permissions
-from Products.CMFCore.utils import getToolByName
-from bika.lims.browser import BrowserView
+import collections
+
+from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.config import PROJECTNAME
-from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t
-from plone.app.layout.globals.interfaces import IViewView
-from bika.lims.content.bikaschema import BikaFolderSchema
-from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.folder.folder import ATFolder, ATFolderSchema
 from bika.lims.interfaces import ISuppliers
+from bika.lims.utils import get_link
+from plone.app.content.browser.interfaces import IFolderContentsView
+from plone.app.folder.folder import ATFolder
+from plone.app.folder.folder import ATFolderSchema
+from plone.app.layout.globals.interfaces import IViewView
+from Products.Archetypes import atapi
+from Products.ATContentTypes.content import schemata
 from zope.interface.declarations import implements
+
+# TODO: Separate content and view into own modules!
+
 
 class SuppliersView(BikaListingView):
     implements(IFolderContentsView, IViewView)
+
     def __init__(self, context, request):
         super(SuppliersView, self).__init__(context, request)
-        self.catalog = 'bika_setup_catalog'
-        self.contentFilter = {'portal_type': 'Supplier', 
-                              'sort_on': 'sortable_title'}
-        self.context_actions = {_('Add'):
-                                {'url': 'createObject?type_name=Supplier',
-                                 'icon': '++resource++bika.lims.images/add.png'}}
+
+        self.catalog = "bika_setup_catalog"
+
+        self.contentFilter = {
+            "portal_type": "Supplier",
+            "sort_on": "sortable_title",
+            "sort_order": "ascending",
+        }
+
+        self.context_actions = {
+            _("Add"): {
+                "url": "createObject?type_name=Supplier",
+                "permission": "Add portal content",
+                "icon": "++resource++bika.lims.images/add.png"}
+        }
+
         self.title = self.context.translate(_("Suppliers"))
-        self.icon = "++resource++bika.lims.images/supplier_big.png"
+        self.icon = "{}/{}".format(
+            self.portal_url,
+            "/++resource++bika.lims.images/supplier_big.png"
+        )
+
         self.description = ""
         self.show_sort_column = False
         self.show_select_row = False
         self.show_select_column = True
         self.pagesize = 25
 
-        self.columns = {
-            'Name': {'title': _('Name'),
-                     'index': 'getName'},
-            'Email': {'title': _('Email'),
-                      'toggle': True},
-            'Phone': {'title': _('Phone'),
-                      'toggle': True},
-            'Fax': {'title': _('Fax'),
-                    'toggle': True},
-        }
+        self.columns = collections.OrderedDict((
+            ("Name", {
+                "title": _("Name"),
+                "index": "getName"}),
+            ("Email", {
+                "title": _("Email"),
+                "toggle": True}),
+            ("Phone", {
+                "title": _("Phone"),
+                "toggle": True}),
+            ("Fax", {"title": _("Fax"),
+                     "toggle": True}),
+        ))
+
         self.review_states = [
-            {'id':'default',
-             'title': _('Active'),
-             'contentFilter': {'inactive_state': 'active'},
-             'transitions': [{'id':'deactivate'}, ],
-             'columns': ['Name', 'Email', 'Phone', 'Fax']},
-            {'id':'inactive',
-             'title': _('Dormant'),
-             'contentFilter': {'inactive_state': 'inactive'},
-             'transitions': [{'id':'activate'}, ],
-             'columns': ['Name', 'Email', 'Phone', 'Fax']},
-            {'id':'all',
-             'title': _('All'),
-             'contentFilter':{},
-             'columns': ['Name', 'Email', 'Phone', 'Fax']},
+            {
+                "id": "default",
+                "title": _("Active"),
+                "contentFilter": {"inactive_state": "active"},
+                "transitions": [{"id": "deactivate"}, ],
+                "columns": self.columns.keys(),
+            }, {
+                "id": "inactive",
+                "title": _("Dormant"),
+                "contentFilter": {"inactive_state": "inactive"},
+                "transitions": [{"id": "activate"}, ],
+                "columns": self.columns.keys(),
+            }, {
+                "id": "all",
+                "title": _("All"),
+                "contentFilter": {},
+                "columns": self.columns.keys(),
+            },
         ]
 
-    def folderitems(self):
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
-            items[x]['Name'] = obj.getName()
-            items[x]['Email'] = obj.getEmailAddress()
-            items[x]['Phone'] = obj.getPhone()
-            items[x]['Fax'] = obj.getFax()
-            items[x]['replace']['Name'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['Name'])
+    def before_render(self):
+        """Before template render hook
+        """
+        # Don't allow any context actions
+        self.request.set("disable_border", 1)
 
-        return items
+    def folderitem(self, obj, item, index):
+        """Service triggered each time an item is iterated in folderitems.
+
+        The use of this service prevents the extra-loops in child objects.
+
+        :obj: the instance of the class to be foldered
+        :item: dict containing the properties of the object to be used by
+            the template
+        :index: current index of the item
+        """
+
+        name = obj.getName()
+        email = obj.getEmailAddress()
+        phone = obj.getPhone()
+        fax = obj.getFax()
+        url = obj.absolute_url()
+
+        item["Name"] = name
+        item["Email"] = email
+        item["Phone"] = phone
+        item["Fax"] = fax
+        item["replace"]["Name"] = get_link(url, value=name)
+
+        return item
+
 
 schema = ATFolderSchema.copy()
+
+
 class Suppliers(ATFolder):
     implements(ISuppliers)
     displayContentsTab = False
     schema = schema
 
-schemata.finalizeATCTSchema(schema, folderish = True, moveDiscussion = False)
+
+schemata.finalizeATCTSchema(schema, folderish=True, moveDiscussion=False)
 atapi.registerType(Suppliers, PROJECTNAME)

--- a/bika/lims/profiles/default/types/Supplier.xml
+++ b/bika/lims/profiles/default/types/Supplier.xml
@@ -26,6 +26,17 @@
  <alias from="view" to="base_view"/>
  <alias from="edit" to="base_edit"/>
 
+ <action title="View"
+         action_id="view"
+         category="object"
+         condition_expr=""
+         url_expr="string:${object_url}"
+         i18n:attributes="title"
+         i18n:domain="plone"
+         visible="True">
+   <permission value="View"/>
+ </action>
+
  <action title="Edit"
          action_id="edit"
          category="object"
@@ -34,14 +45,14 @@
          i18n:attributes="title"
          i18n:domain="plone"
          visible="True">
-  <permission value="Modify portal content"/>
+   <permission value="Modify portal content"/>
  </action>
 
- <action action_id="view"
+ <action action_id="reference_samples"
          title="Reference Samples"
          category="object"
          condition_expr=""
-         url_expr="string:${object_url}/base_view"
+         url_expr="string:${object_url}/reference_samples"
          i18n:attributes="title"
          i18n:domain="plone"
          visible="True">

--- a/bika/lims/upgrade/v01_02_009.py
+++ b/bika/lims/upgrade/v01_02_009.py
@@ -24,6 +24,7 @@ profile = 'profile-{0}:default'.format(product)
 @upgradestep(product, version)
 def upgrade(tool):
     portal = tool.aq_inner.aq_parent
+    setup = portal.portal_setup
     ut = UpgradeUtils(portal)
     ver_from = ut.getInstalledVersion(product)
 
@@ -35,6 +36,8 @@ def upgrade(tool):
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
     # -------- ADD YOUR STUFF HERE --------
+
+    setup.runImportStepFromProfile(profile, 'typeinfo')
 
     # Delete orphaned Attachments
     # https://github.com/senaite/senaite.core/issues/1025


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1033

## Current behavior before PR

Click on supplier navigates to supplier reference samples view

## Desired behavior after PR is merged

Click on supplier navigates to supplier base view


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
