### PR TITLE
Secondary Sample functionality

### DIFF
--- a/bika/lims/adapters/configure.zcml
+++ b/bika/lims/adapters/configure.zcml
@@ -117,6 +117,23 @@
       for="bika.lims.interfaces.IAnalysisRequest"
       name="PreservationFieldsVisibility"
     />
+
+    <!-- DateSampled cannot be edited in Secondary Analysis Requests -->
+    <adapter
+      factory=".widgetvisibility.SecondaryDateSampledFieldVisibility"
+      provides="bika.lims.interfaces.IATWidgetVisibility"
+      for="bika.lims.interfaces.IAnalysisRequestSecondary"
+      name="SecondaryDateSampledFieldVisibility"
+    />
+
+    <!-- Hide/Display PrimarySample field. Always hidden for non-secondary ARs,
+    otherwise readonly mode -->
+    <adapter
+      factory=".widgetvisibility.PrimaryAnalysisRequestFieldVisibility"
+      provides="bika.lims.interfaces.IATWidgetVisibility"
+      for="bika.lims.interfaces.IAnalysisRequest"
+      name="PrimaryAnalysisRequestFieldVisibility"
+    />
     <!---
     END OF FIELDS/WIDGETS VISIBILITY
     -->

--- a/bika/lims/adapters/widgetvisibility.py
+++ b/bika/lims/adapters/widgetvisibility.py
@@ -5,9 +5,10 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-from bika.lims import logger
-from bika.lims.interfaces import IATWidgetVisibility, IAnalysisRequestSecondary
-from bika.lims.interfaces import IBatch, IClient
+from bika.lims.interfaces import IATWidgetVisibility
+from bika.lims.interfaces import IAnalysisRequestSecondary
+from bika.lims.interfaces import IBatch
+from bika.lims.interfaces import IClient
 from bika.lims.utils import getHiddenAttributesForClass
 from zope.interface import implements
 
@@ -30,6 +31,14 @@ class SenaiteATWidgetVisibility(object):
 
     def isVisible(self, field, mode="view", default="visible"):
         """Returns if the field is visible in a given mode
+
+        Possible returned values are:
+        - hidden: Field rendered as a hidden input field
+        - invisible: Field not rendered at all
+        - visible: Field rendered as a label or editable field depending on the
+            mode. E.g. if mode is "edit" and the value returned is "visible",
+            the field will be rendered as an input. If the mode is "view", the
+            field will be rendered as a span.
         """
         raise NotImplementedError("Must be implemented by subclass")
 

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -35,7 +35,7 @@ from zope.interface import implements
 from zope.publisher.interfaces import IPublishTraverse
 
 AR_CONFIGURATION_STORAGE = "bika.lims.browser.analysisrequest.manage.add"
-SKIP_FIELD_ON_COPY = ["Sample", "Remarks"]
+SKIP_FIELD_ON_COPY = ["Sample", "PrimaryAnalysisRequest", "Remarks"]
 
 
 def returns_json(func):
@@ -1088,8 +1088,14 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         container_type_uid = container_type and container_type.UID() or ""
         container_type_title = container_type and container_type.Title() or ""
 
+        # Sampling deviation
+        deviation = obj.getSamplingDeviation()
+        deviation_uid = deviation and deviation.UID() or ""
+        deviation_title = deviation and deviation.Title() or ""
+
         info.update({
-            "sample_id": obj.getSampleID(),
+            "sample_id": obj.getId(),
+            "batch_uid": obj.getBatchUID() or None,
             "date_sampled": self.to_iso_date(obj.getDateSampled()),
             "sampling_date": self.to_iso_date(obj.getSamplingDate()),
             "sample_type_uid": sample_type_uid,
@@ -1104,8 +1110,14 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             "sample_point_title": sample_point_title,
             "environmental_conditions": obj.getEnvironmentalConditions(),
             "composite": obj.getComposite(),
+            "client_uid": obj.getClientUID(),
+            "client_title": obj.getClientTitle(),
+            "contact": self.get_contact_info(obj.getContact()),
+            "client_order_number": obj.getClientOrderNumber(),
             "client_sample_id": obj.getClientSampleID(),
             "client_reference": obj.getClientReference(),
+            "sampling_deviation_uid": deviation_uid,
+            "sampling_deviation_title": deviation_title,
             "sampling_workflow_enabled": obj.getSamplingWorkflowEnabled(),
             "remarks": obj.getRemarks(),
         })
@@ -1247,7 +1259,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             _specifications = self.get_objs_from_record(
                 record, "Specification_uid")
             _templates = self.get_objs_from_record(record, "Template_uid")
-            _samples = self.get_objs_from_record(record, "Sample_uid")
+            _samples = self.get_objs_from_record(record, "PrimaryAnalysisRequest_uid")
             _profiles = self.get_objs_from_record(record, "Profiles_uid")
             _services = self.get_objs_from_record(record, "Analyses")
             _sampletypes = self.get_objs_from_record(record, "SampleType_uid")
@@ -1345,7 +1357,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                     else:
                         service_to_profiles[service_uid] = [uid]
 
