### PR TITLE
Detection limit criteria from retracted analysis is preserved

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Changelog
 
 **Fixed**
 
+- #1039 Detection limit criteria is preserved in retracted analyses
 - #1037 Display supplier view instead of reference samples per default
 - #1030 Earliness of analysis is not expressed as minutes
 - #1029 TAT in Analysis TAT over time report does not display days

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,7 @@ Changelog
 
 **Fixed**
 
-- #1039 Detection limit criteria is preserved in retracted analyses
+- #1039 Detection limit criteria from retracted analysis is preserved
 - #1037 Display supplier view instead of reference samples per default
 - #1030 Earliness of analysis is not expressed as minutes
 - #1029 TAT in Analysis TAT over time report does not display days

--- a/bika/lims/browser/analyses/workflow.py
+++ b/bika/lims/browser/analyses/workflow.py
@@ -124,8 +124,7 @@ class AnalysesWorkflowAction(WorkflowAction):
                 analysis.setUncertainty(uncertainties[uid])
 
             # Need to save the detection limit?
-            if uid in dlimits and dlimits[uid]:
-                analysis.setDetectionLimitOperand(dlimits[uid])
+            analysis.setDetectionLimitOperand(dlimits.get(uid, ""))
 
             # Need to save results?
             submitted = False


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When submitting results for analyses that were generated because of the retraction of analyses with "Display a Detection Limit selector" and a detection limit set, the detection limit criteria ("<"/">") does not change, even if the value is manually set to empty

Linked issue: https://github.com/senaite/senaite.core/issues/1038

## Current behavior before PR

The result for the new analysis of Calcium keeps the detection limit that was set in the retracted analysis

## Desired behavior after PR is merged

The result for the new analysis of Calcium does not keep the detection limit that was set in the retracted analysis.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
