### PR TITLE
Adding Analyses to an existing Worksheet in a non-open status fails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -104,6 +104,7 @@ Changelog
 
 **Fixed**
 
+- #1281 Adding Analyses to an existing Worksheet fails
 - #1269 Render analysis remarks conditionally
 - #1277 Traceback in Manage Analyses
 - #1245 Not all clients are shown in clients drop menu for Productivity Reports

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -156,10 +156,8 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
            - position is overruled if a slot for this analysis' parent exists
            - if position is None, next available pos is used.
         """
-
-        # TODO Workflow - Move these initial checks to the assign guard
         # Cannot add an analysis if not open, unless a retest
-        if api.get_review_status(self) != "open":
+        if api.get_review_status(self) not in ["open", "to_be_verified"]:
             retracted = analysis.getRetestOf()
             if retracted not in self.getAnalyses():
                 return

--- a/bika/lims/tests/doctests/WorkflowAnalysisAssign.rst
+++ b/bika/lims/tests/doctests/WorkflowAnalysisAssign.rst
@@ -180,17 +180,7 @@ to `to_be_verified`, cause all the analyses assigned are in this state:
     >>> api.get_workflow_status_of(worksheet)
     'to_be_verified'
 
-And now, I cannot add analyses anymore:
-
-    >>> worksheet.addAnalysis(fe)
-    >>> filter(lambda an: an.getKeyword() == "Fe", worksheet.getAnalyses())
-    []
-    >>> fe.getWorksheet() is None
-    True
-    >>> api.get_workflow_status_of(fe)
-    'unassigned'
-
-Neither remove:
+In `to_be_verified` status, I cannot remove analyses:
 
     >>> worksheet.removeAnalysis(au)
     >>> map(lambda an: an.getKeyword(), worksheet.getAnalyses())
@@ -198,6 +188,23 @@ Neither remove:
     >>> au.getWorksheetUID() == api.get_uid(worksheet)
     True
     >>> api.get_workflow_status_of(au)
+    'to_be_verified'
+
+But I can still add more analyses:
+
+    >>> worksheet.addAnalysis(fe)
+    >>> filter(lambda an: an.getKeyword() == "Fe", worksheet.getAnalyses())
+    [<Analysis at /plone/clients/client-1/W-0001/Fe>]
+
+Causing the Worksheet to roll back to `open` status:
+
+    >>> api.get_workflow_status_of(worksheet)
+    'open'
+
+If I remove `Fe` analysis again, worksheet is promoted to `to_be_verified`:
+
+    >>> worksheet.removeAnalysis(fe)
+    >>> api.get_workflow_status_of(worksheet)
     'to_be_verified'
 
 Let's create another worksheet and add the remaining analyses:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request allows the user to add new analyses to a Worksheet when its status is `to_be_verified`.

Linked issue: https://github.com/senaite/senaite.core/issues/1281

## Current behavior before PR

Cannot add analyses to a worksheet that is in `to_be_verified` status

## Desired behavior after PR is merged

Can add analyses to a worksheet that is in `to_be_verified` status. In such case, the Worksheet is rolled-back automatically to `open` status.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
