### PR TITLE
Fix leap sample ID sequence after secondary sample

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Changelog
 
 **Fixed**
 
+- #1361 Fix leap sample ID sequence after secondary sample
 - #1344 Handle inline images in Results Interpretation
 - #1336 Fix result capture date inconsistency
 - #1334 Number of analyses are not updated after modifying analyses in a Sample

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -1411,6 +1411,13 @@ class AnalysisRequest(BaseFolder):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
+        """Rename hook called by processForm
+        """
+        # https://github.com/senaite/senaite.core/issues/1327
+        primary = self.getPrimaryAnalysisRequest()
+        if primary:
+            logger.info("Secondary sample detected: Skipping ID generation")
+            return False
         from bika.lims.idserver import renameAfterCreation
         renameAfterCreation(self)
 

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -150,6 +150,7 @@ def get_partition_count(context, default=0):
 
     return len(parent.getDescendants())
 
+
 def get_secondary_count(context, default=0):
     """Returns the number of secondary ARs of this AR
     """
@@ -529,10 +530,6 @@ def generateUniqueId(context, **kw):
 def renameAfterCreation(obj):
     """Rename the content after it was created/added
     """
-    # Check if the _bika_id was already set
-    bika_id = getattr(obj, "_bika_id", None)
-    if bika_id is not None:
-        return bika_id
     # Can't rename without a subtransaction commit when using portal_factory
     transaction.savepoint(optimistic=True)
     # The id returned should be normalized already


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1327

## Current behavior before PR

Leap sample ID sequence after secondary samples

## Desired behavior after PR is merged

Consecutive ID sequence after secondary samples

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
