### PR TITLE
Fix tooltip for blank analyses in worksheet

### DIFF
--- a/bika/lims/browser/worksheet/views/analyses.py
+++ b/bika/lims/browser/worksheet/views/analyses.py
@@ -474,7 +474,7 @@ class AnalysesView(BaseView):
             item_img_text = t(_("Control"))
             if obj.getReferenceType() == "b":
                 item_img = "blank.png"
-                item_img_text = t(_("Duplicate"))
+                item_img_text = t(_("Blank"))
             # parent
             supplier = obj.getSupplier()
             parent_obj = supplier


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Appears "Duplicate" instead of "Blank"

## Current behavior before PR

The tooltip for Blank analyses in worksheet is "Duplicate"

## Desired behavior after PR is merged

The tooltip for Blank analyses in worksheet is "Blank"

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
