### PR TITLE
Default to "Active" Worksheets in listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1154 Default to "Active" Worksheets in listing
 - #1120 Listing: Confirm before transition
 - #1077 Creation of retests for blanks and controls via retraction
 - #1077 Creation of retests for duplicates via retraction

--- a/bika/lims/browser/worksheet/views/folder.py
+++ b/bika/lims/browser/worksheet/views/folder.py
@@ -107,37 +107,15 @@ class FolderView(BikaListingView):
         self.review_states = [
             {
                 "id": "default",
-                "title": _("All"),
+                "title": _("Active"),
                 "contentFilter": {
                     "review_state": [
                         "open",
                         "to_be_verified",
-                        "verified"
                     ],
-                    "sort_on":"CreationDate",
+                    "sort_on": "CreationDate",
                     "sort_order": "reverse"},
-                "transitions":[
-                    {"id": "retract"},
-                    {"id": "verify"},
-                    {"id": "reject"}
-                ],
-                "custom_transitions": [],
-                "columns": self.columns.keys(),
-            }, {
-                # getAuthenticatedMember does not work in __init__ so "mine" is
-                # configured further in "folderitems" below.
-                "id": "mine",
-                "title": _("Mine"),
-                "contentFilter": {
-                    "review_state": [
-                        "open",
-                        "to_be_verified",
-                        "verified",
-                        "rejected"
-                    ],
-                    "sort_on":"CreationDate",
-                    "sort_order": "reverse"},
-                "transitions":[
+                "transitions": [
                     {"id": "retract"},
                     {"id": "verify"},
                     {"id": "reject"}
@@ -177,6 +155,46 @@ class FolderView(BikaListingView):
                     "sort_order": "reverse"
                 },
                 "transitions": [],
+                "custom_transitions": [],
+                "columns": self.columns.keys(),
+            }, {
+                "id": "all",
+                "title": _("All"),
+                "contentFilter": {
+                    "review_state": [
+                        "open",
+                        "to_be_verified",
+                        "verified",
+                        "rejected",
+                    ],
+                    "sort_on":"CreationDate",
+                    "sort_order": "reverse"},
+                "transitions":[
+                    {"id": "retract"},
+                    {"id": "verify"},
+                    {"id": "reject"}
+                ],
+                "custom_transitions": [],
+                "columns": self.columns.keys(),
+            }, {
+                # getAuthenticatedMember does not work in __init__ so "mine" is
+                # configured further in "folderitems" below.
+                "id": "mine",
+                "title": _("Mine"),
+                "contentFilter": {
+                    "review_state": [
+                        "open",
+                        "to_be_verified",
+                        "verified",
+                        "rejected"
+                    ],
+                    "sort_on":"CreationDate",
+                    "sort_order": "reverse"},
+                "transitions":[
+                    {"id": "retract"},
+                    {"id": "verify"},
+                    {"id": "reject"}
+                ],
                 "custom_transitions": [],
                 "columns": self.columns.keys(),
             }
@@ -239,7 +257,7 @@ class FolderView(BikaListingView):
             "id": "reassign",
             "title": _("Reassign")}
         for rs in self.review_states:
-            if rs["id"] not in ["default", "mine", "open"]:
+            if rs["id"] not in ["default", "mine", "open", "all"]:
                 continue
             rs["custom_transitions"].append(reassing_analyst_transition)
         self.show_select_column = True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Worksheets listings displays all worksheets by default. Following the same reasoning as for Analysis Requests, better to display the "active" worksheets instead (open and to_be_verified).

## Current behavior before PR

All worksheets are displayed by default in worksheets listing.

## Desired behavior after PR is merged

Active worksheets are displayed by default in worksheets listing

![captura de pantalla de 2018-12-11 22-40-04](https://user-images.githubusercontent.com/832627/49832248-64a11480-fd96-11e8-8c51-3aeabc9b6493.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