-            # SAMPLES
+            # PRIMARY ANALYSIS REQUESTS
             for uid, obj in _samples.iteritems():
                 # get the sample metadata
                 metadata = self.get_sample_info(obj)

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -1,84 +1,95 @@
-
-/* Please use this command to compile this file into the parent `js` directory:
-    coffee --no-header -w -o ../ -c bika.lims.analysisrequest.add.coffee
- */
-
 (function() {
-  var bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
-    slice = [].slice,
-    hasProp = {}.hasOwnProperty,
-    indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
+  /* Please use this command to compile this file into the parent `js` directory:
+      coffee --no-header -w -o ../ -c bika.lims.analysisrequest.add.coffee
+  */
+  var hasProp = {}.hasOwnProperty,
+    indexOf = [].indexOf;
 
-  window.AnalysisRequestAdd = (function() {
-    function AnalysisRequestAdd() {
-      this.init_file_fields = bind(this.init_file_fields, this);
-      this.on_form_submit = bind(this.on_form_submit, this);
-      this.on_ajax_end = bind(this.on_ajax_end, this);
-      this.on_ajax_start = bind(this.on_ajax_start, this);
-      this.ajax_post_form = bind(this.ajax_post_form, this);
-      this.on_copy_button_click = bind(this.on_copy_button_click, this);
-      this.on_service_category_click = bind(this.on_service_category_click, this);
-      this.on_service_listing_header_click = bind(this.on_service_listing_header_click, this);
-      this.on_analysis_checkbox_click = bind(this.on_analysis_checkbox_click, this);
-      this.on_analysis_profile_removed = bind(this.on_analysis_profile_removed, this);
-      this.on_analysis_profile_selected = bind(this.on_analysis_profile_selected, this);
-      this.on_analysis_template_changed = bind(this.on_analysis_template_changed, this);
-      this.on_specification_changed = bind(this.on_specification_changed, this);
-      this.on_sampletype_changed = bind(this.on_sampletype_changed, this);
-      this.on_sample_changed = bind(this.on_sample_changed, this);
-      this.on_analysis_lock_button_click = bind(this.on_analysis_lock_button_click, this);
-      this.on_analysis_details_click = bind(this.on_analysis_details_click, this);
-      this.on_analysis_specification_changed = bind(this.on_analysis_specification_changed, this);
-      this.on_contact_changed = bind(this.on_contact_changed, this);
-      this.on_client_changed = bind(this.on_client_changed, this);
-      this.hide_all_service_info = bind(this.hide_all_service_info, this);
-      this.get_service = bind(this.get_service, this);
-      this.set_service_spec = bind(this.set_service_spec, this);
-      this.set_service = bind(this.set_service, this);
-      this.set_template = bind(this.set_template, this);
-      this.set_sampletype = bind(this.set_sampletype, this);
-      this.set_sample = bind(this.set_sample, this);
-      this.set_contact = bind(this.set_contact, this);
-      this.set_client = bind(this.set_client, this);
-      this.set_reference_field = bind(this.set_reference_field, this);
-      this.set_reference_field_query = bind(this.set_reference_field_query, this);
-      this.get_field_by_id = bind(this.get_field_by_id, this);
-      this.get_fields = bind(this.get_fields, this);
-      this.get_form = bind(this.get_form, this);
-      this.get_authenticator = bind(this.get_authenticator, this);
-      this.get_base_url = bind(this.get_base_url, this);
-      this.get_portal_url = bind(this.get_portal_url, this);
-      this.update_form = bind(this.update_form, this);
-      this.recalculate_prices = bind(this.recalculate_prices, this);
-      this.recalculate_records = bind(this.recalculate_records, this);
-      this.get_global_settings = bind(this.get_global_settings, this);
-      this.render_template = bind(this.render_template, this);
-      this.template_dialog = bind(this.template_dialog, this);
-      this.debounce = bind(this.debounce, this);
-      this.bind_eventhandler = bind(this.bind_eventhandler, this);
-      this.load = bind(this.load, this);
+  window.AnalysisRequestAdd = class AnalysisRequestAdd {
+    constructor() {
+      this.load = this.load.bind(this);
+      /* METHODS */
+      this.bind_eventhandler = this.bind_eventhandler.bind(this);
+      this.debounce = this.debounce.bind(this);
+      this.template_dialog = this.template_dialog.bind(this);
+      this.render_template = this.render_template.bind(this);
+      this.get_global_settings = this.get_global_settings.bind(this);
+      this.recalculate_records = this.recalculate_records.bind(this);
+      this.recalculate_prices = this.recalculate_prices.bind(this);
+      this.update_form = this.update_form.bind(this);
+      this.get_portal_url = this.get_portal_url.bind(this);
+      this.get_base_url = this.get_base_url.bind(this);
+      this.get_authenticator = this.get_authenticator.bind(this);
+      this.get_form = this.get_form.bind(this);
+      this.get_fields = this.get_fields.bind(this);
+      this.get_field_by_id = this.get_field_by_id.bind(this);
+      this.set_reference_field_query = this.set_reference_field_query.bind(this);
+      this.set_reference_field = this.set_reference_field.bind(this);
+      this.set_client = this.set_client.bind(this);
+      this.set_contact = this.set_contact.bind(this);
+      this.set_sample = this.set_sample.bind(this);
+      this.set_sampletype = this.set_sampletype.bind(this);
+      this.set_template = this.set_template.bind(this);
+      this.set_service = this.set_service.bind(this);
+      this.set_service_spec = this.set_service_spec.bind(this);
+      this.get_service = this.get_service.bind(this);
+      this.hide_all_service_info = this.hide_all_service_info.bind(this);
+      /* EVENT HANDLER */
+      this.on_client_changed = this.on_client_changed.bind(this);
+      this.on_contact_changed = this.on_contact_changed.bind(this);
+      this.on_analysis_specification_changed = this.on_analysis_specification_changed.bind(this);
+      this.on_analysis_details_click = this.on_analysis_details_click.bind(this);
+      this.on_analysis_lock_button_click = this.on_analysis_lock_button_click.bind(this);
+      this.on_sample_changed = this.on_sample_changed.bind(this);
+      this.on_sampletype_changed = this.on_sampletype_changed.bind(this);
+      this.on_specification_changed = this.on_specification_changed.bind(this);
+      this.on_analysis_template_changed = this.on_analysis_template_changed.bind(this);
+      this.on_analysis_profile_selected = this.on_analysis_profile_selected.bind(this);
+      // Note: Context of callback bound to this object
+      this.on_analysis_profile_removed = this.on_analysis_profile_removed.bind(this);
+      this.on_analysis_checkbox_click = this.on_analysis_checkbox_click.bind(this);
+      this.on_service_listing_header_click = this.on_service_listing_header_click.bind(this);
+      this.on_service_category_click = this.on_service_category_click.bind(this);
+      this.on_copy_button_click = this.on_copy_button_click.bind(this);
+      // Note: Context of callback bound to this object
+      this.ajax_post_form = this.ajax_post_form.bind(this);
+      this.on_ajax_start = this.on_ajax_start.bind(this);
+      this.on_ajax_end = this.on_ajax_end.bind(this);
+      // Note: Context of callback bound to this object
+      this.on_form_submit = this.on_form_submit.bind(this);
+      this.init_file_fields = this.init_file_fields.bind(this);
     }
 
-    AnalysisRequestAdd.prototype.load = function() {
+    load() {
       console.debug("AnalysisRequestAdd::load");
+      // load translations
       jarn.i18n.loadCatalog('senaite.core');
       this._ = window.jarn.i18n.MessageFactory("senaite.core");
+      // disable browser autocomplete
       $('input[type=text]').prop('autocomplete', 'off');
+      // storage for global Bika settings
       this.global_settings = {};
+      // services data snapshot from recalculate_records
+      // returns a mapping of arnum -> services data
       this.records_snapshot = {};
+      // brain for already applied templates
       this.applied_templates = {};
+      // Remove the '.blurrable' class to avoid inline field validation
       $(".blurrable").removeClass("blurrable");
+      // bind the event handler to the elements
       this.bind_eventhandler();
+      // N.B.: The new AR Add form handles File fields like this:
+      // - File fields can carry more than one field (see init_file_fields)
+      // - All uploaded files are extracted and added as attachments to the new created AR
+      // - The file field itself (Plone) will stay empty therefore
       this.init_file_fields();
+      // get the global settings on load
       this.get_global_settings();
+      // recalculate records on load (needed for AR copies)
       return this.recalculate_records();
-    };
+    }
 
-
-    /* METHODS */
-
-    AnalysisRequestAdd.prototype.bind_eventhandler = function() {
-
+    bind_eventhandler() {
       /*
        * Binds callbacks on elements
        *
@@ -87,48 +98,68 @@
        *
        */
       console.debug("AnalysisRequestAdd::bind_eventhandler");
+      // Categories header clicked
       $("body").on("click", ".service-listing-header", this.on_service_listing_header_click);
+      // Category toggle button clicked
       $("body").on("click", "tr.category", this.on_service_category_click);
+      // Save button clicked
       $("body").on("click", "[name='save_button']", this.on_form_submit);
+      // Composite Checkbox clicked
       $("body").on("click", "tr[fieldname=Composite] input[type='checkbox']", this.recalculate_records);
+      // InvoiceExclude Checkbox clicked
       $("body").on("click", "tr[fieldname=InvoiceExclude] input[type='checkbox']", this.recalculate_records);
+      // Analysis Checkbox clicked
       $("body").on("click", "tr[fieldname=Analyses] input[type='checkbox']", this.on_analysis_checkbox_click);
+      // Client changed
       $("body").on("selected change", "tr[fieldname=Client] input[type='text']", this.on_client_changed);
+      // Contact changed
       $("body").on("selected change", "tr[fieldname=Contact] input[type='text']", this.on_contact_changed);
+      // Analysis Specification changed
       $("body").on("change", "input.min", this.on_analysis_specification_changed);
       $("body").on("change", "input.max", this.on_analysis_specification_changed);
       $("body").on("change", "input.warn_min", this.on_analysis_specification_changed);
       $("body").on("change", "input.warn_max", this.on_analysis_specification_changed);
+      // Analysis lock button clicked
       $("body").on("click", ".service-lockbtn", this.on_analysis_lock_button_click);
+      // Analysis info button clicked
       $("body").on("click", ".service-infobtn", this.on_analysis_details_click);
-      $("body").on("selected change", "tr[fieldname=Sample] input[type='text']", this.on_sample_changed);
+      // Sample changed
+      $("body").on("selected change", "tr[fieldname=PrimaryAnalysisRequest] input[type='text']", this.on_sample_changed);
+      // SampleType changed
       $("body").on("selected change", "tr[fieldname=SampleType] input[type='text']", this.on_sampletype_changed);
+      // Specification changed
       $("body").on("selected change", "tr[fieldname=Specification] input[type='text']", this.on_specification_changed);
+      // Analysis Template changed
       $("body").on("selected change", "tr[fieldname=Template] input[type='text']", this.on_analysis_template_changed);
+      // Analysis Profile selected
       $("body").on("selected", "tr[fieldname=Profiles] input[type='text']", this.on_analysis_profile_selected);
+      // Analysis Profile deselected
       $("body").on("click", "tr[fieldname=Profiles] img.deletebtn", this.on_analysis_profile_removed);
+      // Copy button clicked
       $("body").on("click", "img.copybutton", this.on_copy_button_click);
-
       /* internal events */
+      // handle value changes in the form
       $(this).on("form:changed", this.debounce(this.recalculate_records, 500));
+      // recalculate prices after data changed
       $(this).on("data:updated", this.debounce(this.recalculate_prices, 3000));
+      // update form from records after the data changed
       $(this).on("data:updated", this.debounce(this.update_form, 300));
+      // hide open service info after data changed
       $(this).on("data:updated", this.debounce(this.hide_all_service_info, 300));
+      // handle Ajax events
       $(this).on("ajax:start", this.on_ajax_start);
       return $(this).on("ajax:end", this.on_ajax_end);
-    };
+    }
 
-    AnalysisRequestAdd.prototype.debounce = function(func, threshold, execAsap) {
-
+    debounce(func, threshold, execAsap) {
       /*
        * Debounce a function call
        * See: https://coffeescript-cookbook.github.io/chapters/functions/debounce
        */
       var timeout;
       timeout = null;
-      return function() {
-        var args, delayed, obj;
-        args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
+      return function(...args) {
+        var delayed, obj;
         obj = this;
         delayed = function() {
           if (!execAsap) {
@@ -143,80 +174,88 @@
         }
         return timeout = setTimeout(delayed, threshold || 100);
       };
-    };
+    }
 
-    AnalysisRequestAdd.prototype.template_dialog = function(template_id, context, buttons) {
-
+    template_dialog(template_id, context, buttons) {
+      var content;
       /*
        * Render the content of a Handlebars template in a jQuery UID dialog
          [1] http://handlebarsjs.com/
          [2] https://jqueryui.com/dialog/
        */
-      var content;
+      // prepare the buttons
       if (buttons == null) {
         buttons = {};
         buttons[this._("Yes")] = function() {
+          // trigger 'yes' event
           $(this).trigger("yes");
           return $(this).dialog("close");
         };
         buttons[this._("No")] = function() {
+          // trigger 'no' event
           $(this).trigger("no");
           return $(this).dialog("close");
         };
       }
+      // render the Handlebars template
       content = this.render_template(template_id, context);
+      // render the dialog box
       return $(content).dialog({
         width: 450,
         resizable: false,
         closeOnEscape: false,
         buttons: buttons,
         open: function(event, ui) {
+          // Hide the X button on the top right border
           return $(".ui-dialog-titlebar-close").hide();
         }
       });
-    };
+    }
 
-    AnalysisRequestAdd.prototype.render_template = function(template_id, context) {
-
+    render_template(template_id, context) {
+      var content, source, template;
       /*
        * Render Handlebars JS template
        */
-      var content, source, template;
-      source = $("#" + template_id).html();
+      // get the template by ID
+      source = $(`#${template_id}`).html();
       if (!source) {
         return;
       }
+      // Compile the handlebars template
       template = Handlebars.compile(source);
+      // Render the template with the given context
       content = template(context);
       return content;
-    };
+    }
 
-    AnalysisRequestAdd.prototype.get_global_settings = function() {
-
+    get_global_settings() {
       /*
        * Submit all form values to the server to recalculate the records
        */
       return this.ajax_post_form("get_global_settings").done(function(settings) {
         console.debug("Global Settings:", settings);
+        // remember the global settings
         this.global_settings = settings;
+        // trigger event for whom it might concern
         return $(this).trigger("settings:updated", settings);
       });
-    };
+    }
 
-    AnalysisRequestAdd.prototype.recalculate_records = function() {
-
+    recalculate_records() {
       /*
        * Submit all form values to the server to recalculate the records
        */
       return this.ajax_post_form("recalculate_records").done(function(records) {
         console.debug("Recalculate Analyses: Records=", records);
+        // remember a services snapshot
         this.records_snapshot = records;
+        // trigger event for whom it might concern
         return $(this).trigger("data:updated", records);
       });
-    };
+    }
 
-    AnalysisRequestAdd.prototype.recalculate_prices = function() {
-
+    recalculate_prices() {
       /*
        * Submit all form values to the server to recalculate the prices of all columns
        */
@@ -230,53 +269,70 @@
         for (arnum in data) {
           if (!hasProp.call(data, arnum)) continue;
           prices = data[arnum];
-          $("#discount-" + arnum).text(prices.discount);
-          $("#subtotal-" + arnum).text(prices.subtotal);
-          $("#vat-" + arnum).text(prices.vat);
-          $("#total-" + arnum).text(prices.total);
+          $(`#discount-${arnum}`).text(prices.discount);
+          $(`#subtotal-${arnum}`).text(prices.subtotal);
+          $(`#vat-${arnum}`).text(prices.vat);
+          $(`#total-${arnum}`).text(prices.total);
         }
+        // trigger event for whom it might concern
         return $(this).trigger("prices:updated", data);
       });
-    };
+    }
 
-    AnalysisRequestAdd.prototype.update_form = function(event, records) {
-
+    update_form(event, records) {
+      var me;
       /*
        * Update form according to the server data
        */
-      var me;
       console.debug("*** update_form ***");
       me = this;
+      // initially hide all lock icons
       $(".service-lockbtn").hide();
+      // set all values for one record (a single column in the AR Add form)
       return $.each(records, function(arnum, record) {
+        // set client
         $.each(record.client_metadata, function(uid, client) {
           return me.set_client(arnum, client);
         });
+        // set contact
         $.each(record.contact_metadata, function(uid, contact) {
           return me.set_contact(arnum, contact);
         });
+        // set services
         $.each(record.service_metadata, function(uid, metadata) {
           var lock;
-          lock = $("#" + uid + "-" + arnum + "-lockbtn");
+          // lock icon (to be displayed when the service cannot be deselected)
+          lock = $(`#${uid}-${arnum}-lockbtn`);
+          // service is included in a profile
           if (uid in record.service_to_profiles) {
             lock.show();
           }
+          // service is part of the template
+          // if uid of record.service_to_templates
+          //   lock.show()
+
+          // select the service
           return me.set_service(arnum, uid, true);
         });
+        // set template
         $.each(record.template_metadata, function(uid, template) {
           return me.set_template(arnum, template);
         });
+        // set specification
         $.each(record.specification_metadata, function(uid, spec) {
           return $.each(spec.specifications, function(uid, service_spec) {
             return me.set_service_spec(arnum, uid, service_spec);
           });
         });
+        // set sample
         $.each(record.sample_metadata, function(uid, sample) {
           return me.set_sample(arnum, sample);
         });
+        // set sampletype
         $.each(record.sampletype_metadata, function(uid, sampletype) {
           return me.set_sampletype(arnum, sampletype);
         });
+        // handle unmet dependencies, one at a time
         return $.each(record.unmet_dependencies, function(uid, dependencies) {
           var context, dialog, service;
           service = record.service_metadata[uid];
@@ -286,32 +342,35 @@
           };
           dialog = me.template_dialog("dependency-add-template", context);
           dialog.on("yes", function() {
+            // select the services
             $.each(dependencies, function(index, service) {
               return me.set_service(arnum, service.uid, true);
             });
+            // trigger form:changed event
             return $(me).trigger("form:changed");
           });
           dialog.on("no", function() {
+            // deselect the dependant service
             me.set_service(arnum, uid, false);
+            // trigger form:changed event
             return $(me).trigger("form:changed");
           });
+          // break the iteration after the first loop to avoid multiple dialogs.
           return false;
         });
       });
-    };
+    }
 
-    AnalysisRequestAdd.prototype.get_portal_url = function() {
-
+    get_portal_url() {
       /*
        * Return the portal url (calculated in code)
        */
       var url;
       url = $("input[name=portal_url]").val();
       return url;
-    };
+    }
 
-    AnalysisRequestAdd.prototype.get_base_url = function() {
-
+    get_base_url() {
       /*
        * Return the current (relative) base url
        */
@@ -321,26 +380,23 @@
         return base_url.split("/portal_factory")[0];
       }
       return base_url.split("/ar_add")[0];
-    };
+    }
 
-    AnalysisRequestAdd.prototype.get_authenticator = function() {
-
+    get_authenticator() {
       /*
        * Get the authenticator value
        */
       return $("input[name='_authenticator']").val();
-    };
+    }
 
-    AnalysisRequestAdd.prototype.get_form = function() {
-
+    get_form() {
       /*
        * Return the form element
        */
       return $("#analysisrequest_add_form");
-    };
+    }
 
-    AnalysisRequestAdd.prototype.get_fields = function(arnum) {
-
+    get_fields(arnum) {
       /*
        * Get all fields of the form
        */
@@ -348,32 +404,35 @@
       form = this.get_form();
       fields_selector = "tr[fieldname] td[arnum] input";
       if (arnum != null) {
-        fields_selector = "tr[fieldname] td[arnum=" + arnum + "] input";
+        fields_selector = `tr[fieldname] td[arnum=${arnum}] input`;
       }
       fields = $(fields_selector, form);
       return fields;
-    };
+    }
 
-    AnalysisRequestAdd.prototype.get_field_by_id = function(id, arnum) {
-
+    get_field_by_id(id, arnum) {
+      var field_id, name, suffix;
       /*
        * Query the field by id
        */
-      var field_id, name, ref, suffix;
-      ref = id.split("_"), name = ref[0], suffix = ref[1];
-      field_id = name + "-" + arnum;
+      // split the fieldname from the suffix
+      [name, suffix] = id.split("_");
+      // append the arnum
+      field_id = `${name}-${arnum}`;
+      // append the suffix if it is there
       if (suffix != null) {
-        field_id = field_id + "_" + suffix;
+        field_id = `${field_id}_${suffix}`;
       }
+      // prepend a hash if it is not there
       if (!id.startsWith("#")) {
-        field_id = "#" + field_id;
+        field_id = `#${field_id}`;
       }
-      console.debug("get_field_by_id: $(" + field_id + ")");
+      console.debug(`get_field_by_id: $(${field_id})`);
+      // query the field
       return $(field_id);
-    };
+    }
 
-    AnalysisRequestAdd.prototype.flush_reference_field = function(field) {
-
+    flush_reference_field(field) {
       /*
        * Empty the reference field
        */
@@ -382,52 +441,52 @@
       if (!catalog_name) {
         return;
       }
+      // flush values
       field.val("");
       $("input[type=hidden]", field.parent()).val("");
       return $(".multiValued-listing", field.parent()).empty();
-    };
+    }
 
-    AnalysisRequestAdd.prototype.set_reference_field_query = function(field, query, type) {
-      var catalog_name, catalog_query, new_query, options, url;
-      if (type == null) {
-        type = "base_query";
-      }
-
+    set_reference_field_query(field, query, type = "base_query") {
       /*
        * Set the catalog search query for the given reference field
        * XXX This is lame! The field should provide a proper API.
        */
+      var catalog_name, catalog_query, new_query, options, url;
       catalog_name = field.attr("catalog_name");
       if (!catalog_name) {
         return;
       }
+      // get the combogrid options
       options = $.parseJSON(field.attr("combogrid_options"));
+      // prepare the new query url
       url = this.get_base_url();
-      url += "/" + options.url;
-      url += "?_authenticator=" + (this.get_authenticator());
-      url += "&catalog_name=" + catalog_name;
-      url += "&colModel=" + ($.toJSON(options.colModel));
-      url += "&search_fields=" + ($.toJSON(options.search_fields));
-      url += "&discard_empty=" + ($.toJSON(options.discard_empty));
+      url += `/${options.url}`;
+      url += `?_authenticator=${this.get_authenticator()}`;
+      url += `&catalog_name=${catalog_name}`;
+      url += `&colModel=${$.toJSON(options.colModel)}`;
+      url += `&search_fields=${$.toJSON(options.search_fields)}`;
+      url += `&discard_empty=${$.toJSON(options.discard_empty)}`;
+      // get the current query (either "base_query" or "search_query" attribute)
       catalog_query = $.parseJSON(field.attr(type));
+      // update this query with the passed in query
       $.extend(catalog_query, query);
       new_query = $.toJSON(catalog_query);
-      console.debug("set_reference_field_query: query=" + new_query);
+      console.debug(`set_reference_field_query: query=${new_query}`);
       if (type === 'base_query') {
-        url += "&base_query=" + new_query;
-        url += "&search_query=" + (field.attr('search_query'));
+        url += `&base_query=${new_query}`;
+        url += `&search_query=${field.attr('search_query')}`;
       } else {
-        url += "&base_query=" + (field.attr('base_query'));
-        url += "&search_query=" + new_query;
+        url += `&base_query=${field.attr('base_query')}`;
+        url += `&search_query=${new_query}`;
       }
       options.url = url;
       options.force_all = "false";
       field.combogrid(options);
       return field.attr("search_query", "{}");
-    };
+    }
 
-    AnalysisRequestAdd.prototype.set_reference_field = function(field, uid, title) {
-
+    set_reference_field(field, uid, title) {
       /*
        * Set the value and the uid of a reference field
        * XXX This is lame! The field should handle this on data change.
@@ -436,29 +495,34 @@
       me = this;
       $field = $(field);
       if (!$field.length) {
-        console.debug("field " + field + " does not exist, skip set_reference_field");
+        console.debug(`field ${field} does not exist, skip set_reference_field`);
         return;
       }
       $parent = field.closest("div.field");
       fieldname = field.attr("name");
-      console.debug("set_reference_field:: field=" + fieldname + " uid=" + uid + " title=" + title);
+      console.debug(`set_reference_field:: field=${fieldname} uid=${uid} title=${title}`);
       uids_field = $("input[type=hidden]", $parent);
       existing_uids = uids_field.val();
+      // uid is already selected
       if (existing_uids.indexOf(uid) >= 0) {
         return;
       }
+      // nothing in the field -> uid is the first entry
       if (existing_uids.length === 0) {
         uids_field.val(uid);
       } else {
+        // append to the list
         uids = uids_field.val().split(",");
         uids.push(uid);
         uids_field.val(uids.join(","));
       }
+      // set the title as the value
       $field.val(title);
+      // handle multivalued reference fields
       mvl = $(".multiValued-listing", $parent);
       if (mvl.length > 0) {
         portal_url = this.get_portal_url();
-        src = portal_url + "/++resource++bika.lims.images/delete.png";
+        src = `${portal_url}/++resource++bika.lims.images/delete.png`;
         img = $("<img class='deletebtn'/>");
         img.attr("src", src);
         img.attr("data-contact-title", title);
@@ -471,10 +535,10 @@
         mvl.append(div);
         return $field.val("");
       }
-    };
+    }
 
-    AnalysisRequestAdd.prototype.set_client = function(arnum, client) {
-
+    set_client(arnum, client) {
+      var contact_title, contact_uid, field, query;
       /*
        * Filter Contacts
        * Filter CCContacts
@@ -484,10 +548,12 @@
        * Filter Specification
        * Filter SamplingRound
        */
-      var contact_title, contact_uid, field, query;
-      field = $("#Contact-" + arnum);
+      // filter Contacts
+      field = $(`#Contact-${arnum}`);
       query = client.filter_queries.contact;
       this.set_reference_field_query(field, query);
+      // handle default contact for /analysisrequests listing
+      // https://github.com/senaite/senaite.core/issues/705
       if (document.URL.indexOf("analysisrequests") > -1) {
         contact_title = client.default_contact.title;
         contact_uid = client.default_contact.uid;
@@ -495,122 +561,164 @@
           this.set_reference_field(field, contact_uid, contact_title);
         }
       }
-      field = $("#CCContact-" + arnum);
+      // filter CCContacts
+      field = $(`#CCContact-${arnum}`);
       query = client.filter_queries.cc_contact;
       this.set_reference_field_query(field, query);
-      field = $("#InvoiceContact-" + arnum);
+      // filter InvoiceContact
+      // XXX Where is this field?
+      field = $(`#InvoiceContact-${arnum}`);
       query = client.filter_queries.invoice_contact;
       this.set_reference_field_query(field, query);
-      field = $("#SamplePoint-" + arnum);
+      // filter Sample Points
+      field = $(`#SamplePoint-${arnum}`);
       query = client.filter_queries.samplepoint;
       this.set_reference_field_query(field, query);
-      field = $("#Template-" + arnum);
+      // filter AR Templates
+      field = $(`#Template-${arnum}`);
       query = client.filter_queries.artemplates;
       this.set_reference_field_query(field, query);
-      field = $("#Profiles-" + arnum);
+      // filter Analysis Profiles
+      field = $(`#Profiles-${arnum}`);
       query = client.filter_queries.analysisprofiles;
       this.set_reference_field_query(field, query);
-      field = $("#Specification-" + arnum);
+      // filter Analysis Specs
+      field = $(`#Specification-${arnum}`);
       query = client.filter_queries.analysisspecs;
       this.set_reference_field_query(field, query);
-      field = $("#SamplingRound-" + arnum);
+      // filter Samplinground
+      field = $(`#SamplingRound-${arnum}`);
       query = client.filter_queries.samplinground;
       this.set_reference_field_query(field, query);
-      field = $("#Sample-" + arnum);
+      // filter Sample
+      field = $(`#PrimaryAnalysisRequest-${arnum}`);
       query = client.filter_queries.sample;
       return this.set_reference_field_query(field, query);
-    };
+    }
 
-    AnalysisRequestAdd.prototype.set_contact = function(arnum, contact) {
-
+    set_contact(arnum, contact) {
       /*
        * Set CC Contacts
        */
       var field, me;
       me = this;
-      field = $("#CCContact-" + arnum);
+      field = $(`#CCContact-${arnum}`);
       return $.each(contact.cccontacts, function(uid, cccontact) {
         var fullname;
         fullname = cccontact.fullname;
         return me.set_reference_field(field, uid, fullname);
       });
-    };
+    }
 
-    AnalysisRequestAdd.prototype.set_sample = function(arnum, sample) {
-
+    set_sample(arnum, sample) {
+      var contact, field, fullname, title, uid, value;
       /*
        * Apply the sample data to all fields of arnum
        */
-      var field, title, uid, value;
-      field = $("#SamplingDate-" + arnum);
+      // set the client
+      field = $(`#Client-${arnum}`);
+      uid = sample.client_uid;
+      title = sample.client_title;
+      this.set_reference_field(field, uid, title);
+      // set the client contact
+      field = $(`#Contact-${arnum}`);
+      contact = sample.contact;
+      uid = contact.uid;
+      fullname = contact.fullname;
+      this.set_reference_field(field, uid, fullname);
+      this.set_contact(arnum, contact);
+      // set the sampling date
+      field = $(`#SamplingDate-${arnum}`);
       value = sample.sampling_date;
       field.val(value);
-      field = $("#DateSampled-" + arnum);
+      // set the date sampled
+      field = $(`#DateSampled-${arnum}`);
       value = sample.date_sampled;
       field.val(value);
-      field = $("#SampleType-" + arnum);
+      // set the sample type (required)
+      field = $(`#SampleType-${arnum}`);
       uid = sample.sample_type_uid;
       title = sample.sample_type_title;
       this.set_reference_field(field, uid, title);
-      field = $("#EnvironmentalConditions-" + arnum);
+      // set environmental conditions
+      field = $(`#EnvironmentalConditions-${arnum}`);
       value = sample.environmental_conditions;
       field.val(value);
-      field = $("#ClientSampleID-" + arnum);
+      // set client sample ID
+      field = $(`#ClientSampleID-${arnum}`);
       value = sample.client_sample_id;
       field.val(value);
-      field = $("#ClientReference-" + arnum);
+      // set client reference
+      field = $(`#ClientReference-${arnum}`);
       value = sample.client_reference;
       field.val(value);
-      field = $("#Composite-" + arnum);
+      // set the client order number
+      field = $(`#ClientOrderNumber-${arnum}`);
+      value = sample.client_order_number;
+      field.val(value);
+      // set composite
+      field = $(`#Composite-${arnum}`);
       field.prop("checked", sample.composite);
-      field = $("#SampleCondition-" + arnum);
+      // set the sample condition
+      field = $(`#SampleCondition-${arnum}`);
       uid = sample.sample_condition_uid;
       title = sample.sample_condition_title;
       this.set_reference_field(field, uid, title);
-      field = $("#SamplePoint-" + arnum);
+      // set the sample point
+      field = $(`#SamplePoint-${arnum}`);
       uid = sample.sample_point_uid;
       title = sample.sample_point_title;
       this.set_reference_field(field, uid, title);
-      field = $("#StorageLocation-" + arnum);
+      // set the storage location
+      field = $(`#StorageLocation-${arnum}`);
       uid = sample.storage_location_uid;
       title = sample.storage_location_title;
       this.set_reference_field(field, uid, title);
-      field = $("#DefaultContainerType-" + arnum);
+      // set the default container type
+      field = $(`#DefaultContainerType-${arnum}`);
       uid = sample.container_type_uid;
       title = sample.container_type_title;
+      this.set_reference_field(field, uid, title);
+      // set the sampling deviation
+      field = $(`#SamplingDeviation-${arnum}`);
+      uid = sample.sampling_deviation_uid;
+      title = sample.sampling_deviation_title;
       return this.set_reference_field(field, uid, title);
-    };
+    }
 
-    AnalysisRequestAdd.prototype.set_sampletype = function(arnum, sampletype) {
-
+    set_sampletype(arnum, sampletype) {
+      var field, query, title, uid;
       /*
        * Recalculate partitions
        * Filter Sample Points
        */
-      var field, query, title, uid;
-      field = $("#SamplePoint-" + arnum);
+      // restrict the sample points
+      field = $(`#SamplePoint-${arnum}`);
       query = sampletype.filter_queries.samplepoint;
       this.set_reference_field_query(field, query);
-      field = $("#DefaultContainerType-" + arnum);
+      // set the default container
+      field = $(`#DefaultContainerType-${arnum}`);
+      // apply default container if the field is empty
       if (!field.val()) {
         uid = sampletype.container_type_uid;
         title = sampletype.container_type_title;
         this.flush_reference_field(field);
         this.set_reference_field(field, uid, title);
       }
-      field = $("#Specification-" + arnum);
+      // restrict the specifications
+      field = $(`#Specification-${arnum}`);
       query = sampletype.filter_queries.specification;
       return this.set_reference_field_query(field, query);
-    };
+    }
 
-    AnalysisRequestAdd.prototype.set_template = function(arnum, template) {
-
+    set_template(arnum, template) {
       /*
        * Apply the template data to all fields of arnum
        */
       var field, me, template_uid, title, uid;
       me = this;
-      field = $("#Template-" + arnum);
+      // apply template only once
+      field = $(`#Template-${arnum}`);
       uid = field.attr("uid");
       template_uid = template.uid;
       if (arnum in this.applied_templates) {
@@ -619,54 +727,65 @@
           return;
         }
       }
+      // remember the template for this ar
       this.applied_templates[arnum] = template_uid;
-      field = $("#SampleType-" + arnum);
+      // set the sample type
+      field = $(`#SampleType-${arnum}`);
       uid = template.sample_type_uid;
       title = template.sample_type_title;
       this.flush_reference_field(field);
       this.set_reference_field(field, uid, title);
-      field = $("#SamplePoint-" + arnum);
+      // set the sample point
+      field = $(`#SamplePoint-${arnum}`);
       uid = template.sample_point_uid;
       title = template.sample_point_title;
       this.flush_reference_field(field);
       this.set_reference_field(field, uid, title);
-      field = $("#Profiles-" + arnum);
+      // set the analysis profile
+      field = $(`#Profiles-${arnum}`);
       uid = template.analysis_profile_uid;
       title = template.analysis_profile_title;
       this.flush_reference_field(field);
       this.set_reference_field(field, uid, title);
-      field = $("#Remarks-" + arnum);
+      // set the remarks
+      field = $(`#Remarks-${arnum}`);
       field.text(template.remarks);
-      field = $("#Composite-" + arnum);
+      // set the composite checkbox
+      field = $(`#Composite-${arnum}`);
       field.prop("checked", template.composite);
+      // set the services
       return $.each(template.service_uids, function(index, uid) {
+        // select the service
         return me.set_service(arnum, uid, true);
       });
-    };
+    }
 
-    AnalysisRequestAdd.prototype.set_service = function(arnum, uid, checked) {
-
+    set_service(arnum, uid, checked) {
+      var el, poc;
       /*
        * Select the checkbox of a service by UID
        */
-      var el, poc;
-      console.debug("*** set_service::AR=" + arnum + " UID=" + uid + " checked=" + checked);
-      el = $("td[fieldname='Analyses-" + arnum + "'] #cb_" + uid);
+      console.debug(`*** set_service::AR=${arnum} UID=${uid} checked=${checked}`);
+      // get the service checkbox element
+      el = $(`td[fieldname='Analyses-${arnum}'] #cb_${uid}`);
+      // select the checkbox
       el.prop("checked", checked);
+      // get the point of capture of this element
       poc = el.closest("tr[poc]").attr("poc");
+      // make the element visible if the categories are visible
       if (this.is_poc_expanded(poc)) {
         return el.closest("tr").addClass("visible");
       }
-    };
+    }
 
-    AnalysisRequestAdd.prototype.set_service_spec = function(arnum, uid, spec) {
-
+    set_service_spec(arnum, uid, spec) {
+      var el, max, min, warn_max, warn_min;
       /*
        * Set the specification of the service
        */
-      var el, max, min, warn_max, warn_min;
-      console.debug("*** set_service_spec::AR=" + arnum + " UID=" + uid + " spec=", spec);
-      el = $("div#" + uid + "-" + arnum + "-specifications");
+      console.debug(`*** set_service_spec::AR=${arnum} UID=${uid} spec=`, spec);
+      // get the service specifications
+      el = $(`div#${uid}-${arnum}-specifications`);
       min = $(".min", el);
       max = $(".max", el);
       warn_min = $(".warn_min", el);
@@ -675,10 +794,9 @@
       max.val(spec.max);
       warn_min.val(spec.warn_min);
       return warn_max.val(spec.warn_max);
-    };
+    }
 
-    AnalysisRequestAdd.prototype.get_service = function(uid) {
-
+    get_service(uid) {
       /*
        * Fetch the service data from server by UID
        */
@@ -693,42 +811,43 @@
       return this.ajax_post_form("get_service", options).done(function(data) {
         return console.debug("get_service::data=", data);
       });
-    };
+    }
 
-    AnalysisRequestAdd.prototype.hide_all_service_info = function() {
-
+    hide_all_service_info() {
       /*
        * hide all open service info boxes
        */
       var info;
       info = $("div.service-info");
       return info.hide();
-    };
+    }
 
-    AnalysisRequestAdd.prototype.is_poc_expanded = function(poc) {
-
+    is_poc_expanded(poc) {
       /*
        * Checks if the point of captures are visible
        */
       var el;
-      el = $("tr.service-listing-header[poc=" + poc + "]");
+      el = $(`tr.service-listing-header[poc=${poc}]`);
       return el.hasClass("visible");
-    };
+    }
 
-    AnalysisRequestAdd.prototype.toggle_poc_categories = function(poc, toggle) {
-
+    toggle_poc_categories(poc, toggle) {
+      var categories, el, services, services_checked, toggle_buttons;
       /*
        * Toggle all categories within a point of capture (lab/service)
        * :param poc: the point of capture (lab/field)
        * :param toggle: services visible if true
        */
-      var categories, el, services, services_checked, toggle_buttons;
       if (toggle == null) {
         toggle = !this.is_poc_expanded(poc);
       }
-      el = $("tr[data-poc=" + poc + "]");
-      categories = $("tr.category." + poc);
-      services = $("tr.service." + poc);
+      // get the element
+      el = $(`tr[data-poc=${poc}]`);
+      // all categories of this poc
+      categories = $(`tr.category.${poc}`);
+      // all services of this poc
+      services = $(`tr.service.${poc}`);
+      // all checked services
       services_checked = $("input[type=checkbox]:checked", services);
       toggle_buttons = $(".service-category-toggle");
       if (toggle) {
@@ -743,13 +862,9 @@
         services.removeClass("expanded");
         return toggle_buttons.text("+");
       }
-    };
+    }
 
-
-    /* EVENT HANDLER */
-
-    AnalysisRequestAdd.prototype.on_client_changed = function(event) {
-
+    on_client_changed(event) {
       /*
        * Eventhandler when the client changed (happens on Batches)
        */
@@ -759,18 +874,19 @@
       $el = $(el);
       uid = $el.attr("uid");
       arnum = $el.closest("[arnum]").attr("arnum");
-      console.debug("°°° on_client_changed: arnum=" + arnum + " °°°");
-      field_ids = ["Contact", "CCContact", "InvoiceContact", "SamplePoint", "Template", "Profiles", "Specification"];
+      console.debug(`°°° on_client_changed: arnum=${arnum} °°°`);
+      // Flush client depending fields
+      field_ids = ["Contact", "CCContact", "InvoiceContact", "SamplePoint", "Template", "Profiles", "PrimaryAnalysisRequest", "Specification"];
       $.each(field_ids, function(index, id) {
         var field;
         field = me.get_field_by_id(id, arnum);
         return me.flush_reference_field(field);
       });
+      // trigger form:changed event
       return $(me).trigger("form:changed");
-    };
+    }
 
-    AnalysisRequestAdd.prototype.on_contact_changed = function(event) {
-
+    on_contact_changed(event) {
       /*
        * Eventhandler when the contact changed
        */
@@ -780,29 +896,30 @@
       $el = $(el);
       uid = $el.attr("uid");
       arnum = $el.closest("[arnum]").attr("arnum");
-      console.debug("°°° on_contact_changed: arnum=" + arnum + " °°°");
+      console.debug(`°°° on_contact_changed: arnum=${arnum} °°°`);
+      // Flush client depending fields
       field_ids = ["CCContact"];
       $.each(field_ids, function(index, id) {
         var field;
         field = me.get_field_by_id(id, arnum);
         return me.flush_reference_field(field);
       });
+      // trigger form:changed event
       return $(me).trigger("form:changed");
-    };
+    }
 
-    AnalysisRequestAdd.prototype.on_analysis_specification_changed = function(event) {
-
+    on_analysis_specification_changed(event) {
+      var me;
       /*
        * Eventhandler when the specification of an analysis service changed
        */
-      var me;
       console.debug("°°° on_analysis_specification_changed °°°");
       me = this;
+      // trigger form:changed event
       return $(me).trigger("form:changed");
-    };
+    }
 
-    AnalysisRequestAdd.prototype.on_analysis_details_click = function(event) {
-
+    on_analysis_details_click(event) {
       /*
        * Eventhandler when the user clicked on the info icon of a service.
        */
@@ -811,28 +928,33 @@
       $el = $(el);
       uid = $el.attr("uid");
       arnum = $el.closest("[arnum]").attr("arnum");
-      console.debug("°°° on_analysis_column::UID=" + uid + "°°°");
+      console.debug(`°°° on_analysis_column::UID=${uid}°°°`);
       info = $("div.service-info", $el.parent());
       info.empty();
       data = info.data("data");
+      // extra data to extend to the template context
       extra = {
         profiles: [],
         templates: [],
         specifications: []
       };
+      // get the current snapshot record for this column
       record = this.records_snapshot[arnum];
+      // inject profile info
       if (uid in record.service_to_profiles) {
         profiles = record.service_to_profiles[uid];
         $.each(profiles, function(index, uid) {
           return extra["profiles"].push(record.profile_metadata[uid]);
         });
       }
+      // inject template info
       if (uid in record.service_to_templates) {
         templates = record.service_to_templates[uid];
         $.each(templates, function(index, uid) {
           return extra["templates"].push(record.template_metadata[uid]);
         });
       }
+      // inject specification info
       if (uid in record.service_to_specifications) {
         specifications = record.service_to_specifications[uid];
         $.each(specifications, function(index, uid) {
@@ -854,14 +976,13 @@
         info.append(template);
         return info.fadeToggle();
       }
-    };
+    }
 
-    AnalysisRequestAdd.prototype.on_analysis_lock_button_click = function(event) {
-
+    on_analysis_lock_button_click(event) {
+      var $el, arnum, buttons, context, dialog, el, me, profile_uid, record, template_uid, uid;
       /*
        * Eventhandler when an Analysis Profile was removed.
        */
-      var $el, arnum, buttons, context, dialog, el, me, profile_uid, record, template_uid, uid;
       console.debug("°°° on_analysis_lock_button_click °°°");
       me = this;
       el = event.currentTarget;
@@ -873,10 +994,12 @@
       context["service"] = record.service_metadata[uid];
       context["profiles"] = [];
       context["templates"] = [];
+      // collect profiles
       if (uid in record.service_to_profiles) {
         profile_uid = record.service_to_profiles[uid];
         context["profiles"].push(record.profile_metadata[profile_uid]);
       }
+      // collect templates
       if (uid in record.service_to_templates) {
         template_uid = record.service_to_templates[uid];
         context["templates"].push(record.template_metadata[template_uid]);
@@ -887,10 +1010,9 @@
         }
       };
       return dialog = this.template_dialog("service-dependant-template", context, buttons);
-    };
+    }
 
-    AnalysisRequestAdd.prototype.on_sample_changed = function(event) {
-
+    on_sample_changed(event) {
       /*
        * Eventhandler when the Sample was changed.
        */
@@ -902,15 +1024,17 @@
       val = $el.val();
       arnum = $el.closest("[arnum]").attr("arnum");
       has_sample_selected = $el.val();
-      console.debug("°°° on_sample_change::UID=" + uid + " Sample=" + val + "°°°");
+      console.debug(`°°° on_sample_change::UID=${uid} PrimaryAnalysisRequest=${val}°°°`);
+      // deselect the sample if the field is empty
       if (!has_sample_selected) {
+        // XXX manually flush UID field
         $("input[type=hidden]", $el.parent()).val("");
       }
+      // trigger form:changed event
       return $(me).trigger("form:changed");
-    };
+    }
 
-    AnalysisRequestAdd.prototype.on_sampletype_changed = function(event) {
-
+    on_sampletype_changed(event) {
       /*
        * Eventhandler when the SampleType was changed.
        * Fires form:changed event
@@ -923,21 +1047,24 @@
       val = $el.val();
       arnum = $el.closest("[arnum]").attr("arnum");
       has_sampletype_selected = $el.val();
-      console.debug("°°° on_sampletype_change::UID=" + uid + " SampleType=" + val + "°°°");
+      console.debug(`°°° on_sampletype_change::UID=${uid} SampleType=${val}°°°`);
+      // deselect the sampletype if the field is empty
       if (!has_sampletype_selected) {
+        // XXX manually flush UID field
         $("input[type=hidden]", $el.parent()).val("");
       }
+      // Flush sampletype depending fields
       field_ids = ["SamplePoint", "Specification"];
       $.each(field_ids, function(index, id) {
         var field;
         field = me.get_field_by_id(id, arnum);
         return me.flush_reference_field(field);
       });
+      // trigger form:changed event
       return $(me).trigger("form:changed");
-    };
+    }
 
-    AnalysisRequestAdd.prototype.on_specification_changed = function(event) {
-
+    on_specification_changed(event) {
       /*
        * Eventhandler when the Specification was changed.
        */
@@ -949,15 +1076,17 @@
       val = $el.val();
       arnum = $el.closest("[arnum]").attr("arnum");
       has_specification_selected = $el.val();
-      console.debug("°°° on_specification_change::UID=" + uid + " Specification=" + val + "°°°");
+      console.debug(`°°° on_specification_change::UID=${uid} Specification=${val}°°°`);
+      // deselect the specification if the field is empty
       if (!has_specification_selected) {
+        // XXX manually flush UID field
         $("input[type=hidden]", $el.parent()).val("");
       }
+      // trigger form:changed event
       return $(me).trigger("form:changed");
-    };
+    }
 
-    AnalysisRequestAdd.prototype.on_analysis_template_changed = function(event) {
-
+    on_analysis_template_changed(event) {
       /*
        * Eventhandler when an Analysis Template was changed.
        */
@@ -969,19 +1098,25 @@
       val = $el.val();
       arnum = $el.closest("[arnum]").attr("arnum");
       has_template_selected = $el.val();
-      console.debug("°°° on_analysis_template_change::UID=" + uid + " Template=" + val + "°°°");
+      console.debug(`°°° on_analysis_template_change::UID=${uid} Template=${val}°°°`);
+      // remember the set uid to handle later removal
       if (uid) {
         $el.attr("previous_uid", uid);
       } else {
         uid = $el.attr("previous_uid");
       }
+      // deselect the template if the field is empty
       if (!has_template_selected && uid) {
+        // forget the applied template
         this.applied_templates[arnum] = null;
+        // XXX manually flush UID field
         $("input[type=hidden]", $el.parent()).val("");
         record = this.records_snapshot[arnum];
         template_metadata = record.template_metadata[uid];
         template_services = [];
+        // prepare a list of services used by the template with the given UID
         $.each(record.template_to_services[uid], function(index, uid) {
+          // service might be deselected before and thus, absent
           if (uid in record.service_metadata) {
             return template_services.push(record.service_metadata[uid]);
           }
@@ -992,23 +1127,32 @@
           context["services"] = template_services;
           dialog = this.template_dialog("template-remove-template", context);
           dialog.on("yes", function() {
+            // deselect the services
             $.each(template_services, function(index, service) {
               return me.set_service(arnum, service.uid, false);
             });
+            // trigger form:changed event
             return $(me).trigger("form:changed");
           });
           dialog.on("no", function() {
+            // trigger form:changed event
             return $(me).trigger("form:changed");
           });
         }
+        // deselect the profile coming from the template
+        // XXX: This is crazy and need to get refactored!
         if (template_metadata.analysis_profile_uid) {
-          field = $("#Profiles-" + arnum);
+          field = $(`#Profiles-${arnum}`);
+          // uid and title of the selected profile
           uid = template_metadata.analysis_profile_uid;
           title = template_metadata.analysis_profile_title;
+          // get the parent field wrapper (field is only the input)
           $parent = field.closest("div.field");
-          item = $(".reference_multi_item[uid=" + uid + "]", $parent);
+          // search for the multi item and remove it
+          item = $(`.reference_multi_item[uid=${uid}]`, $parent);
           if (item.length) {
             item.remove();
+            // remove the uid from the hidden field
             uids_field = $("input[type=hidden]", $parent);
             existing_uids = uids_field.val().split(",");
             remove_index = existing_uids.indexOf(uid);
@@ -1018,46 +1162,50 @@
             uids_field.val(existing_uids.join(","));
           }
         }
+        // deselect the samplepoint
         if (template_metadata.sample_point_uid) {
-          field = $("#SamplePoint-" + arnum);
+          field = $(`#SamplePoint-${arnum}`);
           this.flush_reference_field(field);
         }
+        // deselect the sampletype
         if (template_metadata.sample_type_uid) {
-          field = $("#SampleType-" + arnum);
+          field = $(`#SampleType-${arnum}`);
           this.flush_reference_field(field);
         }
+        // flush the remarks field
         if (template_metadata.remarks) {
-          field = $("#Remarks-" + arnum);
+          field = $(`#Remarks-${arnum}`);
           field.text("");
         }
+        // reset the composite checkbox
         if (template_metadata.composite) {
-          field = $("#Composite-" + arnum);
+          field = $(`#Composite-${arnum}`);
           field.prop("checked", false);
         }
       }
+      // trigger form:changed event
       return $(me).trigger("form:changed");
-    };
+    }
 
-    AnalysisRequestAdd.prototype.on_analysis_profile_selected = function(event) {
-
+    on_analysis_profile_selected(event) {
+      var $el, el, me, uid;
       /*
        * Eventhandler when an Analysis Profile was selected.
        */
-      var $el, el, me, uid;
       console.debug("°°° on_analysis_profile_selected °°°");
       me = this;
       el = event.currentTarget;
       $el = $(el);
       uid = $(el).attr("uid");
+      // trigger form:changed event
       return $(me).trigger("form:changed");
-    };
+    }
 
-    AnalysisRequestAdd.prototype.on_analysis_profile_removed = function(event) {
-
+    on_analysis_profile_removed(event) {
+      var $el, arnum, context, dialog, el, me, profile_metadata, profile_services, record, uid;
       /*
        * Eventhandler when an Analysis Profile was removed.
        */
-      var $el, arnum, context, dialog, el, me, profile_metadata, profile_services, record, uid;
       console.debug("°°° on_analysis_profile_removed °°°");
       me = this;
       el = event.currentTarget;
@@ -1067,6 +1215,7 @@
       record = this.records_snapshot[arnum];
       profile_metadata = record.profile_metadata[uid];
       profile_services = [];
+      // prepare a list of services used by the profile with the given UID
       $.each(record.profile_to_services[uid], function(index, uid) {
         return profile_services.push(record.service_metadata[uid]);
       });
@@ -1076,18 +1225,20 @@
       me = this;
       dialog = this.template_dialog("profile-remove-template", context);
       dialog.on("yes", function() {
+        // deselect the services
         $.each(profile_services, function(index, service) {
           return me.set_service(arnum, service.uid, false);
         });
+        // trigger form:changed event
         return $(me).trigger("form:changed");
       });
       return dialog.on("no", function() {
+        // trigger form:changed event
         return $(me).trigger("form:changed");
       });
-    };
+    }
 
-    AnalysisRequestAdd.prototype.on_analysis_checkbox_click = function(event) {
-
+    on_analysis_checkbox_click(event) {
       /*
        * Eventhandler for Analysis Service Checkboxes.
        */
@@ -1097,12 +1248,12 @@
       checked = el.checked;
       $el = $(el);
       uid = $el.val();
-      console.debug("°°° on_analysis_click::UID=" + uid + " checked=" + checked + "°°°");
+      console.debug(`°°° on_analysis_click::UID=${uid} checked=${checked}°°°`);
+      // trigger form:changed event
       return $(me).trigger("form:changed");
-    };
+    }
 
-    AnalysisRequestAdd.prototype.on_service_listing_header_click = function(event) {
-
+    on_service_listing_header_click(event) {
       /*
        * Eventhandler for analysis service category header rows.
        * Toggles the visibility of all categories within this poc.
@@ -1113,25 +1264,24 @@
       visible = $el.hasClass("visible");
       toggle = !visible;
       return this.toggle_poc_categories(poc, toggle);
-    };
+    }
 
-    AnalysisRequestAdd.prototype.on_service_category_click = function(event) {
-
+    on_service_category_click(event) {
+      var $btn, $el, category, expanded, poc, services, services_checked;
       /*
        * Eventhandler for analysis service category rows.
        * Toggles the visibility of all services within this category.
        * Selected services always stay visible.
        */
-      var $btn, $el, category, expanded, poc, services, services_checked;
       event.preventDefault();
       $el = $(event.currentTarget);
       poc = $el.attr("poc");
       $btn = $(".service-category-toggle", $el);
       expanded = $el.hasClass("expanded");
       category = $el.data("category");
-      services = $("tr." + poc + "." + category);
+      services = $(`tr.${poc}.${category}`);
       services_checked = $("input[type=checkbox]:checked", services);
-      console.debug("°°° on_service_category_click: category=" + category + " °°°");
+      console.debug(`°°° on_service_category_click: category=${category} °°°`);
       if (expanded) {
         $btn.text("+");
         $el.removeClass("expanded");
@@ -1144,16 +1294,15 @@
         services.addClass("visible");
         return services.addClass("expanded");
       }
-    };
+    }
 
-    AnalysisRequestAdd.prototype.on_copy_button_click = function(event) {
-
+    on_copy_button_click(event) {
+      var $el, $td1, $tr, ar_count, el, field, me, mvl, record_one, td1, tr, uid, value;
       /*
        * Eventhandler for the field copy button per row.
        * Copies the value of the first field in this row to the remaining.
        * XXX Refactor
        */
-      var $el, $td1, $tr, ar_count, el, field, i, me, mvl, record_one, results, td1, tr, uid, value;
       console.debug("°°° on_copy_button_click °°°");
       me = this;
       el = event.target;
@@ -1166,7 +1315,10 @@
       if (!(ar_count > 1)) {
         return;
       }
+      // the record data of the first AR
       record_one = this.records_snapshot[0];
+      // ReferenceWidget cannot be simply copied, the combogrid dropdown widgets
+      // don't cooperate and the multiValued div must be copied.
       if ($(td1).find('.ArchetypesReferenceWidget').length > 0) {
         console.debug("-> Copy reference field");
         el = $(td1).find(".ArchetypesReferenceWidget");
@@ -1175,187 +1327,207 @@
         value = field.val();
         mvl = el.find(".multiValued-listing");
         $.each((function() {
-          results = [];
+          var results = [];
           for (var i = 1; 1 <= ar_count ? i <= ar_count : i >= ar_count; 1 <= ar_count ? i++ : i--){ results.push(i); }
           return results;
         }).apply(this), function(arnum) {
           var _el, _field, _td;
+          // skip the first column
           if (!(arnum > 0)) {
             return;
           }
-          _td = $tr.find("td[arnum=" + arnum + "]");
+          _td = $tr.find(`td[arnum=${arnum}]`);
           _el = $(_td).find(".ArchetypesReferenceWidget");
           _field = _el.find("input[type=text]");
+          // flush the field completely
           me.flush_reference_field(_field);
           if (mvl.length > 0) {
+            // multi valued reference field
             $.each(mvl.children(), function(idx, item) {
               uid = $(item).attr("uid");
               value = $(item).text();
               return me.set_reference_field(_field, uid, value);
             });
           } else {
+            // single reference field
             me.set_reference_field(_field, uid, value);
           }
+          // notify that the field changed
           return $(_field).trigger("change");
         });
+        // trigger form:changed event
         $(me).trigger("form:changed");
         return;
       }
+      // Copy <input type="checkbox"> fields
       $td1.find("input[type=checkbox]").each(function(index, el) {
-        var checked, j, results1;
+        var checked;
         console.debug("-> Copy checkbox field");
         $el = $(el);
         checked = $el.prop("checked");
+        // iterate over columns, starting from column 2
         return $.each((function() {
-          results1 = [];
-          for (var j = 1; 1 <= ar_count ? j <= ar_count : j >= ar_count; 1 <= ar_count ? j++ : j--){ results1.push(j); }
-          return results1;
+          var results = [];
+          for (var i = 1; 1 <= ar_count ? i <= ar_count : i >= ar_count; 1 <= ar_count ? i++ : i--){ results.push(i); }
+          return results;
         }).apply(this), function(arnum) {
           var _el, _td;
+          // skip the first column
           if (!(arnum > 0)) {
             return;
           }
-          _td = $tr.find("td[arnum=" + arnum + "]");
+          _td = $tr.find(`td[arnum=${arnum}]`);
           _el = $(_td).find("input[type=checkbox]")[index];
           return $(_el).prop("checked", checked);
         });
       });
+      // Copy <select> fields
       $td1.find("select").each(function(index, el) {
-        var j, results1;
         console.debug("-> Copy select field");
         $el = $(el);
         value = $el.val();
         return $.each((function() {
-          results1 = [];
-          for (var j = 1; 1 <= ar_count ? j <= ar_count : j >= ar_count; 1 <= ar_count ? j++ : j--){ results1.push(j); }
-          return results1;
+          var results = [];
+          for (var i = 1; 1 <= ar_count ? i <= ar_count : i >= ar_count; 1 <= ar_count ? i++ : i--){ results.push(i); }
+          return results;
         }).apply(this), function(arnum) {
           var _el, _td;
+          // skip the first column
           if (!(arnum > 0)) {
             return;
           }
-          _td = $tr.find("td[arnum=" + arnum + "]");
+          _td = $tr.find(`td[arnum=${arnum}]`);
           _el = $(_td).find("select")[index];
           return $(_el).val(value);
         });
       });
+      // Copy <input type="text"> fields
       $td1.find("input[type=text]").each(function(index, el) {
-        var j, results1;
         console.debug("-> Copy text field");
         $el = $(el);
         value = $el.val();
         return $.each((function() {
-          results1 = [];
-          for (var j = 1; 1 <= ar_count ? j <= ar_count : j >= ar_count; 1 <= ar_count ? j++ : j--){ results1.push(j); }
-          return results1;
+          var results = [];
+          for (var i = 1; 1 <= ar_count ? i <= ar_count : i >= ar_count; 1 <= ar_count ? i++ : i--){ results.push(i); }
+          return results;
         }).apply(this), function(arnum) {
           var _el, _td;
+          // skip the first column
           if (!(arnum > 0)) {
             return;
           }
-          _td = $tr.find("td[arnum=" + arnum + "]");
+          _td = $tr.find(`td[arnum=${arnum}]`);
           _el = $(_td).find("input[type=text]")[index];
           return $(_el).val(value);
         });
       });
+      // Copy <textarea> fields
       $td1.find("textarea").each(function(index, el) {
-        var j, results1;
         console.debug("-> Copy textarea field");
         $el = $(el);
         value = $el.val();
         return $.each((function() {
-          results1 = [];
-          for (var j = 1; 1 <= ar_count ? j <= ar_count : j >= ar_count; 1 <= ar_count ? j++ : j--){ results1.push(j); }
-          return results1;
+          var results = [];
+          for (var i = 1; 1 <= ar_count ? i <= ar_count : i >= ar_count; 1 <= ar_count ? i++ : i--){ results.push(i); }
+          return results;
         }).apply(this), function(arnum) {
           var _el, _td;
+          // skip the first column
           if (!(arnum > 0)) {
             return;
           }
-          _td = $tr.find("td[arnum=" + arnum + "]");
+          _td = $tr.find(`td[arnum=${arnum}]`);
           _el = $(_td).find("textarea")[index];
           return $(_el).val(value);
         });
       });
+      // trigger form:changed event
       return $(me).trigger("form:changed");
-    };
+    }
 
-    AnalysisRequestAdd.prototype.ajax_post_form = function(endpoint, options) {
+    ajax_post_form(endpoint, options = {}) {
       var ajax_options, base_url, form, form_data, me, url;
-      if (options == null) {
-        options = {};
-      }
-
       /*
        * Ajax POST the form data to the given endpoint
        */
-      console.debug("°°° ajax_post_form::Endpoint=" + endpoint + " °°°");
+      console.debug(`°°° ajax_post_form::Endpoint=${endpoint} °°°`);
+      // calculate the right form URL
       base_url = this.get_base_url();
-      url = base_url + "/ajax_ar_add/" + endpoint;
-      console.debug("Ajax POST to url " + url);
+      url = `${base_url}/ajax_ar_add/${endpoint}`;
+      console.debug(`Ajax POST to url ${url}`);
+      // extract the form data
       form = $("#analysisrequest_add_form");
+      // form.serialize does not include file attachments
+      // form_data = form.serialize()
       form_data = new FormData(form[0]);
+      // jQuery Ajax options
       ajax_options = {
         url: url,
         type: 'POST',
         data: form_data,
         context: this,
         cache: false,
-        dataType: 'json',
+        dataType: 'json', // data type we expect from the server
         processData: false,
         contentType: false
       };
-      $.extend(ajax_options, options);
+      // contentType: 'application/x-www-form-urlencoded; charset=UTF-8'
 
+      // Update Options
+      $.extend(ajax_options, options);
       /* Execute the request */
+      // Notify Ajax start
       me = this;
       $(me).trigger("ajax:start");
       return $.ajax(ajax_options).always(function(data) {
+        // Always notify Ajax end
         return $(me).trigger("ajax:end");
       });
-    };
+    }
 
-    AnalysisRequestAdd.prototype.on_ajax_start = function() {
-
+    on_ajax_start() {
+      var button;
       /*
        * Ajax request started
        */
-      var button;
       console.debug("°°° on_ajax_start °°°");
+      // deactivate the button
       button = $("input[name=save_button]");
       return button.prop({
         "disabled": true
       });
-    };
+    }
 
-    AnalysisRequestAdd.prototype.on_ajax_end = function() {
-
+    on_ajax_end() {
+      var button;
       /*
        * Ajax request finished
        */
-      var button;
       console.debug("°°° on_ajax_end °°°");
+      // reactivate the button
       button = $("input[name=save_button]");
       return button.prop({
         "disabled": false
       });
-    };
+    }
 
-    AnalysisRequestAdd.prototype.on_form_submit = function(event, callback) {
-
+    on_form_submit(event, callback) {
+      var base_url, me;
       /*
        * Eventhandler for the form submit button.
        * Extracts and submits all form data asynchronous.
        */
-      var base_url, me;
       console.debug("°°° on_form_submit °°°");
       event.preventDefault();
       me = this;
+      // get the right base url
       base_url = me.get_base_url();
+      // remove all errors
       $("div.error").removeClass("error");
       $("div.fieldErrorBox").text("");
+      // Ajax POST to the submit endpoint
       return this.ajax_post_form("submit").done(function(data) {
-
+        var ars, destination, errorbox, field, fieldname, message, msg, parent, q, stickertemplate;
         /*
          * data contains the following useful keys:
          * - errors: any errors which prevented the AR from being created
@@ -1364,21 +1536,20 @@
          *   This includes GET params for printing labels, so that we do not
          *   have to care about this here.
          */
-        var ars, destination, errorbox, field, fieldname, message, msg, parent, q, stickertemplate;
         if (data['errors']) {
           msg = data.errors.message;
           if (msg !== "") {
-            msg = msg + "<br/>";
+            msg = `${msg}<br/>`;
           }
           for (fieldname in data.errors.fielderrors) {
-            field = $("#" + fieldname);
+            field = $(`#${fieldname}`);
             parent = field.parent("div.field");
             if (field && parent) {
               parent.toggleClass("error");
               errorbox = parent.children("div.fieldErrorBox");
               message = data.errors.fielderrors[fieldname];
               errorbox.text(message);
-              msg += message + "<br/>";
+              msg += `${message}<br/>`;
             }
           }
           window.bika.lims.portalMessage(msg);
@@ -1393,56 +1564,66 @@
           return window.location.replace(base_url);
         }
       });
-    };
+    }
 
-    AnalysisRequestAdd.prototype.init_file_fields = function() {
+    init_file_fields() {
       var me;
       me = this;
       return $('tr[fieldname] input[type="file"]').each(function(index, element) {
         var add_btn, add_btn_src, file_field, file_field_div;
+        // Wrap the initial field into a div
         file_field = $(element);
         file_field.wrap("<div class='field'/>");
         file_field_div = file_field.parent();
-        add_btn_src = window.portal_url + "/++resource++bika.lims.images/add.png";
-        add_btn = $("<img class='addbtn' style='cursor:pointer;' src='" + add_btn_src + "' />");
+        // Create and add an ADD Button on the fly
+        add_btn_src = `${window.portal_url}/++resource++bika.lims.images/add.png`;
+        add_btn = $(`<img class='addbtn' style='cursor:pointer;' src='${add_btn_src}' />`);
+        // bind ADD event handler
         add_btn.on("click", element, function(event) {
           return me.file_addbtn_click(event, element);
         });
+        // Attach the Button into the same div container
         return file_field_div.append(add_btn);
       });
-    };
+    }
 
-    AnalysisRequestAdd.prototype.file_addbtn_click = function(event, element) {
-      var arnum, counter, del_btn, del_btn_src, existing_file_field_names, existing_file_fields, file_field, file_field_div, holding_div, name, newfieldname, ref;
+    file_addbtn_click(event, element) {
+      var arnum, counter, del_btn, del_btn_src, existing_file_field_names, existing_file_fields, file_field, file_field_div, holding_div, name, newfieldname;
+      // Clone the file field and wrap it into a div
       file_field = $(element).clone();
       file_field.val("");
       file_field.wrap("<div class='field'/>");
       file_field_div = file_field.parent();
-      ref = $(element).attr("name").split("-"), name = ref[0], arnum = ref[1];
+      [name, arnum] = $(element).attr("name").split("-");
+      // Get all existing input fields and their names
       holding_div = $(element).parent().parent();
       existing_file_fields = holding_div.find("input[type='file']");
       existing_file_field_names = existing_file_fields.map(function(index, element) {
         return $(element).attr("name");
       });
+      // Generate a new name for the field and ensure it is not taken by another field already
       counter = 0;
       newfieldname = $(element).attr("name");
       while (indexOf.call(existing_file_field_names, newfieldname) >= 0) {
-        newfieldname = name + "_" + counter + "-" + arnum;
+        newfieldname = `${name}_${counter}-${arnum}`;
         counter++;
       }
+      // set the new id, name
       file_field.attr("name", newfieldname);
       file_field.attr("id", newfieldname);
-      del_btn_src = window.portal_url + "/++resource++bika.lims.images/delete.png";
-      del_btn = $("<img class='delbtn' style='cursor:pointer;' src='" + del_btn_src + "' />");
+      // Create and add an DELETE Button on the fly
+      del_btn_src = `${window.portal_url}/++resource++bika.lims.images/delete.png`;
+      del_btn = $(`<img class='delbtn' style='cursor:pointer;' src='${del_btn_src}' />`);
+      // Bind an DELETE event handler
       del_btn.on("click", element, function(event) {
         return $(this).parent().remove();
       });
+      // Attach the Button into the same div container
       file_field_div.append(del_btn);
+      // Attach the new field to the outer div of the passed file field
       return $(element).parent().parent().append(file_field_div);
-    };
+    }
 
-    return AnalysisRequestAdd;
-
-  })();
+  };
 
 }).call(this);

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -81,7 +81,7 @@ class window.AnalysisRequestAdd
     # Analysis info button clicked
     $("body").on "click", ".service-infobtn", @on_analysis_details_click
     # Sample changed
