### PR TITLE
Allow sample publication without sending Email

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Changelog
 
 **Changed**
 
+- #1371 Allow sample publication without sending Email
 - #1355 Make api.getId to also consider id metadata column (not only getId)
 - #1352 Make timeit to not display args by default
 - #1330 Make guards to not rely on review history

--- a/bika/lims/__init__.py
+++ b/bika/lims/__init__.py
@@ -32,9 +32,11 @@ from Products.CMFCore.permissions import AddPortalContent
 
 PROJECTNAME = "bika.lims"
 
-# import this to create messages in the bika domain.
-bikaMessageFactory = MessageFactory("senaite.core")
-_ = MessageFactory("senaite.core")
+# senaite message factory
+senaiteMessageFactory = MessageFactory("senaite.core")
+# BBB
+bikaMessageFactory = senaiteMessageFactory
+_ = senaiteMessageFactory
 
 # import this to log messages
 logger = logging.getLogger("senaite.core")

--- a/bika/lims/browser/publish/reports_listing.py
+++ b/bika/lims/browser/publish/reports_listing.py
@@ -70,7 +70,7 @@ class ReportsListingView(BikaListingView):
         }
 
         publish_samples_transition = {
-            "id": "publish_samples_samples",
+            "id": "publish_samples",
             "title": _("Publish"),
             # see senaite.core.browser.workflow
             "url": "workflow_action?action=publish_samples",

--- a/bika/lims/browser/publish/reports_listing.py
+++ b/bika/lims/browser/publish/reports_listing.py
@@ -65,14 +65,16 @@ class ReportsListingView(BikaListingView):
         send_email_transition = {
             "id": "send_email",
             "title": _("Email"),
-            "url": "email"
+            "url": "email",
+            "css_class": "btn-primary",
         }
 
         publish_samples_transition = {
-            "id": "publish",
+            "id": "publish_samples_samples",
             "title": _("Publish"),
             # see senaite.core.browser.workflow
             "url": "workflow_action?action=publish_samples",
+            "css_class": "btn-success",
         }
 
         self.columns = collections.OrderedDict((

--- a/bika/lims/browser/publish/reports_listing.py
+++ b/bika/lims/browser/publish/reports_listing.py
@@ -20,13 +20,13 @@
 
 import collections
 
-from bika.lims import bikaMessageFactory as _BMF
-from bika.lims.browser.bika_listing import BikaListingView
-from bika.lims.utils import to_utf8
-from bika.lims.utils import get_link
-from Products.CMFPlone.utils import safe_unicode
 from bika.lims import api
-from bika.lims import _
+from bika.lims import bikaMessageFactory as _BMF
+from bika.lims import senaiteMessageFactory as _
+from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.utils import get_link
+from bika.lims.utils import to_utf8
+from Products.CMFPlone.utils import safe_unicode
 from ZODB.POSException import POSKeyError
 
 
@@ -62,12 +62,21 @@ class ReportsListingView(BikaListingView):
         self.show_workflow_action_buttons = True
         self.pagesize = 30
 
+        help_email_text = _(
+            "Open email form to send the selected reports to the recipients. "
+            "This will also publish the contained samples of the reports "
+            "after the email was successfully sent.")
+
         send_email_transition = {
             "id": "send_email",
             "title": _("Email"),
             "url": "email",
             "css_class": "btn-primary",
+            "help": help_email_text,
         }
+
+        help_publish_text = _(
+            "Manually publish all contained samples of the selected reports.")
 
         publish_samples_transition = {
             "id": "publish_samples",
@@ -75,6 +84,7 @@ class ReportsListingView(BikaListingView):
             # see senaite.core.browser.workflow
             "url": "workflow_action?action=publish_samples",
             "css_class": "btn-success",
+            "help": help_publish_text,
         }
 
         self.columns = collections.OrderedDict((

--- a/bika/lims/browser/publish/reports_listing.py
+++ b/bika/lims/browser/publish/reports_listing.py
@@ -69,7 +69,7 @@ class ReportsListingView(BikaListingView):
         }
 
         publish_samples_transition = {
-            "id": "publish_samples",
+            "id": "publish",
             "title": _("Publish"),
             # see senaite.core.browser.workflow
             "url": "workflow_action?action=publish_samples",

--- a/bika/lims/browser/publish/reports_listing.py
+++ b/bika/lims/browser/publish/reports_listing.py
@@ -68,6 +68,13 @@ class ReportsListingView(BikaListingView):
             "url": "email"
         }
 
+        publish_samples_transition = {
+            "id": "publish_samples",
+            "title": _("Publish"),
+            # see senaite.core.browser.workflow
+            "url": "workflow_action?action=publish_samples",
+        }
+
         self.columns = collections.OrderedDict((
             ("AnalysisRequest", {
                 "title": _("Sample"),
@@ -96,7 +103,10 @@ class ReportsListingView(BikaListingView):
                 "title": "All",
                 "contentFilter": {},
                 "columns": self.columns.keys(),
-                "custom_transitions": [send_email_transition]
+                "custom_transitions": [
+                    send_email_transition,
+                    publish_samples_transition,
+                ]
             },
         ]
 

--- a/bika/lims/browser/workflow/client.py
+++ b/bika/lims/browser/workflow/client.py
@@ -38,9 +38,13 @@ class WorkflowActionPublishSamplesAdapter(RequestContextAware):
         if published:
             message = _("Published {}".format(
                 ", ".join(map(api.get_id, published))))
+
+        # add the status message for the response
         self.add_status_message(message, "info")
 
-        return self.redirect(redirect_url=self.back_url)
+        # redirect back
+        referer = self.request.get_header("referer")
+        return self.redirect(redirect_url=referer)
 
     def get_sample_uids_in_report(self, report):
         """Return a list of contained sample UIDs

--- a/bika/lims/browser/workflow/client.py
+++ b/bika/lims/browser/workflow/client.py
@@ -6,7 +6,7 @@ from bika.lims import _
 from bika.lims import api
 from bika.lims.browser.workflow import RequestContextAware
 from bika.lims.interfaces import IWorkflowActionUIDsAdapter
-from bika.lims.workflow import wf
+from bika.lims.workflow import doActionFor
 from zope.component.interfaces import implements
 
 
@@ -54,7 +54,7 @@ class WorkflowActionPublishSamplesAdapter(RequestContextAware):
     def publish_sample(self, sample):
         """Set status to prepublished/published/republished
         """
-        status = wf.getInfoFor(sample, "review_state")
+        status = api.get_workflow_status_of(sample)
         transitions = {"verified": "publish", "published": "republish"}
         transition = transitions.get(status, "prepublish")
-        succeed, message = wf.doActionFor(sample, transition)
+        succeed, message = doActionFor(sample, transition)

--- a/bika/lims/browser/workflow/client.py
+++ b/bika/lims/browser/workflow/client.py
@@ -34,8 +34,10 @@ class WorkflowActionPublishSamplesAdapter(RequestContextAware):
                 published.append(sample)
 
         # generate a status message of the published sample IDs
-        message = _("Published {}"
-                    .format(", ".join(map(api.get_id, published))))
+        message = _("No items published")
+        if published:
+            message = _("Published {}".format(
+                ", ".join(map(api.get_id, published))))
         self.add_status_message(message, "info")
 
         return self.redirect(redirect_url=self.back_url)

--- a/bika/lims/browser/workflow/client.py
+++ b/bika/lims/browser/workflow/client.py
@@ -4,10 +4,9 @@ import itertools
 
 from bika.lims import _
 from bika.lims import api
-from bika.lims import logger
 from bika.lims.browser.workflow import RequestContextAware
 from bika.lims.interfaces import IWorkflowActionUIDsAdapter
-from Products.CMFCore.WorkflowCore import WorkflowException
+from bika.lims.workflow import wf
 from zope.component.interfaces import implements
 
 
@@ -55,20 +54,7 @@ class WorkflowActionPublishSamplesAdapter(RequestContextAware):
     def publish_sample(self, sample):
         """Set status to prepublished/published/republished
         """
-        wf = api.get_tool("portal_workflow")
         status = wf.getInfoFor(sample, "review_state")
-        transitions = {"verified": "publish",
-                       "published": "republish"}
+        transitions = {"verified": "publish", "published": "republish"}
         transition = transitions.get(status, "prepublish")
-        logger.info("AR Transition: {} -> {}".format(status, transition))
-        try:
-            wf.doActionFor(sample, transition)
-            return True
-        except WorkflowException as e:
-            logger.debug(e)
-            return False
-
-    def add_status_message(self, message, level="info"):
-        """Set a portal status message
-        """
-        return self.context.plone_utils.addPortalMessage(message, level)
+        succeed, message = wf.doActionFor(sample, transition)

--- a/bika/lims/browser/workflow/client.py
+++ b/bika/lims/browser/workflow/client.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+import itertools
+
+from bika.lims import _
+from bika.lims import api
+from bika.lims import logger
+from bika.lims.browser.workflow import RequestContextAware
+from bika.lims.interfaces import IWorkflowActionUIDsAdapter
+from Products.CMFCore.WorkflowCore import WorkflowException
+from zope.component.interfaces import implements
+
+
+class WorkflowActionPublishSamplesAdapter(RequestContextAware):
+    """Adapter in charge of the client 'publish_samples' action
+    """
+    implements(IWorkflowActionUIDsAdapter)
+
+    def __call__(self, action, uids):
+        published = []
+
+        # get the selected ARReport objects
+        reports = map(api.get_object_by_uid, uids)
+        # get all the contained sample UIDs of the generated PDFs
+        sample_uids = map(self.get_sample_uids_in_report, reports)
+        # uniquify the UIDs of the contained samples
+        unique_sample_uids = set(list(
+            itertools.chain.from_iterable(sample_uids)))
+
+        # publish all the contained samples of the selected reports
+        for uid in unique_sample_uids:
+            sample = api.get_object_by_uid(uid)
+            if self.publish_sample(sample):
+                published.append(sample)
+
+        # generate a status message of the published sample IDs
+        message = _("Published {}"
+                    .format(", ".join(map(api.get_id, published))))
+        self.add_status_message(message, "info")
+
+        return self.redirect(redirect_url=self.back_url)
+
+    def get_sample_uids_in_report(self, report):
+        """Return a list of contained sample UIDs
+        """
+        metadata = report.getMetadata() or {}
+        return metadata.get("contained_requests", [])
+
+    def publish_sample(self, sample):
+        """Set status to prepublished/published/republished
+        """
+        wf = api.get_tool("portal_workflow")
+        status = wf.getInfoFor(sample, "review_state")
+        transitions = {"verified": "publish",
+                       "published": "republish"}
+        transition = transitions.get(status, "prepublish")
+        logger.info("AR Transition: {} -> {}".format(status, transition))
+        try:
+            wf.doActionFor(sample, transition)
+            return True
+        except WorkflowException as e:
+            logger.debug(e)
+            return False
+
+    def add_status_message(self, message, level="info"):
+        """Set a portal status message
+        """
+        return self.context.plone_utils.addPortalMessage(message, level)

--- a/bika/lims/browser/workflow/client.py
+++ b/bika/lims/browser/workflow/client.py
@@ -58,3 +58,4 @@ class WorkflowActionPublishSamplesAdapter(RequestContextAware):
         transitions = {"verified": "publish", "published": "republish"}
         transition = transitions.get(status, "prepublish")
         succeed, message = doActionFor(sample, transition)
+        return succeed

--- a/bika/lims/browser/workflow/configure.zcml
+++ b/bika/lims/browser/workflow/configure.zcml
@@ -213,4 +213,17 @@
     factory=".analysis.WorkflowActionSubmitAdapter"
     provides="bika.lims.interfaces.IWorkflowActionAdapter"
     permission="zope.Public" />
+
+  <!-- Client: "publish_samples" action in the report listing
+
+  Publishes all contained samples of ARReports
+  -->
+  <adapter
+    name="workflow_action_publish_samples"
+    for="bika.lims.interfaces.IClient
+         zope.publisher.interfaces.browser.IBrowserRequest"
+    factory=".client.WorkflowActionPublishSamplesAdapter"
+    provides="bika.lims.interfaces.IWorkflowActionAdapter"
+    permission="senaite.core.permissions.TransitionPublishResults" />
+
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR allows to publish all the contained samples of publication reports.

<img width="1011" alt="" src="https://user-images.githubusercontent.com/713193/57901694-75364900-7866-11e9-886c-dba8ec358c88.png">


## Current behavior before PR

Publication of samples did only happen by sending an email to the contact(s)

## Desired behavior after PR is merged

Publication of samples can be done manually from the Analysis Reports Listing

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
