### PR TITLE
Fixed issue with Analysis and Publication Spec on ARs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ Changelog
 - #1319 Make api.get_review_history to always return a list
 - #1317 Fix Analysis Service URL in Info Popup
 - #1316 Barcodes view does not render all labels once Samples are registered
+- #1356 Fixed selection on Analysis Spec on AR
+- #1353 Fixed saving of PublicationSpecification on AR
 
 
 **Security**

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -710,6 +710,7 @@ schema = BikaSchema.copy() + Schema((
                 # UID is required in colModel
                 {'columnName': 'UID', 'hidden': True},
             ],
+            ui_item="contextual_title",
             showOn=True,
         ),
     ),
@@ -1444,11 +1445,6 @@ class AnalysisRequest(BaseFolder):
 
     def getProfilesTitle(self):
         return [profile.Title() for profile in self.getProfiles()]
-
-    def setPublicationSpecification(self, value):
-        """Never contains a value; this field is here for the UI." \
-        """
-        return value
 
     def getAnalysisService(self):
         proxies = self.getAnalyses(full_objects=False)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
Linked issue: https://github.com/senaite/senaite.core/issues/1353
Linked issue: https://github.com/senaite/senaite.core/issues/1356

## Current behavior before PR
Analysis Spec field is not populated with the selected value
Publication Spec value is not saved

## Desired behavior after PR is merged
Analysis Spec field is populated with the selected value
Publication Spec value is saved

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
