### PR TITLE
Added filtering buttons in Analyses listings (Valid, Invalid and All)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1217 Added filtering buttons in Analyses listings (Valid, Invalid, All)
 - #1193 Added viewlets for partition and primary ARs
 - #1180 Analysis Request field-specific permissions managed in `ar_workflow`
 - #1154 Default to "Active" Worksheets in listing

--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -166,6 +166,33 @@ class AnalysesView(BikaListingView):
         self.review_states = [
             {
                 "id": "default",
+                "title": _("Valid"),
+                "contentFilter": {
+                    "review_state": [
+                        "registered",
+                        "unassigned",
+                        "assigned",
+                        "to_be_verified",
+                        "verified",
+                        "published",
+                    ]
+                },
+                "columns": self.columns.keys()
+            },
+            {
+                "id": "invalid",
+                "contentFilter": {
+                    "review_state": [
+                        "cancelled",
+                        "retracted",
+                        "rejected",
+                    ]
+                },
+                "title": _("Invalid"),
+                "columns": self.columns.keys(),
+            },
+            {
+                "id": "all",
                 "title": _("All"),
                 "contentFilter": {},
                 "columns": self.columns.keys()

--- a/bika/lims/browser/analysisrequest/tables.py
+++ b/bika/lims/browser/analysisrequest/tables.py
@@ -29,15 +29,6 @@ class LabAnalysesTable(AnalysesView):
         self.show_select_column = True
         self.show_search = False
 
-        self.review_states = [
-            {
-                "id": "default",
-                "title": _("All"),
-                "contentFilter": {},
-                "columns": self.columns.keys()
-             },
-        ]
-
 
 class FieldAnalysesTable(AnalysesView):
     """Field Analyses Listing Table for ARs
@@ -56,15 +47,6 @@ class FieldAnalysesTable(AnalysesView):
         self.show_workflow_action_buttons = True
         self.show_select_column = True
         self.show_search = False
-
-        self.review_states = [
-            {
-                "id": "default",
-                "title": _("All"),
-                "contentFilter": {},
-                "columns": self.columns.keys()
-             },
-        ]
 
 
 class QCAnalysesTable(QCAnalysesView):

--- a/bika/lims/browser/fields/aranalysesfield.py
+++ b/bika/lims/browser/fields/aranalysesfield.py
@@ -84,7 +84,6 @@ class ARAnalysesField(ObjectField):
         :type specs: list
         :returns: list of new assigned Analyses
         """
-
         # This setter returns a list of new set Analyses
         new_analyses = []
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Added the filter bar by status in analyses listings, with tree buttons:

- **Valid**: displays analyses with status "registered", "unassigned", "assigned", "to_be_verified", "verified", "published".

- **Invalid**: displays analyses with status "cancelled", "retracted", "rejected"

- **All**: displays all analyses

![captura de pantalla de 2019-01-27 23-14-30](https://user-images.githubusercontent.com/832627/51807710-e12a7c80-228a-11e9-964b-5e64553a6af5.png)

![captura de pantalla de 2019-01-27 23-15-32](https://user-images.githubusercontent.com/832627/51807718-eee00200-228a-11e9-9fb7-e5d18cda7c29.png)

## Current behavior before PR

No filter bar.

## Desired behavior after PR is merged

Filter bar is displayed.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
