### PR TITLE
Skip Reference Types in Upgrade step

### DIFF
--- a/bika/lims/upgrade/v01_03_001.py
+++ b/bika/lims/upgrade/v01_03_001.py
@@ -262,6 +262,7 @@ def commit_transaction(portal):
     logger.info("Commit transaction ... Took {:.2f}s [DONE]"
                 .format(end - start))
 
+
 def reindex_sortable_title(portal):
     """Reindex sortable_title from some catalogs
     """

--- a/bika/lims/upgrade/v01_03_001.py
+++ b/bika/lims/upgrade/v01_03_001.py
@@ -50,6 +50,7 @@ SKIP_TYPES_FOR_AUDIT_LOG = [
     "Sample",
     "SamplePartition",
     "ARReport",
+    "Reference",
 ]
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The `uid_catalog` holds not only UIDs of regular portal types, but also reference objects (`HoldingReference`). In fact, these references are the reason why the UID catalog exists at all.

Therefore, much more objects are inside the `uid_catalog` as actual visible contents exist.

## Current behavior before PR

Although reference objects do not support snapshots, these objects were waked up in the upgrade step.

## Desired behavior after PR is merged

Reference objects are skipped in brain-state in upgrade step

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
