### PR TITLE
Disable caching of persistent objects in action pool

### DIFF
--- a/bika/lims/workflow/__init__.py
+++ b/bika/lims/workflow/__init__.py
@@ -515,7 +515,7 @@ class ActionHandlerPool(object):
         uid = api.get_uid(instance)
         info = self.objects.get(uid, {})
         idx = [] if idxs is _marker else idxs
-        info[action] = {'instance': instance, 'success': success, 'idxs': idx}
+        info[action] = {'success': success, 'idxs': idx}
         self.objects[uid] = info
 
     def succeed(self, instance, action):
@@ -535,11 +535,14 @@ class ActionHandlerPool(object):
         for uid, info in self.objects.items():
             if uid in processed:
                 continue
-            instance = info[info.keys()[0]]["instance"]
+
             idxs = self.get_indexes(uid)
             idxs_str = idxs and ', '.join(idxs) or "-- All indexes --"
-            logger.info("Reindexing {}: {}".format(instance.getId(), idxs_str))
-            instance.reindexObject(idxs=self.get_indexes(uid))
+            instance = api.get_object_by_uid(uid, default=None)
+            if instance:
+                logger.info(
+                    "Reindexing {}: {}".format(instance.getId(), idxs_str))
+                instance.reindexObject(idxs=self.get_indexes(uid))
             processed.append(uid)
         logger.info("Objects processed: {}".format(len(processed)))
         self.objects = collections.OrderedDict()


### PR DESCRIPTION
```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.workflow, line 82, in __call__
  Module bika.lims.browser.workflow.analysis, line 84, in __call__
  Module bika.lims.browser.workflow, line 153, in do_action
  Module bika.lims.workflow, line 541, in resume
  Module ZODB.Connection, line 857, in setstate
ConnectionStateError: Shouldn't load state for 0x04a03d09 when the connection is closed
```

## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1272

## Current behavior before PR

Traceback when multiple results are submitted by concurrent users.

## Desired behavior after PR is merged

No Traceback happens.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
