### PR TITLE
Listing: Removed non-conform handling of disabled fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Changelog
 
 **Changed**
 
+- #1128 Listing: Removed non-conform handling of disabled fields
 - #1123 Listing: Handle visibility of selected rows
 - #1117 Removed `attachment_due` state and transition from analysis workflow
 - #1114 Listing integration for Worksheet Templates

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -262,8 +262,8 @@ class AnalysisRequestAnalysesView(BikaListingView):
             analysis = self.analyses[uid]
             # Might differ from the service keyword
             keyword = analysis.getKeyword()
-            # Mark the row as disabled if the analysis was submitted
-            item["disabled"] = self.is_submitted(analysis)
+            # Mark the row as disabled if the analysis is not in an open state
+            item["disabled"] = not analysis.isOpen()
             # get the hidden status of the analysis
             hidden = analysis.getHidden()
             # get the partition of the analysis

--- a/bika/lims/browser/analysisrequest/workflow.py
+++ b/bika/lims/browser/analysisrequest/workflow.py
@@ -182,12 +182,6 @@ class AnalysisRequestWorkflowAction(AnalysesWorkflowAction):
         ar = self.context
         sample = ar.getSample()
         objects = WorkflowAction._get_selected_items(self)
-        if not objects:
-            message = _("No analyses have been selected")
-            self.context.plone_utils.addPortalMessage(message, 'info')
-            self.destination_url = self.context.absolute_url() + "/analyses"
-            self.request.response.redirect(self.destination_url)
-            return
         Analyses = objects.keys()
         prices = form.get("Price", [None])[0]
 

--- a/bika/lims/browser/fields/aranalysesfield.py
+++ b/bika/lims/browser/fields/aranalysesfield.py
@@ -5,7 +5,6 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-import copy
 import itertools
 
 from AccessControl import ClassSecurityInfo
@@ -19,7 +18,6 @@ from bika.lims.interfaces import IAnalysis
 from bika.lims.interfaces import IAnalysisService
 from bika.lims.interfaces import IARAnalysesField
 from bika.lims.permissions import AddAnalysis
-from bika.lims.permissions import ViewRetractedAnalyses
 from bika.lims.utils.analysis import create_analysis
 from bika.lims.workflow import getReviewHistoryActionsList
 from Products.Archetypes.public import Field
@@ -87,7 +85,7 @@ class ARAnalysesField(ObjectField):
         :type items: list
         :param prices: Mapping of AnalysisService UID -> price
         :type prices: dict
