### PR TITLE
Partition IDs based on their Parent Analysis Request

### DIFF
--- a/bika/lims/browser/idserver/view.py
+++ b/bika/lims/browser/idserver/view.py
@@ -7,6 +7,7 @@
 
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from bika.lims.alphanumber import Alphanumber
 
 from zope.interface import Interface
 from zope.interface import implements
@@ -85,7 +86,10 @@ class IDServerView(BrowserView):
         number = self.storage.get(key) + 1
         spec = {
             "seq": number,
+            "alpha": Alphanumber(number),
             "year": get_current_year(),
+            "parent_analysisrequest": "ParentAR",
+            "parent_ar_id": "ParentARId",
             "sampleType": key.replace(portal_type, "").strip("-"),
         }
         return id_template.format(**spec)

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -34,7 +34,8 @@ from bika.lims.config import PROJECTNAME
 from bika.lims.content.analysisspec import ResultsRangeDict
 from bika.lims.content.bikaschema import BikaSchema
 # Bika Interfaces
-from bika.lims.interfaces import IAnalysisRequest, ICancellable
+from bika.lims.interfaces import IAnalysisRequest, ICancellable, \
+    IAnalysisRequestPartition
 # Bika Permissions
 from bika.lims.permissions import ManageInvoices
 # Bika Utils
@@ -70,6 +71,8 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import _createObjectByType
 from Products.CMFPlone.utils import safe_unicode
 from zope.interface import implements
+from zope.interface import alsoProvides
+from zope.interface import noLongerProvides
 
 
 # SCHEMA DEFINITION
@@ -2373,5 +2376,15 @@ class AnalysisRequest(BaseFolder):
             if not api.get_object(analysis).isOpen():
                 return False
         return True
+
+    def setParentAnalysisRequest(self, value):
+        """Sets a parent analysis request, making the current a partition
+        """
+        self.Schema().getField("ParentAnalysisRequest").set(self, value)
+        if not value:
+            noLongerProvides(self, IAnalysisRequestPartition)
+        else:
+            alsoProvides(self, IAnalysisRequestPartition)
+
 
 registerType(AnalysisRequest, PROJECTNAME)

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -703,6 +703,13 @@ schema = BikaFolderSchema.copy() + Schema((
                 'prefix': 'analysisrequest',
                 'sequence_type': 'generated',
                 'split_length': 1
+            }, {
+                'context': 'parent_analysisrequest',
+                'counter_reference': 'AnalysisRequestParentAnalysisRequest',
+                'counter_type': 'backreference',
+                'form': '{parent_ar_id}-{seq:02d}',
+                'portal_type': 'AnalysisRequestPartition',
+                'sequence_type': 'counter',
             },
         ],
         widget=RecordsWidget(

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -8,16 +8,16 @@
 import re
 
 import transaction
+from DateTime import DateTime
+from Products.ATContentTypes.utils import DT2dt
 from bika.lims import api
 from bika.lims import logger
 from bika.lims.alphanumber import Alphanumber
 from bika.lims.alphanumber import to_alpha
 from bika.lims.browser.fields.uidreferencefield import \
     get_backreferences as get_backuidreferences
-from bika.lims.interfaces import IIdServer
+from bika.lims.interfaces import IIdServer, IAnalysisRequestPartition
 from bika.lims.numbergenerator import INumberGenerator
-from DateTime import DateTime
-from Products.ATContentTypes.utils import DT2dt
 from zope.component import getAdapters
 from zope.component import getUtility
 
@@ -55,6 +55,15 @@ def get_contained_items(obj, spec):
     return obj.objectItems(spec)
 
 
+def get_type_id(context, **kw):
+    """Returns the type id for the context passed in
+    """
+    portal_type = kw.get("portal_type") or api.get_portal_type(context)
+    if IAnalysisRequestPartition.providedBy(context):
+        portal_type = "{}Partition".format(portal_type)
+    return portal_type
+
+
 def get_config(context, **kw):
     """Fetch the config dict from the Bika Setup for the given portal_type
     """
@@ -62,7 +71,7 @@ def get_config(context, **kw):
     config_map = api.get_bika_setup().getIDFormatting()
 
     # allow portal_type override
-    portal_type = kw.get("portal_type") or api.get_portal_type(context)
+    portal_type = get_type_id(context, **kw)
 
     # check if we have a config for the given portal_type
     for config in config_map:
@@ -81,9 +90,8 @@ def get_config(context, **kw):
 def get_variables(context, **kw):
     """Prepares a dictionary of key->value pairs usable for ID formatting
     """
-
     # allow portal_type override
-    portal_type = kw.get("portal_type") or api.get_portal_type(context)
+    portal_type = get_type_id(context, **kw)
 
     # The variables map hold the values that might get into the constructed id
     variables = {
@@ -97,7 +105,7 @@ def get_variables(context, **kw):
     }
 
     # Augment the variables map depending on the portal type
-    if portal_type == "AnalysisRequest":
+    if portal_type in ["AnalysisRequest", "AnalysisRequestPartition"]:
         now = DateTime()
         sampling_date = context.getSamplingDate()
         sampling_date = sampling_date and DT2dt(sampling_date) or DT2dt(now)
@@ -107,8 +115,14 @@ def get_variables(context, **kw):
             'clientId': context.getClientID(),
             'dateSampled': date_sampled,
             'samplingDate': sampling_date,
-            'sampleType': context.getSampleType().getPrefix(),
+            'sampleType': context.getSampleType().getPrefix()
         })
+        if portal_type == "AnalysisRequestPartition":
+            parent_ar = context.getParentAnalysisRequest()
+            variables.update({
+                "parent_analysisrequest": parent_ar,
+                "parent_ar_id": api.get_id(parent_ar)
+            })
 
     elif portal_type == "ARReport":
         variables.update({
@@ -246,7 +260,7 @@ def get_generated_number(context, config, variables, **kw):
     separator = kw.get('separator', '-')
 
     # allow portal_type override
-    portal_type = kw.get("portal_type") or api.get_portal_type(context)
+    portal_type = get_type_id(context, **kw)
 
     # The ID format for string interpolation, e.g. WS-{seq:03d}
     id_template = config.get("form", "")

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -58,10 +58,14 @@ def get_contained_items(obj, spec):
 def get_type_id(context, **kw):
     """Returns the type id for the context passed in
     """
-    portal_type = kw.get("portal_type") or api.get_portal_type(context)
+    portal_type = kw.get("portal_type", None)
+    if portal_type:
+        return portal_type
+
     if IAnalysisRequestPartition.providedBy(context):
-        portal_type = "{}Partition".format(portal_type)
-    return portal_type
+        return "AnalysisRequestPartition"
+
+    return api.get_portal_type(context)
 
 
 def get_config(context, **kw):

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -55,6 +55,11 @@ class IAnalysisRequest(Interface):
     """
 
 
+class IAnalysisRequestPartition(Interface):
+    """Marker interface for Analysis Requests that are also Partitions
+    """
+
+
 class IAnalysisRequestAddView(Interface):
     """AR Add view
     """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the IDs of Partitions to be based on their parent Analysis Request (their primary Sample). Same approach could be used for Secondary ARs.

![captura de pantalla de 2019-02-05 19-09-59](https://user-images.githubusercontent.com/832627/52300997-9b0ba200-2989-11e9-81cb-365be0205c7d.png)



## Current behavior before PR

Partition IDs do not resemble to their primary samples

## Desired behavior after PR is merged

Partition IDs have the following format by default `<primary-ar>-00`, where the last digit is a counter.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
