### PR TITLE
Retracting a calculated Analysis leads to an inconsistent state

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -104,6 +104,7 @@ Changelog
 
 **Fixed**
 
+- #1283 Retracting a calculated Analysis leads to an inconsistent state
 - #1269 Render analysis remarks conditionally
 - #1277 Traceback in Manage Analyses
 - #1245 Not all clients are shown in clients drop menu for Productivity Reports

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -42,7 +42,7 @@ class Analysis(AbstractRoutineAnalysis):
 
         siblings = []
         retracted_states = [STATE_RETRACTED, STATE_REJECTED]
-        for sibling in request.getAnalyses(full_objects=False):
+        for sibling in request.getAnalyses(full_objects=True):
             if api.get_uid(sibling) == self.UID():
                 # Exclude me from the list
                 continue
@@ -54,7 +54,7 @@ class Analysis(AbstractRoutineAnalysis):
 
             siblings.append(sibling)
 
-        return map(api.get_object, siblings)
+        return siblings
 
     def workflow_script_publish(self):
         """

--- a/bika/lims/tests/doctests/WorkflowAnalysisRetract.rst
+++ b/bika/lims/tests/doctests/WorkflowAnalysisRetract.rst
@@ -230,8 +230,9 @@ Retraction of results for analyses with dependents
 
 When retracting an analysis other analyses depends on (dependents), then the
 retraction of a dependency causes the auto-retraction of its dependents.
+Dependencies are retracted too.
 
-Prepare a calculation that depends on `Cu`and assign it to `Fe` analysis:
+Prepare a calculation that depends on `Cu` and assign it to `Fe` analysis:
 
     >>> calc_fe = api.create(bikasetup.bika_calculations, 'Calculation', title='Calc for Fe')
     >>> calc_fe.setFormula("[Cu]*10")
@@ -281,22 +282,25 @@ If I retract `Fe`, `Au` analysis is retracted automatically too:
     >>> api.get_workflow_status_of(au_analysis)
     'retracted'
 
-And two new analyses will be generated in accordance:
+As well as `Cu` analysis (a dependency of `Fe`):
+
+    >>> api.get_workflow_status_of(cu_analysis)
+    'retracted'
+
+Hence, three new analyses are generated in accordance:
 
     >>> analyses = ar.getAnalyses(full_objects=True)
     >>> len(analyses)
-    5
+    6
     >>> au_analyses = filter(lambda an: an.getKeyword()=="Au", analyses)
     >>> sorted(map(api.get_workflow_status_of, au_analyses))
     ['retracted', 'unassigned']
     >>> fe_analyses = filter(lambda an: an.getKeyword()=="Fe", analyses)
     >>> sorted(map(api.get_workflow_status_of, fe_analyses))
     ['retracted', 'unassigned']
-
-While `Cu` analysis remains in `to_be_verified` state:
-
-    >>> api.get_workflow_status_of(cu_analysis)
-    'to_be_verified'
+    >>> cu_analyses = filter(lambda an: an.getKeyword()=="Cu", analyses)
+    >>> sorted(map(api.get_workflow_status_of, cu_analyses))
+    ['retracted', 'unassigned']
 
 And the current state of the Analysis Request is `sample_received` now:
 

--- a/bika/lims/tests/doctests/WorkflowDuplicateAnalysisRetract.rst
+++ b/bika/lims/tests/doctests/WorkflowDuplicateAnalysisRetract.rst
@@ -304,22 +304,25 @@ If I retract `Fe`, `Au` analysis is retracted automatically too:
     >>> api.get_workflow_status_of(au_analysis)
     'retracted'
 
-And two new analyses will be generated in accordance:
+As well as `Cu` analysis (a dependency of `Fe`):
+
+    >>> api.get_workflow_status_of(cu_analysis)
+    'retracted'
+
+Hence, three new analyses are generated in accordance:
 
     >>> analyses = ar.getAnalyses(full_objects=True)
     >>> len(analyses)
-    5
+    6
     >>> au_analyses = filter(lambda an: an.getKeyword()=="Au", analyses)
     >>> sorted(map(api.get_workflow_status_of, au_analyses))
     ['retracted', 'unassigned']
     >>> fe_analyses = filter(lambda an: an.getKeyword()=="Fe", analyses)
     >>> sorted(map(api.get_workflow_status_of, fe_analyses))
     ['retracted', 'unassigned']
-
-While `Cu` analysis remains in `to_be_verified` state:
-
-    >>> api.get_workflow_status_of(cu_analysis)
-    'to_be_verified'
+    >>> fe_analyses = filter(lambda an: an.getKeyword()=="Cu", analyses)
+    >>> sorted(map(api.get_workflow_status_of, fe_analyses))
+    ['retracted', 'unassigned']
 
 And the current state of the Analysis Request is `sample_received` now:
 

--- a/bika/lims/workflow/analysis/events.py
+++ b/bika/lims/workflow/analysis/events.py
@@ -105,6 +105,13 @@ def after_retract(analysis):
     unless the the retracted analysis was assigned to a worksheet. In such case,
     the copy is transitioned to 'assigned' state too
     """
+
+    # Retract our dependents (analyses that depend on this analysis)
+    cascade_to_dependents(analysis, "retract")
+
+    # Retract our dependencies (analyses this analysis depends on)
+    promote_to_dependencies(analysis, "retract")
+
     # Rename the analysis to make way for it's successor.
     # Support multiple retractions by renaming to *-0, *-1, etc
     parent = analysis.aq_parent
@@ -129,9 +136,6 @@ def after_retract(analysis):
     worksheet = analysis.getWorksheet()
     if worksheet:
         worksheet.addAnalysis(new_analysis)
-
-    # Retract our dependents (analyses that depend on this analysis)
-    cascade_to_dependents(analysis, "retract")
 
     # Try to rollback the Analysis Request
     if IRequestAnalysis.providedBy(analysis):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When an analysis with dependencies is retracted, the dependencies weren't retracted, leading analyses in an inconsistent state. With this Pull Request, dependencies (and dependents as well) are retracted when an analysis is retracted.

Linked issue: https://github.com/senaite/senaite.core/issues/1283

## Current behavior before PR

When an analysis is retracted, its dependencies are not retracted

## Desired behavior after PR is merged

When an analysis is retracted, its dependencies are retracted too

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
