### PR TITLE
Remove "submitted by current user" icon from AR listings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,7 @@ Changelog
 
 **Removed**
 
+- #1132 Remove "Submitted by current user" icon from AR listing (performance)
 - #1125 Remove Sample views, listings and links to Sample(s) from everywhere
 - #1118 Removed all legacy Bika Listing / Advanced Filtering from Codebase
 - #1077 Remove Sample-specific states from analysis workflow

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -822,25 +822,7 @@ class AnalysisRequestsView(BikaListingView):
         item["getPreserver"] = ""
         item["getDatePreserved"] = ""
 
-        # Submitting user may not verify results
-        # Thee conditions to improve performance, some functions to check
-        # the condition need to get the full analysis request.
-        if states_dict.get("review_state", "") == "to_be_verified":
-            allowed = user.has_permission(
-                VerifyPermission,
-                username=self.member.getUserName())
-            # TODO-performance: isUserAllowedToVerify getts all analysis
-            # objects inside the analysis request.
-            if allowed:
-                # Gettin the full object if not get before
-                full_object = full_object if full_object else obj.getObject()
-                if not full_object.isUserAllowedToVerify(self.member):
-                    item["after"]["state_title"] = get_image(
-                        "submitted-by-current-user.png",
-                        title=t(_("Cannot verify: Submitted by current user")))
-
         # Advanced partitioning
-        #
         # append the UID of the primary AR as parent
         item["parent"] = obj.getRawParentAnalysisRequest or ""
         # append partition UIDs of this AR as children

--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -963,31 +963,6 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             return user and user.getProperty("fullname") or ""
         return ""
 
-    # TODO Workflow, Analysis - Remove
-    @security.public
-    def isVerifiable(self):
-        """Checks it the current analysis can be verified. This is, its not a
-        cancelled analysis and has no dependenant analyses not yet verified
-        :return: True or False
-        """
-        return guards.guard_verify(self) or guards.guard_multi_verify(self)
-
-    # TODO Workflow, Analysis - Remove
-    @security.public
-    def isUserAllowedToVerify(self, member):
-        """
-        Checks if the specified user has enough privileges to verify the
-        current analysis. Apart of roles, the function also checks if the
-        option IsSelfVerificationEnabled is set to true at Service or
-        Bika Setup levels and validates if according to this value, together
-        with the user roles, the analysis can be verified. Note that this
-        function only returns if the user can verify the analysis, but not if
-        the analysis is ready to be verified (see isVerifiable)
-        :member: user to be tested
-        :return: true or false
-        """
-        return guards.guard_verify(self) or guards.guard_multi_verify(self)
-
     @security.public
     def getObjectWorkflowStates(self):
         """This method is used to populate catalog values


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

It was causing performance issues and since the AR cannot be verified manually, rather automatically when all its analyses get verified, it does not make sense to display that icon there. In addition, the logic was binded to a lot of useless and crappy code.

## Current behavior before PR

The icon "submitted by current user" is displayed in AR listings, but the rendering of the list is slow.

## Desired behavior after PR is merged

The icon "submitted by current user" is not displayed in AR listings, but the list renders with good performance.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
