### PR TITLE
Fixed typo in upgrade step

### DIFF
--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -1055,7 +1055,7 @@ def hide_samples(portal):
 def add_listing_js_to_portal_javascripts(portal):
     """Adds senaite.core.listing.js to the portal_javascripts registry
     """
-    id="++resource++senaite.core.browser.listing.static/js/senaite.core.listing.js"
+    id = "++resource++senaite.core.browser.listing.static/js/senaite.core.listing.js"
     portal_javascripts = portal.portal_javascripts
-    if id not in portal_javascripts.getResouceIds():
+    if id not in portal_javascripts.getResourceIds():
         portal_javascripts.registerResource(id=id)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fixed typo which caused this Traceback on 1.3 upgrade:

```
Traceback (innermost last):

Module ZPublisher.Publish, line 138, in publish
Module ZPublisher.mapply, line 77, in mapply
Module ZPublisher.Publish, line 48, in call_object
Module Products.GenericSetup.tool, line 1053, in manage_doUpgrades
Module Products.GenericSetup.upgrade, line 166, in doStep
Module bika.lims.upgrade, line 55, in wrap_func_args
Module bika.lims.upgrade.v01_03_000, line 117, in upgrade
Module bika.lims.upgrade.v01_03_000, line 1060, in add_listing_js_to_portal_javascripts
AttributeError: getResouceIds
```

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
