### PR TITLE
Consider laboratory workdays only for the late analyses calculation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1347 Consider laboratory workdays only for the late analyses calculation
 - #1324 Audit Log
 
 **Changed**

--- a/bika/lims/config.py
+++ b/bika/lims/config.py
@@ -103,6 +103,16 @@ QCANALYSIS_TYPES = DisplayList((
     ('d', _('Duplicate QC analyses'))
 ))
 
+WEEKDAYS = DisplayList((
+    ('0', _('Monday')),
+    ('1', _('Tuesday')),
+    ('2', _('Wednesday')),
+    ('3', _('Thursday')),
+    ('4', _('Friday')),
+    ('5', _('Saturday')),
+    ('6', _('Sunday')),
+))
+
 currencies = locales.getLocale('en').numbers.currencies.values()
 currencies.sort(lambda x, y: cmp(x.displayName, y.displayName))
 

--- a/bika/lims/content/abstractroutineanalysis.py
+++ b/bika/lims/content/abstractroutineanalysis.py
@@ -313,12 +313,17 @@ class AbstractRoutineAnalysis(AbstractAnalysis):
         if delta.days == 0:
             return end
 
-        # calculate the due date, but consider for the days only working days
-        due = end - delta.days
-
         # get the laboratory workdays
         setup = api.get_setup()
         workdays = setup.getWorkdays()
+
+        # every day is a workday, no need for calculation
+        if workdays == tuple(map(str, range(7))):
+            return end
+
+        # reset the due date to the received date, and add only for configured
+        # workdays another day
+        due = end - delta.days
 
         days = 0
         while days < delta.days:

--- a/bika/lims/content/abstractroutineanalysis.py
+++ b/bika/lims/content/abstractroutineanalysis.py
@@ -323,18 +323,18 @@ class AbstractRoutineAnalysis(AbstractAnalysis):
 
         # reset the due date to the received date, and add only for configured
         # workdays another day
-        due = end - delta.days
+        due_date = end - delta.days
 
         days = 0
         while days < delta.days:
             # add one day to the new due date
-            due += 1
+            due_date += 1
             # skip if the weekday is a non working day
-            if due.asdatetime().weekday() not in workdays:
+            if str(due_date.asdatetime().weekday()) not in workdays:
                 continue
             days += 1
 
-        return due
+        return due_date
 
     @security.public
     def getSampleType(self):

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -550,7 +550,7 @@ schema = BikaFolderSchema.copy() + Schema((
         "Workdays",
         schemata="Sampling",
         vocabulary=WEEKDAYS,
-        default=tuple(map(str, range(5))),
+        default=tuple(map(str, range(7))),
         required=1,
         widget=InAndOutWidget(
             visible=True,

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -30,6 +30,7 @@ from Products.Archetypes.atapi import IntegerField
 from Products.Archetypes.atapi import IntegerWidget
 from Products.Archetypes.atapi import LinesField
 from Products.Archetypes.atapi import MultiSelectionWidget
+from Products.Archetypes.atapi import InAndOutWidget
 from Products.Archetypes.atapi import ReferenceField
 from Products.Archetypes.atapi import Schema
 from Products.Archetypes.atapi import SelectionWidget
@@ -48,6 +49,7 @@ from bika.lims.browser.widgets import RejectionSetupWidget
 from bika.lims.config import ARIMPORT_OPTIONS
 from bika.lims.config import ATTACHMENT_OPTIONS
 from bika.lims.config import CURRENCIES
+from bika.lims.config import WEEKDAYS
 from bika.lims.config import DECIMAL_MARKS
 from bika.lims.config import MULTI_VERIFICATION_TYPE
 from bika.lims.config import PROJECTNAME
@@ -544,6 +546,20 @@ schema = BikaFolderSchema.copy() + Schema((
             description=_("")
         ),
     ),
+    LinesField(
+        "Workdays",
+        schemata="Sampling",
+        vocabulary=WEEKDAYS,
+        default=tuple(map(str, range(5))),
+        required=1,
+        widget=InAndOutWidget(
+            visible=True,
+            label=_("Laboratory Workdays"),
+            description=_("Only laboratory workdays are considered for the "
+                          "analysis turnaround time calculation. "),
+            format="checkbox",
+        )
+    ),
     DurationField(
         'DefaultTurnaroundTime',
         schemata="Sampling",
@@ -554,7 +570,9 @@ schema = BikaFolderSchema.copy() + Schema((
             description=_(
                 "This is the default maximum time allowed for performing "
                 "analyses.  It is only used for analyses where the analysis "
-                "service does not specify a turnaround time."),
+                "service does not specify a turnaround time. "
+                "Only laboratory workdays are considered."
+            ),
         )
     ),
     DurationField(


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Currently the lab manager can specify a turnaround time for analyses as a record of **days**, **hours** and **minutes**:

<img width="832" alt="Setup — SENAITE 2019-04-28 13-26-39" src="https://user-images.githubusercontent.com/713193/56863638-44769880-69b9-11e9-8ee4-e68f9046d71b.png">

However, the calculation when the Analysis Request should be considered as "late" counts every day after the sample was received and does not consider non-workdays of the laboratory.

With this PR the lab manager can configure the laboratory workdays in the setup:

<img width="548" alt="" src="https://user-images.githubusercontent.com/713193/56863676-c1a20d80-69b9-11e9-8841-e2029b06f8c5.png">

Only these workdays are then considered for the late analyses calculation.

## Current behavior before PR

Every weekday was considered in the calculation for late analyses

## Desired behavior after PR is merged

Only configured weekdays are considered in the calculation for late analyses.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
