### PR TITLE
Notify user with failing addresses when emailing of results reports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1422 Notify user with failing addresses when emailing of results reports
 - #1420 Allow to detach a partition from its primary sample
 - #1410 Email API
 

--- a/bika/lims/browser/publish/emailview.py
+++ b/bika/lims/browser/publish/emailview.py
@@ -510,7 +510,9 @@ class EmailView(BrowserView):
                                              attachments=attachments)
             sent = mailapi.send_email(mime_msg)
             if not sent:
-                logger.error("Could not send email to {}".format(pair))
+                msg = "Could not send email to {}".format(pair)
+                self.add_status_message(msg, "warning")
+                logger.error(msg)
             success.append(sent)
 
         if not all(success):

--- a/bika/lims/browser/publish/emailview.py
+++ b/bika/lims/browser/publish/emailview.py
@@ -510,7 +510,8 @@ class EmailView(BrowserView):
                                              attachments=attachments)
             sent = mailapi.send_email(mime_msg)
             if not sent:
-                msg = "Could not send email to {}".format(pair)
+                msg = _("Could not send email to {0} ({1})").format(pair[0],
+                                                                    pair[1])
                 self.add_status_message(msg, "warning")
                 logger.error(msg)
             success.append(sent)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Notifies the user with the unsuccessful email addresses when emailing results reports.

Linked issue: https://github.com/senaite/senaite.core/issues/1423

## Current behavior before PR

User receives a warning stating "Failed to send Email(s)", but without any further information 

## Desired behavior after PR is merged

User receives the same warning as above, plus the list of addresses for which the emailing failed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
