### PR TITLE
Added patient demographics to rejected sample report

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,13 @@ Changelog
 
 **Added**
 
+- #92 re-arranged client information
+- #99 Fetch patient demographics
+- #104 Render patient demographics in HTML
+
+
+**Added**
+
 - #1422 Notify user with failing addresses when emailing of results reports
 - #1420 Allow to detach a partition from its primary sample
 - #1410 Email API

--- a/bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequest_retract_pdf.pt
@@ -76,10 +76,7 @@
                 <td class="label" i18n:translate="">Client</td>
                 <td tal:content="python: client.Title()"></td>
             </tr>
-            <tr>
-                <td class="label" i18n:translate="">Client ID</td>
-                <td tal:content="python: client.getClientID()"></td>
-            </tr>
+
             <tr>
                 <td class="label" i18n:translate="">Physical address</td>
                 <td tal:define="
@@ -91,8 +88,30 @@
                     </tal:addresslines>
                 </td>
             </tr>
+
+            <tr>
+                <td class="label" i18n:translate="">Client ID</td>
+                <td tal:content="python: client.getClientID()"></td>
+            </tr>
         </table>
     </div>
+
+    <tal:patient define="patient python:ar.Schema().getField('Patient');
+                     patient python:patient.get(ar) if patient else None;">
+    <div class="patient" tal:condition="patient">
+        <table cellpadding="0" cellspacing="0" border="0">
+            <tr>
+                <td class="label" i18n:translate="">Name of Patient</td>
+                <td tal:content="python: patient.getFullname()"></td>
+                <td class="label" i18n:translate="">Age</td>
+                <td tal:content="python: patient.getAgeSplittedStr()"></td>
+                <td class="label" i18n:translate="">Sex</td>
+                <td tal:content="python: patient.getGender()"></td>
+            </tr>
+        </table>
+    </div>
+    </tal:patient>
+
 
     <div class="sample">
         <table cellpadding="0" cellspacing="0" border="0">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Rejected sample report is no longer showing patient demographics.

Linked issue: https://github.com/senaite/senaite.core/issues/1434

## Current behavior before PR

The rejected sample report does not show patient demographics.

## Desired behavior after PR is merged

The rejected sample report should include:
- Patient name
- Gender
- Age
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
