### PR TITLE
Reject adapter does not consider analyses have reject action too

### DIFF
--- a/bika/lims/browser/workflow/__init__.py
+++ b/bika/lims/browser/workflow/__init__.py
@@ -160,14 +160,15 @@ class WorkflowActionGenericAdapter(RequestContextAware):
             return False
         return self.context in objects
 
-    def success(self, objects):
+    def success(self, objects, message=None):
         """Redirects the user to success page with informative message
         """
         if self.is_context_only(objects):
             return self.redirect(message=_("Changes saved."))
 
         ids = map(api.get_id, objects)
-        message = _("Saved items: {}").format(", ".join(ids))
+        if not message:
+            message = _("Saved items: {}").format(", ".join(ids))
         return self.redirect(message=message)
 
     def get_form_value(self, form_key, object_brain_uid, default=None):

--- a/bika/lims/browser/workflow/analysisrequest.py
+++ b/bika/lims/browser/workflow/analysisrequest.py
@@ -82,7 +82,7 @@ class WorkflowActionRejectAdapter(WorkflowActionGenericAdapter):
 
         # Redirect the user to success page
         ids =  map(api.get_id, transitioned)
-        message = _("Rejected items: {}".format(", ".join(ids)))
+        message = _("Rejected items: {}").format(", ".join(ids))
         return self.success(transitioned, message=message)
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The adapter traps all workflow "reject" actions from browser, so if the user rejects an analysis (inside a Sample), the Sample Rejection View is rendered instead of transitioning the selected analyses. This commit overcomes this scenario by adding a check in `__call__` and render the view or trigger the reject transition for selected objects instead.

## Current behavior before PR

Cannot reject analyses

## Desired behavior after PR is merged

Can reject analyses

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
