### PR TITLE
Fix Auditlog for removed objects

### DIFF
--- a/bika/lims/api/snapshot.py
+++ b/bika/lims/api/snapshot.py
@@ -305,7 +305,7 @@ def take_snapshot(obj, store=True, **kw):
 
     # return immediately
     if not store:
-        return snapshot
+        return data
 
     # get the snapshot storage
     storage = get_storage(obj)

--- a/bika/lims/api/snapshot.py
+++ b/bika/lims/api/snapshot.py
@@ -305,7 +305,7 @@ def take_snapshot(obj, store=True, **kw):
 
     # return immediately
     if not store:
-        return data
+        return snapshot
 
     # get the snapshot storage
     storage = get_storage(obj)

--- a/bika/lims/api/snapshot.py
+++ b/bika/lims/api/snapshot.py
@@ -26,6 +26,7 @@ from bika.lims import logger
 from bika.lims.api.security import get_roles
 from bika.lims.api.security import get_user_id
 from bika.lims.interfaces import IAuditable
+from bika.lims.interfaces import IDoNotSupportSnapshots
 from DateTime import DateTime
 from persistent.list import PersistentList
 from plone.memoize.ram import cache
@@ -54,6 +55,8 @@ def supports_snapshots(obj):
     :param obj: Content object
     :returns: True/False
     """
+    if IDoNotSupportSnapshots.providedBy(obj):
+        return False
     return IAnnotatable.providedBy(obj)
 
 

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -38,6 +38,11 @@ class IAuditable(Interface):
     """
 
 
+class IDoNotSupportSnapshots(Interface):
+    """Marker inteface for non-auditable contents
+    """
+
+
 class IAuditLogCatalog(Interface):
     """Audit Log Catalog
     """

--- a/bika/lims/subscribers/auditlog.py
+++ b/bika/lims/subscribers/auditlog.py
@@ -94,8 +94,8 @@ def ObjectInitializedEventHandler(obj, event):
     take_snapshot(obj, action="create")
 
 
-def ObjectWillBeRemovedEventHandler(obj, event):
-    """Object will be removed in a moment
+def ObjectRemovedEventHandler(obj, event):
+    """Object removed
     """
 
     # only snapshot supported objects

--- a/bika/lims/subscribers/auditlog.py
+++ b/bika/lims/subscribers/auditlog.py
@@ -4,7 +4,9 @@ from bika.lims import api
 from bika.lims.api.snapshot import has_snapshots
 from bika.lims.api.snapshot import supports_snapshots
 from bika.lims.api.snapshot import take_snapshot
+from bika.lims.interfaces import IDoNotSupportSnapshots
 from DateTime import DateTime
+from zope.interface import alsoProvides
 
 
 def reindex_object(obj):
@@ -19,6 +21,13 @@ def reindex_object(obj):
     TL;DR: `Products.Archetypes.interfaces.IObjectEditedEvent` is fired after
     `reindexObject()` is called. If you manipulate your content object in a
     handler for this event, you need to manually reindex new values.
+    """
+    auditlog_catalog = api.get_tool("auditlog_catalog")
+    auditlog_catalog.reindexObject(obj)
+
+
+def unindex_object(obj):
+    """Unindex the object in the `auditlog_catalog` catalog
     """
     auditlog_catalog = api.get_tool("auditlog_catalog")
     auditlog_catalog.reindexObject(obj)
@@ -83,3 +92,18 @@ def ObjectInitializedEventHandler(obj, event):
 
     # take a new snapshot
     take_snapshot(obj, action="create")
+
+
+def ObjectWillBeRemovedEventHandler(obj, event):
+    """Object will be removed in a moment
+    """
+
+    # only snapshot supported objects
+    if not supports_snapshots(obj):
+        return
+
+    # unindex the object
+    unindex_object(obj)
+
+    # freeze the object
+    alsoProvides(obj, IDoNotSupportSnapshots)

--- a/bika/lims/subscribers/configure.zcml
+++ b/bika/lims/subscribers/configure.zcml
@@ -25,11 +25,11 @@
       handler=".auditlog.ObjectTransitionedEventHandler"
       />
 
-  <!-- Audit Log: Object will be removed Event -->
+  <!-- Audit Log: Object removed Event -->
   <subscriber
       for="*
-           OFS.interfaces.IObjectWillBeMovedEvent"
-      handler=".auditlog.ObjectWillBeRemovedEventHandler"
+           zope.lifecycleevent.interfaces.IObjectRemovedEvent"
+      handler=".auditlog.ObjectRemovedEventHandler"
       />
 
   <!-- Newly created analyses -->

--- a/bika/lims/subscribers/configure.zcml
+++ b/bika/lims/subscribers/configure.zcml
@@ -25,6 +25,13 @@
       handler=".auditlog.ObjectTransitionedEventHandler"
       />
 
+  <!-- Audit Log: Object will be removed Event -->
+  <subscriber
+      for="*
+           OFS.interfaces.IObjectWillBeMovedEvent"
+      handler=".auditlog.ObjectWillBeRemovedEventHandler"
+      />
+
   <!-- Newly created analyses -->
   <subscriber
       for="*


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR unindexes objects which will be removed, e.g. Worksheets.

The issue with WS deletion is that it is done in a WF transitions, which fires an event handler which creates and indexes the object in the auditlog catalog.

## Current behavior before PR

Auditlog catalog contains orphaned objects after a WS was removed 

## Desired behavior after PR is merged

Auditlog catalog contains no orphaned objects after a WS was removed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
