### PR TITLE
Handle None type entries gracefully in Log View

### DIFF
--- a/bika/lims/browser/log.py
+++ b/bika/lims/browser/log.py
@@ -50,6 +50,10 @@ class LogView(BikaListingView):
                 "title": _("State"), "sortable": False}),
         ))
 
+        # Do not display Version column if the content is not versionable
+        if not self.is_versionable():
+            del(self.columns["Version"])
+
         self.review_states = [
             {
                 "id": "default",
@@ -58,6 +62,13 @@ class LogView(BikaListingView):
                 "columns": self.columns.keys(),
             }
         ]
+
+
+    def is_versionable(self):
+        """Checks if the content is versionable
+        """
+        pr = api.get_tool("portal_repository")
+        return pr.isVersionable(self.context)
 
     def update(self):
         """Update hook

--- a/bika/lims/browser/log.py
+++ b/bika/lims/browser/log.py
@@ -47,7 +47,7 @@ class LogView(BikaListingView):
             ("Action", {
                 "title": _("Action"), "sortable": False}),
             ("State", {
-                "title": _("State"), "sortable": False}),
+                "title": _("Outcome state"), "sortable": False}),
         ))
 
         # Do not display Version column if the content is not versionable

--- a/bika/lims/browser/log.py
+++ b/bika/lims/browser/log.py
@@ -149,7 +149,7 @@ class LogView(BikaListingView):
         state = None
         if self.is_versioning_entry(entry):
             # revision entries have no state
-            new_version = self.get_entry_version(entry) + 1
+            new_version = self.get_entry_version(entry)
             state = "{}: {}".format(_("Version"), new_version)
         else:
             # review history items have a state id

--- a/bika/lims/browser/log.py
+++ b/bika/lims/browser/log.py
@@ -115,7 +115,7 @@ class LogView(BikaListingView):
         if self.is_versioning_entry(entry):
             # revision entries have an actor dict
             actor_dict = entry.get("actor")
-            actor = actor_dict.get("fullname") or actor_dict.get("actor_id")
+            actor = actor_dict.get("fullname") or actor_dict.get("actorid")
         else:
             # review history items have only an actor id
             actor = entry.get("actor")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a traceback in the Log View when a transition was done automatically and the `actor` or the `action` is `None`.

## Current behavior before PR

Traceback occurs for automatic transitions:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.listing.view, line 193, in __call__
  Module bika.lims.browser.listing.ajax, line 75, in handle_subpath
  Module bika.lims.browser.listing.decorators, line 45, in wrapper
  Module bika.lims.browser.listing.decorators, line 32, in wrapper
  Module bika.lims.browser.listing.decorators, line 82, in wrapper
  Module bika.lims.browser.listing.ajax, line 427, in ajax_folderitems
  Module bika.lims.browser.listing.decorators, line 70, in wrapper
  Module bika.lims.browser.listing.ajax, line 268, in get_folderitems
  Module bika.lims.browser.log, line 157, in folderitems
  Module bika.lims.browser.log, line 145, in make_log_entry
  Module bika.lims.browser.log, line 105, in get_entry_actor
AttributeError: 'NoneType' object has no attribute 'get'
```

## Desired behavior after PR is merged

No traceback occurs
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
