### PR TITLE
 Primary AR does not recognize created Partitions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Changelog
 
 **Fixed**
 
+- #1090 Primary AR does not recognize created Partitions
 - #1089 Deepcopy Service Interims to Analyses
 - #1082 Worksheet folder listing fixtures for direct analyst assignment
 - #1080 Improve searchability of Client and Multifile fields

--- a/bika/lims/browser/partition_magic.py
+++ b/bika/lims/browser/partition_magic.py
@@ -137,14 +137,19 @@ class PartitionMagicView(BrowserView):
         analyses = map(self.get_object_by_uid, analyses_uids)
         services = map(lambda an: an.getAnalysisService(), analyses)
 
-        ar = crar(
+        partition = crar(
             client,
             self.request,
             record,
             analyses=services,
             specifications=self.get_specifications_for(ar)
         )
-        return ar
+
+        # Reindex Parent Analysis Request
+        # TODO Workflow - AnalysisRequest - Partitions creation
+        ar.reindexObject(idxs=["isRootAncestor"])
+
+        return partition
 
     def get_specifications_for(self, ar):
         """Returns a mapping of service uid -> specification


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

- Reindex primary AR on partitions creation
- Reindex relevant indexes from ancestors on results submission and other transitions

Linked issue: https://github.com/senaite/senaite.core/issues/1078

## Current behavior before PR

- Partitions are not visible below the primary AR
- Progress of Primary Analysis Request does not get updated when results for partitions are submitted

## Desired behavior after PR is merged

- Partition toggle handle is displayed and shows the created partitions correctly on expansion
- Progress of Primary Analysis Request does get updated when results for partitions are submitted

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
