### PR TITLE
Fix set interim values of reference analyses

### DIFF
--- a/bika/lims/browser/listing/ajax.py
+++ b/bika/lims/browser/listing/ajax.py
@@ -11,6 +11,7 @@ from bika.lims.browser.listing.decorators import returns_safe_json
 from bika.lims.browser.listing.decorators import set_application_json_header
 from bika.lims.browser.listing.decorators import translate
 from bika.lims.interfaces import IRoutineAnalysis
+from bika.lims.interfaces import IReferenceAnalysis
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.interface import implements
 from zope.publisher.interfaces import IPublishTraverse
@@ -337,7 +338,11 @@ class AjaxListingView(BrowserView):
     def is_analysis(self, obj):
         """Check if the object is an analysis
         """
-        return IRoutineAnalysis.providedBy(obj)
+        if IRoutineAnalysis.providedBy(obj):
+            return True
+        if IReferenceAnalysis.providedBy(obj):
+            return True
+        return False
 
     def lookup_schema_field(self, obj, fieldname):
         """Lookup  a schema field by name


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR includes reference analyses in the Ajax field setter

## Current behavior before PR

Interim values could not be set for Reference Analyses

## Desired behavior after PR is merged

Interim Fields can be set for Reference Analyses

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
