### PR TITLE
Fix unauthorized access when primary has parttitions for internal use

### DIFF
--- a/bika/lims/subscribers/analysisrequest.py
+++ b/bika/lims/subscribers/analysisrequest.py
@@ -46,6 +46,9 @@ def ObjectModifiedEventHandler(instance, event):
             else:
                 noLongerProvides(analysis, IInternalUse)
 
+            # Reindex analysis security in catalogs
+            analysis.reindexObjectSecurity()
+
         # If internal use is True, cascade same setting to partitions
         if internal_use:
             for partition in instance.getDescendants():


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Security info for analyses from inside samples that have been labeled for internal use needs to be updated. Otherwise when a client contact user access to a primary sample with an internal-use partition, the system throws an Unauthorized message because new security seetings are not yet taken into consideration when querying against analysis catalog in order to retrieve the analyses from child partitions.

## Current behavior before PR

Unauthorized screen is displayed

## Desired behavior after PR is merged

User is authorized and only analyses that do not belong to partitions for internal use are displayed in analyses listing inside Sample view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
