### PR TITLE
Handle inline images in Results Interpretation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Changelog
 
 **Fixed**
 
+- #1344 Handle inline images in Results Interpretation
 - #1336 Fix result capture date inconsistency
 - #1334 Number of analyses are not updated after modifying analyses in a Sample
 - #1319 Make api.get_review_history to always return a list

--- a/bika/lims/browser/analysisrequest/resultsinterpretation.py
+++ b/bika/lims/browser/analysisrequest/resultsinterpretation.py
@@ -18,9 +18,6 @@
 # Copyright 2018-2019 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-import re
-import base64
-
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
@@ -31,8 +28,6 @@ from plone.app.textfield import RichTextValue
 from Products.Archetypes.event import ObjectEditedEvent
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope import event
-
-IMG_DATA_RX = re.compile(r'<img alt="" src="(data:image/.*;base64,)(.*?)" />')
 
 
 class ARResultsInterpretationView(BrowserView):
@@ -57,7 +52,7 @@ class ARResultsInterpretationView(BrowserView):
         protect.CheckAuthenticator(self.request)
         logger.info("Handle ResultsInterpration Submit")
         # Save the results interpretation
-        res = self.get_resultinterpretations()
+        res = self.request.form.get("ResultsInterpretationDepts", [])
         self.context.setResultsInterpretationDepts(res)
         self.add_status_message(_("Changes Saved"), level="info")
         # reindex the object after save to update all catalog metadata
@@ -65,67 +60,6 @@ class ARResultsInterpretationView(BrowserView):
         # notify object edited event
         event.notify(ObjectEditedEvent(self.context))
         return self.request.response.redirect(api.get_url(self.context))
