### PR TITLE
Add getter to access the title of the sample condition directly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1369 Add getter to access the title of the sample condition directly
 - #1347 Consider laboratory workdays only for the late analyses calculation
 - #1324 Audit Log
 

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -1947,6 +1947,15 @@ class AnalysisRequest(BaseFolder):
         return ''
 
     @security.public
+    def getSampleConditionTitle(self):
+        """Helper method to access the title of the sample condition
+        """
+        obj = self.getSampleCondition()
+        if not obj:
+            return ""
+        return api.get_title(obj)
+
+    @security.public
     def getHazardous(self):
         """
         It works as a metacolumn.


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds a simple "Sample Condition Title" getter method to Samples for easy usage as metadata column in Add-ons

## Current behavior before PR

No `getSampleConditionTitle` metadata possible

## Desired behavior after PR is merged

Metadata column `getSampleConditionTitle` possible
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
