### PR TITLE
Listing: Handle visibility of selected rows

### DIFF
--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -45,7 +45,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
         self.show_select_column = True
         self.show_select_all_checkbox = False
         self.pagesize = 999999
-        self.show_search = False
+        self.show_search = True
         self.fetch_transitions_on_select = False
 
         self.categories = []

--- a/bika/lims/browser/listing/src/components/Checkbox.coffee
+++ b/bika/lims/browser/listing/src/components/Checkbox.coffee
@@ -17,18 +17,27 @@ class Checkbox extends React.Component
     if @props.onChange then @props.onChange event
 
   render: ->
-    <input key={@props.name}
-           type="checkbox"
-           uid={@props.uid}
-           name={@props.name}
-           value={@props.value}
-           column_key={@props.column_key}
-           title={@props.title}
-           disabled={@props.disabled}
-           checked={@props.checked}
-           defaultChecked={@props.defaultChecked}
-           className={@props.className}
-           onChange={@on_change}/>
+    field = []
+    field.push (
+      <input key={@props.name}
+             type="checkbox"
+             uid={@props.uid}
+             name={@props.name}
+             value={@props.value}
+             column_key={@props.column_key}
+             title={@props.title}
+             disabled={@props.disabled}
+             checked={@props.checked}
+             defaultChecked={@props.defaultChecked}
+             className={@props.className}
+             onChange={@on_change}/>)
+    if @props.render_hidden
+      field.push(
+        <input key={@props.name + "_hidden"}
+               type="hidden"
+               name={@props.name}
+               value={@props.value}/>)
+    return field
 
 
 export default Checkbox

--- a/bika/lims/browser/listing/src/components/TableCells.coffee
+++ b/bika/lims/browser/listing/src/components/TableCells.coffee
@@ -52,7 +52,7 @@ class TableCells extends React.Component
             name={checkbox_name}
             value={uid}
             disabled={disabled}
-            render_hidden={disabled}
+            render_hidden={disabled}  # render a hidden field when the row is disabled
             checked={selected}
             onChange={@props.on_select_checkbox_checked}/>
         </td>)

--- a/bika/lims/browser/listing/src/components/TableCells.coffee
+++ b/bika/lims/browser/listing/src/components/TableCells.coffee
@@ -52,6 +52,7 @@ class TableCells extends React.Component
             name={checkbox_name}
             value={uid}
             disabled={disabled}
+            render_hidden={disabled}
             checked={selected}
             onChange={@props.on_select_checkbox_checked}/>
         </td>)

--- a/bika/lims/browser/listing/src/components/TableRow.coffee
+++ b/bika/lims/browser/listing/src/components/TableRow.coffee
@@ -7,21 +7,10 @@ class TableRow extends React.Component
   constructor: (props) ->
     super(props)
 
-  is_category_expanded: ->
-    category = @props.category
-    if not category
-      return yes
-    return category in @props.expanded_categories
-
-  is_visible: ->
-    if not @is_category_expanded()
-      return no
-    return yes
-
   render: ->
     <tr className={@props.className}
         onClick={@props.onClick}
-        style={{display: if @is_visible() then "table-row" else "none"}}
+        category={@props.category}
         uid={@props.uid}>
       <TableCells {...@props}/>
     </tr>

--- a/bika/lims/browser/listing/src/components/TableRow.coffee
+++ b/bika/lims/browser/listing/src/components/TableRow.coffee
@@ -7,9 +7,21 @@ class TableRow extends React.Component
   constructor: (props) ->
     super(props)
 
+  is_category_expanded: ->
+    category = @props.category
+    if not category
+      return yes
+    return category in @props.expanded_categories
+
+  is_visible: ->
+    if not @is_category_expanded()
+      return no
+    return yes
+
   render: ->
     <tr className={@props.className}
         onClick={@props.onClick}
+        style={{display: if @is_visible() then "table-row" else "none"}}
         uid={@props.uid}>
       <TableCells {...@props}/>
     </tr>

--- a/bika/lims/browser/listing/src/components/TableRows.coffee
+++ b/bika/lims/browser/listing/src/components/TableRows.coffee
@@ -105,10 +105,8 @@ class TableRows extends React.Component
             expanded={expanded}
             className="categoryrow"
             />)
-        # append expanded rows
-        if expanded
-          content_rows = @build_rows category: category
-          rows = rows.concat content_rows
+        content_rows = @build_rows category: category
+        rows = rows.concat content_rows
     # Render uncatgorized rows
     else
       rows = @build_rows()
@@ -148,6 +146,7 @@ class TableRows extends React.Component
           key={uid}
           item={item}
           uid={uid}
+          category={category}
           expanded={expanded}
           selected={selected}
           disabled={disabled}

--- a/bika/lims/browser/listing/src/components/TableRows.coffee
+++ b/bika/lims/browser/listing/src/components/TableRows.coffee
@@ -105,25 +105,32 @@ class TableRows extends React.Component
             expanded={expanded}
             className="categoryrow"
             />)
