### PR TITLE
Allow analyst to set results (by using save button)

### DIFF
--- a/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
@@ -10,17 +10,21 @@
 
   <permission>BIKA: Assign analyses</permission>
   <permission>BIKA: Unassign analyses</permission>
-  <permission>BIKA: Edit Field Results</permission>
-  <permission>BIKA: Edit Results</permission>
   <permission>BIKA: Retract</permission>
   <permission>BIKA: Verify</permission>
   <permission>BIKA: View Results</permission>
   <permission>Reject</permission>
+  <permission>Modify portal content</permission>
+
   <!-- TODO Workflow - Analysis - Allowing only users with role "Review portal
   content" to access to workflow history may cause problems when functions
   "getReviewHistory", "wasTransitionPerformed" are used. These functions are
   needed in some guards and/or in rollback transitions. Double-check -->
   <permission>Review portal content</permission>
+
+  <!-- TODO Workflow - To remove in favour of Modify portal content -->
+  <permission>BIKA: Edit Field Results</permission>
+  <permission>BIKA: Edit Results</permission>
 
 
   <!-- State: unassigned (initial state)
@@ -33,6 +37,11 @@
     <exit-transition transition_id="submit"/>
     <exit-transition transition_id="reject" />
     <exit-transition transition_id="cancel" />
+    <permission-map name="Modify portal content" acquired="False">
+      <permission-role>Analyst</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
     <permission-map name="BIKA: Edit Field Results" acquired="False">
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
@@ -72,6 +81,11 @@
     <exit-transition transition_id="unassign" />
     <exit-transition transition_id="submit"/>
     <exit-transition transition_id="reject" />
+    <permission-map name="Modify portal content" acquired="False">
+      <permission-role>Analyst</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
     <permission-map name="BIKA: Edit Field Results" acquired="False">
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>

--- a/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
@@ -128,6 +128,8 @@
   Analyses can only be cancelled before results being submitted -->
   <state state_id="cancelled" title="Cancelled" i18n:attributes="title">
     <exit-transition transition_id="reinstate" />
+    <permission-map name="Modify portal content" acquired="False">
+    </permission-map>
     <permission-map name="BIKA: View Results" acquired="False">
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
@@ -147,6 +149,8 @@
     <exit-transition transition_id="attach"/>
     <exit-transition transition_id="retract"/>
     <exit-transition transition_id="reject" />
+    <permission-map name="Modify portal content" acquired="False">
+    </permission-map>
     <permission-map name="BIKA: Edit Field Results" acquired="False">
     </permission-map>
     <permission-map name="BIKA: Edit Results" acquired="False">
@@ -173,6 +177,8 @@
     <exit-transition transition_id="verify" />
     <exit-transition transition_id="retract" />
     <exit-transition transition_id="reject" />
+    <permission-map name="Modify portal content" acquired="False">
+    </permission-map>
     <permission-map name="BIKA: Edit Field Results" acquired="False">
     </permission-map>
     <permission-map name="BIKA: Edit Results" acquired="False">
@@ -205,6 +211,8 @@
   The analysis has been retracted and a retest has been created -->
   <state state_id="retracted" title="Retracted" i18n:attributes="title">
     <exit-transition transition_id="" />
+    <permission-map name="Modify portal content" acquired="False">
+    </permission-map>
     <permission-map name="BIKA: Edit Field Results" acquired="False">
     </permission-map>
     <permission-map name="BIKA: Edit Results" acquired="False">
@@ -227,6 +235,8 @@
   The analysis has been rejected and cannot be used anymore -->
   <state state_id="rejected" title="Rejected" i18n:attributes="title">
     <exit-transition transition_id="" />
+    <permission-map name="Modify portal content" acquired="False">
+    </permission-map>
     <permission-map name="BIKA: Edit Field Results" acquired="False">
     </permission-map>
     <permission-map name="BIKA: Edit Results" acquired="False">
