### PR TITLE
Improve Resultsinterpretation Form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Changelog
 
 **Changed**
 
+- #1173 Improve Resultsinterpretation Form
 - #1161 Listing: Transposed worksheet improvements
 - #1150 Completeness of not yet published Analysis Requests is not 100%
 - #1147 Set empty option selected by default in result options

--- a/bika/lims/browser/analysisrequest/configure.zcml
+++ b/bika/lims/browser/analysisrequest/configure.zcml
@@ -111,15 +111,6 @@
       layer="bika.lims.interfaces.IBikaLIMS"
       />
 
-  <!-- Results Interpretation button clicked iside AR -->
-  <browser:page
-      for="bika.lims.interfaces.IAnalysisRequest"
-      name="arresultsinterpretation_save"
-      class="bika.lims.browser.analysisrequest.resultsinterpretation.Save"
-      permission="zope.Public"
-      layer="bika.lims.interfaces.IBikaLIMS"
-      />
-
   <!-- AR Main View -->
   <browser:page
       for="bika.lims.interfaces.IAnalysisRequest"

--- a/bika/lims/browser/analysisrequest/resultsinterpretation.py
+++ b/bika/lims/browser/analysisrequest/resultsinterpretation.py
@@ -6,52 +6,54 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 from bika.lims import bikaMessageFactory as _
+from bika.lims import logger
 from bika.lims.browser import BrowserView
+from plone import protect
 from plone.app.textfield import RichTextValue
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from Products.CMFPlone import PloneMessageFactory
-from Products.CMFCore.utils import getToolByName
-import plone
 
 
 class ARResultsInterpretationView(BrowserView):
     """ Renders the view for ResultsInterpration per Department
     """
-    template = ViewPageTemplateFile("templates/analysisrequest_results_interpretation.pt")
+    template = ViewPageTemplateFile(
+        "templates/analysisrequest_results_interpretation.pt")
 
     def __init__(self, context, request, **kwargs):
         super(ARResultsInterpretationView, self).__init__(context, request)
         self.context = context
 
     def __call__(self):
-        wf = getToolByName(self.context, 'portal_workflow')
-        mtool = getToolByName(self.context, 'portal_membership')
-        self.allow_edit = mtool.checkPermission('Modify portal content',self.context)
+        if self.request.form.get("submitted", False):
+            self.handle_form_submit()
         return self.template()
 
