### PR TITLE
Fix widget permissions for Specs/Profiles/Templates Widgets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -124,6 +124,7 @@ Changelog
 
 **Security**
 
+- #1258 Fix widget permissions for Specs/Profiles/Templates Widgets
 - #1237 Global Permission and Role Mappings refactoring
 - #1077 Transitions and states strongly bound to DC Workflow + guards security
 

--- a/bika/lims/browser/widgets/analysisprofileanalyseswidget.py
+++ b/bika/lims/browser/widgets/analysisprofileanalyseswidget.py
@@ -11,7 +11,9 @@ import itertools
 from AccessControl import ClassSecurityInfo
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
+from bika.lims.api.security import check_permission
 from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.permissions import FieldEditProfiles
 from bika.lims.utils import get_image
 from bika.lims.utils import get_link
 from plone.memoize import view
@@ -161,13 +163,7 @@ class AnalysisProfileAnalysesView(BikaListingView):
     def is_edit_allowed(self):
         """Check if edit is allowed
         """
-        current_user = api.get_current_user()
-        roles = current_user.getRoles()
-        if "LabManager" in roles:
-            return True
-        if "Manager" in roles:
-            return True
-        return False
+        return check_permission(FieldEditProfiles, self.context)
 
     @view.memoize
     def get_editable_columns(self):

--- a/bika/lims/browser/widgets/analysisspecificationwidget.py
+++ b/bika/lims/browser/widgets/analysisspecificationwidget.py
@@ -11,9 +11,11 @@ from AccessControl import ClassSecurityInfo
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
+from bika.lims.api.security import check_permission
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.config import MAX_OPERATORS
 from bika.lims.config import MIN_OPERATORS
+from bika.lims.permissions import FieldEditSpecification
 from bika.lims.utils import get_image
 from bika.lims.utils import get_link
 from bika.lims.utils import to_choices
@@ -125,13 +127,7 @@ class AnalysisSpecificationView(BikaListingView):
     def is_edit_allowed(self):
         """Check if edit is allowed
         """
-        current_user = api.get_current_user()
-        roles = current_user.getRoles()
-        if "LabManager" in roles:
-            return True
-        if "Manager" in roles:
-            return True
-        return False
+        return check_permission(FieldEditSpecification, self.context)
 
     @view.memoize
     def show_categories_enabled(self):

--- a/bika/lims/browser/widgets/artemplateanalyseswidget.py
+++ b/bika/lims/browser/widgets/artemplateanalyseswidget.py
@@ -11,7 +11,9 @@ import itertools
 from AccessControl import ClassSecurityInfo
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
+from bika.lims.api.security import check_permission
 from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.permissions import FieldEditTemplate
 from bika.lims.utils import get_image
 from bika.lims.utils import get_link
 from bika.lims.utils import t
@@ -172,13 +174,7 @@ class ARTemplateAnalysesView(BikaListingView):
     def is_edit_allowed(self):
         """Check if edit is allowed
         """
-        current_user = api.get_current_user()
-        roles = current_user.getRoles()
-        if "LabManager" in roles:
-            return True
-        if "Manager" in roles:
-            return True
-        return False
+        return check_permission(FieldEditTemplate, self.context)
 
     @view.memoize
     def get_editable_columns(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the edit permissions for Specs/Profiles/Templates Widgets
 
## Current behavior before PR

Only LabManager Role could edit values

## Desired behavior after PR is merged

Roles with the proper field permissions set can edit values

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
