### PR TITLE
Supersed analysis.isOpen() by not ISubmitted.providedBy(analysis)

### DIFF
--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -24,6 +24,7 @@ from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.content.analysisspec import ResultsRangeDict
+from bika.lims.interfaces import ISubmitted
 from bika.lims.utils import dicts_to_dict
 from bika.lims.utils import get_image
 from bika.lims.utils import get_link
@@ -211,7 +212,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
             # Might differ from the service keyword
             keyword = analysis.getKeyword()
             # Mark the row as disabled if the analysis has been submitted
-            item["disabled"] = not analysis.isOpen()
+            item["disabled"] = ISubmitted.providedBy(analysis)
             # get the hidden status of the analysis
             hidden = analysis.getHidden()
             # get the price of the analysis

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -210,9 +210,8 @@ class AnalysisRequestAnalysesView(BikaListingView):
             analysis = self.analyses[uid]
             # Might differ from the service keyword
             keyword = analysis.getKeyword()
-            # Mark the row as disabled if the analysis is not in an open state
-            item["disabled"] = not any([analysis.isOpen(),
-                                        analysis.isRegistered()])
+            # Mark the row as disabled if the analysis has been submitted
+            item["disabled"] = not analysis.isOpen()
             # get the hidden status of the analysis
             hidden = analysis.getHidden()
             # get the price of the analysis

--- a/bika/lims/browser/fields/aranalysesfield.py
+++ b/bika/lims/browser/fields/aranalysesfield.py
@@ -26,7 +26,7 @@ from bika.lims import api
 from bika.lims import logger
 from bika.lims.api.security import check_permission
 from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
-from bika.lims.interfaces import IAnalysis
+from bika.lims.interfaces import IAnalysis, ISubmitted
 from bika.lims.interfaces import IAnalysisService
 from bika.lims.interfaces import IARAnalysesField
 from bika.lims.permissions import AddAnalysis
@@ -105,14 +105,14 @@ class ARAnalysesField(ObjectField):
         # Current assigned analyses
         analyses = instance.objectValues("Analysis")
 
-        # Submitted analyses (non-open) must be retained
-        non_open_analyses = filter(lambda an: not an.isOpen(), analyses)
+        # Submitted analyses must be retained
+        submitted = filter(lambda an: ISubmitted.providedBy(an), analyses)
 
         # Prevent removing all analyses
         #
-        # N.B.: Non-open analyses are rendered disabled in the HTML form.
+        # N.B.: Submitted analyses are rendered disabled in the HTML form.
         #       Therefore, their UIDs are not included in the submitted UIDs.
-        if not items and not non_open_analyses:
+        if not items and not submitted:
             logger.warn("Not allowed to remove all Analyses from AR.")
             return new_analyses
 
@@ -194,7 +194,7 @@ class ARAnalysesField(ObjectField):
                 continue
 
             # Skip non-open Analyses
-            if analysis in non_open_analyses:
+            if analysis in submitted:
                 continue
 
             # Remember assigned attachments

--- a/bika/lims/browser/fields/aranalysesfield.py
+++ b/bika/lims/browser/fields/aranalysesfield.py
@@ -105,12 +105,8 @@ class ARAnalysesField(ObjectField):
         # Current assigned analyses
         analyses = instance.objectValues("Analysis")
 
-        # Analyses which are in a non-open state must be retained, except those
-        # that are in a registered state (the sample has not been received)
+        # Submitted analyses (non-open) must be retained
         non_open_analyses = filter(lambda an: not an.isOpen(), analyses)
-        non_open_analyses = filter(
-            lambda an: api.get_workflow_status_of(an) != "registered",
-            non_open_analyses)
 
         # Prevent removing all analyses
         #

