### PR TITLE
Linking LabContacts to LDAP-user not possible

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -105,6 +105,7 @@ Changelog
 
 **Fixed**
 
+- #1109 Linking LabContacts to LDAP-user not possible
 - #1283 Retracting a calculated Analysis leads to an inconsistent state
 - #1281 Adding Analyses to an existing Worksheet fails
 - #1269 Render analysis remarks conditionally

--- a/bika/lims/api/__init__.py
+++ b/bika/lims/api/__init__.py
@@ -13,7 +13,7 @@ import Missing
 from AccessControl.PermissionRole import rolesForPermissionOn
 from Acquisition import aq_base
 from bika.lims import logger
-from bika.lims.interfaces import IClient, IDeactivable, ICancellable
+from bika.lims.interfaces import IClient
 from bika.lims.interfaces import IContact
 from bika.lims.interfaces import ILabContact
 from DateTime import DateTime
@@ -31,9 +31,11 @@ from Products.CMFCore.interfaces import IFolderish
 from Products.CMFCore.interfaces import ISiteRoot
 from Products.CMFCore.utils import getToolByName
 from Products.CMFCore.WorkflowCore import WorkflowException
+from Products.CMFPlone.RegistrationTool import get_member_by_login_name
 from Products.CMFPlone.utils import _createObjectByType
 from Products.CMFPlone.utils import base_hasattr
 from Products.CMFPlone.utils import safe_unicode
+from Products.PlonePAS.tools.memberdata import MemberData
 from Products.ZCatalog.interfaces import ICatalogBrain
 from zope import globalrequest
 from zope.component import getMultiAdapter
@@ -959,11 +961,12 @@ def get_user(user_or_username):
     :param user_or_username: Plone user or user id
     :returns: Plone MemberData
     """
-    if not user_or_username:
-        return None
-    if hasattr(user_or_username, "getUserId"):
-        return ploneapi.user.get(user_or_username.getUserId())
-    return ploneapi.user.get(userid=user_or_username)
+    user = None
+    if isinstance(user_or_username, MemberData):
+        user = user_or_username
+    if isinstance(user_or_username, basestring):
+        user = get_member_by_login_name(get_portal(), user_or_username, False)
+    return user
 
 
 def get_user_properties(user_or_username):

--- a/bika/lims/browser/contact.py
+++ b/bika/lims/browser/contact.py
@@ -255,6 +255,16 @@ class ContactLoginDetailsView(BrowserView):
         # set the user to the contact
         contact.setUser(username)
 
+        # Additional groups for LabContact users only!
+        # -> This is not visible in the Client Contact Form
+        if "groups" in self.request and self.request["groups"]:
+            groups = self.request["groups"]
+            if not type(groups) in (list, tuple):
+                groups = [groups, ]
+            for group in groups:
+                group = self.portal_groups.getGroupById(group)
+                group.addMember(username)
+
         if self.request.get('mail_me', 0):
             try:
                 reg_tool.registeredNotify(username)

--- a/bika/lims/browser/contact.py
+++ b/bika/lims/browser/contact.py
@@ -6,22 +6,22 @@
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
 import re
-from Acquisition import aq_base
 
 import transaction
-from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.utils import safe_unicode
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from plone import api
-from plone.app.controlpanel.usergroups import UsersOverviewControlPanel
-from plone.protect import CheckAuthenticator
-
 from bika.lims import PMF
+from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
+from bika.lims.api import security
 from bika.lims.browser import BrowserView
 from bika.lims.content.contact import Contact
 from bika.lims.content.labcontact import LabContact
+from plone.app.controlpanel.usergroups import UsersOverviewControlPanel
+from plone.memoize import view
+from plone.protect import CheckAuthenticator
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import safe_unicode
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
 
 class ContactLoginDetailsView(BrowserView):

--- a/bika/lims/browser/contact.py
+++ b/bika/lims/browser/contact.py
@@ -41,8 +41,6 @@ class ContactLoginDetailsView(BrowserView):
             logger.debug("Form Submitted: {}".format(form))
             if form.get("unlink_button", False):
                 self._unlink_user()
-            elif form.get("delete_button", False):
-                self._unlink_user(delete=True)
             elif form.get("search_button", False):
                 logger.debug("Search User")
                 self.newSearch = True
@@ -54,6 +52,15 @@ class ContactLoginDetailsView(BrowserView):
                 self._create_user()
 
         return self.template()
+
+    @view.memoize
+    def get_users(self):
+        """Get all users of the portal
+        """
+        # We make use of the existing controlpanel `@@usergroup-userprefs`
+        # view logic to make sure we get all users from all plugins (e.g. LDAP)
+        users_view = UsersOverviewControlPanel(self.context, self.request)
+        return users_view.doSearch("")
 
     def get_user_properties(self):
         """Return the properties of the User
