### PR TITLE
Disallow AS transitions in Analysis Spec Widget

### DIFF
--- a/bika/lims/browser/widgets/analysisspecificationwidget.py
+++ b/bika/lims/browser/widgets/analysisspecificationwidget.py
@@ -109,7 +109,7 @@ class AnalysisSpecificationView(BikaListingView):
                 "id": "default",
                 "title": _("All"),
                 "contentFilter": {},
-                "transitions": [],
+                "transitions": [{"id": "disallow-all-possible-transitions"}],
                 "columns": self.columns.keys(),
             },
         ]


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR disallows AS transitions in the Analysis Specifications Widget listing

## Current behavior before PR

Deactivate Transition was displayed

## Desired behavior after PR is merged

No transitions are displayed below the Analysis Specifications Widget

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
