### PR TITLE
Added viewlets for partition and primary ARs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1193 Added viewlets for partition and primary ARs
 - #1180 Analysis Request field-specific permissions managed in `ar_workflow`
 - #1154 Default to "Active" Worksheets in listing
 - #1153 Progress bar in Worksheet listing

--- a/bika/lims/browser/viewlets/analysisrequest.py
+++ b/bika/lims/browser/viewlets/analysisrequest.py
@@ -19,3 +19,15 @@ class RetestAnalysisRequestViewlet(ViewletBase):
     """ Current Analysis Request is a retest. Display the link to the invalid
     """
     template = ViewPageTemplateFile("templates/retest_ar_viewlet.pt")
+
+
+class PrimaryAnalysisRequestViewlet(ViewletBase):
+    """ Current Analysis Request is a primary. Diplay links to partitions
+    """
+    template = ViewPageTemplateFile("templates/primary_ar_viewlet.pt")
+
+
+class PartitionAnalysisRequestViewlet(ViewletBase):
+    """ Current Analysis Request is a partition. Display the link to primary
+    """
+    template = ViewPageTemplateFile("templates/partition_ar_viewlet.pt")

--- a/bika/lims/browser/viewlets/configure.zcml
+++ b/bika/lims/browser/viewlets/configure.zcml
@@ -137,4 +137,26 @@
     permission="zope2.View"
     layer="bika.lims.interfaces.IBikaLIMS"
   />
+
+  <!-- Primary Analysis Request viewlet -->
+  <browser:viewlet
+    for="bika.lims.interfaces.IAnalysisRequest"
+    name="bika.lims.primary_ar_viewlet"
+    class=".analysisrequest.PrimaryAnalysisRequestViewlet"
+    manager="plone.app.layout.viewlets.interfaces.IAboveContent"
+    template="templates/primary_ar_viewlet.pt"
+    permission="zope2.View"
+    layer="bika.lims.interfaces.IBikaLIMS"
+  />
+
+  <!-- Partition Analysis Request viewlet -->
+  <browser:viewlet
+    for="bika.lims.interfaces.IAnalysisRequest"
+    name="bika.lims.partition_ar_viewlet"
+    class=".analysisrequest.PartitionAnalysisRequestViewlet"
+    manager="plone.app.layout.viewlets.interfaces.IAboveContent"
+    template="templates/partition_ar_viewlet.pt"
+    permission="zope2.View"
+    layer="bika.lims.interfaces.IBikaLIMS"
+  />
 </configure>

--- a/bika/lims/browser/viewlets/templates/partition_ar_viewlet.pt
+++ b/bika/lims/browser/viewlets/templates/partition_ar_viewlet.pt
@@ -1,0 +1,20 @@
+<div tal:omit-tag=""
+     tal:condition="python:view.context.isPartition()"
+     i18n:domain="senaite.core">
+
+  <div class="visualClear"></div>
+
+  <div id="portal-alert">
+    <div class="portlet-alert-item alert alert-info alert-dismissible">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <strong i18n:translate="">Info</strong>
+      <p class="title" tal:define="parent python:view.context.getParentAnalysisRequest()">
+        <span i18n:translate="">This is a Partition from Sample </span>
+        <a tal:attributes="href python:parent.absolute_url()"
+           tal:content="python:parent.getId()"></a>
+      </p>
+    </div>
+  </div>
+</div>

--- a/bika/lims/browser/viewlets/templates/primary_ar_viewlet.pt
+++ b/bika/lims/browser/viewlets/templates/primary_ar_viewlet.pt
@@ -1,0 +1,25 @@
+<div tal:omit-tag=""
+     tal:define="descendants python:view.context.getDescendants()"
+     tal:condition="python:descendants"
+     i18n:domain="senaite.core">
+
+  <div class="visualClear"></div>
+
+  <div id="portal-alert">
+    <div class="portlet-alert-item alert alert-info alert-dismissible">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <strong i18n:translate="">Info</strong>
+      <p class="title">
+        <span i18n:translate="">The following partitions have been created from this Sample: </span>
+        <tal:parts repeat="part descendants">
+          <a tal:attributes="href python:part.absolute_url()"
+             tal:content="python:part.getId()"></a>
+          <span tal:condition="not:repeat/part/end"
+                tal:replace="string:, "></span>
+        </tal:parts>
+      </p>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

![captura de pantalla de 2019-01-08 23-30-13](https://user-images.githubusercontent.com/832627/50862960-6b26aa00-139d-11e9-8249-4ae4fe587c6a.png)

![captura de pantalla de 2019-01-08 23-29-50](https://user-images.githubusercontent.com/832627/50862966-6feb5e00-139d-11e9-993e-876a704f8c19.png)

## Current behavior before PR

No informative message is displayed when the AR is a partition or a Primary

## Desired behavior after PR is merged

Informative messages (with links) are displayed when the AR is either a Partition or a Primary

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
