### PR TITLE
Remove bika.lims.utils.calcs.js

### DIFF
--- a/bika/lims/profiles/default/jsregistry.xml
+++ b/bika/lims/profiles/default/jsregistry.xml
@@ -107,16 +107,6 @@
               inline="False"
               insert-after="*"
               />
-  <javascript authenticated="True"
-              id="++resource++bika.lims.js/bika.lims.utils.calcs.js"
-              cacheable="True"
-              compression="safe"
-              conditionalcomment=""
-              cookable="True"
-              enabled="on"
-              expression=""
-              inline="False"
-              insert-after="*"/>
 
   <javascript authenticated="True"
               id="++resource++bika.lims.js/bika.lims.batch.js"

--- a/bika/lims/profiles/default/jsregistry.xml
+++ b/bika/lims/profiles/default/jsregistry.xml
@@ -22,8 +22,7 @@
               enabled="on"
               expression=""
               inline="False"
-              insert-after="++resource++bika.lims.js/thirdparty/jquery/jquery-query-2.1.7.js"
-              />
+              insert-after="++resource++bika.lims.js/thirdparty/jquery/jquery-query-2.1.7.js"/>
 
   <javascript authenticated="True"
               id="++resource++bika.lims.js/thirdparty/jquery/jquery-barcode-2.0.2.js"
@@ -34,8 +33,7 @@
               enabled="on"
               expression=""
               inline="False"
-              insert-after="++resource++bika.lims.js/thirdparty/jquery/jquery.json.js"
-              />
+              insert-after="++resource++bika.lims.js/thirdparty/jquery/jquery.json.js"/>
 
   <javascript authenticated="False"
               id="++resource++bika.lims.js/thirdparty/jquery/jquery-timepicker.js"
@@ -46,8 +44,7 @@
               enabled="on"
               expression=""
               inline="False"
-              insert-after="++resource++bika.lims.js/thirdparty/jquery/jquery-barcode-2.0.2.js"
-              />
+              insert-after="++resource++bika.lims.js/thirdparty/jquery/jquery-barcode-2.0.2.js"/>
 
   <javascript authenticated="False"
               id="++resource++bika.lims.js/thirdparty/jquery/jquery.ui.combogrid-1.6.3.js"
@@ -58,8 +55,7 @@
               enabled="on"
               expression=""
               inline="False"
-              insert-after="++resource++bika.lims.js/thirdparty/jquery/jquery-timepicker.js"
-              />
+              insert-after="++resource++bika.lims.js/thirdparty/jquery/jquery-timepicker.js"/>
 
   <javascript cacheable="True"
               id="++resource++plone.app.jquerytools.dateinput.js"
@@ -68,8 +64,7 @@
               enabled="True"
               inline="False"
               expression=""
-              insert-after="++resource++bika.lims.js/thirdparty/jquery/jquery.ui.combogrid-1.6.3.js"
-              />
+              insert-after="++resource++bika.lims.js/thirdparty/jquery/jquery.ui.combogrid-1.6.3.js"/>
 
   <javascript authenticated="False"
               id="++resource++bika.lims.js/thirdparty/d3/d3.js"
@@ -80,10 +75,9 @@
               enabled="on"
               expression=""
               inline="False"
-              insert-after="++resource++plone.app.jquerytools.dateinput.js"
-              />
+              insert-after="++resource++plone.app.jquerytools.dateinput.js"/>
 
-      <javascript authenticated="False"
+  <javascript authenticated="False"
               id="++resource++bika.lims.js/thirdparty/jquery/jquery.qrcode-0.12.0.min.js"
               cacheable="True"
               compression="none"
@@ -92,8 +86,7 @@
               enabled="on"
               expression=""
               inline="False"
-              insert-after="++resource++bika.lims.js/thirdparty/d3/d3.js"
-              />
+              insert-after="++resource++bika.lims.js/thirdparty/d3/d3.js"/>
 
   <!-- Bika LIMS javascripts -->
   <javascript authenticated="False"
@@ -105,8 +98,7 @@
               enabled="on"
               expression=""
               inline="False"
-              insert-after="*"
-              />
+              insert-after="*"/>
 
   <javascript authenticated="True"
               id="++resource++bika.lims.js/bika.lims.batch.js"
@@ -362,81 +354,81 @@
               insert-after="*"/>
 
   <javascript authenticated="False"
