### PR TITLE
 Show "Date Registered" instead of "Date Created" in Analysis Requests listings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Changelog
 
 **Changed**
 
+- #1046 Show "Date Registered" instead of "Date Created" in Analysis Requests listings
 - #1044 State of analyses in retests is set to `received` by default (was `to_be_verified`)
 - #1042 Function api.get_object() supports UID as input param
 - #1036 Manage Analyses: Check permission of the AR to decide if it is frozen

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -9,10 +9,6 @@ import collections
 import json
 import traceback
 
-from DateTime import DateTime
-from Products.Archetypes import PloneMessageFactory as PMF
-from Products.CMFCore.permissions import ModifyPortalContent
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
@@ -21,13 +17,20 @@ from bika.lims.browser.analysisrequest.analysisrequests_filter_bar import \
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.config import PRIORITIES
-from bika.lims.permissions import (AddAnalysisRequest, ManageAnalysisRequests,
-                                   SampleSample)
+from bika.lims.permissions import AddAnalysisRequest
+from bika.lims.permissions import ManageAnalysisRequests
+from bika.lims.permissions import SampleSample
 from bika.lims.permissions import Verify as VerifyPermission
-from bika.lims.utils import getUsers, t
+from bika.lims.utils import get_image
+from bika.lims.utils import getUsers
+from bika.lims.utils import t
 from collective.taskqueue.interfaces import ITaskQueue
+from DateTime import DateTime
 from plone.api import user
