### PR TITLE
Set empty option selected by default in result options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Changelog
 
 **Changed**
 
+- #1146 Set empty option selected by default in result options
 - #1136 Skip objects w/o transitions in allowed transitions calculation
 - #1135 Listing: Separate Remarks Toggle-Handle
 - #1128 Listing: Removed non-conform handling of disabled fields

--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -651,6 +651,8 @@ class AnalysesView(BikaListingView):
         # input field for the introduction of result.
         choices = analysis_brain.getResultOptions
         if choices:
+            # By default set empty as the default selected choice
+            choices.insert(0, dict(ResultValue="", ResultText=""))
             item['choices']['Result'] = choices
 
         if self.is_analysis_edition_allowed(analysis_brain):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Result options should always render an empty option in the listing table

Linked issue: https://github.com/senaite/senaite.core/issues/1143

## Current behavior before PR

By default, the first result option is selected in results entry views

## Desired behavior after PR is merged

By default, an empty result option is selected in results entry views.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
