### PR TITLE
Fix Number Generator Seeding View

### DIFF
--- a/bika/lims/browser/idserver/templates/numbergenerator.pt
+++ b/bika/lims/browser/idserver/templates/numbergenerator.pt
@@ -44,9 +44,6 @@
                      class="form-control"
                      tal:attributes="name string:seeds.${key}:record;
                                      value value"/>
-              <input type="hidden"
-                     tal:attributes="name string:seeds.${key}:record;
-                                     value key"/>
             </div>
 
             <div class="help-block">

--- a/bika/lims/browser/idserver/view.py
+++ b/bika/lims/browser/idserver/view.py
@@ -65,9 +65,12 @@ class IDServerView(BrowserView):
         if form.get("seed", False):
             seeds = form.get("seeds", {})
             for key, value in seeds.items():
-                value = self.to_int(value)
+                value = api.to_int(value, None)
                 message = ""
-                if value == 0:
+                if value is None:
+                    message = _("Could not convert '{}' to an integer"
+                                .format(value))
+                elif value == 0:
                     del self.storage[key]
                     message = _("Removed key {} from storage".format(key))
                 else:
@@ -96,14 +99,6 @@ class IDServerView(BrowserView):
         number_generator = getUtility(INumberGenerator)
         return number_generator.storage
 
-    def to_int(self, number, default=0):
-        """Returns an integer
-        """
-        try:
-            return int(number)
-        except (KeyError, ValueError):
-            return self.to_int(default, 0)
-
     def add_status_message(self, message, level="info"):
         """Set a portal status message
         """
@@ -113,7 +108,7 @@ class IDServerView(BrowserView):
         """Set a number of the number generator
         """
         number_generator = getUtility(INumberGenerator)
-        return number_generator.set_number(key, self.to_int(value))
+        return number_generator.set_number(key, api.to_int(value))
 
     def seed(self):
         """ Reset the number from which the next generated sequence start.

--- a/bika/lims/browser/idserver/view.py
+++ b/bika/lims/browser/idserver/view.py
@@ -18,8 +18,6 @@
 # Copyright 2018-2019 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-import re
-
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims.idserver import get_config


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the `/ng` view when the numbers are seeded.

## Current behavior before PR

All values are flushed 🙈 

## Desired behavior after PR is merged

Numbers are correctly seeded ❤️ 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
