### PR TITLE
Fix remarks popup in Worksheets for published Samples

### DIFF
--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -1132,7 +1132,7 @@
       el = event.currentTarget;
       $(el).prepOverlay({
         subtype: "ajax",
-        filter: "h1,#archetypes-fieldname-Remarks span.remarks_history",
+        filter: "h1,span.remarks_history",
         config: {
           closeOnClick: true,
           closeOnEsc: true,

--- a/bika/lims/browser/js/coffee/bika.lims.worksheet.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.worksheet.coffee
@@ -1058,7 +1058,7 @@ class window.WorksheetManageResultsView
     # https://github.com/plone/plone.app.jquerytools/blob/master/plone/app/jquerytools/browser/overlayhelpers.js
     $(el).prepOverlay
       subtype: "ajax"
-      filter: "h1,#archetypes-fieldname-Remarks span.remarks_history"
+      filter: "h1,span.remarks_history"
       config:
         closeOnClick: yes
         closeOnEsc: yes

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,8 @@ setup(
         "senaite.core.listing>=1.0.0",
         # Python 2.x is not supported by WeasyPrint v43
         'WeasyPrint==0.42.3',
+        # tinycss2 >= 1.0.0 does not support Python 2.x anymore
+        'tinycss2<1.0.0',
         # Add this line *after* senaite.impress 1.2.0 was realeased!
         # 'senaite.impress>=1.2.0',
     ],


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the remarks popups in Worksheets, when the Sample was published and the remarks field is displayed in readonly mode.

## Current behavior before PR

Only the heading appeared in the popup

## Desired behavior after PR is merged

The remarks text appears again in the popup

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
