### PR TITLE
Error when retracting a Reference Analysis from Worksheet

### DIFF
--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -1176,7 +1176,8 @@ class AbstractAnalysis(AbstractBaseAnalysis):
     def getRetest(self):
         """Returns the retest that comes from this analysis, if any
         """
-        back_refs = get_backreferences(self, 'AnalysisRetestOf')
+        relationship = "{}RetestOf".format(self.portal_type)
+        back_refs = get_backreferences(self, relationship)
         if not back_refs:
             return None
         if len(back_refs) > 1:

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -747,11 +747,11 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         """Returns the slot where the instance passed in is located. If not
         found, returns None
         """
-        analysis_type = self.get_analysis_type(instance)
-        container = self.get_container_for(instance)
-        slot = self.get_slot_position(container, analysis_type)
-        analyses = self.get_analyses_at(slot)
-        return instance in analyses and slot or None
+        uid = api.get_uid(instance)
+        slot = filter(lambda s: s['analysis_uid'] == uid, self.getLayout())
+        if not slot:
+            return None
+        return to_int(slot[0]['position'])
 
     def resolve_available_slots(self, worksheet_template, type='a'):
         """Returns the available slots from the current worksheet that fits

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -579,7 +579,7 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         if not IReferenceSample.providedBy(reference):
             return -1
 
-        occupied = self.get_slot_positions(type='all')
+        occupied = self.get_slot_positions(type='all') or [0]
         wst = self.getWorksheetTemplate()
         if not wst:
             # No worksheet template assigned, add a new slot at the end of the

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -367,6 +367,11 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
 
         # Create the reference analysis
         ref_analysis = reference.addReferenceAnalysis(service)
+        if not ref_analysis:
+            logger.warning("Unable to create a reference analysis for "
+                           "reference '{0}' and service '{1}'"
+                           .format(reference.getId(), service.getKeyword()))
+            return None
 
         # Set ReferenceAnalysesGroupID (same id for the analyses from
         # the same Reference Sample and same Worksheet)

--- a/bika/lims/tests/doctests/WorkflowAnalysisRetract.rst
+++ b/bika/lims/tests/doctests/WorkflowAnalysisRetract.rst
@@ -123,6 +123,10 @@ And the Analysis Request has been transitioned to `sample_received`:
 The new analysis is a copy of retracted one:
 
     >>> retest = filter(lambda an: api.get_workflow_status_of(an) == "unassigned", analyses)[0]
+    >>> analysis.getRetest() == retest
+    True
+    >>> retest.getRetestOf() == analysis
+    True
     >>> retest.getKeyword() == analysis.getKeyword()
     True
 

--- a/bika/lims/tests/doctests/WorkflowDuplicateAnalysisRetract.rst
+++ b/bika/lims/tests/doctests/WorkflowDuplicateAnalysisRetract.rst
@@ -148,6 +148,8 @@ The new analysis is a copy of retracted one:
     True
     >>> retest.getRetestOf() == duplicate
     True
+    >>> duplicate.getRetest() == retest
+    True
     >>> retest.getAnalysis() == duplicate.getAnalysis()
     True
 

--- a/bika/lims/tests/doctests/WorkflowReferenceAnalysisRetract.rst
+++ b/bika/lims/tests/doctests/WorkflowReferenceAnalysisRetract.rst
@@ -251,7 +251,6 @@ Retract the first reference analysis. The retest has been added in same slot:
     >>> try_transition(ref_1, "retract", "retracted")
     True
     >>> retest_1 = ref_1.getRetest()
-    >>> import pdb;pdb.set_trace()
     >>> worksheet.get_slot_position_for(retest_1)
     1
 

--- a/bika/lims/tests/doctests/WorkflowReferenceAnalysisRetract.rst
+++ b/bika/lims/tests/doctests/WorkflowReferenceAnalysisRetract.rst
@@ -221,26 +221,21 @@ Create an Analysis Request:
     ... for analysis in ar.getAnalyses(full_objects=True):
     ...     worksheet.addAnalysis(analysis)
 
-Add same reference twice:
+Add same reference sample twice:
 
-    >>> worksheet.addReferenceAnalyses(control_sample, [api.get_uid(Cu)])
-    >>> worksheet.addReferenceAnalyses(control_sample, [api.get_uid(Cu)])
-
-Get the reference analyses and their positions:
-
-    >>> references = worksheet.getReferenceAnalyses()
-    >>> ref_1 = references[0]
-    >>> ref_2 = references[1]
+    >>> ref_1 = worksheet.addReferenceAnalyses(control_sample, [api.get_uid(Cu)])[0]
+    >>> ref_2 = worksheet.addReferenceAnalyses(control_sample, [api.get_uid(Cu)])[0]
     >>> ref_1 != ref_2
     True
+
+Get the reference analyses positions:
+
     >>> ref_1_pos = worksheet.get_slot_position_for(ref_1)
-    >>> api.is_floatable(ref_1_pos)
-    True
+    >>> ref_1_pos
+    1
     >>> ref_2_pos = worksheet.get_slot_position_for(ref_2)
-    >>> api.is_floatable(ref_2_pos)
-    True
-    >>> ref_1_pos != ref_2_pos
-    True
+    >>> ref_2_pos
+    2
 
 Submit both:
 
@@ -255,12 +250,15 @@ Retract the first reference analysis. The retest has been added in same slot:
 
     >>> try_transition(ref_1, "retract", "retracted")
     True
-    >>> worksheet.get_slot_position(ref_1.getRetest()) == ref_1_pos
-    True
+    >>> retest_1 = ref_1.getRetest()
+    >>> import pdb;pdb.set_trace()
+    >>> worksheet.get_slot_position_for(retest_1)
+    1
 
 And the same if we retract the second reference analysis:
 
     >>> try_transition(ref_2, "retract", "retracted")
     True
-    >>> worksheet.get_slot_position(ref_2.getRetest()) == ref_2_pos
-    True
+    >>> retest_2 = ref_2.getRetest()
+    >>> worksheet.get_slot_position_for(retest_2)
+    2

--- a/bika/lims/tests/doctests/WorkflowReferenceAnalysisRetract.rst
+++ b/bika/lims/tests/doctests/WorkflowReferenceAnalysisRetract.rst
@@ -160,6 +160,8 @@ The new analysis is a copy of retracted one:
     True
     >>> retest.getRetestOf() == reference
     True
+    >>> reference.getRetest() == retest
+    True
     >>> retest.getAnalysisService() == reference.getAnalysisService()
     True
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1177

## Current behavior before PR

Error when retracting a reference analysis from a reference sample that have been added twice.

## Desired behavior after PR is merged

The reference analysis is retracted without traceback.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
