### PR TITLE
Number of analyses are not updated after modifying analyses in a Sample

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Fixed**
 
+- #1334 Number of analyses are not updated after modifying analyses in a Sample
 - #1319 Make api.get_review_history to always return a list
 - #1317 Fix Analysis Service URL in Info Popup
 - #1316 Barcodes view does not render all labels once Samples are registered

--- a/bika/lims/browser/workflow/analysisrequest.py
+++ b/bika/lims/browser/workflow/analysisrequest.py
@@ -436,6 +436,9 @@ class WorkflowActionSaveAnalysesAdapter(WorkflowActionGenericAdapter):
         for analysis in sample.objectValues("Analysis"):
             analysis.reindexObject()
 
+        # Reindex the Sample
+        sample.reindexObject()
+
         # Redirect the user to success page
         self.success([sample])
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The number of analyses does not get updated after an analysis added (or removed) in a Sample through Manage Analyses view.

## Current behavior before PR

Number of analyses are not updated after adding or removing analyses.

## Desired behavior after PR is merged

Number of analyses are updated accordingly after adding or removing analyses.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
