### PR TITLE
 Some labels still display "Analysis Requests"

### DIFF
--- a/bika/lims/browser/publish/reports_listing.py
+++ b/bika/lims/browser/publish/reports_listing.py
@@ -56,10 +56,10 @@ class ReportsListingView(BikaListingView):
 
         self.columns = collections.OrderedDict((
             ("AnalysisRequest", {
-                "title": _("Analysis Request"),
+                "title": _("Sample"),
                 "index": "sortable_title"},),
             ("ContainedAnalysisRequests", {
-                "title": _("Analysis Requests in PDF")},),
+                "title": _("Samples in PDF")},),
             ("Metadata", {
                 "title": _("Metadata")},),
             ("State", {

--- a/bika/lims/content/arreport.py
+++ b/bika/lims/content/arreport.py
@@ -37,10 +37,10 @@ schema = BikaSchema.copy() + Schema((
         allowed_types=("AnalysisRequest",),
         relationship="ARReportAnalysisRequest",
         widget=ReferenceWidget(
-            label=_("Contained Analysis Requests"),
+            label=_("Contained Samples"),
             render_own_label=False,
             size=20,
-            description=_("Referenced Analysis Requests in the PDF"),
+            description=_("Referenced Samples in the PDF"),
             visible={
                 "edit": "visible",
                 "view": "visible",


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1267

## Current behavior before PR

"Analysis Request" in listing headers

## Desired behavior after PR is merged

"Sample" in listing headers

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