-    $("body").on "selected change", "tr[fieldname=Sample] input[type='text']", @on_sample_changed
+    $("body").on "selected change", "tr[fieldname=PrimaryAnalysisRequest] input[type='text']", @on_sample_changed
     # SampleType changed
     $("body").on "selected change", "tr[fieldname=SampleType] input[type='text']", @on_sampletype_changed
     # Specification changed
@@ -543,7 +543,7 @@ class window.AnalysisRequestAdd
     @set_reference_field_query field, query
 
     # filter Sample
-    field = $("#Sample-#{arnum}")
+    field = $("#PrimaryAnalysisRequest-#{arnum}")
     query = client.filter_queries.sample
     @set_reference_field_query field, query
 
@@ -566,12 +566,26 @@ class window.AnalysisRequestAdd
      * Apply the sample data to all fields of arnum
     ###
 
+    # set the client
+    field = $("#Client-#{arnum}")
+    uid = sample.client_uid
+    title = sample.client_title
+    @set_reference_field field, uid, title
+
+    # set the client contact
+    field = $("#Contact-#{arnum}")
+    contact = sample.contact
+    uid = contact.uid
+    fullname = contact.fullname
+    @set_reference_field field, uid, fullname
+    @set_contact(arnum, contact)
+
     # set the sampling date
     field = $("#SamplingDate-#{arnum}")
     value = sample.sampling_date
     field.val value
 
