### PR TITLE
Permission for ar_add changed to "AddAnalysisRequest"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,13 +9,14 @@ Changelog
 
 **Changed**
 
+- #1063 Permission for ar_add changed to "AddAnalysisRequest"
 
 **Removed**
 
-- #1059 Removed updates alert viewlet
-- #1060 Removed classic portlets
-- #1058 Removed gpw dependency
-- #1058 Remved broken Quality Control reports
+- #1059 Remove updates alert viewlet
+- #1060 Remove classic portlets
+- #1058 Remove gpw dependency
+- #1058 Remove broken Quality Control reports
 - #1057 Remove z3c.unconfigure dependency
 - #1056 Remove collective.taskqueue dependency
 - #808 Remove old AR Add code

--- a/bika/lims/browser/analysisrequest/configure.zcml
+++ b/bika/lims/browser/analysisrequest/configure.zcml
@@ -16,15 +16,16 @@
       for="bika.lims.interfaces.IClient"
       name="ar_add"
       class="bika.lims.browser.analysisrequest.AnalysisRequestAddView"
-      permission="bika.lims.ManageAnalysisRequests"
+      permission="bika.lims.permissions.AddAnalysisRequest"
       layer="bika.lims.interfaces.IBikaLIMS"
   />
 
+  <!-- TODO Do we need ar_add when the context is an AR? -->
   <browser:page
       for="bika.lims.interfaces.IAnalysisRequest"
       name="ar_add"
       class="bika.lims.browser.analysisrequest.AnalysisRequestAddView"
-      permission="bika.lims.ManageAnalysisRequests"
+      permission="bika.lims.permissions.AddAnalysisRequest"
       layer="bika.lims.interfaces.IBikaLIMS"
   />
 
@@ -32,7 +33,7 @@
       for="bika.lims.interfaces.IAnalysisRequestsFolder"
       name="ar_add"
       class="bika.lims.browser.analysisrequest.AnalysisRequestAddView"
-      permission="bika.lims.ManageAnalysisRequests"
+      permission="bika.lims.permissions.AddAnalysisRequest"
       layer="bika.lims.interfaces.IBikaLIMS"
   />
 
@@ -40,7 +41,7 @@
       for="bika.lims.interfaces.IBatch"
       name="ar_add"
       class="bika.lims.browser.analysisrequest.AnalysisRequestAddView"
-      permission="bika.lims.ManageAnalysisRequests"
+      permission="bika.lims.permissions.AddAnalysisRequest"
       layer="bika.lims.interfaces.IBikaLIMS"
   />
 
@@ -48,7 +49,7 @@
       for="bika.lims.interfaces.ISample"
       name="ar_add"
       class="bika.lims.browser.analysisrequest.AnalysisRequestAddView"
-      permission="bika.lims.ManageAnalysisRequests"
+      permission="bika.lims.permissions.AddAnalysisRequest"
       layer="bika.lims.interfaces.IBikaLIMS"
   />
 

--- a/bika/lims/browser/analysisrequest/configure.zcml
+++ b/bika/lims/browser/analysisrequest/configure.zcml
@@ -20,15 +20,6 @@
       layer="bika.lims.interfaces.IBikaLIMS"
   />
 
-  <!-- TODO Do we need ar_add when the context is an AR? -->
-  <browser:page
-      for="bika.lims.interfaces.IAnalysisRequest"
-      name="ar_add"
-      class="bika.lims.browser.analysisrequest.AnalysisRequestAddView"
-      permission="bika.lims.permissions.AddAnalysisRequest"
-      layer="bika.lims.interfaces.IBikaLIMS"
-  />
-
   <browser:page
       for="bika.lims.interfaces.IAnalysisRequestsFolder"
       name="ar_add"

--- a/bika/lims/browser/analysisrequest/templates/analysisrequests.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequests.pt
@@ -19,7 +19,7 @@
              tal:attributes="src view/icon"
              style="height:32px;width:auto;"/>
         <span tal:content="python:view.context.translate(view.title)"/>
-          <span tal:condition="python:checkPermission('Add portal content', context)"
+          <span tal:condition="python:checkPermission('BIKA: Add Analysis Request', context)"
                 style="padding-left:0.5em;display:inline-block;">
           <form method="GET" class="form-inline" action="ar_add">
             <input type="number"