-        content_rows = @build_rows category: category
-        rows = rows.concat content_rows
+        # concatenate the categorized rows in the right order
+        rows = rows.concat @build_rows
+          props: {category: category}
     # Render uncatgorized rows
     else
       rows = @build_rows()
 
     return rows
 
-  build_rows: ({category, folderitems} = {}) ->
+  build_rows: ({props}={}) ->
     rows = []
 
-    category ?= null
-    folderitems ?= @props.folderitems
+    props ?= {}
+    category = props.category or null
+    folderitems = props.folderitems or @props.folderitems
 
     for item, item_index in folderitems
 
       # skip items of other categories
       if category and @get_item_category(item) != category
         continue
+
+      # skip items in collapsed categories except the selected ones
+      if category and not @is_category_expanded category
+        if not @is_selected item
+          continue
 
       uid = @get_item_uid item
       css = @get_item_css item
@@ -179,7 +186,10 @@ class TableRows extends React.Component
         # use the global children mapping to get the lazy fetched folderitem
         children = @get_children item
         if children.length > 0
-          child_rows = @build_rows folderitems: children
+          child_rows = @build_rows
+            props:
+              category: category
+              folderitems: children
           rows = rows.concat child_rows
 
     return rows

--- a/bika/lims/browser/listing/src/listing.coffee
+++ b/bika/lims/browser/listing/src/listing.coffee
@@ -362,21 +362,6 @@ class ListingController extends React.Component
     # Override the form action when a custom URL is given
     if url then form.action = url
 
-    # TODO
-    # Inject all hidden input fields for UIDs that are currently not in the DOM.
-    # This happens when an item was selected and then the results were filtered,
-    # e.g. by a searchbox search. However, eventually set field values of the
-    # selected items get lost. Therefore, this needs to get refactored soon.
-    for uid in @state.selected_uids
-      # skip injection if the element is currently in the DOM
-      if document.querySelectorAll("input[value='#{uid}']:not([disabled])").length > 0
-        continue
-      input = document.createElement "input"
-      input.setAttribute "type", "hidden"
-      input.setAttribute "name", "#{@state.select_checkbox_name}:list"
-      input.setAttribute "value", uid
-      form.appendChild input
-
     return form.submit()
 
   selectUID: (uid, toggle) ->

--- a/bika/lims/browser/listing/src/listing.coffee
+++ b/bika/lims/browser/listing/src/listing.coffee
@@ -576,8 +576,10 @@ class ListingController extends React.Component
     ###
     folderitems ?= @state.folderitems
     mapping = {}
-    folderitems.map (item) ->
-      mapping[item.uid] = item
+    folderitems.map (item, index) ->
+      # transposed cells do not have an uid, so we use the index instead
+      uid = item.uid or index
+      mapping[uid] = item
     return mapping
 
   get_item_count: ->

--- a/bika/lims/browser/listing/src/listing.coffee
+++ b/bika/lims/browser/listing/src/listing.coffee
@@ -568,26 +568,15 @@ class ListingController extends React.Component
     if @state.filter
       return [].concat @state.categories
 
-    # no categories are expanded if no items are selected
-    if not @state.selected_uids
-      return []
+    return []
 
-    categories = []
-    for folderitem in @state.folderitems
-      # item is selected, get the category
-      if folderitem.uid in @state.selected_uids
-        category = folderitem.category
-        if category not in categories
-          categories.push category
-
-    return categories
-
-  get_folderitems_by_uid: ->
+  get_folderitems_by_uid: (folderitems) ->
     ###
      * Create a mapping of UID -> folderitem
     ###
+    folderitems ?= @state.folderitems
     mapping = {}
-    @state.folderitems.map (item) ->
+    folderitems.map (item) ->
       mapping[item.uid] = item
     return mapping
 
@@ -651,6 +640,40 @@ class ListingController extends React.Component
     me = this
     promise.then (data) ->
       console.debug "ListingController::fetch_folderitems: GOT RESPONSE=", data
+
+      # N.B. Always keep selected folderitems, because otherwise modified fields
+      #      won't get send to the server on form submit
+      #
+      # TODO refactor this logic
+      # -------------------------------8<--------------------------------------
+      # existing folderitems from the state as a UID -> folderitem mapping
+      existing_folderitems = me.get_folderitems_by_uid me.state.folderitems
+      # new folderitems from the server as a UID -> folderitem mapping
+      new_folderitems = me.get_folderitems_by_uid data.folderitems
+      # new categories from the server
+      new_categories = data.categories or []
+
+      # keep selected and potentially modified folderitems in the table
+      for uid in me.state.selected_uids
+        # inject missing folderitems into the server sent folderitems
+        if uid not of new_folderitems
+          # get the missing folderitem from the current state
+          folderitem = existing_folderitems[uid]
+          # inject it to the new folderitems list from the server
+          new_folderitems[uid] = existing_folderitems[uid]
+          # also append the category if it is missing
+          category = folderitem.category
+          if category and category not in new_categories
+            new_categories.push category
+            # unfortunately any sortKey sorting of the category get lost here
+            new_categories.sort()
+
+      # write back new categories
+      data.categories = new_categories
+      # write back new folderitems
+      data.folderitems = Object.values new_folderitems
+      # -------------------------------->8-------------------------------------
+
       if items_only
         data = {"folderitems": data.folderitems}
       me.setState data, ->
