### PR TITLE
Update Changes.rst

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,7 @@ Changelog
 - #1341 Moved Agilent instruments from core to senaite.instruments
 - #1356 Fixed selection on Analysis Spec on AR
 - #1353 Fixed saving of PublicationSpecification on AR
+- #1376 Fixed ft120.py to properly import winescan ft120 CSV files
 
 
 **Security**


### PR DESCRIPTION
#1376 Fixed ft120.py to properly import winescan ft120 CSV files

## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR

## Desired behavior after PR is merged

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
