### PR TITLE
Move create_partitions logic to utils package

### DIFF
--- a/bika/lims/browser/partition_magic.py
+++ b/bika/lims/browser/partition_magic.py
@@ -3,38 +3,15 @@
 from collections import OrderedDict
 from collections import defaultdict
 
+from Products.Five.browser import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
 from bika.lims.decorators import returns_super_model
-from bika.lims import workflow as wf
-from bika.lims import api
-from bika.lims.interfaces import IProxyField
-from bika.lims.utils.analysisrequest import create_analysisrequest as crar
-from Products.Five.browser import BrowserView
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from bika.lims.utils.analysisrequest import create_partition
 
 DEFAULT_NUMBER_OF_PARTITIONS = 0
-
-PARTITION_SKIP_FIELDS = [
-    "Analyses",
-    "Attachment",
-    "Client",
-    "Container",
-    "Preservation",
-    "Profile",
-    "Profiles",
-    "RejectionReasons",
-    "Remarks",
-    "ResultsInterpretation",
-    "ResultsInterpretationDepts",
-    "Sample",
-    "SampleType",
-    "Template",
-    "creation_date",
-    "id",
-    "modification_date",
-    "ParentAnalysisRequest",
-]
 
 
 class PartitionMagicView(BrowserView):
@@ -90,14 +67,18 @@ class PartitionMagicView(BrowserView):
                 # The creation of partitions w/o analyses is allowed. Maybe the
                 # user wants to add the analyses later manually or wants to keep
                 # this partition stored in a freezer for some time
+                # Note we set "remove_primary_analyses" to False cause we want
+                # user to be able to add same analyses to different partitions.
                 analyses_uids = partition.get("analyses", [])
