### PR TITLE
Inconsistencies on Detection Limit Operand submission

### DIFF
--- a/bika/lims/browser/workflow/analysis.py
+++ b/bika/lims/browser/workflow/analysis.py
@@ -64,7 +64,7 @@ class WorkflowActionSubmitAdapter(WorkflowActionGenericAdapter):
             analysis.setUncertainty(uncertainty)
 
             # Save detection limit
-            dlimit = self.get_form_value("DetectionLimit", uid, "")
+            dlimit = self.get_form_value("DetectionLimitOperand", uid, "")
             analysis.setDetectionLimitOperand(dlimit)
 
             # Interim fields


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Although the detection limit operand, together with result are saved correctly when the button "Save" is pressed, the detection limit operand gets lost after the "Submit" button is pressed. The logic in charge of storing the values on submission was not storing the detection limit correctly.

Linked issue: https://github.com/senaite/senaite.core/issues/1184

## Current behavior before PR

Inconsistencies with DL after submit

## Desired behavior after PR is merged

No inconsistencies with DL after submit

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
