### PR TITLE
Fix typo in SamplingFieldsVisibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,7 +89,7 @@ Changelog
 
 
 **Fixed**
-
+- #1212 Fix typo in SamplingFieldsVisibility
 - #1191 Some worksheets pre-1.3 with published analyses remain in open/to_be_verified state
 - #1190 Fixed evolution chart for reference analyses
 - #1183 Fix results calculation of dependent calculations

--- a/bika/lims/adapters/widgetvisibility.py
+++ b/bika/lims/adapters/widgetvisibility.py
@@ -119,7 +119,7 @@ class SamplingFieldsVisibility(SenaiteATWidgetVisibility):
 
     def isVisible(self, field, mode="view", default="visible"):
         # If object has been already created, get SWF statues from it.
-        sw_enabled = False
+        swf_enabled = False
         if hasattr(self.context, 'getSamplingWorkflowEnabled') and \
                 self.context.getSamplingWorkflowEnabled() is not '':
             swf_enabled = self.context.getSamplingWorkflowEnabled()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a variable typo for `SamplingFieldsVisibility`.

## Current behavior before PR

Variable was defined as `sw_enabled `

## Desired behavior after PR is merged

Variable should be called `sw_enabled `

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
