### PR TITLE
Selective reindexing of indexes in transitions

### DIFF
--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -207,7 +207,8 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
 
         # Reindex
         if reindex:
-            self.reindexObject(idxs=["getAnalysesUIDs", "getDepartmentUIDs"])
+            idxs = ["getAnalysesUIDs", "getDepartmentUIDs", "review_state"]
+            self.reindexObject(idxs=idxs)
 
         # Try to rollback the worksheet to prevent inconsistencies
         doActionFor(self, "rollback_to_open")

--- a/bika/lims/workflow/analysis/events.py
+++ b/bika/lims/workflow/analysis/events.py
@@ -8,6 +8,7 @@
 import transaction
 from Products.CMFCore.utils import getToolByName
 
+from bika.lims import api
 from bika.lims.interfaces import IDuplicateAnalysis
 from bika.lims.interfaces.analysis import IRequestAnalysis
 from bika.lims.utils.analysis import create_analysis
@@ -110,8 +111,8 @@ def after_retract(analysis):
     delattr(parent, '_verifyObjectPaste')
 
     # Create a copy of the retracted analysis
-    new_analysis = create_analysis(parent, analysis)
-    new_analysis.setRetestOf(analysis)
+    analysis_uid = api.get_uid(analysis)
+    new_analysis = create_analysis(parent, analysis, RetestOf=analysis_uid)
 
     # Assign the new analysis to this same worksheet, if any.
     worksheet = analysis.getWorksheet()
@@ -214,7 +215,7 @@ def reindex_request(analysis, idxs=None):
         # Analysis not directly bound to an Analysis Request. Do nothing
         return
 
-    n_idxs = ['assigned_state', 'isRootAncestor', 'getDueDate']
+    n_idxs = ['assigned_state', 'getDueDate']
     n_idxs = idxs and list(set(idxs + n_idxs)) or n_idxs
     request = analysis.getRequest()
     ancestors = [request] + request.getAncestors(all_ancestors=True)

--- a/bika/lims/workflow/indexes.py
+++ b/bika/lims/workflow/indexes.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE
+#
+# Copyright 2018 by it's authors.
+# Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
+
+# Mapping of indexes to be reindexed for each portal type after a given
+# transition is performed.
+# - If None is set for a given portal type and transition, doActionFor will
+#   only reindex "review_state"
+# - If a given transition is not present or contains an empty list, doActionFor
+#   will reindex all indexes.
+ACTIONS_TO_INDEXES = {
+    "Analysis": {
+        "assign": [
+            "getAnalyst",
+            "getWorksheetUID",
+        ],
+        "cancel": [
+            "cancellation_state",
+        ],
+        "reinstate": [
+            "cancellation_state",
+        ],
+        "reject": [
+            "getWorksheetUID",
+        ],
+        "retract": [
+            "id",
+            "title",
+        ],
+        "submit": [
+            "getAnalyst",
+            "getDueDate",
+            "getInstrumentUID",
+            "getMethodUID",
+            "getResultCaptureDate",
+        ],
+        "unassign": [
+            "getAnalyst",
+            "getWorksheetUID",
+        ],
+        "verify": [
+            "review_state",
+        ],
+    },
+
+    "DuplicateAnalysis": {
+        "retract": [
+            "id",
+            "title",
+        ],
+        "submit": [
+            "getAnalyst",
+            "getDueDate",
+            "getInstrumentUID",
+            "getMethodUID",
+            "getResultCaptureDate",
+        ],
+        "unassign": None,
+        "verify": [
+            "review_state",
+        ],
+    },
+
+    "ReferenceAnalysis": {
+        "retract": [
+            "review_state",
+        ],
+        "submit": [
+            "getAnalyst",
+            "getDueDate",
+            "getInstrumentUID",
+            "getMethodUID",
+            "getResultCaptureDate",
+            "review_state",
+        ],
+        "unassign": None,
+        "verify": [
+            "review_state",
+        ],
+    },
+
+    "Worksheet": {
+        "attach": [
+            "getAnalysesUIDs",
+            "getDepartmentUIDs",
+        ],
+        "rollback_to_open": [
+            "getAnalysesUIDs",
+            "getDepartmentUIDs",
+        ],
+        "submit": [
+            "getAnalysesUIDs",
+            "getDepartmentUIDs",
+        ],
+        "verify": [
+            "getAnalysesUIDs",
+            "getDepartmentUIDs",
+        ],
+    },
+
+    "AnalysisRequest": {
+        "rollback_to_receive": [
+            "assigned_state",
+            "getDueDate",
+        ],
+        "submit": [
+            "assigned_state",
+            "getDueDate",
+        ],
+        "verify": [
+            "getDateVerified",
+        ]
+    }
+}


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

There is no need to reindex all indexes after a transition is performed for a given object. In fact, in most cases there's only the need to reindex two or three indexes. Reindexing only those indexes that might
be affected by the transition might boost the overall performance, specially on big dbs.

With this PR, the system uses the `ACTION_INDEXES` mapping (located at `workflow.indexes`) to infere the indexes that need to be reindexed for a given portal_type after a transition is performed. If no indexes are found in the mapping, the system behaves as usual, reindexing all the indexes of the object.

## Current behavior before PR

After a transition, all indexes from the object are reindexed, regardless of the transition performed.

## Desired behavior after PR is merged

After a transition, only the indexes that might be affected by that transition are reindexed. Better performance

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
