### PR TITLE
Ensure analyses from primary are removed after being added to partitions

### DIFF
--- a/bika/lims/browser/partition_magic.py
+++ b/bika/lims/browser/partition_magic.py
@@ -81,6 +81,10 @@ class PartitionMagicView(BrowserView):
                 )
                 partitions.append(partition)
 
+                # Remove analyses from primary once all partitions are created
+                primary = api.get_object(primary_uid)
+                self.push_primary_analyses_for_removal(primary, analyses_uids)
+
                 logger.info("Successfully created partition: {}".format(
                     api.get_path(partition)))
 
@@ -107,7 +111,7 @@ class PartitionMagicView(BrowserView):
         """
         to_remove = self.analyses_to_remove.get(analysis_request, [])
         to_remove.extend(analyses)
-        self.analyses_to_remove[analysis_request] = to_remove
+        self.analyses_to_remove[analysis_request] = list(set(to_remove))
 
     def remove_primary_analyses(self):
         """Remove analyses relocated to partitions


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Partition magic does not remove the analyses added in partitions.

## Current behavior before PR

Partition magic does not remove the analyses added in partitions.

## Desired behavior after PR is merged

Partition magic does remove the analyses added in partitions.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
