### PR TITLE
Assigning the same Analyses to different Partitions raise an Error

### DIFF
--- a/bika/lims/browser/partition_magic.py
+++ b/bika/lims/browser/partition_magic.py
@@ -44,6 +44,8 @@ class PartitionMagicView(BrowserView):
         self.context = context
         self.request = request
         self.back_url = self.context.absolute_url()
+        self.analyses_to_remove = dict()
+
 
     def __call__(self):
         form = self.request.form
@@ -94,6 +96,9 @@ class PartitionMagicView(BrowserView):
             if not partitions:
                 # If no partitions were created, show a warning message
                 return self.redirect(message=_("No partitions were created"))
+
+            # Remove analyses from primary Analysis Requests
+            self.remove_primary_analyses()
 
             message = _("Created {} partitions: {}".format(
                 len(partitions), ", ".join(map(api.get_title, partitions))))
@@ -146,14 +151,28 @@ class PartitionMagicView(BrowserView):
         )
 
         # Remove selected analyses from the parent Analysis Request
-        analyses_ids = map(api.get_id, analyses)
-        ar.manage_delObjects(analyses_ids)
+        self.push_primary_analyses_for_removal(ar, analyses)
 
         # Reindex Parent Analysis Request
         # TODO Workflow - AnalysisRequest - Partitions creation
         ar.reindexObject(idxs=["isRootAncestor"])
 
         return partition
+
+    def push_primary_analyses_for_removal(self, analysis_request, analyses):
+        """Stores the analyses to be removed after partitions creation
+        """
+        to_remove = self.analyses_to_remove.get(analysis_request, [])
+        to_remove.extend(analyses)
+        self.analyses_to_remove[analysis_request] = to_remove
+
+    def remove_primary_analyses(self):
+        """Remove analyses relocated to partitions
+        """
+        for ar, analyses in self.analyses_to_remove.items():
+            analyses_ids = list(set(map(api.get_id, analyses)))
+            ar.manage_delObjects(analyses_ids)
+        self.analyses_to_remove = dict()
 
     def get_specifications_for(self, ar):
         """Returns a mapping of service uid -> specification

--- a/bika/lims/browser/partition_magic.py
+++ b/bika/lims/browser/partition_magic.py
@@ -247,12 +247,13 @@ class PartitionMagicView(BrowserView):
     def get_analysis_data_for(self, ar):
         """Return the Analysis data for this AR
         """
-        analyses = ar.getAnalyses()
+        # Exclude analyses from children (partitions)
+        analyses = ar.objectValues("Analysis")
         out = []
         for an in analyses:
             info = self.get_base_info(an)
             info.update({
-                "service_uid": an.getServiceUID,
+                "service_uid": an.getServiceUID(),
             })
             out.append(info)
         return out

--- a/bika/lims/workflow/analysisrequest/guards.py
+++ b/bika/lims/workflow/analysisrequest/guards.py
@@ -60,12 +60,12 @@ def guard_create_partitions(analysis_request):
     # Allow only the creation of partitions if all analyses from the Analysis
     # Request are in unassigned state. Otherwise, we could end up with
     # inconsistencies, because original analyses are deleted when the partition
-    # is created
-    for analysis in analysis_request.getAnalyses():
+    # is created. Note here we exclude analyses from children (partitions).
+    analyses = analysis_request.objectValues("Analysis")
+    for analysis in analyses:
         if api.get_workflow_status_of(analysis) != "unassigned":
             return False
-
-    return True
+    return analyses and True or False
 
 
 def guard_submit(analysis_request):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes possible to assign same analyses to different partitions in partition magic view. It also ensures the analyses displayed in partition magic are those from the Primary Analysis Request only.

Linked issue: https://github.com/senaite/senaite.core/issues/1166

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.partition_magic, line 86, in __call__
  Module bika.lims.browser.partition_magic, line 150, in create_partition
  Module Products.Archetypes.BaseFolder, line 116, in manage_delObjects
  Module OFS.ObjectManager, line 301, in _getOb
AttributeError: conc_caso4_vdi3492
```

## Desired behavior after PR is merged

No traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