@@ -72,7 +79,7 @@ class ContactLoginDetailsView(BrowserView):
             ps = plone_user.getPropertysheet(sheet)
             out.update(dict(ps.propertyItems()))
 
-        portal = api.portal.get()
+        portal = api.get_portal()
         mtool = getToolByName(self.context, 'portal_membership')
 
         out["id"] = userid
@@ -96,17 +103,11 @@ class ContactLoginDetailsView(BrowserView):
         """Search Plone users which are not linked to a contact or lab contact
         """
 
-        # We make use of the existing controlpanel `@@usergroup-userprefs` view
-        # logic to make sure we get all users from all plugins (e.g. LDAP)
-        users_view = UsersOverviewControlPanel(self.context, self.request)
+        # Only users with at nost these roles are displayed
+        linkable_roles = {"Authenticated", "Member", "Client"}
 
-        # expected roles for client contacts
-        # Client groups users have 'Member' and 'Client' roles.
-        client_contact_roles = {'Authenticated', 'Member', 'Client'}
-
-        users = users_view.doSearch("")
         out = []
-        for user in users:
+        for user in self.get_users():
             userid = user.get("id", None)
 
             if userid is None:
@@ -123,11 +124,8 @@ class ContactLoginDetailsView(BrowserView):
                 # weird things could happen (a client contact assigned to a
                 # user with labman privileges, different contacts from
                 # different clients assigned to the same user, etc.)
