### PR TITLE
API functions improved

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Changelog
 
 **Changed**
 
+- #1081 API functions improved
 - #1076 Instrument QC Viewlet Availability
 - #1071 Reinvented Listing Tables
 - #1066 Set default page size for listings to 50

--- a/bika/lims/api/__init__.py
+++ b/bika/lims/api/__init__.py
@@ -124,11 +124,17 @@ def get_portal():
     return ploneapi.portal.getSite()
 
 
-def get_bika_setup():
+def get_setup():
     """Fetch the `bika_setup` folder.
     """
     portal = get_portal()
     return portal.get("bika_setup")
+
+
+def get_bika_setup():
+    """Fetch the `bika_setup` folder.
+    """
+    return get_setup()
 
 
 def create(container, portal_type, *args, **kwargs):
@@ -512,7 +518,6 @@ def get_object_by_path(path, default=_marker):
         fail("get_object_by_path first argument must be a path; {} received"
              .format(path))
 
-    pc = get_portal_catalog()
     portal = get_portal()
     portal_path = get_path(portal)
     portal_url = get_url(portal)
@@ -530,12 +535,7 @@ def get_object_by_path(path, default=_marker):
     if path == portal_path:
         return portal
 
-    res = pc(path=dict(query=path, depth=0))
-    if not res:
-        if default is not _marker:
-            return default
-        fail("Object at path '{}' not found".format(path))
-    return get_object(res[0])
+    return portal.restrictedTraverse(path, default)
 
 
 def get_path(brain_or_object):
@@ -759,6 +759,13 @@ def get_workflow_status_of(brain_or_object, state_var="review_state"):
     :returns: Status
     :rtype: str
     """
+    # Try to get the state from the catalog brain first
+    if is_brain(brain_or_object):
+        if state_var in brain_or_object.schema():
+            state = brain_or_object[state_var]
+            if state is not Missing.Value:
+                return state
+    # Retrieve the sate from the object
     workflow = get_tool("portal_workflow")
     obj = get_object(brain_or_object)
     return workflow.getInfoFor(ob=obj, name=state_var, default='')
@@ -1370,3 +1377,15 @@ def to_searchable_text_metadata(value):
     if not isinstance(value, basestring):
         value = str(value)
     return safe_unicode(value)
+
+
+def get_registry_record(name, default=None):
+    """Returns the value of a registry record
+
+    :param name: [required] name of the registry record
+    :type name: str
+    :param default: The value returned if the record is not found
+    :type default: anything
+    :returns: value of the registry record
+    """
+    return ploneapi.portal.get_registry_record(name, default=default)

--- a/bika/lims/api/__init__.py
+++ b/bika/lims/api/__init__.py
@@ -762,9 +762,8 @@ def get_workflow_status_of(brain_or_object, state_var="review_state"):
     # Try to get the state from the catalog brain first
     if is_brain(brain_or_object):
         if state_var in brain_or_object.schema():
-            state = brain_or_object[state_var]
-            if state is not Missing.Value:
-                return state
+            return brain_or_object[state_var]
+
     # Retrieve the sate from the object
     workflow = get_tool("portal_workflow")
     obj = get_object(brain_or_object)

--- a/bika/lims/tests/doctests/API.rst
+++ b/bika/lims/tests/doctests/API.rst
@@ -1527,5 +1527,6 @@ Fetch a value of a registry record::
 
 If the record is not found, the default is returned::
 
+    >>> key = "non.existing.key"
     >>> api.get_registry_record(key, default="NX_KEY")
     'NX_KEY'

--- a/bika/lims/tests/doctests/API.rst
+++ b/bika/lims/tests/doctests/API.rst
@@ -45,11 +45,18 @@ The Portal is the Bika LIMS root object::
 Getting the Bika Setup object
 -----------------------------
 
-The Bika Setup object gives access to all of the Bika configuration settings::
+The Setup object gives access to all of the Bika configuration settings::
+
+    >>> setup = api.get_setup()
+    >>> setup
+    <BikaSetup at /plone/bika_setup>
 
     >>> bika_setup = api.get_bika_setup()
-    >>> bika_setup
+    >>> setup
     <BikaSetup at /plone/bika_setup>
+
+    >>> setup == bika_setup
+    True
 
 
 Creating new Content
@@ -678,6 +685,11 @@ This function returns the state of a given object::
     >>> api.get_workflow_status_of(client)
     'active'
 
+It is also able to return the state from a brain without waking it up::
+
+    >>> api.get_workflow_status_of(brain)
+    'active'
+
 It is also capable to get the state of another state variable::
 
     >>> api.get_workflow_status_of(client, "review_state")
@@ -1223,6 +1235,7 @@ Checks if an UID is a valid 23 alphanumeric uid and with a brain:
     >>> api.is_uid(uid, validate=True)
     True
 
+
 Check if a Date is valid
 ------------------------
 
@@ -1501,3 +1514,18 @@ Convert to dhm format
 
     >>> api.to_dhm_format(minutes=122.4567, seconds=6)
     '2h 3m'
+
+
+Get a registry record
+---------------------
+
+Fetch a value of a registry record::
+
+    >>> key = "Products.CMFPlone.i18nl10n.override_dateformat.Enabled"
+    >>> api.get_registry_record(key)
+    False
+
+If the record is not found, the default is returned::
+
+    >>> api.get_registry_record(key, default="NX_KEY")
+    'NX_KEY'


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR improves several API functions

## Current behavior before PR

- Function `get_workflow_status_of` always operated on the object
- Function `get_setup` missing
- Function `get_registry_record` missing
- Function `get_object_by_path` not working for objects not registered in `portal_catalog`

## Desired behavior after PR is merged

- Function `get_workflow_status_of` tries to retrieve the state first from the catalog brain before waking up the object
- Function `get_setup` added
- Function `get_registry_record` added
- Function `get_object_by_path` working for objects not registered in `portal_catalog`


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
