### PR TITLE
Samples rejection view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 
 **Added**
 
-- #1390 Added Samples rejection view
+- #1309 Added Samples rejection view
 - #1291 "Remove" transition for empty Worksheets
 - #1259 Added Facscalibur instrument import interface
 - #1244 Added "Body for Sample Invalidation email" field in setup

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1390 Added Samples rejection view
 - #1291 "Remove" transition for empty Worksheets
 - #1259 Added Facscalibur instrument import interface
 - #1244 Added "Body for Sample Invalidation email" field in setup

--- a/bika/lims/browser/analysisrequest/configure.zcml
+++ b/bika/lims/browser/analysisrequest/configure.zcml
@@ -172,4 +172,13 @@
       layer="bika.lims.interfaces.IBikaLIMS"
       />
 
+  <!-- Sample (AR) Rejection View -->
+  <browser:page
+      for="*"
+      name="reject_samples"
+      class=".reject_samples.RejectSamplesView"
+      permission="senaite.core.permissions.ManageAnalysisRequests"
+      layer="bika.lims.interfaces.IBikaLIMS"
+  />
+
 </configure>

--- a/bika/lims/browser/analysisrequest/reject_samples.py
+++ b/bika/lims/browser/analysisrequest/reject_samples.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE
+#
+# Copyright 2019 by it's authors.
+# Some rights reserved. See LICENSE.rst, CONTRIBUTORS.rst.
+
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from bika.lims import api
+from bika.lims import bikaMessageFactory as _
+from bika.lims import logger
+from bika.lims import workflow as wf
+from bika.lims.browser import BrowserView, ulocalized_time
+from bika.lims.catalog.analysisrequest_catalog import \
+    CATALOG_ANALYSIS_REQUEST_LISTING
+from plone.memoize import view
+
+
+class RejectSamplesView(BrowserView):
+    """View that renders the Samples rejection view
+    """
+    template = ViewPageTemplateFile("templates/reject_samples.pt")
+
+    def __init__(self, context, request):
+        super(RejectSamplesView, self).__init__(context, request)
+        self.context = context
+        self.request = request
+        self.back_url = self.context.absolute_url()
+
+    def __call__(self):
+        form = self.request.form
+
+        # Form submit toggle
+        form_submitted = form.get("submitted", False)
+
+        # Buttons
+        form_continue = form.get("button_continue", False)
+        form_cancel = form.get("button_cancel", False)
+
+        # Is Rejection Workflow Enabled
+        if not api.get_setup().isRejectionWorkflowEnabled():
+            return self.redirect(message=_("Rejection workflow is not enabled"),
+                                 level="warning")
+
+        # Get the objects from request
+        samples = self.get_samples_from_request()
+
+        # No Samples selected
+        if not samples:
+            return self.redirect(message=_("No items selected"),
+                                 level="warning")
+
+        # Handle rejection
+        if form_submitted and form_continue:
+            logger.info("*** REJECT SAMPLES (1 of 2) ***")
+
+            selected_samples = []
+
+
+            if not selected_samples:
+                return self.redirect(message=_("No samples were rejected"))
+
+            message = _("Rejected {} samples: {}").format(
+                len(samples), ", ".join(map(api.get_id, selected_samples)))
+            return self.redirect(message=message)
+
+        # Handle cancel
+        if form_submitted and form_cancel:
+            logger.info("*** CANCEL REJECTION ***")
+            return self.redirect(message=_("Rejection cancelled"))
+
+        return self.template()
+
+    @view.memoize
+    def get_samples_from_request(self):
+        """Returns a list of objects coming from the "uids" request parameter
+        """
+        uids = self.request.form.get("uids", "")
+        if isinstance(uids, basestring):
+            uids = uids.split(",")
+
+        uids = list(set(uids))
+        if not uids:
+            return []
+
+        # Filter those analysis requests "reject" transition is allowed
+        query = dict(portal_type="AnalysisRequest", UID=uids)
+        brains = api.search(query, CATALOG_ANALYSIS_REQUEST_LISTING)
+        samples = map(api.get_object, brains)
+        return filter(lambda ob: wf.isTransitionAllowed(ob, "reject"), samples)
+
+    @view.memoize
+    def get_rejection_reasons(self):
+        """Returns the list of available rejection reasons
+        """
+        return api.get_setup().getRejectionReasonsItems()
+
+    def get_samples_data(self):
+        """Returns a list of Samples data (dictionary)
+        """
+        for obj in self.get_samples_from_request():
+            obj = api.get_object(obj)
+            yield {
+                "obj": obj,
+                "id": api.get_id(obj),
+                "uid": api.get_uid(obj),
+                "title": api.get_title(obj),
+                "path": api.get_path(obj),
+                "url": api.get_url(obj),
+                "sample_type": api.get_title(obj.getSampleType()),
+                "client_title": obj.getClientTitle(),
+                "date": ulocalized_time(obj.created(), long_format=True),
+            }
+
+    def redirect(self, redirect_url=None, message=None, level="info"):
+        """Redirect with a message
+        """
+        if redirect_url is None:
+            redirect_url = self.back_url
+        if message is not None:
+            self.add_status_message(message, level)
+        return self.request.response.redirect(redirect_url)
+
+    def add_status_message(self, message, level="info"):
+        """Set a portal status message
+        """
+        return self.context.plone_utils.addPortalMessage(message, level)

