### PR TITLE
Traceback when invalidating an Analysis Request with retracted analyses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,7 @@ Changelog
 
 **Fixed**
 
+- #1124 Traceback when invalidating an Analysis Request with retracted analyses
 - #1090 Primary AR does not recognize created Partitions
 - #1089 Deepcopy Service Interims to Analyses
 - #1082 Worksheet folder listing fixtures for direct analyst assignment

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -32,7 +32,6 @@ from bika.lims.workflow import doActionFor, ActionHandlerPool, \
 from bika.lims.workflow import doActionsFor
 from bika.lims.workflow import getReviewHistoryActionsList
 from email.Utils import formataddr
-from plone import api as plone_api
 
 
 def create_analysisrequest(client, request, values, analyses=None,
@@ -279,7 +278,7 @@ def _resolve_items_to_service_uids(items):
             continue
 
         # Maybe object UID.
-        portal = portal if portal else plone_api.portal.get()
+        portal = portal if portal else api.get_portal()
         bsc = bsc if bsc else getToolByName(portal, 'bika_setup_catalog')
         brains = bsc(UID=item)
         if brains:

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -13,6 +13,7 @@ from email.mime.text import MIMEText
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import _createObjectByType
 from Products.CMFPlone.utils import safe_unicode
+from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
 from bika.lims.idserver import renameAfterCreation
@@ -31,7 +32,7 @@ from bika.lims.workflow import doActionFor, ActionHandlerPool, \
 from bika.lims.workflow import doActionsFor
 from bika.lims.workflow import getReviewHistoryActionsList
 from email.Utils import formataddr
-from plone import api
+from plone import api as plone_api
 
 
 def create_analysisrequest(client, request, values, analyses=None,
@@ -278,7 +279,7 @@ def _resolve_items_to_service_uids(items):
             continue
 
         # Maybe object UID.
-        portal = portal if portal else api.portal.get()
+        portal = portal if portal else plone_api.portal.get()
         bsc = bsc if bsc else getToolByName(portal, 'bika_setup_catalog')
         brains = bsc(UID=item)
         if brains:

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -422,9 +422,9 @@ def create_retest(ar):
     renameAfterCreation(retest)
 
     # 2. Copy the analyses from the source
-    intermediate_statuses = ['retracted', 'reflexed']
+    intermediate_states = ['retracted', 'reflexed']
     for an in ar.getAnalyses(full_objects=True):
-        if (api.get_workflow_status_of(an) in intermediate_statuses):
+        if (api.get_workflow_status_of(an) in intermediate_states):
             # Exclude intermediate analyses
             continue
 

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -421,8 +421,12 @@ def create_retest(ar):
     renameAfterCreation(retest)
 
     # 2. Copy the analyses from the source
-    criteria = dict(full_objects=True, retracted=False, reflexed=False)
-    for an in ar.getAnalyses(**criteria):
+    intermediate_statuses = ['retracted', 'reflexed']
+    for an in ar.getAnalyses(full_objects=True):
+        if (api.get_workflow_status_of(an) in intermediate_statuses):
+            # Exclude intermediate analyses
+            continue
+
         nan = _createObjectByType("Analysis", retest, an.getKeyword())
 
         # Make a copy


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The ARAnalysesField` does not longer support `retracted` and `reflexed` variables. Maybe does in future.

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.analysisrequest.workflow, line 57, in __call__
  Module bika.lims.browser.analysisrequest.workflow, line 386, in workflow_action_invalidate
  Module bika.lims.api, line 944, in do_transition_for
  Module plone.api.content, line 2, in transition
  Module plone.api.validation, line 77, in wrapped
  Module plone.api.content, line 2, in transition
  Module plone.api.validation, line 149, in wrapped
  Module plone.api.content, line 2, in transition
  Module plone.api.validation, line 112, in wrapped
  Module plone.api.content, line 485, in transition
  Module Products.CMFCore.WorkflowTool, line 241, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 552, in _invokeWithNotification
  Module Products.DCWorkflow.DCWorkflow, line 282, in doActionFor
  Module Products.DCWorkflow.DCWorkflow, line 421, in _changeStateOf
  Module Products.DCWorkflow.DCWorkflow, line 531, in _executeTransition
  Module zope.event, line 31, in notify
  Module zope.component.event, line 24, in dispatch
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module zope.component.event, line 32, in objectEventNotify
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module bika.lims.workflow, line 186, in AfterTransitionEventHandler
  Module bika.lims.workflow, line 161, in call_workflow_event
  Module bika.lims.workflow.analysisrequest.events, line 160, in after_invalidate
  Module bika.lims.utils.analysisrequest, line 426, in create_retest
  Module Products.CMFPlone.utils, line 340, in _createObjectByType
  Module Products.CMFCore.TypesTool, line 552, in _constructInstance
  Module bika.lims.content.analysis, line 4, in addAnalysis
  Module OFS.ObjectManager, line 325, in _setObject
  Module Products.CMFCore.PortalFolder, line 310, in _checkId
  Module OFS.ObjectManager, line 116, in checkValidId
BadRequest: The id "Optik_AAB003-22" is invalid - it is already in use.
```

## Desired behavior after PR is merged

Analysis Request is transitioned to `invalid` state and a retest is created automatically without Traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
