### PR TITLE
Preserve review history in 1.3 upgrade

### DIFF
--- a/bika/lims/api/__init__.py
+++ b/bika/lims/api/__init__.py
@@ -689,7 +689,7 @@ def get_review_history(brain_or_object, rev=True):
         logger.error("Cannot retrieve review_history on {}: {}".format(
             obj, message))
     if not isinstance(review_history, (list, tuple)):
-        logger.error("get_review_history: expected list, recieved {}".format(
+        logger.error("get_review_history: expected list, received {}".format(
             review_history))
         review_history = []
     if rev is True:

--- a/bika/lims/upgrade/v01_03_000.py
+++ b/bika/lims/upgrade/v01_03_000.py
@@ -8,6 +8,8 @@
 import time
 
 import transaction
+from Acquisition import aq_base
+from Products.Archetypes.config import UID_CATALOG
 from bika.lims import api
 from bika.lims import logger
 from bika.lims.catalog.analysis_catalog import CATALOG_ANALYSIS_LISTING
@@ -24,7 +26,7 @@ from bika.lims.interfaces.analysis import IRequestAnalysis
 from bika.lims.permissions import TransitionVerify
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
-from bika.lims.workflow import ActionHandlerPool
+from bika.lims.workflow import ActionHandlerPool, getAllowedTransitions
 from bika.lims.workflow import changeWorkflowState
 from bika.lims.workflow import doActionFor as do_action_for
 from bika.lims.workflow import isTransitionAllowed
@@ -87,6 +89,60 @@ CSS_TO_REMOVE = [
     "++resource++bika.lims.css/hide_editable_border.css",
     "print.css",
 ]
+
+
+NEW_SENAITE_WORKFLOW_BINDINGS = (
+    # List of portal types that will be bound to a new senaite_* workflow (the
+    # current workflow(s) they are bound to will not be kept.
+    # This is used to keep the review_state of objects after rebinding to the
+    # new senaite_* workflow.
+    # Note that types bound to "senaite_one_state" (and the like) workflow are
+    # not considered here because they are mostly folders created on
+    # installation time and for which there is no need to keep track of
+    # review_history
+    "AnalysisCategory",
+    "AnalysisProfile",
+    "AnalysisService",
+    "AnalysisSpec",
+    "ARTemplate",
+    "AttachmentType",
+    "Batch",
+    "BatchLabel",
+    "Calculation",
+    "Client",
+    "Contact",
+    "Container",
+    "ContainerType",
+    "Department",
+    "IdentifierType",
+    "Instrument",
+    "InstrumentLocation",
+    "InstrumentMaintenanceTask",
+    "InstrumentScheduledTask",
+    "InstrumentType",
+    "LabContact",
+    "LabProduct",
+    "Manufacturer",
+    "Method",
+    "Preservation",
+    "Pricelist",
+    "ReferenceDefinition",
+    "ReflexRule",
+    "SampleCondition",
+    "SampleMatrix",
+    "SamplePoint",
+    "SampleType",
+    "SamplingDeviation",
+    "SamplingRound",
+    "SRTemplate",
+    "StorageLocation",
+    "SubGroup",
+    "Supplier",
+    "SupplierContact",
+    "SupplyOrder",
+    "WorksheetTemplate",
+)
+review_history_cache = dict()
 
 @upgradestep(product, version)
 def upgrade(tool):
@@ -595,10 +651,16 @@ def update_workflows(portal):
     # Remove rejected duplicates
     remove_rejected_duplicates(portal)
 
+    # Cache review_history
+    cache_affected_objects_review_history(portal)
+
     # Re-import rolemap and workflow tools
     setup = portal.portal_setup
     setup.runImportStepFromProfile(profile, 'rolemap')
     setup.runImportStepFromProfile(profile, 'workflow')
+
+    # Restore review_history for objects bound to senaite_* workflow
+    restore_review_history_for_affected_objects(portal)
 
     # Remove duplicates not assigned to any worksheet
     remove_orphan_duplicates(portal)
@@ -2107,3 +2169,115 @@ def remove_invoices(portal):
 
     # delete the invoices folder
     portal.manage_delObjects(invoices.getId())
+
+
+def restore_review_history_for_affected_objects(portal):
+    """Applies the review history for objects that are bound to new senaite_*
+    workflows
+    """
+    actions_by_type = {}
+
+    def get_purged_review_history_for(brain_or_object):
+        """Returns the review history for the object passed in, but filtered
+        with the actions that match with the workflow currently bound to the
+        object plus those actions that are None (for initial state)
+        """
+        available_actions = get_available_actions_for(brain_or_object)
+        history = review_history_cache.get(api.get_uid(brain_or_object), [])
+        history = filter(lambda action: action["action"] in available_actions
+                         or action["action"] is None, history)
+        if not history:
+            history = create_initial_review_history(brain_or_object)
+        return history
+
+    def get_available_actions_for(brain_or_object):
+        """Returns the available actions for the workflows currently bound to
+        the object passed in
+        """
+        portal_type = api.get_portal_type(brain_or_object)
+        if portal_type not in actions_by_type:
+            # Retrieve the actions from the workflows this object is bound to
+            obj = api.get_object(brain_or_object)
+            actions_by_type[portal_type] = getAllowedTransitions(obj)
+
+        allowed_actions = actions_by_type.get(portal_type, None)
+        if not allowed_actions:
+            logger.warn("Cannot retrieve available actions for {}").format(
+                portal_type)
+            return []
+
+        return allowed_actions
+
+    logger.info("Restoring review_history ...")
+    query = dict(portal_type=NEW_SENAITE_WORKFLOW_BINDINGS)
+    brains = api.search(query, UID_CATALOG)
+    total = len(brains)
+    for num, brain in enumerate(brains):
+        if num % 100 == 0:
+            logger.info("Restoring review_history: {}/{}"
+                        .format(num, total))
+
+        review_history = api.get_review_history(brain)
+        if review_history:
+            # Nothing to do. The object already has the review history set
+            continue
+
+        # Object without review history. Set the review_history manually
+        review_history = get_purged_review_history_for(brain)
+        obj = aq_base(api.get_object(brain))
+        obj.workflow_history = review_history
+
+
+def cache_affected_objects_review_history(portal):
+    """Fills the review_history_cache dict. The keys are the uids of the objects
+    to be bound to new workflow and the values are their current review_history
+    """
+    logger.info("Caching review_history ...")
+    query = dict(portal_type=NEW_SENAITE_WORKFLOW_BINDINGS)
+    brains = api.search(query, UID_CATALOG)
+    total = len(brains)
+    for num, brain in enumerate(brains):
+        if num % 100 == 0:
+            logger.info("Caching review_history: {}/{}"
+                        .format(num, total))
+        review_history = get_review_history_for(brain)
+        review_history_cache[api.get_uid(brain)] = review_history
+
+
+def get_review_history_for(brain_or_object):
+    """Returns the review history list for the given object. If there is no
+    review history for the object, it returns a default review history
+    """
+    review_history = api.get_review_history(brain_or_object, rev=False)
+    if review_history:
+        return review_history
+
+    # No review_history for this object!. This object was probably
+    # migrated to 1.3.0 before review_history was handled in this
+    # upgrade step.
+    # https://github.com/senaite/senaite.core/issues/1270
+    return create_initial_review_history(brain_or_object)
+
+
+def create_initial_review_history(brain_or_object):
+    """Creates a new review history for the given object
+    """
+    obj = api.get_object(brain_or_object)
+
+    # It shouldn't be necessary to walk-through all workflows from this object,
+    # cause there are no objects with more than one workflow bound in 1.3.
+    # Nevertheless, one never knows if there is an add-on that does.
+    review_history = list()
+    wf_tool = api.get_tool("portal_workflow")
+    for wf_id in api.get_workflows_for(obj):
+        wf = wf_tool.getWorkflowById(wf_id)
+        review_history.append({
+            'action': None,
+            'actor': obj.Creator(),
+            'comments': 'Default review_history (by 1.3 upgrade step)',
+            'review_state': wf.initial_state,
+            'time': obj.created(),
+        })
+
+    # Sort by time (from oldest to newest)
+    return sorted(review_history, key=lambda st: st.get("time"))

--- a/bika/lims/workflow/__init__.py
+++ b/bika/lims/workflow/__init__.py
@@ -12,7 +12,7 @@ from AccessControl.SecurityInfo import ModuleSecurityInfo
 from Products.Archetypes.config import UID_CATALOG
 from Products.CMFCore.WorkflowCore import WorkflowException
 from Products.CMFCore.utils import getToolByName
-from bika.lims import PMF
+from bika.lims import PMF, deprecated
 from bika.lims import api
 from bika.lims import logger
 from bika.lims.browser import ulocalized_time
@@ -279,17 +279,8 @@ def getReviewHistory(instance, reverse=True):
     """Returns the review history for the instance
     :returns: the list of historic events as dicts
     """
-    review_history = []
-    workflow = getToolByName(instance, 'portal_workflow')
-    try:
-        review_history = list(workflow.getInfoFor(instance, 'review_history'))
-    except WorkflowException:
-        logger.error("Unable to retrieve review history from {}:{}"
-                     .format(instance.portal_type, instance.getId()))
-    if reverse:
-        # invert the list, so we always see the most recent matching event
-        review_history.reverse()
-    return review_history
+    return api.get_review_history(instance, rev=reverse)
+
 
 def getCurrentState(obj, stateflowid='review_state'):
     """ The current state of the object for the state flow id specified


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

In 1.3, most of setup objects are bound to new `senaite_*` workflows (e.g. `senaite_deactivable_workflow`), but their original review history was not kept. This Pull Request addresses this issue for new upgrades to 1.3, but also resets the workflow history in previously upgraded instances.

Linked issue: https://github.com/senaite/senaite.core/issues/1270

## Current behavior before PR

Review history of objects that come from 1.2.9 is not preserved in 1.3

## Desired behavior after PR is merged

Review history of objects that come from 1.2.9 is preserved in 1.3

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
