### PR TITLE
Reduce the noise in the diff for object paths

### DIFF
--- a/bika/lims/api/snapshot.py
+++ b/bika/lims/api/snapshot.py
@@ -363,6 +363,9 @@ def compare_last_two_snapshots(obj, raw=False):
 def diff_values(value_a, value_b, raw=False):
     """Returns a human-readable diff between two values
 
+    TODO: Provide an adapter per content type for this task to enable a more
+          specific diff between the values
+
     :param value_a: First value to compare
     :param value_b: Second value to compare
     :param raw: True to compare the raw values, e.g. UIDs
@@ -389,19 +392,29 @@ def _process_value(value):
     """
     if not value:
         value = _("Not set")
-    # XXX: bad data, e.g. in AS Method field
-    elif value == "None":
-        value = _("Not set")
-    # 0 is detected as the portal UID
-    elif value == "0":
-        pass
-    elif api.is_uid(value):
-        value = _get_title_or_id_from_uid(value)
+    # handle strings
+    elif isinstance(value, basestring):
+        # XXX: bad data, e.g. in AS Method field
+        if value == "None":
+            value = _("Not set")
+        # 0 is detected as the portal UID
+        elif value == "0":
+            value = "0"
+        # handle physical paths
+        elif value.startswith("/"):
+            # remove the portal path to reduce noise in virtual hostings
+            portal_path = api.get_path(api.get_portal())
+            value = value.replace(portal_path, "", 1)
+        elif api.is_uid(value):
+            value = _get_title_or_id_from_uid(value)
+    # handle dictionaries
     elif isinstance(value, (dict)):
         value = json.dumps(sorted(value.items()), indent=1)
+    # handle lists and tuples
     elif isinstance(value, (list, tuple)):
         value = sorted(map(_process_value, value))
         value = "; ".join(value)
+    # handle unicodes
     elif isinstance(value, unicode):
         value = api.safe_unicode(value).encode("utf8")
     return str(value)

--- a/bika/lims/api/snapshot.py
+++ b/bika/lims/api/snapshot.py
@@ -415,7 +415,7 @@ def _process_value(value):
         value = sorted(map(_process_value, value))
         value = "; ".join(value)
     # handle unicodes
-    elif isinstance(value, unicode):
+    if isinstance(value, unicode):
         value = api.safe_unicode(value).encode("utf8")
     return str(value)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR unifies object paths to reduce the noise in diffs.

## Current behavior before PR

Changes where detected in the object paths when changes where made from different virtual hosts.

<img width="1393" alt="" src="https://user-images.githubusercontent.com/713193/57917466-06bcaf80-7895-11e9-9159-21e5cd7cf8fe.png">

## Desired behavior after PR is merged

Changes in object paths are ignored

<img width="1490" alt="" src="https://user-images.githubusercontent.com/713193/57917572-408db600-7895-11e9-8dfa-9f8eb471a0a4.png">


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
