### PR TITLE
Improve searchability of Client and Multifile fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,7 @@ Changelog
 
 **Fixed**
 
+- #1080 Improve searchability of Client and Multifile fields
 - #1072 Calculations with dependents do not work after 1.2.9 update
 - #1069 Cannot get the allowed transitions (guard_sample_prep_transition)
 - #1065 Creation of reflex rules does not work with senaite.lims add-on

--- a/bika/lims/content/client.py
+++ b/bika/lims/content/client.py
@@ -29,7 +29,6 @@ from Products.Archetypes.public import StringWidget
 from Products.Archetypes.public import registerType
 from Products.Archetypes.utils import DisplayList
 from Products.ATContentTypes.content import schemata
-from Products.CMFPlone.utils import safe_unicode
 from zope.interface import implements
 
 
@@ -167,8 +166,7 @@ class Client(Organisation):
     def Title(self):
         """Return the Organisation's Name as its title
         """
-        name = self.schema["Name"].get(self)
-        return safe_unicode(name).encode("utf-8")
+        return self.getName()
 
     security.declarePublic("getContactFromUsername")
 

--- a/bika/lims/content/multifile.py
+++ b/bika/lims/content/multifile.py
@@ -20,6 +20,7 @@ schema = BikaSchema.copy() + atapi.Schema((
     atapi.StringField(
         "DocumentID",
         required=1,
+        searchable=True,
         validators=("uniquefieldvalidator",),
         widget=atapi.StringWidget(
             label=_("Document ID"),
@@ -44,6 +45,7 @@ schema = BikaSchema.copy() + atapi.Schema((
 
     atapi.StringField(
         "DocumentLocation",
+        searchable=True,
         widget=atapi.StringWidget(
             label=_("Document Location"),
             description=_("Location where the document set is shelved"),
@@ -53,6 +55,7 @@ schema = BikaSchema.copy() + atapi.Schema((
     atapi.StringField(
         "DocumentType",
         required=1,
+        searchable=True,
         widget=atapi.StringWidget(
             label=_("Document Type"),
             description=_("Type of document (e.g. user manual, instrument "
@@ -76,6 +79,11 @@ class Multifile(BaseContent):
         # ResourceLockedError: Object "multifile..." is locked via WebDAV
         self.wl_clearLocks()
         renameAfterCreation(self)
+
+    def Title(self):
+        """Return the DocumentID as Title
+        """
+        return self.getDocumentID()
 
 
 atapi.registerType(Multifile, config.PROJECTNAME)

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -76,6 +76,12 @@ def upgrade(tool):
     # https://github.com/senaite/senaite.core/pull/1072
     rebind_calculations(portal)
 
+    # Reindex Multifiles, so that the fields are searchable by the catalog
+    reindex_multifiles(portal)
+
+    # Reindex Clients, so that the fields are searchable by the catalog
+    reindex_clients(portal)
+
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
 
@@ -297,3 +303,33 @@ def rebind_calculations(portal):
                             calc.getInterimFields())
         analysis.setCalculation(calc)
         analysis.setInterimFields(an_interims + calc_interims)
+
+
+def reindex_multifiles(portal):
+    """Reindex Multifiles to be searchable by the catalog
+    """
+    logger.info("Reindexing Multifiles ...")
+
+    brains = api.search(dict(portal_type="Multifile"), "bika_setup_catalog")
+    total = len(brains)
+
+    for num, brain in enumerate(brains):
+        if num % 100 == 0:
+            logger.info("Reindexing Multifile: {0}/{1}".format(num, total))
+        obj = api.get_object(brain)
+        obj.reindexObject()
+
+
+def reindex_clients(portal):
+    """Reindex Clients to be searchable by their ClientName
+    """
+    logger.info("Reindexing Clients ...")
+
+    brains = api.search(dict(portal_type="Client"), "portal_catalog")
+    total = len(brains)
+
+    for num, brain in enumerate(brains):
+        if num % 100 == 0:
+            logger.info("Reindexing Client: {0}/{1}".format(num, total))
+        obj = api.get_object(brain)
+        obj.reindexObject()

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -77,9 +77,11 @@ def upgrade(tool):
     rebind_calculations(portal)
 
     # Reindex Multifiles, so that the fields are searchable by the catalog
+    # https://github.com/senaite/senaite.core/pull/1080
     reindex_multifiles(portal)
 
     # Reindex Clients, so that the fields are searchable by the catalog
+    # https://github.com/senaite/senaite.core/pull/1080
     reindex_clients(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR improves the searchability of Client and Multifile fields, especially for the Spotlight search. 
Also see https://github.com/senaite/senaite.lims/pull/88

## Current behavior before PR

- Multifiles were not found by the Spotlight search
- Client names with unicode characters were not found by the Spotlight search

## Desired behavior after PR is merged

Spotlight search finds Multifiles and Clients

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
