### PR TITLE
Fix adapter priority for widget visibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Changelog
 
 **Fixed**
 
+- #1425 Fix adapter priority for widget visibility
 - #1421 Fix Search Query for Batches Listing
 - #1418 Subscriber adapters not supported in clients listing
 - #1419 Mixed permissions for transitions in client workflow

--- a/bika/lims/adapters/widgetvisibility.py
+++ b/bika/lims/adapters/widgetvisibility.py
@@ -219,7 +219,7 @@ class SecondaryDateSampledFieldVisibility(SenaiteATWidgetVisibility):
     """
     def __init__(self, context):
         super(SecondaryDateSampledFieldVisibility, self).__init__(
-            context=context, sort=3, field_names=["DateSampled"])
+            context=context, sort=20, field_names=["DateSampled"])
 
     def isVisible(self, field, mode="view", default="visible"):
         """Returns whether the field is visible in a given mode
@@ -230,7 +230,10 @@ class SecondaryDateSampledFieldVisibility(SenaiteATWidgetVisibility):
         # If this is a Secondary Analysis Request, this field is not editable
         if IAnalysisRequestSecondary.providedBy(self.context):
             return "invisible"
-        return default
+
+        # Delegate to SamplingFieldsVisibility adapter
+        return SamplingFieldsVisibility(self.context).isVisible(
+            field, mode=mode, default=default)
 
 
 class PrimaryAnalysisRequestFieldVisibility(SenaiteATWidgetVisibility):

--- a/bika/lims/adapters/widgetvisibility.py
+++ b/bika/lims/adapters/widgetvisibility.py
@@ -172,7 +172,7 @@ class RegistryHiddenFieldsVisibility(SenaiteATWidgetVisibility):
     def __init__(self, context):
         field_names = getHiddenAttributesForClass(context.portal_type)
         super(RegistryHiddenFieldsVisibility, self).__init__(
-            context=context, sort=-1, field_names=[field_names,])
+            context=context, sort=float("inf"), field_names=[field_names, ])
 
     def isVisible(self, field, mode="view", default="visible"):
         return "invisible"

--- a/bika/lims/monkey/Widget.py
+++ b/bika/lims/monkey/Widget.py
@@ -74,9 +74,10 @@ def isVisible(self, instance, mode='view', default="visible", field=None):
             continue
         adapter_state = adapter(instance, mode, field, state)
         adapter_name = adapter.__class__.__name__
-        logger.info("IATWidgetVisibility rule {} for {}.{} ({}): {} -> {}"
-            .format(adapter_name, instance.id, field.getName(), mode, state,
-                    adapter_state))
+        logger.info(
+            "IATWidgetVisibility Adapter <{} sort:{}> for {}.{} ({}): {} -> {}"
+            .format(adapter_name, adapter.sort, instance.id, field.getName(),
+                    mode, state, adapter_state))
         return adapter_state
 
     return state

--- a/bika/lims/monkey/Widget.py
+++ b/bika/lims/monkey/Widget.py
@@ -75,9 +75,9 @@ def isVisible(self, instance, mode='view', default="visible", field=None):
         adapter_state = adapter(instance, mode, field, state)
         adapter_name = adapter.__class__.__name__
         logger.info(
-            "IATWidgetVisibility Adapter <{} sort:{}> for {}.{} ({}): {} -> {}"
-            .format(adapter_name, adapter.sort, instance.id, field.getName(),
-                    mode, state, adapter_state))
+            "IATWidgetVisibility: <{} for {}.{} mode:{} sort:{}> {} -> {}"
+            .format(adapter_name, instance.id, field.getName(), mode,
+                    adapter.sort, state, adapter_state))
         return adapter_state
 
     return state

--- a/bika/lims/monkey/Widget.py
+++ b/bika/lims/monkey/Widget.py
@@ -77,8 +77,6 @@ def isVisible(self, instance, mode='view', default="visible", field=None):
         logger.info("IATWidgetVisibility rule {} for {}.{} ({}): {} -> {}"
             .format(adapter_name, instance.id, field.getName(), mode, state,
                     adapter_state))
-        if adapter_state == state:
-            continue
         return adapter_state
 
     return state


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue where a custom adapter with higher "sort" priority did not "win", because its returned visibility value was skipped.

## Current behavior before PR

Default `DateReceivedFieldVisibility` adapter always took precedence over a custom adapter which returned the value "visible" for the "edit" state.

## Desired behavior after PR is merged

Custom visibility adapter *always* takes precedence when its "sort" key is *higher* than the default adapter.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
