### PR TITLE
Improve performance of service popups

### DIFF
--- a/bika/lims/browser/templates/analysisservice_info.pt
+++ b/bika/lims/browser/templates/analysisservice_info.pt
@@ -17,7 +17,7 @@
       <!-- Service Info -->
       <div class="row"
            tal:define="service view/get_service"
-           tal:condition="service">
+           tal:condition="nocall:service">
         <div class="col-sm-12">
           <h3>
             <img tal:replace="structure python:view.get_icon_for('analysisservice')"/>
@@ -106,7 +106,7 @@
       <!-- Methods -->
       <div class="row"
            tal:define="methods view/get_methods"
-           tal:condition="methods">
+           tal:condition="nocall:methods">
         <div class="col-sm-12">
           <h3>
             <img tal:replace="structure python:view.get_icon_for('method')"/>
@@ -139,7 +139,7 @@
       <!-- Calculation -->
       <div class="row"
            tal:define="calc view/get_calculation"
-           tal:condition="calc">
+           tal:condition="nocall:calc">
         <div class="col-sm-12">
           <h3>
             <img tal:replace="structure python:view.get_icon_for('calculation')"/>
@@ -229,7 +229,7 @@
       <!-- Analyis Log Table -->
       <div class="row"
            tal:define="logview view/analysis_log_view"
-           tal:condition="logview">
+           tal:condition="nocall:logview">
         <div class="col-sm-12">
           <h3>
             <img tal:replace="structure python:view.get_icon_for('calendar')"/>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR improves the rendering speed of service popups by not calling the objects in conditional checks.

## Current behavior before PR

Rendering is slow

## Desired behavior after PR is merged

Rendering almost instantly
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
