### PR TITLE
Analyses Requests w/o submitted results always appear as not late

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1051 Show the Due date in late's image tooltip in Analysis Requests listings
 - #1048 Allow to set the pagesize in listings and show total number of results
 - #1031 Added profiling and timing decorators
 - #1001 Option to show Interim fields on results reports

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,7 @@ Changelog
 
 **Fixed**
 
+- #1051 Analyses Requests w/o submitted results always appear as not late
 - #1041 Reject transition is available to Client once AR/Sample is received
 - #1043 Invalid AR Retested informative message is not prominent enough
 - #1039 Detection limit criteria from retracted analysis is preserved

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -754,8 +754,9 @@ class AnalysisRequestsView(BikaListingView):
 
         due_date = obj.getDueDate
         if due_date and due_date < (obj.getDatePublished or DateTime()):
-            after_icons += get_image("late.png",
-                                     title=t(_("Late Analyses")))
+            due_date_str = self.ulocalized_time(due_date)
+            img_title = "{}: {}".format(t(_("Late Analyses")), due_date_str)
+            after_icons += get_image("late.png", title=img_title)
 
         if obj.getSamplingDate and obj.getSamplingDate > DateTime():
             after_icons += get_image("calendar.png",

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -759,7 +759,8 @@ class AnalysisRequestsView(BikaListingView):
                 """<img src='%s/++resource++bika.lims.images/delete.png'
                     title='%s'/>
                 """ % (self.portal_url, t(_("Results have been withdrawn")))
-        if obj.getLate:
+        due_date = obj.getDueDate
+        if due_date and due_date < (obj.getDatePublished or DateTime()):
             after_icons += \
                 """<img src='%s/++resource++bika.lims.images/late.png'
                     title='%s'>

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -756,7 +756,6 @@ class AnalysisRequestsView(BikaListingView):
         if due_date and due_date < (obj.getDatePublished or DateTime()):
             after_icons += get_image("late.png",
                                      title=t(_("Late Analyses")))
-                    title=t(_("Late Analyses")))
 
         if obj.getSamplingDate and obj.getSamplingDate > DateTime():
             after_icons += get_image("calendar.png",

--- a/bika/lims/catalog/analysisrequest_catalog.py
+++ b/bika/lims/catalog/analysisrequest_catalog.py
@@ -28,6 +28,7 @@ _indexes_dict = {
     'getDateReceived': 'DateIndex',
     'getDateVerified': 'DateIndex',
     'getDatePublished': 'DateIndex',
+    'getDueDate': 'DateIndex',
     'getSampler': 'FieldIndex',
     'getReceivedBy': 'FieldIndex',
     'getDepartmentUIDs': 'KeywordIndex',
@@ -97,8 +98,7 @@ _columns_list = [
     'getPrinted',
     'getSamplingDeviationTitle',
     'getPrioritySortkey',
-    # TODO: This should be updated through a clock
-    'getLate',
+    'getDueDate',
     'getInvoiceExclude',
     'getHazardous',
     'getSamplingWorkflowEnabled',

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -1982,6 +1982,12 @@ class AnalysisRequest(BaseFolder):
                 manager_list.append(manager)
         return manager_list
 
+    def getDueDate(self):
+        """Returns the earliest due date of the analyses this Analysis Request
+        contains."""
+        min_date = map(lambda an: an.getDueDate, self.getAnalyses())
+        return min_date and min(min_date) or None
+
     security.declareProtected(View, 'getLate')
 
     def getLate(self):

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -1985,8 +1985,8 @@ class AnalysisRequest(BaseFolder):
     def getDueDate(self):
         """Returns the earliest due date of the analyses this Analysis Request
         contains."""
-        min_date = map(lambda an: an.getDueDate, self.getAnalyses())
-        return min_date and min(min_date) or None
+        due_dates = map(lambda an: an.getDueDate, self.getAnalyses())
+        return due_dates and min(due_dates) or None
 
     security.declareProtected(View, 'getLate')
 

--- a/bika/lims/upgrade/v01_02_009.py
+++ b/bika/lims/upgrade/v01_02_009.py
@@ -63,6 +63,9 @@ def upgrade(tool):
     # Update workflow states and permissions for AR/Sample rejection
     update_rejection_permissions(portal)
 
+    # Remove getLate and add getDueDate metadata in ar_catalog
+    update_analaysisrequests_due_date(portal)
+
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
 
@@ -309,3 +312,30 @@ def update_rolemappings_for(brains, workflow_id):
             logger.info("Updating role mappings: {0}/{1}"
                         .format(num, total))
     logger.info("{} objects updated".format(num))
+
+
+def update_analaysisrequests_due_date(portal):
+    """Removes the metadata getLate from ar-catalog and adds the column
+    getDueDate"""
+    logger.info("Updating getLate -> getDueDate metadata columns ...")
+    catalog = api.get_tool(CATALOG_ANALYSIS_REQUEST_LISTING)
+    if "getLate" in catalog.schema():
+        catalog.delColumn("getLate")
+
+    if "getDueDate" in catalog.schema():
+        logger.info("getDueDate already in catalog [SKIP]")
+        return
+
+    logger.info("Adding Column 'getDueDate' to catalog '{}' ..."
+                .format(catalog.id))
+    catalog.addColumn("getDueDate")
+    catalog.addIndex("getDueDate", "DateIndex")
+    catalog.manage_reindexIndex("getDueDate")
+
+    # No need to go through all Analysis Requests. getLate metadata column was
+    query = dict(portal_type="AnalysisRequest")
+    for analysis_request in api.search(query, CATALOG_ANALYSIS_REQUEST_LISTING):
+        analysis_request = api.get_object(analysis_request)
+        analysis_request.reindexObject(idxs=['getDueDate'])
+
+    logger.info("Updating getLate -> getDueDate metadata columns [DONE]")

--- a/bika/lims/upgrade/v01_02_009.py
+++ b/bika/lims/upgrade/v01_02_009.py
@@ -332,7 +332,6 @@ def update_analaysisrequests_due_date(portal):
     catalog.addIndex("getDueDate", "DateIndex")
     catalog.manage_reindexIndex("getDueDate")
 
-    # No need to go through all Analysis Requests. getLate metadata column was
     query = dict(portal_type="AnalysisRequest")
     for analysis_request in api.search(query, CATALOG_ANALYSIS_REQUEST_LISTING):
         analysis_request = api.get_object(analysis_request)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Since `getLate` is returning a bool value and the ar lists are using brains to display the "late" icon, Analyses Requests without submitted analyses always appear as they were in time.

## Current behavior before PR

Late icon in analysis requests listings is not trustworthy

## Desired behavior after PR is merged

Late icon in analysis requests listings is displayed correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
