### PR TITLE
 Use id in api.get_id if a brain and id attribute is present

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Changelog
 
 **Changed**
 
+- #1355 Make api.getId to also consider id metadata column (not only getId)
 - #1352 Make timeit to not display args by default
 - #1330 Make guards to not rely on review history
 

--- a/bika/lims/api/__init__.py
+++ b/bika/lims/api/__init__.py
@@ -357,8 +357,11 @@ def get_id(brain_or_object):
     :returns: Plone ID
     :rtype: string
     """
-    if is_brain(brain_or_object) and base_hasattr(brain_or_object, "getId"):
-        return brain_or_object.getId
+    if is_brain(brain_or_object):
+        if base_hasattr(brain_or_object, "getId"):
+            return brain_or_object.getId
+        if base_hasattr(brain_or_object, "id"):
+            return brain_or_object.id
     return get_object(brain_or_object).getId()
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The api's function relies on "getId" metadata only atm. Nevertheless, `uid_catalog` is oftenly used to retrieve brains and this catalog does not contain the metadata column getId. One option would be to add this same column in `uid_catalog`, but since `getId` is a function that overrides `Plone.Archetypes.BaseObject.getId`, that in turn does `return self.id`, we can assume that `getId` will always return the same value as `id`:

https://github.com/plone/Products.Archetypes/blob/b73976f4f8ce8e8c814a89e849350c3a912aa428/Products/Archetypes/BaseObject.py#L199-L201

The motivation of this change is that when a huge database is used and the id formatting for a given content type (say `AnalysisRequest`) is changed, the reseed of the id causes the instance to wake-up all objects stored:

https://github.com/senaite/senaite.core/blob/954575059f7c4c652ab2ff56bc7015332580075f/bika/lims/idserver.py#L353-L358

Note `get_ids_by_prefix` relies on `search_by_prefix`, that does the search against `uid_catalog` and also calls `api.getId`:

https://github.com/senaite/senaite.core/blob/954575059f7c4c652ab2ff56bc7015332580075f/bika/lims/idserver.py#L344-L350

This happens when this is called:

https://github.com/senaite/senaite.core/blob/master/bika/lims/idserver.py#L457

If the amount of objects is ~100k or more, it means that the instance gets freezed and the RAM consumption easily increases to values between 8G and 10G. Of course, this causes a huge footprint on performance.

With this change, the system behaves faster in this scenario and the RAM is kept under control to a reasonable value of ~4G max (db with >1M objects).

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
