### PR TITLE
Allow the creation of empty partitions (without analyses)

### DIFF
--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -125,9 +125,7 @@ def get_services_uids(context=None, analyses_serv=None, values=None):
         analyses_profiles = [analyses_profiles]
 
     if not analyses_services and not analyses_profiles:
-        raise RuntimeError(
-                "create_analysisrequest: no analyses services or analysis"
-                " profile provided")
+        return []
 
     # Add analysis services UIDs from profiles to analyses_services variable.
     if analyses_profiles:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request allows the creation of partitions without analyses. Maybe the user wants to add the analyses later manually or wants to keep this partition stored in a freezer for some time. 

## Current behavior before PR

Is not possible to create partitions without analyses.

## Desired behavior after PR is merged

Possibility to create partitions without analyses.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