--- a/bika/lims/browser/analysisrequest/reject_samples.py
+++ b/bika/lims/browser/analysisrequest/reject_samples.py
@@ -27,7 +27,18 @@ class RejectSamplesView(BrowserView):
         self.context = context
         self.request = request
         self.back_url = self.context.absolute_url()
-        self.notify = api.get_setup().getNotifyOnSampleRejection()
+
+    @property
+    def is_notification_enabled(self):
+        """Returns whether the notification on sample rejection is enabled
+        """
+        return api.get_setup().getNotifyOnSampleRejection()
+
+    @property
+    def is_rejection_workflow_enabled(self):
+        """Return whether the rejection workflow is enabled
+        """
+        return api.get_setup().isRejectionWorkflowEnabled()
 
     def __call__(self):
         form = self.request.form
@@ -40,7 +51,7 @@ class RejectSamplesView(BrowserView):
         form_cancel = form.get("button_cancel", False)
 
         # Is Rejection Workflow Enabled
-        if not api.get_setup().isRejectionWorkflowEnabled():
+        if not self.is_rejection_workflow_enabled:
             return self.redirect(message=_("Rejection workflow is not enabled"),
                                  level="warning")
 
@@ -124,7 +135,6 @@ class RejectSamplesView(BrowserView):
         """Returns a list of Samples data (dictionary)
         """
         for obj in self.get_samples_from_request():
-            obj = api.get_object(obj)
             yield {
                 "obj": obj,
                 "id": api.get_id(obj),
@@ -132,7 +142,7 @@ class RejectSamplesView(BrowserView):
                 "title": api.get_title(obj),
                 "path": api.get_path(obj),
                 "url": api.get_url(obj),
-                "sample_type": api.get_title(obj.getSampleType()),
+                "sample_type": obj.getSampleTypeTitle(),
                 "client_title": obj.getClientTitle(),
                 "date": ulocalized_time(obj.created(), long_format=True),
             }

--- a/bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt
@@ -28,25 +28,6 @@
         </div>
       </tal:analyses>
 
-      <!-- Rejection Widget -->
-      <div class="row">
-        <div class="col-sm-12">
-          <tal:rejection define="field python:context.Schema()['RejectionReasons'];
-                                 widget python:field.widget;
-                                 errors python:{};">
-            <table style="display: none;">
-              <td>
-                <span tal:replace="python:widget.label"/>
-              </td>
-              <td>
-                <metal:widget use-macro="python:context.widget('RejectionReasons', mode='edit')" />
-              </td>
-            </table>
-          </tal:rejection>
-        </div>
-      </div>
-      <!-- /Rejection Widget -->
-
     </metal:content-core>
 
   </body>

--- a/bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequest_manage_results.pt
@@ -102,26 +102,6 @@
         </div>
       </div>
       <!-- /Remarks Widget -->
