### PR TITLE
Some indexes and columns for partitioning were missing

### DIFF
--- a/bika/lims/catalog/analysisrequest_catalog.py
+++ b/bika/lims/catalog/analysisrequest_catalog.py
@@ -44,6 +44,7 @@ _indexes_dict = {
     # Searchable Text Index by wildcards
     # http://zope.readthedocs.io/en/latest/zope2book/SearchingZCatalog.html#textindexng
     'listing_searchable_text': 'TextIndexNG3',
+    'isRootAncestor': 'BooleanIndex',
 }
 # Defining the columns for this catalog
 _columns_list = [
@@ -85,11 +86,13 @@ _columns_list = [
     'getDateReceived',
     'getDateVerified',
     'getDatePublished',
+    'getDescendantsUIDs',
     'getDistrict',
     'getProfilesUID',
     'getProfilesURL',
     'getProfilesTitle',
     'getProfilesTitleStr',
+    'getRawParentAnalysisRequest',
     'getProvince',
     'getTemplateUID',
     'getTemplateURL',


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

In fresh instances, some indexes for partitioning view were missing

## Current behavior before PR

```
2018-11-14 20:53:54 ERROR Zope.SiteErrorLog 1542225234.990.0735445282768 http://localhost:8080/senaite/analysisrequests/base_view/folderitems
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.bika_listing, line 572, in __call__
  Module bika.lims.browser.listing.ajax, line 82, in handle_subpath
  Module bika.lims.browser.listing.decorators, line 45, in wrapper
  Module bika.lims.browser.listing.decorators, line 32, in wrapper
  Module bika.lims.browser.listing.decorators, line 82, in wrapper
  Module bika.lims.browser.listing.ajax, line 411, in ajax_folderitems
  Module bika.lims.browser.listing.decorators, line 70, in wrapper
  Module bika.lims.browser.listing.ajax, line 269, in get_folderitems
  Module bika.lims.browser.analysisrequest.analysisrequests, line 668, in folderitems
  Module bika.lims.browser.bika_listing, line 1035, in folderitems
  Module bika.lims.browser.analysisrequest.analysisrequests, line 888, in folderitem
AttributeError: getRawParentAnalysisRequest
```

## Desired behavior after PR is merged

Analysis Request listing is rendered without errors

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
