### PR TITLE
Cache possible transitions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1233 Cache possible transitions
 - #1231 Add Client ID Column in Batch Listing
 - #1230 Add Client ID Column in Sample Listing
 - #1222 Added User and Security API

--- a/bika/lims/workflow/__init__.py
+++ b/bika/lims/workflow/__init__.py
@@ -9,10 +9,9 @@ import collections
 import sys
 
 from AccessControl.SecurityInfo import ModuleSecurityInfo
-from Products.CMFCore.WorkflowCore import WorkflowException
-from Products.CMFCore.utils import getToolByName
 from bika.lims import PMF
-from bika.lims import enum, api
+from bika.lims import api
+from bika.lims import enum
 from bika.lims import logger
 from bika.lims.browser import ulocalized_time
 from bika.lims.interfaces import IJSONReadExtender
@@ -20,6 +19,11 @@ from bika.lims.jsonapi import get_include_fields
 from bika.lims.utils import changeWorkflowState
 from bika.lims.utils import t
 from bika.lims.workflow.indexes import ACTIONS_TO_INDEXES
+from plone.memoize.volatile import ATTR
+from plone.memoize.volatile import CONTAINER_FACTORY
+from plone.memoize.volatile import cache
+from Products.CMFCore.utils import getToolByName
+from Products.CMFCore.WorkflowCore import WorkflowException
 from zope.interface import implements
 
 security = ModuleSecurityInfo('bika.lims.workflow')

--- a/bika/lims/workflow/__init__.py
+++ b/bika/lims/workflow/__init__.py
@@ -15,6 +15,7 @@ from bika.lims import enum
 from bika.lims import logger
 from bika.lims.api.security import get_local_roles_for
 from bika.lims.api.security import get_roles
+from bika.lims.api.security import get_user_id
 from bika.lims.browser import ulocalized_time
 from bika.lims.interfaces import IJSONReadExtender
 from bika.lims.jsonapi import get_include_fields
@@ -36,13 +37,13 @@ security.declarePublic('guard_handler')
 _marker = object()
 
 
-def store_on_instance(func, instance, transition_id, *args, **kw):
+def store_on_instance(func, instance, *args, **kw):
     """Hold the cache storage on the portal
     """
     return instance.__dict__.setdefault(ATTR, CONTAINER_FACTORY())
 
 
-def cache_transitions(func, instance, transition_id, *args, **kw):
+def cache_transitions(func, instance, *args, **kw):
     """Cache key for the possible transitions of the object
     """
     keys = []
@@ -50,22 +51,37 @@ def cache_transitions(func, instance, transition_id, *args, **kw):
     # Generate Cache key for Analyses
     if api.get_portal_type(instance) == "Analysis":
         # Possible transitions of analyes depend on the workflow state of the
-        # containing sample, on the workflow state of the analysis itself and
-        # on the roles the current user has.
+        # containing sample, on the workflow state of the analysis itself,
+        # the roles the current user and if it has a result.
         # Furthermore, it relies on the type of muti-verification and the
         # number of remaining verifications
         parent = api.get_parent(instance)
         setup = api.get_setup()
         keys = [
+            get_user_id(),
             api.get_workflow_status_of(parent),
+            api.get_modification_date(parent).ISO(),
             api.get_workflow_status_of(instance),
-            transition_id,
+            api.get_modification_date(instance).ISO(),
+            api.get_modification_date(setup).ISO(),
+            str(instance.getResult()),
+            "-".join(map(lambda i: str(i.get("value", "")),
+                         instance.getInterimFields())),
+            "-".join(map(lambda d: api.get_workflow_status_of(d),
+                     instance.getDependents())),
+            "-".join(map(lambda d: api.get_modification_date(d).ISO(),
+                     instance.getDependents())),
+            "-".join(map(lambda d: api.get_workflow_status_of(d),
+                     instance.getDependencies())),
+            "-".join(map(lambda d: api.get_modification_date(d).ISO(),
+                     instance.getDependencies())),
             "-".join(get_roles()),
             "-".join(get_local_roles_for(instance)),
-            str(setup.getSelfVerificationEnabled()),
-            str(instance.getNumberOfRemainingVerifications()),
-            setup.getTypeOfmultiVerification(),
         ]
+
+        # Append any further arguments if passed, e.g. the transition_id
+        for arg in args:
+            keys.append(str(arg))
 
     if len(keys) == 0:
         raise DontCache

--- a/bika/lims/workflow/__init__.py
+++ b/bika/lims/workflow/__init__.py
@@ -52,13 +52,19 @@ def cache_transitions(func, instance, transition_id, *args, **kw):
         # Possible transitions of analyes depend on the workflow state of the
         # containing sample, on the workflow state of the analysis itself and
         # on the roles the current user has.
+        # Furthermore, it relies on the type of muti-verification and the
+        # number of remaining verifications
         parent = api.get_parent(instance)
+        setup = api.get_setup()
         keys = [
             api.get_workflow_status_of(parent),
             api.get_workflow_status_of(instance),
             transition_id,
             "-".join(get_roles()),
             "-".join(get_local_roles_for(instance)),
+            str(setup.getSelfVerificationEnabled()),
+            str(instance.getNumberOfRemainingVerifications()),
+            setup.getTypeOfmultiVerification(),
         ]
 
     if len(keys) == 0:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a Performance issue for Samples/Worksheets with many Analyses while checking for the allowed transitions

## Current behavior before PR

Allowed transitions of analyses were checked multiple times, although the WF state of the analyses did not change.

## Desired behavior after PR is merged

Allowed transitions are cached per analysis depending on the WF state

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
