### PR TITLE
Analysts and Labclerks cannot create worksheets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,7 @@ Changelog
 
 **Fixed**
 
-- #1390 Analysts and Labclerks cannot create worksheets
+- #1389 Analysts and Labclerks cannot create worksheets
 - #1386 No auto-rejection of Sample when rejection reasons are set in Add form
 - #1382 Fix double publication of the same sample when using multi-reports
 - #1368 Fix WF state propagation on partition verification

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ Changelog
 
 **Fixed**
 
+- #1390 Analysts and Labclerks cannot create worksheets
 - #1386 No auto-rejection of Sample when rejection reasons are set in Add form
 - #1382 Fix double publication of the same sample when using multi-reports
 - #1368 Fix WF state propagation on partition verification

--- a/bika/lims/subscribers/configure.zcml
+++ b/bika/lims/subscribers/configure.zcml
@@ -66,4 +66,10 @@
       handler="bika.lims.subscribers.pricelist.ObjectModifiedEventHandler"
       />
 
+  <!-- Setup: Object modified event -->
+  <subscriber
+    for="bika.lims.interfaces.IBikaSetup
+         zope.lifecycleevent.interfaces.IObjectModifiedEvent"
+    handler="bika.lims.subscribers.setup.ObjectModifiedEventHandler" />
+
 </configure>

--- a/bika/lims/subscribers/setup.py
+++ b/bika/lims/subscribers/setup.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2019 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.lims import api
+from bika.lims import permissions
+
+
+def ObjectModifiedEventHandler(instance, event):
+    """Actions to be taken when Setup object is modified
+    """
+    update_worksheet_manage_permissions(instance)
+
+
+def update_worksheet_manage_permissions(senaite_setup):
+    """Updates the permissions 'Manage Worksheets' and 'Edit Worksheet' based
+    on the setting 'RestrictWorksheetManagement' from Setup
+    """
+    roles = ["LabManager", "Manager"]
+    if not senaite_setup.getRestrictWorksheetManagement():
+        # LabManagers, Analysts and LabClerks can create and manage worksheets
+        roles.extend(["Analyst", "LabClerk"])
+
+    worksheets = api.get_portal().worksheets
+    worksheets.manage_permission(permissions.ManageWorksheets, roles, acquire=1)
+    worksheets.manage_permission(permissions.EditWorksheet, roles, acquire=1)
+    worksheets.reindexObject()

--- a/bika/lims/upgrade/v01_03_001.py
+++ b/bika/lims/upgrade/v01_03_001.py
@@ -38,6 +38,7 @@ from bika.lims.interfaces import IReceived
 from bika.lims.interfaces import ISubmitted
 from bika.lims.interfaces import IVerified
 from bika.lims.setuphandlers import setup_auditlog_catalog
+from bika.lims.subscribers.setup import update_worksheet_manage_permissions
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
 from bika.lims.workflow import get_review_history_statuses
@@ -103,6 +104,10 @@ def upgrade(tool):
     # Remove unnecessary indexes/metadata from worksheet catalog
     # https://github.com/senaite/senaite.core/pull/1362
     cleanup_worksheet_catalog(portal)
+
+    # Apply permissions for Manage Worksheets
+    # https://github.com/senaite/senaite.core/issues/1387
+    update_worksheet_manage_permissions(api.get_setup())
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
@@ -319,6 +324,7 @@ def reindex_sortable_title(portal):
         catalog = api.get_tool(catalog_name)
         catalog.reindexIndex("sortable_title", None, pghandler=handler)
         commit_transaction(portal)
+
 
 def cleanup_worksheet_catalog(portal):
     """Removes stale indexes and metadata from worksheet_catalog.


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1387

## Current behavior before PR

Analysts and Labclerks cannot create/edit worksheets, even if the option "Restrict Worksheet Management" from Setup is unchecked.

## Desired behavior after PR is merged

Analysts and Labclerks can create worksheets when the option "Restrict Worksheet Management" from Setup is selected. If the option is not selected, LabClerks and Analysts cannot create/edit Worksheets.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
