### PR TITLE
Updated buildout to Plone 4.3.18

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -8,14 +8,14 @@
 #
 
 [buildout]
-extends = http://dist.plone.org/release/4.3.17/versions.cfg
+extends = http://dist.plone.org/release/4.3.18/versions.cfg
 versions = versions
 develop = .
 
 index = https://pypi.python.org/simple/
 
 find-links =
-    http://dist.plone.org/release/4.3.17
+    http://dist.plone.org/release/4.3.18
     http://dist.plone.org/thirdparty
 
 parts =
@@ -70,7 +70,7 @@ mode = 755
 
 [lxml]
 recipe = z3c.recipe.staticlxml
-egg = lxml==3.6.0
+egg = lxml==4.2.1
 force = false
 static-build = true
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR updates the Plone version in the provided buildout config

## Current behavior before PR

Plone 4.3.17 was used

## Desired behavior after PR is merged

Plone 4.3.18 was used

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
