### PR TITLE
Secondary AR changes received date of sample

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Changelog
 - #1027 Rename `retract_ar` transition to `invalidate`
 - #1012 Refactored Contacts listing
 - #1010 Increased max length of Results options to 255 chars (was 40)
+- #899 Sample's Date Received editable only when `received` analyses exist
 
 **Removed**
 
@@ -32,6 +33,7 @@ Changelog
 
 **Fixed**
 
+- #1049 Secondary Analysis Request changes received date of Sample
 - #1041 Reject transition is available to Client once AR/Sample is received
 - #1043 Invalid AR Retested informative message is not prominent enough
 - #1039 Detection limit criteria from retracted analysis is preserved
@@ -50,7 +52,6 @@ Changelog
 - #991 New client contacts do not have access to their own AR Templates
 - #996 Hide checkbox labels on category expansion
 - #990 Fix client analysisspecs view
-- #899 Secondary AR changes received date of sample
 - #888 Order of Interim Fields not maintained on ARs
 
 

--- a/bika/lims/browser/analysisrequest/workflow.py
+++ b/bika/lims/browser/analysisrequest/workflow.py
@@ -131,7 +131,6 @@ class AnalysisRequestWorkflowAction(AnalysesWorkflowAction):
         if nr_parts > nr_existing:
             for i in range(nr_parts - nr_existing):
                 part = _createObjectByType("SamplePartition", sample, tmpID())
-                part.setDateReceived = DateTime()
                 part.processForm()
         # remove excess parts
         if nr_existing > nr_parts:

--- a/bika/lims/content/samplepartition.py
+++ b/bika/lims/content/samplepartition.py
@@ -176,16 +176,10 @@ class SamplePartition(BaseContent, HistoryAwareMixin):
     @security.public
     def after_receive_transition_event(self):
         """Method triggered after a 'receive' transition for the current Sample
-        Partition is performed. Stores value for "Date Received" field and also
-        triggers the 'receive' transition for depedendent objects, such as
-        Analyses associated to this Sample Partition. If all Sample Partitions
-        that belongs to the same sample as the current Sample Partition have
-        been transitioned to the "received" state, promotes to Sample
+        Partition is performed.
         This function is called automatically by
         bika.lims.workflow.AfterTransitionEventHandler
         """
-        self.setDateReceived(DateTime())
-        self.reindexObject(idxs=["getDateReceived", ])
         self._cascade_promote_transition('receive', 'sample_received')
 
     def guard_to_be_preserved(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The DateSampled field of an a secondary AR is misleading; it is set to the date at which the automatically initiated 'receive' transition is fired against the secondary AR, and does not reflect the actual date that the sample was received. The problem was not with the AR transition, but with the transition to`received` of the newly created SamplePartition: SamplePartition object has no DateReceived field, so setting the value for DateReceived was modifying the value from its parent - the Sample - (because of acquisition)

Linked issue: https://github.com/senaite/senaite.core/issues/863

## Current behavior before PR

When creating a secondary AR, `DateReceived` from Sample is changed to the current date.

## Desired behavior after PR is merged

When creating a secondary AR, `DateReceived` from Sample is not changed.



--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
