### PR TITLE
Embed raw HTML to have the image size correctly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,14 @@
-.. image:: https://raw.githubusercontent.com/senaite/senaite.core/master/static/senaite-logo.png
-   :alt: senaite.core
-   :height: 64 px
-   :align: center
+.. raw:: html
+
+  <div align="center">
+    <h1>
+      <a href="https://github.com/senaite/senaite.core">
+        <div>
+          <img src="https://raw.githubusercontent.com/senaite/senaite.core/master/static/senaite-logo.png" alt="senaite.core" height="64" />
+        </div>
+      </a>
+    </h1>
+  </div>
 
 — **SENAITE.CORE**: *Open Soure LIMS Core based on Plone CMS*
 

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@
     </h1>
   </div>
 
-— **SENAITE.CORE**: *Open Soure LIMS Core based on Plone CMS*
+— **SENAITE.CORE**: *Open Source LIMS Core based on the CMS Plone*
 
 .. image:: https://img.shields.io/pypi/v/senaite.core.svg?style=flat-square
     :target: https://pypi.python.org/pypi/senaite.core


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR embeds raw HTML for the logo to have the image size correctly.
Also see: https://stackoverflow.com/questions/35486427/how-to-resize-images-included-in-github-documentation-pages

## Current behavior before PR

Logo displayed on the full screen width

## Desired behavior after PR is merged

Logo size corrected to 64px height

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
