### PR TITLE
Copy choices list to avoid persitent changes

### DIFF
--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -7,6 +7,7 @@
 
 import json
 from collections import OrderedDict
+from copy import copy
 
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
@@ -651,6 +652,8 @@ class AnalysesView(BikaListingView):
         # input field for the introduction of result.
         choices = analysis_brain.getResultOptions
         if choices:
+            # N.B.we copy here the list to avoid persistent changes
+            choices = copy(choices)
             # By default set empty as the default selected choice
             choices.insert(0, dict(ResultValue="", ResultText=""))
             item['choices']['Result'] = choices


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes persistent changes of the choices list introduced by https://github.com/senaite/senaite.core/pull/1147

## Current behavior before PR

Result options were growing after each reload with empty options

## Desired behavior after PR is merged

Result options stay immutable


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
