### PR TITLE
Traceback in manage results view

### DIFF
--- a/bika/lims/browser/attachment.py
+++ b/bika/lims/browser/attachment.py
@@ -158,7 +158,7 @@ class AttachmentsView(BrowserView):
 
             # XXX: refactor out dependency to this view.
             view = api.get_view("manage_results", context=self.context, request=self.request)
-            analyses = view._getAnalyses()
+            analyses = self.context.getAnalyses()
             allowed_states = ["assigned", "unassigned", "to_be_verified"]
             for analysis in analyses:
                 if analysis.portal_type not in ('Analysis', 'DuplicateAnalysis'):

--- a/bika/lims/browser/worksheet/views/results.py
+++ b/bika/lims/browser/worksheet/views/results.py
@@ -143,7 +143,7 @@ class ManageResultsView(BrowserView):
         """
         outdict = {}
         allowed_states = ['assigned', 'unassigned']
-        for analysis in self._getAnalyses():
+        for analysis in self.context.getAnalyses():
             # TODO Workflow - Analysis Use a query instead of this
             if api.get_workflow_status_of(analysis) not in allowed_states:
                 continue


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fixes a traceback in manage results view

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.worksheet.views.results, line 72, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 158, in render
  Module chameleon.zpt.template, line 297, in render
  Module chameleon.template, line 203, in render
  Module chameleon.template, line 183, in render
  Module 0a54e5c0713c10c746312f6be4908ee2.py, line 1733, in render
  Module f6a921bdcf6fdb875ef0b674c35c50d5.py, line 1466, in render_master
  Module f6a921bdcf6fdb875ef0b674c35c50d5.py, line 604, in render_content
  Module 0a54e5c0713c10c746312f6be4908ee2.py, line 990, in __fill_content_core
  Module five.pt.expressions, line 161, in __call__
  Module bika.lims.browser.worksheet.views.results, line 146, in get_wide_interims
AttributeError: 'ManageResultsView' object has no attribute '_getAnalyses'

 - Expression: "provider:plone.abovecontentbody"
 - Filename:   ... rc/senaite/lims/skins/senaite_templates/main_template.pt
 - Location:   (line 148: col 90)
 - Source:     ... ent="structure provider:plone.abovecontentbody" tal:conditio ...
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Expression: "here/main_template/macros/master"
 - Filename:   ... ika/lims/browser/worksheet/views/../templates/results.pt
 - Location:   (line 5: col 23)
 - Source:     metal:use-macro="here/main_template/macros/master"
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  repeat: {...} (0)
               template: <ViewPageTemplateFile - at 0x7f2f710f9d50>
               views: <ViewMapper - at 0x7f2f70fea3d0>
               modules: <instance - at 0x7f2f903555f0>
               args: <tuple - at 0x7f2f97ca2050>
               here: <ImplicitAcquisitionWrapper WS-002 at 0x7f2f744d2f50>
               user: <ImplicitAcquisitionWrapper - at 0x7f2f744d20a0>
               loop: {...} (2)
               nothing: <NoneType - at 0x8f5320>
               translate: <function translate at 0x7f2f70e54668>
               container: <ImplicitAcquisitionWrapper WS-002 at 0x7f2f744d2f50>
               root: <ImplicitAcquisitionWrapper Zope at 0x7f2f74bb9820>
               request: <instance - at 0x7f2f710dd998>
               wrapped_repeat: <SafeMapping - at 0x7f2f76a5a5d0>
               traverse_subpath: <list - at 0x7f2f71d98d88>
               default: <object - at 0x7f2f97c8b560>
               context: <ImplicitAcquisitionWrapper WS-002 at 0x7f2f744d2f50>
               view: <ManageResultsView manage_results at 0x7f2f70f09ed0>
               target_language: <NoneType - at 0x8f5320>
               macroname: master
               options: {...} (0)
```

## Desired behavior after PR is merged

No Traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
