### PR TITLE
Allow the removal of empty Worksheets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1291 "Remove" transition for empty Worksheets
 - #1259 Added Facscalibur instrument import interface
 - #1244 Added "Body for Sample Invalidation email" field in setup
 - #1231 Add Client ID Column in Batch Listing

--- a/bika/lims/browser/worksheet/views/folder.py
+++ b/bika/lims/browser/worksheet/views/folder.py
@@ -117,11 +117,7 @@ class FolderView(BikaListingView):
                     ],
                     "sort_on": "CreationDate",
                     "sort_order": "reverse"},
-                "transitions": [
-                    {"id": "retract"},
-                    {"id": "verify"},
-                    {"id": "reject"}
-                ],
+                "transitions": [],
                 "custom_transitions": [],
                 "columns": self.columns.keys(),
             }, {
@@ -141,11 +137,7 @@ class FolderView(BikaListingView):
                     "review_state": "to_be_verified",
                     "sort_on": "CreationDate",
                     "sort_order": "reverse"},
-                "transitions": [
-                    {"id": "retract"},
-                    {"id": "verify"},
-                    {"id": "reject"}
-                ],
+                "transitions": [],
                 "custom_transitions": [],
                 "columns": self.columns.keys()
             }, {
@@ -171,11 +163,7 @@ class FolderView(BikaListingView):
                     ],
                     "sort_on":"CreationDate",
                     "sort_order": "reverse"},
-                "transitions":[
-                    {"id": "retract"},
-                    {"id": "verify"},
-                    {"id": "reject"}
-                ],
+                "transitions":[],
                 "custom_transitions": [],
                 "columns": self.columns.keys(),
             }, {
@@ -192,11 +180,7 @@ class FolderView(BikaListingView):
                     ],
                     "sort_on":"CreationDate",
                     "sort_order": "reverse"},
-                "transitions":[
-                    {"id": "retract"},
-                    {"id": "verify"},
-                    {"id": "reject"}
-                ],
+                "transitions":[],
                 "custom_transitions": [],
                 "columns": self.columns.keys(),
             }

--- a/bika/lims/permissions.py
+++ b/bika/lims/permissions.py
@@ -111,6 +111,7 @@ TransitionReopenSamplingRound = "senaite.core: Transition: Reopen Sampling Round
 
 # Transition permissions (Worksheet)
 TransitionRejectWorksheet = "senaite.core: Transition: Reject Worksheet"
+TransitionRemoveWorksheet = "senaite.core: Transition: Remove Worksheet"
 
 
 # Field Permissions

--- a/bika/lims/permissions.zcml
+++ b/bika/lims/permissions.zcml
@@ -96,6 +96,7 @@
 
   # Transition Permissions (Worksheet)
   <permission id="senaite.core.permissions.TransitionRejectWorksheet" title="senaite.core: Transition: Reject Worksheet"/>
+  <permission id="senaite.core.permissions.TransitionRemoveWorksheet" title="senaite.core: Transition: Remove Worksheet"/>
 
 
   # Field Permissions

--- a/bika/lims/profiles/default/rolemap.xml
+++ b/bika/lims/profiles/default/rolemap.xml
@@ -529,6 +529,10 @@
       <role name="LabManager"/>
       <role name="Manager"/>
     </permission>
+    <permission name="senaite.core: Transition: Remove Worksheet" acquire="False">
+      <role name="LabManager"/>
+      <role name="Manager"/>
+    </permission>
 
 
     <!-- Field permissions -->

--- a/bika/lims/profiles/default/workflows/bika_worksheet_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_worksheet_workflow/definition.xml
@@ -13,6 +13,7 @@
   <permission>senaite.core: Edit Worksheet</permission>
   <permission>senaite.core: Transition: Retract</permission>
   <permission>senaite.core: Transition: Reject Worksheet</permission>
+  <permission>senaite.core: Transition: Remove Worksheet</permission>
   <permission>senaite.core: Transition: Unassign Analysis</permission>
   <permission>senaite.core: View Results</permission>
   <permission>Modify portal content</permission>
@@ -21,6 +22,7 @@
     <exit-transition transition_id="attach" />
     <exit-transition transition_id="reject" />
     <permission-map name="senaite.core: Transition: Reject Worksheet" acquired="True"/>
+    <permission-map name="senaite.core: Transition: Remove Worksheet" acquired="False"/>
     <permission-map name="senaite.core: Add Attachment" acquired="False">
       <permission-role>Analyst</permission-role>
       <permission-role>LabClerk</permission-role>
@@ -53,7 +55,9 @@
 
   <state state_id="open" title="Open" i18n:attributes="title">
     <exit-transition transition_id="submit" />
