### PR TITLE
Fix bad import of API Exception Class

### DIFF
--- a/bika/lims/validators.py
+++ b/bika/lims/validators.py
@@ -10,17 +10,17 @@ import string
 import types
 from time import strptime as _strptime
 
+from bika.lims import api
+from bika.lims import bikaMessageFactory as _
+from bika.lims import logger
+from bika.lims.api import APIError
+from bika.lims.utils import to_utf8
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
-from Products.ZCTextIndex.ParseTree import ParseError
 from Products.validation import validation
 from Products.validation.interfaces.IValidator import IValidator
+from Products.ZCTextIndex.ParseTree import ParseError
 from zope.interface import implements
-
-from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import to_utf8
-from bika.lims import api
-from bika.lims import logger
 
 
 class IdentifierTypeAttributesValidator:
@@ -110,7 +110,7 @@ class UniqueFieldValidator:
             catalogs = api.get_catalogs_for(context)
             catalog = catalogs[0]
             return map(api.get_object, catalog(query))
-        except (IndexError, UnicodeDecodeError, ParseError, api.BikaLIMSError) as e:
+        except (IndexError, UnicodeDecodeError, ParseError, APIError) as e:
             # fall back to the object values of the parent
             logger.warn("UniqueFieldValidator: Catalog query {} failed "
                         "for catalog {} ({}) -> returning object values of {}"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1300

## Current behavior before PR

Traceback occurs when a new instrument is created

## Desired behavior after PR is merged

No Traceback occurse when a new instrument is created

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
