### PR TITLE
 fix dashboard links for samples indicators when sampling workflow is enabled

### DIFF
--- a/bika/lims/browser/dashboard/dashboard.py
+++ b/bika/lims/browser/dashboard/dashboard.py
@@ -400,7 +400,7 @@ class DashboardView(BrowserView):
             # Samples awaiting to be preserved
             name = _('Samples to be preserved')
             desc = _("To be preserved")
-            purl = 'sanalysisrequests?analysisrequests_review_state=to_be_preserved'
+            purl = 'analysisrequests?analysisrequests_review_state=to_be_preserved'
             query['review_state'] = ['to_be_preserved', ]
             out.append(self._getStatistics(name, desc, purl, catalog, query, total))
 

--- a/bika/lims/browser/dashboard/dashboard.py
+++ b/bika/lims/browser/dashboard/dashboard.py
@@ -393,21 +393,21 @@ class DashboardView(BrowserView):
             # Samples awaiting to be sampled or scheduled
             name = _('Samples to be sampled')
             desc = _("To be sampled")
-            purl = 'samples?samples_review_state=to_be_sampled'
+            purl = 'analysisrequests?analysisrequests_review_state=to_be_sampled'
             query['review_state'] = ['to_be_sampled', ]
             out.append(self._getStatistics(name, desc, purl, catalog, query, total))
 
             # Samples awaiting to be preserved
             name = _('Samples to be preserved')
             desc = _("To be preserved")
-            purl = 'samples?samples_review_state=to_be_preserved'
+            purl = 'sanalysisrequests?analysisrequests_review_state=to_be_preserved'
             query['review_state'] = ['to_be_preserved', ]
             out.append(self._getStatistics(name, desc, purl, catalog, query, total))
 
             # Samples scheduled for Sampling
             name = _('Samples scheduled for sampling')
             desc = _("Sampling scheduled")
-            purl = 'samples?samples_review_state=scheduled_sampling'
+            purl = 'analysisrequests?analysisrequests_review_state=scheduled_sampling'
             query['review_state'] = ['scheduled_sampling', ]
             out.append(self._getStatistics(name, desc, purl, catalog, query, total))
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

To fix dashboard links for samples indicators when sampling workflow is enabled.

Dashboard links currently pointing to sample?sample_review_state. It should actually point to analysisrequests?analysisrequests_review_state

Change "sample?sample_review_state" to "analysisrequests?analysisrequests_review_state"

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR
Clicking dashboard link takes to error page

## Desired behavior after PR is merged
Dashboard link takes to correct page
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
