### PR TITLE
Also consider the detached states as cancellable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ Changelog
 
 **Fixed**
 
+- #1403 Also consider the detached states as cancellable
 - #1397 Fix Worksheet does not show the contained analyses
 - #1395 Make Action Handler Pool Thread-Safe
 - #1389 Analysts and Labclerks cannot create worksheets

--- a/bika/lims/workflow/analysisrequest/guards.py
+++ b/bika/lims/workflow/analysisrequest/guards.py
@@ -182,6 +182,10 @@ def guard_cancel(analysis_request):
     # no need to look through analyses from partitions again, but through the
     # analyses directly bound to the current Analysis Request.
     cancellable_states = ["unassigned", "registered"]
+
+    # also consider the detached states as cancellable
+    cancellable_states += ANALYSIS_DETACHED_STATES
+
     for analysis in analysis_request.objectValues("Analysis"):
         if api.get_workflow_status_of(analysis) not in cancellable_states:
             return False


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR allows Sample cancellation when all contained analyses are in detached states

## Current behavior before PR

Sample was stuck in the "Received" state when all contained analyses were retracted

## Desired behavior after PR is merged

Sample can be cancelled when all contained analyses are retracted

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