@@ -272,6 +282,8 @@
   Analysis Request they belong to is published -->
   <state state_id="published" title="Published" i18n:attributes="title">
     <exit-transition transition_id="" />
+    <permission-map name="Modify portal content" acquired="False">
+    </permission-map>
     <permission-map name="BIKA: Edit Field Results" acquired="False">
     </permission-map>
     <permission-map name="BIKA: Edit Results" acquired="False">

--- a/bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
@@ -8,11 +8,14 @@
              i18n:domain="senaite.core">
 
   <permission>BIKA: Unassign analyses</permission>
-  <permission>BIKA: Edit Results</permission>
   <permission>BIKA: Retract</permission>
   <permission>BIKA: Verify</permission>
   <permission>BIKA: View Results</permission>
   <permission>Delete objects</permission>
+  <permission>Modify portal content</permission>
+
+  <!-- TODO Workflow - To remove in favour of "Modify portal content" -->
+  <permission>BIKA: Edit Results</permission>
 
 
   <!-- State: assigned (initial state)
@@ -22,6 +25,11 @@
   <state state_id="assigned" title="Assigned" i18n:attributes="title">
     <exit-transition transition_id="unassign" />
     <exit-transition transition_id="submit" />
+    <permission-map name="Modify portal content" acquired="False">
+      <permission-role>Analyst</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
     <permission-map name="BIKA: Edit Results" acquired="False">
       <permission-role>Analyst</permission-role>
       <permission-role>LabManager</permission-role>
@@ -49,6 +57,8 @@
   <state state_id="attachment_due" title="Attachment due" i18n:attributes="title">
     <exit-transition transition_id="attach" />
     <exit-transition transition_id="retract" />
+    <permission-map name="Modify portal content" acquired="False">
+    </permission-map>
     <permission-map name="BIKA: Edit Results" acquired="False">
     </permission-map>
     <permission-map name="BIKA: Retract" acquired="False">
@@ -84,6 +94,8 @@
     <exit-transition transition_id="multi_verify" />
     <exit-transition transition_id="verify" />
     <exit-transition transition_id="retract" />
+    <permission-map name="Modify portal content" acquired="False">
+    </permission-map>
     <permission-map name="BIKA: Edit Results" acquired="False">
     </permission-map>
     <permission-map name="BIKA: View Results" acquired="False">
@@ -121,6 +133,8 @@
   The duplicate analysis has been retracted and a retest has been created -->
   <state state_id="retracted" title="Retracted" i18n:attributes="title">
     <exit-transition transition_id="" />
+    <permission-map name="Modify portal content" acquired="False">
+    </permission-map>
     <permission-map name="BIKA: Edit Results" acquired="False">
     </permission-map>
     <permission-map name="BIKA: View Results" acquired="False">
@@ -139,6 +153,8 @@
     bounded in a Worksheet. Hence, we can unassign a duplicate once verified
     if its counterpart analysis can be unassigned. More info in guard. -->
     <exit-transition transition_id="unassign" />
+    <permission-map name="Modify portal content" acquired="False">
+    </permission-map>
     <permission-map name="BIKA: Edit Results" acquired="False">
     </permission-map>
     <permission-map name="BIKA: View Results" acquired="False">

--- a/bika/lims/profiles/default/workflows/bika_referenceanalysis_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_referenceanalysis_workflow/definition.xml
@@ -13,6 +13,10 @@
   <permission>BIKA: Verify</permission>
   <permission>BIKA: View Results</permission>
   <permission>Delete objects</permission>
+  <permission>Modify portal content</permission>
+
+  <!-- TODO Workflow - To remove in favour of "Modify portal content" -->
+  <permission>BIKA: Edit Results</permission>
 
   <!-- State: assigned (initial state)
   Reference analyses are assigned to a Worksheet or to an Instrument if is an
@@ -52,6 +56,8 @@
     <exit-transition transition_id="retract" />
     <exit-transition transition_id="reject" />
     <exit-transition transition_id="unassign" />