-        :param specs: List of AnalysisService UID -> Result Range Record mappings
+        :param specs: List of AnalysisService UID -> Result Range mappings
         :type specs: list
         :returns: list of new assigned Analyses
         """
@@ -184,7 +182,8 @@ class ARAnalysesField(ObjectField):
                 # exist anymore
                 an_uid = api.get_uid(analysis)
                 part_ans = part.getAnalyses() or []
-                part_ans = filter(lambda an: api.get_uid(an) != an_uid, part_ans)
+                part_ans = filter(
+                    lambda an: api.get_uid(an) != an_uid, part_ans)
                 part.setAnalyses(part_ans)
             # Unset the Analysis-to-Partition reference
             analysis.setSamplePartition(None)
@@ -305,7 +304,7 @@ class ARAnalysesField(ObjectField):
 
     security.declarePublic('Vocabulary')
 
-    @deprecated("Please refactor, this method will be removed in senaite.core 1.5")
+    @deprecated("This method will be removed in senaite.core 1.3")
     def Vocabulary(self, content_instance=None):
         """Create a vocabulary from analysis services
         """
@@ -316,7 +315,7 @@ class ARAnalysesField(ObjectField):
 
     security.declarePublic('Services')
 
-    @deprecated("Please refactor, this method will be removed in senaite.core 1.5")
+    @deprecated("This method will be removed in senaite.core 1.3")
     def Services(self):
         """Fetch and return analysis service objects
         """

--- a/bika/lims/browser/listing/src/components/Checkbox.coffee
+++ b/bika/lims/browser/listing/src/components/Checkbox.coffee
@@ -12,32 +12,23 @@ class Checkbox extends React.Component
     el = event.currentTarget
     checked = el.checked
     console.debug "Checkbox::on_change: checked=#{checked}"
-
     # propagate event
     if @props.onChange then @props.onChange event
 
   render: ->
-    field = []
-    field.push (
-      <input key={@props.name}
-             type="checkbox"
-             uid={@props.uid}
-             name={@props.name}
-             value={@props.value}
-             column_key={@props.column_key}
-             title={@props.title}
-             disabled={@props.disabled}
-             checked={@props.checked}
-             defaultChecked={@props.defaultChecked}
-             className={@props.className}
-             onChange={@on_change}/>)
-    if @props.render_hidden
-      field.push(
-        <input key={@props.name + "_hidden"}
-               type="hidden"
-               name={@props.name}
-               value={@props.value}/>)
-    return field
+    <input key={@props.name}
+           type="checkbox"
+           uid={@props.uid}
+           name={@props.name}
+           value={@props.value}
+           column_key={@props.column_key}
+           title={@props.title}
+           disabled={@props.disabled}
+           checked={@props.checked}
+           defaultChecked={@props.defaultChecked}
+           className={@props.className}
+           onChange={@on_change}
+           {...@props.attrs}/>
 
 
 export default Checkbox

--- a/bika/lims/browser/listing/src/components/HiddenField.coffee
+++ b/bika/lims/browser/listing/src/components/HiddenField.coffee
@@ -15,7 +15,8 @@ class HiddenField extends React.Component
            name={@props.name}
            value={@props.value}
            column_key={@props.column_key}
-           className={@props.className} />
+           className={@props.className}
+           {...@props.attrs}/>
 
 
 export default HiddenField

--- a/bika/lims/browser/listing/src/components/MultiSelect.coffee
+++ b/bika/lims/browser/listing/src/components/MultiSelect.coffee
@@ -46,7 +46,8 @@ class MultiSelect extends React.Component
                  value={value}
                  onChange={@on_change}
                  onBlur={@on_blur}
-                 column_key={@props.column_key}/> {title}
+                 column_key={@props.column_key}
+                 {...@props.attrs}/> {title}
         </li>
       )
 

--- a/bika/lims/browser/listing/src/components/NumericField.coffee
+++ b/bika/lims/browser/listing/src/components/NumericField.coffee
@@ -80,7 +80,8 @@ class NumericField extends React.Component
              className={@props.className}
              placeholder={@props.placeholder}
              onBlur={@on_blur}
-             onChange={@on_change}/>
+             onChange={@on_change}
+             {...@props.attrs}/>
       {@props.after and <span dangerouslySetInnerHTML={{__html: @props.after}}></span>}
     </span>
 

--- a/bika/lims/browser/listing/src/components/ReadonlyField.coffee
+++ b/bika/lims/browser/listing/src/components/ReadonlyField.coffee
@@ -21,7 +21,7 @@ class ReadonlyField extends React.Component
       return (
         <span className={@props.className}>
           {@props.before and <span dangerouslySetInnerHTML={{__html: @props.before}}></span>}
-          <span dangerouslySetInnerHTML={{__html: @props.formatted_value}}></span>
+          <span dangerouslySetInnerHTML={{__html: @props.formatted_value}} {...@props.attrs}></span>
           {@props.after and <span dangerouslySetInnerHTML={{__html: @props.after}}></span>}
         </span>
       )

--- a/bika/lims/browser/listing/src/components/StringField.coffee
+++ b/bika/lims/browser/listing/src/components/StringField.coffee
@@ -59,7 +59,8 @@ class StringField extends React.Component
            className={@props.className or "form-control input-sm"}
            placeholder={@props.placeholder}
            onBlur={@on_blur}
-           onChange={@on_change}/>
+           onChange={@on_change}
+           {...@props.attrs}/>
 
 
 export default StringField

--- a/bika/lims/browser/listing/src/components/TableCell.coffee
+++ b/bika/lims/browser/listing/src/components/TableCell.coffee
@@ -566,19 +566,6 @@ class TableCell extends React.Component
     else if type == "numeric"
       field = field.concat @create_numeric_field()
 
-    # TODO: Handle hidden field rendering in the field components directly
-    #       -> see approach in Checkbox component
-    #
-    # N.B. Disabled fields are not send to the server on form submit!
-    #      -> Render hidden field for each disabled input
-    if @is_disabled() and type isnt "readonly"
-      converter = @ZPUBLISHER_CONVERTER[type]
-      fieldname = @get_name() + converter
-      field = field.concat @create_hidden_field
-        props:
-          key: "#{name}_disabled"
-          name: fieldname
-
     return field
 
   render: ->

--- a/bika/lims/browser/listing/src/components/TableCells.coffee
+++ b/bika/lims/browser/listing/src/components/TableCells.coffee
@@ -52,7 +52,6 @@ class TableCells extends React.Component
             name={checkbox_name}
             value={uid}
             disabled={disabled}
-            render_hidden={disabled}  # render a hidden field when the row is disabled
             checked={selected}
             onChange={@props.on_select_checkbox_checked}/>
         </td>)

--- a/bika/lims/content/abstractbaseanalysis.py
+++ b/bika/lims/content/abstractbaseanalysis.py
@@ -966,3 +966,11 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
         """
         tat = self.Schema().getField("MaxTimeAllowed").get(self)
         return tat or self.bika_setup.getDefaultTurnaroundTime()