--- a/bika/lims/browser/batch/analysisrequests.py
+++ b/bika/lims/browser/batch/analysisrequests.py
@@ -5,18 +5,14 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims import api
-from bika.lims import bikaMessageFactory as _
-from bika.lims.browser.analysisrequest import AnalysisRequestAddView as _ARAV
-from bika.lims.browser.analysisrequest import AnalysisRequestsView as _ARV
-from bika.lims.permissions import *
+from bika.lims.browser.analysisrequest import AnalysisRequestsView as BaseView
 from plone.app.layout.globals.interfaces import IViewView
 from zope.interface import implements
 
 
-class AnalysisRequestsView(_ARV, _ARAV):
+class AnalysisRequestsView(BaseView):
     template = ViewPageTemplateFile(
         "../analysisrequest/templates/analysisrequests.pt")
     implements(IViewView)
@@ -28,16 +24,6 @@ class AnalysisRequestsView(_ARV, _ARAV):
                               'sort_on': 'created',
                               'sort_order': 'reverse',
                               'cancellation_state':'active'}
-
-    def __call__(self):
-        self.context_actions = {}
-        mtool = getToolByName(self.context, 'portal_membership')
-        if mtool.checkPermission(AddAnalysisRequest, self.portal):
-            self.context_actions[self.context.translate(_('Add new'))] = {
-                'url': self.context.absolute_url() + "/ar_add?ar_count=1",
-                'icon': '++resource++bika.lims.images/add.png'}
-
-        return super(AnalysisRequestsView, self).__call__()
 
     def getMemberDiscountApplies(self):
         client = self.context.getClient()

--- a/bika/lims/browser/batch/analysisrequests.py
+++ b/bika/lims/browser/batch/analysisrequests.py
@@ -8,14 +8,11 @@
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims import api
 from bika.lims.browser.analysisrequest import AnalysisRequestsView as BaseView
-from plone.app.layout.globals.interfaces import IViewView
-from zope.interface import implements
 
 
 class AnalysisRequestsView(BaseView):
     template = ViewPageTemplateFile(
         "../analysisrequest/templates/analysisrequests.pt")
-    implements(IViewView)
 
     def __init__(self, context, request):
         super(AnalysisRequestsView, self).__init__(context, request)

--- a/bika/lims/browser/batch/analysisrequests.py
+++ b/bika/lims/browser/batch/analysisrequests.py
@@ -5,14 +5,11 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims import api
 from bika.lims.browser.analysisrequest import AnalysisRequestsView as BaseView
 
 
 class AnalysisRequestsView(BaseView):
-    template = ViewPageTemplateFile(
-        "../analysisrequest/templates/analysisrequests.pt")
 
     def __init__(self, context, request):
         super(AnalysisRequestsView, self).__init__(context, request)
@@ -21,15 +18,3 @@ class AnalysisRequestsView(BaseView):
                               'sort_on': 'created',
                               'sort_order': 'reverse',
                               'cancellation_state':'active'}
-
-    def getMemberDiscountApplies(self):
-        client = self.context.getClient()
-        return client and client.getMemberDiscountApplies() or False
-
-    def getRestrictedCategories(self):
-        client = self.context.getClient()
-        return client and client.getRestrictedCategories() or []
-
-    def getDefaultCategories(self):
-        client = self.context.getClient()
-        return client and client.getDefaultCategories() or []


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Although in `senaite.core`, client contacts are not able to create Batches and/or add Analysis Requests into them, other add-ons (such as `senaite.health`) allow client contacts to add Analysis Requests inside their own Batches, as well as in other contexts (e.g. Patient).

The AR Add button rendering is done in the template itself (so there is no need to add the action in the listing view as in the past), but it checks for the permission `Add portal content`. On the other hand, permission `ManageAnalysisRequests` is required for `ar_add` browser views.

With this Pull Request, the permission for adding new Analysis Requests and rendering of the "AR Add" button in listings is changed to "AddAnalysisRequest", that matches better and allows us more functional granularity when users other than labman/labclerk are logged in.

Also, cleaned up Batches/AnalysisRequests view a bit.

## Current behavior before PR

Analysis Request Add button in listings relies on "Add portal content" and `ar_add` browser views rely on "ManageAnalysisRequests" permission.

## Desired behavior after PR is merged

Both Analysis Request Add button in listings and `ar_add` browser views rely on "AddAnalysisRequest" permission.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