+    <permission-map name="Modify portal content" acquired="False">
+    </permission-map>
     <permission-map name="BIKA: Edit Results" acquired="False">
     </permission-map>
     <permission-map name="BIKA: Retract" acquired="False">
@@ -71,6 +77,8 @@
 
   <state state_id="rejected" title="Rejected" i18n:attributes="title">
     <exit-transition transition_id="" />
+    <permission-map name="Modify portal content" acquired="False">
+    </permission-map>
     <permission-map name="BIKA: Edit Results" acquired="False">
     </permission-map>
     <permission-map name="BIKA: View Results" acquired="False">
@@ -90,6 +98,8 @@
     <exit-transition transition_id="retract" />
     <exit-transition transition_id="reject" />
     <exit-transition transition_id="unassign" />
+    <permission-map name="Modify portal content" acquired="False">
+    </permission-map>
     <permission-map name="BIKA: Edit Results" acquired="False">
     </permission-map>
     <permission-map name="BIKA: View Results" acquired="False">
@@ -115,6 +125,8 @@
 
   <state state_id="verified" title="Verified" i18n:attributes="title">
     <exit-transition transition_id="unassign" />
+    <permission-map name="Modify portal content" acquired="False">
+    </permission-map>
     <permission-map name="BIKA: Edit Results" acquired="False">
     </permission-map>
     <permission-map name="BIKA: View Results" acquired="False">
@@ -130,6 +142,8 @@
   The reference analysis has been retracted and a retest has been created -->
   <state state_id="retracted" title="Retracted" i18n:attributes="title">
     <exit-transition transition_id="" />
+    <permission-map name="Modify portal content" acquired="False">
+    </permission-map>
     <permission-map name="BIKA: Edit Results" acquired="False">
     </permission-map>
     <permission-map name="BIKA: View Results" acquired="False">

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -654,82 +654,50 @@ def fix_cancelled_analyses_inconsistencies(portal):
 
 def get_role_mappings_candidates(portal):
     logger.info("Getting candidates for role mappings ...")
-
     candidates = list()
-    wf_tool = api.get_tool("portal_workflow")
-
     # Analysis workflow
-    workflow = wf_tool.getWorkflowById("bika_analysis_workflow")
-    if "BIKA: Verify" not in workflow.states.to_be_verified.permissions:
-        candidates.append(
-            ("bika_analysis_workflow",
-             dict(portal_type="Analysis",
-                  review_state=["to_be_verified", "sample_received"]),
-             CATALOG_ANALYSIS_LISTING))
-
-    # Analysis workflow: multi-verify transition
-    if "multi_verify" not in workflow.transitions:
-        candidates.append(
-            ("bika_analysis_workflow",
-             dict(portal_type="Analysis",
-                  review_state=["to_be_verified", "sample_received"]),
-             CATALOG_ANALYSIS_LISTING))
-
-    # Duplicate Analysis Workflow
-    workflow = wf_tool.getWorkflowById("bika_duplicateanalysis_workflow")
-    if "BIKA: Verify" not in workflow.states.to_be_verified.permissions:
-        candidates.append(
-            ("bika_duplicateanalysis_workflow",
-             dict(portal_type="DuplicateAnalysis",
-                  review_state=["to_be_verified", "sample_received"]),
-             CATALOG_ANALYSIS_LISTING))
-
-    # Duplicate Analysis Workflow: unasssigned
-    if "unassigned" in workflow.states:
-        candidates.append(
-            ("bika_duplicateanalysis_workflow",
-             dict(portal_type="DuplicateAnalysis",
-                  review_state=["to_be_verified", "sample_received"]),
-             CATALOG_ANALYSIS_LISTING))
-
-    # Duplicate Analysis workflow: multi-verify transition
-    if "multi_verify" not in workflow.transitions:
-        candidates.append(
-            ("bika_duplicateanalysis_workflow",
-             dict(portal_type="DuplicateAnalysis",
-                  review_state=["to_be_verified", "sample_received"]),
-             CATALOG_ANALYSIS_LISTING))
-
+    candidates.extend(get_rm_candidates_for_analysisworkfklow(portal))
+    # Duplicate analysis workflow
+    candidates.extend(get_rm_candidates_for_duplicateanalysisworkflow(portal))
     # Reference Analysis Workflow
