### PR TITLE
Some instances < 1.3.0 does not have unassigned state for analysis wf

### DIFF
--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -832,20 +832,22 @@ def get_rm_candidates_for_analysisworkfklow(portal):
              CATALOG_ANALYSIS_LISTING))
 
     # Analysis workflow: "Modify portal content" for "unassigned"
-    if "Modify portal content" not in workflow.states.unassigned.permissions:
-        candidates.append(
-            (wf_id,
-             dict(portal_type="Analysis",
-                  review_state=["unassigned"]),
-             CATALOG_ANALYSIS_LISTING))
+    if "unassigned" in workflow.states:
+        if "Modify portal content" not in workflow.states.unassigned.permissions:
+            candidates.append(
+                (wf_id,
+                 dict(portal_type="Analysis",
+                      review_state=["unassigned"]),
+                 CATALOG_ANALYSIS_LISTING))
 
     # Analysis workflow: "Modify portal content" for "assigned"
-    if "Modify portal content" not in workflow.states.assigned.permissions:
-        candidates.append(
-            (wf_id,
-             dict(portal_type="Analysis",
-                  review_state=["assigned"]),
-             CATALOG_ANALYSIS_LISTING))
+    if "assigned" in workflow.states:
+        if "Modify portal content" not in workflow.states.assigned.permissions:
+            candidates.append(
+                (wf_id,
+                 dict(portal_type="Analysis",
+                      review_state=["assigned"]),
+                 CATALOG_ANALYSIS_LISTING))
 
 
     # Just in case (some buddies use 'retract' in 'verified' state)


### PR DESCRIPTION
When running the upgrade step 1.3.0 for some instances, the following traceback occurs:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.GenericSetup.tool, line 1053, in manage_doUpgrades
  Module Products.GenericSetup.upgrade, line 166, in doStep
  Module bika.lims.upgrade, line 55, in wrap_func_args
  Module bika.lims.upgrade.v01_03_000, line 102, in upgrade
  Module bika.lims.upgrade.v01_03_000, line 440, in update_workflows
  Module bika.lims.upgrade.v01_03_000, line 673, in get_role_mappings_candidates
  Module bika.lims.upgrade.v01_03_000, line 835, in get_rm_candidates_for_analysisworkfklow
AttributeError: unassigned
```

The reason is that somehow, these instances do not have the state `unassigned` registered in `analysis_workflow`


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
