### PR TITLE
Remove `uniquefieldvalidator` for Client Names 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -151,6 +151,7 @@ Changelog
 
 **Removed**
 
+- #1232 Remove `uniquefieldvalidator` for Client Names
 - #1026 Removed auto-digest of results reports on verify transitions
 - #1005 Removed databasesanitize package
 - #992 Removed "Attach" report option for Attachments

--- a/bika/lims/content/organisation.py
+++ b/bika/lims/content/organisation.py
@@ -27,7 +27,6 @@ schema = BikaFolderSchema.copy() + BikaSchema.copy() + ManagedSchema((
         "Name",
         required=1,
         searchable=True,
-        validators=("uniquefieldvalidator", ),
         widget=StringWidget(
             label=_("Name"),
         ),

--- a/bika/lims/content/organisation.py
+++ b/bika/lims/content/organisation.py
@@ -6,177 +6,208 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 from AccessControl import ClassSecurityInfo
-from Products.ATExtensions.ateapi import RecordWidget
-from Products.Archetypes.public import *
-from bika.lims.config import PROJECTNAME
-from Products.CMFCore import permissions as CMFCorePermissions
-from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.utils import safe_unicode
-from bika.lims.content.bikaschema import BikaSchema, BikaFolderSchema
-from archetypes.referencebrowserwidget import ReferenceBrowserWidget
-from plone.app.folder.folder import ATFolder
+from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.fields import AddressField
 from bika.lims.browser.widgets import AddressWidget
-from bika.lims import PMF, bikaMessageFactory as _
+from bika.lims.config import PROJECTNAME
+from bika.lims.content.bikaschema import BikaFolderSchema
+from bika.lims.content.bikaschema import BikaSchema
+from plone.app.folder.folder import ATFolder
+from Products.Archetypes.public import ManagedSchema
+from Products.Archetypes.public import StringField
+from Products.Archetypes.public import StringWidget
+from Products.Archetypes.public import registerType
+from Products.CMFCore import permissions as CMFCorePermissions
+from Products.CMFPlone.utils import safe_unicode
+
 
 schema = BikaFolderSchema.copy() + BikaSchema.copy() + ManagedSchema((
-    StringField('Name',
-        required = 1,
-        searchable = True,
-        validators = ('uniquefieldvalidator',),
-        widget = StringWidget(
+
+    StringField(
+        "Name",
+        required=1,
+        searchable=True,
+        validators=("uniquefieldvalidator", ),
+        widget=StringWidget(
             label=_("Name"),
         ),
     ),
-    StringField('TaxNumber',
-        widget = StringWidget(
+
+    StringField(
+        "TaxNumber",
+        widget=StringWidget(
             label=_("VAT number"),
         ),
     ),
-    StringField('Phone',
-        widget = StringWidget(
+
+    StringField(
+        "Phone",
+        widget=StringWidget(
             label=_("Phone"),
         ),
     ),
-    StringField('Fax',
-        widget = StringWidget(
+
+    StringField(
+        "Fax",
+        widget=StringWidget(
             label=_("Fax"),
         ),
     ),
-    StringField('EmailAddress',
-        schemata = 'Address',
-        widget = StringWidget(
+
+    StringField(
+        "EmailAddress",
+        schemata="Address",
+        widget=StringWidget(
             label=_("Email Address"),
         ),
-        validators = ('isEmail',)
+        validators=("isEmail", )
     ),
-    AddressField('PhysicalAddress',
-        schemata = 'Address',
-        widget = AddressWidget(
-           label=_("Physical address"),
+
+    AddressField(
+        "PhysicalAddress",
+        schemata="Address",
+        widget=AddressWidget(
+            label=_("Physical address"),
         ),
-        subfield_validators = {
-            'country': 'inline_field_validator',
-            'state': 'inline_field_validator',
-            'district': 'inline_field_validator',
+        subfield_validators={
+            "country": "inline_field_validator",
+            "state": "inline_field_validator",
+            "district": "inline_field_validator",
         },
     ),
-    AddressField('PostalAddress',
-        schemata = 'Address',
-        widget = AddressWidget(
-           label=_("Postal address"),
+
+    AddressField(
+        "PostalAddress",
+        schemata="Address",
+        widget=AddressWidget(
+            label=_("Postal address"),
         ),
-        subfield_validators = {
-            'country': 'inline_field_validator',
-            'state': 'inline_field_validator',
-            'district': 'inline_field_validator',
+        subfield_validators={
+            "country": "inline_field_validator",
+            "state": "inline_field_validator",
+            "district": "inline_field_validator",
         },
     ),
-    AddressField('BillingAddress',
-        schemata = 'Address',
-        widget = AddressWidget(
-           label=_("Billing address"),
+
+    AddressField(
+        "BillingAddress",
+        schemata="Address",
+        widget=AddressWidget(
+            label=_("Billing address"),
         ),
-        subfield_validators = {
-            'country': 'inline_field_validator',
-            'state': 'inline_field_validator',
-            'district': 'inline_field_validator',
+        subfield_validators={
+            "country": "inline_field_validator",
+            "state": "inline_field_validator",
+            "district": "inline_field_validator",
         },
     ),
-    StringField('AccountType',
-        schemata = 'Bank details',
-        widget = StringWidget(
+
+    StringField(
+        "AccountType",
+        schemata="Bank details",
+        widget=StringWidget(
             label=_("Account Type"),
         ),
     ),
-    StringField('AccountName',
-        schemata = 'Bank details',
-        widget = StringWidget(
+
+    StringField(
+        "AccountName",
+        schemata="Bank details",
+        widget=StringWidget(
             label=_("Account Name"),
         ),
     ),
-    StringField('AccountNumber',
-        schemata = 'Bank details',
-        widget = StringWidget(
+
+    StringField(
+        "AccountNumber",
+        schemata="Bank details",
+        widget=StringWidget(
             label=_("Account Number"),
         ),
     ),
-    StringField('BankName',
-        schemata = 'Bank details',
-        widget = StringWidget(
+
+    StringField(
+        "BankName",
+        schemata="Bank details",
+        widget=StringWidget(
             label=_("Bank name"),
         ),
     ),
-    StringField('BankBranch',
-        schemata = 'Bank details',
-        widget = StringWidget(
+
+    StringField(
+        "BankBranch",
+        schemata="Bank details",
+        widget=StringWidget(
             label=_("Bank branch"),
         ),
     ),
 ),
 )
 
-IdField = schema['id']
-IdField.widget.visible = {'edit': 'visible', 'view': 'invisible'}
-# Don't make title required - it will be computed from the Organisation's
-# Name
-TitleField = schema['title']
+IdField = schema["id"]
+IdField.widget.visible = {"edit": "visible", "view": "invisible"}
+
+TitleField = schema["title"]
 TitleField.required = 0
-TitleField.widget.visible = {'edit': 'hidden', 'view': 'invisible'}
+TitleField.widget.visible = {"edit": "hidden", "view": "invisible"}
+
 
 class Organisation(ATFolder):
+    """Base class for Clients, Suppliers and for the Laboratory
+    """
+
     security = ClassSecurityInfo()
     displayContentsTab = False
     schema = schema
 
-    security.declareProtected(CMFCorePermissions.View, 'getSchema')
+    security.declareProtected(CMFCorePermissions.View, "getSchema")
+
     def getSchema(self):
         return self.schema
 
     def Title(self):
-        """ Return the Organisation's Name as its title """
-        field = self.getField('Name')
-        field = field and field.get(self) or ''
-        return safe_unicode(field).encode('utf-8')
+        """Return the name of the Organisation
+        """
+        field = self.getField("Name")
+        field = field and field.get(self) or ""
+        return safe_unicode(field).encode("utf-8")
 
     def setTitle(self, value):
+        """Set the name of the Organisation
+        """
         return self.setName(value)
 
     def getPossibleAddresses(self):
-        return ['PhysicalAddress', 'PostalAddress', 'BillingAddress']
+        """Get the possible address fields
+        """
+        return ["PhysicalAddress", "PostalAddress", "BillingAddress"]
 
     def getPrintAddress(self):
+        """Get an address for printing
+        """
         address_lines = []
-        use_address = None
-        if self.getPostalAddress().has_key('city') \
-        and self.getPostalAddress()['city']:
-            use_address = self.getPostalAddress()
-        elif self.getPhysicalAddress().has_key('city') \
-        and self.getPhysicalAddress()['city']:
-                use_address = self.getPhysicalAddress()
-        elif self.getBillingAddress().has_key('city') \
-        and self.getBillingAddress()['city']:
-            use_address = self.getBillingAddress()
-        if use_address:
-            if use_address['address']:
-                address_lines.append(use_address['address'])
-            city_line = ''
-            if use_address['city']:
-                city_line += use_address['city'] + ' '
-            if use_address['zip']:
-                city_line += use_address['zip'] + ' '
-            if city_line:
-                address_lines.append(city_line)
 
-            statecountry_line = ''
-            if use_address['state']:
-                statecountry_line += use_address['state'] + ', '
-            if use_address['country']:
-                statecountry_line += use_address['country']
-            if statecountry_line:
-                address_lines.append(statecountry_line)
+        addresses = [
+            self.getPostalAddress(),
+            self.getPhysicalAddress(),
+            self.getBillingAddress(),
+        ]
 
+        for address in addresses:
+            city = address.get("city", "")
+            zip = address.get("zip", "")
+            state = address.get("state", "")
+            country = address.get("country", "")
+
+            if city:
+                address_lines = [
+                    address["address"].strip(),
+                    "{} {}".format(city, zip).strip(),
+                    "{} {}".format(state, country).strip(),
+                ]
+                break
 
         return address_lines
+
 
 registerType(Organisation, PROJECTNAME)

--- a/bika/lims/tests/test_validation.py
+++ b/bika/lims/tests/test_validation.py
@@ -25,8 +25,8 @@ class Tests(DataTestCase):
         clients = self.portal.clients
         client1 = clients['client-2']  # not Happy Hills
         self.assertEqual(
-            client1.schema.get('Name').validate('Happy Hills', client1),
-            u"Validation failed: 'Happy Hills' is not unique")
+            client1.schema.get('ClientID').validate('HH', client1),
+            u"Validation failed: 'HH' is not unique")
         self.assertEqual(
             None,
             client1.schema.get(


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/908

This PR removes the unique field validator for Clients and Suppliers, which inherit from Organisation. 

## Current behavior before PR

Name of Clients/Suppliers needed to be unique

## Desired behavior after PR is merged

Name of Clients/Suppliers does not need to be unique

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