-    workflow = wf_tool.getWorkflowById("bika_referenceanalysis_workflow")
-    if "BIKA: Verify" not in workflow.states.to_be_verified.permissions:
-        candidates.append(
-            ("bika_referenceanalysis_workflow",
-             dict(portal_type="ReferenceAnalysis",
-                  review_state=["to_be_verified", "sample_received"]),
-             CATALOG_ANALYSIS_LISTING))
+    candidates.extend(get_rm_candidates_for_referenceanalysisworkflow(portal))
+    # Analysis Request workflow
+    candidates.extend(get_rm_candidates_for_ar_workflow(portal))
+    # Worksheet workflow
+    candidates.extend(get_rm_candidates_for_worksheet_workflow(portal))
 
-    # Reference Analysis workflow: multi-verify transition
-    if "multi_verify" not in workflow.transitions:
-        candidates.append(
-            ("bika_referenceanalysis_workflow",
-             dict(portal_type="ReferenceAnalysis",
-                  review_state=["to_be_verified", "sample_received"]),
-             CATALOG_ANALYSIS_LISTING))
+    return candidates
 
-    # Reference Analysis Workflow: unasssigned
-    if "unassigned" in workflow.states:
+
+def get_workflow_by_id(portal, workflow_id):
+    wf_tool = api.get_tool("portal_workflow")
+    return wf_tool.getWorkflowById(workflow_id)
+
+
+def get_rm_candidates_for_worksheet_workflow(portal):
+    wf_id = "bika_worksheet_workflow"
+    logger.info("Getting candidates for role mappings: {} ...".format(wf_id))
+    workflow = get_workflow_by_id(portal, wf_id)
+    candidates = list()
+    if "rollback_to_open" not in workflow.transitions:
         candidates.append(
-            ("bika_referenceanalysis_workflow",
-             dict(portal_type="ReferenceAnalysis",
-                  review_state=["to_be_verified", "sample_received"]),
-             CATALOG_ANALYSIS_LISTING))
+            ("bika_worksheet_workflow",
+             dict(portal_type="Worksheet",
+                  review_state=["to_be_verified"]),
+             CATALOG_WORKSHEET_LISTING))
+    return candidates
+
+
+def get_rm_candidates_for_ar_workflow(portal):
+    wf_id = "bika_ar_workflow"
+    logger.info("Getting candidates for role mappings: {} ...".format(wf_id))
+    workflow = get_workflow_by_id(portal, wf_id)
+    candidates = list()
 
     # Analysis Request workflow: rollback_to_receive
