### PR TITLE
Remove transition filtering in Worksheet listings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Changelog
 
 **Removed**
 
+- #1328 Remove transition filtering in Worksheet listings
 
 **Fixed**
 

--- a/bika/lims/browser/worksheet/views/analyses.py
+++ b/bika/lims/browser/worksheet/views/analyses.py
@@ -128,11 +128,6 @@ class AnalysesView(BaseView):
                 "id": "default",
                 "title": _("All"),
                 "contentFilter": {},
-                "transitions": [
-                    {"id": "submit"},
-                    {"id": "verify"},
-                    {"id": "retract"},
-                    {"id": "unassign"}],
                 "columns": self.columns.keys(),
             },
         ]


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the manual transition filtering in the Worksheet Analyses Views (classic/transposed)

## Current behavior before PR

Reject transition did not appear, although the guard allowed the transition

## Desired behavior after PR is merged

All allowed and possible transitions are displayed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
