### PR TITLE
Swap arguments in invalidation notification

### DIFF
--- a/bika/lims/browser/workflow/analysisrequest.py
+++ b/bika/lims/browser/workflow/analysisrequest.py
@@ -186,14 +186,14 @@ class WorkflowActionInvalidateAdapter(WorkflowActionGenericAdapter):
         """Returns the laboratory email formatted
         """
         lab = api.get_bika_setup().laboratory
-        return self.get_formatted_email((lab.getEmailAddress(), lab.getName()))
+        return self.get_formatted_email((lab.getName(), lab.getEmailAddress()))
 
     def get_lab_managers_formatted_emails(self):
         """Returns a list with lab managers formatted emails
         """
         users = api.get_users_by_roles("LabManager")
-        users = map(lambda user: (user.getProperty("email"),
-                                  user.getProperty("fullname")), users)
+        users = map(lambda user: (user.getProperty("fullname"),
+                                  user.getProperty("email")), users)
         return map(self.get_formatted_email, users)
 
     def get_contact_formatted_email(self, contact):
@@ -201,7 +201,7 @@ class WorkflowActionInvalidateAdapter(WorkflowActionGenericAdapter):
         """
         contact_name = contact.Title()
         contact_email = contact.getEmailAddress()
-        return self.get_formatted_email((contact_email, contact_name))
+        return self.get_formatted_email((contact_name, contact_email))
 
     def get_sample_contacts_formatted_emails(self, sample):
         """Returns a list with the formatted emails from sample contacts


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
After invalidating samples the notification of client contacts and labmanagers fails, because realname and e-mail addresses are swapped in the code in comparison to earlier versions.

Error message (part):
`Unable to send an email to alert lab client contacts that the Sample has been retracted: {'"user@domain.loc" <FullName>': (550, '5.1.1 <Fullname>: Recipient address rejected: User unknown in local recipient table'), '"domadmin@domain.loc" <LabAdministrator>': (550, '5.1.1 <LabAdministrator>: Recipient address rejected: User unknown in local recipient table'), 
[...]`

## Current behavior before PR
Invalidation nofications  cannot be sent to the recipients.

## Desired behavior after PR is merged
Invalidation nofications  are sent to the recipients.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