-    workflow = wf_tool.getWorkflowById("bika_ar_workflow")
     if "rollback_to_receive" not in workflow.transitions:
         candidates.append(
-            ("bika_ar_workflow",
+            (wf_id,
              dict(portal_type="AnalysisRequest",
                   review_state=["to_be_verified"]),
              CATALOG_ANALYSIS_REQUEST_LISTING))
@@ -737,22 +705,135 @@ def get_role_mappings_candidates(portal):
     # Analysis Request workflow: cancel permissions - do not allow cancel
     # transition from attachment_due and to_be_verified states
     candidates.append(
-        ("bika_ar_workflow",
+        (wf_id,
         dict(portal_type="AnalysisRequest",
              review_state=["attachment_due", "to_be_verified"]),
              CATALOG_ANALYSIS_REQUEST_LISTING))
-
-    # Worksheet workflow: rollback_to_open
-    workflow = wf_tool.getWorkflowById("bika_worksheet_workflow")
-    if "rollback_to_open" not in workflow.transitions:
-        candidates.append(
-            ("bika_worksheet_workflow",
-             dict(portal_type="Worksheet",
-                  review_state=["to_be_verified"]),
-             CATALOG_WORKSHEET_LISTING))
-
     return candidates
 
+
+def get_rm_candidates_for_referenceanalysisworkflow(portal):
+    wf_id = "bika_referenceanalysis_workflow"
+    logger.info("Getting candidates for role mappings: {} ...".format(wf_id))
+    workflow = get_workflow_by_id(portal, wf_id)
+    candidates = list()
+    if "BIKA: Verify" not in workflow.states.to_be_verified.permissions:
+        candidates.append(
+            (wf_id,
+             dict(portal_type="ReferenceAnalysis",
+                  review_state=["to_be_verified", "sample_received"]),
+             CATALOG_ANALYSIS_LISTING))
+
+    # Reference Analysis workflow: multi-verify transition
+    if "multi_verify" not in workflow.transitions:
+        candidates.append(
+            (wf_id,
+             dict(portal_type="ReferenceAnalysis",
+                  review_state=["to_be_verified", "sample_received"]),
+             CATALOG_ANALYSIS_LISTING))
+
+    # Reference Analysis Workflow: unasssigned
+    if "unassigned" in workflow.states:
+        candidates.append(
+            (wf_id,
+             dict(portal_type="ReferenceAnalysis",
+                  review_state=["to_be_verified", "sample_received"]),
+             CATALOG_ANALYSIS_LISTING))
+
+    # "Modify portal content" for "unassigned"
+    if "Modify portal content" not in workflow.states.unassigned.permissions:
+        candidates.append(
+            (wf_id,
+             dict(portal_type="ReferenceAnalysis",
+                  review_state=["unassigned", "assigned"]),
+             CATALOG_ANALYSIS_LISTING))
+
+    # "Modify portal content" for "assigned"
+    if "Modify portal content" not in workflow.states.assigned.permissions:
+        candidates.append(
+            (wf_id,
+             dict(portal_type="ReferenceAnalysis",
+                  review_state=["assigned"]),
+             CATALOG_ANALYSIS_LISTING))
+    return candidates
+
+
+def get_rm_candidates_for_duplicateanalysisworkflow(portal):
+    wf_id = "bika_duplicateanalysis_workflow"
+    logger.info("Getting candidates for role mappings: {} ...".format(wf_id))
+    workflow = get_workflow_by_id(portal, wf_id)
+
+    candidates = list()
+    if "BIKA: Verify" not in workflow.states.to_be_verified.permissions:
+        candidates.append(
+            (wf_id,
+             dict(portal_type="DuplicateAnalysis",
+                  review_state=["to_be_verified", "sample_received"]),
+             CATALOG_ANALYSIS_LISTING))
+
+    # Duplicate Analysis Workflow: unasssigned
+    if "unassigned" in workflow.states:
+        candidates.append(
+            (wf_id,
+             dict(portal_type="DuplicateAnalysis",
+                  review_state=["to_be_verified", "sample_received"]),
+             CATALOG_ANALYSIS_LISTING))
+
+    # Analysis workflow: "Modify portal content" for "assigned"
+    if "Modify portal content" not in workflow.states.assigned.permissions:
+        candidates.append(
+            (wf_id,
+             dict(portal_type="DuplicateAnalysis",
+                  review_state=["assigned"]),
+             CATALOG_ANALYSIS_LISTING))
+
+    # Duplicate Analysis workflow: multi-verify transition
+    if "multi_verify" not in workflow.transitions:
+        candidates.append(
+            (wf_id,
+             dict(portal_type="DuplicateAnalysis",
+                  review_state=["to_be_verified", "sample_received"]),
+             CATALOG_ANALYSIS_LISTING))
+    return candidates
+
+
+def get_rm_candidates_for_analysisworkfklow(portal):
+    wf_id = "bika_analysis_workflow"
+    logger.info("Getting candidates for role mappings: {} ...".format(wf_id))
+    workflow = get_workflow_by_id(portal, wf_id)
+
+    candidates = list()
+    if "BIKA: Verify" not in workflow.states.to_be_verified.permissions:
+        candidates.append(
+            (wf_id,
+             dict(portal_type="Analysis",
+                  review_state=["to_be_verified", "sample_received"]),
+             CATALOG_ANALYSIS_LISTING))
+
+    # Analysis workflow: multi-verify transition
+    if "multi_verify" not in workflow.transitions:
+        candidates.append(
+            (wf_id,
+             dict(portal_type="Analysis",
+                  review_state=["to_be_verified", "sample_received"]),
+             CATALOG_ANALYSIS_LISTING))
+
+    # Analysis workflow: "Modify portal content" for "unassigned"
+    if "Modify portal content" not in workflow.states.unassigned.permissions:
+        candidates.append(
+            (wf_id,
+             dict(portal_type="Analysis",
+                  review_state=["unassigned", "assigned"]),
+             CATALOG_ANALYSIS_LISTING))
+
+    # Analysis workflow: "Modify portal content" for "assigned"
+    if "Modify portal content" not in workflow.states.assigned.permissions:
+        candidates.append(
+            (wf_id,
+             dict(portal_type="Analysis",
+                  review_state=["assigned"]),
+             CATALOG_ANALYSIS_LISTING))
+    return candidates
 
 def decouple_analyses_from_sample_workflow(portal):
     logger.info("Decoupling analyses from sample workflow ...")

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -745,7 +745,7 @@ def get_rm_candidates_for_referenceanalysisworkflow(portal):
         candidates.append(
             (wf_id,
              dict(portal_type="ReferenceAnalysis",
-                  review_state=["unassigned", "assigned"]),
+                  review_state=["unassigned"]),
              CATALOG_ANALYSIS_LISTING))
 
     # "Modify portal content" for "assigned"
@@ -823,7 +823,7 @@ def get_rm_candidates_for_analysisworkfklow(portal):
         candidates.append(
             (wf_id,
              dict(portal_type="Analysis",
-                  review_state=["unassigned", "assigned"]),
+                  review_state=["unassigned"]),
              CATALOG_ANALYSIS_LISTING))
 
     # Analysis workflow: "Modify portal content" for "assigned"

