### PR TITLE
Make use of adapters for import and export instrument interfaces

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Changelog
 
 **Changed**
 
+- #1206 Make use of adapters for instrument import/export interfaces
 - #1203 Remove explicit definition of transitions in AR listing
 - #1192 Integrate Container and Preservation in Partition Magic
 - #1180 Analysis Request default ID Format becomes {sampleType}-{seq:04d}

--- a/bika/lims/content/instrument.py
+++ b/bika/lims/content/instrument.py
@@ -370,13 +370,8 @@ def getImportDataInterfaces(context, import_only=False):
     """ Return the current list of import data interfaces
     """
     from bika.lims.exportimport import instruments
-    exims = []
-    for exim_id in instruments.__all__:
-        exim = instruments.getExim(exim_id)
-        if import_only and not hasattr(exim, 'Import'):
-            pass
-        else:
-            exims.append((exim_id, exim.title))
+    exims = instruments.get_instrument_import_interfaces()
+    exims = map(lambda imp: (imp[0], imp[1].title), exims)
     exims.sort(lambda x, y: cmp(x[1].lower(), y[1].lower()))
     exims.insert(0, ('', t(_('None'))))
     return DisplayList(exims)

--- a/bika/lims/exportimport/dataimport.py
+++ b/bika/lims/exportimport/dataimport.py
@@ -7,10 +7,9 @@
 
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t
 from bika.lims.browser import BrowserView
-from bika.lims.content.instrument import getDataInterfaces
 from bika.lims.exportimport import instruments
+from bika.lims.exportimport.instruments import get_instrument_import_interfaces
 from bika.lims.exportimport.load_setup_data import LoadSetupData
 from bika.lims.interfaces import ISetupDataSetList
 from plone.app.layout.globals.interfaces import IViewView
@@ -60,7 +59,7 @@ class ImportView(BrowserView):
         request.set('disable_border', 1)
 
     def getDataInterfaces(self):
-        return getDataInterfaces(self.context)
+        return get_instrument_import_interfaces()
 
     def getSetupDatas(self):
         datasets = []

--- a/bika/lims/exportimport/instruments/__init__.py
+++ b/bika/lims/exportimport/instruments/__init__.py
@@ -187,6 +187,7 @@ def is_import_interface(instrument_interface):
         obj_name = instrument_interface.__name__.replace(__name__, "")
         if obj_name[1:] in __all__ and hasattr(instrument_interface, "Import"):
             return True
+    return False
 
 
 def is_export_interface(instrument_interface):
@@ -200,6 +201,7 @@ def is_export_interface(instrument_interface):
         obj_name = instrument_interface.__name__.replace(__name__, "")
         if obj_name[1:] in __all__ and hasattr(instrument_interface, "Export"):
             return True
+    return False
 
 
 def get_instrument_import_interfaces():

--- a/bika/lims/exportimport/instruments/__init__.py
+++ b/bika/lims/exportimport/instruments/__init__.py
@@ -170,8 +170,9 @@ def get_instrument_interfaces():
     for name, obj in inspect.getmembers(curr_module):
         if hasattr(obj, '__name__'):
             obj_name = obj.__name__.replace(__name__, "")
-            if obj_name[1:] in __all__:
-                interfaces.append((obj.__name__, obj))
+            obj_name = obj_name and obj_name[1:] or ""
+            if obj_name in __all__:
+                interfaces.append((obj_name, obj))
     return interfaces
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

At the moment, the interfaces for instrument results import and export are loaded by inspecting members inside `exportimport.instruments` module. This is not reliable, specially when one wants to add his/her own instrument interfaces in another add-on.

This Pull Request adds three new markers for instrument interfaces: `IInstrumentInterface`, `IInstrumentImportInterface` and `IInstrumentExportInterface`. This allows to add new instrument interfaces not included in `senaite.core` by using adapters.

This Pull Request keeps the "classic" way instrument interfaces were loaded, but this will probably be purged and all instrument interfaces moved outside `senaite.core`, in a specific add-on. At that point, all instrument interfaces will be loaded by making use of adapters and old code removed.

## Current behavior before PR

Instrument interfaces (either for export and for import) are loaded by inspecting members inside `exportimport.instruments` module.

## Desired behavior after PR is merged

User can add new instrument interfaces in add-ons other than `senaite.core` by making use of adapters and any of these three marker interfaces: `IInstrumentInterface`, `IInstrumentImportInterface` and `IInstrumentExportInterface`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
