### PR TITLE
Analysis Requests nav item keeps its old name after upgrade

### DIFF
--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -1533,10 +1533,10 @@ def rename_analysis_requests_actions(portal):
     def rename_ar_action(content_type):
         if hasattr(content_type, "analysisrequests"):
             content_type.analysisrequests.setTitle("Samples")
-            content_type.reindexObject()
+            content_type.analysisrequests.reindexObject()
         if hasattr(content_type, "artemplates"):
             content_type.artemplates.setTitle("Sample Templates")
-            content_type.reindexObject()
+            content_type.artemplates.reindexObject()
 
     rename_ar_action(portal)
     for client in portal.clients.objectValues("Client"):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Although the upgrade step renames the link to "Samples", the folder object was not reindexed, so the new name was not displayed in nav bar. Same for action views inside Client and Batch objects.

## Current behavior before PR

Analysis Requests link from nav bar keeps the old name

## Desired behavior after PR is merged

Analysis Requests link from nav bar is displayed as "Samples"

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
