### PR TITLE
Integrated listing JS in portal_javascripts registry

### DIFF
--- a/bika/lims/browser/listing/templates/contents_table.pt
+++ b/bika/lims/browser/listing/templates/contents_table.pt
@@ -1,14 +1,6 @@
 <tal:contents_table
   define="portal context/@@plone_portal_state/portal;">
 
-  <tal:js
-    define="portal_url portal/absolute_url;
-            static_url string:${portal_url}/++resource++senaite.core.browser.listing.static;">
-    <script type="text/javascript"
-            src="senaite.core.listing.js"
-            tal:attributes="src string:${static_url}/js/senaite.core.listing.js"></script>
-  </tal:js>
-
   <form name="listing_form"
         class="form form-inline"
         method="post"

--- a/bika/lims/profiles/default/jsregistry.xml
+++ b/bika/lims/profiles/default/jsregistry.xml
@@ -505,4 +505,16 @@
               inline="False"
               insert-after="*"/>
 
+  <!-- Listing ReactJS (not managed by bika.lims.loader) -->
+  <javascript authenticated="False"
+              id="++resource++senaite.core.browser.listing.static/js/senaite.core.listing.js"
+              cacheable="True"
+              compression="safe"
+              conditionalcomment=""
+              cookable="True"
+              enabled="on"
+              expression=""
+              inline="False"
+              insert-after="*"/>
+
  </object>

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -112,6 +112,10 @@ def upgrade(tool):
     # https://github.com/senaite/senaite.core/pull/1125
     hide_samples(portal)
 
+    # Add Listing JS to portal_javascripts registry
+    # https://github.com/senaite/senaite.core/pull/
+    add_listing_js_to_portal_javascripts(portal)
+
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
 
@@ -1047,3 +1051,11 @@ def hide_samples(portal):
     del_index(portal,CATALOG_ANALYSIS_REQUEST_LISTING, "getSampleUID")
     del_metadata(portal, CATALOG_ANALYSIS_REQUEST_LISTING, "getSampleUID")
 
+
+def add_listing_js_to_portal_javascripts(portal):
+    """Adds senaite.core.listing.js to the portal_javascripts registry
+    """
+    id="++resource++senaite.core.browser.listing.static/js/senaite.core.listing.js"
+    portal_javascripts = portal.portal_javascripts
+    if id not in portal_javascripts.getResouceIds():
+        portal_javascripts.registerResource(id=id)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR moves the listing ReactJS into the portal_javascripts registry

## Current behavior before PR

JS was included in each content_table template

## Desired behavior after PR is merged

JS is included globally in portal_javascripts

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
