### PR TITLE
Listing: Set the value directly on the field in the ajax endpoint

### DIFF
--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -1069,7 +1069,8 @@ class AnalysesView(BikaListingView):
         full_obj = self.get_object(analysis_brain)
         item['Hidden'] = full_obj.getHidden()
         if IRoutineAnalysis.providedBy(full_obj):
-            item['allow_edit'].append('Hidden')
+            if self.has_permission('Modify portal content'):
+                item['allow_edit'].append('Hidden')
 
     def _folder_item_fieldicons(self, analysis_brain):
         """Resolves if field-specific icons must be displayed for the object

--- a/bika/lims/browser/listing/ajax.py
+++ b/bika/lims/browser/listing/ajax.py
@@ -384,13 +384,14 @@ class AjaxListingView(BrowserView):
 
         # field exists, set it with the value
         if field:
+            # https://github.com/senaite/senaite.core/pull/1200
             # N.B. We don't use the `edit` method here to bypass the instance
             #      permission check for `Modify portal content`.
             # obj.edit(**{field.getName(): value})
 
             # get the field mutator (works only for AT content types)
-            mutator = field.getMutator(obj)
-            if mutator:
+            if hasattr(obj, "getMutator"):
+                mutator = field.getMutator(obj)
                 mapply(mutator, value)
             else:
                 # Set the value on the field directly

--- a/bika/lims/browser/listing/ajax.py
+++ b/bika/lims/browser/listing/ajax.py
@@ -390,7 +390,7 @@ class AjaxListingView(BrowserView):
             # obj.edit(**{field.getName(): value})
 
             # get the field mutator (works only for AT content types)
-            if hasattr(obj, "getMutator"):
+            if hasattr(field, "getMutator"):
                 mutator = field.getMutator(obj)
                 mapply(mutator, value)
             else:

--- a/bika/lims/browser/listing/ajax.py
+++ b/bika/lims/browser/listing/ajax.py
@@ -383,7 +383,12 @@ class AjaxListingView(BrowserView):
 
         # field exists, set it with the value
         if field:
-            obj.edit(**{field.getName(): value})
+            # N.B. We don't use the `edit` method here to bypass the instance
+            #      permission check for `Modify portal content`.
+            # obj.edit(**{field.getName(): value})
+            #
+            # Set the value on the field directly
+            field.set(obj, value)
             updated_objects.append(obj)
 
         # check if the object is an analysis and has an interim
@@ -578,7 +583,8 @@ class AjaxListingView(BrowserView):
         # sanity check
         for key, value in query.iteritems():
             if key not in valid_catalog_indexes:
-                return self.error("{} is not a valid catalog index".format(key))
+                return self.error(
+                    "{} is not a valid catalog index".format(key))
 
         # set the content filter
         self.contentFilter = query

--- a/bika/lims/browser/listing/ajax.py
+++ b/bika/lims/browser/listing/ajax.py
@@ -10,8 +10,9 @@ from bika.lims.browser.listing.decorators import inject_runtime
 from bika.lims.browser.listing.decorators import returns_safe_json
 from bika.lims.browser.listing.decorators import set_application_json_header
 from bika.lims.browser.listing.decorators import translate
-from bika.lims.interfaces import IRoutineAnalysis
 from bika.lims.interfaces import IReferenceAnalysis
+from bika.lims.interfaces import IRoutineAnalysis
+from Products.Archetypes.utils import mapply
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.interface import implements
 from zope.publisher.interfaces import IPublishTraverse
@@ -386,9 +387,15 @@ class AjaxListingView(BrowserView):
             # N.B. We don't use the `edit` method here to bypass the instance
             #      permission check for `Modify portal content`.
             # obj.edit(**{field.getName(): value})
-            #
-            # Set the value on the field directly
-            field.set(obj, value)
+
+            # get the field mutator (works only for AT content types)
+            mutator = field.getMutator(obj)
+            if mutator:
+                mapply(mutator, value)
+            else:
+                # Set the value on the field directly
+                field.set(obj, value)
+
             updated_objects.append(obj)
 
         # check if the object is an analysis and has an interim

--- a/bika/lims/browser/listing/view.py
+++ b/bika/lims/browser/listing/view.py
@@ -214,6 +214,13 @@ class ListingView(AjaxListingView):
         """
         return self.contents_table_template()
 
+    @view.memoize
+    def has_permission(self, permission):
+        """Checks if the current context has the given permission
+        """
+        sm = getSecurityManager()
+        return sm.checkPermission(permission, self.context)
+
     @property
     def review_state(self):
         """Get workflow state of object in wf_id.


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes how values are set on schema fields in the listing.

Before the endpoint used the `edit` method of the instance, which calls the `updateAll` from Archetypes.Schema: https://github.com/plone/Products.Archetypes/blob/master/Products/Archetypes/Schema/__init__.py#L523

The value couldn't be set when the object did not grant the `Modify portal content` permission to the user.

## Current behavior before PR

Instance permission checks were performed by using the `instance.edit` method.
Therefore, no value could be set if the content itself did not grant the `Modify portal content` permission

## Desired behavior after PR is merged

Instance permission checks are bypassed and the field is directly set

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
