### PR TITLE
Fix ft120.py to properly import winescan ft120 CSV files

### DIFF
--- a/bika/lims/exportimport/instruments/foss/winescan/ft120.py
+++ b/bika/lims/exportimport/instruments/foss/winescan/ft120.py
@@ -141,7 +141,7 @@ class WinescanFT120CSVParser(WinescanCSVParser):
                 # 2/11/2005 13:33 PM
                 from datetime import datetime
                 dtobj = datetime.strptime(dtstr, '%d/%m/%Y %H:%M %p')
-                dateTime = dtobj.strftime("%Y%m%d %H:%M:%S")
+                dateTime = dtobj.strftime("%Y%m%d %H:%M")
             except:
                 pass
             del values['Date']


### PR DESCRIPTION
Actual Winescan CSV output file only has 20/05/19,12:59 p.m (hour:minute:-- no second information)

Import is now functioning properly in my fork with that change

## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1375

## Current behavior before PR
Winescan ft120 csv import results in below error
dateTime UnboundLocalError: local variable 'dateTime' referenced before assignment

## Desired behavior after PR is merged
Winescan ft120 CSV import is working properly
![image](https://user-images.githubusercontent.com/20146320/58014316-af486900-7b4c-11e9-817f-13503b200820.png)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
