### PR TITLE
Fix Analysis Request - Analyses inconsistencies

### DIFF
--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -1080,15 +1080,11 @@ def fix_ar_analyses_inconsistencies(portal):
                      review_state=review_states)
         for brain in api.search(query, CATALOG_ANALYSIS_LISTING):
             analysis = api.get_object(brain)
-            # If the analysis is assigned to a worksheet, try to unassign first
+            # If the analysis is assigned to a worksheet, unassign first
             ws = analysis.getWorksheet()
             if ws:
-                success = do_action_for(analysis, "unassign")
-                if not success[0]:
-                    # The state does not allow the unassignment, let's do it
-                    # manually (w/o transition)
-                    remove_analysis_from_worksheet(analysis)
-                    reindex_request(analysis)
+                remove_analysis_from_worksheet(analysis)
+                reindex_request(analysis)
 
             # Force the new state
             changeWorkflowState(analysis, wf_id, status)

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -1090,7 +1090,7 @@ def fix_ar_analyses_inconsistencies(portal):
             if num % 100 == 0:
                 logger.info("Fixing inconsistent analyses from {} ARs: {}/{}"
                             .format(status, num, total))
-            fix_analyses(api.get_object(brain), status)
+            fix_analyses(brain, status)
 
     logger.info("Fixing Analysis Request - Analyses inconsistencies ...")
     fix_ar_analyses("cancelled", wf_state_id="cancellation_state")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

In some migrated instances, user can assign analyses from Analysis Requests that are in "rejected", "cancelled" or "invalid" states.
This Pull Request handles these edge-cases in the migration properly.

## Current behavior before PR

User can assign analyses their AR is in "cancelled", "rejected" or "invalid" state.

## Desired behavior after PR is merged

User cannot assign analyses when their AR is in "cancelled", "rejected" or "invalid" state.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
