### PR TITLE
Use the actor of the submit transition as analyst in analyses

### DIFF
--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -948,13 +948,22 @@ class AbstractAnalysis(AbstractBaseAnalysis):
 
     @security.public
     def getAnalyst(self):
+        """Returns the stored Analyst or the user who submitted the result
+        """
+        analyst = self.getField("Analyst").get(self)
+        if not analyst:
+            analyst = self.getSubmittedBy()
+        return analyst
+
+    @security.public
+    def getAssignedAnalyst(self):
         """Returns the Analyst assigned to the worksheet this
         analysis is assigned to
         """
         worksheet = self.getWorksheet()
-        if worksheet:
-            return worksheet.getAnalyst() or ""
-        return ""
+        if not worksheet:
+            return ""
+        return worksheet.getAnalyst()
 
     @security.public
     def getAnalystName(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR uses the submitter of the analyses as the analyst in listings.

## Current behavior before PR

Analyst column appears empty if it was not assigned to a worksheet

## Desired behavior after PR is merged

The submitter of the analysis appears as the Analyst in listings

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
