### PR TITLE
Fix result capture date inconsistency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Fixed**
 
+- #1336 Fix result capture date inconsistency
 - #1334 Number of analyses are not updated after modifying analyses in a Sample
 - #1319 Make api.get_review_history to always return a list
 - #1317 Fix Analysis Service URL in Info Popup

--- a/bika/lims/browser/workflow/analysis.py
+++ b/bika/lims/browser/workflow/analysis.py
@@ -102,10 +102,12 @@ class WorkflowActionSubmitAdapter(WorkflowActionGenericAdapter):
             hidden = self.get_form_value("Hidden", uid, "")
             analysis.setHidden(hidden == "on")
 
-            # Result
+            # Only set result if it differs from the actual value to preserve
+            # the result capture date
             result = self.get_form_value("Result", uid,
                                          default=analysis.getResult())
-            analysis.setResult(result)
+            if result != analysis.getResult():
+                analysis.setResult(result)
 
         # Submit all analyses
         transitioned = self.do_action(action, objects)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the inconsistency of the result capture date between the saved value and the submitted value.

## Current behavior before PR

The submitted value overrides the capture date of the saved value

## Desired behavior after PR is merged

The result capture date is kept to the date when the system received the result for the first time

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
