### PR TITLE
Set AR Specifications setting disabled by default in setup

### DIFF
--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -346,7 +346,7 @@ schema = BikaFolderSchema.copy() + Schema((
     BooleanField(
         'EnableARSpecs',
         schemata="Analyses",
-        default=True,
+        default=False,
         widget=BooleanWidget(
             label=_("Enable AR Specifications"),
             description=_(


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

With this Pull Request sets the setting AR Specifications from setup is set to False

## Current behavior before PR

By default, AR Specifications setting is enabled

## Desired behavior after PR is merged

By default, AR Specifications setting is disabled

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