+    <exit-transition transition_id="remove" />
     <permission-map name="senaite.core: Transition: Reject Worksheet" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Remove Worksheet" acquired="True"/>
     <permission-map name="senaite.core: Add Attachment" acquired="False">
       <permission-role>Analyst</permission-role>
       <permission-role>LabClerk</permission-role>
@@ -87,6 +91,7 @@
   <state state_id="rejected" title="Rejected" i18n:attributes="title">
     <exit-transition transition_id="" />
     <permission-map name="senaite.core: Transition: Reject Worksheet" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Remove Worksheet" acquired="False"/>
     <permission-map name="senaite.core: Add Attachment" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
@@ -113,6 +118,7 @@
     <exit-transition transition_id="reject" />
     <exit-transition transition_id="rollback_to_open" />
     <permission-map name="senaite.core: Transition: Reject Worksheet" acquired="True"/>
+    <permission-map name="senaite.core: Transition: Remove Worksheet" acquired="False"/>
     <permission-map name="senaite.core: Add Attachment" acquired="False">
       <permission-role>Analyst</permission-role>
       <permission-role>LabClerk</permission-role>
@@ -148,6 +154,7 @@
   <state state_id="verified" title="Verified" i18n:attributes="title">
     <exit-transition transition_id="retract" />
     <permission-map name="senaite.core: Transition: Reject Worksheet" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Remove Worksheet" acquired="False"/>
     <permission-map name="senaite.core: Add Attachment" acquired="False">
       <permission-role>Analyst</permission-role>
       <permission-role>LabClerk</permission-role>
@@ -224,6 +231,19 @@
     <action url="" category="workflow" icon="">Rollback</action>
     <guard>
       <guard-expression>python:here.guard_handler("rollback_to_open")</guard-expression>
+    </guard>
+  </transition>
+
+  <!-- Transition: remove
+  This transition is used for removing empty Worksheets
+  -->
+  <transition transition_id="remove" title="Remove"
+              new_state="open" trigger="USER" before_script=""
+              after_script="" i18n:attributes="title">
+    <action url="" category="workflow" icon="">Remove</action>
+    <guard>
+      <guard-permission>senaite.core: Transition: Remove Worksheet</guard-permission>
+      <guard-expression>python:here.guard_handler("remove")</guard-expression>
     </guard>
   </transition>
 

