### PR TITLE
Containers and Preservations appear duplicated in selection lists

### DIFF
--- a/bika/lims/browser/templates/partition_magic.pt
+++ b/bika/lims/browser/templates/partition_magic.pt
@@ -152,9 +152,9 @@
                           </label>
                           <div class="form-group">
                             <select name="partitions.container_uid:records" class="form-control">
+                              <option value=""></option>
                               <tal:options repeat="container view/get_container_data"
                                           define="part_container_uid python:containers.get(partition, '');">
-                                <option value=""></option>
                                 <option tal:attributes="value container/uid;
                                                         selected python:container.get('uid') == part_container_uid"
                                         tal:content="container/title">
@@ -172,9 +172,9 @@
                           </label>
                           <div class="form-group">
                             <select name="partitions.preservation_uid:records" class="form-control">
+                              <option value=""></option>
                               <tal:options repeat="preservation view/get_preservation_data"
                                           define="part_preservation_uid python:preservations.get(partition, '');">
-                                <option value=""></option>
                                 <option tal:attributes="value preservation/uid;
                                                         selected python:preservation.get('uid') == part_preservation_uid"
                                         tal:content="preservation/title">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Containers and Preservations selection lists contain empty options in between

## Current behavior before PR

Containers and Preservations selection lists contain empty options in between

## Desired behavior after PR is merged

Containers and Preservations selection lists do not contain empty options in between

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
