### PR TITLE
Remove unnecessary code from worksheet listing that slows down the rendering

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,6 @@ Changelog
 
 **Added**
 
-- #1362 Faster worksheet listing
 - #1347 Consider laboratory workdays only for the late analyses calculation
 - #1324 Audit Log
 
@@ -18,6 +17,7 @@ Changelog
 
 **Removed**
 
+- #1362 Remove unnecessary code from worksheet listing (bad performance)
 - #1346 Remove Searchable Text Overrides
 - #1328 Remove transition filtering in Worksheet listings
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1362 Faster worksheet listing
 - #1347 Consider laboratory workdays only for the late analyses calculation
 - #1324 Audit Log
 

--- a/bika/lims/browser/worksheet/views/folder.py
+++ b/bika/lims/browser/worksheet/views/folder.py
@@ -296,32 +296,17 @@ class FolderView(BikaListingView):
         :index: current index of the item
         """
 
-        layout = obj.getLayout
         title = api.get_title(obj)
         url = api.get_url(obj)
 
         item["CreationDate"] = self.ulocalized_time(obj.created)
-        if len(obj.getAnalysesUIDs) == 0:
-            item["table_row_class"] = "state-empty-worksheet"
 
         title_link = "{}/{}".format(url, "add_analyses")
-        if len(layout) > 0:
+        if len(obj.getAnalysesUIDs) > 0:
             title_link = "{}/{}".format(url, "manage_results")
 
         item["Title"] = title
         item["replace"]["Title"] = get_link(title_link, value=title)
-
-        pos_parent = {}
-        for slot in layout:
-            # compensate for bad data caused by a stupid bug.
-            if type(slot["position"]) in (list, tuple):
-                slot["position"] = slot["position"][0]
-            if slot["position"] == "new":
-                continue
-            if slot["position"] in pos_parent:
-                continue
-            pos_parent[slot["position"]] =\
-                self.rc.lookupObject(slot.get("container_uid"))
 
         # Total QC Analyses
         item["NumQCAnalyses"] = str(obj.getNumberOfQCAnalyses)

--- a/bika/lims/catalog/worksheet_catalog.py
+++ b/bika/lims/catalog/worksheet_catalog.py
@@ -44,8 +44,6 @@ _columns_list = [
     'getWorksheetTemplateTitle',
     'getWorksheetTemplateURL',
     'getAnalysesUIDs',
-    # TODO-catalog: getLayout returns a dictionary, too big?
-    'getLayout',
     # Only used to list
     'getNumberOfQCAnalyses',
     'getNumberOfRegularAnalyses',

--- a/bika/lims/upgrade/v01_03_001.py
+++ b/bika/lims/upgrade/v01_03_001.py
@@ -31,6 +31,7 @@ from bika.lims.api.snapshot import take_snapshot
 from bika.lims.catalog.analysis_catalog import CATALOG_ANALYSIS_LISTING
 from bika.lims.catalog.analysisrequest_catalog import \
     CATALOG_ANALYSIS_REQUEST_LISTING
+from bika.lims.catalog.worksheet_catalog import CATALOG_WORKSHEET_LISTING
 from bika.lims.config import PROJECTNAME as product
 from bika.lims.interfaces import IReceived
 from bika.lims.interfaces import ISubmitted
@@ -92,6 +93,10 @@ def upgrade(tool):
     # Reindex sortable_title to make sorting case-insenstive
     # https://github.com/senaite/senaite.core/pull/1337
     reindex_sortable_title(portal)
+
+    # Remove unnecessary indexes/metadata from worksheet catalog
+    # https://github.com/senaite/senaite.core/pull/1362
+    cleanup_worksheet_catalog(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
@@ -277,3 +282,48 @@ def reindex_sortable_title(portal):
         catalog = api.get_tool(catalog_name)
         catalog.reindexIndex("sortable_title", None, pghandler=handler)
         commit_transaction(portal)
+
+def cleanup_worksheet_catalog(portal):
+    """Removes stale indexes and metadata from worksheet_catalog.
+    """
+    cat_id = CATALOG_WORKSHEET_LISTING
+    logger.info("Cleaning up indexes and metadata from {} ...".format(cat_id))
+    indexes_to_remove = [
+    ]
+    metadata_to_remove = [
+        "getLayout",
+    ]
+    for index in indexes_to_remove:
+        del_index(portal, cat_id, index)
+
+    for metadata in metadata_to_remove:
+        del_metadata(portal, cat_id, metadata)
+    commit_transaction(portal)
+
+
+def del_index(portal, catalog_id, index_name):
+    logger.info("Removing '{}' index from '{}' ..."
+                .format(index_name, catalog_id))
+    catalog = api.get_tool(catalog_id)
+    if index_name not in catalog.indexes():
+        logger.info("Index '{}' not in catalog '{}' [SKIP]"
+                    .format(index_name, catalog_id))
+        return
+    catalog.delIndex(index_name)
+    logger.info("Removing old index '{}' ...".format(index_name))
+
+
+def del_metadata(portal, catalog_id, column, refresh_catalog=False):
+    logger.info("Removing '{}' metadata from '{}' ..."
+                .format(column, catalog_id))
+    catalog = api.get_tool(catalog_id)
+    if column not in catalog.schema():
+        logger.info("Metadata '{}' not in catalog '{}' [SKIP]"
+                    .format(column, catalog_id))
+        return
+    catalog.delColumn(column)
+
+    if refresh_catalog:
+        logger.info("Refreshing catalog '{}' ...".format(catalog_id))
+        handler = ZLogHandler(steps=100)
+        catalog.refreshCatalog(pghandler=handler)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This pull request removes some stale code that had a big impact on performance regarding worksheet list. The stale code was inspecting the analyses included in worksheets and eventually wake up the container, mostly `AnalysisRequest` objects.

## Current behavior before PR

Worksheet listing is slow

## Desired behavior after PR is merged

List of worksheet is rendered almost immediately

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
