### PR TITLE
Calculations with dependents do not work after 1.2.9 update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Changelog
 
 **Fixed**
 
+- #1071 Calculations with dependents do not work after 1.2.9 update
 - #1069 Cannot get the allowed transitions (guard_sample_prep_transition)
 - #1065 Creation of reflex rules does not work with senaite.lims add-on
 

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -71,6 +71,11 @@ def upgrade(tool):
     # https://github.com/senaite/senaite.core/pull/1069
     remove_sample_prep_workflow(portal)
 
+    # Rebind calculations of active analyses. The analysis Calculation (an
+    # HistoryAwareField) cannot resolve DependentServices
+    # https://github.com/senaite/senaite.core/pull/1072
+    rebind_calculations(portal)
+
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
 
@@ -238,3 +243,41 @@ def remove_sample_prep_workflow(portal):
                 logger.info("Removing state '{}' from '{}'"
                             .format(state_trans, wf_id))
                 workflow.states.deleteStates([state_trans])
+
+
+def rebind_calculations(portal):
+    """Rebind calculations of active analyses. The analysis Calculation (an
+    HistoryAwareField) cannot resolve DependentServices"""
+    logger.info("Rebinding calculations to analyses ...")
+    review_states = ["sample_due",
+                     "attachment_due",
+                     "sample_received",
+                     "to_be_verified"]
+    calcs = api.search(dict(portal_type="Calculation"), "bika_setup_catalog")
+    calcs = {api.get_uid(calc): api.get_object(calc) for calc in calcs}
+    query = dict(review_state=review_states)
+    analyses = api.search(query, CATALOG_ANALYSIS_LISTING)
+    total = len(analyses)
+    for num, analysis in enumerate(analyses):
+        if num % 100 == 0:
+            logger.info("Rebinding calculations to analyses: {0}/{1}"
+                        .format(num, total))
+        analysis = api.get_object(analysis)
+        calc = analysis.getCalculation()
+        if not calc:
+            continue
+
+        calc_uid = api.get_uid(calc)
+        if calc_uid not in calcs:
+            logger.warn("Calculation with UID {} not found!".format(calc_uid))
+            continue
+
+        calc = calcs[calc_uid]
+        an_interims = analysis.getInterimFields()
+        an_interims_keys = map(lambda interim: interim.get('keyword'),
+                               an_interims)
+        calc_interims = filter(lambda interim: interim.get('keyword')
+                                            not in an_interims_keys,
+                            calc.getInterimFields())
+        analysis.setCalculation(calc)
+        analysis.setInterimFields(an_interims + calc_interims)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Presumably, after 1.2.9, analyses that are binded to a Calculation with dependent services (its result depends on the result of other analyses) are not working. 

## Current behavior before PR

Results for analyses with dependents don't get calculated automatically.

## Desired behavior after PR is merged

Results for analyses with dependents do get calculated automatically.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
