### PR TITLE
Do not modify the analysis ID on retraction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Changelog
 
 **Changed**
 
+- #1215 Do not modify the ID of analysis on retraction
 - #1207 Make use of adapters for instrument auto-import
 - #1206 Make use of adapters for instrument import/export interfaces
 - #1203 Remove explicit definition of transitions in AR listing

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Changelog
 
 **Changed**
 
+- #1215 Do not copy CaptureDate and Result in retest analyses when created
 - #1215 Do not modify the ID of analysis on retraction
 - #1207 Make use of adapters for instrument auto-import
 - #1206 Make use of adapters for instrument import/export interfaces

--- a/bika/lims/tests/doctests/WorkflowAnalysisReject.rst
+++ b/bika/lims/tests/doctests/WorkflowAnalysisReject.rst
@@ -486,6 +486,7 @@ In `verified` state, the analysis cannot be rejected:
 
     >>> bikasetup.setSelfVerificationEnabled(True)
     >>> analysis = analysis.getRetest()
+    >>> analysis.setResult(12)
     >>> success = do_action_for(analysis, "submit")
     >>> success = do_action_for(analysis, "verify")
     >>> api.get_workflow_status_of(analysis)

--- a/bika/lims/tests/doctests/WorkflowAnalysisRetract.rst
+++ b/bika/lims/tests/doctests/WorkflowAnalysisRetract.rst
@@ -130,13 +130,19 @@ The new analysis is a copy of retracted one:
     >>> retest.getKeyword() == analysis.getKeyword()
     True
 
-And keeps the same results as the retracted one:
+But it does not keep the result:
 
-    >>> retest.getResult() == analysis.getResult()
+    >>> not retest.getResult()
+    True
+
+And Result capture date is None:
+
+    >>> not retest.getResultCaptureDate()
     True
 
 If I submit the result for the new analysis:
 
+    >>> retest.setResult(analysis.getResult())
     >>> try_transition(retest, "submit", "to_be_verified")
     True
 

--- a/bika/lims/tests/test_AnalysisRequest_retract.py
+++ b/bika/lims/tests/test_AnalysisRequest_retract.py
@@ -83,6 +83,7 @@ class TestAnalysisRequestRetract(DataTestCase):
                 continue
 
             # Check "submit" transition -> to_be_verified
+            analysis.setResult(12)
             api.do_transition_for(analysis, "submit")
             self.assertEquals(
                 api.get_workflow_status_of(analysis, "review_state"),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The analysis ID was changed on retraction with the aim to keep the same ID for the retest. So, if the analysis ID was "Mg", after retraction it was changed to "Mg-1", while "Mg" ID was set to the retest.

This commit changes this behavior so the ID of the original analysis is kept, while the ID of the retest is set to "<keyword>-<num>".

## Current behavior before PR

Retests acquire the ID of the retracted analysis, while the ID of the retracted analysis is modified.

## Desired behavior after PR is merged

The ID of the retracted analysis does not get modified.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
