### PR TITLE
Allow to set the pagesize in listings and show total number of results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Changelog
 
 **Changed**
 
+- #1048 Allow to set the pagesize in listings and show total number of results
 - #1044 State of analyses in retests is set to `received` by default (was `to_be_verified`)
 - #1042 Function api.get_object() supports UID as input param
 - #1036 Manage Analyses: Check permission of the AR to decide if it is frozen

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -505,6 +505,7 @@ class BikaListingView(BrowserView):
         self.base_url = context.absolute_url()
         self.field_icons = {}
         self.items = []
+        self.total = 0
         self.limit_from = 0
         self.member = None
         self.mtool = None
@@ -917,6 +918,7 @@ class BikaListingView(BrowserView):
         results = []
         self.show_more = False
         brains = self._fetch_brains(self.limit_from)
+        self.total = len(brains)
         for obj in brains:
             # avoid creating unnecessary info for items outside the current
             # batch;  only the path is needed for the "select all" case...
@@ -1426,6 +1428,7 @@ class BikaListingView(BrowserView):
         results = []
         self.show_more = False
         brains = self._fetch_brains(self.limit_from)
+        self.total = len(brains)
         for obj in brains:
             # avoid creating unnecessary info for items outside the current
             # batch;  only the path is needed for the "select all" case...
@@ -1802,6 +1805,7 @@ class BikaListingTable(tableview.Table):
         self.request = bika_listing.request
         self.form_id = bika_listing.form_id
         self.items = folderitems
