### PR TITLE
Function api.get_object() supports UID as input param

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Changelog
 
 **Changed**
 
+- #1042 Function api.get_object() supports UID as input param
 - #1036 Manage Analyses: Check permission of the AR to decide if it is frozen
 - #764 Code cleanup and redux of 2-Dimensional-CSV instrument interface
 - #1032 Refactored and fixed inconsistencies with Analysis TAT logic
@@ -27,7 +28,6 @@ Changelog
 - #1026 Removed auto-digest of results reports on verify transitions
 - #1005 Removed databasesanitize package
 - #992 Removed "Attach" report option for Attachments
-
 
 **Fixed**
 

--- a/bika/lims/api/__init__.py
+++ b/bika/lims/api/__init__.py
@@ -240,19 +240,21 @@ def is_object(brain_or_object):
     return False
 
 
-def get_object(brain_or_object):
+def get_object(brain_object_uid):
     """Get the full content object
 
-    :param brain_or_object: A single catalog brain or content object
-    :type brain_or_object: PortalObject/ATContentType/DexterityContentType
-    /CatalogBrain
+    :param brain_object_uid: A catalog brain or content object or uid
+    :type brain_object_uid: PortalObject/ATContentType/DexterityContentType
+    /CatalogBrain/basestring
     :returns: The full object
     """
-    if not is_object(brain_or_object):
-        fail("{} is not supported.".format(repr(brain_or_object)))
-    if is_brain(brain_or_object):
-        return brain_or_object.getObject()
-    return brain_or_object
+    if is_uid(brain_object_uid):
+        return get_object_by_uid(brain_object_uid)
+    if not is_object(brain_object_uid):
+        fail("{} is not supported.".format(repr(brain_object_uid)))
+    if is_brain(brain_object_uid):
+        return brain_object_uid.getObject()
+    return brain_object_uid
 
 
 def is_portal(brain_or_object):
@@ -1216,6 +1218,8 @@ def is_uid(uid, validate=False):
     """
     if not isinstance(uid, basestring):
         return False
+    if uid == '0':
+        return True
     if len(uid) != 32:
         return False
     if not UID_RX.match(uid):

--- a/bika/lims/tests/doctests/API.rst
+++ b/bika/lims/tests/doctests/API.rst
@@ -122,12 +122,28 @@ Now we show it with catalog results::
     >>> api.get_object(api.get_object(brain))
     <Client at /plone/clients/client-1>
 
+
+The function also accepts a UID:
+
+    >>> api.get_object(api.get_uid(brain))
+    <Client at /plone/clients/client-1>
+
+And returns the portal object when UID=="0"
+
+    >>> api.get_object("0")
+    <PloneSite at /plone>
+
 No supported objects raise an error::
 
     >>> api.get_object(object())
     Traceback (most recent call last):
     [...]
     BikaLIMSError: <object object at 0x...> is not supported.
+
+    >>> api.get_object("i_am_not_an_uid")
+    Traceback (most recent call last):
+    [...]
+    BikaLIMSError: 'i_am_not_an_uid' is not supported.
 
 To check if an object is supported, e.g. is an ATCT, Dexterity, ZCatalog or
 Portal object, we can use the `is_object` function::
@@ -144,8 +160,8 @@ Portal object, we can use the `is_object` function::
     >>> api.is_object(None)
     False
 
-  >>> api.is_object(object())
-    False
+    >>> api.is_object(object())
+      False
 
 
 Checking if an Object is the Portal
@@ -1175,10 +1191,12 @@ Checks if an UID is a valid 23 alphanumeric uid:
     >>> api.is_uid("")
     False
 
-    >>> api.is_uid("0")
-    False
-
     >>> api.is_uid('0e1dfc3d10d747bf999948a071bc161e')
+    True
+
+Per convention we assume "0" is the uid for portal object (PloneSite):
+
+    >>> api.is_uid("0")
     True
 
 Checks if an UID is a valid 23 alphanumeric uid and with a brain:
@@ -1192,11 +1210,11 @@ Checks if an UID is a valid 23 alphanumeric uid and with a brain:
     >>> api.is_uid("", validate=True)
     False
 
-    >>> api.is_uid("0", validate=True)
-    False
-
     >>> api.is_uid('0e1dfc3d10d747bf999948a071bc161e', validate=True)
     False
+
+    >>> api.is_uid("0", validate=True)
+    True
 
     >>> asfolder = self.portal.bika_setup.bika_analysisservices
     >>> serv = api.create(asfolder, "AnalysisService", title="AS test")

--- a/bika/lims/tests/doctests/API.rst
+++ b/bika/lims/tests/doctests/API.rst
@@ -161,7 +161,7 @@ Portal object, we can use the `is_object` function::
     False
 
     >>> api.is_object(object())
-      False
+    False
 
 
 Checking if an Object is the Portal


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

With this Pull Request, the function `api.get_object` supports now a UID as input parameter. The function returns the portal object when UID=="0"

`api.get_object_by_uid` and `api.get_object` can be used equally, with same result, when a UID is passed in.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
