### PR TITLE
Improved analysis reindex upgrade step

### DIFF
--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -2003,6 +2003,10 @@ def reindex_submitted_analyses(portal):
     logger.info("Processing {} analyses".format(total))
 
     for num, brain in enumerate(brains):
+        # skip analyses which have an analyst
+        if brain.getAnalyst:
+            continue
+        # reindex analyses which have no annalyst set, but a result
         if brain.getResult not in ["", None]:
             analysis = brain.getObject()
             analysis.reindexObject()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Only reindex analyses which have an result, but not an analyst set in metadata

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