--- a/bika/lims/workflow/__init__.py
+++ b/bika/lims/workflow/__init__.py
@@ -299,13 +299,10 @@ def getReviewHistory(instance):
     review_history = []
     workflow = getToolByName(instance, 'portal_workflow')
     try:
-        # https://jira.bikalabs.com/browse/LIMS-2242:
-        # Sometimes the workflow history is inexplicably missing!
         review_history = list(workflow.getInfoFor(instance, 'review_history'))
     except WorkflowException:
-        logger.error(
-            "workflow history is inexplicably missing."
-            " https://jira.bikalabs.com/browse/LIMS-2242")
+        logger.error("Unable to retrieve review history from {}:{}"
+                     .format(instance.portal_type, instance.getId()))
     # invert the list, so we always see the most recent matching event
     review_history.reverse()
     return review_history


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Workflows for analyses have become more restrictive because of the changes done recently as a huge effort that, amongst other objectives, was meant to improve security and audit for all analyses transitions and modifications. Before these improvements, the submission of results was not strictly binded to permissions and privileges. With this PR, we define where the permission "Modify portal content" takes effect and which roles has this permission granted. As a result, analyses can only be edited in `unassigned` and `assigned` states and only the following roles are allowed to do so:  `LabManager`, `Manager` and `Analyst`.

## Current behavior before PR

Analyst was not able to save results

## Desired behavior after PR is merged

Analyst can save results in `unassigned` and `assigned` states

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
