### PR TITLE
ID Server Suffix Support for Retested ARs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ Changelog
 
 **Changed**
 
+- #1243 ID Server Suffix Support for Retested ARs
 - #1240 Support action-specific `workflow_action` requests with named adapters
 - #1215 Do not copy CaptureDate and Result in retest analyses when created
 - #1215 Do not modify the ID of analysis on retraction

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -710,6 +710,12 @@ schema = BikaFolderSchema.copy() + Schema((
                 'form': '{parent_ar_id}-{seq:02d}',
                 'portal_type': 'AnalysisRequestPartition',
                 'sequence_type': 'counter',
+            }, {
+                'form': '{parent_base_id}-R{retest_count:02d}',
+                'portal_type': 'AnalysisRequestRetest',
+                'prefix': 'analysisrequestretest',
+                'sequence_type': '',
+                'split-length': 1
             },
         ],
         widget=RecordsWidget(

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -704,12 +704,11 @@ schema = BikaFolderSchema.copy() + Schema((
                 'sequence_type': 'generated',
                 'split_length': 1
             }, {
-                'context': 'parent_analysisrequest',
-                'counter_reference': 'AnalysisRequestParentAnalysisRequest',
-                'counter_type': 'backreference',
-                'form': '{parent_ar_id}-{seq:02d}',
+                'form': '{parent_ar_id}-P{partition_count:02d}',
                 'portal_type': 'AnalysisRequestPartition',
-                'sequence_type': 'counter',
+                'prefix': 'analysisrequestpartition',
+                'sequence_type': '',
+                'split-length': 1
             }, {
                 'form': '{parent_base_id}-R{retest_count:02d}',
                 'portal_type': 'AnalysisRequestRetest',

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -216,6 +216,9 @@ def get_variables(context, **kw):
             parent_ar = context.getInvalidated()
             parent_ar_id = api.get_id(parent_ar)
             parent_base_id = strip_suffix(parent_ar_id)
+            # keep the full ID if the retracted AR is a partition
+            if context.isPartition():
+                parent_base_id = parent_ar_id
             retest_count = get_retest_count(context)
             test_count = test_count + retest_count
             variables.update({

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -149,13 +149,13 @@ def get_variables(context, **kw):
 
     # The variables map hold the values that might get into the constructed id
     variables = {
-        'context': context,
-        'id': api.get_id(context),
-        'portal_type': portal_type,
-        'year': get_current_year(),
-        'parent': api.get_parent(context),
-        'seq': 0,
-        'alpha': Alphanumber(0),
+        "context": context,
+        "id": api.get_id(context),
+        "portal_type": portal_type,
+        "year": get_current_year(),
+        "parent": api.get_parent(context),
+        "seq": 0,
+        "alpha": Alphanumber(0),
     }
 
     # Augment the variables map depending on the portal type
@@ -165,11 +165,12 @@ def get_variables(context, **kw):
         sampling_date = sampling_date and DT2dt(sampling_date) or DT2dt(now)
         date_sampled = context.getDateSampled()
         date_sampled = date_sampled and DT2dt(date_sampled) or DT2dt(now)
+
         variables.update({
-            'clientId': context.getClientID(),
-            'dateSampled': date_sampled,
-            'samplingDate': sampling_date,
-            'sampleType': context.getSampleType().getPrefix()
+            "clientId": context.getClientID(),
+            "dateSampled": date_sampled,
+            "samplingDate": sampling_date,
+            "sampleType": context.getSampleType().getPrefix(),
         })
 
         # Partition
@@ -212,7 +213,7 @@ def get_variables(context, **kw):
 
     elif portal_type == "ARReport":
         variables.update({
-            'clientId': context.aq_parent.getClientID(),
+            "clientId": context.aq_parent.getClientID(),
         })
 
     return variables
@@ -336,7 +337,7 @@ def get_alpha_or_number(number, template):
 def get_counted_number(context, config, variables, **kw):
     """Compute the number for the sequence type "Counter"
     """
-    # This "context" is defined by the user in Bika Setup and can be actually
+    # This "context" is defined by the user in the Setup and can be actually
     # anything. However, we assume it is something like "sample" or similar
     ctx = config.get("context")
 
@@ -435,18 +436,18 @@ def generateUniqueId(context, **kw):
 
     # Sequence Type is "Counter", so we use the length of the backreferences or
     # contained objects of the evaluated "context" defined in the config
-    if sequence_type == 'counter':
+    if sequence_type in ["counter"]:
         number = get_counted_number(context, config, variables, **kw)
 
     # Sequence Type is "Generated", so the ID is constructed according to the
     # configured split length
-    if sequence_type == 'generated':
+    if sequence_type in ["generated"]:
         number = get_generated_number(context, config, variables, **kw)
 
     # store the new sequence number to the variables map for str interpolation
     if isinstance(number, Alphanumber):
         variables["alpha"] = number
-    variables["seq"] = int(number)
+    variables["seq"] = to_int(number)
 
     # The ID formatting template from user config, e.g. {sampleId}-R{seq:02d}
     id_template = config.get("form", "")

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -9,16 +9,18 @@ import itertools
 import re
 
 import transaction
-from DateTime import DateTime
-from Products.ATContentTypes.utils import DT2dt
 from bika.lims import api
 from bika.lims import logger
 from bika.lims.alphanumber import Alphanumber
 from bika.lims.alphanumber import to_alpha
 from bika.lims.browser.fields.uidreferencefield import \
     get_backreferences as get_backuidreferences
-from bika.lims.interfaces import IIdServer, IAnalysisRequestPartition
+from bika.lims.interfaces import IAnalysisRequestPartition
+from bika.lims.interfaces import IAnalysisRequestRetest
+from bika.lims.interfaces import IIdServer
 from bika.lims.numbergenerator import INumberGenerator
+from DateTime import DateTime
+from Products.ATContentTypes.utils import DT2dt
 from zope.component import getAdapters
 from zope.component import getUtility
 

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -60,6 +60,11 @@ class IAnalysisRequestPartition(Interface):
     """
 
 
+class IAnalysisRequestRetest(Interface):
+    """Marker interface for Analysis Requests that are Retests
+    """
+
+
 class IAnalysisRequestAddView(Interface):
     """AR Add view
     """

--- a/bika/lims/tests/doctests/ARAnalysesField.rst
+++ b/bika/lims/tests/doctests/ARAnalysesField.rst
@@ -835,7 +835,7 @@ However, this retest AR **references the same Attachments** as the original AR:
     True
 
     >>> att_ar.getLinkedRequests()
-    [<AnalysisRequest at /plone/clients/client-1/water-0004>, <AnalysisRequest at /plone/clients/client-1/water-0003>]
+    [<AnalysisRequest at /plone/clients/client-1/water-0003-R01>, <AnalysisRequest at /plone/clients/client-1/water-0003>]
 
     >>> att_ar.getLinkedAnalyses()
     []
@@ -849,7 +849,7 @@ And all contained Analyses of the retest keep references to the same Attachments
     []
 
     >>> att_an.getLinkedAnalyses()
-    [<Analysis at /plone/clients/client-1/water-0004/NoCalc>, <Analysis at /plone/clients/client-1/water-0003/NoCalc>]
+    [<Analysis at /plone/clients/client-1/water-0003/NoCalc>, <Analysis at /plone/clients/client-1/water-0003-R01/NoCalc>]
 
 This means that removing that attachment from the retest should **not** delete
 the attachment from the original AR:

--- a/bika/lims/tests/doctests/ARAnalysesField.rst
+++ b/bika/lims/tests/doctests/ARAnalysesField.rst
@@ -823,11 +823,11 @@ A new AR is automatically created for retesting:
 
     >>> ar_retest = ar3.getRetest()
     >>> ar_retest
-    <AnalysisRequest at /plone/clients/client-1/water-0004>
+    <AnalysisRequest at /plone/clients/client-1/water-0003-R01>
 
     >>> an_retest = ar3.getRetest()[analysisservice5.getKeyword()]
     >>> an_retest
-    <Analysis at /plone/clients/client-1/water-0004/NoCalc>
+    <Analysis at /plone/clients/client-1/water-0003-R01/NoCalc>
 
 However, this retest AR **references the same Attachments** as the original AR:
 

--- a/bika/lims/tests/doctests/AnalysisRequestInvalidate.rst
+++ b/bika/lims/tests/doctests/AnalysisRequestInvalidate.rst
@@ -207,7 +207,7 @@ the invalidated:
 
     >>> retest = ar.getRetest()
     >>> retest
-    <AnalysisRequest at /plone/clients/client-1/water-0002>
+    <AnalysisRequest at /plone/clients/client-1/water-0001-R01>
 
     >>> retest.getInvalidated()
     <AnalysisRequest at /plone/clients/client-1/water-0001>
@@ -270,10 +270,10 @@ as the invalidated (retest):
 
     >>> retest2 = retest.getRetest()
     >>> retest2
-    <AnalysisRequest at /plone/clients/client-1/water-0003>
+    <AnalysisRequest at /plone/clients/client-1/water-0001-R02>
 
     >>> retest2.getInvalidated()
-    <AnalysisRequest at /plone/clients/client-1/water-0002>
+    <AnalysisRequest at /plone/clients/client-1/water-0001-R01>
 
     >>> retest2.getInvalidated().getInvalidated()
     <AnalysisRequest at /plone/clients/client-1/water-0001>

--- a/bika/lims/tests/doctests/IDServer.rst
+++ b/bika/lims/tests/doctests/IDServer.rst
@@ -45,6 +45,7 @@ Needed Imports:
     >>> from bika.lims import idserver
     >>> from bika.lims.interfaces import INumberGenerator
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.workflow import doActionFor as do_action_for
 
 Functional Helpers:
 
@@ -129,6 +130,13 @@ An `AnalysisService` defines a analysis service offered by the laboratory:
     >>> analysisservice
     <...analysisservice-1>
 
+
+ID generation
+-------------
+
+IDs can contain *alphanumeric* or *numeric* numbers, depending on the provided
+ID Server configuration.
+
 Set up `ID Server` configuration:
 
     >>> values = [
@@ -177,14 +185,15 @@ Create a second `AnalysisRequest`:
     >>> ar.getId() == "water-{}-AA002".format(year)
     True
 
-Create a forth `Batch`::
+Create a `Batch`:
 
     >>> batches = self.portal.batches
     >>> batch = api.create(batches, "Batch", ClientID="RB")
     >>> batch.getId() == "BA-{}-0001".format(year)
     True
 
-Change ID formats and create new `AnalysisRequest`::
+Change ID formats and create new `AnalysisRequest`:
+
     >>> values = [
     ...            {'form': '{clientId}-{dateSampled:%Y%m%d}-{sampleType}-{seq:04d}',
     ...             'portal_type': 'AnalysisRequest',
@@ -213,7 +222,8 @@ Change ID formats and create new `AnalysisRequest`::
     >>> ar.getId()
     'RB-20170131-water-0001'
 
-Re-seed and create a new `Batch`::
+Re-seed and create a new `Batch`:
+
     >>> ploneapi.user.grant_roles(user=current_user,roles = ['Manager'])
     >>> transaction.commit()
     >>> browser.open(portal_url + '/ng_seed?prefix=batch-BA&seed=10')
@@ -225,7 +235,8 @@ Re-seed and create a new `Batch`::
     >>> ar.getId()
     'RB-20170131-water-0002'
 
-Change ID formats and use alphanumeric ids::
+Change ID formats and use alphanumeric ids:
+
     >>> sampletype2 = api.create(bika_sampletypes, "SampleType", Prefix="WB")
     >>> sampletype2
     <...sampletype-2>
@@ -249,7 +260,8 @@ Change ID formats and use alphanumeric ids::
     >>> ar.getId()
     'WB-AAA2'
 
-Now generate 8 more ARs to force the alpha segment to change
+Now generate 8 more ARs to force the alpha segment to change:
+
     >>> for num in range(8):
     ...     ar = create_analysisrequest(client, request, values, service_uids)
     >>> ar.getId()
@@ -286,6 +298,123 @@ Now generate 8 more ARs to force the alpha segment to change
     'WBAAC2'
 
 TODO: Test the case when numbers are exhausted in a sequence!
+
+
+IDs with Suffix
+---------------
+
+In SENAITE < 1.3.0 it was differentiated between an *Analysis Request* and a
+*Sample*. The *Analysis Request* acted as a "holder" of a *Sample* and the ID
+used to be the same as the holding *Sample* but with the suffix `-R01`.
+
+This suffix was incremented, e.g. `-R01` to `-R02`, when a retest was requested,
+while keeping the ID of the previous part constant.
+
+With SENAITE 1.3.0 there is no differentiation anymore between Analysis Request
+and Sample. However, some labs might still want to follow the old ID scheme with
+the suffix and incrementation of retests to keep their analysis reports in a
+sane state.
+
+Therefore, the ID Server also supports Suffixes and the logic to generated the
+next suffix number for retests:
+
+
+    >>> values = [
+    ...            {'form': '{sampleType}-{year}-{seq:04d}-R01',
+    ...             'portal_type': 'AnalysisRequest',
+    ...             'prefix': 'analysisrequest',
+    ...             'sequence_type': 'generated',
+    ...             'split_length': 2},
+    ...            {'form': '{invalidated_sample_id}-R{next_suffix_count:02d}',
+    ...             'portal_type': 'AnalysisRequestRetest',
+    ...             'prefix': 'analysisrequestretest',
+    ...             'sequence_type': 'counter',
+    ...             'counter_type': 'backreference',
+    ...             'counter_ref': 'AnalysisRequestRetracted',
+    ...             'split_length': 1},
+    ...          ]
+
+    >>> setup.setIDFormatting(values)
+
+Allow self-verification of results:
+
+    >>> setup.setSelfVerificationEnabled(True)
+
+Create a new `AnalysisRequest`:
+
+    >>> values = {'Client': client.UID(),
+    ...           'Contact': contact.UID(),
+    ...           'SamplingDate': sample_date,
+    ...           'DateSampled': sample_date,
+    ...           'SampleType': sampletype.UID(),
+    ...          }
+
+    >>> service_uids = [analysisservice.UID()]
+    >>> ar = create_analysisrequest(client, request, values, service_uids)
+    >>> ar.getId() == "water-{}-0001-R01".format(year)
+    True
+
+Receive the Sample:
+
+    >>> do_action_for(ar, "receive")[0]
+    True
+
+Submit and verify results:
+
+    >>> an = ar.getAnalyses(full_objects=True)[0]
+    >>> an.setResult(5)
+
+    >>> do_action_for(an, "submit")[0]
+    True
+
+    >>> do_action_for(an, "verify")[0]
+    True
+
+The AR should benow in the state `verified`:
+
+     >>> api.get_workflow_status_of(ar)
+     'verified'
+
+We can invalidate it now:
+
+    >>> do_action_for(ar, "invalidate")[0]
+    True
+
+
+Now a retest was created with the same ID as the invalidated AR, but an
+incremented suffix:
+
+    >>> retest = ar.getRetest()
+    >>> retest.getId() == "water-{}-0001-R02".format(year)
+    True
+
+Submit and verify results of the retest:
+
+    >>> an = retest.getAnalyses(full_objects=True)[0]
+    >>> an.setResult(5)
+
+    >>> do_action_for(an, "submit")[0]
+    True
+
+    >>> do_action_for(an, "verify")[0]
+    True
+
+The Retest should benow in the state `verified`:
+
+     >>> api.get_workflow_status_of(retest)
+     'verified'
+
+We can invalidate it now:
+
+    >>> do_action_for(retest, "invalidate")[0]
+    True
+
+Now a retest of the retest was created with the same ID as the invalidated AR,
+but an incremented suffix:
+
+    >>> retest = retest.getRetest()
+    >>> retest.getId() == "water-{}-0001-R03".format(year)
+    True
 
 
 ID Slicing

--- a/bika/lims/tests/doctests/IDServer.rst
+++ b/bika/lims/tests/doctests/IDServer.rst
@@ -325,12 +325,10 @@ next suffix number for retests:
     ...             'prefix': 'analysisrequest',
     ...             'sequence_type': 'generated',
     ...             'split_length': 2},
-    ...            {'form': '{invalidated_sample_id}-R{next_suffix_count:02d}',
+    ...            {'form': '{parent_base_id}-R{test_count:02d}',
     ...             'portal_type': 'AnalysisRequestRetest',
     ...             'prefix': 'analysisrequestretest',
-    ...             'sequence_type': 'counter',
-    ...             'counter_type': 'backreference',
-    ...             'counter_ref': 'AnalysisRequestRetracted',
+    ...             'sequence_type': '',
     ...             'split_length': 1},
     ...          ]
 

--- a/bika/lims/tests/doctests/IDServer.rst
+++ b/bika/lims/tests/doctests/IDServer.rst
@@ -1,15 +1,14 @@
 ID Server
 =========
 
-The ID Server in Bika LIMS provides IDs for content items base of the given
+The ID Server in SENAITE LIMS provides IDs for content items base of the given
 format specification. The format string is constructed in the same way as a
 python format() method based predefined variables per content type. The only
 variable available to all type is 'seq'. Currently, seq can be constructed
 either using number generator or a counter of existing items. For generated IDs,
 one can specifypoint at which the format string will be split to create the
-generator key. For counter IDs, one must specify context and the type of
-counter which is either the number of backreferences or the number of contained
-objects.
+generator key. For counter IDs, one must specify context and the type of counter
+which is either the number of backreferences or the number of contained objects.
 
 Configuration Settings:
 * format:
@@ -64,17 +63,17 @@ Variables:
     >>> sample_date = DateTime(2017, 1, 31)
     >>> portal = self.portal
     >>> request = self.request
-    >>> bika_setup = portal.bika_setup
-    >>> bika_sampletypes = bika_setup.bika_sampletypes
-    >>> bika_samplepoints = bika_setup.bika_samplepoints
-    >>> bika_analysiscategories = bika_setup.bika_analysiscategories
-    >>> bika_analysisservices = bika_setup.bika_analysisservices
-    >>> bika_labcontacts = bika_setup.bika_labcontacts
-    >>> bika_storagelocations = bika_setup.bika_storagelocations
-    >>> bika_samplingdeviations = bika_setup.bika_samplingdeviations
-    >>> bika_sampleconditions = bika_setup.bika_sampleconditions
+    >>> setup = portal.bika_setup
+    >>> bika_sampletypes = setup.bika_sampletypes
+    >>> bika_samplepoints = setup.bika_samplepoints
+    >>> bika_analysiscategories = setup.bika_analysiscategories
+    >>> bika_analysisservices = setup.bika_analysisservices
+    >>> bika_labcontacts = setup.bika_labcontacts
+    >>> bika_storagelocations = setup.bika_storagelocations
+    >>> bika_samplingdeviations = setup.bika_samplingdeviations
+    >>> bika_sampleconditions = setup.bika_sampleconditions
     >>> portal_url = portal.absolute_url()
-    >>> bika_setup_url = portal_url + "/bika_setup"
+    >>> setup_url = portal_url + "/bika_setup"
     >>> browser = self.getBrowser()
     >>> current_user = ploneapi.user.get_current()
 
@@ -146,7 +145,7 @@ Set up `ID Server` configuration:
     ...             'value': ''},
     ...          ]
 
-    >>> bika_setup.setIDFormatting(values)
+    >>> setup.setIDFormatting(values)
 
 An `AnalysisRequest` can be created:
 
@@ -200,7 +199,7 @@ Change ID formats and create new `AnalysisRequest`::
     ...             'value': ''},
     ...          ]
 
-    >>> bika_setup.setIDFormatting(values)
+    >>> setup.setIDFormatting(values)
 
     >>> values = {'Client': client.UID(),
     ...           'Contact': contact.UID(),
@@ -239,7 +238,7 @@ Change ID formats and use alphanumeric ids::
     ...             'split_length': 1},
     ...          ]
 
-    >>> bika_setup.setIDFormatting(values)
+    >>> setup.setIDFormatting(values)
     >>> values = {'SampleType': sampletype2.UID(),}
     >>> service_uids = [analysisservice.UID()]
     >>> ar = create_analysisrequest(client, request, values, service_uids)
@@ -266,7 +265,7 @@ And try now without separators:
     ...             'split_length': 1},
     ...          ]
 
-    >>> bika_setup.setIDFormatting(values)
+    >>> setup.setIDFormatting(values)
     >>> values = {'SampleType': sampletype2.UID(),}
     >>> service_uids = [analysisservice.UID()]
     >>> ar = create_analysisrequest(client, request, values, service_uids)
@@ -386,7 +385,7 @@ Analysis Request:
     ...             'split_length': 2},
     ...          ]
 
-    >>> bika_setup.setIDFormatting(id_formatting)
+    >>> setup.setIDFormatting(id_formatting)
     >>> values = {'Client': client.UID(),
     ...           'Contact': contact.UID(),
     ...           'SamplingDate': sample_date,
@@ -425,7 +424,7 @@ Do the same, but with an ID formatting without separators:
     ...             'split_length': 2},
     ...          ]
 
-    >>> bika_setup.setIDFormatting(id_formatting)
+    >>> setup.setIDFormatting(id_formatting)
     >>> ar = create_analysisrequest(client, request, values, service_uids)
     >>> ar.getId()
     'NGwaterAA001'

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -198,6 +198,9 @@ def upgrade(tool):
     # Apply IAnalysisRequestRetest marker interface to retested ARs
     apply_analysis_request_retest_interface(portal)
 
+    # Set the ID formatting for AR restest
+    set_retest_id_formatting(portal)
+
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
 
@@ -1700,3 +1703,14 @@ def apply_analysis_request_retest_interface(portal):
         if ar.getInvalidated():
             alsoProvides(ar, IAnalysisRequestRetest)
     commit_transaction(portal)
+
+
+def set_retest_id_formatting(portal):
+    """Sets the default id formatting for AR retests
+    """
+    part_id_format = dict(
+        form="{parent_base_id}-{seq:02d}-R{seq:02d}",
+        portal_type="AnalysisRequestRetest",
+        prefix="analysisrequestretest",
+        sequence_type="")
+    set_id_format(portal, part_id_format)

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -1496,12 +1496,10 @@ def set_partitions_id_formatting(portal):
     """Sets the default id formatting for AR-like partitions
     """
     part_id_format = dict(
-        context="parent_analysisrequest",
-        counter_reference="AnalysisRequestParentAnalysisRequest",
-        counter_type="backreference",
-        form="{parent_ar_id}-{seq:02d}",
+        form="{parent_ar_id}-P{partition_count:02d}",
         portal_type="AnalysisRequestPartition",
-        sequence_type="counter")
+        prefix="analysisrequestretest",
+        sequence_type="")
     set_id_format(portal, part_id_format)
 
 

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -6,10 +6,8 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 import time
-import transaction
 
-from Products.DCWorkflow.Guard import Guard
-from Products.ZCatalog.ProgressHandler import ZLogHandler
+import transaction
 from bika.lims import api
 from bika.lims import logger
 from bika.lims.catalog.analysis_catalog import CATALOG_ANALYSIS_LISTING
@@ -17,19 +15,24 @@ from bika.lims.catalog.analysisrequest_catalog import \
     CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.catalog.worksheet_catalog import CATALOG_WORKSHEET_LISTING
 from bika.lims.config import PROJECTNAME as product
-from bika.lims.interfaces import IDuplicateAnalysis, IReferenceAnalysis, \
-    INumberGenerator, IAnalysisRequestPartition
+from bika.lims.interfaces import IAnalysisRequestPartition
+from bika.lims.interfaces import IAnalysisRequestRetest
+from bika.lims.interfaces import IDuplicateAnalysis
+from bika.lims.interfaces import INumberGenerator
+from bika.lims.interfaces import IReferenceAnalysis
 from bika.lims.interfaces.analysis import IRequestAnalysis
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
-from bika.lims.workflow import changeWorkflowState, ActionHandlerPool
-from bika.lims.workflow import isTransitionAllowed
+from bika.lims.workflow import ActionHandlerPool
+from bika.lims.workflow import changeWorkflowState
 from bika.lims.workflow import doActionFor as do_action_for
-from bika.lims.workflow.analysis.events import remove_analysis_from_worksheet, \
-    reindex_request
-
-from zope.interface import alsoProvides
+from bika.lims.workflow import isTransitionAllowed
+from bika.lims.workflow.analysis.events import reindex_request
+from bika.lims.workflow.analysis.events import remove_analysis_from_worksheet
+from Products.DCWorkflow.Guard import Guard
+from Products.ZCatalog.ProgressHandler import ZLogHandler
 from zope.component import getUtility
+from zope.interface import alsoProvides
 
 version = '1.3.0'  # Remember version number in metadata.xml and setup.py
 profile = 'profile-{0}:default'.format(product)

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -9,25 +9,29 @@ import os
 import tempfile
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from email.Utils import formataddr
 
-from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.utils import _createObjectByType
-from Products.CMFPlone.utils import safe_unicode
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
 from bika.lims.idserver import renameAfterCreation
-from bika.lims.interfaces import IAnalysisService, IRoutineAnalysis, \
-    IAnalysisRequest
+from bika.lims.interfaces import IAnalysisRequest
+from bika.lims.interfaces import IAnalysisRequestRetest
+from bika.lims.interfaces import IAnalysisService
+from bika.lims.interfaces import IRoutineAnalysis
 from bika.lims.utils import attachPdf
 from bika.lims.utils import changeWorkflowState
+from bika.lims.utils import copy_field_values
 from bika.lims.utils import createPdf
 from bika.lims.utils import encode_header
-from bika.lims.utils import tmpID, copy_field_values
+from bika.lims.utils import tmpID
 from bika.lims.utils import to_utf8
-from bika.lims.workflow import doActionFor, ActionHandlerPool, \
-    push_reindex_to_actions_pool
-from email.Utils import formataddr
+from bika.lims.workflow import ActionHandlerPool
+from bika.lims.workflow import doActionFor
+from bika.lims.workflow import push_reindex_to_actions_pool
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import _createObjectByType
+from Products.CMFPlone.utils import safe_unicode
 
 
 def create_analysisrequest(client, request, values, analyses=None,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR enhances the ID Server machinery to support suffixes in Samples (ARs) to mimic the behavior of Senaite versions < 1.3.0 with the `-R01` suffix of the initial AR, and the consecutive `-Rnn` suffixes for the retested ARs. 

The introduced behavior keeps now for retests the *base ID* of the invalidated AR. The *base ID* is the ID without the suffix (aka the Sample ID). Therefore it will work even for ARs introduced in Senaite < 1.3.0.

The following **new** variables are supported now for the type `AnalysisRequestRetest`:

- `parent_ar_id`: The original ID of the invalidated AR, e.g. `Water-0001-R01`
- `parent_base_id`: The *base ID* (aka the Sample ID) with the suffix removed, e.g. `Water-0001`
- `retest_count`: The current retest count, e.g. 1 for the first invalidation
- `test_count`: The total number of tests (initial test + retests) or just the number of retests + 1

A full (advanced) configuration would look like this:

```json
[
  {
    "form": "{sampleType}-{year}-{seq:04d}-R01",
    "portal_type": "AnalysisRequest",
    "prefix": "analysisrequest",
    "sequence_type": "generated",
    "split_length": 2,
  }, {
    "form": "{parent_base_id}-R{test_count:02d}",
    "portal_type": "AnalysisRequestRetest",
    "prefix": "analysisrequestretest",
    "sequence_type": "",
  },
]
``` 

The following **new** variables are supported now for the type `AnalysisRequestPartition`:

- `parent_ar_id`:  The original ID of the parent AR, e.g. `Water-0001-R01`
- `parent_base_id`: The "base" ID with the suffix removed of the parent AR
- `partition_count`: The current number of created partitions

A full (advanced) configuration would look like this:

```json
[
  {
    "form": "{sampleType}-{year}-{seq:04d}-R01",
    "portal_type": "AnalysisRequest",
    "prefix": "analysisrequest",
    "sequence_type": "generated",
    "split_length": 2,
  }, {
    "form": "{parent_base_id}-R{test_count:02d}",
    "portal_type": "AnalysisRequestRetest",
    "prefix": "analysisrequestretest",
    "sequence_type": "",
  }, {
    "form": "{parent_ar_id}-P{partition_count:02d}",
    "portal_type": "AnalysisRequestPartition",
    "prefix": "analysisrequestpartition",
    "sequence_type": "",
  },
]
``` 

Also see here for further information:
https://github.com/senaite/senaite.core/pull/1228

## Current behavior before PR

Sample Suffix not supported

## Desired behavior after PR is merged

Sample Suffix supported

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
