### PR TITLE
Removed __version__ from __init__ module

### DIFF
--- a/bika/lims/__init__.py
+++ b/bika/lims/__init__.py
@@ -8,8 +8,6 @@
 import logging
 import warnings
 
-import pkg_resources
-
 import App
 from AccessControl import allow_module
 from bika.lims.permissions import ADD_CONTENT_PERMISSION
@@ -20,12 +18,6 @@ from Products.CMFCore.utils import ContentInit
 from zope.i18nmessageid import MessageFactory
 
 PROJECTNAME = "bika.lims"
-
-try:
-    __version__ = pkg_resources.get_distribution("senaite.core").version
-except TypeError:
-    __version__ = pkg_resources.get_distribution("bika.lims").version
-    print "Using old distribution name: bika.lims"
 
 # import this to create messages in the bika domain.
 bikaMessageFactory = MessageFactory("senaite.core")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the `__version__` fetch in the `__init__` module.

The `__version__` is not needed, because the single version to use is located in `setup.py`.

## Current behavior before PR

`__version__` retrieved from `pkg_resources`

## Desired behavior after PR is merged

`__version__` not set

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
