### PR TITLE
Traceback in upgrade step 1.3.0 when getting role mappings candidates

### DIFF
--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -743,14 +743,6 @@ def get_rm_candidates_for_referenceanalysisworkflow(portal):
                   review_state=["to_be_verified", "sample_received"]),
              CATALOG_ANALYSIS_LISTING))
 
-    # "Modify portal content" for "unassigned"
-    if "Modify portal content" not in workflow.states.unassigned.permissions:
-        candidates.append(
-            (wf_id,
-             dict(portal_type="ReferenceAnalysis",
-                  review_state=["unassigned"]),
-             CATALOG_ANALYSIS_LISTING))
-
     # "Modify portal content" for "assigned"
     if "Modify portal content" not in workflow.states.assigned.permissions:
         candidates.append(


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Reference Analysis' workflow does not have an `unassigned` state. When transition `unassigned` takes  place for a reference analysis, it is removed because it does not make sense for a reference analysis to exist if does not belong to neither a Worksheet (regular QC test) nor an Instrument (internal calibration test). The upgrade step was assuming reference analysis had an `unassigned` state.

This Pull Request fixes the following Traceback:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.GenericSetup.tool, line 1053, in manage_doUpgrades
  Module Products.GenericSetup.upgrade, line 166, in doStep
  Module bika.lims.upgrade, line 55, in wrap_func_args
  Module bika.lims.upgrade.v01_03_000, line 101, in upgrade
  Module bika.lims.upgrade.v01_03_000, line 431, in update_workflows
  Module bika.lims.upgrade.v01_03_000, line 668, in get_role_mappings_candidates
  Module bika.lims.upgrade.v01_03_000, line 749, in get_rm_candidates_for_referenceanalysisworkflow
AttributeError: unassigned
```

## Current behavior before PR

Traceback is rised when upgrade step 1.3.0 is run

## Desired behavior after PR is merged

Senaite gets updated to 1.3.0 without traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
