### PR TITLE
Fix WF state propagation on partition verification

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Changelog
 
 **Fixed**
 
+- #1368 Fix WF state propagation on partition verification
 - #1361 Fix leap sample ID sequence after secondary sample
 - #1344 Handle inline images in Results Interpretation
 - #1336 Fix result capture date inconsistency

--- a/bika/lims/workflow/analysisrequest/guards.py
+++ b/bika/lims/workflow/analysisrequest/guards.py
@@ -94,11 +94,11 @@ def guard_verify(analysis_request):
     """
     analyses_ready = False
     for analysis in analysis_request.getAnalyses():
+        analysis = api.get_object(analysis)
         analysis_status = api.get_workflow_status_of(analysis)
         if analysis_status in ANALYSIS_DETACHED_STATES:
             continue
         # All analyses must be in verified (or further) status
-        analysis = api.get_object(analysis)
         if not IVerified.providedBy(analysis):
             return False
         analyses_ready = True

--- a/bika/lims/workflow/analysisrequest/guards.py
+++ b/bika/lims/workflow/analysisrequest/guards.py
@@ -97,7 +97,7 @@ def guard_verify(analysis_request):
         analysis_status = api.get_workflow_status_of(analysis)
         if analysis_status in ANALYSIS_DETACHED_STATES:
             continue
-        if analysis_status != 'verified':
+        if analysis_status not in ['verified', 'published']:
             return False
         analyses_ready = True
     return analyses_ready

--- a/bika/lims/workflow/analysisrequest/guards.py
+++ b/bika/lims/workflow/analysisrequest/guards.py
@@ -94,13 +94,13 @@ def guard_verify(analysis_request):
     """
     analyses_ready = False
     for analysis in analysis_request.getAnalyses():
-        analysis = api.get_object(analysis)
-        # All analyses must be in verified (or further) status
-        if not IVerified.providedBy(analysis):
-            return False
         analysis_status = api.get_workflow_status_of(analysis)
         if analysis_status in ANALYSIS_DETACHED_STATES:
             continue
+        # All analyses must be in verified (or further) status
+        analysis = api.get_object(analysis)
+        if not IVerified.providedBy(analysis):
+            return False
         analyses_ready = True
     return analyses_ready
 

--- a/bika/lims/workflow/analysisrequest/guards.py
+++ b/bika/lims/workflow/analysisrequest/guards.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims import api
+from bika.lims.interfaces import IVerified
 from bika.lims.workflow import isTransitionAllowed
 
 # States to be omitted in regular transitions
@@ -94,11 +95,12 @@ def guard_verify(analysis_request):
     analyses_ready = False
     for analysis in analysis_request.getAnalyses():
         analysis = api.get_object(analysis)
+        # All analyses must be in verified (or further) status
+        if not IVerified.providedBy(analysis):
+            return False
         analysis_status = api.get_workflow_status_of(analysis)
         if analysis_status in ANALYSIS_DETACHED_STATES:
             continue
-        if analysis_status not in ['verified', 'published']:
-            return False
         analyses_ready = True
     return analyses_ready
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the WF state propagation on the parent sample in the following setup:

- Sample consists of two partitions
- First sample was verified and published (all Analyses are in `published` state)
- Second sample was verified (all Analyses are in `verified` state)

The guard currently disallows the `verify` transition of **samples**, if not all contained analyses are in the state `verified`.

However, since we allow partitions, the contained Analyses might be partially in the state `published` as well.

## Current behavior before PR

Parent Sample is stuck in the `to_be_verified` state

## Desired behavior after PR is merged

Parent Sample is transitioned to the `verified` state automatically and can be published later explicitly.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
