### PR TITLE
 Worksheet does not show the contained analyses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Changelog
 
 **Fixed**
 
+- #1397 Fix Worksheet does not show the contained analyses
 - #1395 Make Action Handler Pool Thread-Safe
 - #1389 Analysts and Labclerks cannot create worksheets
 - #1386 No auto-rejection of Sample when rejection reasons are set in Add form

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -217,6 +217,9 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         # Try to rollback the worksheet to prevent inconsistencies
         doActionFor(self, "rollback_to_open")
 
+        # Reindex Analysis
+        push_reindex_to_actions_pool(analysis, idxs=["getWorksheetUID"])
+
         # Reindex Worksheet
         idxs = ["getAnalysesUIDs"]
         push_reindex_to_actions_pool(self, idxs=idxs)

--- a/bika/lims/upgrade/v01_03_001.py
+++ b/bika/lims/upgrade/v01_03_001.py
@@ -115,6 +115,10 @@ def upgrade(tool):
     catalog = api.get_tool(CATALOG_ANALYSIS_REQUEST_LISTING)
     catalog.addColumn("getInternalUse")
 
+    # Reindex getWorksheetUID from analysis catalog to ensure all analyses are
+    # visible in Worksheet view
+    reindex_getWorksheetUID(portal)
+
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
 
@@ -376,3 +380,14 @@ def del_metadata(portal, catalog_id, column, refresh_catalog=False):
         logger.info("Refreshing catalog '{}' ...".format(catalog_id))
         handler = ZLogHandler(steps=100)
         catalog.refreshCatalog(pghandler=handler)
+
+
+def reindex_getWorksheetUID(portal):
+    """Reindex getWorksheetUID index from analysis_catalog
+    """
+    catalog_name = CATALOG_ANALYSIS_LISTING
+    logger.info("Reindexing getWorksheetUID for {} ...".format(catalog_name))
+    handler = ZLogHandler(steps=100)
+    catalog = api.get_tool(catalog_name)
+    catalog.reindexIndex("getWorksheetUID", None, pghandler=handler)
+    commit_transaction(portal)

--- a/bika/lims/upgrade/v01_03_001.py
+++ b/bika/lims/upgrade/v01_03_001.py
@@ -117,6 +117,7 @@ def upgrade(tool):
 
     # Reindex getWorksheetUID from analysis catalog to ensure all analyses are
     # visible in Worksheet view
+    # https://github.com/senaite/senaite.core/pull/1397
     reindex_getWorksheetUID(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Sometimes, analyses assigned to a worksheet are not displayed in Worksheet's view. This Pull Request ensures that `getWorksheetUID` index is always reindexed after an analysis being assigned to a Worksheet.

Linked issue: https://github.com/senaite/senaite.core/issues/1360

## Current behavior before PR

Sometimes, analyses assigned to a worksheet are not displayed in Worksheet's view

## Desired behavior after PR is merged

Analyses assigned to a Worksheet are always displayed in Worksheet's view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
