### PR TITLE
Deepcopy Service Interims to Analyses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Changelog
 
 **Fixed**
 
+- #1089 Deepcopy Service Interims to Analyses
 - #1082 Worksheet folder listing fixtures for direct analyst assignment
 - #1080 Improve searchability of Client and Multifile fields
 - #1072 Calculations with dependents do not work after 1.2.9 update

--- a/bika/lims/browser/fields/aranalysesfield.py
+++ b/bika/lims/browser/fields/aranalysesfield.py
@@ -5,6 +5,7 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
+import copy
 import itertools
 
 from AccessControl import ClassSecurityInfo
@@ -295,6 +296,8 @@ class ARAnalysesField(ObjectField):
         :param service: Analysis Service Object
         """
         service_interims = service.getInterimFields()
+        # avoid references from the analyses interims to the service interims
+        service_interims = copy.deepcopy(service_interims)
         analysis.setInterimFields(service_interims)
 
     def _update_price(self, analysis, service, prices):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue that interims were passed by reference to new created Analyses

## Current behavior before PR

Changing Interim values of an Analysis changed the value of the original Service Interim as well

## Desired behavior after PR is merged

Changing Interim values of an Analysis has no effect on the original Service Interim
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
