### PR TITLE
Set the state of analyses in retests to `received` by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Changelog
 
 **Changed**
 
+- #1044 State of analyses in retests is set to `received` by default (was `to_be_verified`)
 - #1036 Manage Analyses: Check permission of the AR to decide if it is frozen
 - #764 Code cleanup and redux of 2-Dimensional-CSV instrument interface
 - #1032 Refactored and fixed inconsistencies with Analysis TAT logic

--- a/bika/lims/browser/analysisrequest/workflow.py
+++ b/bika/lims/browser/analysisrequest/workflow.py
@@ -378,7 +378,6 @@ class AnalysisRequestWorkflowAction(AnalysesWorkflowAction):
         return self.workflow_action_default(action='verify', came_from=came_from)
 
     def workflow_action_invalidate(self):
-
         # AR should be retracted
         # Can't transition inactive ARs
         if not api.is_active(self.context):

--- a/bika/lims/tests/doctests/AnalysisRequestInvalidate.rst
+++ b/bika/lims/tests/doctests/AnalysisRequestInvalidate.rst
@@ -191,7 +191,7 @@ When an Analysis Request is invalidated two things should happen:
     `verified` state.
 
     2- A new Analysis Request (retest) is created automatically, with same
-    analyses as the invalidated, but in `to_be_verified` state.
+    analyses as the invalidated, but in `sample_received` state.
 
 Invalidate the Analysis Request:
 
@@ -214,13 +214,13 @@ the invalidated:
     <AnalysisRequest at /plone/clients/client-1/water-0001-R01>
 
     >>> api.get_workflow_status_of(retest)
-    'to_be_verified'
+    'sample_received'
 
-    >>> not_to_be_verified = 0
+    >>> not_received = 0
     >>> for analysis in retest.getAnalyses(full_objects=True):
-    ...     if api.get_workflow_status_of(analysis) != 'to_be_verified':
-    ...         not_to_be_verified += 1
-    >>> not_to_be_verified
+    ...     if api.get_workflow_status_of(analysis) != 'sample_received':
+    ...         not_received += 1
+    >>> not_received
     0
 
     >>> retest_ans = map(lambda an: an.getKeyword(), retest.getAnalyses(full_objects=True))
@@ -235,7 +235,17 @@ Invalidate the retest
 We can even invalidate the retest generated previously. As a result, a new
 retest will be created.
 
-First, verify all analyses from the retest:
+First, submit all analyses from the retest:
+
+    >>> for analysis in retest.getAnalyses(full_objects=True):
+    ...     transitioned = do_action_for(analysis, 'submit')
+    >>> transitioned[0]
+    True
+
+    >>> api.get_workflow_status_of(retest)
+    'to_be_verified'
+
+Now, verify all analyses from the retest:
 
     >>> for analysis in retest.getAnalyses(full_objects=True):
     ...     transitioned = do_action_for(analysis, 'verify')
@@ -276,13 +286,13 @@ as the invalidated (retest):
     <AnalysisRequest at /plone/clients/client-1/water-0001-R01>
 
     >>> api.get_workflow_status_of(retest2)
-    'to_be_verified'
+    'sample_received'
 
-    >>> not_to_be_verified = 0
+    >>> not_received = 0
     >>> for analysis in retest2.getAnalyses(full_objects=True):
-    ...     if api.get_workflow_status_of(analysis) != 'to_be_verified':
-    ...         not_to_be_verified += 1
-    >>> not_to_be_verified
+    ...     if api.get_workflow_status_of(analysis) != 'sample_received':
+    ...         not_received += 1
+    >>> not_received
     0
 
     >>> retest_ans = map(lambda an: an.getKeyword(), retest2.getAnalyses(full_objects=True))

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -405,7 +405,7 @@ def create_retest(ar):
 
     if not ar.isInvalid():
         # Analysis Request must be in 'invalid' state
-        raise ValueError("Cannot create a retest from a valid Analysis Request"
+        raise ValueError("Cannot do a retest from an invalid Analysis Request"
                          .format(repr(ar)))
 
     # 1. Create the Retest (Analysis Request)
@@ -425,17 +425,17 @@ def create_retest(ar):
         copy_field_values(an, nan, ignore_fieldnames=ignore_fieldnames)
         nan.unmarkCreationFlag()
 
-        # Set the workflow state of the analysis to 'to_be_verified', cause it
-        # already has a result in place
-        # TODO: We loose here the info about who submitted the result!
-        changeWorkflowState(nan, 'bika_analysis_workflow', 'to_be_verified')
+        # Set the workflow state of the analysis to 'sample_received'. Since we
+        # keep the results of the previous analyses, these will be preserved,
+        # only awaiting for their submission
+        changeWorkflowState(nan, 'bika_analysis_workflow', 'sample_received')
         nan.reindexObject()
 
     # 3. Assign the source to retest
     retest.setInvalidated(ar)
 
-    # 4. Transition the retest to "to_be_verified"!
-    changeWorkflowState(retest, 'bika_ar_workflow', 'to_be_verified')
+    # 4. Transition the retest to "sample_received"!
+    changeWorkflowState(retest, 'bika_ar_workflow', 'sample_received')
 
     # 5. Reindex and other stuff
     retest.reindexObject()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Set the status of the analyses from a retest (Analysis Request generated automatically when another Analysis Request is invalidated) to `received` instead of `to_be_verified`

Linked issue: https://github.com/senaite/senaite.core/issues/980

## Current behavior before PR

When transitioning an Analysis Request to "invalid" state and new AR is created automatically, as a copy of the previous one, but keeps the analyses in status `to_be_verified` instead of `received`. Thus, the labman is forced to retract all analyses to allow an analyst to introduce results again

## Desired behavior after PR is merged

The AR transition to "invalid" state and new AR is created automatically, as a copy of the previous one, but in status `received`. Lab personnel can resubmit results directly.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
