### PR TITLE
Fix Analysis Service URL in Info Popup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #1317 Fix Analysis Service URL in Info Popup
 - #1316 Barcodes view does not render all labels once Samples are registered
 
 

--- a/bika/lims/browser/analysisservice.py
+++ b/bika/lims/browser/analysisservice.py
@@ -79,6 +79,16 @@ class AnalysisServiceInfoView(BrowserView):
         service_uid = self.request.form.get("service_uid")
         return api.get_object_by_uid(service_uid, None)
 
+    @view.memoize
+    def get_service_url(self):
+        service = self.get_service()
+        return api.get_url(service)
+
+    @view.memoize
+    def is_accredited(self):
+        service = self.get_service()
+        return service.getAccredited()
+
     def get_analysis_or_service(self):
         analysis = self.get_analysis()
         if analysis:

--- a/bika/lims/browser/templates/analysisservice_info.pt
+++ b/bika/lims/browser/templates/analysisservice_info.pt
@@ -35,7 +35,13 @@
                 <td>
                   <a href="#"
                      target="_blank"
-                     tal:attributes="href service/absolute_url">
+                     tal:attributes="href python:view.get_service_url()">
+                    <span tal:content="string:★"
+                          style="font-family:Lucida Console, Courier, monospace;"
+                          title="Accredited"
+                          i18n:attributes="title"
+                          tal:condition="view/is_accredited">
+                    </span>
                     <span tal:content="service/Title"></span>
                   </a>
                 </td>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the generated Link URL for Analyses in the Info Popup

## Current behavior before PR

Click on the Analysis Service Link in the Popup results in a 404 Error

## Desired behavior after PR is merged

Click on the Analysis Service Link in the Popup shows the Service Page

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
