### PR TITLE
Add Client ID Column in Sample Listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1230 Add Client ID Column in Sample Listing
 - #1222 Added User and Security API
 - #1217 Added filtering buttons in Analyses listings (Valid, Invalid, All)
 - #1193 Added viewlets for partition and primary ARs

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -131,6 +131,12 @@ class AnalysisRequestsView(BikaListingView):
                 "attr": "getClientTitle",
                 "replace_url": "getClientURL",
                 "toggle": True}),
+            ("ClientID", {
+                "title": _("Client ID"),
+                "replace_url": "getClientURL",
+                "attr": "getClientID",
+                "replace_url": "getClientURL",
+                "toggle": True}),
             ("Province", {
                 "title": _("Province"),
                 "sortable": True,

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -133,7 +133,7 @@ class AnalysisRequestsView(BikaListingView):
                 "toggle": True}),
             ("ClientID", {
                 "title": _("Client ID"),
-                "replace_url": "getClientURL",
+                "index": "getClientID",
                 "attr": "getClientID",
                 "replace_url": "getClientURL",
                 "toggle": True}),

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -15,12 +15,11 @@ from bika.lims.config import PRIORITIES
 from bika.lims.permissions import AddAnalysisRequest
 from bika.lims.permissions import ManageAnalysisRequests
 from bika.lims.permissions import SampleSample
-from bika.lims.permissions import Verify as VerifyPermission
-from bika.lims.utils import get_image, get_progress_bar_html
+from bika.lims.utils import get_image
+from bika.lims.utils import get_progress_bar_html
 from bika.lims.utils import getUsers
 from bika.lims.utils import t
 from DateTime import DateTime
-from plone.api import user
 from Products.CMFCore.permissions import ModifyPortalContent
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 

--- a/bika/lims/catalog/analysisrequest_catalog.py
+++ b/bika/lims/catalog/analysisrequest_catalog.py
@@ -62,6 +62,7 @@ _columns_list = [
     'getBatchURL',
     'getClientUID',
     'getClientTitle',
+    'getClientID',
     'getClientURL',
     'getContactUID',
     'getContactUsername',

--- a/bika/lims/catalog/analysisrequest_catalog.py
+++ b/bika/lims/catalog/analysisrequest_catalog.py
@@ -20,6 +20,7 @@ _indexes_dict = {
     # TODO: Can be removed? Same as id
     'sortable_title': 'FieldIndex',
     'getClientUID': 'FieldIndex',
+    'getClientID': 'FieldIndex',
     'cancellation_state': 'FieldIndex',
     'getBatchUID': 'FieldIndex',
     'getDateSampled': 'DateIndex',

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -185,6 +185,7 @@ def upgrade(tool):
     apply_analysis_request_partition_interface(portal)
 
     # Updates Indexes/Metadata of bika_catalog_analysisrequest_listing
+    # https://github.com/senaite/senaite.core/pull/1230
     update_ar_listing_catalog(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -184,6 +184,9 @@ def upgrade(tool):
     # Apply IAnalysisRequestPartition marker interface to preexisting partitions
     apply_analysis_request_partition_interface(portal)
 
+    # Updates Indexes/Metadata of bika_catalog_analysisrequest_listing
+    update_ar_listing_catalog(portal)
+
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
 
@@ -1614,3 +1617,28 @@ def apply_analysis_request_partition_interface(portal):
         if ar.getParentAnalysisRequest():
             alsoProvides(ar, IAnalysisRequestPartition)
     commit_transaction(portal)
+
+
+def update_ar_listing_catalog(portal):
+    """Add Indexes/Metadata to bika_catalog_analysisrequest_listing
+    """
+    cat_id = CATALOG_ANALYSIS_REQUEST_LISTING
+    catalog = api.get_tool(cat_id)
+
+    logger.info("Updating Indexes/Metadata of Catalog '{}'".format(cat_id))
+
+    indexes_to_add = [
+        # name, attribute, metatype
+        ("getClientID", "getClientID", "FieldIndex"),
+    ]
+
+    metadata_to_add = [
+        "getClientID",
+    ]
+
+    for index in indexes_to_add:
+        add_index(portal, cat_id, *index)
+
+    for metadata in metadata_to_add:
+        refresh = metadata not in catalog.schema()
+        add_metadata(portal, cat_id, metadata, refresh_catalog=refresh)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds a sortable "Client ID" column to the AR list. The reason why this is needed is because Client Titles might not be unique for large labs and they might want to see the Client IDs instead.

## Current behavior before PR

No Client ID in Samples Listing

## Desired behavior after PR is merged

Client ID available in Samples Listing as well as sortable.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
