### PR TITLE
Notify object modified event in ajax set field endpoint

### DIFF
--- a/bika/lims/browser/listing/ajax.py
+++ b/bika/lims/browser/listing/ajax.py
@@ -15,6 +15,7 @@ from bika.lims.interfaces import IRoutineAnalysis
 from Products.Archetypes.utils import mapply
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.interface import implements
+from zope.lifecycleevent import modified
 from zope.publisher.interfaces import IPublishTraverse
 
 
@@ -417,8 +418,8 @@ class AjaxListingView(BrowserView):
         # unify the list of updated objects
         updated_objects = list(set(updated_objects))
 
-        # reindex updated objects
-        map(lambda o: o.reindexObject(), updated_objects)
+        # notify that the objects were modified
+        map(modified, updated_objects)
 
         return updated_objects
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Notify `zope.lifecycleevent.interfaces.IObjectModifiedEvent` when fields are updated in the ajax listing endpoint

## Current behavior before PR

No object modified event was sent when the field was set in the ajax listing endpoint

## Desired behavior after PR is merged

Object modified event is send when the field is set in the ajax listing endpoint


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
