### PR TITLE
Use the value set for ui_item property when displaying ReferenceWidget

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Changelog
 
 **Fixed**
 
+- #1423 Use the value set for ui_item property when displaying ReferenceWidget
 - #1421 Fix Search Query for Batches Listing
 - #1418 Subscriber adapters not supported in clients listing
 - #1419 Mixed permissions for transitions in client workflow

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1422 Notify user with failing addresses when emailing of results reports
 - #1420 Allow to detach a partition from its primary sample
 - #1410 Email API
 

--- a/bika/lims/browser/publish/emailview.py
+++ b/bika/lims/browser/publish/emailview.py
@@ -510,7 +510,9 @@ class EmailView(BrowserView):
                                              attachments=attachments)
             sent = mailapi.send_email(mime_msg)
             if not sent:
-                logger.error("Could not send email to {}".format(pair))
+                msg = "Could not send email to {}".format(pair)
+                self.add_status_message(msg, "warning")
+                logger.error(msg)
             success.append(sent)
 
         if not all(success):

--- a/bika/lims/browser/publish/emailview.py
+++ b/bika/lims/browser/publish/emailview.py
@@ -510,7 +510,8 @@ class EmailView(BrowserView):
                                              attachments=attachments)
             sent = mailapi.send_email(mime_msg)
             if not sent:
-                msg = "Could not send email to {}".format(pair)
+                msg = _("Could not send email to {0} ({1})").format(pair[0],
+                                                                    pair[1])
                 self.add_status_message(msg, "warning")
                 logger.error(msg)
             success.append(sent)

--- a/bika/lims/skins/bika/bika_widgets/referencewidget.pt
+++ b/bika/lims/skins/bika/bika_widgets/referencewidget.pt
@@ -21,9 +21,11 @@
                                   id string:parent-fieldname-$fieldName-$uid">
           <span metal:define-slot="inside"
                 tal:define="value accessor;
-                            value python: (value and hasattr(value, 'Title')) and value.Title() or '';"
-                tal:attributes="value python: value.strip();"
-                tal:content="value">reference</span>
+                            text_default python: (value and hasattr(value, 'Title')) and value.Title() or '';
+                            text_attr widget/ui_item|nothing;
+                            text python:text_attr and getattr(value, text_attr, text_default) or text_default;"
+                tal:attributes="value text;"
+                tal:content="text">reference</span>
         </span>
       </tal:singlevalued>
 
@@ -65,20 +67,18 @@
                 </tal:repeat>
           </div>
 
+          <tal:input_field define="val python:context.Schema()[fieldName].getAccessor(context)();
+                                   text_default val/Title|nothing;
+                                   text_attr widget/ui_item|nothing;
+                                   text python:text_attr and getattr(val, text_attr, text_default) or text_default;">
           <input
                  type="text"
-                 name=""
-                 id=""
-                 uid=""
                  class="blurrable firstToFocus referencewidget"
-                 value=""
-                 size="30"
-                 tal:define="val python:context.Schema()[fieldName].getAccessor(context)();"
                  tal:condition="python:context.Schema()[fieldName].required"
                  tal:attributes="name fieldName;
                                  required python:True;
                                  id fieldName;
-                                 value val/Title|nothing;
+                                 value text;
                                  uid val/UID|nothing;
                                  size widget/size;
                                  placeholder widget/placeholder|nothing;
@@ -96,17 +96,11 @@
                  />
           <input
                  type="text"
-                 name=""
-                 id=""
-                 uid=""
                  class="blurrable firstToFocus referencewidget"
-                 value=""
-                 size="30"
-                 tal:define="val python:context.Schema()[fieldName].getAccessor(context)();"
                  tal:condition="python:not context.Schema()[fieldName].required"
                  tal:attributes="name fieldName;
                                  id fieldName;
-                                 value val/Title|nothing;
+                                 value text;
                                  uid val/UID|nothing;
                                  size widget/size;
                                  placeholder widget/placeholder|nothing;
@@ -163,6 +157,7 @@
                  tal:attributes="name string:${fieldName}_uid;
                                  id string:${fieldName}_uid;
                                  value python:widget.initial_uid_field_value(val);"/>
+          </tal:input_field>
         </metal:fill>
       </metal:use>
     </metal:define>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When reference widget is rendered by default for a field with a value already set (before user selects an item from the list), the value displayed in the input field is always the Title of the referenced object. This is fine in most cases, except those for which the the value for `ui_item` differs from 'Title'. In such case, the field will display the value for the attr that matches with `ui_item` property after an item is selected, but not the first time is rendered (or when displayed in read-only mode).

## Current behavior before PR

The value set for property `ui_item` is not taken into consideration when `ReferenceWidget` is rendered.

## Desired behavior after PR is merged

The value set for property `ui_item` is taken into consideration when `ReferenceWidget` is rendered.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
