### PR TITLE
Misspelling guard_handle -> guard_handler

### DIFF
--- a/bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
@@ -1163,7 +1163,7 @@
     <action url="" category="workflow" icon="">Create partitions</action>
     <guard>
       <guard-permission>BIKA: Edit Results</guard-permission>
-      <guard-expression>python:here.guard_handle("create_partitions")</guard-expression>
+      <guard-expression>python:here.guard_handler("create_partitions")</guard-expression>
     </guard>
   </transition>
   <!-- /Transition: create_partitions -->


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

In a fresh instance, guard handler for `create partitions` was not properly set.

## Current behavior before PR

```
2018-11-14 21:24:20 ERROR Zope.SiteErrorLog 1542227060.510.890346230813 http://localhost:8080/senaite/analysisrequests/base_view/transitions
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.bika_listing, line 572, in __call__
  Module bika.lims.browser.listing.ajax, line 82, in handle_subpath
  Module bika.lims.browser.listing.decorators, line 45, in wrapper
  Module bika.lims.browser.listing.decorators, line 32, in wrapper
  Module bika.lims.browser.listing.decorators, line 82, in wrapper
  Module bika.lims.browser.listing.ajax, line 478, in ajax_transitions
  Module bika.lims.browser.listing.ajax, line 191, in get_allowed_transitions_for
  Module bika.lims.browser.listing.ajax, line 153, in get_transitions_for
  Module bika.lims.api, line 924, in get_transitions_for
  Module Products.CMFPlone.WorkflowTool, line 95, in getTransitionsFor
  Module Products.DCWorkflow.DCWorkflow, line 398, in _checkTransitionGuard
  Module Products.DCWorkflow.Guard, line 89, in check
  Module Products.CMFCore.Expression, line 47, in __call__
  Module Products.PageTemplates.ZRPythonExpr, line 48, in __call__
   - __traceback_info__: here.guard_handle("create_partitions")
  Module PythonExpr, line 1, in <expression>
AttributeError: guard_handle
```

## Desired behavior after PR is merged

When an Analysis Request is selected, the transitions appear properly without traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
