### PR TITLE
Hide partitions to clients when "ShowPartitions" setting from setup is disabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Changelog
 
 **Changed**
 
+- #1392 Hide partitions to clients when "Show Partitions" is not selected
 - #1371 Allow sample publication without sending Email
 - #1355 Make api.getId to also consider id metadata column (not only getId)
 - #1352 Make timeit to not display args by default

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -720,8 +720,11 @@ class AnalysisRequestsView(BikaListingView):
         # Advanced partitioning
         # append the UID of the primary AR as parent
         item["parent"] = obj.getRawParentAnalysisRequest or ""
+
         # append partition UIDs of this AR as children
-        item["children"] = obj.getDescendantsUIDs or []
+        item["children"] = []
+        if self.show_partitions:
+            item["children"] = obj.getDescendantsUIDs or []
 
         return item
 
@@ -761,3 +764,10 @@ class AnalysisRequestsView(BikaListingView):
 
     def getDefaultAddCount(self):
         return self.context.bika_setup.getDefaultNumberOfARsToAdd()
+
+    @property
+    def show_partitions(self):
+        if api.get_current_client():
+            # If current user is a client contact, delegate to ShowPartitions
+            return api.get_setup().getShowPartitions()
+        return True

--- a/bika/lims/browser/analysisrequest/templates/analysisrequest_analysisservices.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequest_analysisservices.pt
@@ -125,8 +125,7 @@
 					<em class="discreet"
                         tal:attributes="
                             class python:'partnr_'+serviceUID;
-                            column column;
-                            style python:'' if context.bika_setup.getShowPartitions() else 'display:none';"/>
+                            column column;"/>
 				</td>
 			</tal:i>
 		</tal:i>

--- a/bika/lims/browser/viewlets/analysisrequest.py
+++ b/bika/lims/browser/viewlets/analysisrequest.py
@@ -20,6 +20,7 @@
 
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from plone.app.layout.viewlets import ViewletBase
+from bika.lims import api
 
 
 class InvalidAnalysisRequestViewlet(ViewletBase):
@@ -38,6 +39,15 @@ class PrimaryAnalysisRequestViewlet(ViewletBase):
     """ Current Analysis Request is a primary. Display links to partitions
     """
     template = ViewPageTemplateFile("templates/primary_ar_viewlet.pt")
+
+    def get_partitions(self):
+        """Returns whether this viewlet is visible or not
+        """
+        # If current user is a client contact, rely on Setup's ShowPartitions
+        if api.get_current_client():
+            if not api.get_setup().getShowPartitions():
+                return []
+        return self.context.getDescendants()
 
 
 class PartitionAnalysisRequestViewlet(ViewletBase):

--- a/bika/lims/browser/viewlets/templates/primary_ar_viewlet.pt
+++ b/bika/lims/browser/viewlets/templates/primary_ar_viewlet.pt
@@ -1,5 +1,5 @@
 <div tal:omit-tag=""
-     tal:define="descendants python:view.context.getDescendants()"
+     tal:define="descendants python:view.get_partitions()"
      tal:condition="python:descendants"
      i18n:domain="senaite.core">
 

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -530,11 +530,15 @@ schema = BikaFolderSchema.copy() + Schema((
     ),
     BooleanField(
         'ShowPartitions',
-        schemata="Sampling",
-        default=True,
+        schemata="Appearance",
+        default=False,
         widget=BooleanWidget(
-            label=_("Display individual sample partitions "),
-            description=_("Turn this on if you want to work with sample partitions")
+            label=_("Display sample partitions to clients"),
+            description=_("Choose whether to display sample partitions to "
+                          "client contacts. If not selected, partitions won't "
+                          "be neither listed in sample listings nor a message "
+                          "will be displayed with links to them in primary "
+                          "sample view")
         ),
     ),
     BooleanField(

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -534,11 +534,11 @@ schema = BikaFolderSchema.copy() + Schema((
         default=False,
         widget=BooleanWidget(
             label=_("Display sample partitions to clients"),
-            description=_("Choose whether to display sample partitions to "
-                          "client contacts. If not selected, partitions won't "
-                          "be neither listed in sample listings nor a message "
-                          "will be displayed with links to them in primary "
-                          "sample view")
+            description=_(
+                "Select to show sample partitions to client contacts. "
+                "If deactivated, partitions won't be included in listings "
+                "and no info message with links to the primary sample will "
+                "be displayed to client contacts.")
         ),
     ),
     BooleanField(

--- a/bika/lims/workflow/analysisrequest/guards.py
+++ b/bika/lims/workflow/analysisrequest/guards.py
@@ -51,10 +51,6 @@ def guard_create_partitions(analysis_request):
     """Returns true if partitions can be created using the analysis request
     passed in as the source.
     """
-    if not analysis_request.bika_setup.getShowPartitions():
-        # If partitions are disabled in Setup, return False
-        return False
-
     if analysis_request.isPartition():
         # Do not allow the creation of partitions from partitions
         return False


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request changes the behavior of "ShowPartitions" setting from setup. Until now, this setting was only used to display/hide partitions in templates edit view and allow/disallow the "Create partitions" transition. With this change, this setting is used to display/hide individual partitions to client contacts (e.g. from listings), while the transition "create partitions" and "parts" in templates are always displayed regardless of this setting. Note that client contact has always access to primary sample (where all analyses are listed, even if they belong to a partition).

Lab personnel view with ShowPartitions disabled:

![Captura de 2019-06-12 21-27-01](https://user-images.githubusercontent.com/832627/59380795-2d69eb00-8d5a-11e9-8e3a-a6d16a4bccf4.png)


Client view with ShowPartitions disabled:

![Captura de 2019-06-12 21-27-14](https://user-images.githubusercontent.com/832627/59380760-1cb97500-8d5a-11e9-89bc-631e34f5bcb2.png)


## Current behavior before PR

Partitions are always displayed to client contacts (in listings or in primary_ar_viewlet)

## Desired behavior after PR is merged

Partitions are not displayed to client contact when ShowPartitions setting is set to False.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
