### PR TITLE
Fix double publication of the same sample when using multi-reports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ Changelog
 
 **Fixed**
 
+- #1382 Fix double publication of the same sample when using multi-reports
 - #1368 Fix WF state propagation on partition verification
 - #1367 Clients can see interim values of analyses not yet verified
 - #1361 Fix leap sample ID sequence after secondary sample

--- a/bika/lims/browser/publish/emailview.py
+++ b/bika/lims/browser/publish/emailview.py
@@ -201,6 +201,9 @@ class EmailView(BrowserView):
                     field = report.getField("ContainedAnalysisRequests")
                     contained_ars = field.get(report) or []
                     for obj in contained_ars:
+                        # skip the primary AR
+                        if obj == ar:
+                            continue
                         self.publish(obj)
 
                     # add new recipients to the AR Report


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the immediate republication of the primary sample during email submission.

## Current behavior before PR

Sample get published twice during email submission and the audit-log contains the "republish" transition as the most recent entry.

## Desired behavior after PR is merged

Sample get published once during email submission and the audit-log contains the "publish" transition as the most recent entry.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
