### PR TITLE
Python 2.x is not supported by WeasyPrint v43. Pinned version: 0.42.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Changelog
 
 **Changed**
 
+- #1064 Python 2.x is not supported by WeasyPrint v43. Pinned version: 0.42.3
 
 **Removed**
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
         'plone.app.iterate',
         'magnitude',
         'jarn.jsi18n',
-        'WeasyPrint',
         'collective.progressbar',
         'plone.app.dexterity',
         'plone.app.relationfield',
@@ -60,6 +59,8 @@ setup(
         'plone.resource',
         'CairoSVG==1.0.20',
         'zopyx.txng3.ext==3.4.0'
+        # Python 2.x is not supported by WeasyPrint v43
+        'WeasyPrint==0.42.3',
     ],
     extras_require={
         'test': [

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'z3c.jbot',
         'plone.resource',
         'CairoSVG==1.0.20',
-        'zopyx.txng3.ext==3.4.0'
+        'zopyx.txng3.ext==3.4.0',
         # Python 2.x is not supported by WeasyPrint v43
         'WeasyPrint==0.42.3',
     ],


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Python <3.4 is not supported by WeasyPrint v43:
https://github.com/Kozea/WeasyPrint/releases

## Current behavior before PR

```
  File "/tmp/easy_install-Po1dD7/WeasyPrint-43rc1/setup.py", line 20, in <module>
    "Development Status :: 5 - Production/Stable",
RuntimeError: WeasyPrint does not support Python 2.x anymore. Please use Python 3 or install an older version of WeasyPrint.
```

## Desired behavior after PR is merged

No traceback. SENAITE gets installed w/o problems.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