+        self.total = bika_listing.total
 
     def rendered_items(self, cat=None, **kwargs):
         """Render the table rows of items in a particular category.

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -8,6 +8,8 @@
 
   window.BikaListingTableView = (function() {
     function BikaListingTableView() {
+      this.on_pagesize_keypress = bind(this.on_pagesize_keypress, this);
+      this.on_pagesize_change = bind(this.on_pagesize_change, this);
       this.on_show_more_click = bind(this.on_show_more_click, this);
       this.on_column_header_click = bind(this.on_column_header_click, this);
       this.on_ajax_submit_end = bind(this.on_ajax_submit_end, this);
@@ -88,6 +90,8 @@
       $("form").on("click", "td.review_state_selector a", this.on_review_state_filter_click);
       $(document).on("click", this.on_click);
       $(document).on("click", ".contextmenu tr", this.on_contextmenu_item_click);
+      $("form").on("change", "input.pagesize_input", this.on_pagesize_change);
+      $("form").on("keypress", "input.pagesize_input", this.on_pagesize_keypress);
       $(this).on("ajax:submit:start", this.on_ajax_submit_start);
       return $(this).on("ajax:submit:end", this.on_ajax_submit_end);
     };
@@ -970,6 +974,40 @@
       pagesize = this.parse_int($el.attr("data-pagesize"));
       limit_from = this.parse_int($el.attr("data-limitfrom"));
       return this.show_more(form_id, pagesize, limit_from);
+    };
+
+    BikaListingTableView.prototype.on_pagesize_change = function(event) {
+
+      /*
+       * Eventhandler when the Pagesize changed
+       */
+      var $el, el, form_id, pagesize;
+      console.debug("°°° ListingTableView::on_pagesize_change °°°");
+      el = event.currentTarget;
+      $el = $(el);
+      pagesize = this.parse_int($el.val());
+      if (pagesize < 1) {
+        pagesize = 1;
+      }
+      if (pagesize > 100) {
+        pagesize = 250;
+      }
+      $el.val(pagesize);
+      form_id = $el.parents("form").attr("id");
+      return this.show_more(form_id, pagesize, 0);
+    };
+
+    BikaListingTableView.prototype.on_pagesize_keypress = function(event) {
+
+      /*
+       * Eventhandler when the Pagesize changed
+       */
+      console.debug("°°° ListingTableView::on_pagesize_keypress °°°");
+      if (event.which === 13) {
+        console.debug("ListingTableView::on_pagesize_keypress: capture Enter key");
+        event.preventDefault();
+        return this.on_pagesize_change(event);
+      }
     };
 
     return BikaListingTableView;

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -989,7 +989,7 @@
       if (pagesize < 1) {
         pagesize = 1;
       }
-      if (pagesize > 100) {
+      if (pagesize > 250) {
         pagesize = 250;
       }
       $el.val(pagesize);

--- a/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
@@ -1104,7 +1104,7 @@ class window.BikaListingTableView
     pagesize = @parse_int $el.val()
 
     if pagesize < 1 then pagesize = 1
-    if pagesize > 100 then pagesize = 250
+    if pagesize > 250 then pagesize = 250
 
     $el.val pagesize
 

--- a/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
@@ -86,6 +86,10 @@ class window.BikaListingTableView
     # bind event handler for contextmenu clicks
     $(document).on "click", ".contextmenu tr", @on_contextmenu_item_click
 
+    # Pagesize changed
+    $("form").on "change", "input.pagesize_input", @on_pagesize_change
+    $("form").on "keypress", "input.pagesize_input", @on_pagesize_keypress
+
     # Ajax form submit events
     $(this).on "ajax:submit:start", @on_ajax_submit_start
     $(this).on "ajax:submit:end", @on_ajax_submit_end
@@ -1085,3 +1089,36 @@ class window.BikaListingTableView
     limit_from = @parse_int $el.attr "data-limitfrom"
 
     @show_more form_id, pagesize, limit_from
+
+  on_pagesize_change: (event) =>
+    ###
+     * Eventhandler when the Pagesize changed
+    ###
+    console.debug "°°° ListingTableView::on_pagesize_change °°°"
+
+    # current event target (Show More button)
+    el = event.currentTarget
+    $el = $(el)
+
+    # get the pagesize
+    pagesize = @parse_int $el.val()
+
+    if pagesize < 1 then pagesize = 1
+    if pagesize > 100 then pagesize = 250
+
+    $el.val pagesize
+
+    form_id = $el.parents("form").attr "id"
+    @show_more form_id, pagesize, 0
+
+  on_pagesize_keypress: (event) =>
+    ###
+     * Eventhandler when the Pagesize changed
+    ###
+    console.debug "°°° ListingTableView::on_pagesize_keypress °°°"
+
+    # Prevent form submit
+    if event.which == 13
+      console.debug "ListingTableView::on_pagesize_keypress: capture Enter key"
+      event.preventDefault()
+      @on_pagesize_change(event)

--- a/bika/lims/browser/templates/bika_listing_table.pt
+++ b/bika/lims/browser/templates/bika_listing_table.pt
@@ -307,14 +307,19 @@
                           tal:condition="view/bika_listing/show_workflow_action_buttons">
                     </span>
                   </td>
+                  <!-- Paging and Show More Button -->
                   <td class="batching" style="text-align:right">
 
-                    <span class='number-items' i18n:domain="senaite.core" i18n:translate="" tal:condition="python:len(view.items) != 1">
-                      <span i18n:name="nr_items" tal:replace="python:len(view.items)"/> Items
+                    <!-- number displayed -->
+                    <span class="number-items">
+                      <span tal:replace="python:len(view.items)"/>
                     </span>
-                    <span class='number-items' i18n:translate="" tal:condition="python:len(view.items) == 1">
-                      <span i18n:name="nr_items" tal:replace="python:len(view.items)"/> Item
+                    <span i18n:translate="">of</span>
+                    <!-- total -->
+                    <span class="number-total">
+                      <span tal:replace="python:view.bika_listing.total"/>
                     </span>
+                    <span i18n:translate="">Results</span>
 
                     <tal:showmore define="pagesize        python:view.bika_listing.pagesize;
                                           sort_on         python:view.bika_listing.get_sort_on();
@@ -325,6 +330,13 @@
                                           next_pagesize   python:pagesize+next_limit_from;
                                           form_id         python:view.bika_listing.form_id;"
                                   condition="python:view.bika_listing.show_more">
+
+                      <input tal:attributes="name string:${form_id}_pagesize;
+                                             value pagesize"
+                             class="pagesize_input"
+                             type="number"
+                             min="1"
+                             max="250"/>
 
                       <a tal:attributes="href           python:view.bika_listing.GET_url(pagesize=next_pagesize,limit_from=limit_from,sort_on=sort_on,sort_order=sort_order);
                                          data-ajax-url  python:'%s&rows_only=%s' % (view.bika_listing.GET_url(pagesize=pagesize),form_id);


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR displays the total number of results in listings and allows the user to manually set the pagesize up to a maximum of 250 results.

## Current behavior before PR

Only the current number of results was displayed

## Desired behavior after PR is merged

The current number and the total number of results is displayed.
A number input field allows to set the pagesize up to 250 items

<img width="300" alt="pagesize" src="https://user-images.githubusercontent.com/713193/46575185-cfa62780-c9b0-11e8-8dd4-38a6ab4069b6.png">


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
