### PR TITLE
Traceback when using "Submit" of the global WF menu

### DIFF
--- a/bika/lims/browser/workflow/analysis.py
+++ b/bika/lims/browser/workflow/analysis.py
@@ -26,6 +26,12 @@ class WorkflowActionSubmitAdapter(WorkflowActionGenericAdapter):
         interims_data = self.get_interims_data()
 
         for analysis in objects:
+
+            # Using the global WF menu passes the AR as context
+            # https://github.com/senaite/senaite.core/issues/1306
+            if not IAnalysis.providedBy(analysis):
+                continue
+
             uid = api.get_uid(analysis)
 
             # Need to save remarks?

--- a/bika/lims/browser/workflow/analysis.py
+++ b/bika/lims/browser/workflow/analysis.py
@@ -1,8 +1,6 @@
 import json
 from collections import defaultdict
 
-from DateTime import DateTime
-from Products.CMFPlone.i18nl10n import ulocalized_time
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
@@ -10,7 +8,10 @@ from bika.lims.api.analysis import is_out_of_range
 from bika.lims.browser.referenceanalysis import AnalysesRetractedListReport
 from bika.lims.browser.workflow import WorkflowActionGenericAdapter
 from bika.lims.catalog.analysis_catalog import CATALOG_ANALYSIS_LISTING
+from bika.lims.interfaces import IAnalysis
 from bika.lims.interfaces import IReferenceAnalysis
+from DateTime import DateTime
+from Products.CMFPlone.i18nl10n import ulocalized_time
 
 
 class WorkflowActionSubmitAdapter(WorkflowActionGenericAdapter):

--- a/bika/lims/tests/doctests/WorkflowAnalysisReject.rst
+++ b/bika/lims/tests/doctests/WorkflowAnalysisReject.rst
@@ -350,6 +350,51 @@ Reset self-verification:
     >>> bikasetup.setSelfVerificationEnabled(False)
 
 
+Rejection of retests
+--------------------
+
+Create an Analysis Request, receive and submit all results:
+
+    >>> ar = new_ar([Cu, Fe, Au])
+    >>> success = do_action_for(ar, "receive")
+    >>> analyses = ar.getAnalyses(full_objects=True)
+    >>> for analysis in analyses:
+    ...     analysis.setResult(12)
+    ...     success = do_action_for(analysis, "submit")
+    >>> api.get_workflow_status_of(ar)
+    'to_be_verified'
+
+Retract one of the analyses:
+
+    >>> analysis = analyses[0]
+    >>> success = do_action_for(analysis, "retract")
+    >>> api.get_workflow_status_of(analysis)
+    'retracted'
+
+    >>> api.get_workflow_status_of(ar)
+    'received'
+
+Reject the retest:
+
+    >>> retest = analysis.getRetest()
+    >>> success = do_action_for(retest, "reject")
+    >>> api.get_workflow_status_of(retest)
+    'rejected'
+
+    >>> api.get_workflow_status_of(ar)
+    'to_be_verified'
+
+Verify remaining analyses:
+
+    >>> bikasetup.setSelfVerificationEnabled(True)
+    >>> success = do_action_for(analyses[1], "verify")
+    >>> success = do_action_for(analyses[2], "verify")
+    >>> bikasetup.setSelfVerificationEnabled(False)
+
+    >>> api.get_workflow_status_of(ar)
+    'verified'
+
+
 Check permissions for Reject transition
 ---------------------------------------
 

--- a/bika/lims/tests/doctests/WorkflowAnalysisReject.rst
+++ b/bika/lims/tests/doctests/WorkflowAnalysisReject.rst
@@ -372,7 +372,7 @@ Retract one of the analyses:
     'retracted'
 
     >>> api.get_workflow_status_of(ar)
-    'received'
+    'sample_received'
 
 Reject the retest:
 

--- a/bika/lims/workflow/analysis/events.py
+++ b/bika/lims/workflow/analysis/events.py
@@ -152,8 +152,14 @@ def after_reject(analysis):
     # Reject our dependents (analyses that depend on this analysis)
     cascade_to_dependents(analysis, "reject")
 
-    # Try to rollback the Analysis Request (all analyses rejected)
     if IRequestAnalysis.providedBy(analysis):
+        # Try verify (for when remaining analyses are in 'verified')
+        doActionFor(analysis.getRequest(), "verify")
+
+        # Try submit (remaining analyses are in 'to_be_verified')
+        doActionFor(analysis.getRequest(), "submit")
+
+        # Try rollback (no remaining analyses or some not submitted)
         doActionFor(analysis.getRequest(), "rollback_to_receive")
         reindex_request(analysis)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1306

## Current behavior before PR

Traceback occurs when triggering the "submit" transition of the global WF menu

## Desired behavior after PR is merged

No Traceback occurs when triggering the "submit" transition of the global WF menu

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
