### PR TITLE
Duplication of Analyses in "Add Analyses" view when partitions are involved

### DIFF
--- a/bika/lims/browser/partition_magic.py
+++ b/bika/lims/browser/partition_magic.py
@@ -145,6 +145,10 @@ class PartitionMagicView(BrowserView):
             specifications=self.get_specifications_for(ar)
         )
 
+        # Remove selected analyses from the parent Analysis Request
+        analyses_ids = map(api.get_id, analyses)
+        ar.manage_delObjects(analyses_ids)
+
         # Reindex Parent Analysis Request
         # TODO Workflow - AnalysisRequest - Partitions creation
         ar.reindexObject(idxs=["isRootAncestor"])


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Analyses from the Parent AR (or the primary Analysis Request) are displayed in the Add Analyses view, even if they were added into a new partition. The reason is that the parent analyses were not removed after their "reassignment" to the partition.

Linked issue: https://github.com/senaite/senaite.core/issues/1156

## Current behavior before PR

Analyses from the primary AR are displayed in Add Analyses (Worksheet creation)

## Desired behavior after PR is merged

Analyses from the primary AR are not displayed in Add Analyses (Worksheet creation)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
