### PR TITLE
Allow capture of text results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1401 Allow capture of text results
 - #1391 Samples for internal use (lab personnel) only
 - #1384 Added missing Html Field to ARReport
 - #1369 Add getter to access the title of the sample condition directly

--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -736,6 +736,7 @@ class AnalysesView(BikaListingView):
         item["Result"] = result
         item["CaptureDate"] = capture_date_str
         item["result_captured"] = capture_date_str
+        item["string_result"] = False
 
         # Edit mode enabled of this Analysis
         if self.is_analysis_edition_allowed(analysis_brain):
@@ -754,6 +755,10 @@ class AnalysesView(BikaListingView):
                 # By default set empty as the default selected choice
                 choices.insert(0, dict(ResultValue="", ResultText=""))
                 item["choices"]["Result"] = choices
+            else:
+                # If not choices, set whether the result must be floatable
+                obj = self.get_object(analysis_brain)
+                item["string_result"] = obj.getStringResult()
 
         if not result:
             return

--- a/bika/lims/content/abstractbaseanalysis.py
+++ b/bika/lims/content/abstractbaseanalysis.py
@@ -728,7 +728,8 @@ schema = BikaSchema.copy() + Schema((
     Hidden,
     SelfVerification,
     NumberOfRequiredVerifications,
-    Remarks
+    Remarks,
+    StringResult,
 ))
 
 schema['id'].widget.visible = False

--- a/bika/lims/content/abstractbaseanalysis.py
+++ b/bika/lims/content/abstractbaseanalysis.py
@@ -593,6 +593,19 @@ ResultOptions = RecordsField(
     )
 )
 
+# Allow/disallow the capture of text as the result of the analysis
+StringResult = BooleanField(
+    "StringResult",
+    schemata="Analysis",
+    default=False,
+    widget=BooleanWidget(
+        label=_("String result"),
+        description=_(
+            "Enable this option to allow the capture of text as result"
+        )
+    )
+)
+
 # If the service is meant for providing an interim result to another analysis,
 # or if the result is only used for internal processes, then it can be hidden
 # from the client in the final report (and in manage_results view)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Requests allow the capture of text results. Until now, direct capture of text results was not possible and pre-selected list of options was the only chance for text entry.

Requires: https://github.com/senaite/senaite.core.listing/pull/18

A new "String result" setting has been added in Analysis Service edit view (tab "Analysis"):

![Captura de 2019-06-25 22-47-43](https://user-images.githubusercontent.com/832627/60134367-a841f580-979f-11e9-8941-05a313783bc2.png)

When the analysis has this setting enabled, the results entry looks like follows:

![Captura de 2019-06-25 23-05-08](https://user-images.githubusercontent.com/832627/60134406-b42db780-979f-11e9-9a76-50a1da482bd1.png)

## Current behavior before PR

Capture of text results is not possible

## Desired behavior after PR is merged

Capture of text results is possible if setting "String Result" is enabled for a given analysis

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
