### PR TITLE
Remove "Unpublished" filter from Analysis Requests listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,7 @@ Changelog
 
 **Removed**
 
+- #1149 Remove "Unpublished" filter from Analysis Requests listing
 - #1132 Remove "Submitted by current user" icon from AR listing (performance)
 - #1125 Remove Sample views, listings and links to Sample(s) from everywhere
 - #1118 Removed all legacy Bika Listing / Advanced Filtering from Codebase

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -369,38 +369,6 @@ class AnalysisRequestsView(BikaListingView):
                 "custom_transitions": [],
                 "columns": self.columns.keys(),
             }, {
-                "id": "unpublished",
-                "title": _("Unpublished"),
-                "contentFilter": {
-                    "cancellation_state": "active",
-                    "review_state": (
-                        "sample_registered",
-                        "to_be_sampled",
-                        "to_be_preserved",
-                        "sample_due",
-                        "sample_received",
-                        "to_be_verified",
-                        "attachment_due",
-                        "verified",
-                    ),
-                    "sort_on": "created",
-                    "sort_order": "descending",
-                },
-                "transitions": [
-                    {"id": "sample"},
-                    {"id": "preserve"},
-                    {"id": "receive"},
-                    {"id": "retract"},
-                    {"id": "verify"},
-                    {"id": "prepublish"},
-                    {"id": "publish"},
-                    {"id": "republish"},
-                    {"id": "cancel"},
-                    {"id": "reinstate"},
-                ],
-                "custom_transitions": [print_stickers],
-                "columns": self.columns.keys(),
-            }, {
                 "id": "cancelled",
                 "title": _("Cancelled"),
                 "contentFilter": {


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This filter not only displays the Analysis Requests for which the publication step is the only remaining one, but also all the ARs that are in previous states (sample_received, to_be_verified, etc.).
The previous state before publish is "verified", for which a filter already exists.

## Current behavior before PR

"Unpublished" filter in Analysis Requests listing available.

## Desired behavior after PR is merged

"Unpublished" filter in Analysis Requests not available.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