-          id="++resource++bika.lims.js/bika.lims.samplingrounds.js"
-          cacheable="True"
-          compression="safe"
-          conditionalcomment=""
-          cookable="True"
-          enabled="on"
-          expression=""
-          inline="False"
-          insert-after="*"/>
+              id="++resource++bika.lims.js/bika.lims.samplingrounds.js"
+              cacheable="True"
+              compression="safe"
+              conditionalcomment=""
+              cookable="True"
+              enabled="on"
+              expression=""
+              inline="False"
+              insert-after="*"/>
 
   <javascript authenticated="False"
-          id="++resource++bika.lims.js/bika.lims.samplinground.print.js"
-          cacheable="True"
-          compression="safe"
-          conditionalcomment=""
-          cookable="True"
-          enabled="on"
-          expression=""
-          inline="False"
-          insert-after="*"/>
+              id="++resource++bika.lims.js/bika.lims.samplinground.print.js"
+              cacheable="True"
+              compression="safe"
+              conditionalcomment=""
+              cookable="True"
+              enabled="on"
+              expression=""
+              inline="False"
+              insert-after="*"/>
 
   <javascript authenticated="False"
-          id="++resource++bika.lims.js/bika.lims.rejection.js"
-          cacheable="True"
-          compression="safe"
-          conditionalcomment=""
-          cookable="True"
-          enabled="on"
-          expression=""
-          inline="False"
-          insert-after="*"/>
+              id="++resource++bika.lims.js/bika.lims.rejection.js"
+              cacheable="True"
+              compression="safe"
+              conditionalcomment=""
+              cookable="True"
+              enabled="on"
+              expression=""
+              inline="False"
+              insert-after="*"/>
 
   <javascript authenticated="False"
-          id="++resource++bika.lims.js/bika.lims.reflexrule.js"
-          cacheable="True"
-          compression="safe"
-          conditionalcomment=""
-          cookable="True"
-          enabled="on"
-          expression=""
-          inline="False"
-          insert-after="*"/>
+              id="++resource++bika.lims.js/bika.lims.reflexrule.js"
+              cacheable="True"
+              compression="safe"
+              conditionalcomment=""
+              cookable="True"
+              enabled="on"
+              expression=""
+              inline="False"
+              insert-after="*"/>
 
   <javascript authenticated="False"
-          id="++resource++bika.lims.js/bika.lims.department.js"
-          cacheable="True"
-          compression="safe"
-          conditionalcomment=""
-          cookable="True"
-          enabled="on"
-          expression=""
-          inline="False"
-          insert-after="*"/>
-
-      <javascript authenticated="False"
-          id="++resource++bika.lims.js/bika.lims.calculation.edit.js"
-          cacheable="True"
-          compression="safe"
-          conditionalcomment=""
-          cookable="True"
-          enabled="on"
-          expression=""
-          inline="False"
-          insert-after="*"/>
+              id="++resource++bika.lims.js/bika.lims.department.js"
+              cacheable="True"
+              compression="safe"
+              conditionalcomment=""
+              cookable="True"
+              enabled="on"
+              expression=""
+              inline="False"
+              insert-after="*"/>
 
   <javascript authenticated="False"
-          id="++resource++bika.lims.js/bika.lims.worksheettemplate.js"
-          cacheable="True"
-          compression="safe"
-          conditionalcomment=""
-          cookable="True"
-          enabled="on"
-          expression=""
-          inline="False"
-          insert-after="*"/>
+              id="++resource++bika.lims.js/bika.lims.calculation.edit.js"
+              cacheable="True"
+              compression="safe"
+              conditionalcomment=""
+              cookable="True"
+              enabled="on"
+              expression=""
+              inline="False"
+              insert-after="*"/>
+
+  <javascript authenticated="False"
+              id="++resource++bika.lims.js/bika.lims.worksheettemplate.js"
+              cacheable="True"
+              compression="safe"
+              conditionalcomment=""
+              cookable="True"
+              enabled="on"
+              expression=""
+              inline="False"
+              insert-after="*"/>
 
   <!-- Add javascripts ALWAYS BEFORE this one -->
   <javascript authenticated="False"
@@ -450,4 +442,4 @@
               inline="False"
               insert-after="*"/>
 
- </object>
+</object>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the portal JS registration for the removed `bika.lims.utils.calcs.js`

## Current behavior before PR

Error occurs in the JS console for new installed Senaite Installations:

<img width="515" alt="Kunden — SENAITE 2019-03-14 09-52-07" src="https://user-images.githubusercontent.com/713193/54343354-e37c4680-463e-11e9-88f1-87f1e47e3462.png">


## Desired behavior after PR is merged

No JS Error occurs for new created Senaite Installations

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
