### PR TITLE
Avoid conflict errors during email publication

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ Changelog
 
 **Fixed**
 
+- #1404 Avoid conflict errors during email publication
 - #1397 Fix Worksheet does not show the contained analyses
 - #1395 Make Action Handler Pool Thread-Safe
 - #1389 Analysts and Labclerks cannot create worksheets

--- a/bika/lims/browser/publish/emailview.py
+++ b/bika/lims/browser/publish/emailview.py
@@ -186,6 +186,9 @@ class EmailView(BrowserView):
                 success = self.send_email(
                     recipients, subject, body, attachments=attachments)
 
+                # make a savepoint to avoid multiple email send
+                transaction.savepoint(optimistic=True)
+
             if success:
                 # selected name, email pairs which received the email
                 pairs = map(self.parse_email, recipients)

--- a/bika/lims/browser/publish/emailview.py
+++ b/bika/lims/browser/publish/emailview.py
@@ -187,6 +187,7 @@ class EmailView(BrowserView):
                     recipients, subject, body, attachments=attachments)
 
                 # make a savepoint to avoid multiple email send
+                # http://www.zodb.org/en/latest/reference/transaction.html
                 transaction.savepoint(optimistic=True)
 
             if success:

--- a/bika/lims/browser/publish/emailview.py
+++ b/bika/lims/browser/publish/emailview.py
@@ -32,15 +32,15 @@ from smtplib import SMTPException
 from string import Template
 
 import transaction
+from bika.lims import _
+from bika.lims import api
 from bika.lims import logger
+from bika.lims.decorators import returns_json
 from bika.lims.utils import to_utf8
 from Products.CMFCore.WorkflowCore import WorkflowException
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from bika.lims import api
-from bika.lims import _
-from bika.lims.decorators import returns_json
 from ZODB.POSException import POSKeyError
 from zope.interface import implements
 from zope.publisher.interfaces import IPublishTraverse


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Email publication of many reports leads often to conflict errors which cause the emails to be sent up to 3 times because of the ZODB conflict resolution 

## Current behavior before PR

Emails where sent up to 3 times during email publication due to publication conflicts

## Desired behavior after PR is merged

Publication of each sample is done in an own transaction to minimize the risk of database conflicts
 
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
