### PR TITLE
Fixed Analysis Edit Permission in Registered State

### DIFF
--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -262,7 +262,7 @@ class AnalysesView(BikaListingView):
             return False
 
         # Check if the user is allowed to enter a value to to Result field
-        elif not self.has_permission("Field: Edit Result", analysis_obj):
+        if not self.has_permission("Field: Edit Result", analysis_obj):
             return False
 
         # Is the instrument out of date?

--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -261,6 +261,10 @@ class AnalysesView(BikaListingView):
             # lab analyses.
             return False
 
+        # Check if the user is allowed to enter a value to to Result field
+        elif not self.has_permission("Field: Edit Result", analysis_obj):
+            return False
+
         # Is the instrument out of date?
         # The user can assign a result to the analysis if it does not have any
         # instrument assigned or the instrument assigned is valid.
@@ -661,26 +665,21 @@ class AnalysesView(BikaListingView):
         item['CaptureDate'] = capture_date_str
         item['result_captured'] = capture_date_str
 
-        # Note: As soon as we have a separate content type for field analysis,
-        #       we can solely rely on the field permission "Field: Edit Result"
         if self.is_analysis_edition_allowed(analysis_brain):
-            if self.has_permission("Field: Edit Remarks", analysis_brain):
-                item['allow_edit'].extend(['Remarks'])
+            item['allow_edit'].extend(['Remarks'])
+            item['allow_edit'].extend(['Result'])
 
-            if self.has_permission("Field: Edit Result", analysis_brain):
-                item['allow_edit'].extend(['Result'])
-
-                # If this analysis has a predefined set of options as result,
-                # tell the template that selection list (choices) must be
-                # rendered instead of an input field for the introduction of
-                # result.
-                choices = analysis_brain.getResultOptions
-                if choices:
-                    # N.B.we copy here the list to avoid persistent changes
-                    choices = copy(choices)
-                    # By default set empty as the default selected choice
-                    choices.insert(0, dict(ResultValue="", ResultText=""))
-                    item['choices']['Result'] = choices
+            # If this analysis has a predefined set of options as result,
+            # tell the template that selection list (choices) must be
+            # rendered instead of an input field for the introduction of
+            # result.
+            choices = analysis_brain.getResultOptions
+            if choices:
+                # N.B.we copy here the list to avoid persistent changes
+                choices = copy(choices)
+                # By default set empty as the default selected choice
+                choices.insert(0, dict(ResultValue="", ResultText=""))
+                item['choices']['Result'] = choices
 
         # Wake up the object only if necessary. If there is no result set, then
         # there is no need to go further with formatted result

--- a/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
@@ -620,6 +620,7 @@
     <action url="" category="workflow" icon="">Submit for verification</action>
     <guard>
       <guard-permission>BIKA: Edit Results</guard-permission>
+      <guard-permission>BIKA: Edit Field Results</guard-permission>
       <guard-expression>python:here.guard_handler("submit")</guard-expression>
     </guard>
   </transition>

--- a/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
@@ -22,8 +22,15 @@
   needed in some guards and/or in rollback transitions. Double-check -->
   <permission>Review portal content</permission>
 
-  <!-- TODO: We need different Analysis objects for Field- and Lab- Analyses.
-  Then we can rely solely on the Workflow Field permission -->
+  <!-- TODO: We need different Analysis objects for Field- and Lab- Analyses,
+             then we can rely solely on the Workflow Field permission.
+
+  At the moment we need to grant the Sampler the edit field permission for field
+  analyses, but this should not be allowed for lab analyses.
+
+  Hence, the view needs to check *first* if the object is a field or lab
+  analysis and *afterwards* if the "Field: Edit Result" permission is granted.
+  -->
   <permission>BIKA: Edit Field Results</permission>
   <permission>BIKA: Edit Results</permission>
 
@@ -65,8 +72,6 @@
 
     <!-- Lab results are not editable, because the sample did not yet arrive in the lab -->
     <permission-map name="BIKA: Edit Results" acquired="False">
-      <permission-role>Manager</permission-role>
-      <permission-role>Sampler</permission-role>
     </permission-map>
 
     <!-- FIELD PERMISSIONS (initialized) -->

--- a/bika/lims/tests/doctests/WorkflowAnalysisSubmit.rst
+++ b/bika/lims/tests/doctests/WorkflowAnalysisSubmit.rst
@@ -750,6 +750,9 @@ Exactly these roles can submit:
     >>> get_roles_for_permission("BIKA: Edit Results", analysis)
     ['Analyst', 'LabManager', 'Manager']
 
+    >>> get_roles_for_permission("BIKA: Edit Field Results", analysis)
+    ['LabManager', 'Manager', 'Sampler']
+
 And these roles can view results:
 
     >>> get_roles_for_permission("BIKA: View Results", analysis)
@@ -762,7 +765,7 @@ Current user can submit because has the `LabManager` role:
 
 But cannot for other roles:
 
-    >>> setRoles(portal, TEST_USER_ID, ['Authenticated', 'LabClerk', 'RegulatoryInspector', 'Sampler'])
+    >>> setRoles(portal, TEST_USER_ID, ['Authenticated', 'LabClerk', 'RegulatoryInspector'])
     >>> isTransitionAllowed(analysis, "submit")
     False
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an inconsistency introduced in PR https://github.com/senaite/senaite.core/pull/1214

## Current behavior before PR

Managers can edit Analyses Results in the state "Registered"

## Desired behavior after PR is merged

Managers can **not** edit Analyses Results in the state "Registered"

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
