### PR TITLE
Fix translate utility function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,7 @@ Changelog
 
 **Fixed**
 
+- #1047 Fix translate utility function
 - #1041 Reject transition is available to Client once AR/Sample is received
 - #1043 Invalid AR Retested informative message is not prominent enough
 - #1039 Detection limit criteria from retracted analysis is preserved

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -61,7 +61,9 @@ def t(i18n_msg):
     """
     text = to_unicode(i18n_msg)
     try:
-        text = translate(text)
+        request = api.get_request()
+        domain = getattr(i18n_msg, "domain", "senaite.core")
+        text = translate(text, domain=domain, context=request)
     except UnicodeDecodeError:
         # TODO: This is only a quick fix
         logger.warn("{} couldn't be translated".format(text))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the `t` function to actually translate the passed in message id.

## Current behavior before PR

Passed in text was not translated

## Desired behavior after PR is merged

Passed in text is translated

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
