### PR TITLE
Render attachments in report in worksheets too

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,7 @@ Changelog
 
 **Changed**
 
+- #1249 Render attachments in report in worksheets too
 - #1243 ID Server Suffix Support for Retested ARs
 - #1240 Support action-specific `workflow_action` requests with named adapters
 - #1215 Do not copy CaptureDate and Result in retest analyses when created

--- a/bika/lims/browser/attachment.py
+++ b/bika/lims/browser/attachment.py
@@ -122,7 +122,7 @@ class AttachmentsView(BrowserView):
         service_uid = self.request.get('Service', None)
         AttachmentType = form.get('AttachmentType', '')
         AttachmentKeys = form.get('AttachmentKeys', '')
-        ReportOption = form.get('ReportOption', 'i')
+        ReportOption = form.get('ReportOption', 'r')
 
         # nothing to do if the attachment file is missing
         if attachment_file is None:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Rendering option for attachments are handled differently in sample and worksheet view.

## Current behavior before PR
In worksheet view added attachments are ignored in report.

## Desired behavior after PR is merged
In worksheet view added attachments are rendered in report as in sample view.
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
