### PR TITLE
Render analysis remarks conditionally

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -103,6 +103,7 @@ Changelog
 
 **Fixed**
 
+- #1269 Render analysis remarks conditionally
 - #1245 Not all clients are shown in clients drop menu for Productivity Reports
 - #1239 Fix and Improve Stickers
 - #1214 Disallow entry of analysis results if the sample is not yet received

--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -664,7 +664,6 @@ class AnalysesView(BikaListingView):
         item['result_captured'] = capture_date_str
 
         if self.is_analysis_edition_allowed(analysis_brain):
-            item['allow_edit'].extend(['Remarks'])
             item['allow_edit'].extend(['Result'])
 
             # If this analysis has a predefined set of options as result,
@@ -1130,22 +1129,20 @@ class AnalysesView(BikaListingView):
             self.field_icons[uid].extend(alerts)
 
     def _folder_item_remarks(self, analysis_brain, item):
-        """Renders the Remarks field for the passed in analysis and if the
-        edition of the analysis is permitted, adds a button to toggle the
-        visibility of remarks field
+        """Renders the Remarks field for the passed in analysis
+
+        If the edition of the analysis is permitted, adds the field into the
+        list of editable fields.
 
         :param analysis_brain: Brain that represents an analysis
-        :param item: analysis' dictionary counterpart that represents a row"""
-        item['Remarks'] = analysis_brain.getRemarks
+        :param item: analysis' dictionary counterpart that represents a row
+        """
 
-        if not self.is_analysis_edition_allowed(analysis_brain):
-            # Edition not allowed, do not add the remarks toggle button, the
-            # remarks field will be displayed without the option to hide it
-            return
+        if self.analysis_remarks_enabled():
+            item["Remarks"] = analysis_brain.getRemarks
 
-        if not self.analysis_remarks_enabled():
-            # Remarks not enabled in Setup, so don't display the balloon button
-            return
+        if self.is_analysis_edition_allowed(analysis_brain):
+            item["allow_edit"].extend(["Remarks"])
 
     def _append_html_element(self, item, element, html, glue="&nbsp;",
                              after=True):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds the analysis remarks only if the option "Add a remarks field to all analyses" is enabled in the setup

## Current behavior before PR

Remarks field was always inserted in the folderitem

## Desired behavior after PR is merged

Remarks field is only inserted in the folderitem when the option "Add a remarks field to all analyses" is enabled in setup and made editable together with the result field
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
