### PR TITLE
Analyses remain in "sample_received" after upgrade 1.3.0

### DIFF
--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -751,7 +751,6 @@ def get_role_mappings_candidates(portal):
 
 def decouple_analyses_from_sample_workflow(portal):
     logger.info("Decoupling analyses from sample workflow ...")
-    import pdb;pdb.set_trace()
     add_index(portal, catalog_id=CATALOG_ANALYSIS_LISTING,
               index_name="isSampleReceived",
               index_attribute="isSampleReceived",

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -751,7 +751,7 @@ def get_role_mappings_candidates(portal):
 
 def decouple_analyses_from_sample_workflow(portal):
     logger.info("Decoupling analyses from sample workflow ...")
-
+    import pdb;pdb.set_trace()
     add_index(portal, catalog_id=CATALOG_ANALYSIS_LISTING,
               index_name="isSampleReceived",
               index_attribute="isSampleReceived",
@@ -763,7 +763,7 @@ def decouple_analyses_from_sample_workflow(portal):
                    "not_requested", "registered"]
     wf_tool = api.get_tool("portal_workflow")
     workflow = wf_tool.getWorkflowById(wf_id)
-    query = dict(portal_type=["Analysis" "DuplicateAnalysis"],
+    query = dict(portal_type=["Analysis", "DuplicateAnalysis"],
                  review_state=affected_rs)
     brains = api.search(query, CATALOG_ANALYSIS_LISTING)
     total = len(brains)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Analyses remain in "sample_received" state after upgrade 1.3.0

## Current behavior before PR

Analyses remain in "sample_received" state after upgrade 1.3.0

## Desired behavior after PR is merged

Analyses assigned to a worksheet acquires the review_state "assigned" and those w/o worksheet acquire the review_state "unassigned"

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
