### PR TITLE
Fix WorkflowWorksheetRetract doctest

### DIFF
--- a/bika/lims/workflow/worksheet/events.py
+++ b/bika/lims/workflow/worksheet/events.py
@@ -20,3 +20,10 @@ def after_submit(obj):
     # all the analyses that contain have been submitted manually after
     # the results input
     wf.doActionFor(obj, 'attach')
+
+
+def after_retract(worksheet):
+    """Retracts all analyses the worksheet contains
+    """
+    for analysis in worksheet.getAnalyses():
+       wf.doActionFor(analysis, "retract")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Although present in https://github.com/senaite/senaite.core/pull/1157 , `after_retract` function was not merged into master.

## Current behavior before PR

WorkflowWorksheetRetract doctest fails

## Desired behavior after PR is merged

WorkflowWorksheetRetract doctest passes

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
