### PR TITLE
Remove guard_to_be_preserved from analysis

### DIFF
--- a/bika/lims/content/abstractroutineanalysis.py
+++ b/bika/lims/content/abstractroutineanalysis.py
@@ -519,13 +519,3 @@ class AbstractRoutineAnalysis(AbstractAnalysis):
             # Once we have the rules, the system has to execute its
             # instructions if the result has the expected result.
             doReflexRuleAction(self, action_row)
-
-    @security.public
-    def guard_to_be_preserved(self):
-        """Returns if the Sample Partition to which this Analysis belongs needs
-        to be prepreserved, so the Analysis. If the analysis has no Sample
-        Partition assigned, returns False.
-        Delegates to Sample Partitions's guard_to_be_preserved
-        """
-        part = self.getSamplePartition()
-        return part and part.guard_to_be_preserved()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This is unused code. `to_be_preserved` state and transition are no longer supported in `analysis_workflow`

Preservation is a state that depends on the analyses to be performed, but in any case, the sample is what might need to be preserved, not the analysis.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
