### PR TITLE
Fix occasional "OSError: [Errno 24] Too many open files" traceback in frontpage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ before_script:
   # - unzip chromedriver_linux64.zip
   # - sudo mv chromedriver /usr/bin/
   ###
-  - export DISPLAY=99.0
-  - sh -e /etc/init.d/xvfb start
+  # - export DISPLAY=99.0
+  # - sh -e /etc/init.d/xvfb start
 before_install:
   - mkdir -p $TRAVIS_BUILD_DIR/buildout-cache/{eggs,downloads}
   - echo "[buildout]" > $TRAVIS_BUILD_DIR/default.cfg

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,9 +17,10 @@ Changelog
 
 **Fixed**
 
+- #1414 Occasional "OSError: [Errno 24] Too many open files" in frontpage
+
 
 **Security**
-
 
 
 1.3.1 (2019-07-01)

--- a/bika/lims/browser/senaitefrontpage.py
+++ b/bika/lims/browser/senaitefrontpage.py
@@ -33,7 +33,6 @@ class FrontPageView(BrowserView):
     template = ViewPageTemplateFile("templates/senaite-frontpage.pt")
 
     def __call__(self):
-        self.set_versions()
         self.icon = self.portal_url + "/++resource++bika.lims.images/chevron_big.png"
         bika_setup = getToolByName(self.context, "bika_setup")
         login_url = '{}/{}'.format(self.portal_url, 'login')
@@ -102,15 +101,3 @@ class FrontPageView(BrowserView):
             return []
         current_user = ploneapi.user.get_current()
         return ploneapi.user.get_roles(user=current_user)
-
-    def set_versions(self):
-        """Configure a list of product versions from portal.quickinstaller
-        """
-        self.versions = {}
-        self.upgrades = {}
-        qi = getToolByName(self.context, "portal_quickinstaller")
-        for key in qi.keys():
-            self.versions[key] = qi.getProductVersion(key)
-            info = qi.upgradeInfo(key)
-            if info and 'installedVersion' in info:
-                self.upgrades[key] = info['installedVersion']

--- a/bika/lims/browser/templates/senaite-frontpage.pt
+++ b/bika/lims/browser/templates/senaite-frontpage.pt
@@ -13,12 +13,6 @@
 
     <h1 class="documentFirstHeading" i18n:translate="">
       <img tal:attributes="src view/icon"/> Welcome to SENAITE
-      <tal:version condition="python:'senaite.core' not in view.upgrades">
-        <span tal:replace="python:view.versions.get('senaite.core')" i18n:name="version"/>
-      </tal:version>
-      <tal:upgrade condition="python:'senaite.core' in view.upgrades">
-        <span tal:replace="python:view.upgrades.get('senaite.core'"/>
-      </tal:upgrade>
     </h1>
 
   </metal:content-title>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fix an occasional traceback raised by frontpage. The retrieval of versions (something that never worked) is removed from frontpage.

## Current behavior before PR

No occasional traceback

```
Traceback (innermost last):

  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.senaitefrontpage, line 36, in __call__
  Module bika.lims.browser.senaitefrontpage, line 114, in set_versions
  Module Products.CMFPlone.QuickInstallerTool, line 24, in upgradeInfo
  Module Products.CMFQuickInstallerTool.QuickInstallerTool, line 249, in isProductAvailable
  Module Products.CMFQuickInstallerTool.QuickInstallerTool, line 195, in isProductInstallable
  Module Products.CMFQuickInstallerTool.QuickInstallerTool, line 171, in getInstallMethod
  Module Products.CMFQuickInstallerTool.utils, line 76, in get_install_method
  Module Products.CMFQuickInstallerTool.utils, line 80, in get_method
  Module Products.CMFQuickInstallerTool.utils, line 55, in get_packages
  Module OFS.Application, line 553, in get_products

OSError: [Errno 24] Too many open files: '/home/senaite/senaite/products'
```

## Desired behavior after PR is merged

No traceback.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