-
-      <!-- Rejection Widget -->
-      <div class="row">
-        <div class="col-sm-12">
-          <tal:rejection define="field python:context.Schema()['RejectionReasons'];
-                                 widget python:field.widget;
-                                 errors python:{};">
-            <table style="display: none;">
-              <td>
-                <span tal:replace="python:widget.label"/>
-              </td>
-              <td>
-                <metal:widget use-macro="python:context.widget('RejectionReasons', mode='edit')" />
-              </td>
-            </table>
-          </tal:rejection>
-        </div>
-      </div>
-      <!-- /Rejection Widget -->
-
     </metal:content-core>
 
   </body>

--- a/bika/lims/browser/analysisrequest/templates/reject_samples.pt
+++ b/bika/lims/browser/analysisrequest/templates/reject_samples.pt
@@ -104,6 +104,18 @@
                             tal:attributes="name string:samples.other_reasons:records"></textarea>
                         </div>
                       </div>
+
+                      <!-- Send email notification -->
+                      <div class="col-sm-12">
+                        <div class="form-group field">
+                          <input type="checkbox" name="samples.notify:records"
+                            tal:attributes="checked python:view.notify">
+                          <label i18n:translate="">Email notification</label><br/>
+                          <span i18n:translate="">
+                            Send an email notification to client contact
+                          </span>
+                        </div>
+                      </div>
                     </td>
                   </tr>
                 </tbody>

--- a/bika/lims/browser/analysisrequest/templates/reject_samples.pt
+++ b/bika/lims/browser/analysisrequest/templates/reject_samples.pt
@@ -1,0 +1,137 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="senaite.core">
+  <head>
+    <metal:block fill-slot="javascript_head_slot"
+                 tal:define="portal context/@@plone_portal_state/portal;">
+    </metal:block>
+    <metal:block fill-slot="style_slot"
+                 tal:define="portal context/@@plone_portal_state/portal;">
+    </metal:block>
+  </head>
+  <body>
+
+    <!-- Title -->
+    <metal:title fill-slot="content-title">
+      <h1 i18n:translate="">
+        Reject samples
+      </h1>
+    </metal:title>
+
+    <!-- Description -->
+    <metal:description fill-slot="content-description">
+      <p i18n:translate="">
+        <a tal:attributes="href view/back_url"
+           i18n:name="back_link"
+           i18n:translate="">
+          &larr; Back
+        </a>
+      </p>
+    </metal:description>
+
+    <!-- Content -->
+    <metal:core fill-slot="content-core">
+      <div id="reject-samples-view"
+           class="row"
+           tal:define="portal context/@@plone_portal_state/portal;">
+
+        <div class="col-sm-12">
+          <form class="form"
+                id="reject_samples_form"
+                name="reject_samples_form"
+                method="POST">
+
+            <!-- Hidden Fields -->
+            <input type="hidden" name="submitted" value="1"/>
+            <input tal:replace="structure context/@@authenticator/authenticator"/>
+
+            <tal:samples repeat="sample view/get_samples_data">
+
+              <!-- Remember the initial UIDs coming in -->
+              <input type="hidden" name="uids:list" tal:attributes="value sample/uid"/>
+
+              <table class="table table-bordered" style="margin-bottom:1.5em;">
+
+                <!-- Sample line header -->
+                <thead>
+                  <tr>
+                    <th class="info">
+                      <!-- Sample Title -->
+                      <div class="col-sm-12">
+                        <h2>
+                          <span class="text-primary" tal:content="sample/title"/>
+                          <span class="small" tal:content="sample/sample_type"/>
+                          <div class="small">
+                            <span tal:content="sample/client_title"/>
+                          </div>
+                        </h2>
+                        <input name="sample.uid:record"
+                               type="hidden"
+                               tal:attributes="value sample/uid;
+                                               name string:sample.${sample/uid}:record"/>
+                      </div>
+                    </th>
+                  </tr>
+                </thead>
+
+                <!-- Sample line content (rejection reasons checkboxes) -->
+                <tbody>
+                  <tr>
+                    <td>
+                      <!-- Rejection reasons -->
+                      <input type="hidden" name="samples.uid:records" tal:attributes="value sample/uid"/>
+                      <div class="col-sm-12">
+                        <div class="form-group field"
+                             tal:define="reasons python: view.get_rejection_reasons()">
+                          <tal:reasons repeat="reason reasons" condition="reasons">
+                            <div>
+                              <input type="checkbox"
+                                     tal:attributes="name string:reason.${sample/uid};
+                                                     sample_uid string:${sample/uid};">
+                              <label tal:attributes="for string:reason.${sample/uid}"
+                                     tal:content="reason"></label>
+                            </div>
+                          </tal:reasons>
+                          <div tal:condition="python: not reasons"
+                               i18n:translate="">There are no pre-defined conditions set</div>
+                        </div>
+                      </div>
+                      <div class="col-sm-12">
+                        <div class="form-group field">
+                          <label for="" i18n:translate="">Other reasons</label>
+                          <textarea cols="5"
+                            tal:attributes="name string:other_reason.${sample/uid};
+                                            sample_uid string:${sample/uid}"></textarea>
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </tal:samples>
+
+            <!-- Form Controls -->
+            <div>
+              <!-- Cancel -->
+              <input class="btn btn-default btn-sm"
+                     type="submit"
+                     name="button_cancel"
+                     i18n:attributes="value"
+                     value="Cancel ⎋"/>
+              <!-- Continue -->
+              <input class="btn btn-success btn-sm"
+                     type="submit"
+                     name="button_continue"
+                     i18n:attributes="value"
+                     value="Continue (1/2) ⇶"/>
+            </div>
+
+          </form>
+        </div>
+
+      </div>
+    </metal:core>
+  </body>
+</html>

