### PR TITLE
Traceback on instrument results auto-import

### DIFF
--- a/bika/lims/exportimport/instruments/__init__.py
+++ b/bika/lims/exportimport/instruments/__init__.py
@@ -249,5 +249,6 @@ def get_automatic_parser(exim_id, infile):
     parser_func = parser_func and parser_func[0][1] or None
     if not parser_func or not hasattr(adapter, parser_func):
         return None
+    parser_func = getattr(adapter, parser_func)
     return parser_func(infile)
   


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Unable to auto-import instrument results files. 

See https://community.senaite.org/t/how-to-autoimport-results-from-instruments/176 for detailed information about how to configure Senaite to auto-import results files.

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.resultsimport.resultsimport, line 84, in __call__
  Module bika.lims.exportimport.instruments, line 252, in get_automatic_parser
TypeError: 'str' object is not callable
```

## Desired behavior after PR is merged

No Traceback arises.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
