### PR TITLE
Added "Body for Sample Invalidation email" field in setup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1244 Added "Body for Sample Invalidation email" field in setup
 - #1231 Add Client ID Column in Batch Listing
 - #1230 Add Client ID Column in Sample Listing
 - #1222 Added User and Security API

--- a/bika/lims/browser/workflow/analysisrequest.py
+++ b/bika/lims/browser/workflow/analysisrequest.py
@@ -113,7 +113,7 @@ class WorkflowActionInvalidateAdapter(WorkflowActionGenericAdapter):
             return self.redirect(message=_("No changes made"), level="warning")
 
         # Need to notify client contacts?
-        if not self.context.bika_setup.getNotifyOnARRetract():
+        if not self.context.bika_setup.getNotifyOnSampleInvalidation():
             return self.success(transitioned)
 
         # Alert the client contacts who ordered the results, stating that a

--- a/bika/lims/browser/workflow/analysisrequest.py
+++ b/bika/lims/browser/workflow/analysisrequest.py
@@ -166,20 +166,13 @@ class WorkflowActionInvalidateAdapter(WorkflowActionGenericAdapter):
         """
         retest = sample.getRetest()
         lab_address = api.get_bika_setup().laboratory.getPrintAddress()
-        body = Template(_(
-            "Some non-conformities have been detected in the results report "
-            "published for Sample $sample_link. "
-            "<br/><br/> "
-            "A new Sample $retest_link has been created automatically, and the "
-            "previous request has been invalidated. "
-            "<br/><br/> "
-            "The root cause is under investigation and corrective "
-            "action has been initiated. "
-            "<br/><br/> "
-            "$lab_address")
-        ).safe_substitute(
+        setup = api.get_setup()
+        body = Template(setup.getEmailBodySampleInvalidation())\
+            .safe_substitute(
             dict(sample_link=self.get_html_link(sample),
                  retest_link=self.get_html_link(retest),
+                 sample_id=api.get_id(sample),
+                 retest_id=api.get_id(retest),
                  lab_address="<br/>".join(lab_address)))
         return body
 

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -576,14 +576,13 @@ schema = BikaFolderSchema.copy() + Schema((
         ),
     ),
     BooleanField(
-        'NotifyOnRejection',
+        'NotifyOnSampleRejection',
         schemata="Notifications",
         default=False,
         widget=BooleanWidget(
-            label=_("Sample rejection email notification"),
+            label=_("Email notification on Sample rejection"),
             description=_("Select this to activate automatic notifications "
-                          "via email to the Client when a Sample or Analysis "
-                          "Request is rejected.")
+                          "via email to the Client when a Sample is rejected.")
         ),
     ),
     BooleanField(
@@ -593,8 +592,8 @@ schema = BikaFolderSchema.copy() + Schema((
         widget=BooleanWidget(
             label=_("Email notification on Sample invalidation"),
             description=_("Select this to activate automatic notifications "
-                          "via email to the Client and Lab Managers when an Analysis "
-                          "Request is invalidated.")
+                          "via email to the Client and Lab Managers when a "
+                          "Sample is invalidated.")
         ),
     ),
     StringField(
@@ -783,17 +782,6 @@ schema = BikaFolderSchema.copy() + Schema((
                           "for Samples and Samples. A 'Reject' "
                           "option will be displayed in the actions menu for "
                           "these objects.")
-        ),
-    ),
-    BooleanField(
-        'NotifyOnRejection',
-        schemata="Notifications",
-        default=False,
-        widget=BooleanWidget(
-            label=_("Email notification on rejection"),
-            description=_("Select this to activate automatic notifications "
-                          "via email to the Client when a Sample or Analysis "
-                          "Request is rejected.")
         ),
     ),
     IntegerField(

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -587,7 +587,7 @@ schema = BikaFolderSchema.copy() + Schema((
         ),
     ),
     BooleanField(
-        'NotifyOnARRetract',
+        'NotifyOnSampleInvalidation',
         schemata="Notifications",
         default=True,
         widget=BooleanWidget(

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -7,6 +7,26 @@
 
 
 from AccessControl import ClassSecurityInfo
+from Products.ATExtensions.ateapi import RecordsField
+from Products.Archetypes.Field import TextField
+from Products.Archetypes.Widget import RichWidget
+from Products.Archetypes.atapi import BooleanField
+from Products.Archetypes.atapi import BooleanWidget
+from Products.Archetypes.atapi import DecimalWidget
+from Products.Archetypes.atapi import FixedPointField
+from Products.Archetypes.atapi import IntegerField
+from Products.Archetypes.atapi import IntegerWidget
+from Products.Archetypes.atapi import LinesField
+from Products.Archetypes.atapi import MultiSelectionWidget
+from Products.Archetypes.atapi import ReferenceField
+from Products.Archetypes.atapi import Schema
+from Products.Archetypes.atapi import SelectionWidget
+from Products.Archetypes.atapi import StringField
+from Products.Archetypes.atapi import TextAreaWidget
+from Products.Archetypes.atapi import registerType
+from Products.Archetypes.utils import DisplayList
+from Products.Archetypes.utils import IntDisplayList
+from Products.CMFCore.utils import getToolByName
 from archetypes.referencebrowserwidget import ReferenceBrowserWidget
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.fields import DurationField
@@ -28,24 +48,6 @@ from bika.lims.locales import COUNTRIES
 from bika.lims.numbergenerator import INumberGenerator
 from bika.lims.vocabularies import getStickerTemplates as _getStickerTemplates
 from plone.app.folder import folder
-from Products.Archetypes.atapi import BooleanField
-from Products.Archetypes.atapi import BooleanWidget
-from Products.Archetypes.atapi import DecimalWidget
-from Products.Archetypes.atapi import FixedPointField
-from Products.Archetypes.atapi import IntegerField
-from Products.Archetypes.atapi import IntegerWidget
-from Products.Archetypes.atapi import LinesField
-from Products.Archetypes.atapi import MultiSelectionWidget
-from Products.Archetypes.atapi import ReferenceField
-from Products.Archetypes.atapi import Schema
-from Products.Archetypes.atapi import SelectionWidget
-from Products.Archetypes.atapi import StringField
-from Products.Archetypes.atapi import TextAreaWidget
-from Products.Archetypes.atapi import registerType
-from Products.Archetypes.utils import DisplayList
-from Products.Archetypes.utils import IntDisplayList
-from Products.ATExtensions.ateapi import RecordsField
-from Products.CMFCore.utils import getToolByName
 from zope.component import getUtility
 from zope.interface import implements
 
@@ -594,6 +596,37 @@ schema = BikaFolderSchema.copy() + Schema((
             description=_("Select this to activate automatic notifications "
                           "via email to the Client and Lab Managers when a "
                           "Sample is invalidated.")
+        ),
+    ),
+    TextField(
+        "EmailBodySampleInvalidation",
+        default_content_type='text/html',
+        default_output_type='text/x-html-safe',
+        schemata="Notifications",
+        label=_("Email body for Sample Invalidation notifications"),
+        default=
+            "Some non-conformities have been detected in the results report "
+            "published for Sample $sample_link. "
+            "<br/><br/> "
+            "A new Sample $retest_link has been created automatically, and the "
+            "previous request has been invalidated. "
+            "<br/><br/> "
+            "The root cause is under investigation and corrective "
+            "action has been initiated. "
+            "<br/><br/> "
+            "$lab_address",
+        widget=RichWidget(
+            label=_("Email body for Sample Invalidation notifications"),
+            description=_("Set the text for the body of the email to be sent, "
+                          ", if option 'Email notification on Sample "
+                          "'invalidation' enabled,  to the Sample's client "
+                          "contact. You can use reserved keywords: $sample_id, "
+                          "$sample_link, $retest_id, $retest_link, "
+                          "$lab_address"),
+            default_mime_type='text/x-rst',
+            output_mime_type='text/x-html',
+            allow_file_upload=False,
+            rows=10,
         ),
     ),
     StringField(

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -93,6 +93,10 @@ def upgrade(tool):
     setup.runImportStepFromProfile(profile, 'typeinfo')
     setup.runImportStepFromProfile(profile, 'content')
 
+    # Notify on AR Retraction --> Notify on Sample Invalidation
+    # https://github.com/senaite/senaite.core/pull/1244
+    update_notify_on_sample_invalidation(portal)
+
     # Remove stale indexes from bika_catalog
     # https://github.com/senaite/senaite.core/pull/1180
     remove_stale_indexes_from_bika_catalog(portal)
@@ -1676,3 +1680,12 @@ def update_bika_catalog(portal):
     for metadata in metadata_to_add:
         refresh = metadata not in catalog.schema()
         add_metadata(portal, cat_id, metadata, refresh_catalog=refresh)
+
+
+def update_notify_on_sample_invalidation(portal):
+    """The name of the Setup field was NotifyOnARRetract, so it was
+    confusing
+    """
+    setup = api.get_setup()
+    old_value = setup.__dict__.get("NotifyOnARRetract", True)
+    setup.setNotifyOnSampleInvalidation(old_value)

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -1695,4 +1695,3 @@ def update_notify_on_sample_invalidation(portal):
     # NotifyOnRejection --> NotifyOnSampleRejection
     old_value = setup.__dict__.get("NotifyOnRejection", False)
     setup.setNotifyOnSampleRejection(old_value)
-

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -1684,8 +1684,15 @@ def update_bika_catalog(portal):
 
 def update_notify_on_sample_invalidation(portal):
     """The name of the Setup field was NotifyOnARRetract, so it was