--- a/bika/lims/browser/analysisrequest/templates/reject_samples.pt
+++ b/bika/lims/browser/analysisrequest/templates/reject_samples.pt
@@ -67,43 +67,41 @@
                             <span tal:content="sample/client_title"/>
                           </div>
                         </h2>
-                        <input name="sample.uid:record"
-                               type="hidden"
-                               tal:attributes="value sample/uid;
-                                               name string:sample.${sample/uid}:record"/>
                       </div>
                     </th>
                   </tr>
                 </thead>
 
-                <!-- Sample line content (rejection reasons checkboxes) -->
+                <!-- Sample line content -->
                 <tbody>
                   <tr>
-                    <td>
-                      <!-- Rejection reasons -->
+                    <td tal:define="reasons python: view.get_rejection_reasons()">
                       <input type="hidden" name="samples.uid:records" tal:attributes="value sample/uid"/>
+
+                      <!-- Pre-defined rejection reasons -->
                       <div class="col-sm-12">
-                        <div class="form-group field"
-                             tal:define="reasons python: view.get_rejection_reasons()">
+                        <div class="form-group field">
+                          <label i18n:translate="">Rejection reasons</label>
                           <tal:reasons repeat="reason reasons" condition="reasons">
-                            <div>
+                            <div tal:define="index repeat/reason/index">
                               <input type="checkbox"
-                                     tal:attributes="name string:reason.${sample/uid};
-                                                     sample_uid string:${sample/uid};">
-                              <label tal:attributes="for string:reason.${sample/uid}"
-                                     tal:content="reason"></label>
+                                     tal:attributes="name string:samples.reasons:records:list;
+                                                     value reason">
+                              <span tal:content="reason"></span>
                             </div>
                           </tal:reasons>
                           <div tal:condition="python: not reasons"
                                i18n:translate="">There are no pre-defined conditions set</div>
                         </div>
                       </div>
+
+                      <!-- Other rejection reasons -->
                       <div class="col-sm-12">
                         <div class="form-group field">
-                          <label for="" i18n:translate="">Other reasons</label>
+                          <label tal:condition="reasons" i18n:translate="">Other reasons</label>
+                          <label tal:condition="python: not reasons" i18n:translate="">Rejection reasons</label>
                           <textarea cols="5"
-                            tal:attributes="name string:other_reason.${sample/uid};
-                                            sample_uid string:${sample/uid}"></textarea>
+                            tal:attributes="name string:samples.other_reasons:records"></textarea>
                         </div>
                       </div>
                     </td>
@@ -125,7 +123,7 @@
                      type="submit"
                      name="button_continue"
                      i18n:attributes="value"
-                     value="Continue (1/2) ⇶"/>
+                     value="Reject ⇶"/>
             </div>
 
           </form>

