### PR TITLE
BadRequest: Cannot get the allowed transitions (guard_sample_prep_transition)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Changelog
 
 **Fixed**
 
+- #1069 Cannot get the allowed transitions (guard_sample_prep_transition)
 - #1065 Creation of reflex rules does not work with senaite.lims add-on
 
 

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -10,8 +10,6 @@ from bika.lims import logger
 from bika.lims.config import PROJECTNAME as product
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
-from plone.portlets.interfaces import IPortletType
-from zope import component
 
 version = '1.3.0'  # Remember version number in metadata.xml and setup.py
 profile = 'profile-{0}:default'.format(product)
@@ -61,6 +59,10 @@ def upgrade(tool):
     # https://github.com/senaite/senaite.core/pull/1060
     purge_portlets(portal)
 
+    # Fix Cannot get the allowed transitions (guard_sample_prep_transition)
+    # https://github.com/senaite/senaite.core/pull/1069
+    remove_sample_prep_workflow(portal)
+
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
 
@@ -99,3 +101,27 @@ def purge_portlets(portal):
     setup = portal.portal_setup
     setup.runImportStepFromProfile(profile, 'portlets')
     logger.info("Purging portlets [DONE]")
+
+
+def remove_sample_prep_workflow(portal):
+    """Removes sample_prep and sample_prep_complete transitions
+    """
+    # There is no need to walk through objects because of:
+    # https://github.com/senaite/senaite.core/blob/master/bika/lims/upgrade/v01_02_008.py#L187
+    logger.info("Removing 'sample_prep' related states and transitions ...")
+    workflow_ids = ["bika_sample_workflow",
+                    "bika_ar_workflow",
+                    "bika_analysis_workflow"]
+    to_remove = ["sample_prep", "sample_prep_complete"]
+    wf_tool = api.get_tool("portal_workflow")
+    for wf_id in workflow_ids:
+        workflow = wf_tool.getWorkflowById(wf_id)
+        for state_trans in to_remove:
+            if state_trans in workflow.transitions:
+                logger.info("Removing transition '{}' from '{}'"
+                            .format(state_trans, wf_id))
+                workflow.transitions.deleteTransitions([state_trans])
+            if state_trans in workflow.states:
+                logger.info("Removing state '{}' from '{}'"
+                            .format(state_trans, wf_id))
+                workflow.states.deleteStates([state_trans])


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Although basic handling of sample preparation was removed in 1.2.8 (https://github.com/senaite/senaite.core/pull/900), the states and transitions involved weren't. The guard `guard_sample_prep_transition` was removed later, without noticing that the transition `sample_prep` (and related states) were still there. As a result, when rendering some lists, a traceback is rised because the system is not able to find the proper guard.

This PR should be back-ported to 1.2.9

## Current behavior before PR

Unable to select items from listings (analysis requests, samples, analyses):

```
Traceback (most recent call last):
  File "/senaite/buildout-cache/eggs/plone.jsonapi.core-0.6-py2.7.egg/plone/jsonapi/core/browser/decorators.py", line 24, in decorator
    return f(*args, **kwargs)
  File "/senaite/buildout-cache/eggs/plone.jsonapi.core-0.6-py2.7.egg/plone/jsonapi/core/browser/api.py", line 60, in to_json
    return self.dispatch()
  File "/senaite/buildout-cache/eggs/plone.jsonapi.core-0.6-py2.7.egg/plone/jsonapi/core/browser/api.py", line 54, in dispatch
    return router(self.context, self.request, path)
  File "/senaite/buildout-cache/eggs/plone.jsonapi.core-0.6-py2.7.egg/plone/jsonapi/core/browser/router.py", line 138, in __call__
    return self.view_functions[endpoint](context, request, **values)
  File "/senaite/zinstance/src/senaite.core/bika/lims/jsonapi/allowedtransitionsfor.py", line 59, in allowed_transitions_for_many
    raise BadRequest(msg)
BadRequest: Cannot get the allowed transitions (guard_sample_prep_transition)
```

## Desired behavior after PR is merged

No Traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
