### PR TITLE
Clients can see interim values of analyses not yet verified

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Changelog
 
 **Fixed**
 
+- #1367 Clients can see interim values of analyses not yet verified
 - #1361 Fix leap sample ID sequence after secondary sample
 - #1344 Handle inline images in Results Interpretation
 - #1336 Fix result capture date inconsistency

--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -770,15 +770,22 @@ class AnalysesView(BikaListingView):
         :param item: analysis' dictionary counterpart that represents a row
         """
 
+        if not self.has_permission(ViewResults, analysis_brain):
+            # Hide interims and calculation if user cannot view results
+            return
+
         is_editable = self.is_analysis_edition_allowed(analysis_brain)
+
         # Set interim fields. Note we add the key 'formatted_value' to the list
         # of interims the analysis has already assigned.
         interim_fields = analysis_brain.getInterimFields or list()
+
         for interim_field in interim_fields:
             interim_keyword = interim_field.get('keyword', '')
             if not interim_keyword:
                 continue
-            interim_value = interim_field.get('value', '')
+
+            interim_value = interim_field.get("value", "")
             interim_formatted = formatDecimalMark(interim_value, self.dmk)
             interim_field['formatted_value'] = interim_formatted
             item[interim_keyword] = interim_field


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The system hiddens the final result of the analysis if the current user is a client contact and the analysis hasn't been yet verified. The same principle was not applied for interim results though.

## Current behavior before PR

Labmanager:

![Captura de 2019-05-15 08-38-21](https://user-images.githubusercontent.com/832627/57753611-df2ae300-76ec-11e9-896c-48a10a23e4e0.png)

Client contact:

![Captura de 2019-05-15 08-42-21](https://user-images.githubusercontent.com/832627/57753815-60827580-76ed-11e9-9f7f-6553088f2a05.png)

## Desired behavior after PR is merged

Client contact:

![Captura de 2019-05-15 08-36-17](https://user-images.githubusercontent.com/832627/57753618-e3570080-76ec-11e9-9b22-f71aff438f2c.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