--- a/bika/lims/browser/analysisrequest/templates/reject_samples.pt
+++ b/bika/lims/browser/analysisrequest/templates/reject_samples.pt
@@ -82,14 +82,12 @@
                       <div class="col-sm-12">
                         <div class="form-group field">
                           <label i18n:translate="">Rejection reasons</label>
-                          <tal:reasons repeat="reason reasons" condition="reasons">
-                            <div tal:define="index repeat/reason/index">
-                              <input type="checkbox"
-                                     tal:attributes="name string:samples.reasons:records:list;
-                                                     value reason">
-                              <span tal:content="reason"></span>
-                            </div>
-                          </tal:reasons>
+                          <div tal:condition="reasons" tal:repeat="reason reasons">
+                            <input type="checkbox"
+                                   tal:attributes="name string:samples.reasons:records:list;
+                                                   value reason">
+                            <span tal:content="reason"></span>
+                          </div>
                           <div tal:condition="python: not reasons"
                                i18n:translate="">There are no pre-defined conditions set</div>
                         </div>
@@ -109,7 +107,7 @@
                       <div class="col-sm-12">
                         <div class="form-group field">
                           <input type="checkbox" name="samples.notify:records"
-                            tal:attributes="checked python:view.notify">
+                            tal:attributes="checked python:view.is_notification_enabled">
                           <label i18n:translate="">Email notification</label><br/>
                           <span i18n:translate="">
                             Send an email notification to client contact
@@ -129,18 +127,16 @@
                      type="submit"
                      name="button_cancel"
                      i18n:attributes="value"
-                     value="Cancel ⎋"/>
+                     value="Cancel"/>
               <!-- Continue -->
               <input class="btn btn-success btn-sm"
                      type="submit"
                      name="button_continue"
                      i18n:attributes="value"
-                     value="Reject ⇶"/>
+                     value="Reject"/>
             </div>
-
           </form>
         </div>
-
       </div>
     </metal:core>
   </body>

--- a/bika/lims/browser/templates/header_table.pt
+++ b/bika/lims/browser/templates/header_table.pt
@@ -9,8 +9,6 @@
           tal:attributes="src python:portal.absolute_url() + '/bika_widgets/datetimewidget.js'"></script>
       <script type="text/javascript"
           tal:attributes="src python:portal.absolute_url() + '/bika_widgets/referencewidget.js'"></script>
-      <script type="text/javascript"
-          tal:attributes="src python:portal.absolute_url() + '/bika_widgets/rejectionwidget.js'"></script>
   </head>
 
   <body

--- a/bika/lims/browser/viewlets/analysisrequest.py
+++ b/bika/lims/browser/viewlets/analysisrequest.py
@@ -37,3 +37,9 @@ class SecondaryAnalysisRequestViewlet(ViewletBase):
     """ Current Analysis Request is a secondary. Display the link to primary
     """
     template = ViewPageTemplateFile("templates/secondary_ar_viewlet.pt")
+
+
+class RejectedAnalysisRequestViewlet(ViewletBase):
+    """Current ANalysis Request was rejected. Display the reasons
+    """
+    template = ViewPageTemplateFile("templates/rejected_ar_viewlet.pt")

--- a/bika/lims/browser/viewlets/configure.zcml
+++ b/bika/lims/browser/viewlets/configure.zcml
@@ -171,4 +171,14 @@
     layer="bika.lims.interfaces.IBikaLIMS"
   />
 
+  <!-- Rejected Analysis Request viewlet -->
+  <browser:viewlet
+    for="bika.lims.interfaces.IAnalysisRequest"
+    name="bika.lims.rejected_ar_viewlet"
+    class=".analysisrequest.RejectedAnalysisRequestViewlet"
+    manager="plone.app.layout.viewlets.interfaces.IAboveContent"
+    template="templates/rejected_ar_viewlet.pt"
+    permission="zope2.View"
+    layer="bika.lims.interfaces.IBikaLIMS"
+  />
 </configure>

