### PR TITLE
No auto-rejection of Sample when rejection reasons are set in Add form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ Changelog
 
 **Fixed**
 
+- #1386 No auto-rejection of Sample when rejection reasons are set in Add form
 - #1382 Fix double publication of the same sample when using multi-reports
 - #1368 Fix WF state propagation on partition verification
 - #1367 Clients can see interim values of analyses not yet verified

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -86,6 +86,10 @@ def create_analysisrequest(client, request, values, analyses=None,
                                      analyses_serv=analyses)
     ar.setAnalyses(service_uids, prices=prices, specs=specifications)
 
+    # Handle rejection reasons
+    rejection_reasons = resolve_rejection_reasons(values)
+    ar.setRejectionReasons(rejection_reasons)
+
     # Handle secondary Analysis Request
     primary = ar.getPrimaryAnalysisRequest()
     if primary:
@@ -117,6 +121,10 @@ def create_analysisrequest(client, request, values, analyses=None,
             # Reindex the AR
             ar.reindexObject()
 
+            # If rejection reasons have been set, reject automatically
+            if rejection_reasons:
+                doActionFor(ar, "reject")
+
             # In "received" state already
             return ar
 
@@ -124,6 +132,11 @@ def create_analysisrequest(client, request, values, analyses=None,
     success, message = doActionFor(ar, "no_sampling_workflow")
     if not success:
         doActionFor(ar, "to_be_sampled")
+
+    # If rejection reasons have been set, reject the sample automatically
+    if rejection_reasons:
+        doActionFor(ar, "reject")
+
     return ar
 
 
@@ -475,3 +488,33 @@ def fields_to_dict(obj, skip_fields=None):
             continue
         data[field_name] = field.get(obj)
     return data
+
+
+def resolve_rejection_reasons(values):
+    """Resolves the rejection reasons from the submitted values to the format
+    supported by Sample's Rejection Reason field
+    """
+    rejection_reasons = values.get("RejectionReasons")
+    if not rejection_reasons:
+        return []
+
+    # Predefined reasons selected?
+    selected = rejection_reasons[0] or {}
+    if selected.get("checkbox") == "on":
+        selected = selected.get("multiselection") or []
+    else:
+        selected = []
+
+    # Other reasons set?
+    other = values.get("RejectionReasons.textfield")
+    if other:
+        other = other[0] or {}
+        other = other.get("other", "")
+    else:
+        other = ""
+
+    # If neither selected nor other reasons are set, return empty
+    if any([selected, other]):
+        return {"selected": selected, "other": other}
+
+    return []

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -515,6 +515,6 @@ def resolve_rejection_reasons(values):
 
     # If neither selected nor other reasons are set, return empty
     if any([selected, other]):
-        return {"selected": selected, "other": other}
+        return [{"selected": selected, "other": other}]
 
     return []


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request sets the rejection reasons submitted in Sample Add form to the newly created Sample and if any rejection reason is set, then automatically transitions the Sample to rejected status.

## Current behavior before PR

When user sets rejection reasons in Add form, the newly created Sample is not automatically transitioned to rejected status.

## Desired behavior after PR is merged

When user sets rejection reasons in Add form, the newly created Sample is automatically transitioned to rejected status.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