-                user_obj = api.user.get(userid=userid)
-                user_roles = api.user.get_roles(user=user_obj)
-                comparison = client_contact_roles.symmetric_difference(
-                    set(user_roles))
-                if comparison:
+                user_roles = security.get_roles(user=userid)
+                if not linkable_roles.issuperset(set(user_roles)):
                     continue
             userdata = {
                 "userid": userid,
@@ -138,7 +136,9 @@ class ContactLoginDetailsView(BrowserView):
             # filter out users which do not match the searchstring
             if self.searchstring:
                 s = self.searchstring.lower()
-                if not any(map(lambda v: re.search(s, str(v).lower()), userdata.values())):
+                if not any(
+                        map(lambda v: re.search(s, str(v).lower()),
+                            userdata.values())):
                     continue
 
             # update data (maybe for later use)
@@ -171,24 +171,19 @@ class ContactLoginDetailsView(BrowserView):
         if userid:
             try:
                 self.context.setUser(userid)
-                # If we are linking Client Contact, let it see the Client
-                if self.context.aq_parent.portal_type == 'Client':
-                    self.context.aq_parent.manage_setLocalRoles(self.context.getUsername(), ['Owner', ])
-                self.add_status_message(_("User linked to this Contact"), "info")
+                self.add_status_message(
+                    _("User linked to this Contact"), "info")
             except ValueError, e:
                 self.add_status_message(e, "error")
         else:
-            self.add_status_message(_("Please select a User from the list"), "info")
+            self.add_status_message(
+                _("Please select a User from the list"), "info")
 
-    def _unlink_user(self, delete=False):
+    def _unlink_user(self):
         """Unlink and delete the User from the current Contact
         """
-        if delete:
-            self.add_status_message(_("Unlinked and deleted User"), "warning")
-            self.context.unlinkUser(delete=True)
-        else:
-            self.add_status_message(_("Unlinked User"), "info")
-            self.context.unlinkUser()
+        self.context.unlinkUser()
+        self.add_status_message(_("Unlinked User"), "info")
 
     def add_status_message(self, message, severity="info"):
         """Set a portal message
@@ -237,15 +232,11 @@ class ContactLoginDetailsView(BrowserView):
         if len(password) < 5:
             return error('password', PMF("Passwords must contain at least 5 "
                                          "characters."))
-        # We make use of the existing controlpanel `@@usergroup-userprefs`
-        # view logic to make sure we get all users from all plugins (e.g. LDAP)
-        users_view = UsersOverviewControlPanel(self.context, self.request)
-        users = users_view.doSearch("")
-        for user in users:
+        for user in self.get_users():
             userid = user.get("id", None)
             if userid is None:
                 continue
-            user_obj = api.user.get(userid=userid)
+            user_obj = api.get_user(userid)
             if user_obj.getUserName() == username:
                 msg = "Username {} already exists, please, choose " \
                       "another one.".format(username)
@@ -261,52 +252,21 @@ class ContactLoginDetailsView(BrowserView):
         except ValueError, msg:
             return error(None, msg)
 
+        # set the user to the contact
         contact.setUser(username)
-
-        # TODO: Not sure if this is the correct behaviour after
-        # senaite-integration since there have been changes in permissions.
-        # If we're being created in a Client context, then give
-        # the contact an Owner local role on client.
-        if contact.aq_parent.portal_type == 'Client':
-            self.set_client_contact_permissions(contact)
-
-        # Additional groups for LabContact users.
-        # not required (not available for client Contact)
-        if 'groups' in self.request and self.request['groups']:
-            groups = self.request['groups']
-            if not type(groups) in (list, tuple):
-                groups = [groups, ]
-            for group in groups:
-                group = self.portal_groups.getGroupById(group)
-                group.addMember(username)
 
         if self.request.get('mail_me', 0):
             try:
                 reg_tool.registeredNotify(username)
-            except:
+            except Exception:
                 transaction.abort()
                 message = _("SMTP server disconnected. User creation aborted.")
                 return error(None, message)
-        contact.reindexObject()
+
         message = _("Member registered and linked to the current Contact.")
         self.context.plone_utils.addPortalMessage(message, 'info')
         return self.request.response.redirect(
             self.context.absolute_url() + "/login_details")
-
-    def set_client_contact_permissions(self, contact):
-        """Confer local owner role to client contact, and ensure
-        that they have access to client contents.
-        """
-        username = contact.getUsername()
-        contact.aq_parent.manage_setLocalRoles(username, ['Owner', ])
-        if hasattr(aq_base(contact.aq_parent), 'reindexObjectSecurity'):
-            contact.aq_parent.reindexObjectSecurity()
-        # Reindex setup objects located inside this client
-        bsc = contact.bika_setup_catalog
-        for brain in bsc(getClientUID=contact.aq_parent.UID()):
-            brain.getObject().reindexObjectSecurity()
-        # Grant roles to user
-        api.user.grant_roles(username=username, roles=['Member', 'Client'])
 
     def tabindex(self):
         i = 0

--- a/bika/lims/browser/templates/login_details.pt
+++ b/bika/lims/browser/templates/login_details.pt
@@ -106,14 +106,6 @@
             <!-- Form Controls -->
             <div class="formControls" tal:condition="active">
               <input class="context"
-                     style="color:red;"
-                     type="submit"
-                     tabindex=""
-                     name="delete_button"
-                     value="Unlink and delete User"
-                     i18n:attributes="value"
-                     tal:attributes="tabindex tabindex/next;" />
-              <input class="context"
                      type="submit"
                      tabindex=""
                      name="unlink_button"
@@ -152,7 +144,6 @@
         <legend i18n:translate="">Link an existing User</legend>
         <p tal:condition="view/is_contact"
            i18n:translate="">
-            Only existing users in "Client" group are displayed.
         </p>
         <form id="user_search_form"
               method="post">

--- a/bika/lims/content/contact.py
+++ b/bika/lims/content/contact.py
@@ -5,25 +5,26 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
 
-"""The contact person at an organisation.
-"""
 import types
 
 from AccessControl import ClassSecurityInfo
+from Acquisition import aq_base
 from Acquisition import aq_inner
 from Acquisition import aq_parent
-from Products.Archetypes import atapi
-from Products.Archetypes.utils import DisplayList
-from Products.CMFPlone.utils import safe_unicode
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
 from bika.lims.api import is_active
 from bika.lims.config import PROJECTNAME
 from bika.lims.content.person import Person
-from bika.lims.interfaces import IContact, IClient, IDeactivable
+from bika.lims.interfaces import IClient
+from bika.lims.interfaces import IContact
+from bika.lims.interfaces import IDeactivable
 from plone import api
-from zope.interface import implements
+from Products.Archetypes import atapi
+from Products.Archetypes.utils import DisplayList
 from Products.CMFCore.permissions import ModifyPortalContent
+from Products.CMFPlone.utils import safe_unicode
+from zope.interface import implements
 
 ACTIVE_STATES = ["active"]
 

--- a/bika/lims/content/contact.py
+++ b/bika/lims/content/contact.py
@@ -93,7 +93,7 @@ class Contact(Person):
         """
         return is_active(self)
 
-    security.declareProtected(ModifyPortalContent, 'getUser')
+    @security.protected(ModifyPortalContent)
     def getUser(self):
         """Returns the linked Plone User or None
         """
@@ -103,7 +103,7 @@ class Contact(Person):
         user = api.user.get(userid=username)
         return user
 
-    security.declareProtected(ModifyPortalContent, 'setUser')
+    @security.protected(ModifyPortalContent)
     def setUser(self, user_or_username):
         """Link the user to the Contact
 
@@ -129,7 +129,7 @@ class Contact(Person):
         # Link the User
         return self._linkUser(user)
 
-    security.declareProtected(ModifyPortalContent, 'unlinkUser')
+    @security.protected(ModifyPortalContent)
     def unlinkUser(self, delete=False):
         """Unlink the user to the Contact
 
@@ -154,7 +154,7 @@ class Contact(Person):
             return True
         return False
 
-    security.declareProtected(ModifyPortalContent, 'hasUser')
+    @security.protected(ModifyPortalContent)
     def hasUser(self):
         """Check if Contact has a linked a System User
         """
@@ -235,7 +235,7 @@ class Contact(Person):
 
         return True
 
-    security.declarePrivate('_unlinkUser')
+    @security.private
     def _unlinkUser(self):
         """Remove the UID of the current Contact in the User properties and
         update all relevant own properties.
@@ -270,7 +270,7 @@ class Contact(Person):
 
         return True
 
-    security.declarePrivate('_addUserToGroup')
+    @security.private
     def _addUserToGroup(self, username, group="Clients"):
         """Add user to the goup
         """
@@ -296,7 +296,7 @@ class Contact(Person):
             if hasattr(parent, 'reindexObjectSecurity'):
                 parent.reindexObjectSecurity()
 
-    security.declarePrivate('_delLocalOwnerRole')
+    @security.private
     def _delLocalOwnerRole(self, username):
         """Remove local owner role from parent object
         """

--- a/bika/lims/tests/doctests/ContactUser.rst
+++ b/bika/lims/tests/doctests/ContactUser.rst
@@ -228,20 +228,6 @@ Search for linkable users:
     >>> linkable_users = login_details_view.linkable_users()
     >>> linkable_user_ids = map(lambda x: x.get("id"), linkable_users)
 
-None of the two users should be in the search results, cause any of the two
-has the role `Client` assigned:
-
-    >>> user1.id in linkable_user_ids
-    False
-
-    >>> user2.id in linkable_user_ids
-    False
-
-So, we apply the `Client` roles to both users:
-
-    >>> setRoles(portal, "user-1", ['Authenticated', 'Member', 'Client'])
-    >>> setRoles(portal, "user-2", ['Authenticated', 'Member', 'Client'])
-
 Both users should be now in the search results:
 
     >>> linkable_users = login_details_view.linkable_users()
@@ -252,6 +238,16 @@ Both users should be now in the search results:
 
     >>> user2.id in linkable_user_ids
     True
+
+Users with higher roles should not be listed:
+
+    >>> setRoles(portal, "user-2", ['Member', 'Client', 'LabClerk'])
+
+    >>> linkable_users = login_details_view.linkable_users()
+    >>> linkable_user_ids = map(lambda x: x.get("id"), linkable_users)
+
+    >>> user2.id in linkable_user_ids
+    False
 
 This contact is not linked to a user::
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1109

This PR refactors the user->contact linking behavior

## Current behavior before PR

- No (LDAP) users were found
- Linked users could not see contents before they were added to the client

## Desired behavior after PR is merged

- Users which have at most the roles "Client" or "Member" are found
- Linked users can see all contents of the client

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
