### PR TITLE
Fix instrument notification display in Manage Results View

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,6 +90,7 @@ Changelog
 
 **Fixed**
 
+- #1213 Fix instrument notification display in Manage Results View
 - #1191 Some worksheets pre-1.3 with published analyses remain in open/to_be_verified state
 - #1190 Fixed evolution chart for reference analyses
 - #1183 Fix results calculation of dependent calculations

--- a/bika/lims/browser/analysisrequest/manage_results.py
+++ b/bika/lims/browser/analysisrequest/manage_results.py
@@ -41,4 +41,4 @@ class AnalysisRequestManageResultsView(AnalysisRequestViewView):
             message = _("Some analyses use out-of-date or uncalibrated "
                         "instruments. Results edition not allowed")
             message = "%s: %s" % (message, (', '.join(invalid)))
-            self.context.plone_utils.addPortalMessage(message, 'warn')
+            self.context.plone_utils.addPortalMessage(message, 'warning')


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the display of the instrument notification in Manage Results View

## Current behavior before PR

<img width="1188" alt="" src="https://user-images.githubusercontent.com/713193/51668232-10f32f00-1fc2-11e9-91ae-263f2cb68181.png">

## Desired behavior after PR is merged

<img width="1179" alt="" src="https://user-images.githubusercontent.com/713193/51668286-28321c80-1fc2-11e9-9f67-65b116c281a1.png">


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
