### PR TITLE
Render HTML Texts in Info Popups correctly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Changelog
 
 **Fixed**
 
+- #1426 Render HTML Texts in Info Popups correctly
 - #1425 Fix adapter priority for widget visibility
 - #1421 Fix Search Query for Batches Listing
 - #1418 Subscriber adapters not supported in clients listing

--- a/bika/lims/browser/templates/analysisreport_info.pt
+++ b/bika/lims/browser/templates/analysisreport_info.pt
@@ -164,7 +164,7 @@
                       <span i18n:translate="">Subject</span>
                     </td>
                     <td>
-                      <span tal:content="record/email_subject|default">-</span>
+                      <span tal:content="structure record/email_subject|default">-</span>
                     </td>
                   </tr>
                   <!-- Body Text -->
@@ -173,7 +173,7 @@
                       <span i18n:translate="">Text</span>
                     </td>
                     <td>
-                      <pre class="small" tal:content="record/email_body|default">-</pre>
+                      <pre class="small" tal:content="structure record/email_body|default">-</pre>
                     </td>
                   </tr>
                   <!-- Attachments -->

--- a/bika/lims/browser/templates/analysisservice_info.pt
+++ b/bika/lims/browser/templates/analysisservice_info.pt
@@ -51,7 +51,7 @@
                   <span i18n:translate="">Description</span>
                 </td>
                 <td>
-                  <span tal:content="service/Description"></span>
+                  <span tal:content="structure service/Description"></span>
                 </td>
               </tr>
               <tr>
@@ -134,7 +134,7 @@
                      tal:content="method/Title"/>
                 </td>
                 <td>
-                  <span tal:content="method/Description"></span>
+                  <span tal:content="structure method/Description"></span>
                 </td>
               </tr>
             </table>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR renders HTML text in popups properly

## Current behavior before PR

Description texts in info popups containing HTML, e.g. `<br>` were not rendered correctly

## Desired behavior after PR is merged

Description texts in info popups containing HTML, e.g. `<br>` are rendered correctly


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