@@ -661,25 +684,6 @@ class ListingController extends React.Component
           console.debug "ListingController::fetch_folderitems: NEW STATE=", me.state
         # turn loader off
         me.toggle_loader off
-
-    return promise
-
-  fetch_folderitems_by_query: (query) ->
-    ###
-     * Fetch the folderitems with the given catalog query
-    ###
-
-    # turn loader on
-    @toggle_loader on
-
-    # fetch the folderitems from the server
-    promise = @api.query_folderitems query
-
-    me = this
-    promise.then (data) ->
-      console.debug "ListingController::query_folderitems: GOT RESPONSE=", data
-      # turn loader off
-      me.toggle_loader off
 
     return promise
 

--- a/bika/lims/browser/listing/src/listing.css
+++ b/bika/lims/browser/listing/src/listing.css
@@ -40,6 +40,11 @@
 .ajax-contents-table td.result.state-invalid { border-left:2px solid #e65100 !important; }
 .ajax-contents-table tr.state-invalid:hover { background-color: rgba(244, 67, 54, 0.2); }
 
+/* state rejected */
+.ajax-contents-table tr.state-rejected { border-left:2px solid #ddd; }
+.ajax-contents-table td.result.state-rejected { border-left:2px solid transparent; }
+.ajax-contents-table tr.state-invalid:hover { background-color: #ddd; }
+
 /* state assigned */
 .ajax-contents-table tr.state-assigned { border-left:2px solid #ddd; }
 .ajax-contents-table td.result.state-assigned { border-left:2px solid transparent; }

--- a/bika/lims/browser/listing/src/listing.css
+++ b/bika/lims/browser/listing/src/listing.css
@@ -78,7 +78,7 @@
 .ajax-contents-table th.active.descending span:after { content: "▼"; margin-left: 0.5em; }
 
 /* category */
-.ajax-contents-table tr.categoryrow { background-color: rgba(96, 125, 139, 0.1)!important; cursor: pointer; font-weight: bold; font-size: 115%; color: #3E4551; background-color: #fcf8e3; }
+.ajax-contents-table tr.categoryrow { border-left: none; background-color: rgba(96, 125, 139, 0.1)!important; cursor: pointer; font-weight: bold; font-size: 115%; color: #3E4551; }
 
 /* table load mask */
 #table-overlay {

--- a/bika/lims/browser/widgets/analysisprofileanalyseswidget.py
+++ b/bika/lims/browser/widgets/analysisprofileanalyseswidget.py
@@ -41,7 +41,7 @@ class AnalysisProfileAnalysesView(BikaListingView):
         self.show_select_all_checkbox = False
         self.pagesize = 999999
         self.allow_edit = True
-        self.show_search = False
+        self.show_search = True
         self.omit_form = True
         self.fetch_transitions_on_select = False
 

--- a/bika/lims/browser/widgets/analysisspecificationwidget.py
+++ b/bika/lims/browser/widgets/analysisspecificationwidget.py
@@ -42,7 +42,7 @@ class AnalysisSpecificationView(BikaListingView):
         self.show_select_all_checkbox = False
         self.pagesize = 999999
         self.allow_edit = True
-        self.show_search = False
+        self.show_search = True
         self.omit_form = True
         self.fetch_transitions_on_select = False
 

--- a/bika/lims/browser/widgets/artemplateanalyseswidget.py
+++ b/bika/lims/browser/widgets/artemplateanalyseswidget.py
@@ -42,7 +42,7 @@ class ARTemplateAnalysesView(BikaListingView):
         self.show_select_all_checkbox = False
         self.pagesize = 999999
         self.allow_edit = True
-        self.show_search = False
+        self.show_search = True
         self.omit_form = True
         self.fetch_transitions_on_select = False
 

--- a/bika/lims/browser/widgets/serviceswidget.py
+++ b/bika/lims/browser/widgets/serviceswidget.py
@@ -49,8 +49,7 @@ class ServicesView(BikaListingView):
         self.show_select_all_checkbox = False
         self.pagesize = 999999
         self.allow_edit = True
-        # remove the searchbox
-        self.show_search = False
+        self.show_search = True
         # omit the outer form
         self.omit_form = True
         # no need to fetch the allowed transitions on select


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR avoids the removal of selected rows from the DOM if e.g. the category was collapsed or the user filtered the list through the searchbox

## Current behavior before PR

Selected rows were removed from the DOM and modified fields got lost

## Desired behavior after PR is merged

Selected rows are always kept visible, no matter if the row was collapsed or filtered

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
