### PR TITLE
Subscriber adapters not supported in clients listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Changelog
 
 **Fixed**
 
+- #1418 Subscriber adapters not supported in clients listing
 - #1414 Occasional "OSError: [Errno 24] Too many open files" in frontpage
 
 

--- a/bika/lims/browser/clientfolder.py
+++ b/bika/lims/browser/clientfolder.py
@@ -132,6 +132,9 @@ class ClientFolderContentsView(BikaListingView):
     def before_render(self):
         """Before template render hook
         """
+        # Call `before_render` from the base class
+        BikaListingView.before_render(self)
+
         # Render the Add button if the user has the AddClient permission
         if check_permission(AddClient, self.context):
             self.context_actions[_("Add")] = {
@@ -168,6 +171,11 @@ class ClientFolderContentsView(BikaListingView):
         :return: the dict representation of the item
         :rtype: dict
         """
+        # Call the folderitem method from the base class
+        item = BikaListingView.folderitem(self, obj, item, index)
+        if not item:
+            return None
+
         # render a link to the defined start page
         link_url = "{}/{}".format(item["url"], self.landing_page)
         item["replace"]["title"] = get_link(link_url, item["title"])

--- a/bika/lims/browser/clientfolder.py
+++ b/bika/lims/browser/clientfolder.py
@@ -133,7 +133,7 @@ class ClientFolderContentsView(BikaListingView):
         """Before template render hook
         """
         # Call `before_render` from the base class
-        BikaListingView.before_render(self)
+        super(ClientFolderContentsView, self).before_render()
 
         # Render the Add button if the user has the AddClient permission
         if check_permission(AddClient, self.context):
@@ -171,11 +171,6 @@ class ClientFolderContentsView(BikaListingView):
         :return: the dict representation of the item
         :rtype: dict
         """
-        # Call the folderitem method from the base class
-        item = BikaListingView.folderitem(self, obj, item, index)
-        if not item:
-            return None
-
         # render a link to the defined start page
         link_url = "{}/{}".format(item["url"], self.landing_page)
         item["replace"]["title"] = get_link(link_url, item["title"])
@@ -189,6 +184,7 @@ class ClientFolderContentsView(BikaListingView):
         phone = obj.getPhone()
         if phone:
             item["replace"]["Phone"] = get_link("tel:{}".format(phone), phone)
+
         return item
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The custom `ClientFolderView` was overriding `before_render` and `folder_item` functions, but without calling their respective functions from the base class. Thus, subscriber adapters where
not considered in clients listing.

## Current behavior before PR

Client listing cannot be extended or its behavior changed by means of subscriber adapters.

## Desired behavior after PR is merged

Client listing can be extended or its behavior changed by means of subscriber adapters.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
