### PR TITLE
Replace "Request ID" header from Samples listings by "Sample ID"

### DIFF
--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -76,7 +76,7 @@ class AnalysisRequestsView(BikaListingView):
                 "sortable": False,
                 "toggle": True}),
             ("getId", {
-                "title": _("Request ID"),
+                "title": _("Sample ID"),
                 "attr": "getId",
                 "replace_url": "getURL",
                 "index": "getId"}),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Replace "Request ID" header from Samples listings by "Sample ID"

## Current behavior before PR

"Request ID" is displayed as column header

## Desired behavior after PR is merged

"Sample ID" is displayed as column header

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
