### PR TITLE
Added missing IVerified import in sample view

### DIFF
--- a/bika/lims/browser/analysisrequest/view.py
+++ b/bika/lims/browser/analysisrequest/view.py
@@ -22,6 +22,7 @@ from bika.lims import api
 from bika.lims.browser import BrowserView
 from bika.lims.browser.header_table import HeaderTableView
 from bika.lims.interfaces import IReceived
+from bika.lims.interfaces import IVerified
 from bika.lims.permissions import EditFieldResults
 from bika.lims.permissions import EditResults
 from bika.lims.utils import check_permission


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds the missing import `IVerified`
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
