### PR TITLE
Added missing Html Field to ARReport

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1384 Added missing Html Field to ARReport
 - #1369 Add getter to access the title of the sample condition directly
 - #1347 Consider laboratory workdays only for the late analyses calculation
 - #1324 Audit Log

--- a/bika/lims/content/arreport.py
+++ b/bika/lims/content/arreport.py
@@ -31,11 +31,11 @@ from plone.app.blob.field import BlobField
 from Products.Archetypes import atapi
 from Products.Archetypes.public import BaseFolder
 from Products.Archetypes.public import Schema
+from Products.Archetypes.public import TextField
 from Products.Archetypes.references import HoldingReference
 from Products.ATExtensions.ateapi import RecordField
 from Products.ATExtensions.ateapi import RecordsField
 from zope.interface import implements
-
 
 schema = BikaSchema.copy() + Schema((
     UIDReferenceField(
@@ -80,8 +80,12 @@ schema = BikaSchema.copy() + Schema((
         "Metadata",
         multiValued=True,
     ),
+    TextField(
+        "Html"
+    ),
     BlobField(
         "Pdf",
+        default_content_type="application/pdf",
     ),
     RecordsField(
         "Recipients",


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds a `Html` Textfield to the `ARReport` type. This field is populated during report creation in `senaite.impress`

## Current behavior before PR

No `Html` field exist on `ARReport`

## Desired behavior after PR is merged

`Html` field exist on `ARReport`
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