-
-                partition = self.create_partition(
-                    primary_uid=primary_uid,
-                    sampletype_uid=sampletype_uid,
-                    container_uid=container_uid,
-                    preservation_uid=preservation_uid,
-                    analyses_uids=analyses_uids)
+                partition = create_partition(
+                    request=self.request,
+                    analysis_request=primary_uid,
+                    sample_type=sampletype_uid,
+                    container=container_uid,
+                    preservation=preservation_uid,
+                    analyses=analyses_uids,
+                    remove_primary_analyses=False,
+                )
                 partitions.append(partition)
 
                 logger.info("Successfully created partition: {}".format(
@@ -121,74 +102,6 @@ class PartitionMagicView(BrowserView):
 
         return self.template()
 
-    def create_partition(self, primary_uid, sampletype_uid, container_uid,
-                         preservation_uid, analyses_uids):
-        """Create a new partition (AR)
-        """
-        logger.info("*** CREATE PARTITION ***")
-
-        ar = self.get_object_by_uid(primary_uid)
-        record = {
-            "InternalUse": True,
-            "ParentAnalysisRequest": primary_uid,
-            "SampleType": sampletype_uid,
-            "Container": container_uid,
-            "Preservation": preservation_uid,
-        }
-
-        for fieldname, field in api.get_fields(ar).items():
-            # if self.is_proxy_field(field):
-            #     logger.info("Skipping proxy field {}".format(fieldname))
-            #     continue
-            if self.is_computed_field(field):
-                logger.info("Skipping computed field {}".format(fieldname))
-                continue
-            if fieldname in PARTITION_SKIP_FIELDS:
-                logger.info("Skipping field {}".format(fieldname))
-                continue
-            fieldvalue = field.get(ar)
-            record[fieldname] = fieldvalue
-            logger.info("Update record '{}': {}".format(
-                fieldname, repr(fieldvalue)))
-
-        client = ar.getClient()
-        analyses = map(self.get_object_by_uid, analyses_uids)
-        services = map(lambda an: an.getAnalysisService(), analyses)
-
-        partition = crar(
-            client,
-            self.request,
-            record,
-            analyses=services,
-            specifications=self.get_specifications_for(ar)
-        )
-
-        # Remove selected analyses from the parent Analysis Request
-        self.push_primary_analyses_for_removal(ar, analyses)
-
-        # Reindex Parent Analysis Request
-        ar.reindexObject(idxs=["isRootAncestor"])
-
-        # Manually set the Date Received to match with its parent. This is
-        # necessary because crar calls to processForm, so DateReceived is not
-        # set because the partition has not been received yet
-        partition.setDateReceived(ar.getDateReceived())
-        partition.reindexObject(idxs="getDateReceived")
-
-        # Force partition to same status as the primary
-        status = api.get_workflow_status_of(ar)
-        wf.changeWorkflowState(partition, "bika_ar_workflow", status)
-
-        # And initialize the analyses the partition contains. This is required
-        # here because the transition "initialize" of analyses rely on a guard,
-        # so the initialization can only be performed when the sample has been
-        # received (DateReceived is set)
-        wf.ActionHandlerPool.get_instance().queue_pool()
-        for analysis in partition.getAnalyses(full_objects=True):
-            wf.doActionFor(analysis, "initialize")
-        wf.ActionHandlerPool.get_instance().resume()
-        return partition
-
     def push_primary_analyses_for_removal(self, analysis_request, analyses):
         """Stores the analyses to be removed after partitions creation
         """
@@ -203,24 +116,6 @@ class PartitionMagicView(BrowserView):
             analyses_ids = list(set(map(api.get_id, analyses)))
             ar.manage_delObjects(analyses_ids)
         self.analyses_to_remove = dict()
-
-    def get_specifications_for(self, ar):
-        """Returns a mapping of service uid -> specification
-        """
-        spec = ar.getSpecification()
-        if not spec:
-            return []
-        return spec.getResultsRange()
-
-    def is_proxy_field(self, field):
-        """Checks if the field is a proxy field
-        """
-        return IProxyField.providedBy(field)
-
-    def is_computed_field(self, field):
-        """Checks if the field is a coumputed field
-        """
-        return field.type == "computed"
 
     def get_ar_data(self):
         """Returns a list of AR data

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -336,3 +336,109 @@ def create_retest(ar):
     # Resume the actions pool
     actions_pool.resume()
     return retest
+
+
+def create_partition(analysis_request, request, analyses, sample_type=None,
+                     container=None, preservation=None, skip_fields=None,
+                     remove_primary_analyses=True):
+    """
+    Creates a partition for the analysis_request (primary) passed in
+    :param analysis_request: uid/brain/object of IAnalysisRequest type
+    :param request: the current request object
+    :param analyses: uids/brains/objects of IAnalysis type
+    :param sampletype: uid/brain/object of SampleType
+    :param container: uid/brain/object of Container
+    :param preservation: uid/brain/object of Preservation
+    :param skip_fields: names of fields to be skipped on copy from primary
+    :param remove_primary_analyses: removes the analyses from the parent
+    :return: the new partition
+    """
+    partition_skip_fields = [
+        "Analyses",
+        "Attachment",
+        "Client",
+        "Profile",
+        "Profiles",
+        "RejectionReasons",
+        "Remarks",
+        "ResultsInterpretation",
+        "ResultsInterpretationDepts",
+        "Sample",
+        "Template",
+        "creation_date",
+        "id",
+        "modification_date",
+        "ParentAnalysisRequest",
+    ]
+    if skip_fields:
+        partition_skip_fields.extend(skip_fields)
+        partition_skip_fields = list(set(partition_skip_fields))
+
+    # Copy field values from the primary analysis request
+    ar = api.get_object(analysis_request)
+    record = fields_to_dict(ar, partition_skip_fields)
+
+    # Update with values that are partition-specific
+    record.update({
+        "InternalUse": True,
+        "ParentAnalysisRequest": api.get_uid(ar),
+    })
+    if sample_type is not None:
+        record["SampleType"] = sample_type and api.get_uid(sample_type) or ""
+    if container is not None:
+        record["Container"] = container and api.get_uid(container) or ""
+    if preservation is not None:
+        record["Preservation"] = preservation and api.get_uid(preservation) or ""
+
+    # Create the Partition
+    client = ar.getClient()
+    analyses = list(set(map(api.get_object, analyses)))
+    services = map(lambda an: an.getAnalysisService(), analyses)
+    specs = ar.getSpecification()
+    specs = specs and specs.getResultsRange() or []
+    partition = create_analysisrequest(client, request=request, values=record,
+                                       analyses=services, specifications=specs)
+
+    # Remove analyses from the primary
+    if remove_primary_analyses:
+        analyses_ids = map(api.get_id, analyses)
+        ar.manage_delObjects(analyses_ids)
+
+    # Reindex Parent Analysis Request
+    ar.reindexObject(idxs=["isRootAncestor"])
+
+    # Manually set the Date Received to match with its parent. This is
+    # necessary because crar calls to processForm, so DateReceived is not
+    # set because the partition has not been received yet
+    partition.setDateReceived(ar.getDateReceived())
+    partition.reindexObject(idxs="getDateReceived")
+
+    # Force partition to same status as the primary
+    status = api.get_workflow_status_of(ar)
+    changeWorkflowState(partition, "bika_ar_workflow", status)
+
+    # And initialize the analyses the partition contains. This is required
+    # here because the transition "initialize" of analyses rely on a guard,
+    # so the initialization can only be performed when the sample has been
+    # received (DateReceived is set)
+    ActionHandlerPool.get_instance().queue_pool()
+    for analysis in partition.getAnalyses(full_objects=True):
+        doActionFor(analysis, "initialize")
+    ActionHandlerPool.get_instance().resume()
+    return partition
+
+
+def fields_to_dict(obj, skip_fields=None):
+    """
+    Generates a dictionary with the field values of the object passed in, where
+    keys are the field names. Skips computed fields
+    """
+    data = {}
+    obj = api.get_object(obj)
+    for field_name, field in api.get_fields(obj).items():
+        if skip_fields and field_name in skip_fields:
+            continue
+        if field.type == "computed":
+            continue
+        data[field_name] = field.get(obj)
+    return data


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

As per the comments in https://github.com/senaite/senaite.core/pull/1246 , this Pull Request moves the logic of `create_partition` from `partition_magic` view to `utils.analysisrequest` module

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
