### PR TITLE
Do not allow to publish analyses individually

### DIFF
--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -1217,9 +1217,5 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         return api.get_object_by_uid(back_refs[0])
 
     @security.public
-    def guard_publish_transition(self):
-        return guards.publish(self)
-
-    @security.public
     def guard_attach_transition(self):
         return guards.attach(self)

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2865,10 +2865,6 @@ class AnalysisRequest(BaseFolder):
         return guards.schedule_sampling(self)
 
     @security.public
-    def guard_publish_transition(self):
-        return guards.publish(self)
-
-    @security.public
     def guard_prepublish_transition(self):
         return guards.prepublish(self)
 

--- a/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
@@ -252,8 +252,11 @@
     </permission-map>
   </state>
 
+  <!-- State: published
+  The analysis has been published. Analyses cannot be published individually,
+  rather analyses transitions to this state automatically when the whole
+  Analysis Request they belong to is published -->
   <state state_id="published" title="Published" i18n:attributes="title">
-    <exit-transition transition_id="publish" />
     <permission-map name="BIKA: Edit Field Results" acquired="False">
     </permission-map>
     <permission-map name="BIKA: Edit Results" acquired="False">
@@ -396,11 +399,19 @@
     </guard>
   </transition>
 
-  <transition transition_id="publish" title="Publish" new_state="published" trigger="USER" before_script="" after_script="" i18n:attributes="title">
+  <!-- Transition: publish
+  The publication cannot be done manually (see the guard), it takes place
+  automatically when the Analysis Request is published -->
+  <transition transition_id="publish" title="Publish" new_state="published"
+              trigger="USER" before_script="" after_script=""
+              i18n:attributes="title">
     <action url="" category="workflow" icon="">Publish</action>
     <guard>
-      <guard-permission>BIKA: Publish</guard-permission>
-      <guard-expression>python:here.guard_publish_transition()</guard-expression>
+      <!-- There is no guard-permission here because this transition takes
+      place automatically as soon as the Analysis Request  is published. Hence,
+      this transition is governed by the permission "Publish" assigned to the
+      Analysis Request the analysis belongs to -->
+      <guard-expression>python:here.guard_handler("publish")</guard-expression>
     </guard>
   </transition>
 

--- a/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
@@ -257,6 +257,7 @@
   rather analyses transitions to this state automatically when the whole
   Analysis Request they belong to is published -->
   <state state_id="published" title="Published" i18n:attributes="title">
+    <exit-transition transition_id="" />
     <permission-map name="BIKA: Edit Field Results" acquired="False">
     </permission-map>
     <permission-map name="BIKA: Edit Results" acquired="False">

--- a/bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
@@ -1100,7 +1100,7 @@
     <action url="" category="workflow" icon="">Publish</action>
     <guard>
       <guard-permission>BIKA: Publish</guard-permission>
-      <guard-expression>python:here.guard_publish_transition()</guard-expression>
+      <guard-expression>python:here.guard_handler("publish")</guard-expression>
     </guard>
   </transition>
 

