### PR TITLE
Fix Traceback on the ID Server Seeding View

### DIFF
--- a/bika/lims/browser/idserver/templates/numbergenerator.pt
+++ b/bika/lims/browser/idserver/templates/numbergenerator.pt
@@ -33,38 +33,45 @@
           <div class="field form-group field"
                tal:define="value python:view.storage[key]">
 
-            <label class="form-control-label">
+            <label for="number">
               <span i18n:translate="">Key</span>:
-              <span tal:content="key"/>
+              <span class="text-primary" tal:content="key"/>
             </label>
 
-            <div class="form-group input-group">
+            <div class="input-group col-sm-6">
+              <span class="input-group-addon">seq:</span>
+              <input type="number"
+                     class="form-control"
+                     tal:attributes="name string:seeds.${key}:record;
+                                     value value"/>
               <input type="hidden"
                      tal:attributes="name string:seeds.${key}:record;
                                      value key"/>
-              <input type="number"
-                     tal:attributes="name string:seeds.${key}:record;
-                                     value value"/>
-              <span class="label label-info">
-                Next ID is <span tal:content="python:view.get_next_id_for(key)"/>
-              </span>
             </div>
+
+            <div class="help-block">
+              <span i18n:translate="">ID Template</span>:
+              <code tal:content="python:view.get_id_template_for(key)"/>
+            </div>
+
 
           </div>
         </tal:numbers>
 
 
-        <input class="btn btn-warn btn-sm allowMultiSubmit"
+        <input class="btn btn-primary btn-sm allowMultiSubmit"
                type="submit"
                name="seed"
                i18n:attributes="value"
                value="Seed"/>
 
-        <input class="btn btn-warning btn-sm allowMultiSubmit"
+        <!-- enable via the dev-tools if you know what you are doing... -->
+        <input class="btn btn-danger btn-sm allowMultiSubmit"
                type="submit"
+               disabled="disabled"
                name="flush"
                i18n:attributes="value"
-               value="Flush"/>
+               value="Reset Numbers"/>
       </form>
 
     </div>

--- a/bika/lims/browser/idserver/view.py
+++ b/bika/lims/browser/idserver/view.py
@@ -18,22 +18,18 @@
 # Copyright 2018-2019 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from Products.Five import BrowserView
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from bika.lims.alphanumber import Alphanumber
-
-from zope.interface import Interface
-from zope.interface import implements
-from zope.component import getUtility
-
-from plone import protect
+import re
 
 from bika.lims import api
-from bika.lims import logger
-from bika.lims.idserver import get_config
-from bika.lims.idserver import get_current_year
 from bika.lims import bikaMessageFactory as _
+from bika.lims.idserver import get_config
 from bika.lims.numbergenerator import INumberGenerator
+from plone import protect
+from Products.Five import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from zope.component import getUtility
+from zope.interface import Interface
+from zope.interface import implements
 
 
 class IIDserverView(Interface):
@@ -90,22 +86,12 @@ class IDServerView(BrowserView):
 
         return self.template()
 
-    def get_next_id_for(self, key):
+    def get_id_template_for(self, key):
         """Get a preview of the next number
         """
         portal_type = key.split("-")[0]
         config = get_config(None, portal_type=portal_type)
-        id_template = config.get("form", "")
-        number = self.storage.get(key) + 1
-        spec = {
-            "seq": number,
-            "alpha": Alphanumber(number),
-            "year": get_current_year(),
-            "parent_analysisrequest": "ParentAR",
-            "parent_ar_id": "ParentARId",
-            "sampleType": key.replace(portal_type, "").strip("-"),
-        }
-        return id_template.format(**spec)
+        return config.get("form", "")
 
     @property
     def storage(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1321

This PR fixes and improves the `/ng` (Manage Number Generator) View

## Current behavior before PR

Traceback on ID Server Seeding View

## Desired behavior after PR is merged

No Traceback on ID Server Seeding View

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
