### PR TITLE
Reject transition is available to Client once AR/Sample is received

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Changelog
 
 **Fixed**
 
+- #1041 Reject transition is available for Client once AR/Sample is received
 - #1039 Detection limit criteria from retracted analysis is preserved
 - #1037 Display supplier view instead of reference samples per default
 - #1030 Earliness of analysis is not expressed as minutes

--- a/bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
@@ -26,6 +26,12 @@
   <permission>Modify portal content</permission>
   <permission>View</permission>
 
+  <!--
+  Client can only reject an AR when is not yet received.
+  Labman can only reject an AR when is not yet verified.
+   -->
+  <permission>Reject Analysis Request</permission>
+
   <state state_id="sample_registered" title="Registered" i18n:attributes="title">
     <description>Creating an AR</description>
     <exit-transition transition_id="sampling_workflow"/>
@@ -99,6 +105,15 @@
       <permission-role>Sampler</permission-role>
       <permission-role>SamplingCoordinator</permission-role>
       <permission-role>Verifier</permission-role>
+    </permission-map>
+
+    <!-- Reject Analysis Request -->
+    <permission-map name="Reject Analysis Request" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>Client</permission-role>
+      <permission-role>Owner</permission-role>
     </permission-map>
   </state>
 
@@ -187,6 +202,15 @@
       <permission-role>Sampler</permission-role>
       <permission-role>SamplingCoordinator</permission-role>
       <permission-role>Verifier</permission-role>
+    </permission-map>
+
+    <!-- Reject Analysis Request -->
+    <permission-map name="Reject Analysis Request" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>Client</permission-role>
+      <permission-role>Owner</permission-role>
     </permission-map>
   </state>
 
@@ -280,6 +304,15 @@
       <permission-role>SamplingCoordinator</permission-role>
       <permission-role>Verifier</permission-role>
     </permission-map>
+
+    <!-- Reject Analysis Request -->
+    <permission-map name="Reject Analysis Request" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>Client</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
   </state>
 
   <state state_id="sampled" title="Sampled" i18n:attributes="title">
@@ -365,6 +398,15 @@
       <permission-role>Sampler</permission-role>
       <permission-role>SamplingCoordinator</permission-role>
       <permission-role>Verifier</permission-role>
+    </permission-map>
+
+    <!-- Reject Analysis Request -->
+    <permission-map name="Reject Analysis Request" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>Client</permission-role>
+      <permission-role>Owner</permission-role>
     </permission-map>
   </state>
 
@@ -457,6 +499,15 @@
       <permission-role>Sampler</permission-role>
       <permission-role>SamplingCoordinator</permission-role>
       <permission-role>Verifier</permission-role>
+    </permission-map>
+
+    <!-- Reject Analysis Request -->
+    <permission-map name="Reject Analysis Request" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>Client</permission-role>
+      <permission-role>Owner</permission-role>
     </permission-map>
   </state>
 
@@ -551,6 +602,13 @@
       <permission-role>SamplingCoordinator</permission-role>
       <permission-role>Verifier</permission-role>
     </permission-map>
+
+    <!-- Reject Analysis Request -->
+    <permission-map name="Reject Analysis Request" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
+    </permission-map>
   </state>
 
   <state state_id="attachment_due" title="Attachment due" i18n:attributes="title">
@@ -637,6 +695,12 @@
       <permission-role>Sampler</permission-role>
       <permission-role>SamplingCoordinator</permission-role>
       <permission-role>Verifier</permission-role>
+    </permission-map>
+
+    <!-- Reject Analysis Request -->
+    <permission-map name="Reject Analysis Request" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
     </permission-map>
   </state>
 
@@ -728,6 +792,15 @@
       <permission-role>SamplingCoordinator</permission-role>
       <permission-role>Verifier</permission-role>
     </permission-map>
+
+    <!-- Reject Analysis Request -->
+    <permission-map name="Reject Analysis Request" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>Client</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
   </state>
 
   <state state_id="to_be_verified" title="To be verified" i18n:attributes="title">
@@ -814,12 +887,17 @@
       <permission-role>SamplingCoordinator</permission-role>
       <permission-role>Verifier</permission-role>
     </permission-map>
+
+    <!-- Reject Analysis Request -->
+    <permission-map name="Reject Analysis Request" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+    </permission-map>
   </state>
 
   <state state_id="verified" title="Verified" i18n:attributes="title">
     <exit-transition transition_id="publish" />
     <exit-transition transition_id="invalidate" />
-    <exit-transition transition_id="reject" />
     <permission-map name="BIKA: Add Analysis" acquired="False">
     </permission-map>
     <permission-map name="BIKA: Add Attachment" acquired="False">