--- a/bika/lims/browser/viewlets/templates/rejected_ar_viewlet.pt
+++ b/bika/lims/browser/viewlets/templates/rejected_ar_viewlet.pt
@@ -1,0 +1,30 @@
+<div tal:omit-tag=""
+     tal:define="rejected python:view.context.getRejectionReasons()"
+     tal:condition="python:rejected"
+     i18n:domain="senaite.core">
+
+  <div class="visualClear"></div>
+
+  <div id="portal-alert" tal:define="sample python:view.context">
+    <div class="portlet-alert-item alert alert-warning alert-dismissible">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <strong class="bigger" i18n:translate="">Rejected sample</strong>
+      <p class="title">
+        <span i18n:translate="">This Sample has been rejected due to the following reasons: </span>
+      </p>
+      <p tal:define="reasons python:sample.getSelectedRejectionReasons()"
+         tal:condition="reasons">
+        <ul>
+        <li tal:repeat="reason reasons" tal:content="reason"></li>
+        </ul>
+      </p>
+      <p tal:define="other_reasons python:sample.getOtherRejectionReasons()"
+         tal:condition="other_reasons">
+        <span i18n:translate="">Other reasons: </span>
+        <span tal:content="other_reasons"></span>
+      </p>
+    </div>
+  </div>
+</div>

--- a/bika/lims/browser/workflow/analysisrequest.py
+++ b/bika/lims/browser/workflow/analysisrequest.py
@@ -62,6 +62,16 @@ class WorkflowActionPublishAdapter(RequestContextAware):
         return self.redirect(redirect_url=url)
 
 
+class WorkflowActionRejectAdapter(RequestContextAware):
+    """Adapter in charge of Analysis Requests 'reject' action
+    """
+    implements(IWorkflowActionUIDsAdapter)
+
+    def __call__(self, action, uids):
+        url = "{}/reject_samples?uids={}".format(self.back_url, ",".join(uids))
+        return self.redirect(redirect_url=url)
+
+
 class WorkflowActionReceiveAdapter(WorkflowActionGenericAdapter):
     """Adapter in charge of Analysis Request receive action
     """

--- a/bika/lims/browser/workflow/configure.zcml
+++ b/bika/lims/browser/workflow/configure.zcml
@@ -157,6 +157,18 @@
     provides="bika.lims.interfaces.IWorkflowActionAdapter"
     permission="zope.Public" />
 
+  <!-- Analysis Request: "reject"
+  Note this applies wide, cause at the moment, this action only exists
+  for Analysis Requests and we always want this adapter to be in charge,
+  regardless of the context (Analysis Requests listing, Client folder, etc.) -->
+  <adapter
+    name="workflow_action_reject"
+    for="*
+         zope.publisher.interfaces.browser.IBrowserRequest"
+    factory=".analysisrequest.WorkflowActionRejectAdapter"
+    provides="bika.lims.interfaces.IWorkflowActionAdapter"
+    permission="zope.Public" />
+
   <!-- Analysis Request: "save_analyses" -->
   <adapter
     name="workflow_action_save_analyses"

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2326,5 +2326,21 @@ class AnalysisRequest(BaseFolder):
             secondary.setSamplingDate(value)
             secondary.reindexObject(idxs="getSamplingDate")
 
+    def getSelectedRejectionReasons(self):
+        """Returns a list with the selected rejection reasons, if any
+        """
+        reasons = self.getRejectionReasons()
+        if not reasons:
+            return []
+        return reasons[0].get("selected", [])
+
+    def getOtherRejectionReasons(self):
+        """Returns other rejection reasons custom text, if any
+        """
+        reasons = self.getRejectionReasons()
+        if not reasons:
+            return ""
+        return reasons[0].get("other", "")
+
 
 registerType(AnalysisRequest, PROJECTNAME)

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -558,17 +558,6 @@ schema = BikaFolderSchema.copy() + Schema((
                 "in the sample types setup"),
         )
     ),
