### PR TITLE
Fix instrument QC Analyses Table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,7 @@ Changelog
 
 **Fixed**
 
+- #1142 Fix instrument QC Analyses Table
 - #1137 Fixed and refactored log view
 - #1124 Traceback when invalidating an Analysis Request with retracted analyses
 - #1090 Primary AR does not recognize created Partitions

--- a/bika/lims/browser/instrument.py
+++ b/bika/lims/browser/instrument.py
@@ -488,6 +488,20 @@ class InstrumentReferenceAnalysesViewView(BrowserView):
         # Call listing hooks
         view.update()
         view.before_render()
+
+        # TODO Refactor QC Charts as React Components
+        # The current QC Chart is rendered by looking at the value from a hidden
+        # input with id "graphdata", that is rendered below the contents listing
+        # (see instrument_referenceanalyses.pt).
+        # The value is a json, is built by folderitem function and is returned
+        # by self.chart.get_json(). This function is called directly by the
+        # template on render, but the template itself does not directly render
+        # the contents listing, but is done asyncronously.
+        # Hence the function at this point returns an empty dictionary because
+        # folderitems hasn't been called yet. As a result, the chart appears
+        # empty. Here, we force folderitems function to be called in order to
+        # ensure the graphdata is filled before the template is rendered.
+        view.get_folderitems()
         return view
 
 

--- a/bika/lims/browser/instrument.zcml
+++ b/bika/lims/browser/instrument.zcml
@@ -12,6 +12,15 @@
       layer="bika.lims.interfaces.IBikaLIMS"
     />
 
+    <!-- Instrument Reference Analyses Table -->
+    <browser:page
+      for="bika.lims.interfaces.IInstrument"
+      name="table_instrument_referenceanalyses"
+      class="bika.lims.browser.instrument.InstrumentReferenceAnalysesView"
+      permission="zope.Public"
+      layer="bika.lims.interfaces.IBikaLIMS"
+    />
+
     <browser:page
       for="bika.lims.interfaces.IInstrument"
       name="certifications"

--- a/bika/lims/browser/templates/instrument_referenceanalyses.pt
+++ b/bika/lims/browser/templates/instrument_referenceanalyses.pt
@@ -1,19 +1,19 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:tal="http://xml.zope.org/namespaces/tal"
-    xmlns:metal="http://xml.zope.org/namespaces/metal"
-    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-    metal:use-macro="here/main_template/macros/master"
-    i18n:domain="senaite.core">
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="senaite.core">
 
-<body>
+  <body>
     <metal:content-title fill-slot="content-title">
-    <h1>
+      <h1>
         <img tal:condition="view/icon | nothing"
              src="" tal:attributes="src view/icon"/>
         <span class="documentFirstHeading"
               tal:content="context/title"></span>
-    </h1>
-    <h2 tal:content="view/title"></h2>
+      </h1>
+      <h2 tal:content="view/title"></h2>
     </metal:content-title>
 
     <metal:content-description fill-slot="content-description">
@@ -21,32 +21,38 @@
 
     <metal:content-core fill-slot="content-core">
 
-    <!-- Chart container -->
-    <div class='chart-container'>
-        <div class='chart-options'>
-            <label for='selanalyses' i18n:translate="">Analysis</label>
-            <select id='selanalyses' name='selanalyses'>
-            </select>&nbsp;&nbsp;
-            <label for='selqcsample' i18n:translate="">Reference Sample</label>
-            <select id='selqcsample' name='selqcsample'>
-            </select>&nbsp;&nbsp;
-            <label for='interpolation' i18n:translate="">Interpolation</label>
-            <select id='interpolation' name='interpolation'>
-                <option value='basis' i18n:translate="" selected>Basis</option>
-                <option value='cardinal' i18n:translate="">Cardinal</option>
-                <option value='linear' i18n:translate="">Linear</option>
-            </select>&nbsp;&nbsp;
-            <a id='printgraph' class='print-16' href='#' i18n:translate="">Print</a>
+      <div class="row">
+        <!-- Chart container -->
+        <div class="col-sm-12 chart-container">
+          <div class="chart-options">
+            <label for="selanalyses" i18n:translate="">Analysis</label>
+            <select id="selanalyses" name="selanalyses">
+            </select>
+            <label for="selqcsample" i18n:translate="">Reference Sample</label>
+            <select id="selqcsample" name="selqcsample">
+            </select>
+            <label for="interpolation" i18n:translate="">Interpolation</label>
+            <select id="interpolation" name="interpolation">
+              <option value="basis" i18n:translate="" selected>Basis</option>
+              <option value="cardinal" i18n:translate="">Cardinal</option>
+              <option value="linear" i18n:translate="">Linear</option>
+            </select>
+            <a id="printgraph" class="print-16" href="#" i18n:translate="">Print</a>
+          </div>
+          <div id="chart"></div>
         </div>
-        <div id='chart'></div>
-    </div>
+      </div>
 
-    <!-- Reference Analyses table -->
-    <tal:analysestable>
-    <tal:parts replace="structure view/get_analyses_table"/>
-    <input type="hidden" id='graphdata' tal:attributes="value view/get_analyses_json"/>
-    </tal:analysestable>
+      <!-- Reference Analyses table -->
+      <div class="row">
+        <div class="col-sm-12">
+          <tal:referenceanalyses define="table view/get_analyses_table_view">
+            <span tal:replace="structure python:table.ajax_contents_table()"/>
+            <input type="hidden" id="graphdata" tal:attributes="value python:table.chart.get_json()"/>
+          </tal:referenceanalyses>
+        </div>
+      </div>
 
     </metal:content-core>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR migrates the Instrument QC Analyses table to use the new Ajax Listing

## Current behavior before PR

Traceback occurs in Instrument QC Analyses

## Desired behavior after PR is merged

Instrument QC Analyses Table is displayed correctly (and the chart as well)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
