### PR TITLE
Add AR's rollback to receive after verified analysis retraction

### DIFF
--- a/bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
@@ -870,6 +870,7 @@
   <state state_id="verified" title="Verified" i18n:attributes="title">
     <exit-transition transition_id="publish" />
     <exit-transition transition_id="invalidate" />
+    <exit-transition transition_id="rollback_to_receive" />
     <permission-map name="BIKA: Add Analysis" acquired="False">
     </permission-map>
     <permission-map name="BIKA: Add Attachment" acquired="False">

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -720,8 +720,7 @@ def get_rm_candidates_for_ar_workflow(portal):
         (wf_id,
          dict(portal_type="AnalysisRequest",
               review_state=["verified"]),
-         CATALOG_ANALYSIS_REQUEST_LISTING)
-    )
+         CATALOG_ANALYSIS_REQUEST_LISTING))
     return candidates
 
 
@@ -845,8 +844,7 @@ def get_rm_candidates_for_analysisworkfklow(portal):
         (wf_id,
          dict(portal_type="Analysis",
               review_state=["verified"]),
-         CATALOG_ANALYSIS_REQUEST_LISTING)
-    )
+         CATALOG_ANALYSIS_LISTING))
     return candidates
 
 

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -714,6 +714,14 @@ def get_rm_candidates_for_ar_workflow(portal):
         dict(portal_type="AnalysisRequest",
              review_state=["attachment_due", "to_be_verified"]),
              CATALOG_ANALYSIS_REQUEST_LISTING))
+
+    # To ensure the rollback_to_receive is possible from a verified state
+    candidates.append(
+        (wf_id,
+         dict(portal_type="AnalysisRequest",
+              review_state=["verified"]),
+         CATALOG_ANALYSIS_REQUEST_LISTING)
+    )
     return candidates
 
 
@@ -830,6 +838,15 @@ def get_rm_candidates_for_analysisworkfklow(portal):
              dict(portal_type="Analysis",
                   review_state=["assigned"]),
              CATALOG_ANALYSIS_LISTING))
+
+
+    # Just in case (some buddies use 'retract' in 'verified' state)
+    candidates.append(
+        (wf_id,
+         dict(portal_type="Analysis",
+              review_state=["verified"]),
+         CATALOG_ANALYSIS_REQUEST_LISTING)
+    )
     return candidates
 
 

--- a/bika/lims/workflow/analysis/events.py
+++ b/bika/lims/workflow/analysis/events.py
@@ -135,6 +135,11 @@ def after_retract(analysis):
     # Retract our dependents (analyses that depend on this analysis)
     cascade_to_dependents(analysis, "retract")
 
+    # Try to rollback the Analysis Request (all analyses rejected)
+    if IRequestAnalysis.providedBy(analysis):
+        doActionFor(analysis.getRequest(), "rollback_to_receive")
+        reindex_request(analysis)
+
 
 def after_reject(analysis):
     """Function triggered after the "reject" transition for the analysis passed

--- a/bika/lims/workflow/analysis/events.py
+++ b/bika/lims/workflow/analysis/events.py
@@ -135,7 +135,7 @@ def after_retract(analysis):
     # Retract our dependents (analyses that depend on this analysis)
     cascade_to_dependents(analysis, "retract")
 
-    # Try to rollback the Analysis Request (all analyses rejected)
+    # Try to rollback the Analysis Request
     if IRequestAnalysis.providedBy(analysis):
         doActionFor(analysis.getRequest(), "rollback_to_receive")
         reindex_request(analysis)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

By default, Senaite does not allow the retraction of verified analyses, but is quite common this restriction to be removed in custom add-ons. This commit adds the rollback of Analysis Request to `recieved` status by default when the transition takes place, so only adding the exit transition `retract` in analysis workflow for verified state,in custom add-ons should be enough for this to work:

In `analysis_workflow`:
```xml
<state state_id="verified" title="Verified" i18n:attributes="title">
    <exit-transition transition_id="publish" />
    <exit-transition transition_id="retract" />
    ...
</state>
```
This PR already takes care of updating the role mappings for:
- ARs that are in a verified state
- Analyses that are in a verified state

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