--- a/bika/lims/tests/doctests/WorkflowWorksheetRemove.rst
+++ b/bika/lims/tests/doctests/WorkflowWorksheetRemove.rst
@@ -1,0 +1,173 @@
+Worksheet remove guard and event
+================================
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t WorkflowWorksheetRemove
+
+
+Test Setup
+----------
+
+Needed Imports:
+
+    >>> from AccessControl.PermissionRole import rolesForPermissionOn
+    >>> from DateTime import DateTime
+    >>> from bika.lims import api
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+    >>> from bika.lims.workflow import isTransitionAllowed
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+
+Functional Helpers:
+
+    >>> def new_ar(services):
+    ...     values = {
+    ...         'Client': client.UID(),
+    ...         'Contact': contact.UID(),
+    ...         'DateSampled': DateTime(),
+    ...         'SampleType': sampletype.UID()}
+    ...     service_uids = map(api.get_uid, services)
+    ...     ar = create_analysisrequest(client, request, values, service_uids)
+    ...     do_action_for(ar, "receive")
+    ...     return ar
+
+    >>> def get_roles_for_permission(permission, context):
+    ...     allowed = set(rolesForPermissionOn(permission, context))
+    ...     return sorted(allowed)
+
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = portal.bika_setup
+
+We need to create some basic objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
+    >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH", MemberDiscountApplies=True)
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(setup.bika_sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.bika_departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = api.create(setup.bika_analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> Cu = api.create(setup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID(), Accredited=True)
+    >>> Fe = api.create(setup.bika_analysisservices, "AnalysisService", title="Iron", Keyword="Fe", Price="10", Category=category.UID())
+    >>> Au = api.create(setup.bika_analysisservices, "AnalysisService", title="Gold", Keyword="Au", Price="20", Category=category.UID())
+
+
+Retract transition and guard basic constraints
+----------------------------------------------
+
+Create a Worksheet:
+
+    >>> ar = new_ar([Cu, Fe, Au])
+    >>> ws = api.create(portal.worksheets, "Worksheet")
+    >>> for analysis in ar.getAnalyses(full_objects=True):
+    ...     ws.addAnalysis(analysis)
+
+The status of the worksheet is "open":
+
+    >>> api.get_workflow_status_of(ws)
+    'open'
+
+And is not possible to remove unless empty:
+
+    >>> isTransitionAllowed(ws, "remove")
+    False
+
+    >>> for analysis in ws.getAnalyses():
+    ...     success = do_action_for(analysis, "unassign")
+    >>> isTransitionAllowed(ws, "remove")
+    True
+
+If we do "remove", the Worksheet object is deleted:
+
+    >>> container = ws.aq_parent
+    >>> len(container.objectValues("Worksheet"))
+    1
+    >>> success = do_action_for(ws, "remove")
+    >>> len(container.objectValues("Worksheet"))
+    0
+
+Try now for all possible statuses:
+
+    >>> analyses = ar.getAnalyses(full_objects=True)
+    >>> cu = filter(lambda an: an.getKeyword() == "Cu", analyses)[0]
+    >>> fe = filter(lambda an: an.getKeyword() == "Fe", analyses)[0]
+    >>> ws = api.create(portal.worksheets, "Worksheet")
+    >>> ws.addAnalysis(cu)
+    >>> cu.setResult(12)
+    >>> success = do_action_for(cu, "submit")
+
+For `to_be_verified` status:
+
+    >>> api.get_workflow_status_of(ws)
+    'to_be_verified'
+    >>> isTransitionAllowed(ws, "remove")
+    False
+
+For `rejected` status:
+
+    >>> success = do_action_for(ws, "reject")
+    >>> api.get_workflow_status_of(ws)
+    'rejected'
+    >>> isTransitionAllowed(ws, "remove")
+    False
+
+For `verified` status:
+
+    >>> setup.setSelfVerificationEnabled(True)
+    >>> ws = api.create(portal.worksheets, "Worksheet")
+    >>> ws.addAnalysis(fe)
+    >>> fe.setResult(12)
+    >>> success = do_action_for(fe, "submit")
+    >>> verified = do_action_for(fe, "verify")
+    >>> api.get_workflow_status_of(ws)
+    'verified'
+    >>> isTransitionAllowed(ws, "remove")
+    False
+    >>> setup.setSelfVerificationEnabled(False)
+
+
+Check permissions for Remove transition
+---------------------------------------
+
+Create an empty Worksheet:
+
+    >>> ws = api.create(portal.worksheets, "Worksheet")
+
+The status of the Worksheet is `open`:
+
+    >>> api.get_workflow_status_of(ws)
+    'open'
+
+Exactly these roles can remove:
+
+    >>> get_roles_for_permission("senaite.core: Transition: Remove Worksheet", ws)
+    ['LabManager', 'Manager']
+
+Current user can remove because has the `LabManager` role:
+
+    >>> isTransitionAllowed(ws, "remove")
+    True
+
+Also if the user has the role `Manager`:
+
+    >>> setRoles(portal, TEST_USER_ID, ['Manager',])
+    >>> isTransitionAllowed(ws, "remove")
+    True
+
+But cannot for other roles:
+
+    >>> other_roles = ['Analyst', 'Authenticated', 'LabClerk', 'Verifier']
+    >>> setRoles(portal, TEST_USER_ID, other_roles)
+    >>> isTransitionAllowed(ws, "remove")
+    False
+
+Reset the roles for current user:
+
+    >>> setRoles(portal, TEST_USER_ID, ['LabManager',])

--- a/bika/lims/workflow/worksheet/events.py
+++ b/bika/lims/workflow/worksheet/events.py
@@ -27,3 +27,10 @@ def after_retract(worksheet):
     """
     for analysis in worksheet.getAnalyses():
        wf.doActionFor(analysis, "retract")
+
+
+def after_remove(worksheet):
+    """Removes the worksheet from the system
+    """
+    container = worksheet.aq_parent
+    container.manage_delObjects([worksheet.getId()])

--- a/bika/lims/workflow/worksheet/guards.py
+++ b/bika/lims/workflow/worksheet/guards.py
@@ -91,3 +91,12 @@ def guard_rollback_to_open(worksheet):
         if api.get_review_status(analysis) in ["assigned"]:
             return True
     return False
+
+
+def guard_remove(worksheet):
+    """Return whether the workflow can be removed. Returns true if the worksheet
+    does not contain any analysis
+    """
+    if worksheet.getAnalyses():
+        return False
+    return True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds the transition "Remove" for worksheets, but only available for worksheets without analyses assigned and when the current user has the permission "Transition: Remove Worksheet" granted.

Linked issue: https://github.com/senaite/senaite.core/issues/1067

## Current behavior before PR

Cannot remove empty worksheets

## Desired behavior after PR is merged

Can remove empty worksheets

![Captura de 2019-03-18 23-45-27](https://user-images.githubusercontent.com/832627/54570136-be405d00-49dd-11e9-890d-269d143f9480.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
