### PR TITLE
Fixed evolution chart for reference analyses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,6 +84,7 @@ Changelog
 
 **Fixed**
 
+- #1190 Fixed evolution chart for reference analyses
 - #1183 Fix results calculation of dependent calculations
 - #1175 Fixed Version Display of SENAITE CORE Add-on in the Quickinstaller Tool
 - #1142 Fix instrument QC Analyses Table

--- a/bika/lims/browser/referencesample.zcml
+++ b/bika/lims/browser/referencesample.zcml
@@ -32,7 +32,7 @@
 
     <browser:page
       for="bika.lims.interfaces.IReferenceSample"
-      name="reference_analyses_table"
+      name="table_referenceanalyses"
       class="bika.lims.browser.referencesample.ReferenceAnalysesView"
       permission="bika.lims.ManageReference"
       layer="bika.lims.interfaces.IBikaLIMS"

--- a/bika/lims/browser/referencesample.zcml
+++ b/bika/lims/browser/referencesample.zcml
@@ -32,6 +32,14 @@
 
     <browser:page
       for="bika.lims.interfaces.IReferenceSample"
+      name="reference_analyses_table"
+      class="bika.lims.browser.referencesample.ReferenceAnalysesView"
+      permission="bika.lims.ManageReference"
+      layer="bika.lims.interfaces.IBikaLIMS"
+    />
+
+    <browser:page
+      for="bika.lims.interfaces.IReferenceSample"
       name="results"
       class="bika.lims.browser.referencesample.ReferenceResultsView"
       permission="bika.lims.ManageReference"

--- a/bika/lims/browser/templates/referencesample_analyses.pt
+++ b/bika/lims/browser/templates/referencesample_analyses.pt
@@ -40,8 +40,8 @@
 
     <!-- Reference Analyses table -->
     <tal:analysestable>
-    <tal:parts replace="structure view/get_analyses_table"/>
-    <input type="hidden" id='graphdata' tal:attributes="value view/get_analyses_json"/>
+      <tal:parts replace="structure view/get_analyses_table"/>
+      <input type="hidden" id='graphdata' tal:attributes="value view/get_analyses_json"/>
     </tal:analysestable>
 
     </metal:content-core>

--- a/bika/lims/browser/templates/referencesample_analyses.pt
+++ b/bika/lims/browser/templates/referencesample_analyses.pt
@@ -1,18 +1,18 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:tal="http://xml.zope.org/namespaces/tal"
-    xmlns:metal="http://xml.zope.org/namespaces/metal"
-    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-    metal:use-macro="here/main_template/macros/master"
-    i18n:domain="senaite.core">
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="senaite.core">
 
-<body>
+  <body>
     <metal:content-title fill-slot="content-title">
-    <h1>
+      <h1>
         <img tal:condition="view/icon | nothing"
              src="" tal:attributes="src view/icon"/>
         <span class="documentFirstHeading"
               tal:content="context/title"></span>
-    </h1>
+      </h1>
     </metal:content-title>
 
     <metal:content-description fill-slot="content-description">
@@ -20,30 +20,39 @@
 
     <metal:content-core fill-slot="content-core">
 
-    <!-- Chart container -->
-    <div class='chart-container'>
-        <div class='chart-options'>
-            <input type='hidden' id='selqcsample' name='selqcsample'>
-            <label for='selanalyses'>Analysis</label>
-            <select id='selanalyses' name='selanalyses'>
-            </select>&nbsp;&nbsp;
-            <label for='interpolation'>Interpolation</label>
-            <select id='interpolation' name='interpolation'>
-                <option value='basis' selected>Basis</option>
-                <option value='cardinal'>Cardinal</option>
-                <option value='linear'>Linear</option>
-            </select>&nbsp;&nbsp;
-            <a id='printgraph' class='print-16' href='#' i18n:translate="">Print</a>
+      <div class="row">
+        <!-- Chart container -->
+        <div class="col-sm-12 chart-container">
+          <div class="chart-options">
+            <input type="hidden" id="selqcsample" name="selqcsample">
+            <label for="selanalyses" i18n:translate="">Analysis</label>
+            <select id="selanalyses" name="selanalyses">
+            </select>
+            <label for="interpolation" i18n:translate="">Interpolation</label>
+            <select id="interpolation" name="interpolation">
+              <option value="basis" i18n:translate="" selected>Basis</option>
+              <option value="cardinal" i18n:translate="">Cardinal</option>
+              <option value="linear" i18n:translate="">Linear</option>
+            </select>
+            <a href="#"
+               id="printgraph"
+               class="print-16 btn btn-xs btn-default"
+               i18n:translate="">Print</a>
+          </div>
+          <div id="chart"></div>
         </div>
-        <div id='chart'></div>
-    </div>
+      </div>
 
-    <!-- Reference Analyses table -->
-    <tal:analysestable>
-      <tal:parts replace="structure view/get_analyses_table"/>
-      <input type="hidden" id='graphdata' tal:attributes="value view/get_analyses_json"/>
-    </tal:analysestable>
+      <!-- Reference Analyses table -->
+      <div class="row">
+        <div class="col-sm-12">
+          <tal:referenceanalyses define="table view/get_analyses_table_view">
+            <span tal:replace="structure python:table.ajax_contents_table()"/>
+            <input type="hidden" id="graphdata" tal:attributes="value python:table.chart.get_json()"/>
+          </tal:referenceanalyses>
+        </div>
+      </div>
 
     </metal:content-core>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the reference analyses evolution chart

## Current behavior before PR

Evolution chart not displayed for reference analyses

## Desired behavior after PR is merged

Evolution chart displayed for reference analyses

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
