### PR TITLE
Make Forumula a required field on Calculation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 - #1355 Make api.getId to also consider id metadata column (not only getId)
 - #1352 Make timeit to not display args by default
 - #1330 Make guards to not rely on review history
+- #1339 Make Forumula a required field on Calculation
 
 **Removed**
 

--- a/bika/lims/content/calculation.py
+++ b/bika/lims/content/calculation.py
@@ -111,6 +111,7 @@ schema = BikaSchema.copy() + Schema((
 
     TextField(
         'Formula',
+        required=True,
         validators=('formulavalidator',),
         default_content_type='text/plain',
         allowable_content_types=('text/plain',),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1339

## Current behavior before PR
Formula is optional on edit but fails when used to import results

## Desired behavior after PR is merged
Formula is required on Add and Edit

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