-
-    def get_resultinterpretations(self):
-        """Return the result interpretations for each department
-        """
-        out = []
-        items = self.request.form.get("ResultsInterpretationDepts", [])
-        for item in items:
-            # Handle inline images in the HTML
-            richtext = self.convert_inline_images(item.get("richtext", ""))
-            # N.B. we get here a ZPublisher record. Converting to dict ensures
-            #      we can set values as well.
-            data = dict(item)
-            data["richtext"] = richtext
-            out.append(data)
-        return out
-
-    def convert_inline_images(self, html):
-        """Converts inline images in the HTML to attachments
-
-        Inline images can be added by FireFox and look like this in HTML:
-        <img alt="" src="data:image/png;base64,<BASE64_ENCODED_IMAGE>"/>
-
-        Also see: https://github.com/senaite/senaite.core/issues/1333
-        """
-        images = re.findall(IMG_DATA_RX, html)
-        if images:
-            count = len(images)
-            # found inline images, convert to Attachments
-            logger.info("Converting {} inline images to attachments for {}"
-                        .format(count, api.get_path(self.context)))
-            for group in images:
-                data_type = group[0]
-                data = group[1]
-                filedata = base64.decodestring(data)
-                filename = _("Results Interpretation")
-                attachment = self.add_attachment(filedata, filename)
-                # remove the image data base64 prefix
-                html = html.replace(data_type, "", 1)
-                # remove the base64 image data with the attachment URL
-                html = html.replace(data, "{}/AttachmentFile".format(
-                    attachment.absolute_url()))
-            self.add_status_message(
-                _("Converted {} inline image(s) to attachment files".
-                  format(count)), level="info")
-        return html
-
-    def add_attachment(self, filedata, filename=""):
-        """Add a new attachment
-        """
-        # Add a new Attachment
-        client = self.context.getClient()
-        attachment = api.create(client, "Attachment")
-        # Ignore in report
-        attachment.setReportOption("i")
-        attachment.setAttachmentFile(filedata)
-        fileobj = attachment.getAttachmentFile()
-        fileobj.filename = filename
-        self.context.addAttachment(attachment)
-        attachment.processForm()
-        self.context.reindexObject()
-        return attachment
 
     def add_status_message(self, message, level="info"):
         """Set a portal status message

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -117,7 +117,7 @@ from zope.interface import alsoProvides
 from zope.interface import implements
 from zope.interface import noLongerProvides
 
-IMG_DATA_RX = re.compile(r'<img alt="" src="(data:image/.*;base64,)(.*?)" />')
+IMG_DATA_RX = re.compile(r'<img.*?src="(data:image/.*;base64,)(.*?)" />')
 
 
 # SCHEMA DEFINITION
@@ -2464,7 +2464,7 @@ class AnalysisRequest(BaseFolder):
                 # Ignore in report
                 attachment.setReportOption("i")
                 # remove the image data base64 prefix
-                html = html.replace(data_type, "", 1)
+                html = html.replace(data_type, "")
                 # remove the base64 image data with the attachment URL
                 html = html.replace(data, "{}/AttachmentFile".format(
                     attachment.absolute_url()))

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -117,7 +117,7 @@ from zope.interface import alsoProvides
 from zope.interface import implements
 from zope.interface import noLongerProvides
 
-IMG_DATA_RX = re.compile(r'<img.*?src="(data:image/.*;base64,)(.*?)" />')
+IMG_DATA_RX = re.compile(r'<img.*?src="(data:image/.*;base64,)(.*?)".*?/>')
 
 
 # SCHEMA DEFINITION

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -22,7 +22,7 @@ import base64
 import re
 import sys
 from decimal import Decimal
-from urllib.parse import urljoin
+from urlparse import urljoin
 
 from AccessControl import ClassSecurityInfo
 from bika.lims import api

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2450,6 +2450,8 @@ class AnalysisRequest(BaseFolder):
             inline_images = re.findall(IMG_DATA_RX, html)
             # convert to inline images -> attachments
             for data_type, data in inline_images:
+                logger.info("Converting inline image to Attachment for {}"
+                            .format(api.get_path(self)))
                 filedata = base64.decodestring(data)
                 filename = _("Results Interpretation")
                 attachment = self.createAttachment(filedata, filename)

--- a/bika/lims/upgrade/v01_03_001.py
+++ b/bika/lims/upgrade/v01_03_001.py
@@ -74,6 +74,10 @@ def upgrade(tool):
     setup.runImportStepFromProfile(profile, "toolset")
     setup.runImportStepFromProfile(profile, "content")
 
+    # Convert inline images
+    # https://github.com/senaite/senaite.core/issues/1333
+    convert_inline_images_to_attachments(portal)
+
     # https://github.com/senaite/senaite.core/pull/1324
     # initialize auditlogging
     setup_auditlog_catalog(portal)
@@ -90,6 +94,18 @@ def upgrade(tool):
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
+
+
+def convert_inline_images_to_attachments(portal):
+    """Convert base64 inline images to attachments
+    """
+    catalog = api.get_tool("uid_catalog")
+    samples = catalog({"portal_type": "AnalysisRequest"})
+    for sample in samples:
+        obj = api.get_object(sample)
+        # get/set the resultsinterpretations
+        ri = obj.getResultsInterpretationDepts()
+        obj.setResultsInterpretationDepts(ri)
 
 
 def init_auditlog(portal):

--- a/bika/lims/upgrade/v01_03_001.py
+++ b/bika/lims/upgrade/v01_03_001.py
@@ -106,12 +106,16 @@ def convert_inline_images_to_attachments(portal):
                 "for inline base64 images...".format(total))
     for num, brain in enumerate(brains):
         if num and num % 1000 == 0:
+            transaction.commit()
             logger.info("{}/{} samples processed"
                         .format(num, total))
         obj = api.get_object(brain)
         # get/set the resultsinterpretations
         ri = obj.getResultsInterpretationDepts()
         obj.setResultsInterpretationDepts(ri)
+
+    # Commit all changes
+    transaction.commit()
 
 
 def init_auditlog(portal):

--- a/bika/lims/upgrade/v01_03_001.py
+++ b/bika/lims/upgrade/v01_03_001.py
@@ -100,9 +100,15 @@ def convert_inline_images_to_attachments(portal):
     """Convert base64 inline images to attachments
     """
     catalog = api.get_tool("uid_catalog")
-    samples = catalog({"portal_type": "AnalysisRequest"})
-    for sample in samples:
-        obj = api.get_object(sample)
+    brains = catalog({"portal_type": "AnalysisRequest"})
+    total = len(brains)
+    logger.info("Checking result interpretations of {} samples "
+                "for inline base64 images...".format(total))
+    for num, brain in enumerate(brains):
+        if num and num % 1000 == 0:
+            logger.info("{}/{} samples processed"
+                        .format(num, total))
+        obj = api.get_object(brain)
         # get/set the resultsinterpretations
         ri = obj.getResultsInterpretationDepts()
         obj.setResultsInterpretationDepts(ri)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1333

## Current behavior before PR

FireFox creates inline images in results interpretations, which will grow the size of the object and the snapshots

## Desired behavior after PR is merged

Inline images in resultsinterpretations are converted to attachments during save

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
