### PR TITLE
Update worksheet and analysis request when analyses are unassigned

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Changelog
 
 **Changed**
 
+- #1109 Unassignment of an analysis causes the removal of its duplicates
 - #1077 Rejection of an analysis causes the removal of its duplicates
 - #1077 Don't allow to cancel Analysis Requests with assigned/submitted analyses
 - #1077 Decouple `cancellation_workflow` from Analysis content type

--- a/bika/lims/tests/doctests/WorkflowAnalysisUnassign.rst
+++ b/bika/lims/tests/doctests/WorkflowAnalysisUnassign.rst
@@ -1,0 +1,141 @@
+Analysis unassign guard and event
+=================================
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t WorkflowAnalysisUnassign
+
+
+Test Setup
+----------
+
+Needed Imports:
+
+    >>> from AccessControl.PermissionRole import rolesForPermissionOn
+    >>> from bika.lims import api
+    >>> from bika.lims.catalog.worksheet_catalog import CATALOG_WORKSHEET_LISTING
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+    >>> from bika.lims.workflow import isTransitionAllowed
+    >>> from DateTime import DateTime
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+
+Functional Helpers:
+
+    >>> def start_server():
+    ...     from Testing.ZopeTestCase.utils import startZServer
+    ...     ip, port = startZServer()
+    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
+
+    >>> def timestamp(format="%Y-%m-%d"):
+    ...     return DateTime().strftime(format)
+
+    >>> def start_server():
+    ...     from Testing.ZopeTestCase.utils import startZServer
+    ...     ip, port = startZServer()
+    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
+
+    >>> def new_ar(services):
+    ...     values = {
+    ...         'Client': client.UID(),
+    ...         'Contact': contact.UID(),
+    ...         'DateSampled': date_now,
+    ...         'SampleType': sampletype.UID()}
+    ...     service_uids = map(api.get_uid, services)
+    ...     ar = create_analysisrequest(client, request, values, service_uids)
+    ...     return ar
+
+    >>> def try_transition(object, transition_id, target_state_id):
+    ...      success = do_action_for(object, transition_id)[0]
+    ...      state = api.get_workflow_status_of(object)
+    ...      return success and state == target_state_id
+
+    >>> def get_roles_for_permission(permission, context):
+    ...     allowed = set(rolesForPermissionOn(permission, context))
+    ...     return sorted(allowed)
+
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> bikasetup = portal.bika_setup
+    >>> date_now = DateTime().strftime("%Y-%m-%d")
+    >>> date_future = (DateTime() + 5).strftime("%Y-%m-%d")
+
+We need to create some basic objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
+    >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH", MemberDiscountApplies=True)
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(bikasetup.bika_sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> labcontact = api.create(bikasetup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(bikasetup.bika_departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = api.create(bikasetup.bika_analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> Cu = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID(), Accredited=True)
+    >>> Fe = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Iron", Keyword="Fe", Price="10", Category=category.UID())
+    >>> Au = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Gold", Keyword="Au", Price="20", Category=category.UID())
+
+
+Unassign transition and guard basic constraints
+-----------------------------------------------
+
+Create an Analysis Request:
+
+    >>> ar = new_ar([Cu, Fe, Au])
+    >>> transitioned = do_action_for(ar, "receive")
+
+The status of the analyses is `unassigned`:
+
+    >>> analyses = ar.getAnalyses(full_objects=True)
+    >>> map(api.get_workflow_status_of, analyses)
+    ['unassigned', 'unassigned', 'unassigned']
+
+Create a Worksheet and add the analyses:
+
+    >>> worksheet = api.create(portal.worksheets, "Worksheet")
+    >>> for analysis in analyses:
+    ...     worksheet.addAnalysis(analysis)
+    >>> sorted((map(lambda an: an.getKeyword(), worksheet.getAnalyses())))
+    ['Au', 'Cu', 'Fe']
+    >>> map(api.get_workflow_status_of, analyses)
+    ['assigned', 'assigned', 'assigned']
+
+The worksheet has now 3 analyses assigned:
+
+    >>> worksheet.getNumberOfRegularAnalyses()
+    3
+    >>> worksheet.getNumberOfQCAnalyses()
+    0
+
+And metadata gets updated accordingly:
+
+    >>> query = dict(UID=api.get_uid(worksheet))
+    >>> ws_brain = api.search(query, CATALOG_WORKSHEET_LISTING)[0]
+    >>> ws_brain.getNumberOfRegularAnalyses
+    3
+    >>> ws_brain.getNumberOfQCAnalyses
+    0
+    >>> an_uids = sorted(map(api.get_uid, worksheet.getAnalyses()))
+    >>> sorted(ws_brain.getAnalysesUIDs) == an_uids
+    True
+
+When we unassign the `Cu` analysis, the workseet gets updated:
+
+    >>> cu = filter(lambda an: an.getKeyword() == 'Cu', worksheet.getAnalyses())[0]
+    >>> succeed = do_action_for(cu, "unassign")
+    >>> api.get_workflow_status_of(cu)
+    'unassigned'
+    >>> cu in worksheet.getAnalyses()
+    False
+    >>> worksheet.getNumberOfRegularAnalyses()
+    2
+    >>> ws_brain = api.search(query, CATALOG_WORKSHEET_LISTING)[0]
+    >>> ws_brain.getNumberOfRegularAnalyses
+    2
+    >>> api.get_uid(cu) in ws_brain.getAnalysesUIDs
+    False
+    >>> len(ws_brain.getAnalysesUIDs)
+    2

--- a/bika/lims/workflow/analysis/events.py
+++ b/bika/lims/workflow/analysis/events.py
@@ -27,6 +27,11 @@ def after_unassign(analysis):
     """Function triggered after an 'unassign' transition for the analysis passed
     in is performed.
     """
+    # Remove from the worksheet
+    remove_analysis_from_worksheet(analysis)
+    # Unassign our dependents (analyses that depend on this analysis)
+    cascade_to_dependents(analysis, "unassign")
+    # Reindex the Analysis Request
     reindex_request(analysis)
 
 
@@ -34,21 +39,8 @@ def after_cancel(analysis):
     """Function triggered after a "cancel" transition is performed. Removes the
     cancelled analysis from the worksheet, if any.
     """
-    worksheet = analysis.getWorksheet()
-    if worksheet:
-        # Remove the analysis from the worksheet
-        analyses = filter(lambda an: an != analysis, worksheet.getAnalyses())
-        worksheet.setAnalyses(analyses)
-        worksheet.purgeLayout()
-        if analyses:
-            # Maybe this analysis was the only one that was not yet submitted,
-            # so try to submit or verify the Worksheet to be consistent with
-            # the current states of the analyses it contains.
-            doActionFor(worksheet, "submit")
-            doActionFor(worksheet, "verify")
-        else:
-            # We've removed all analyses. Rollback to "open"
-            doActionFor(worksheet, "rollback_to_open")
+    # Remove from the worksheet
+    remove_analysis_from_worksheet(analysis)
 
 
 def after_reinstate(analysis):
@@ -67,8 +59,7 @@ def after_submit(analysis):
     bika.lims.workfow.AfterTransitionEventHandler
     """
     # Promote to analyses this analysis depends on
-    for dependency in analysis.getDependencies():
-        doActionFor(dependency, "submit")
+    promote_to_dependencies(analysis, "submit")
 
     # TODO: REFLEX TO REMOVE
     # Do all the reflex rules process
@@ -120,8 +111,7 @@ def after_retract(analysis):
         worksheet.addAnalysis(new_analysis)
 
     # Retract our dependents (analyses that depend on this analysis)
-    for dependent in analysis.getDependents():
-        doActionFor(dependent, 'retract')
+    cascade_to_dependents(analysis, "retract")
 
 
 def after_reject(analysis):
@@ -132,8 +122,7 @@ def after_reject(analysis):
         worksheet.removeAnalysis(analysis)
 
     # Reject our dependents (analyses that depend on this analysis)
-    for dependent in analysis.getDependents():
-        doActionFor(dependent, "reject")
+    cascade_to_dependents(analysis, "reject")
 
     # Try to rollback the Analysis Request (all analyses rejected)
     if IRequestAnalysis.providedBy(analysis):
@@ -149,10 +138,8 @@ def after_verify(analysis):
     This function is called automatically by
     bika.lims.workfow.AfterTransitionEventHandler
     """
-
     # Promote to analyses this analysis depends on
-    for dependency in analysis.getDependencies():
-        doActionFor(dependency, 'verify')
+    promote_to_dependencies(analysis, "verify")
 
     # TODO: REFLEX TO REMOVE
     # Do all the reflex rules process
@@ -221,3 +208,44 @@ def reindex_request(analysis, idxs=None):
     ancestors = [request] + request.getAncestors(all_ancestors=True)
     for ancestor in ancestors:
         push_reindex_to_actions_pool(ancestor, n_idxs)
+
+
+def remove_analysis_from_worksheet(analysis):
+    """Removes the analysis passed in from the worksheet, if assigned to any
+    """
+    worksheet = analysis.getWorksheet()
+    if not worksheet:
+        return
+
+    analyses = filter(lambda an: an != analysis, worksheet.getAnalyses())
+    worksheet.setAnalyses(analyses)
+    worksheet.purgeLayout()
+    if analyses:
+        # Maybe this analysis was the only one that was not yet submitted or
+        # verified, so try to submit or verify the Worksheet to be aligned
+        # with the current states of the analyses it contains.
+        doActionFor(worksheet, "submit")
+        doActionFor(worksheet, "verify")
+    else:
+        # We've removed all analyses. Rollback to "open"
+        doActionFor(worksheet, "rollback_to_open")
+
+    # Reindex the Worksheet
+    idxs = ["getAnalysesUIDs", "getDepartmentUIDs"]
+    push_reindex_to_actions_pool(worksheet, idxs=idxs)
+
+
+def cascade_to_dependents(analysis, transition_id):
+    """Cascades the transition to dependent analyses (those that depend on the
+    analysis passed in), if any
+    """
+    for dependent in analysis.getDependents():
+        doActionFor(dependent, transition_id)
+
+
+def promote_to_dependencies(analysis, transition_id):
+    """Promotes the transition to the analyses this analysis depends on
+    (dependencies), if any
+    """
+    for dependency in analysis.getDependencies():
+        doActionFor(dependency, transition_id)

--- a/bika/lims/workflow/analysis/events.py
+++ b/bika/lims/workflow/analysis/events.py
@@ -27,8 +27,6 @@ def after_unassign(analysis):
     """Function triggered after an 'unassign' transition for the analysis passed
     in is performed.
     """
-    # Unassign our dependents (analyses that depend on this analysis)
-    cascade_to_dependents(analysis, "unassign")
     # Remove from the worksheet
     remove_analysis_from_worksheet(analysis)
     # Reindex the Analysis Request

--- a/bika/lims/workflow/analysis/events.py
+++ b/bika/lims/workflow/analysis/events.py
@@ -27,10 +27,10 @@ def after_unassign(analysis):
     """Function triggered after an 'unassign' transition for the analysis passed
     in is performed.
     """
-    # Remove from the worksheet
-    remove_analysis_from_worksheet(analysis)
     # Unassign our dependents (analyses that depend on this analysis)
     cascade_to_dependents(analysis, "unassign")
+    # Remove from the worksheet
+    remove_analysis_from_worksheet(analysis)
     # Reindex the Analysis Request
     reindex_request(analysis)
 
@@ -216,6 +216,11 @@ def remove_analysis_from_worksheet(analysis):
     worksheet = analysis.getWorksheet()
     if not worksheet:
         return
+
+    # Removal of a routine analysis causes the removal of their duplicates
+    if not IDuplicateAnalysis.providedBy(analysis):
+        for dup in worksheet.get_duplicates_for(analysis):
+            doActionFor(dup, "unassign")
 
     analyses = filter(lambda an: an != analysis, worksheet.getAnalyses())
     worksheet.setAnalyses(analyses)

--- a/bika/lims/workflow/duplicateanalysis/events.py
+++ b/bika/lims/workflow/duplicateanalysis/events.py
@@ -33,6 +33,7 @@ def after_verify(duplicate_analysis):
 def after_unassign(duplicate_analysis):
     """Removes the duplicate from the system
     """
+    analysis_events.after_unassign(duplicate_analysis)
     parent = duplicate_analysis.aq_parent
     logger.info("Removing duplicate '{}' from '{}'"
                 .format(duplicate_analysis.getId(), parent.getId()))

--- a/bika/lims/workflow/referenceanalysis/events.py
+++ b/bika/lims/workflow/referenceanalysis/events.py
@@ -30,6 +30,7 @@ def after_verify(reference_analysis):
 def after_unassign(reference_analysis):
     """Removes the reference analysis from the system
     """
+    analysis_events.after_unassign(reference_analysis)
     ref_sample = reference_analysis.aq_parent
     ref_sample.manage_delObjects([reference_analysis.getId()])
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

- Update worksheet and analysis request metadata + indexes when analyses are unassigned
- Automatically remove duplicate when an analysis is unassigned

## Current behavior before PR

Worksheet metadata gets updated after an analysis is unassigned

## Desired behavior after PR is merged

Worksheet metadata does get updated after an analysis is unassigned

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
