### PR TITLE
Barcodes view does not render all labels once Sample(s) is/are registered

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Changelog
 
 **Fixed**
 
+- #1316 Barcodes view does not render all labels once Samples are registered
+
 
 **Security**
 

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1663,17 +1663,14 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
         # Display a portal message
         self.context.plone_utils.addPortalMessage(message, level)
-        # Automatic label printing won't print "register" labels for sec. ARs
+
+        # Automatic label printing
         bika_setup = api.get_bika_setup()
         auto_print = bika_setup.getAutoPrintStickers()
-
-        # https://github.com/bikalabs/bika.lims/pull/2153
-        new_ars = [uid for key, uid in ARs.items() if key[-1] == '1']
-
-        if 'register' in auto_print and new_ars:
+        if 'register' in auto_print and ARs:
             return {
                 'success': message,
-                'stickers': new_ars,
+                'stickers': ARs.values(),
                 'stickertemplate': bika_setup.getAutoStickerTemplate()
             }
         else:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Because of a legacy pre1.3 code, only the samples with an ID (field Title) ending with "1" were rendered in barcodes/stickers view. This was a [hack from the old days](https://github.com/bikalims/bika.lims/pull/2153/files#diff-bb53acee20ee8d0bd59001312bbe9fd3R473) to prevent secondary samples to be rendered in the barcodes view (why?). This PRs removes that code and ensure that UIDs of all processed samples are sent to the barcodes view.

Linked issue: https://github.com/senaite/senaite.core/issues/1315

## Current behavior before PR

The barcode (stickers) view does not display labels for all registered samples or the view is not rendered at all

## Desired behavior after PR is merged

Barcodes/Stickers view display labels for all registered samples

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
