### PR TITLE
Fix Upgrade step 1.3.1 fails when running multiple times

### DIFF
--- a/bika/lims/upgrade/v01_03_001.py
+++ b/bika/lims/upgrade/v01_03_001.py
@@ -112,8 +112,7 @@ def upgrade(tool):
 
     # Add getInternalUse metadata
     # https://github.com/senaite/senaite.core/pull/1391
-    catalog = api.get_tool(CATALOG_ANALYSIS_REQUEST_LISTING)
-    catalog.addColumn("getInternalUse")
+    add_metadata(portal, CATALOG_ANALYSIS_REQUEST_LISTING, "getInternalUse")
 
     # Reindex getWorksheetUID from analysis catalog to ensure all analyses are
     # visible in Worksheet view
@@ -366,6 +365,20 @@ def del_index(portal, catalog_id, index_name):
     catalog.delIndex(index_name)
     logger.info("Removing old index '{}' ...".format(index_name))
 
+
+def add_metadata(portal, catalog_id, column, refresh_catalog=False):
+    logger.info("Adding '{}' metadata to '{}' ...".format(column, catalog_id))
+    catalog = api.get_tool(catalog_id)
+    if column in catalog.schema():
+        logger.info("Metadata '{}' already in catalog '{}' [SKIP]"
+                    .format(column, catalog_id))
+        return
+    catalog.addColumn(column)
+
+    if refresh_catalog:
+        logger.info("Refreshing catalog '{}' ...".format(catalog_id))
+        handler = ZLogHandler(steps=100)
+        catalog.refreshCatalog(pghandler=handler)
 
 def del_metadata(portal, catalog_id, column, refresh_catalog=False):
     logger.info("Removing '{}' metadata from '{}' ..."


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1398

## Current behavior before PR

Upgrade step 1.3.1 fails with traceback when run more than once:

```
2019-06-20 16:26:53 ERROR Zope.SiteErrorLog 1561040813.560.824146100697 http://localhost:1183/senaitelims/portal_setup/manage_doUpgrades
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.GenericSetup.tool, line 1053, in manage_doUpgrades
  Module Products.GenericSetup.upgrade, line 166, in doStep
  Module bika.lims.upgrade, line 68, in wrap_func_args
  Module bika.lims.upgrade.v01_03_001, line 116, in upgrade
  Module Products.ZCatalog.ZCatalog, line 884, in addColumn
  Module Products.ZCatalog.Catalog, line 169, in addColumn
CatalogError: The column getInternalUse already exists
```

## Desired behavior after PR is merged

No traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
