### PR TITLE
Cache allowed transitions for analyses on the request

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Changelog
 
 **Changed**
 
+- #1417 Cache allowed transitions for analyses on the request
 - #1413 Improved Email Publication
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This improves the rendering performance of worksheets containing a huge
amount of analyses with dependencies.

## Current behavior before PR

The guard `guard_retract` of worksheets checks for all contained analyses if the "retract" transition is allowed. This code fetches all dependencies of each analysis, which causes the same analyses to be checked multiple times.

Example:

A worksheet containing 434 Analyses with dependencies takes `326.86s` to render

## Desired behavior after PR is merged

Checked analyses cache their value on the request, so that these analyses are skipped.
In the example above this improves rendering speed by a factor `≈5,65` to `57.86s`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
