### PR TITLE
Traceback in Manage Analyses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -103,6 +103,7 @@ Changelog
 
 **Fixed**
 
+- #1277 Traceback in Manage Analyses
 - #1245 Not all clients are shown in clients drop menu for Productivity Reports
 - #1239 Fix and Improve Stickers
 - #1214 Disallow entry of analysis results if the sample is not yet received

--- a/bika/lims/browser/workflow/analysisrequest.py
+++ b/bika/lims/browser/workflow/analysisrequest.py
@@ -1,19 +1,20 @@
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from email.Utils import formataddr
 from string import Template
 
-from DateTime import DateTime
-from Products.CMFPlone.utils import safe_unicode
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
-from bika.lims.browser.workflow import WorkflowActionGenericAdapter, \
-    RequestContextAware
+from bika.lims.browser.workflow import RequestContextAware
+from bika.lims.browser.workflow import WorkflowActionGenericAdapter
 from bika.lims.content.analysisspec import ResultsRangeDict
-from bika.lims.interfaces import IAnalysisRequest, IWorkflowActionUIDsAdapter
+from bika.lims.interfaces import IAnalysisRequest
+from bika.lims.interfaces import IWorkflowActionUIDsAdapter
 from bika.lims.utils import encode_header
 from bika.lims.utils import t
-from email.Utils import formataddr
+from DateTime import DateTime
+from Products.CMFPlone.utils import safe_unicode
 from zope.component.interfaces import implements
 
 

--- a/bika/lims/browser/workflow/analysisrequest.py
+++ b/bika/lims/browser/workflow/analysisrequest.py
@@ -363,6 +363,15 @@ class WorkflowActionSaveAnalysesAdapter(WorkflowActionGenericAdapter):
         if not IAnalysisRequest.providedBy(sample):
             return self.redirect(message=_("No changes made"), level="warning")
 
+        # NOTE: https://github.com/senaite/senaite.core/issues/1276
+        #
+        # Explicitly lookup the UIDs from the request, because the default
+        # behavior of the method `get_uids` in `WorkflowActionGenericAdapter`
+        # falls back to the UID of the current context if no UIDs were
+        # submitted, which is in that case an `AnalysisRequest`.
+        service_uids = self.get_uids_from_request()
+        services = map(api.get_object, service_uids)
+
         # Get form values
         form = self.request.form
         prices = form.get("Price", [None])[0]

--- a/bika/lims/browser/workflow/analysisrequest.py
+++ b/bika/lims/browser/workflow/analysisrequest.py
@@ -350,11 +350,12 @@ class WorkflowActionScheduleSamplingAdapter(WorkflowActionGenericAdapter):
         sample.setSamplingDate(DateTime(sampled))
         return True
 
+
 class WorkflowActionSaveAnalysesAdapter(WorkflowActionGenericAdapter):
     """Adapter in charge of "save analyses" action in Analysis Request.
     """
 
-    def __call__(self, action, services):
+    def __call__(self, action, objects):
         """The objects passed in are Analysis Services and the context is the
         Analysis Request
         """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1276

## Current behavior before PR

Traceback occurs if the Analysis to be removed is the last open besides already verified analyses

## Desired behavior after PR is merged

No traceback occurs when the Analysis to be removed is the last open analysis besides already verified analyses

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
