### PR TITLE
Fixed icons for lab contacts

### DIFF
--- a/bika/lims/profiles/default/controlpanel.xml
+++ b/bika/lims/profiles/default/controlpanel.xml
@@ -32,7 +32,7 @@
 
  <configlet title="Lab Contacts" action_id="bika_labcontacts"
     appId="bika.lims" category="bika" condition_expr=""
-    icon_expr="string:++resource++bika.lims.images/lab_contact.png"
+    icon_expr="string:++resource++bika.lims.images/labcontact.png"
     url_expr="string:$portal_url/bika_setup/bika_labcontacts"
     visible="True"
     i18n:attributes="title">

--- a/bika/lims/profiles/default/types/Department.xml
+++ b/bika/lims/profiles/default/types/Department.xml
@@ -48,7 +48,7 @@
          action_id="labcontacts"
          category="object"
          condition_expr=""
-         icon_expr="string:${portal_url}/images/lab_contact.png"
+         icon_expr="string:${portal_url}/images/labcontact.png"
          url_expr="string:${object_url}/labcontacts"
          i18n:attributes="title"
          i18n:domain="plone"

--- a/bika/lims/profiles/default/types/LabContacts.xml
+++ b/bika/lims/profiles/default/types/LabContacts.xml
@@ -6,7 +6,7 @@
         purge="True">
  <property name="title" i18n:translate="">Lab Contacts</property>
  <property name="description"></property>
- <property name="content_icon">++resource++bika.lims.images/lab_contact.png</property>
+ <property name="content_icon">++resource++bika.lims.images/labcontact.png</property>
  <property name="content_meta_type">LabContacts</property>
  <property name="product">bika.lims</property>
  <property name="factory">addLabContacts</property>

--- a/bika/lims/upgrade/v01_03_001.py
+++ b/bika/lims/upgrade/v01_03_001.py
@@ -74,6 +74,7 @@ def upgrade(tool):
     setup.runImportStepFromProfile(profile, "typeinfo")
     setup.runImportStepFromProfile(profile, "toolset")
     setup.runImportStepFromProfile(profile, "content")
+    setup.runImportStepFromProfile(profile, "controlpanel")
 
     # Convert inline images
     # https://github.com/senaite/senaite.core/issues/1333


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the typeinfo and controlpanel configs to match the changed labcontact icon

## Current behavior before PR

No icon displayed for labcontacts controlpanel

## Desired behavior after PR is merged

Icon displayed for labcontacts controlpanel

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
