### PR TITLE
Import workflow profile first in migration

### DIFF
--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -56,6 +56,7 @@ def upgrade(tool):
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
     # -------- ADD YOUR STUFF BELOW --------
+    setup.runImportStepFromProfile(profile, 'workflow')
     setup.runImportStepFromProfile(profile, 'typeinfo')
     setup.runImportStepFromProfile(profile, 'content')
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an `AttributeError` traceback in the 1.3 migration

## Current behavior before PR

Traceback occurs:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.GenericSetup.tool, line 1053, in manage_doUpgrades
  Module Products.GenericSetup.upgrade, line 166, in doStep
  Module bika.lims.upgrade, line 55, in wrap_func_args
  Module bika.lims.upgrade.v01_03_000, line 102, in upgrade
  Module bika.lims.upgrade.v01_03_000, line 440, in update_workflows
  Module bika.lims.upgrade.v01_03_000, line 673, in get_role_mappings_candidates
  Module bika.lims.upgrade.v01_03_000, line 835, in get_rm_candidates_for_analysisworkfklow
AttributeError: unassigned
```

## Desired behavior after PR is merged

No traceback occurs

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
