### PR TITLE
Creation of partition requires analyses to be in unassigned state

### DIFF
--- a/bika/lims/workflow/analysisrequest/guards.py
+++ b/bika/lims/workflow/analysisrequest/guards.py
@@ -57,6 +57,14 @@ def guard_create_partitions(analysis_request):
         # Do not allow the creation of partitions from partitions
         return False
 
+    # Allow only the creation of partitions if all analyses from the Analysis
+    # Request are in unassigned state. Otherwise, we could end up with
+    # inconsistencies, because original analyses are deleted when the partition
+    # is created
+    for analysis in analysis_request.getAnalyses():
+        if api.get_workflow_status_of(analysis) != "unassigned":
+            return False
+
     return True
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Allow only the creation of partitions if all analyses from the Analysis Request are in unassigned state. Otherwise, we could end up with inconsistencies, because original analyses are deleted when the partition is created.

## Current behavior before PR

Possibility to create partitions from ARs with already processed (assigned, submitted, verified, etc.) analyses.

## Desired behavior after PR is merged

Do not allow the creation of partitions from an AR if some analyses have been processed.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
