### PR TITLE
Fix traceback in info popup template

### DIFF
--- a/bika/lims/browser/templates/analysisservice_info.pt
+++ b/bika/lims/browser/templates/analysisservice_info.pt
@@ -82,7 +82,7 @@
                   <span i18n:translate="">Unit</span>
                 </td>
                 <td>
-                  <span tal:content="service/Unit"></span>
+                  <span tal:content="service/Unit|nothing"></span>
                 </td>
               </tr>
               <tr>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a traceback that occurs in the info popup for some demo data 

## Current behavior before PR

Traceback occurs for non-existing Unit:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.analysisservice, line 41, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 158, in render
  Module chameleon.zpt.template, line 305, in render
  Module chameleon.template, line 203, in render
  Module chameleon.template, line 183, in render
  Module a30918065fe4230a856ebd714f52ea13.py, line 2057, in render
  Module a5e48e8cacef0ec4fb67b1e991e2a7bb.py, line 1468, in render_master
  Module a5e48e8cacef0ec4fb67b1e991e2a7bb.py, line 605, in render_content
  Module a30918065fe4230a856ebd714f52ea13.py, line 756, in __fill_content_core
  Module five.pt.expressions, line 154, in __call__
  Module five.pt.expressions, line 123, in traverse
  Module OFS.Traversable, line 285, in unrestrictedTraverse
   - __traceback_info__: ([], 'Unit')
AttributeError: Unit

 - Expression: "ajax_load"
 - Filename:   ... rc/senaite/lims/skins/senaite_templates/main_template.pt
 - Location:   (line 148: col 142)
 - Source:     ... tentbody" tal:condition="not:ajax_load" />
                                                ^^^^^^^^^
 - Expression: "here/main_template/macros/master"
 - Filename:   ... core/bika/lims/browser/templates/analysisservice_info.pt
 - Location:   (line 5: col 30)
 - Source:     metal:use-macro="here/main_template/macros/master"
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  repeat: {...} (0)
               template: <ViewPageTemplateFile - at 0x10e2cf5d0>
               views: <ViewMapper - at 0x10e2cfa10>
               modules: <instance - at 0x105a2ae18>
               args: <tuple - at 0x102eda050>
               here: <ImplicitAcquisitionWrapper WS-001 at 0x10de49a50>
               wrapped_repeat: <SafeMapping - at 0x10de535d0>
               user: <ImplicitAcquisitionWrapper - at 0x10de49370>
               nothing: <NoneType - at 0x102e4fe08>
               translate: <function translate at 0x10dfd76e0>
               container: <ImplicitAcquisitionWrapper WS-001 at 0x10de49a50>
               root: <ImplicitAcquisitionWrapper Zope at 0x10f381870>
               request: <instance - at 0x10f787b48>
               traverse_subpath: <list - at 0x10e132680>
               default: <object - at 0x102f31c00>
               context: <ImplicitAcquisitionWrapper WS-001 at 0x10de49a50>
               view: <AnalysisServiceInfoView analysisservice_info at 0x10e2cfb10>
               target_language: <NoneType - at 0x102e4fe08>
               macroname: master
               options: {...} (0)
               loop: {...} (1)
```

## Desired behavior after PR is merged

No traceback occurs

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