-    # set the date sampeld
+    # set the date sampled
     field = $("#DateSampled-#{arnum}")
     value = sample.date_sampled
     field.val value
@@ -595,6 +609,11 @@ class window.AnalysisRequestAdd
     # set client reference
     field = $("#ClientReference-#{arnum}")
     value = sample.client_reference
+    field.val value
+
+    # set the client order number
+    field = $("#ClientOrderNumber-#{arnum}")
+    value = sample.client_order_number
     field.val value
 
     # set composite
@@ -623,6 +642,12 @@ class window.AnalysisRequestAdd
     field = $("#DefaultContainerType-#{arnum}")
     uid = sample.container_type_uid
     title = sample.container_type_title
+    @set_reference_field field, uid, title
+
+    # set the sampling deviation
+    field = $("#SamplingDeviation-#{arnum}")
+    uid = sample.sampling_deviation_uid
+    title = sample.sampling_deviation_title
     @set_reference_field field, uid, title
 
 
@@ -830,6 +855,7 @@ class window.AnalysisRequestAdd
       "SamplePoint"
       "Template"
       "Profiles"
+      "PrimaryAnalysisRequest"
       "Specification"
     ]
     $.each field_ids, (index, id) ->
@@ -982,7 +1008,7 @@ class window.AnalysisRequestAdd
     val = $el.val()
     arnum = $el.closest("[arnum]").attr "arnum"
     has_sample_selected = $el.val()
