### PR TITLE
Fix stripping fieldnames with single letters of "g" "e" "t"

### DIFF
--- a/bika/lims/browser/listing/ajax.py
+++ b/bika/lims/browser/listing/ajax.py
@@ -349,7 +349,9 @@ class AjaxListingView(BrowserView):
         updated_objects = []
 
         # sanitize the name
-        fieldname = name.lstrip("get")
+        fieldname = name
+        if fieldname.startswith("get"):
+            fieldname = name.lstrip("get")
 
         # fetch the schema field
         field = obj.getField(fieldname)

--- a/bika/lims/browser/listing/ajax.py
+++ b/bika/lims/browser/listing/ajax.py
@@ -234,18 +234,6 @@ class AjaxListingView(BrowserView):
 
         return transitions
 
-    def base_info(self, brain_or_object):
-        """Object/Brain Base info
-        """
-        info = {
-            "id": api.get_id(brain_or_object),
-            "uid": api.get_uid(brain_or_object),
-            "url": api.get_url(brain_or_object),
-            "title": api.get_title(brain_or_object),
-            "portal_type": api.get_portal_type(brain_or_object),
-        }
-        return info
-
     def get_category_uid(self, brain_or_object, accessor="getCategoryUID"):
         """Get the category UID from the brain or object
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes that interim fields with single letters of "g", "e", "t" get stripped and not set

## Current behavior before PR

Interim field with the Keyword "t" was not set

## Desired behavior after PR is merged

Interim field with the Keyword "t" is set

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