-    def getText(self, department, mode='raw'):
-        """ Returns the text saved for the selected department.
+    def handle_form_submit(self):
+        """Handle form submission
+        """
+        protect.CheckAuthenticator(self.request)
+        logger.info("Handle ResultsInterpration Submit")
+        # Save the results interpretation
+        res = self.request.form.get("ResultsInterpretationDepts", [])
+        self.context.setResultsInterpretationDepts(res)
+        self.add_status_message(_("Changes Saved"), level="info")
+
+    def add_status_message(self, message, level="info"):
+        """Set a portal status message
+        """
+        return self.context.plone_utils.addPortalMessage(message, level)
+
+    def is_edit_allowed(self):
+        """Check if edit is allowed
+        """
+        checkPermission = self.context.portal_membership.checkPermission
+        return checkPermission("Modify portal content", self.context)
+
+    def get_text(self, department, mode="raw"):
+        """Returns the text saved for the selected department
         """
         row = self.context.getResultsInterpretationByDepartment(department)
-        rt = RichTextValue(row.get('richtext',''), 'text/plain', 'text/html')
-        if mode=='output':
+        rt = RichTextValue(row.get("richtext", ""), "text/plain", "text/html")
+        if mode == "output":
             return rt.output
-        else:
-            return rt.raw
-
-
-class Save:
-    """
-        Saves the ResultsInterpretation by department to the AR
-    """
-    def __init__(self, context, request):
-        self.context = context
-        self.request = request
-
-    def __call__(self):
-        form = self.request.form
-        plone.protect.CheckAuthenticator(form)
-
-        # Save the results interpretation
-        res = form.get('ResultsInterpretationDepts',[])
-        self.context.setResultsInterpretationDepts(res)
+        return rt.raw

--- a/bika/lims/browser/analysisrequest/templates/analysisrequest_results_interpretation.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequest_results_interpretation.pt
@@ -1,95 +1,120 @@
+<!-- Readonly Resultsinterpretation Field -->
 <tal:readonly
-    tal:define="fieldName string:ResultsInterpretationDepts"
-    tal:condition="python:view.allow_edit == False">
-    <div class='arresultsinterpretation-container'
-         tal:define="departments python:context.getDepartments()">
-        <!-- Tabs for departments -->
-        <ul>
-            <li>
-                <a class="department-tab" href='#'
-                   tal:attributes="data-uid python:fieldName+'-general';"
-                   i18n:translate="">General</a>
-            </li>
-            <tal:depts repeat="dep departments">
-            <li>
-                <a class="department-tab" href='#'
-                   tal:attributes="data-uid python:fieldName+'-'+dep.UID();"
-                   tal:content="dep/Title"></a>
-            </li>
-            </tal:depts>
-        </ul>
-        <div class="department-area"
-            tal:attributes="id python:fieldName+'-general';">
-            <div tal:replace="structure python:view.getText(None, 'raw')"></div>
-        </div>
-        <tal:department repeat="dept departments">
-        <div class="department-area"
-            tal:define="uid dept/UID"
-            tal:attributes="id python:fieldName+'-'+uid;">
-            <div tal:replace="structure python:view.getText(dept, 'raw')"></div>
-        </div>
-        </tal:department>
+  tal:define="fieldName string:ResultsInterpretationDepts"
+  tal:condition="python:not view.is_edit_allowed()">
+
+  <div class="arresultsinterpretation-container"
+       tal:define="departments python:context.getDepartments()">
+
+    <!-- Tabs for departments -->
+    <ul class="nav nav-tabs">
+      <li class="active">
+        <a class="department-tab"
+            href="#"
+            tal:attributes="data-uid python:fieldName+'-general';"
+            i18n:translate="">General</a>
+      </li>
+      <tal:depts repeat="dep departments">
+        <li>
+          <a class="department-tab"
+              href="#"
+              tal:attributes="data-uid python:fieldName+'-'+dep.UID();"
+              tal:content="dep/Title"></a>
+        </li>
+      </tal:depts>
+    </ul>
+
+    <div class="department-area"
+         tal:attributes="id python:fieldName+'-general';">
+      <div tal:content="structure python:view.get_text(None, 'raw')"/>
     </div>
+
+    <tal:department repeat="dept departments">
+      <div class="department-area"
+           tal:define="uid dept/UID"
+           tal:attributes="id python:fieldName+'-'+uid;">
+        <div tal:content="structure python:view.get_text(dept, 'raw')">
+      </div>
+    </tal:department>
+
+  </div>
 </tal:readonly>
 
+
+<!-- Editable Resultsinterpretation Field -->
 <tal:edit
-    tal:define="fieldName string:ResultsInterpretationDepts"
-    tal:condition="python:view.allow_edit == True">
-    <form name="arresultsinterpretation_form"
-          enctype="multipart/form-data"
-          action="arresultsinterpretation_save"
-          method="POST">
-    <span tal:replace="structure context/@@authenticator/authenticator"/>
-    <div class='arresultsinterpretation-container'
+  tal:define="fieldName string:ResultsInterpretationDepts"
+  tal:condition="python:view.is_edit_allowed()">
+
+  <form class="form"
+        name="arresultsinterpretation_form"
+        action="."
+        enctype="multipart/form-data"
+        method="POST">
+
+    <input type="hidden" name="submitted" value="1"/>
+    <input tal:replace="structure context/@@authenticator/authenticator"/>
+
+    <div class="arresultsinterpretation-container"
          tal:define="departments python:context.getDepartments()">
-        <!-- Tabs for departments -->
-        <ul>
-            <li>
-                <a class="department-tab" href='#'
-                   tal:attributes="data-uid python:fieldName+'-general';"
-                   i18n:translate="">General</a>
-            </li>
-            <tal:depts repeat="dep departments">
-            <li>
-                <a class="department-tab" href='#'
-                   tal:attributes="data-uid python:fieldName+'-'+dep.UID();"
-                   tal:content="dep/Title"></a>
-            </li>
-            </tal:depts>
-        </ul>
-        <!-- TextAreas (RichText) for results interpretation -->
-        <div class="department-area"
+      <!-- Tabs for departments -->
+      <ul class="nav nav-tabs">
+        <li class="active">
+          <a class="department-tab"
+              href="#"
+              tal:attributes="data-uid python:fieldName+'-general';"
+              i18n:translate="">General</a>
+        </li>
+        <tal:depts repeat="dep departments">
+          <li>
+            <a class="department-tab"
+                href="#"
+                tal:attributes="data-uid python:fieldName+'-'+dep.UID();"
+                tal:content="dep/Title"></a>
+          </li>
+        </tal:depts>
+      </ul>
+
+      <!-- TextAreas (RichText) for results interpretation -->
+      <div class="department-area"
             tal:attributes="id python:fieldName+'-general';">
-            <input tal:attributes="name  string:${fieldName}.uid:records:ignore_empty;
-                                   id    string:${fieldName}-uid-0;
-                                   value string:general;" type='hidden'/>
-            <textarea class="pat-tinymce mce_editable"
-                tal:define="configuration_method nocall:here/@@tinymce-jsonconfiguration;
-                            configuration_json python:configuration_method(field=None);"
-                tal:attributes="name  string:${fieldName}.richtext:records:ignore_empty;
-                                id    string:${fieldName}-richtext-0;
-                                data-mce-config configuration_json;"
-                tal:content="python: view.getText(None, 'raw')">
-            </textarea>
-        </div>
-        <tal:department repeat="dept departments">
+
+        <input type="hidden"
+              tal:attributes="name string:${fieldName}.uid:records:ignore_empty;
+                              id string:${fieldName}-uid-0;
+                              value string:general;"/>
+
+        <textarea class="pat-tinymce mce_editable"
+                  tal:define="configuration_method nocall:here/@@tinymce-jsonconfiguration;
+                              configuration_json python:configuration_method(field=None);"
+                  tal:attributes="name string:${fieldName}.richtext:records:ignore_empty;
+                                  id string:${fieldName}-richtext-0;
+                                  data-mce-config configuration_json;"
+                  tal:content="python: view.get_text(None, 'raw')">
+        </textarea>
+      </div>
+
+      <tal:department repeat="dept departments">
         <div class="department-area"
             tal:define="uid dept/UID"
             tal:attributes="id python:fieldName+'-'+uid;">
-            <input tal:attributes="name  string:${fieldName}.uid:records:ignore_empty;
-                                   id    string:${fieldName}-uid-${repeat/dept/number};
-                                   value string:${uid};" type='hidden'>
-            <textarea class="pat-tinymce mce_editable"
-                tal:define="configuration_method nocall:here/@@tinymce-jsonconfiguration;
-                            configuration_json python:configuration_method(field=None);"
-                tal:attributes="name  string:${fieldName}.richtext:records:ignore_empty;
-                                id    string:${fieldName}-richtext-${repeat/dept/number};
-                                data-mce-config configuration_json;"
-                tal:content="python: view.getText(dept, 'raw')">
-            </textarea>
+
+          <input type="hidden"
+                tal:attributes="name string:${fieldName}.uid:records:ignore_empty;
+                                id string:${fieldName}-uid-${repeat/dept/number};
+                                value string:${uid};"/>
+
+          <textarea class="pat-tinymce mce_editable"
+                    tal:define="configuration_method nocall:here/@@tinymce-jsonconfiguration;
+                          configuration_json python:configuration_method(field=None);"
+                    tal:attributes="name  string:${fieldName}.richtext:records:ignore_empty;
+                          id string:${fieldName}-richtext-${repeat/dept/number};
+                          data-mce-config configuration_json;"
+                    tal:content="python:view.get_text(dept, 'raw')">
+          </textarea>
         </div>
-        </tal:department>
+      </tal:department>
     </div>
-    <input type="submit" name="send" i18n:translate="value" value="Save" />
-    </form>
+    <button type="submit" class="btn btn-primary btn-xs" i18n:translate="">Save</button>
+  </form>
 </tal:edit>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR improves the AR Resultsinterpretation field

## Current behavior before PR

- No status message displayed after save
- Clicking again on the submit button displays browser alert "do you want to submit again?"

## Desired behavior after PR is merged

- Status message displayed after save
- Clicking again on the submit button submits the form again w/o alert

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