-    console.debug "°°° on_sample_change::UID=#{uid} Sample=#{val}°°°"
+    console.debug "°°° on_sample_change::UID=#{uid} PrimaryAnalysisRequest=#{val}°°°"
 
     # deselect the sample if the field is empty
     if not has_sample_selected

--- a/bika/lims/browser/viewlets/analysisrequest.py
+++ b/bika/lims/browser/viewlets/analysisrequest.py
@@ -22,7 +22,7 @@ class RetestAnalysisRequestViewlet(ViewletBase):
 
 
 class PrimaryAnalysisRequestViewlet(ViewletBase):
-    """ Current Analysis Request is a primary. Diplay links to partitions
+    """ Current Analysis Request is a primary. Display links to partitions
     """
     template = ViewPageTemplateFile("templates/primary_ar_viewlet.pt")
 
@@ -31,3 +31,9 @@ class PartitionAnalysisRequestViewlet(ViewletBase):
     """ Current Analysis Request is a partition. Display the link to primary
     """
     template = ViewPageTemplateFile("templates/partition_ar_viewlet.pt")
+
+
+class SecondaryAnalysisRequestViewlet(ViewletBase):
+    """ Current Analysis Request is a secondary. Display the link to primary
+    """
+    template = ViewPageTemplateFile("templates/secondary_ar_viewlet.pt")

--- a/bika/lims/browser/viewlets/configure.zcml
+++ b/bika/lims/browser/viewlets/configure.zcml
@@ -159,4 +159,16 @@
     permission="zope2.View"
     layer="bika.lims.interfaces.IBikaLIMS"
   />
+
+  <!-- Secondary Analysis Request viewlet -->
+  <browser:viewlet
+    for="bika.lims.interfaces.IAnalysisRequestSecondary"
+    name="bika.lims.secondary_ar_viewlet"
+    class=".analysisrequest.SecondaryAnalysisRequestViewlet"
+    manager="plone.app.layout.viewlets.interfaces.IAboveContent"
+    template="templates/secondary_ar_viewlet.pt"
+    permission="zope2.View"
+    layer="bika.lims.interfaces.IBikaLIMS"
+  />
+
 </configure>

--- a/bika/lims/browser/viewlets/templates/secondary_ar_viewlet.pt
+++ b/bika/lims/browser/viewlets/templates/secondary_ar_viewlet.pt
@@ -1,0 +1,21 @@
+<div tal:omit-tag=""
+     tal:define="primary python:view.context.getPrimaryAnalysisRequest()"
+     tal:condition="python:primary"
+     i18n:domain="senaite.core">
+
+  <div class="visualClear"></div>
+
+  <div id="portal-alert">
+    <div class="portlet-alert-item alert alert-info alert-dismissible">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <strong i18n:translate="">Info</strong>
+      <p class="title">
+        <span i18n:translate="">This is a Secondary Sample of </span>
+        <a tal:attributes="href python:primary.absolute_url()"
+           tal:content="python:primary.getId()"></a>
+      </p>
+    </div>
+  </div>
+</div>

--- a/bika/lims/catalog/analysisrequest_catalog.py
+++ b/bika/lims/catalog/analysisrequest_catalog.py
@@ -42,6 +42,7 @@ _indexes_dict = {
     # http://zope.readthedocs.io/en/latest/zope2book/SearchingZCatalog.html#textindexng
     'listing_searchable_text': 'TextIndexNG3',
     'isRootAncestor': 'BooleanIndex',
+    'is_received': 'BooleanIndex',
 }
 # Defining the columns for this catalog
 _columns_list = [

--- a/bika/lims/catalog/indexers/analysisrequest.py
+++ b/bika/lims/catalog/indexers/analysisrequest.py
@@ -52,3 +52,13 @@ def listing_searchable_text(instance):
 
     # Concatenate all strings to one text blob
     return " ".join(entries)
+
+
+@indexer(IAnalysisRequest)
+def is_received(instance):
+    """Returns whether the Analysis Request has been received
+    """
+    if instance.getDateReceived():
+        return True
+
+    return False

--- a/bika/lims/catalog/indexers/analysisrequest.py
+++ b/bika/lims/catalog/indexers/analysisrequest.py
@@ -60,5 +60,4 @@ def is_received(instance):
     """
     if instance.getDateReceived():
         return True
