### PR TITLE
 Make Parent ARs to follow their partitions in workflow

### DIFF
--- a/bika/lims/browser/fields/aranalysesfield.py
+++ b/bika/lims/browser/fields/aranalysesfield.py
@@ -59,43 +59,22 @@ class ARAnalysesField(ObjectField):
         """Returns a list of Analyses assigned to this AR
 
         Return a list of catalog brains unless `full_objects=True` is passed.
-        Overrides "ViewRetractedAnalyses" when `retracted=True` is passed.
         Other keyword arguments are passed to bika_analysis_catalog
 
         :param instance: Analysis Request object
-        :param kwargs: Keyword arguments to be passed to control the output
+        :param kwargs: Keyword arguments to inject in the search query
         :returns: A list of Analysis Objects/Catalog Brains
         """
-        full_objects = kwargs and kwargs.get("full_objects", False)
-        reflexed = kwargs and kwargs.get("get_reflexed", True)
-        retracted = kwargs and kwargs.get("retracted", True)
-        if retracted:
-            mtool = getToolByName(instance, 'portal_membership')
-            retracted = mtool.checkPermission(ViewRetractedAnalyses, instance)
-
         catalog = getToolByName(instance, CATALOG_ANALYSIS_LISTING)
         query = dict(
             [(k, v) for k, v in kwargs.items() if k in catalog.indexes()])
         query['portal_type'] = "Analysis"
         query['getRequestUID'] = api.get_uid(instance)
         analyses = catalog(query)
-        if not full_objects and reflexed and retracted:
+        if not kwargs.get("full_objects", False):
             return analyses
 
-        out_analyses = list()
-        for analysis in analyses:
-            analysis_obj = None
-            if not retracted and analysis.review_state == 'retracted':
-                continue
-            if not reflexed:
-                analysis_obj = api.get_object(analysis)
-                if analysis_obj.getReflexRuleActionsTriggered():
-                    continue
-            if full_objects:
-                analysis = analysis_obj and analysis_obj or api.get_object(
-                    analysis)
-            out_analyses.append(analysis)
-        return out_analyses
+        return map(api.get_object, analyses)
 
     security.declarePrivate('set')
 

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -1993,8 +1993,11 @@ class AnalysisRequest(BaseFolder):
     def getLate(self):
         """Return True if there is at least one late analysis in this Request
         """
-        for analysis in self.getAnalyses(full_objects=True, retracted=False):
-            if analysis.isLateAnalysis():
+        for analysis in self.getAnalyses():
+            if analysis.review_state == "retracted":
+                continue
+            analysis_obj = api.get_object(analysis)
+            if analysis_obj.isLateAnalysis():
                 return True
         return False
 

--- a/bika/lims/skins/bika/guard_attach_transition.py
+++ b/bika/lims/skins/bika/guard_attach_transition.py
@@ -58,7 +58,7 @@ if context.portal_type in ("Analysis",
 if context.portal_type == "AnalysisRequest":
     # Allow transition to 'to_be_verified'
     # if all analyses are at least to_be_verified
-    for a in context.objectValues('Analysis'):
+    for a in context.getAnalyses(full_objects=True):
         review_state = workflow.getInfoFor(a, 'review_state')
         if review_state in ('to_be_sampled', 'to_be_preserved', 'sample_due',
                             'sample_received', 'attachment_due'):

--- a/bika/lims/skins/bika/guard_submit_transition.py
+++ b/bika/lims/skins/bika/guard_submit_transition.py
@@ -57,7 +57,7 @@ if context.portal_type == "Analysis":
 if context.portal_type == "AnalysisRequest":
     # Only transition to 'attachment_due' if all analyses are at least there.
     has_analyses = False
-    for a in context.objectValues('Analysis'):
+    for a in context.getAnalyses(full_objects=True):
         has_analyses = True
         review_state = workflow.getInfoFor(a, 'review_state')
         if review_state in ('to_be_sampled', 'to_be_preserved',

--- a/bika/lims/workflow/analysisrequest/events.py
+++ b/bika/lims/workflow/analysisrequest/events.py
@@ -169,6 +169,20 @@ def after_attach(obj):
     pass
 
 
+def after_submit(obj):
+    """Function called after a 'submit' transition is triggered
+    """
+    # Promote to parent AR
+    parent_ar = obj.getParentAnalysisRequest()
+    if parent_ar:
+        doActionFor(parent_ar, "submit")
+
+    # Cascade to partitions
+    parts = obj.getDescendants(all_descendants=False)
+    for part in parts:
+        doActionFor(part, "submit")
+
+
 def after_verify(obj):
     """Method triggered after a 'verify' transition for the Analysis Request
     passed in is performed. Responsible of triggering cascade actions to
@@ -178,7 +192,15 @@ def after_verify(obj):
     :param obj: Analysis Request affected by the transition
     :type obj: AnalysisRequest
     """
-    pass
+    # Promote to parent AR
+    parent_ar = obj.getParentAnalysisRequest()
+    if parent_ar:
+        doActionFor(parent_ar, "verify")
+
+    # Cascade to partitions
+    parts = obj.getDescendants(all_descendants=False)
+    for part in parts:
+        doActionFor(part, "verify")
 
 
 def after_publish(obj):
@@ -194,6 +216,11 @@ def after_publish(obj):
     for analysis in ans:
         doActionFor(analysis, 'publish')
 
+    # Cascade to partitions
+    parts = obj.getDescendants(all_descendants=False)
+    for part in parts:
+        doActionFor(part, "publish")
+
 
 def after_reinstate(obj):
     """Method triggered after a 'reinstate' transition for the Analysis Request
@@ -207,6 +234,11 @@ def after_reinstate(obj):
     for analysis in ans:
         doActionFor(analysis, 'reinstate')
 
+    # Promote to parent AR
+    parent_ar = obj.getParentAnalysisRequest()
+    if parent_ar:
+        doActionFor(parent_ar, "reinstate")
+
 
 def after_cancel(obj):
     """Method triggered after a 'cancel' transition for the Analysis Request
@@ -219,3 +251,8 @@ def after_cancel(obj):
     ans = obj.getAnalyses(full_objects=True, cancellation_state='active')
     for analysis in ans:
         doActionFor(analysis, 'cancel')
+
+    # Cascade to partitions
+    parts = obj.getDescendants(all_descendants=False)
+    for part in parts:
+        doActionFor(part, "cancel")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request must be considered as part of [Enhanced Partitioning System #1068](https://github.com/senaite/senaite.core/pull/1068)

When all the partitions from an AR has been submitted (their status is `to_be_verified`), the parent AR must transition automatically too. The same principle applies for the rest of transitions ("verify", "publish", "cancel" and "reinstate").

With the same reasoning, when the Parent AR is transitioned to "published", "cancelled", etc., the partitions must follow.

Apart from the above, this Pull Request also comes with_
- A refactoring of `ARAnalysisField.get`. Basically, the support for `get_reflexed` and `retracted` kwargs have been removed. These args were not used almost anywhere, but was increasing the complexity of the function unnecessarily.
- When an `AfterTransitionHandler` is called, the system now inspects for a `workflow.<portal_type>.events.after_<transition_id>` as the first choice. If the function is not found or not callable, the old behavior (inspection of `<instance>.workflow_script_<transition_id>` and `<instance>.<transition_id>_transition_event` is used as a fallback. Note: `<instance>.<transition_id>_transition_event` will be removed in favor of the first choice in further PRs.

## Current behavior before PR

Parent Analysis Request does not follow the transitions/states of the partitions

## Desired behavior after PR is merged

Parent Analysis Request follow the transitions/states of the partitions

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
