### PR TITLE
Unauthorized error in get_method_instrument_constraints

### DIFF
--- a/bika/lims/browser/analysis.zcml
+++ b/bika/lims/browser/analysis.zcml
@@ -12,7 +12,7 @@
       for="*"
       name="get_method_instrument_constraints"
       class="bika.lims.browser.analysis.ajaxGetMethodInstrumentConstraints"
-      permission="cmf.ModifyPortalContent"
+      permission="zope2.View"
       layer="bika.lims.interfaces.IBikaLIMS"
     />
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Traceback arises when `ajaxGetMethodInstrumentConstraints` is called

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
