### PR TITLE
Fixed Link for Partition Magic JS

### DIFF
--- a/bika/lims/browser/templates/partition_magic.pt
+++ b/bika/lims/browser/templates/partition_magic.pt
@@ -8,7 +8,7 @@
                  tal:define="portal context/@@plone_portal_state/portal;">
       <script type="text/javascript"
               src="partition_magic.js"
-              tal:attributes="src string:${portal/absolute_url}/++resource++bika.lims.js/partition_magic.js"></script>
+              tal:attributes="src string:${portal/absolute_url}/++resource++bika.lims.js/senaite.core.partitionmagic.js"></script>
     </metal:block>
     <metal:block fill-slot="style_slot"
                  tal:define="portal context/@@plone_portal_state/portal;">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1079

## Current behavior before PR

Partition Analyses not selectable via row-click 

## Desired behavior after PR is merged

Partition Analyses selectable via row-click 


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
