### PR TITLE
Display "unassign" transition in Worksheet context only

### DIFF
--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -222,6 +222,8 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         """ Unassigns the analysis passed in from the worksheet.
         Delegates to 'unassign' transition for the analysis passed in
         """
+        # We need to bypass the guard's check for current context!
+        api.get_request().set("ws_uid", api.get_uid(self))
         if analysis.getWorksheet() == self:
             doActionFor(analysis, "unassign")
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The transition "unassign" is currently displayed for analyses listings in contexts other than Worksheet (e.g. in Sample -AR- context). Although this is not a problem because for the unassignment of an Analysis from a worksheet there is no need to know the worksheet the analysis is assigned to, it might be confusing and could accidentally cause undesired unassignments.

This commit, makes the unassign transition button to only be displayed inside worksheet contexts. It also injects the current worksheet uid in the request when calling "removeAnalysis" from Worksheet context. Otherwise, wouldn't be possible to unassign the analysis programatically regardless of the current context.

## Current behavior before PR

Unassign button is displayed inside Sample -AR- context.

![captura de pantalla de 2019-01-28 10-15-42](https://user-images.githubusercontent.com/832627/51825754-bde0eb00-22e5-11e9-886b-6f1ecf779c4f.png)


## Desired behavior after PR is merged

Unassign button is only displayed inside Worksheet context.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