--- a/bika/lims/tests/doctests/WorkflowAnalysisPublish.rst
+++ b/bika/lims/tests/doctests/WorkflowAnalysisPublish.rst
@@ -1,0 +1,144 @@
+Analysis publication guard and event
+====================================
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t WorkflowAnalysisPublish
+
+
+Test Setup
+----------
+
+Needed Imports:
+
+    >>> from AccessControl.PermissionRole import rolesForPermissionOn
+    >>> from bika.lims import api
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+    >>> from bika.lims.workflow import getAllowedTransitions
+    >>> from bika.lims.workflow import isTransitionAllowed
+    >>> from DateTime import DateTime
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+
+Functional Helpers:
+
+    >>> def start_server():
+    ...     from Testing.ZopeTestCase.utils import startZServer
+    ...     ip, port = startZServer()
+    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
+
+    >>> def timestamp(format="%Y-%m-%d"):
+    ...     return DateTime().strftime(format)
+
+    >>> def start_server():
+    ...     from Testing.ZopeTestCase.utils import startZServer
+    ...     ip, port = startZServer()
+    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
+
+    >>> def new_ar(services):
+    ...     values = {
+    ...         'Client': client.UID(),
+    ...         'Contact': contact.UID(),
+    ...         'DateSampled': date_now,
+    ...         'SampleType': sampletype.UID()}
+    ...     service_uids = map(api.get_uid, services)
+    ...     ar = create_analysisrequest(client, request, values, service_uids)
+    ...     transitioned = do_action_for(ar, "receive")
+    ...     return ar
+
+    >>> def try_transition(object, transition_id, target_state_id):
+    ...      success = do_action_for(object, transition_id)[0]
+    ...      state = api.get_workflow_status_of(object)
+    ...      return success and state == target_state_id
+
+    >>> def submit_analyses(ar):
+    ...     for analysis in ar.getAnalyses(full_objects=True):
+    ...         analysis.setResult(13)
+    ...         do_action_for(analysis, "submit")
+
+    >>> def verify_analyses(ar):
+    ...     for analysis in ar.getAnalyses(full_objects=True):
+    ...         do_action_for(analysis, "verify")
+
+    >>> def get_roles_for_permission(permission, context):
+    ...     allowed = set(rolesForPermissionOn(permission, context))
+    ...     return sorted(allowed)
+
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> bikasetup = portal.bika_setup
+    >>> date_now = DateTime().strftime("%Y-%m-%d")
+    >>> date_future = (DateTime() + 5).strftime("%Y-%m-%d")
+
+We need to create some basic objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
+    >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH", MemberDiscountApplies=True)
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(bikasetup.bika_sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> labcontact = api.create(bikasetup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(bikasetup.bika_departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = api.create(bikasetup.bika_analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> Cu = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID(), Accredited=True)
+    >>> Fe = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Iron", Keyword="Fe", Price="10", Category=category.UID())
+    >>> Au = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Gold", Keyword="Au", Price="20", Category=category.UID())
+    >>> bikasetup.setSelfVerificationEnabled(True)
+
+Publish transition and guard basic constraints
+----------------------------------------------
+
+Create an Analysis Request, submit results and verify:
+
+    >>> ar = new_ar([Cu, Fe, Au])
+    >>> submit_analyses(ar)
+    >>> verify_analyses(ar)
+    >>> api.get_workflow_status_of(ar)
+    'verified'
+
+I cannot publish the analyses individually:
+
+    >>> analyses = ar.getAnalyses(full_objects=True)
+    >>> try_transition(analyses[0], "publish", "published")
+    False
+    >>> api.get_workflow_status_of(analyses[0])
+    'verified'
+
+    >>> try_transition(analyses[1], "publish", "published")
+    False
+    >>> api.get_workflow_status_of(analyses[1])
+    'verified'
+
+    >>> try_transition(analyses[2], "publish", "published")
+    False
+    >>> api.get_workflow_status_of(analyses[2])
+    'verified'
+
+But if we publish the Analysis Request, analyses will follow:
+
+    >>> success = do_action_for(ar, "publish")
+    >>> api.get_workflow_status_of(ar)
+    'published'
+    >>> map(api.get_workflow_status_of, analyses)
+    ['published', 'published', 'published']
+
+
+Check permissions for Published state
+-------------------------------------
+
+In published state, exactly these roles can view results:
+
+    >>> analysis = ar.getAnalyses(full_objects=True)[0]
+    >>> api.get_workflow_status_of(analysis)
+    'published'
+    >>> get_roles_for_permission("BIKA: View Results", analysis)
+    ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Owner', 'RegulatoryInspector']
+
+And no transition can be done from this state:
+
+    >>> getAllowedTransitions(analysis)
+    []

--- a/bika/lims/workflow/analysis/events.py
+++ b/bika/lims/workflow/analysis/events.py
@@ -170,6 +170,12 @@ def after_verify(analysis):
         reindex_request(analysis)
 
 
+def after_publish(analysis):
+    """Function triggered after a "publish" transition is performed.
+    """
+    pass
+
+
 def after_attach(obj):
     if skip(obj, "attach"):
         return

--- a/bika/lims/workflow/analysis/guards.py
+++ b/bika/lims/workflow/analysis/guards.py
@@ -10,19 +10,6 @@ from bika.lims.interfaces.analysis import IRequestAnalysis
 from bika.lims import workflow as wf
 
 
-def publish(obj):
-    """ Returns true if the 'publish' transition can be performed to the
-    analysis passed in.
-    In accordance with bika_analysis_workflow, 'publish'
-    transition can only be performed if the state of the analysis is verified,
-    so this guard only checks if the analysis state is active: there is no need
-    of additional checks, cause the DC Workflow machinery will already take
-    care of them.
-    :returns: true or false
-    """
-    return wf.isBasicTransitionAllowed(obj)
-
-
 def attach(obj):
     if not wf.isBasicTransitionAllowed(obj):
         return False
@@ -251,3 +238,11 @@ def guard_reject(analysis):
             return False
 
     return True
+
+
+def guard_publish(analysis):
+    """Return whether the transition "publish" can be performed or not. Returns
+    True only when the Analysis Request the analysis belongs to is in published
+    state. Otherwise, returns False.
+    """
+    return api.get_workflow_status_of(analysis.getRequest()) == "published"

--- a/bika/lims/workflow/analysisrequest/events.py
+++ b/bika/lims/workflow/analysisrequest/events.py
@@ -206,7 +206,7 @@ def after_verify(obj):
         doActionFor(part, "verify")
 
 
-def after_publish(obj):
+def after_publish(analysis_request):
     """Method triggered after an 'publish' transition for the Analysis Request
     passed in is performed. Performs the 'publish' transition to children.
     This function is called automatically by
@@ -215,12 +215,11 @@ def after_publish(obj):
     :type obj: AnalysisRequest
     """
     # Transition the children
-    ans = obj.getAnalyses(full_objects=True)
-    for analysis in ans:
+    for analysis in analysis_request.getAnalyses(full_objects=True):
         doActionFor(analysis, 'publish')
 
     # Cascade to partitions
-    parts = obj.getDescendants(all_descendants=False)
+    parts = analysis_request.getDescendants(all_descendants=False)
     for part in parts:
         doActionFor(part, "publish")
 

--- a/bika/lims/workflow/analysisrequest/guards.py
+++ b/bika/lims/workflow/analysisrequest/guards.py
@@ -129,7 +129,7 @@ def prepublish(obj):
     return False
 
 
-def publish(obj):
+def guard_publish(analysis_request):
     """Returns True if 'publish' transition can be applied to the Analysis
     Request passed in. Returns true if the Analysis Request is active (not in
     a cancelled/inactive state). As long as 'publish' transition, in accordance
@@ -137,7 +137,7 @@ def publish(obj):
     verified or published, there is no need of additional validations.
     :returns: true or false
     """
-    return isBasicTransitionAllowed(obj)
+    return isBasicTransitionAllowed(analysis_request)
 
 
 def guard_rollback_to_receive(analysis_request):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Transition "publish" should only be available at Analysis Request context and should not appear in analyses listings.

## Current behavior before PR

Transition "publish" shows up in worksheet transposed view.

## Desired behavior after PR is merged

Transition "publish" does not show up in worksheet transposed view.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
