### PR TITLE
Make timeit() to not display args by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Changelog
 
 **Changed**
 
+- #1352 Make timeit to not display args by default
 - #1330 Make guards to not rely on review history
 
 **Removed**

--- a/bika/lims/decorators.py
+++ b/bika/lims/decorators.py
@@ -112,7 +112,7 @@ def profileit(path=None):
     return inner
 
 
-def timeit(threshold=0):
+def timeit(threshold=0, show_args=False):
     """Decorator to log the execution time of a function
     """
 
@@ -124,8 +124,12 @@ def timeit(threshold=0):
             end = time.time()
             duration = float(end-start)
             if duration > threshold:
-                logger.info("Execution of '{}{}' took {:2f}s".format(
-                    func.__name__, args, duration))
+                if show_args:
+                    logger.info("Execution of '{}{}' took {:2f}s".format(
+                        func.__name__, args, duration))
+                else:
+                    logger.info("Execution of '{}' took {:2f}s".format(
+                        func.__name__, duration))
             return return_value
         return wrapper
     return inner


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

timeit decorator was displaying the representation of args in the log. Although in some cases this might be useful, in most cases, is not desirable, especially when args are tuples, lists or dicts.

An additional attribute `show_args` has been added.

## Current behavior before PR

```
INFO senaite.core Execution of 'get_ar_uids(<my.lims.browser.reports.productivity_resultsbyclient.Report object at 0x7ff8693b54d0>, [<Products.ZCatalog.Catalog.mybrains object at 0x7ff83b34a460>, <Products.ZCatalog.Catalog.mybrains object at 0x7ff83b34adb8>, <Products.ZCatalog.Catalog.mybrains object at 0x7ff83b34ae20>, <Products.ZCatalog.Catalog.mybrains object at 0x7ff83b34ae88>])' took 2.748781s
````

## Desired behavior after PR is merged

```
INFO senaite.core Execution of 'get_ar_uids' took 2.748781s
````
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
