### PR TITLE
Disallow AS transitions in AR manage analyses

### DIFF
--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -104,7 +104,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
                 "title": _("All"),
                 "contentFilter": {"inactive_state": "active"},
                 "columns": columns,
-                "transitions": [],
+                "transitions": [{"id": "disallow-all-possible-transitions"}],
                 "custom_transitions": [
                     {
                         "id": "save_analyses_button",


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR disallows AS transitions in the AR manage analyses listing

## Current behavior before PR

Deactivate transition was displayed

## Desired behavior after PR is merged

Only custom "Save" transition is displayed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
