### PR TITLE
Added Submitter column in Sample's analysis listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1431 Added Submitter column in Sample's analyses listing
 - #1422 Notify user with failing addresses when emailing of results reports
 - #1420 Allow to detach a partition from its primary sample
 - #1410 Email API

--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -159,6 +159,9 @@ class AnalysesView(BikaListingView):
                 "title": _("Captured"),
                 "index": "getResultCaptureDate",
                 "sortable": False}),
+            ("SubmittedBy", {
+                "title": _("Submitter"),
+                "sortable": False}),
             ("DueDate", {
                 "title": _("Due Date"),
                 "index": "getDueDate",
@@ -550,6 +553,8 @@ class AnalysesView(BikaListingView):
         self._folder_item_instrument(obj, item)
         # Fill analyst
         self._folder_item_analyst(obj, item)
+        # Fill submitted by
+        self._folder_item_submitted_by(obj, item)
         # Fill attachments
         self._folder_item_attachments(obj, item)
         # Fill uncertainty
@@ -885,6 +890,17 @@ class AnalysesView(BikaListingView):
         # Analyst is editable
         item['Analyst'] = obj.getAnalyst or api.get_current_user().id
         item['choices']['Analyst'] = self.get_analysts()
+
+    def _folder_item_submitted_by(self, obj, item):
+        submitted_by = obj.getSubmittedBy
+        if submitted_by:
+            user = self.get_user_by_id(submitted_by)
+            user_name = user and user.getProperty("fullname") or submitted_by
+            item['SubmittedBy'] = user_name
+
+    @viewcache.memoize
+    def get_user_by_id(self, user_id):
+        return api.get_user(user_id)
 
     def _folder_item_attachments(self, obj, item):
         item['Attachments'] = ''

--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -984,7 +984,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
     def getAnalyst(self):
         """Returns the stored Analyst or the user who submitted the result
         """
-        analyst = self.getField("Analyst").get(self)
+        analyst = self.getField("Analyst").get(self) or self.getAssignedAnalyst()
         if not analyst:
             analyst = self.getSubmittedBy()
         return analyst or ""


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The value displayed for column "Analyst" in analyses listing might be confusing. "Analyst" displays the analyst assigned to the analysis, that might be different from the user who actually submitted the result. To prevent confusions, this Pull Request adds the column "Submitter" in the analyses listing from inside Sample context.

## Current behavior before PR

User has to look at the info panel to know the user who actually submitted the result, that might be different from the value displayed under column "Analyst".

## Desired behavior after PR is merged

No confusions. In the "Analyst" columns, the user assigned (either directly or through a Worksheet) to the analysis is displayed. The column "Submitter" displays the user who actually submitted the result.

![Captura de 2019-09-03 17-42-14](https://user-images.githubusercontent.com/832627/64188187-34dcf400-ce72-11e9-90d5-63bc21e9144f.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