-
     return False

--- a/bika/lims/catalog/indexers/configure.zcml
+++ b/bika/lims/catalog/indexers/configure.zcml
@@ -10,6 +10,9 @@
   <!-- Partitioning. Analyses masking in searches -->
   <adapter name="getAncestorsUIDs" factory=".requestanalysis.getAncestorsUIDs"/>
 
+  <!-- Whether the Analysis Request has been received -->
+  <adapter name="is_received" factory=".analysisrequest.is_received"/>
+
   <!-- Whether the object is neither cancelled nor invalid -->
   <adapter name="is_active" factory=".is_active"/>
 

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -27,8 +27,7 @@ from bika.lims.browser.widgets import RemarksWidget
 from bika.lims.browser.widgets import SelectionWidget as BikaSelectionWidget
 from bika.lims.browser.widgets.durationwidget import DurationWidget
 from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
-from bika.lims.catalog.analysisrequest_catalog import \
-    CATALOG_ANALYSIS_REQUEST_LISTING
+from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.config import PRIORITIES
 from bika.lims.config import PROJECTNAME
 from bika.lims.content.analysisspec import ResultsRangeDict
@@ -245,6 +244,7 @@ schema = BikaSchema.copy() + Schema((
     ReferenceField(
         "PrimaryAnalysisRequest",
         allowed_types=("AnalysisRequest",),
+        referenceClass=HoldingReference,
         relationship='AnalysisRequestPrimaryAnalysisRequest',
         mode="rw",
         read_permission=View,
@@ -280,7 +280,6 @@ schema = BikaSchema.copy() + Schema((
     ReferenceField(
         'Batch',
         allowed_types=('Batch',),
-        referenceClass=HoldingReference,
         relationship='AnalysisRequestBatch',
         mode="rw",
         read_permission=View,

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -270,7 +270,7 @@ schema = BikaSchema.copy() + Schema((
                  'label': _('Client'), 'align': 'left'},
                 {'columnName': 'UID', 'hidden': True},
             ],
-            base_query={'is_active': True},
+            base_query={'is_active': True, 'is_received': True},
             sidx='getId',
             sord='desc',
             showOn=True,

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -27,6 +27,8 @@ from bika.lims.browser.widgets import RemarksWidget
 from bika.lims.browser.widgets import SelectionWidget as BikaSelectionWidget
 from bika.lims.browser.widgets.durationwidget import DurationWidget
 from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
+from bika.lims.catalog.analysisrequest_catalog import \
+    CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.config import PRIORITIES
 from bika.lims.config import PROJECTNAME
 from bika.lims.content.analysisspec import ResultsRangeDict
@@ -237,9 +239,47 @@ schema = BikaSchema.copy() + Schema((
         ),
     ),
 
+    # Field for the creation of Secondary Analysis Requests.
+    # This field is meant to be displayed in AR Add form only. A viewlet exists
+    # to inform the user this Analysis Request is secondary
+    ReferenceField(
+        "PrimaryAnalysisRequest",
+        allowed_types=("AnalysisRequest",),
+        relationship='AnalysisRequestPrimaryAnalysisRequest',
+        mode="rw",
+        read_permission=View,
+        write_permission=FieldEditClient,
+        widget=ReferenceWidget(
+            label=_("Primary Sample"),
+            description=_("Select a sample to create a secondary Sample"),
+            size=20,
+            render_own_label=True,
+            visible={
+                'add': 'edit',
+            },
+            catalog_name=CATALOG_ANALYSIS_REQUEST_LISTING,
+            colModel=[
+                {'columnName': 'getId', 'width': '20',
+                 'label': _('Sample ID'), 'align': 'left'},
+                {'columnName': 'getClientSampleID', 'width': '20',
+                 'label': _('Client SID'), 'align': 'left'},
+                {'columnName': 'getSampleTypeTitle', 'width': '30',
+                 'label': _('Sample Type'), 'align': 'left'},
+                {'columnName': 'getClientTitle', 'width': '30',
+                 'label': _('Client'), 'align': 'left'},
+                {'columnName': 'UID', 'hidden': True},
+            ],
+            base_query={'is_active': True},
+            sidx='getId',
+            sord='desc',
+            showOn=True,
+        )
+    ),
+
     ReferenceField(
         'Batch',
         allowed_types=('Batch',),
+        referenceClass=HoldingReference,
         relationship='AnalysisRequestBatch',
         mode="rw",
         read_permission=View,

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2378,52 +2378,32 @@ class AnalysisRequest(BaseFolder):
         relationship = "AnalysisRequestPrimaryAnalysisRequest"
         return self.getBackReferences(relationship=relationship)
 
-    def syncPrimarySecondaryValue(self, field_name, value, idxs=None):
-        """Sets the value of the given field to this instance and promotes same
-        value to Primary Analysis Requests (if any) and cascades same value to
-        Secondaries (if any)
-        """
-        self.Schema().getField(field_name).set(self, value)
-        # Promote to primary if necessary
-        primary = self.getPrimaryAnalysisRequest()
-        if primary:
-            field = primary.getField(field_name)
-            primary_value = field.get(primary)
-            if primary_value != value:
-                field.getMutator(primary)(value)
-
-        # Cascade to secondaries
-        for secondary in self.getSecondaryAnalysisRequests():
-            field = secondary.getField(field_name)
-            secondary_value = field.get(secondary)
-            if secondary_value != value:
-                field.getMutator(secondary)(value)
-
-        if idxs:
-            self.reindexObject()
-        else:
-            self.reindexObject(idxs=idxs)
-
     def setDateReceived(self, value):
         """Sets the date received to this analysis request and to secondary
         analysis requests
         """
-        idxs = ["getDateReceived", "is_received"]
-        self.syncPrimarySecondaryValue("DateReceived", value, idxs=idxs)
+        self.Schema().getField('DateReceived').set(self, value)
+        for secondary in self.getSecondaryAnalysisRequests():
+            secondary.setDateReceived(value)
+            secondary.reindexObject(idxs=["getDateReceived", "is_received"])
 
     def setDateSampled(self, value):
         """Sets the date sampled to this analysis request and to secondary
         analysis requests
         """
-        idxs = ["getDateSampled"]
-        self.syncPrimarySecondaryValue("DateSampled", value, idxs=idxs)
+        self.Schema().getField('DateSampled').set(self, value)
+        for secondary in self.getSecondaryAnalysisRequests():
+            secondary.setDateSampled(value)
+            secondary.reindexObject(idxs="getDateSampled")
 
     def setSamplingDate(self, value):
         """Sets the sampling date to this analysis request and to secondary
         analysis requests
         """
-        idxs = ["getSamplingDate"]
-        self.syncPrimarySecondaryValue("SamplingDate", value, idxs=idxs)
+        self.Schema().getField('SamplingDate').set(self, value)
+        for secondary in self.getSecondaryAnalysisRequests():
+            secondary.setSamplingDate(value)
+            secondary.reindexObject(idxs="getSamplingDate")
 
 
 registerType(AnalysisRequest, PROJECTNAME)

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2385,7 +2385,7 @@ class AnalysisRequest(BaseFolder):
         self.Schema().getField('DateReceived').set(self, value)
         for secondary in self.getSecondaryAnalysisRequests():
             secondary.setDateReceived(value)
-            secondary.reindexObject(idxs="getDateReceived")
+            secondary.reindexObject(idxs=["getDateReceived", "is_received"])
 
     def setDateSampled(self, value):
         """Sets the date sampled to this analysis request and to secondary
@@ -2395,5 +2395,15 @@ class AnalysisRequest(BaseFolder):
         for secondary in self.getSecondaryAnalysisRequests():
             secondary.setDateSampled(value)
             secondary.reindexObject(idxs="getDateSampled")
+
+    def setSamplingDate(self, value):
+        """Sets the sampling date to this analysis request and to secondary
+        analysis requests
+        """
+        self.Schema().getField('SamplingDate').set(self, value)
+        for secondary in self.getSecondaryAnalysisRequests():
+            secondary.setSamplingDate(value)
+            secondary.reindexObject(idxs="getSamplingDate")
+
 
 registerType(AnalysisRequest, PROJECTNAME)

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -256,6 +256,7 @@ schema = BikaSchema.copy() + Schema((
             render_own_label=True,
             visible={
                 'add': 'edit',
+                'header_table': 'prominent',
             },
             catalog_name=CATALOG_ANALYSIS_REQUEST_LISTING,
             colModel=[
@@ -1322,6 +1323,7 @@ schema['title'].widget.visible = False
 schema.moveField('Client', before='Contact')
 schema.moveField('ResultsInterpretation', pos='bottom')
 schema.moveField('ResultsInterpretationDepts', pos='bottom')
+schema.moveField("PrimaryAnalysisRequest", before="Client")
 
 
 class AnalysisRequest(BaseFolder):
@@ -2371,5 +2373,28 @@ class AnalysisRequest(BaseFolder):
         else:
             alsoProvides(self, IAnalysisRequestPartition)
 
+    def getSecondaryAnalysisRequests(self):
+        """Returns the secondary analysis requests from this analysis request
+        """
+        relationship = "AnalysisRequestPrimaryAnalysisRequest"
+        return self.getBackReferences(relationship=relationship)
+
+    def setDateReceived(self, value):
+        """Sets the date received to this analysis request and to secondary
+        analysis requests
+        """
+        self.Schema().getField('DateReceived').set(self, value)
+        for secondary in self.getSecondaryAnalysisRequests():
+            secondary.setDateReceived(value)
+            secondary.reindexObject(idxs="getDateReceived")
+
+    def setDateSampled(self, value):
+        """Sets the date sampled to this analysis request and to secondary
+        analysis requests
+        """
+        self.Schema().getField('DateSampled').set(self, value)
+        for secondary in self.getSecondaryAnalysisRequests():
+            secondary.setDateSampled(value)
+            secondary.reindexObject(idxs="getDateSampled")
 
 registerType(AnalysisRequest, PROJECTNAME)

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2378,32 +2378,52 @@ class AnalysisRequest(BaseFolder):
         relationship = "AnalysisRequestPrimaryAnalysisRequest"
         return self.getBackReferences(relationship=relationship)
 
+    def syncPrimarySecondaryValue(self, field_name, value, idxs=None):
+        """Sets the value of the given field to this instance and promotes same
+        value to Primary Analysis Requests (if any) and cascades same value to
+        Secondaries (if any)
+        """
+        self.Schema().getField(field_name).set(self, value)
+        # Promote to primary if necessary
+        primary = self.getPrimaryAnalysisRequest()
+        if primary:
+            field = primary.getField(field_name)
+            primary_value = field.get(primary)
+            if primary_value != value:
+                field.getMutator(primary)(value)
+
+        # Cascade to secondaries
+        for secondary in self.getSecondaryAnalysisRequests():
+            field = secondary.getField(field_name)
+            secondary_value = field.get(secondary)
+            if secondary_value != value:
+                field.getMutator(secondary)(value)
+
+        if idxs:
+            self.reindexObject()
+        else:
+            self.reindexObject(idxs=idxs)
+
     def setDateReceived(self, value):
         """Sets the date received to this analysis request and to secondary
         analysis requests
         """
-        self.Schema().getField('DateReceived').set(self, value)
-        for secondary in self.getSecondaryAnalysisRequests():
-            secondary.setDateReceived(value)
-            secondary.reindexObject(idxs=["getDateReceived", "is_received"])
+        idxs = ["getDateReceived", "is_received"]
+        self.syncPrimarySecondaryValue("DateReceived", value, idxs=idxs)
 
     def setDateSampled(self, value):
         """Sets the date sampled to this analysis request and to secondary
         analysis requests
         """
-        self.Schema().getField('DateSampled').set(self, value)
-        for secondary in self.getSecondaryAnalysisRequests():
-            secondary.setDateSampled(value)
-            secondary.reindexObject(idxs="getDateSampled")
+        idxs = ["getDateSampled"]
+        self.syncPrimarySecondaryValue("DateSampled", value, idxs=idxs)
 
     def setSamplingDate(self, value):
         """Sets the sampling date to this analysis request and to secondary
         analysis requests
         """
-        self.Schema().getField('SamplingDate').set(self, value)
-        for secondary in self.getSecondaryAnalysisRequests():
-            secondary.setSamplingDate(value)
-            secondary.reindexObject(idxs="getSamplingDate")
+        idxs = ["getSamplingDate"]
+        self.syncPrimarySecondaryValue("SamplingDate", value, idxs=idxs)
 
 
 registerType(AnalysisRequest, PROJECTNAME)

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -739,6 +739,12 @@ schema = BikaFolderSchema.copy() + Schema((
                 'prefix': 'analysisrequestretest',
                 'sequence_type': '',
                 'split-length': 1
+            }, {
+                'form': '{parent_ar_id}-S{secondary_count:02d}',
+                'portal_type': 'AnalysisRequestSecondary',
+                'prefix': 'analysisrequestsecondary',
+                'sequence_type': '',
+                'split-length': 1
             },
         ],
         widget=RecordsWidget(

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -15,9 +15,10 @@ from bika.lims.alphanumber import Alphanumber
 from bika.lims.alphanumber import to_alpha
 from bika.lims.browser.fields.uidreferencefield import \
     get_backreferences as get_backuidreferences
-from bika.lims.interfaces import IAnalysisRequest, IAnalysisRequestSecondary
+from bika.lims.interfaces import IAnalysisRequest
 from bika.lims.interfaces import IAnalysisRequestPartition
 from bika.lims.interfaces import IAnalysisRequestRetest
+from bika.lims.interfaces import IAnalysisRequestSecondary
 from bika.lims.interfaces import IIdServer
 from bika.lims.numbergenerator import INumberGenerator
 from DateTime import DateTime

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -65,6 +65,11 @@ class IAnalysisRequestRetest(Interface):
     """
 
 
+class IAnalysisRequestSecondary(Interface):
+    """Marker interface for Secondary Analysis Requests
+    """
+
+
 class IAnalysisRequestAddView(Interface):
     """AR Add view
     """

--- a/bika/lims/tests/doctests/SecondaryAnalysisRequest.rst
+++ b/bika/lims/tests/doctests/SecondaryAnalysisRequest.rst
@@ -202,13 +202,53 @@ Create a single partition from the secondary Analysis Request:
     >>> partition
     <AnalysisRequest at /plone/clients/client-1/W-0001-S03-P01>
 
+    >>> partition.isPartition()
+    True
+
+    >>> partition.getParentAnalysisRequest()
+    <AnalysisRequest at /plone/clients/client-1/W-0001-S03>
+
 Partition does not provide `IAnalysisRequestSecondary`:
 
     >>> IAnalysisRequestSecondary.providedBy(partition)
     False
+
+And does not keep the original Primary Analysis Request:
+
+    >>> partition.getPrimaryAnalysisRequest() is None
+    True
 
 If we create another partition, the generated ID is increased in one unit:
 
     >>> partition = create_partition(secondary, request, analyses_2)
     >>> partition
     <AnalysisRequest at /plone/clients/client-1/W-0001-S03-P02>
+
+We can even create a secondary Analysis Request from a partition as the source:
+
+    >>> values = {
+    ...     "Client": client.UID(),
+    ...     "Contact": contact.UID(),
+    ...     "SampleType": sampletype.UID(),
+    ...     "PrimaryAnalysisRequest": partition }
+
+    >>> service_uids = map(api.get_uid, [Cu, Fe, Au])
+    >>> secondary = create_analysisrequest(client, request, values, service_uids)
+    >>> secondary
+    <AnalysisRequest at /plone/clients/client-1/W-0001-S03-P02-S01>
+
+But note this new secondary is not considered a partition of a partition:
+
+    >>> secondary.isPartition()
+    False
+
+But keeps the partition as the primary:
+
+    >>> secondary.getPrimaryAnalysisRequest()
+    <AnalysisRequest at /plone/clients/client-1/W-0001-S03-P02>
+
+We can also create new partitions from this weird secondary:
+
+    >>> partition = create_partition(secondary, request, secondary.getAnalyses())
+    >>> partition
+    <AnalysisRequest at /plone/clients/client-1/W-0001-S03-P02-S01-P01>

--- a/bika/lims/tests/doctests/SecondaryAnalysisRequest.rst
+++ b/bika/lims/tests/doctests/SecondaryAnalysisRequest.rst
@@ -172,6 +172,17 @@ Dates for secondaries are updated in accordance:
     >>> third.getDateReceived() == secondary.getDateReceived() == primary.getDateReceived()
     True
 
+But even if I manually set a date for a secondary, the corresponding values for
+the rest (primary included) are kept in sync too:
+
+    >>> new_datetime = DateTime() +  20
+    >>> third.setDateReceived(new_datetime)
+    >>> third.getDateReceived() == new_datetime
+    True
+
+    >>> third.getDateReceived() == secondary.getDateReceived() == primary.getDateReceived()
+    True
+
 
 Secondary Analysis Requests and partitions
 ------------------------------------------

--- a/bika/lims/tests/doctests/SecondaryAnalysisRequest.rst
+++ b/bika/lims/tests/doctests/SecondaryAnalysisRequest.rst
@@ -1,0 +1,214 @@
+Secondary Analysis Request
+==========================
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t SecondaryAnalysisRequest
+
+
+Test Setup
+----------
+
+Needed Imports:
+
+    >>> from DateTime import DateTime
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import setRoles
+    >>> from bika.lims import api
+    >>> from bika.lims.interfaces import IAnalysisRequestSecondary
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.utils.analysisrequest import create_partition
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = portal.bika_setup
+
+Some basic objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ["LabManager",])
+    >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH", MemberDiscountApplies=True)
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(setup.bika_sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.bika_departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = api.create(setup.bika_analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> Cu = api.create(setup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID(), Accredited=True)
+    >>> Fe = api.create(setup.bika_analysisservices, "AnalysisService", title="Iron", Keyword="Fe", Price="10", Category=category.UID())
+    >>> Au = api.create(setup.bika_analysisservices, "AnalysisService", title="Gold", Keyword="Au", Price="20", Category=category.UID())
+
+
+Create Secondary Analysis Request
+---------------------------------
+
+To create a Secondary Analysis Request we need first a primary (or source
+Analysis Request) to which the secondary analysis request will refer to:
+
+    >>> values = {
+    ...     "Client": client.UID(),
+    ...     "Contact": contact.UID(),
+    ...     "SamplingDate": DateTime(),
+    ...     "DateSampled": DateTime(),
+    ...     "SampleType": sampletype.UID() }
+    >>> service_uids = map(api.get_uid, [Cu, Fe, Au])
+    >>> primary = create_analysisrequest(client, request, values, service_uids)
+    >>> primary
+    <AnalysisRequest at /plone/clients/client-1/W-0001>
+
+Receive the primary analysis request:
+
+    >>> transitioned = do_action_for(primary, "receive")
+    >>> api.get_workflow_status_of(primary)
+    'sample_received'
+
+Create the Secondary Analysis Request:
+
+    >>> values = {
+    ...     "Client": client.UID(),
+    ...     "Contact": contact.UID(),
+    ...     "SampleType": sampletype.UID(),
+    ...     "PrimaryAnalysisRequest": primary }
+
+    >>> service_uids = map(api.get_uid, [Cu, Fe, Au])
+    >>> secondary = create_analysisrequest(client, request, values, service_uids)
+    >>> secondary
+    <AnalysisRequest at /plone/clients/client-1/W-0001-S01>
+
+    >>> secondary.getPrimaryAnalysisRequest()
+    <AnalysisRequest at /plone/clients/client-1/W-0001>
+
+The secondary AnalysisRequest also provides `IAnalysisRequestSecondary`:
+
+    >>> IAnalysisRequestSecondary.providedBy(secondary)
+    True
+
+Dates match with those from the primary Analysis Request:
+
+    >>> secondary.getDateSampled() == primary.getDateSampled()
+    True
+
+    >>> secondary.getSamplingDate() == primary.getSamplingDate()
+    True
+
+The secondary sample is automatically transitioned to `sample_received`:
+
+    >>> api.get_workflow_status_of(secondary)
+    'sample_received'
+
+The SampleReceived date matches with the primary's:
+
+    >>> secondary.getDateReceived() == primary.getDateReceived()
+    True
+
+Analyses have been also initialized automatically:
+
+    >>> analyses = secondary.getAnalyses(full_objects=True)
+    >>> map(api.get_workflow_status_of, analyses)
+    ['unassigned', 'unassigned', 'unassigned']
+
+If I create another secondary sample using same AR as the primary:
+
+    >>> values = {
+    ...     "Client": client.UID(),
+    ...     "Contact": contact.UID(),
+    ...     "SampleType": sampletype.UID(),
+    ...     "PrimaryAnalysisRequest": primary }
+
+    >>> service_uids = map(api.get_uid, [Cu, Fe, Au])
+    >>> secondary = create_analysisrequest(client, request, values, service_uids)
+
+The ID suffix of the new secondary sample increases in one unit:
+
+    >>> secondary.getId()
+    'W-0001-S02'
+
+If I create a secondary sample from another secondary AR as the primary:
+
+    >>> values = {
+    ...     "Client": client.UID(),
+    ...     "Contact": contact.UID(),
+    ...     "SampleType": sampletype.UID(),
+    ...     "PrimaryAnalysisRequest": secondary }
+
+    >>> service_uids = map(api.get_uid, [Cu, Fe, Au])
+    >>> third = create_analysisrequest(client, request, values, service_uids)
+
+The ID suffix is extended accordingly:
+
+    >>> third.getId()
+    'W-0001-S02-S01'
+
+And the associated primary AR is the secondary sample we created earlier:
+
+    >>> third.getPrimaryAnalysisRequest()
+    <AnalysisRequest at /plone/clients/client-1/W-0001-S02>
+
+And of course, keeps same date values:
+
+
+    >>> third.getDateSampled() == secondary.getDateSampled()
+    True
+
+    >>> third.getSamplingDate() == secondary.getSamplingDate()
+    True
+
+    >>> third.getDateReceived() == secondary.getDateReceived()
+    True
+
+If we change the dates from the root Primary:
+
+    >>> primary.setSamplingDate(DateTime() + 5)
+    >>> primary.setDateSampled(DateTime() + 10)
+    >>> primary.setDateReceived(DateTime() + 15)
+
+Dates for secondaries are updated in accordance:
+
+    >>> third.getSamplingDate() == secondary.getSamplingDate() == primary.getSamplingDate()
+    True
+    >>> third.getDateSampled() == secondary.getDateSampled() == primary.getDateSampled()
+    True
+    >>> third.getDateReceived() == secondary.getDateReceived() == primary.getDateReceived()
+    True
+
+
+Secondary Analysis Requests and partitions
+------------------------------------------
+
+When partitions are created from a secondary Analysis Request, the partitions
+themselves are not considered secondaries from the primary AR, but partitions
+of a Secondary Analysis Request.
+
+Create a secondary Analysis Request:
+
+    >>> values = {
+    ...     "Client": client.UID(),
+    ...     "Contact": contact.UID(),
+    ...     "SampleType": sampletype.UID(),
+    ...     "PrimaryAnalysisRequest": primary }
+
+    >>> service_uids = map(api.get_uid, [Cu, Fe, Au])
+    >>> secondary = create_analysisrequest(client, request, values, service_uids)
+    >>> secondary
+    <AnalysisRequest at /plone/clients/client-1/W-0001-S03>
+
+Create a single partition from the secondary Analysis Request:
+
+    >>> analyses = secondary.getAnalyses()
+    >>> analyses_1 = analyses[0:1]
+    >>> analyses_2 = analyses[1:]
+    >>> partition = create_partition(secondary, request, analyses_1)
+    >>> partition
+    <AnalysisRequest at /plone/clients/client-1/W-0001-S03-P01>
+
+Partition does not provide `IAnalysisRequestSecondary`:
+
+    >>> IAnalysisRequestSecondary.providedBy(partition)
+    False
+
+If we create another partition, the generated ID is increased in one unit:
+
+    >>> partition = create_partition(secondary, request, analyses_2)
+    >>> partition
+    <AnalysisRequest at /plone/clients/client-1/W-0001-S03-P02>

--- a/bika/lims/tests/doctests/SecondaryAnalysisRequest.rst
+++ b/bika/lims/tests/doctests/SecondaryAnalysisRequest.rst
@@ -172,17 +172,6 @@ Dates for secondaries are updated in accordance:
     >>> third.getDateReceived() == secondary.getDateReceived() == primary.getDateReceived()
     True
 
-But even if I manually set a date for a secondary, the corresponding values for
-the rest (primary included) are kept in sync too:
-
-    >>> new_datetime = DateTime() +  20
-    >>> third.setDateReceived(new_datetime)
-    >>> third.getDateReceived() == new_datetime
-    True
-
-    >>> third.getDateReceived() == secondary.getDateReceived() == primary.getDateReceived()
-    True
-
 
 Secondary Analysis Requests and partitions
 ------------------------------------------

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -235,12 +235,12 @@ def upgrade(tool):
     set_retest_id_formatting(portal)
 
     # Set the ID formatting for Secondary ARs
+    # https://github.com/senaite/senaite.core/pull/1284
     set_secondary_id_formatting(portal)
 
     # Reindex submitted analyses to update the analyst
     # https://github.com/senaite/senaite.core/pull/1254
     reindex_submitted_analyses(portal)
-
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -234,6 +234,9 @@ def upgrade(tool):
     # https://github.com/senaite/senaite.core/pull/1243
     set_retest_id_formatting(portal)
 
+    # Set the ID formatting for Secondary ARs
+    set_secondary_id_formatting(portal)
+
     # Reindex submitted analyses to update the analyst
     # https://github.com/senaite/senaite.core/pull/1254
     reindex_submitted_analyses(portal)
@@ -1992,11 +1995,22 @@ def set_retest_id_formatting(portal):
     """Sets the default id formatting for AR retests
     """
     part_id_format = dict(
-        form="{parent_base_id}-{seq:02d}-R{seq:02d}",
+        form="{parent_base_id}-R{retest_count:02d}",
         portal_type="AnalysisRequestRetest",
         prefix="analysisrequestretest",
         sequence_type="")
     set_id_format(portal, part_id_format)
+
+
+def set_secondary_id_formatting(portal):
+    """Sets the default id formatting for secondary ARs
+    """
+    secondary_id_format = dict(
+        form="{parent_ar_id}-S{secondary_count:02d}",
+        portal_type="AnalysisRequestSecondary",
+        prefix="analysisrequestsecondary",
+        sequence_type="")
+    set_id_format(portal, secondary_id_format)
 
 
 def reindex_submitted_analyses(portal):

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -238,6 +238,7 @@ def upgrade(tool):
     # https://github.com/senaite/senaite.core/pull/1254
     reindex_submitted_analyses(portal)
 
+
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
 
@@ -1785,6 +1786,7 @@ def update_ar_listing_catalog(portal):
         # name, attribute, metatype
         ("getClientID", "getClientID", "FieldIndex"),
         ("is_active", "is_active", "BooleanIndex"),
+        ("is_received", "is_received", "BooleanIndex"),
     ]
 
     metadata_to_add = [

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -9,16 +9,15 @@ import os
 import tempfile
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-
-from bika.lims.workflow.analysisrequest import AR_WORKFLOW_ID
 from email.Utils import formataddr
 
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
 from bika.lims.idserver import renameAfterCreation
-from bika.lims.interfaces import IAnalysisRequest, IAnalysisRequestSecondary
+from bika.lims.interfaces import IAnalysisRequest
 from bika.lims.interfaces import IAnalysisRequestRetest
+from bika.lims.interfaces import IAnalysisRequestSecondary
 from bika.lims.interfaces import IAnalysisService
 from bika.lims.interfaces import IRoutineAnalysis
 from bika.lims.utils import attachPdf
@@ -28,9 +27,10 @@ from bika.lims.utils import createPdf
 from bika.lims.utils import encode_header
 from bika.lims.utils import tmpID
 from bika.lims.utils import to_utf8
-from bika.lims.workflow import ActionHandlerPool, get_review_history_statuses
+from bika.lims.workflow import ActionHandlerPool
 from bika.lims.workflow import doActionFor
 from bika.lims.workflow import push_reindex_to_actions_pool
+from bika.lims.workflow.analysisrequest import AR_WORKFLOW_ID
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import _createObjectByType
 from Products.CMFPlone.utils import safe_unicode

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -385,6 +385,7 @@ def create_partition(analysis_request, request, analyses, sample_type=None,
         "id",
         "modification_date",
         "ParentAnalysisRequest",
+        "PrimaryAnalysisRequest",
     ]
     if skip_fields:
         partition_skip_fields.extend(skip_fields)

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -78,6 +78,9 @@ def create_analysisrequest(client, request, values, analyses=None,
         # Mark the secondary with the `IAnalysisRequestSecondary` interface
         alsoProvides(ar, IAnalysisRequestSecondary)
 
+        # Rename the secondary according to the ID server setup
+        renameAfterCreation(ar)
+
         # Set dates to match with those from the primary
         ar.setDateSampled(primary.getDateSampled())
         ar.setSamplingDate(primary.getSamplingDate())

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -75,16 +75,15 @@ def create_analysisrequest(client, request, values, analyses=None,
     # If Secondary Analysis Request, set same status as the
     primary = ar.getPrimaryAnalysisRequest()
     if primary:
-
         # Mark the secondary with the `IAnalysisRequestSecondary` interface
         alsoProvides(ar, IAnalysisRequestSecondary)
 
+        # Set dates to match with those from the primary
         ar.setDateSampled(primary.getDateSampled())
         ar.setSamplingDate(primary.getSamplingDate())
-        # Secondary AR does not longer comes from a Sample, rather from an AR.
-        # If the Primary AR has been received, then force the transition of the
-        # secondary to received and set the description/comment in the
-        # transition accordingly so it will be displayed later in the log tab
+
+        # Force the transition of the secondary to received and set the
+        # description/comment in the transition accordingly.
         date_received = primary.getDateReceived()
         if date_received:
             ar.setDateReceived(date_received)

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -32,8 +32,8 @@ from bika.lims.utils import to_utf8
 from bika.lims.workflow import ActionHandlerPool
 from bika.lims.workflow import doActionFor
 from bika.lims.workflow import push_reindex_to_actions_pool
-from bika.lims.workflow.analysisrequest import AR_WORKFLOW_ID, \
-    do_action_to_analyses
+from bika.lims.workflow.analysisrequest import AR_WORKFLOW_ID
+from bika.lims.workflow.analysisrequest import do_action_to_analyses
 from email.Utils import formataddr
 from zope.interface import alsoProvides
 

--- a/bika/lims/workflow/__init__.py
+++ b/bika/lims/workflow/__init__.py
@@ -254,6 +254,13 @@ def getReviewHistoryActionsList(instance, reverse=False):
     return map(lambda event: event["action"], review_history)
 
 
+def get_review_history_statuses(instance, reverse=False):
+    """Returns a list with the statuses of the instance from the review_history
+    """
+    review_history = getReviewHistory(instance, reverse=reverse)
+    return map(lambda event: event["review_state"], review_history)
+
+
 def get_prev_status_from_history(instance, status=None):
     """Returns the previous status of the object. If status is set, returns the
     previous status before the object reached the status passed in.

--- a/bika/lims/workflow/indexes.py
+++ b/bika/lims/workflow/indexes.py
@@ -101,6 +101,7 @@ ACTIONS_TO_INDEXES = {
         "receive": {
             "getDueDate",
             "getDateReceived",
+            "is_received",
         },
         "rollback_to_receive": [
             "assigned_state",


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This functionality mimics the same functionality of secondary Analysis Requests from pre-1.3 versions. 
A field "Primary Sample" has been added in Add form, so the user can choose any of the Samples active and received in the system. Once a primary sample is selected, some fields of the form get populated automatically (e.g. Client, Contact, Sample Type, Sample Point, Client Reference, Client Sample ID, Date Sampled, etc.) with same data as the primary one.

Once the secondary sample is created, the Sample status becomes "received" automatically and the values for fields Date Sampled and Date Received are no longer editable (displayed in read-only mode). Nevertheless, if any of these two fields are edited in the primary, values for all secondaries will be updated in accordance.

The id of secondary samples follow this format: `{parent_ar_id}-S{secondary_count:02d}`, so if the primary sample is `AP-0003`, the IDs of secondary Samples will be `AP-0003-S01`, `AP-0003-S02`, etc. The "S" (of "Secondary") has been used in order to prevent confusions with Partitions ("P" char) or Retests ("R" char).

![Captura de 2019-03-14 23-46-17](https://user-images.githubusercontent.com/832627/54396470-62ab6200-46b3-11e9-943c-fe8383dc2b8f.png)

![Captura de 2019-03-14 23-47-34](https://user-images.githubusercontent.com/832627/54396532-8ff81000-46b3-11e9-9b41-b52daca3ca64.png)



## Current behavior before PR

No support for secondary samples.

## Desired behavior after PR is merged

Support for secondary samples.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
