### PR TITLE
Allow manual entry (if granted) of results if instrument is invalid

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -149,6 +149,7 @@ Changelog
 
 **Fixed**
 
+- #1216 Allow manual entry (if granted) of results if instrument is invalid
 - #1051 Analyses Requests w/o submitted results always appear as not late
 - #1047 Fix translate utility function
 - #1049 Secondary Analysis Request changes received date of Sample

--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -237,7 +237,11 @@ class AnalysesView(BikaListingView):
         # Is the instrument out of date?
         # The user can assign a result to the analysis if it does not have any
         # instrument assigned or the instrument assigned is valid.
-        return self.is_analysis_instrument_valid(analysis_brain)
+        if not self.is_analysis_instrument_valid(analysis_brain):
+            # return if it is allowed to enter a manual result
+            return analysis_obj.getManualEntryOfResults()
+
+        return True
 
     @viewcache.memoize
     def is_analysis_instrument_valid(self, analysis_brain):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR allows the results entry (if allowed by the service) to analyses with invalid instruments assigned.

## Current behavior before PR

Entry of an analysis result was not allowed, if the instrument was not valid.

## Desired behavior after PR is merged

Entry of an analysis result is allowed if the AS has the "Manual entry of results" option set, even if the instrument is not valid.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
