### PR TITLE
Mixed permissions for transitions in client workflow

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Changelog
 
 **Fixed**
 
+- #1419 Mixed permissions for transitions in client workflow
 - #1414 Occasional "OSError: [Errno 24] Too many open files" in frontpage
 
 

--- a/bika/lims/profiles/default/workflows/senaite_client_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_client_workflow/definition.xml
@@ -144,7 +144,7 @@
   <transition transition_id="activate" title="Activate" new_state="active" trigger="USER" before_script="" after_script="" i18n:attributes="title">
     <action url="" category="workflow" icon="">Activate</action>
     <guard>
-      <guard-permission>senaite.core: Transition: Deactivate</guard-permission>
+      <guard-permission>senaite.core: Transition: Activate</guard-permission>
       <guard-expression>python:here.guard_handler("activate")</guard-expression>
     </guard>
   </transition>
@@ -152,7 +152,7 @@
   <transition transition_id="deactivate" title="Deactivate" new_state="inactive" trigger="USER" before_script="" after_script="" i18n:attributes="title">
     <action url="" category="workflow" icon="">Deactivate</action>
     <guard>
-      <guard-permission>senaite.core: Transition: Activate</guard-permission>
+      <guard-permission>senaite.core: Transition: Deactivate</guard-permission>
       <guard-expression>python:here.guard_handler("deactivate")</guard-expression>
     </guard>
   </transition>

--- a/bika/lims/upgrade/v01_03_002.py
+++ b/bika/lims/upgrade/v01_03_002.py
@@ -43,5 +43,9 @@ def upgrade(tool):
 
     # -------- ADD YOUR STUFF BELOW --------
 
+    # Mixed permissions for transitions in client workflow
+    # https://github.com/senaite/senaite.core/pull/1419
+    setup.runImportStepFromProfile(profile, "workflow")
+
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The permissions for transitions "activate" and "deactivate" were mixed in client workflow.

## Current behavior before PR

Permission "Transition: Activate" is bound to "deactivate" transition, while permission "Transition: Deactivate" is bound to "activate" transition.

## Desired behavior after PR is merged

Permissions for transitions are bound to their respective transitions.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