-    RecordsField(
-        'RejectionReasons',
-        schemata="Sampling",
-        widget=RejectionSetupWidget(
-            label=_("Enable sampling rejection"),
-            description=_("Select this to activate the rejection workflow "
-                          "for Samples and Samples. A 'Reject' "
-                          "option will be displayed in the actions menu for "
-                          "these objects.")
-        ),
-    ),
     BooleanField(
         'NotifyOnSampleRejection',
         schemata="Notifications",
@@ -914,6 +903,16 @@ class BikaSetup(folder.ATFolder):
             return True if checkbox == 'on' and len(widget[0]) > 1 else False
         else:
             return False
+
+    def getRejectionReasonsItems(self):
+        """Return the list of predefined rejection reasons
+        """
+        reasons = self.getRejectionReasons()
+        if not reasons:
+            return []
+        reasons = reasons[0]
+        keys = filter(lambda key: key != "checkbox", reasons.keys())
+        return map(lambda key: reasons[key], sorted(keys)) or []
 
     def _getNumberOfRequiredVerificationsVocabulary(self):
         """

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -815,9 +815,8 @@ schema = BikaFolderSchema.copy() + Schema((
         widget=RejectionSetupWidget(
             label=_("Enable the rejection workflow"),
             description=_("Select this to activate the rejection workflow "
-                          "for Samples and Samples. A 'Reject' "
-                          "option will be displayed in the actions menu for "
-                          "these objects.")
+                          "for Samples. A 'Reject' option will be displayed in "
+                          "the actions menu.")
         ),
     ),
     IntegerField(

--- a/bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
@@ -1409,8 +1409,7 @@
   <transition transition_id="reject" title="Reject" new_state="rejected" trigger="USER" before_script="" after_script="" i18n:attributes="title">
     <action url="" category="workflow" icon="">Reject</action>
     <guard>
-      <!-- TODO: Better to move this guard-expression with guard.handler -->
-      <guard-expression>python:here.bika_setup.isRejectionWorkflowEnabled()</guard-expression>
+      <guard-expression>python:here.guard_handler("reject")</guard-expression>
       <guard-permission>senaite.core: Transition: Reject Sample</guard-permission>
     </guard>
   </transition>

--- a/bika/lims/workflow/analysisrequest/events.py
+++ b/bika/lims/workflow/analysisrequest/events.py
@@ -33,19 +33,6 @@ def after_reject(analysis_request):
     do_action_to_descendants(analysis_request, "reject")
     do_action_to_analyses(analysis_request, "reject")
 
-    # TODO Workflow - AnalysisRequest - Revisit rejection notification
-    if not analysis_request.bika_setup.getNotifyOnSampleRejection():
-        return
-
-    ancestor = analysis_request.getParentAnalysisRequest()
-    if ancestor and api.get_workflow_status_of(ancestor) == "rejected":
-        # No need to notify, notification done by the ancestor
-        return
-
-    # Notify the Client about the Rejection.
-    from bika.lims.utils.analysisrequest import notify_rejection
-    notify_rejection(analysis_request)
-
 
 def after_retract(analysis_request):
     """Method triggered after a 'retract' transition for the Analysis Request

--- a/bika/lims/workflow/analysisrequest/guards.py
+++ b/bika/lims/workflow/analysisrequest/guards.py
@@ -165,3 +165,10 @@ def guard_sample(analysis_request):
 
     current_user = api.get_current_user()
     return "Sampler" in current_user.getRolesInContext(analysis_request)
+
+
+def guard_reject(analysis_request):
+    """Returns whether 'reject' transition can be performed or not. Returns
+    True only if setup's isRejectionWorkflowEnabled is True
+    """
+    return analysis_request.bika_setup.isRejectionWorkflowEnabled()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds a Samples rejection view where the user can choose the reasons of rejection and whether a notification email has to be sent to the client contact.

Linked issue: https://github.com/senaite/senaite.core/issues/1238

## Current behavior before PR

User cannot neither choose the reasons of rejection nor e-mail notification.

## Desired behavior after PR is merged

User can choose the reasons of rejection and e-mail notification.

![Captura de 2019-03-28 19-19-37](https://user-images.githubusercontent.com/832627/55183694-b37d8900-5190-11e9-8200-e5b45bbcadd4.png)

![Captura de 2019-03-28 19-17-47](https://user-images.githubusercontent.com/832627/55183705-b8dad380-5190-11e9-8cb4-1fc19f4509fa.png)

![Captura de 2019-03-28 20-11-08](https://user-images.githubusercontent.com/832627/55185908-a6af6400-5195-11e9-8eb9-6db3b06a627d.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
