### PR TITLE
Add function addAttachment in Sample to preserve previous attachments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Changelog
 
 **Fixed**
 
+- #1316 Barcodes view does not render all labels once Samples are registered
+
 
 **Security**
 

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1663,17 +1663,14 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
         # Display a portal message
         self.context.plone_utils.addPortalMessage(message, level)
-        # Automatic label printing won't print "register" labels for sec. ARs
+
+        # Automatic label printing
         bika_setup = api.get_bika_setup()
         auto_print = bika_setup.getAutoPrintStickers()
-
-        # https://github.com/bikalabs/bika.lims/pull/2153
-        new_ars = [uid for key, uid in ARs.items() if key[-1] == '1']
-
-        if 'register' in auto_print and new_ars:
+        if 'register' in auto_print and ARs:
             return {
                 'success': message,
-                'stickers': new_ars,
+                'stickers': ARs.values(),
                 'stickertemplate': bika_setup.getAutoStickerTemplate()
             }
         else:

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1637,17 +1637,13 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             # We keep the title to check if AR is newly created
             # and UID to print stickers
             ARs[ar.Title()] = ar.UID()
-
-            _attachments = []
             for attachment in attachments.get(n, []):
                 if not attachment.filename:
                     continue
                 att = _createObjectByType("Attachment", client, tmpID())
                 att.setAttachmentFile(attachment)
                 att.processForm()
-                _attachments.append(att)
-            if _attachments:
-                ar.setAttachment(_attachments)
+                ar.addAttachment(att)
         actions.resume()
 
         level = "info"

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2358,9 +2358,16 @@ class AnalysisRequest(BaseFolder):
     def addAttachment(self, attachment):
         """Adds an attachment or a list of attachments to the Analysis Request
         """
-        if not isinstance(attachment, list):
+        if not isinstance(attachment, (list, tuple)):
             attachment = [attachment]
+
         original = self.getAttachment() or []
+
+        # Function addAttachment can accept brain, objects or uids
+        original = map(api.get_uid, original)
+        attachment = map(api.get_uid, attachment)
+
+        # Boil out attachments already assigned to this Analysis Request
         attachment = filter(lambda at: at not in original, attachment)
         if attachment:
             original.extend(attachment)

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2355,5 +2355,15 @@ class AnalysisRequest(BaseFolder):
             return ""
         return reasons[0].get("other", "")
 
+    def addAttachment(self, attachment):
+        """Adds an attachment or a list of attachments to the Analysis Request
+        """
+        if not isinstance(attachment, list):
+            attachment = [attachment]
+        original = self.getAttachment() or []
+        attachment = filter(lambda at: at not in original, attachment)
+        if attachment:
+            original.extend(attachment)
+            self.setAttachment(original)
 
 registerType(AnalysisRequest, PROJECTNAME)

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -250,10 +250,7 @@ def notify_rejection(analysisrequest):
         att.setAttachmentFile(attf)
         att.unmarkCreationFlag()
         renameAfterCreation(att)
-        atts = analysisrequest.getAttachment() + [att] if \
-            analysisrequest.getAttachment() else [att]
-        atts = [a.UID() for a in atts]
-        analysisrequest.setAttachment(atts)
+        analysisrequest.addAttachment(att)
         os.remove(pdf_fn)
 
     # This is the message for the email's body


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

In some cases, we automatically create an attachment on Sample creation as part of the workflow logic (e.g. in `after_no_sampling_workflow` transition). Sample Add view does not take this into consideration, and when attachments are set in Sample view, the previous attachments in the Sample are removed.

## Current behavior before PR

Attachments automatically created on `after_no_sampling_workflow` transition are not preserved when attachments are specified in Sample Add form.

## Desired behavior after PR is merged

Attachments automatically created on `after_no_sampling_workflow` transition are preserved when attachments are specified in Sample Add form.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
