### PR TITLE
Not all clients are shown in clients drop menu for Productivity Reports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -99,6 +99,7 @@ Changelog
 
 **Fixed**
 
+- #1245 Not all clients are shown in clients drop menu for Productivity Reports
 - #1239 Fix and Improve Stickers
 - #1214 Disallow entry of analysis results if the sample is not yet received
 - #1213 Fix instrument notification display in Manage Results View

--- a/bika/lims/browser/reports/selection_macros/__init__.py
+++ b/bika/lims/browser/reports/selection_macros/__init__.py
@@ -275,7 +275,7 @@ class SelectionMacrosView(BrowserView):
     @ram.cache(_cache_key_select_client)
     def select_client(self, style=None):
         self.style = style
-        self.clients = self.pc(portal_type='Client', inactive_state='active',
+        self.clients = self.pc(portal_type='Client',
                                sort_on='sortable_title')
         return self.select_client_pt()
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Client selection lists in reports (productivity, admin, etc.) were not populated with the clients. With this Pull Requests, all clients are listed there, even if they are not active anymore (maybe the labman wants to generate a report of an inactive client).

Linked issue: https://github.com/senaite/senaite.core/issues/1084

## Current behavior before PR

Client selection lists in Reports empty

## Desired behavior after PR is merged

Client selection lists in Reports are populated accordingly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