--- a/bika/lims/content/abstractbaseanalysis.py
+++ b/bika/lims/content/abstractbaseanalysis.py
@@ -1038,11 +1038,3 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
         """
         tat = self.Schema().getField("MaxTimeAllowed").get(self)
         return tat or self.bika_setup.getDefaultTurnaroundTime()
-
-    @security.public
-    def isOpen(self):
-        """Checks if the Analysis is either in "assigned" or "unassigned" state
-
-        return: True if the WF state is either "assigned" or "unassigned"
-        """
-        return not ISubmitted.providedBy(self)

--- a/bika/lims/content/abstractbaseanalysis.py
+++ b/bika/lims/content/abstractbaseanalysis.py
@@ -29,7 +29,7 @@ from bika.lims.browser.widgets.referencewidget import ReferenceWidget
 from bika.lims.config import ATTACHMENT_OPTIONS
 from bika.lims.config import SERVICE_POINT_OF_CAPTURE
 from bika.lims.content.bikaschema import BikaSchema
-from bika.lims.interfaces import IBaseAnalysis
+from bika.lims.interfaces import IBaseAnalysis, ISubmitted
 from bika.lims.permissions import FieldEditAnalysisHidden
 from bika.lims.permissions import FieldEditAnalysisRemarks
 from bika.lims.permissions import FieldEditAnalysisResult
@@ -1045,7 +1045,7 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
 
         return: True if the WF state is either "assigned" or "unassigned"
         """
-        return api.get_workflow_status_of(self) in ["assigned", "unassigned"]
+        return not ISubmitted.providedBy(self)
 
     @security.public
     def isRegistered(self):

--- a/bika/lims/content/abstractbaseanalysis.py
+++ b/bika/lims/content/abstractbaseanalysis.py
@@ -1046,11 +1046,3 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
         return: True if the WF state is either "assigned" or "unassigned"
         """
         return not ISubmitted.providedBy(self)
-
-    @security.public
-    def isRegistered(self):
-        """Checks if the Analysis is in "registered" state
-
-        return: True if the WF state is "registered"
-        """
-        return api.get_workflow_status_of(self) in ["registered"]

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2288,7 +2288,7 @@ class AnalysisRequest(BaseFolder):
         submitted yet (are in a open status)
         """
         for analysis in self.getAnalyses():
-            if not ISubmitted.providedBy(api.get_object(analysis)):
+            if ISubmitted.providedBy(api.get_object(analysis)):
                 return False
         return True
 

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -51,6 +51,7 @@ from bika.lims.content.bikaschema import BikaSchema
 from bika.lims.interfaces import IAnalysisRequest
 from bika.lims.interfaces import IAnalysisRequestPartition
 from bika.lims.interfaces import ICancellable
+from bika.lims.interfaces import ISubmitted
 from bika.lims.permissions import FieldEditBatch
 from bika.lims.permissions import FieldEditClient
 from bika.lims.permissions import FieldEditClientOrderNumber
@@ -2287,7 +2288,7 @@ class AnalysisRequest(BaseFolder):
         submitted yet (are in a open status)
         """
         for analysis in self.getAnalyses():
-            if not api.get_object(analysis).isOpen():
+            if not ISubmitted.providedBy(api.get_object(analysis)):
                 return False
         return True
 

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2283,8 +2283,8 @@ class AnalysisRequest(BaseFolder):
         return self.getSamplingWorkflowEnabled()
 
     def isOpen(self):
-        """Returns whether all analyses from this Analysis Request are open
-        (their status is either "assigned" or "unassigned")
+        """Returns whether all analyses from this Analysis Request haven't been
+        submitted yet (are in a open status)
         """
         for analysis in self.getAnalyses():
             if not api.get_object(analysis).isOpen():


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The possible statuses before an analysis is submitted are "registered", "assigned" and "unassigned". In earlier versions, `isOpen` was checking the review status for "assigned" and "unassigned", but `isOpen` function was used everywhere together with `isRegistered`. Once an analysis is submitted, the object is marked with `ISubmitted` interface.

This Pull Request omits the check for review status, rather it only checks if the object is provided by `ISubmitted` interface, that makes the system to behave faster and reduces the complexity in those places where both `isOpen` and `isRegistered` were checked.

## Current behavior before PR

Functions isOpen and isRegistered available for analysis types

## Desired behavior after PR is merged

Functions isOpen and isRegistered no longer available. `ISubmitted` marker is used instead.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
