### PR TITLE
Creation of reflex rules does not work with senaite.lims add-on

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Changelog
 
 **Fixed**
 
+- #1065 Creation of reflex rules does not work with senaite.lims is installed
+
 
 **Security**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,7 @@ Changelog
 
 **Fixed**
 
-- #1065 Creation of reflex rules does not work with senaite.lims is installed
+- #1065 Creation of reflex rules does not work with senaite.lims add-on
 
 
 **Security**

--- a/bika/lims/skins/bika/bika_widgets/reflexrulewidget.js
+++ b/bika/lims/skins/bika/bika_widgets/reflexrulewidget.js
@@ -685,7 +685,7 @@ jQuery(function($){
             action_define_div_controller(action_div);
             // Creates a new local id if a new analysis is created
             var set_new = $(action_div)
-                .find("select[id^='ReflexRules-setresulton-']'")
+                .find("select[id^='ReflexRules-setresulton-']")
                 .find(":selected").attr('value');
             if (set_new == 'new') {
                 if (!first_setup){
@@ -791,7 +791,7 @@ jQuery(function($){
             .find('select[id^="ReflexRules-action-"]')
             .find(":selected").attr('value');
         var set_new = $(action_div)
-            .find("select[id^='ReflexRules-setresulton-']'")
+            .find("select[id^='ReflexRules-setresulton-']")
             .find(":selected").attr('value');
         if (set_new == 'new') {
             local_id = new_localid(selection);


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fixed a misstype in js, that although working with jQuery-2.1.7 (the version that comes with `senaite.core` by default), was not working with jQuery-2.2.4 (version that comes with `senaite.lims`)

## Current behavior before PR

Cannot create derivative rules in Reflex Rule edit view

## Desired behavior after PR is merged

Can create derivative rules in Reflex Rule edit view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