-from plone.protect import CheckAuthenticator, PostOnly
+from plone.protect import CheckAuthenticator
+from plone.protect import PostOnly
+from Products.CMFCore.permissions import ModifyPortalContent
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import queryUtility
 
 

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -111,12 +111,12 @@ class AnalysisRequestsView(BikaListingView):
                 "sortable": True,
                 "toggle": False}),
             ("Creator", {
-                "title": PMF("Creator"),
+                "title": _("Creator"),
                 "index": "getCreatorFullName",
                 "sortable": True,
                 "toggle": True}),
             ("Created", {
-                "title": PMF("Date Created"),
+                "title": _("Date Registered"),
                 "index": "created",
                 "toggle": False}),
             ("getSample", {

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -54,7 +54,7 @@ class AnalysisRequestsView(BikaListingView):
         # catalog used for the query
         self.catalog = CATALOG_ANALYSIS_REQUEST_LISTING
 
-        # see: https://docs.plone.org/develop/plone/searching_and_indexing/query.html#searching-for-content-within-a-folder
+        # https://docs.plone.org/develop/plone/searching_and_indexing/query.html#searching-for-content-within-a-folder
         self.contentFilter = {
             "sort_on": "created",
             "sort_order": "descending",
@@ -473,8 +473,8 @@ class AnalysisRequestsView(BikaListingView):
                 "columns": self.columns.keys(),
             }, {
                 "id": "assigned",
-                "title": "<img title='%s' src='%s/++resource++bika.lims.images/assigned.png'/>" % (
-                    t(_("Assigned")), self.portal_url),
+                "title": get_image("assigned.png",
+                                   title=t(_("Assigned"))),
                 "contentFilter": {
                     "assigned_state": "assigned",
                     "cancellation_state": "active",
@@ -493,8 +493,8 @@ class AnalysisRequestsView(BikaListingView):
                 "columns": self.columns.keys(),
             }, {
                 "id": "unassigned",
-                "title": "<img title='%s' src='%s/++resource++bika.lims.images/unassigned.png'/>" % (
-                    t(_("Unassigned")), self.portal_url),
+                "title": get_image("unassigned.png",
+                                   title=t(_("Unsassigned"))),
                 "contentFilter": {
                     "assigned_state": "unassigned",
                     "cancellation_state": "active",
@@ -535,7 +535,8 @@ class AnalysisRequestsView(BikaListingView):
         # remove `scheduled_sampling` filter
         if not setup.getScheduleSamplingEnabled():
             self.review_states = filter(
-                lambda x: x.get("id") != "scheduled_sampling", self.review_states)
+                lambda x: x.get("id") != "scheduled_sampling",
+                self.review_states)
 
         # remove `to_be_preserved` filter
         if not setup.getSamplePreservationEnabled():
@@ -631,7 +632,7 @@ class AnalysisRequestsView(BikaListingView):
         if client:
             self.contentFilter['path'] = {
                 "query": "/".join(client.getPhysicalPath()),
-                "level": 0 }
+                "level": 0}
             # No need to display the Client column
             self.remove_column('Client')
 
@@ -728,22 +729,14 @@ class AnalysisRequestsView(BikaListingView):
             printed = obj.getPrinted if hasattr(obj, "getPrinted") else "0"
             print_icon = ""
             if printed == "0":
-                print_icon = \
-                    """<img src='%s/++resource++bika.lims.images/delete.png'
-                        title='%s'>
-                    """ % (self.portal_url, t(_("Not printed yet")))
+                print_icon = get_image("delete.png",
+                                       title=t(_("Not printed yet")))
             elif printed == "1":
-                print_icon = \
-                    """<img src='%s/++resource++bika.lims.images/ok.png'
-                        title='%s'>
-                    """ % (self.portal_url, t(_("Printed")))
+                print_icon = get_image("ok.png",
+                                       title=t(_("Printed")))
             elif printed == "2":
-                print_icon = \
-                    """<img
-                        src='%s/++resource++bika.lims.images/exclamation.png'
-                            title='%s'>
-                        """ \
-                    % (self.portal_url, t(_("Republished after last print")))
+                print_icon = get_image("exclamation.png",
+                                       title=t(_("Republished after last print")))
             item["after"]["Printed"] = print_icon
         item["SamplingDeviation"] = obj.getSamplingDeviationTitle
 
@@ -753,36 +746,23 @@ class AnalysisRequestsView(BikaListingView):
         # Getting a dictionary with each workflow id and current state in it
         states_dict = obj.getObjectWorkflowStates
         if obj.assigned_state == 'assigned':
-            after_icons += \
-                """<img src='%s/++resource++bika.lims.images/worksheet.png'
-                    title='%s'/>
-                """ % (self.portal_url, t(_("All analyses assigned")))
+            after_icons += get_image("worksheet.png",
+                                     title=t(_("All analyses assigned")))
         if states_dict.get('review_state', '') == 'invalid':
-            after_icons += \
-                """<img src='%s/++resource++bika.lims.images/delete.png'
-                    title='%s'/>
-                """ % (self.portal_url, t(_("Results have been withdrawn")))
+            after_icons += get_image("delete.png",
+                                     title=t(_("Results have been withdrawn")))
         if obj.getLate:
-            after_icons += \
-                """<img src='%s/++resource++bika.lims.images/late.png'
-                    title='%s'>
-                """ % (self.portal_url, t(_("Late Analyses")))
+            after_icons += get_image("late.png",
+                                     title=t(_("Late Analyses")))
         if obj.getSamplingDate and obj.getSamplingDate > DateTime():
-            after_icons += \
-                """<img src='%s/++resource++bika.lims.images/calendar.png'
-                    title='%s'>
-                """ % (self.portal_url, t(_("Future dated sample")))
+            after_icons += get_image("calendar.png",
+                                     title=t(_("Future dated sample")))
         if obj.getInvoiceExclude:
-            after_icons += \
-                """<img
-                    src='%s/++resource++bika.lims.images/invoice_exclude.png'
-                    title='%s'>
-                """ % (self.portal_url, t(_("Exclude from invoice")))
+            after_icons += get_image("invoice_exclude.png",
+                                     title=t(_("Exclude from invoice")))
         if obj.getHazardous:
-            after_icons += \
-                """<img src='%s/++resource++bika.lims.images/hazardous.png'
-                    title='%s'>
-                """ % (self.portal_url, t(_("Hazardous")))
+            after_icons += get_image("hazardous.png",
+                                     title=t(_("Hazardous")))
         if after_icons:
             item['after']['getId'] = after_icons
 
@@ -890,10 +870,9 @@ class AnalysisRequestsView(BikaListingView):
                 # Gettin the full object if not get before
                 full_object = full_object if full_object else obj.getObject()
                 if not full_object.isUserAllowedToVerify(self.member):
-                    item["after"]["state_title"] = \
-                        """<img src='++resource++bika.lims.images/submitted-by-current-user.png'
-                            title='%s'/>
-                        """ % t(_("Cannot verify: Submitted by current user"))
+                    item["after"]["state_title"] = get_image(
+                        "submitted-by-current-user.png",
+                        title=t(_("Cannot verify: Submitted by current user")))
         return item
 
     def pending_tasks(self):
@@ -932,12 +911,12 @@ class QueuedAnalysisRequestsCount():
         creating Analysis Requests asynchronously"""
         try:
             PostOnly(self.context.REQUEST)
-        except:
+        except Exception:
             logger.error(traceback.format_exc())
             return json.dumps({"count": 0})
         try:
             CheckAuthenticator(self.request.form)
-        except:
+        except Exception:
             logger.error(traceback.format_exc())
             return json.dumps({"count": 0})
         task_queue = queryUtility(ITaskQueue, name="ar-create")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/923

Also refactored the code to be PEP8 compliant

## Current behavior before PR

Analysis Requests Listing shows "Date Created"

## Desired behavior after PR is merged

Analysis Requests Listing shows "Date Registered"


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
