### PR TITLE
Remove collective.taskqueue dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Changelog
 
 **Removed**
 
+- #1056 Remove collective.taskqueue dependency
 - #808 Remove old AR Add code
 
 

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -24,7 +24,6 @@ from bika.lims.permissions import Verify as VerifyPermission
 from bika.lims.utils import get_image
 from bika.lims.utils import getUsers
 from bika.lims.utils import t
-from collective.taskqueue.interfaces import ITaskQueue
 from DateTime import DateTime
 from plone.api import user
 from plone.protect import CheckAuthenticator
@@ -905,12 +904,6 @@ class AnalysisRequestsView(BikaListingView):
                         "submitted-by-current-user.png",
                         title=t(_("Cannot verify: Submitted by current user")))
         return item
-
-    def pending_tasks(self):
-        task_queue = queryUtility(ITaskQueue, name='ar-create')
-        if task_queue is None:
-            return 0
-        return len(task_queue)
 
     @property
     def copy_to_new_allowed(self):

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ setup(
         'z3c.jbot',
         'plone.resource',
         'CairoSVG==1.0.20',
-        'collective.taskqueue',
         'zopyx.txng3.ext==3.4.0'
     ],
     extras_require={


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Remove `collective.taskqueue` dependency. Add-on no longer used.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
