### PR TITLE
Add "Auto-partition" bool field in Template

### DIFF
--- a/bika/lims/browser/analysisrequest/workflow.py
+++ b/bika/lims/browser/analysisrequest/workflow.py
@@ -209,9 +209,7 @@ class AnalysisRequestWorkflowAction(AnalysesWorkflowAction):
         if not IAnalysisRequest.providedBy(obj):
             return False
         template = obj.getTemplate()
-        if not template:
-            return False
-        return template.getAutoPartition()
+        return template and template.getAutoPartition()
 
     def workflow_action_receive(self):
         action, came_from = WorkflowAction._get_form_workflow_action(self)

--- a/bika/lims/browser/analysisrequest/workflow.py
+++ b/bika/lims/browser/analysisrequest/workflow.py
@@ -209,10 +209,9 @@ class AnalysisRequestWorkflowAction(AnalysesWorkflowAction):
         if not IAnalysisRequest.providedBy(obj):
             return False
         template = obj.getTemplate()
-        if not template or not template.getAutoPartition():
+        if not template:
             return False
-        partitions = template.getPartitions()
-        return partitions and len(partitions) > 0
+        return template.getAutoPartition()
 
     def workflow_action_receive(self):
         action, came_from = WorkflowAction._get_form_workflow_action(self)

--- a/bika/lims/content/artemplate.py
+++ b/bika/lims/content/artemplate.py
@@ -217,6 +217,17 @@ schema = BikaSchema.copy() + Schema((
         ),
     ),
 
+    BooleanField(
+        "AutoPartition",
+        schemata="Sample Partitions",
+        default=True,
+        widget=BooleanWidget(
+            label=_("Auto-partition on receive"),
+            description=_("Automatically redirect the user to the partitions "
+                          "creation view when Sample is received.")
+        ),
+    ),
+
     ReferenceField(
         "AnalysisProfile",
         schemata="Analyses",


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

By default, when a Template is used for Sample creation, the system redirects to the partitioning view when the Sample is received. Nevertheless, some laboratories do not perform the partitioning at the same time the sample is received, rather they do it in a separate process, either because the user in charge of reception does not have the skills for the partitioning or because they sent the sample to a department that is specifically in charge of partitioning and storage.

With the changes provided in this commit, the user (labman) can enable/disable the auto-partitioning on reception in the Template itself. Hence, when this option is disabled, the user will not be redirected to the partitions creation view, while the primary sample will be successfully transitioned to `received` status.

![captura de pantalla de 2019-01-10 19-26-48](https://user-images.githubusercontent.com/832627/50988781-e9a25980-150d-11e9-9bc0-e8f0e3692f1c.png)

## Current behavior before PR

Partitions creation view is automatically displayed when receiving a Sample (for which a template was used)

## Desired behavior after PR is merged

Partitions creation view is automatically displayed when receiveing a Sample if the option "Auto-partition on receive" from the Template is enabled.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
