### PR TITLE
Removed guard permissions for state_change/getHistory

### DIFF
--- a/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
@@ -728,12 +728,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <!-- TODO Workflow - Analysis - Allowing only users with role "Review
-      portal content" to access to workflow history may cause problems when
-      functions "getReviewHistory", "wasTransitionPerformed" are used. These
-      functions are needed in some guards and/or in rollback transitions -->
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
@@ -1451,8 +1451,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_arimport_workflow/definition.xml
@@ -101,8 +101,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/bika_arimports_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_arimports_workflow/definition.xml
@@ -85,8 +85,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
@@ -352,8 +352,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
   <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">

--- a/bika/lims/profiles/default/workflows/bika_referenceanalysis_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_referenceanalysis_workflow/definition.xml
@@ -370,8 +370,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_referencesample_workflow/definition.xml
@@ -156,8 +156,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/bika_reject_analysis_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_reject_analysis_workflow/definition.xml
@@ -62,8 +62,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/bika_sample_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_sample_workflow/definition.xml
@@ -62,8 +62,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
   <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">

--- a/bika/lims/profiles/default/workflows/bika_samplinground_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_samplinground_workflow/definition.xml
@@ -125,8 +125,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/bika_worksheet_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_worksheet_workflow/definition.xml
@@ -294,8 +294,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/senaite_batch_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_batch_workflow/definition.xml
@@ -259,8 +259,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/senaite_cancellable_type_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_cancellable_type_workflow/definition.xml
@@ -129,8 +129,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/senaite_client_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_client_workflow/definition.xml
@@ -192,8 +192,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/senaite_clientcontact_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_clientcontact_workflow/definition.xml
@@ -129,8 +129,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/senaite_clients_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_clients_workflow/definition.xml
@@ -75,8 +75,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/senaite_deactivable_type_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_deactivable_type_workflow/definition.xml
@@ -129,8 +129,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/senaite_instruments_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_instruments_workflow/definition.xml
@@ -103,8 +103,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/senaite_labcontact_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_labcontact_workflow/definition.xml
@@ -139,8 +139,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/senaite_laboratory_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_laboratory_workflow/definition.xml
@@ -68,8 +68,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/senaite_one_state_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_one_state_workflow/definition.xml
@@ -61,8 +61,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/senaite_referencesamples_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_referencesamples_workflow/definition.xml
@@ -115,8 +115,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/senaite_reports_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_reports_workflow/definition.xml
@@ -141,8 +141,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/senaite_setup_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_setup_workflow/definition.xml
@@ -80,8 +80,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/senaite_supplyorder_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_supplyorder_workflow/definition.xml
@@ -123,8 +123,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/profiles/default/workflows/senaite_worksheets_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_worksheets_workflow/definition.xml
@@ -105,8 +105,6 @@
       <expression>state_change/getHistory</expression>
     </default>
     <guard>
-      <guard-permission>Request review</guard-permission>
-      <guard-permission>Review portal content</guard-permission>
     </guard>
   </variable>
 

--- a/bika/lims/upgrade/v01_03_001.py
+++ b/bika/lims/upgrade/v01_03_001.py
@@ -42,6 +42,7 @@ def upgrade(tool):
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
     # -------- ADD YOUR STUFF BELOW --------
+    setup.runImportStepFromProfile(profile, 'workflow')
 
 
     logger.info("{0} upgraded to version {1}".format(product, version))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the guard permissions for the `state_change/getHistory` workflow variable to grant access to the review history when checking for `was_transition_performed`

## Current behavior before PR

Verify transition did not display for Lab Managers on Analyses with dependencies in Worksheets

## Desired behavior after PR is merged

Verify transition displays for Lab Managers on Analyses with dependencies in Worksheets

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
