### PR TITLE
Make api.get_review_history to always return a list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #1319 Make api.get_review_history to always return a list
 - #1317 Fix Analysis Service URL in Info Popup
 - #1316 Barcodes view does not render all labels once Samples are registered
 

--- a/bika/lims/api/__init__.py
+++ b/bika/lims/api/__init__.py
@@ -705,6 +705,19 @@ def get_review_history(brain_or_object, rev=True):
         logger.error("get_review_history: expected list, received {}".format(
             review_history))
         review_history = []
+
+    if isinstance(review_history, tuple):
+        # Products.CMFDefault.DefaultWorkflow.getInfoFor always returns a
+        # tuple when "review_history" is passed in:
+        # https://github.com/zopefoundation/Products.CMFDefault/blob/master/Products/CMFDefault/DefaultWorkflow.py#L244
+        #
+        # On the other hand, Products.DCWorkflow.getInfoFor relies on
+        # Expression.StateChangeInfo, that always returns a list, except when no
+        # review_history is found:
+        # https://github.com/zopefoundation/Products.DCWorkflow/blob/master/Products/DCWorkflow/DCWorkflow.py#L310
+        # https://github.com/zopefoundation/Products.DCWorkflow/blob/master/Products/DCWorkflow/Expression.py#L94
+        review_history = list(review_history)
+
     if rev is True:
         review_history.reverse()
     return review_history


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Products.CMFDefault.DefaultWorkflow.getInfoFor always returns a tuple when "review_history" is passed in:
https://github.com/zopefoundation/Products.CMFDefault/blob/master/Products/CMFDefault/DefaultWorkflow.py#L244

On the other hand, Products.DCWorkflow.getInfoFor relies on Expression.StateChangeInfo, that always returns a list, except when no review_history is found:
https://github.com/zopefoundation/Products.DCWorkflow/blob/master/Products/DCWorkflow/DCWorkflow.py#L310
https://github.com/zopefoundation/Products.DCWorkflow/blob/master/Products/DCWorkflow/Expression.py#L94

## Current behavior before PR

```
Traceback (innermost last):
  ....
  Module Products.Archetypes.CatalogMultiplex, line 118, in reindexObject
  Module Products.CMFPlone.CatalogTool, line 349, in catalog_object
  Module Products.ZCatalog.ZCatalog, line 476, in catalog_object
  Module Products.ZCatalog.Catalog, line 334, in catalogObject
  Module Products.ZCatalog.Catalog, line 284, in updateMetadata
  Module Products.ZCatalog.Catalog, line 410, in recordify
  Module bika.lims.content.abstractanalysis, line 989, in getAnalyst
  Module bika.lims.content.abstractanalysis, line 1033, in getSubmittedBy
  Module bika.lims.workflow, line 320, in getTransitionActor
  Module bika.lims.workflow, line 295, in getReviewHistory
  Module bika.lims.api, line 709, in get_review_history
AttributeError: 'tuple' object has no attribute 'reverse'
```

## Desired behavior after PR is merged

No traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
