### PR TITLE
Fix "Submit" button does not have any effect with reference analyses

### DIFF
--- a/bika/lims/browser/analyses/workflow.py
+++ b/bika/lims/browser/analyses/workflow.py
@@ -66,8 +66,7 @@ class AnalysesWorkflowAction(WorkflowAction):
         # _get_selected_items from the base class, cause that function fetches
         # the objects by uid, but sequentially one by one
         actions_pool = ActionsPool()
-        query = dict(UID=uids, cancellation_state="active")
-        for brain in api.search(query, CATALOG_ANALYSIS_LISTING):
+        for brain in api.search({"UID": uids}, CATALOG_ANALYSIS_LISTING):
             uid = api.get_uid(brain)
             analysis = api.get_object(brain)
 

--- a/bika/lims/browser/analyses/workflow.py
+++ b/bika/lims/browser/analyses/workflow.py
@@ -25,6 +25,7 @@ from bika.lims.workflow import doActionFor
 class AnalysesWorkflowAction(WorkflowAction):
     """Workflow actions taken in lists that contains analyses"""
 
+    # TODO Workflow - Clean-up and move this stuff to after_submit event
     def workflow_action_submit(self):
         uids = self.get_selected_uids()
         if not uids:
@@ -66,7 +67,7 @@ class AnalysesWorkflowAction(WorkflowAction):
         # _get_selected_items from the base class, cause that function fetches
         # the objects by uid, but sequentially one by one
         actions_pool = ActionsPool()
-        query = dict(UID=uids, cancellation_state="active")
+        query = dict(UID=uids)
         for brain in api.search(query, CATALOG_ANALYSIS_LISTING):
             uid = api.get_uid(brain)
             analysis = api.get_object(brain)

--- a/bika/lims/browser/analyses/workflow.py
+++ b/bika/lims/browser/analyses/workflow.py
@@ -66,7 +66,8 @@ class AnalysesWorkflowAction(WorkflowAction):
         # _get_selected_items from the base class, cause that function fetches
         # the objects by uid, but sequentially one by one
         actions_pool = ActionsPool()
-        for brain in api.search({"UID": uids}, CATALOG_ANALYSIS_LISTING):
+        query = dict(UID=uids, cancellation_state="active")
+        for brain in api.search(query, CATALOG_ANALYSIS_LISTING):
             uid = api.get_uid(brain)
             analysis = api.get_object(brain)
 

--- a/bika/lims/catalog/indexers/requestanalysis.py
+++ b/bika/lims/catalog/indexers/requestanalysis.py
@@ -1,5 +1,4 @@
 from bika.lims import api
-from bika.lims.interfaces import IReferenceAnalysis
 from bika.lims.interfaces.analysis import IRequestAnalysis
 from plone.indexer import indexer
 

--- a/bika/lims/catalog/indexers/requestanalysis.py
+++ b/bika/lims/catalog/indexers/requestanalysis.py
@@ -14,7 +14,7 @@ def getAncestorsUIDs(instance):
     return [api.get_uid(request)] + parents
 
 
-@indexer(IRequestAnalysis, IReferenceAnalysis)
+@indexer(IRequestAnalysis)
 def cancellation_state(instance):
     """Acts as a mask for cancellation_workflow that is not bound to Analysis
     content type. Returns 'active' or 'cancelled'

--- a/bika/lims/catalog/indexers/requestanalysis.py
+++ b/bika/lims/catalog/indexers/requestanalysis.py
@@ -1,4 +1,5 @@
 from bika.lims import api
+from bika.lims.interfaces import IReferenceAnalysis
 from bika.lims.interfaces.analysis import IRequestAnalysis
 from plone.indexer import indexer
 
@@ -13,7 +14,7 @@ def getAncestorsUIDs(instance):
     return [api.get_uid(request)] + parents
 
 
-@indexer(IRequestAnalysis)
+@indexer(IRequestAnalysis, IReferenceAnalysis)
 def cancellation_state(instance):
     """Acts as a mask for cancellation_workflow that is not bound to Analysis
     content type. Returns 'active' or 'cancelled'


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When the workflow action is triggered, the selected analyses are filtered by cancellation state, but `IReferenceAnalysis` does not have the indexer `cancellation_state`. This Pull Request ~~adds the `cancellation_state` indexer for Reference Analyses and also~~ removes the unnecessary filter in the worksheet's submit workflow action.

EDIT: reference analyses cannot be cancelled, so it does not make sense to add an indexer for them. They cannot be cancelled, but unassigned (translated as "Remove"). The reason is that the Analysis Request is the entity that can be cancelled (when all its analyses are in an `unassigned` state), the analyses only follows (they cannot be cancelled directly).

## Current behavior before PR

Unable to submit Reference Analyses (blanks and controls)

## Desired behavior after PR is merged

Reference Analyses get submitted w/o problems.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