-    confusing
+    confusing. There was also two fields "NotifyOnRejection"
     """
     setup = api.get_setup()
+
+    # NotifyOnARRetract --> NotifyOnSampleInvalidation
     old_value = setup.__dict__.get("NotifyOnARRetract", True)
     setup.setNotifyOnSampleInvalidation(old_value)
+
+    # NotifyOnRejection --> NotifyOnSampleRejection
+    old_value = setup.__dict__.get("NotifyOnRejection", False)
+    setup.setNotifyOnSampleRejection(old_value)
+

--- a/bika/lims/workflow/analysisrequest/events.py
+++ b/bika/lims/workflow/analysisrequest/events.py
@@ -34,7 +34,7 @@ def after_reject(analysis_request):
     do_action_to_analyses(analysis_request, "reject")
 
     # TODO Workflow - AnalysisRequest - Revisit rejection notification
-    if not analysis_request.bika_setup.getNotifyOnRejection():
+    if not analysis_request.bika_setup.getNotifyOnSampleRejection():
         return
 
     ancestor = analysis_request.getParentAnalysisRequest()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

With this Pull Request, Labman can set the text from the notification email body on Sample invalidation. It also allows some keywords.

![captura de 2019-02-17 17-47-25](https://user-images.githubusercontent.com/832627/52916230-08e69080-32dd-11e9-86a6-995dc01fcc4f.png)


## Current behavior before PR

Cannot modify the body text for sample invalidation email notification.

## Desired behavior after PR is merged

Can modify the body text for sample invalidation email notification.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
