### PR TITLE
Support for radio copy in Sample Add view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1310 Support for radio copy in Sample Add view
 - #1291 "Remove" transition for empty Worksheets
 - #1259 Added Facscalibur instrument import interface
 - #1244 Added "Body for Sample Invalidation email" field in setup

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -1441,6 +1441,27 @@
           return $(_el).val(value);
         });
       });
+      // Copy <input type="radio"> fields
+      $td1.find("input[type=radio]").each(function(index, el) {
+        var checked;
+        console.debug("-> Copy radio field");
+        $el = $(el);
+        checked = $(el).is(":checked");
+        return $.each((function() {
+          var results = [];
+          for (var i = 1; 1 <= ar_count ? i <= ar_count : i >= ar_count; 1 <= ar_count ? i++ : i--){ results.push(i); }
+          return results;
+        }).apply(this), function(arnum) {
+          var _el, _td;
+          // skip the first column
+          if (!(arnum > 0)) {
+            return;
+          }
+          _td = $tr.find(`td[arnum=${arnum}]`);
+          _el = $(_td).find("input[type=radio]")[index];
+          return $(_el).prop("checked", checked);
+        });
+      });
       // trigger form:changed event
       return $(me).trigger("form:changed");
     }

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -1403,6 +1403,18 @@ class window.AnalysisRequestAdd
         _el = $(_td).find("textarea")[index]
         $(_el).val value
 
+    # Copy <input type="radio"> fields
+    $td1.find("input[type=radio]").each (index, el) ->
+      console.debug "-> Copy radio field"
+      $el = $(el)
+      checked = $(el).is ":checked"
+      $.each [1..ar_count], (arnum) ->
+        # skip the first column
+        return unless arnum > 0
+        _td = $tr.find("td[arnum=#{arnum}]")
+        _el = $(_td).find("input[type=radio]")[index]
+        $(_el).prop "checked", checked
+
     # trigger form:changed event
     $(me).trigger "form:changed"
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Copy action support for radio elements in AR Add view

## Current behavior before PR

Radio elements do not get copied across columns in AR Add view

## Desired behavior after PR is merged

Radio elements do get copied across columns in AR Add view

![Captura de 2019-03-29 01-16-16](https://user-images.githubusercontent.com/832627/55201015-459d8580-51c1-11e9-9df9-900f0254a196.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
