### PR TITLE
Fix sporadic traceback while fixing ar-analyses inconsistencies

### DIFF
--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -973,7 +973,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         workflow = getToolByName(self, 'portal_workflow')
         states = {}
         for w in workflow.getWorkflowsFor(self):
-            state = w._getWorkflowStateOf(self).id
+            state = api.get_workflow_status_of(self, w.state_var)
             states[w.state_var] = state
         return states
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fix sporadic Traceback when running upgrade step v1.3.0.

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.GenericSetup.tool, line 1053, in manage_doUpgrades
  Module Products.GenericSetup.upgrade, line 166, in doStep
  Module bika.lims.upgrade, line 55, in wrap_func_args
  Module bika.lims.upgrade.v01_03_000, line 123, in upgrade
  Module bika.lims.upgrade.v01_03_000, line 1114, in fix_ar_analyses_inconsistencies
  Module bika.lims.upgrade.v01_03_000, line 1108, in fix_ar_analyses
  Module bika.lims.upgrade.v01_03_000, line 1096, in fix_analyses
  Module bika.lims.utils, line 351, in changeWorkflowState
  Module Products.Archetypes.CatalogMultiplex, line 118, in reindexObject
  Module Products.CMFPlone.CatalogTool, line 349, in catalog_object
  Module Products.ZCatalog.ZCatalog, line 476, in catalog_object
  Module Products.ZCatalog.Catalog, line 340, in catalogObject
  Module Products.ZCatalog.Catalog, line 284, in updateMetadata
  Module Products.ZCatalog.Catalog, line 410, in recordify
  Module bika.lims.content.abstractanalysis, line 976, in getObjectWorkflowStates
AttributeError: 'NoneType' object has no attribute 'id'
```

## Desired behavior after PR is merged

Upgrade step finishes without traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