+
+    @security.public
+    def isOpen(self):
+        """Checks if the Analysis is either in "assigned" or "unassigned" state
+
+        return: True if the WF state is either "assigned" or "unassigned"
+        """
+        return api.get_workflow_status_of(self) in ["assigned", "unassigned"]

--- a/bika/lims/tests/doctests/RemoveAnalysesFromAnalysisRequest.rst
+++ b/bika/lims/tests/doctests/RemoveAnalysesFromAnalysisRequest.rst
@@ -148,8 +148,30 @@ transitions to "to_be_verified" because follows `Fe`:
     >>> api.get_workflow_status_of(ar)
     'to_be_verified'
 
-And if we remove analysis `Fe` (in `to_be_verified` state), the Analysis Request
-will follow `Au` analysis (that is `verified`):
+Analyses which are in the state `to_be_verified` can **not** be removed.
+Therefore, if we try to remove the analysis `Fe` (in `to_be_verified` state),
+the Analysis Request will stay in `to_be_verified` and the Analysis will still
+be assigned:
+
+    >>> new_analyses = ar.setAnalyses([Au])
+
+    >>> analysis_fe in ar.objectValues()
+    True
+
+    >>> analysis_au in ar.objectValues()
+    True
+
+    >>> api.get_workflow_status_of(ar)
+    'to_be_verified'
+
+The only way to remove the `Fe` analysis is to retract it first:
+
+    >>> transitioned = do_action_for(analysis_fe, "retract")
+    >>> api.get_workflow_status_of(analysis_fe)
+    'retracted'
+
+And if we remove analysis `Fe`, the Analysis Request will follow `Au` analysis
+(that is `verified`):
 
     >>> new_analyses = ar.setAnalyses([Au])
     >>> api.get_workflow_status_of(ar)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the non HTML conformant handling of disabled fields.

The only place where folderitems were marked as disabled was in the "Manage Analyses" form of ARs. Hence, the `ARAnalyses` field was changed to handle the omitted form data of disabled fields correctly.

## Current behavior before PR

Hidden fields are injected when the folderitem was marked as "disabled"

## Desired behavior after PR is merged

No hidden fields are injected when the folderitem is marked as "disabled"

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