@@ -889,7 +967,6 @@
   <state state_id="published" title="Published" i18n:attributes="title">
     <exit-transition transition_id="republish"/>
     <exit-transition transition_id="invalidate"/>
-    <exit-transition transition_id="reject"/>
     <permission-map name="BIKA: Add Analysis" acquired="False">
     </permission-map>
     <permission-map name="BIKA: Cancel and reinstate" acquired="False">
@@ -1153,6 +1230,7 @@
     <action url="" category="workflow" icon="">Reject</action>
     <guard>
       <guard-expression>python:here.bika_setup.isRejectionWorkflowEnabled()</guard-expression>
+      <guard-permission>Reject Analysis Request</guard-permission>
     </guard>
   </transition>
 

--- a/bika/lims/profiles/default/workflows/bika_sample_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_sample_workflow/definition.xml
@@ -19,6 +19,12 @@
   <permission>Modify portal content</permission>
   <permission>View</permission>
 
+  <!--
+  Client can only reject a Sample when is not yet received.
+  Labman can only reject a Sample when is not yet verified.
+   -->
+  <permission>Reject Sample</permission>
+
   <state state_id="sample_registered" title="Sample registered" i18n:attributes="title">
     <exit-transition transition_id="sampling_workflow"/>
     <exit-transition transition_id="no_sampling_workflow"/>
@@ -47,6 +53,15 @@
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+
+    <!-- Reject Sample -->
+    <permission-map name="Reject Sample" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>Client</permission-role>
       <permission-role>Owner</permission-role>
     </permission-map>
   </state>
@@ -103,6 +118,15 @@
       <permission-role>Owner</permission-role>
       <permission-role>Sampler</permission-role>
       <permission-role>SamplingCoordinator</permission-role>
+    </permission-map>
+
+    <!-- Reject Sample -->
+    <permission-map name="Reject Sample" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>Client</permission-role>
+      <permission-role>Owner</permission-role>
     </permission-map>
   </state>
 
@@ -163,6 +187,15 @@
       <permission-role>Sampler</permission-role>
       <permission-role>SamplingCoordinator</permission-role>
     </permission-map>
+
+    <!-- Reject Sample -->
+    <permission-map name="Reject Sample" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>Client</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
   </state>
 
   <state state_id="sampled" title="Sampled" i18n:attributes="title">
@@ -213,6 +246,15 @@
       <permission-role>Owner</permission-role>
       <permission-role>Sampler</permission-role>
       <permission-role>SamplingCoordinator</permission-role>
+    </permission-map>
+
+    <!-- Reject Sample -->
+    <permission-map name="Reject Sample" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>Client</permission-role>
+      <permission-role>Owner</permission-role>
     </permission-map>
   </state>
 
@@ -267,6 +309,15 @@
       <permission-role>Sampler</permission-role>
       <permission-role>SamplingCoordinator</permission-role>
     </permission-map>
+
+    <!-- Reject Sample -->
+    <permission-map name="Reject Sample" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>Client</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
   </state>
 
   <state state_id="sample_received" title="Sample received" i18n:attributes="title">
@@ -310,6 +361,13 @@
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>Owner</permission-role>
+    </permission-map>
+
+    <!-- Reject Sample -->
+    <permission-map name="Reject Sample" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
     </permission-map>
   </state>
 
@@ -365,6 +423,15 @@
       <permission-role>Sampler</permission-role>
       <permission-role>SamplingCoordinator</permission-role>
     </permission-map>
+
+    <!-- Reject Sample -->
+    <permission-map name="Reject Sample" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>Client</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
   </state>
 
   <state state_id="rejected" title="Rejected" i18n:attributes="title">
@@ -416,6 +483,12 @@
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
     </permission-map>
+
+    <!-- Reject Sample -->
+    <permission-map name="Reject Sample" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
+    </permission-map>
   </state>
 
   <state state_id="disposed" title="Disposed" i18n:attributes="title">
@@ -441,6 +514,12 @@
     <permission-map name="View" acquired="False">
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
+    </permission-map>
+
+    <!-- Reject Sample -->
+    <permission-map name="Reject Sample" acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>LabManager</permission-role>
     </permission-map>
   </state>
 
@@ -521,6 +600,7 @@
     <action url="" category="workflow" icon="">Reject</action>
     <guard>
       <guard-expression>python:here.bika_setup.isRejectionWorkflowEnabled()</guard-expression>
+      <guard-permission>Reject Sample</guard-permission>
     </guard>
   </transition>
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fixed permission issues regarding to "reject" transition from both `ar_workflow` and `sample_workflow` workflows.

Linked issue: https://github.com/senaite/senaite.core/issues/1040

## Current behavior before PR

Reject transition is available to Client once AR/Sample is received

## Desired behavior after PR is merged

Reject transition is not available to Client once AR/Sample is received

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
