### PR TITLE
Publish verified partitions

### DIFF
--- a/bika/lims/browser/publish/emailview.py
+++ b/bika/lims/browser/publish/emailview.py
@@ -430,22 +430,24 @@ class EmailView(BrowserView):
     def publish_samples(self):
         """Publish all samples of the reports
         """
-        reports = self.reports
-        for report in reports:
-            # publish the primary sample
-            primary_sample = report.getAnalysisRequest()
-            self.publish(primary_sample)
-            # publish the contained samples
-            contained_samples = report.getContainedAnalysisRequests()
-            for sample in contained_samples:
-                # skip the primary sample
-                if sample == primary_sample:
-                    continue
-                self.publish(sample)
+        samples = set()
+
+        # collect primary + contained samples of the reports
+        for report in self.reports:
+            samples.add(report.getAnalysisRequest())
+            samples.update(report.getContainedAnalysisRequests())
+
+        # publish all samples + their partitions
+        for sample in samples:
+            self. publish(sample)
 
     def publish(self, sample):
         """Set status to prepublished/published/republished
         """
+        # publish partitions
+        for partition in sample.getDescendants():
+            self.publish(partition)
+
         wf = api.get_tool("portal_workflow")
         status = wf.getInfoFor(sample, "review_state")
         transitions = {"verified": "publish",
@@ -460,10 +462,8 @@ class EmailView(BrowserView):
             wf.doActionFor(sample, transition)
             # Commit the changes
             transaction.commit()
-            return True
         except WorkflowException as e:
             logger.error(e)
-            return False
 
     def render_email_template(self, template):
         """Return the rendered email template


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the primary sample publication behaviour, so that verified partitions are transitioned to the `publish*  state if they were in *verified* state before.

## Current behavior before PR

If a primary sample with descendants (partitions) is pre-published, none of the *verified* partitions is published.

## Desired behavior after PR is merged

If a primary sample with descendants (partitions) is pre-published, all of the *verified* partitions are published.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
