### PR TITLE
Setting in setup for auto-reception of samples upon creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ Changelog
 
 **Added**
 
-- #1431 Added Submitter column in Sample's analyses listing
+- #1436 Setting in setup for auto-reception of samples upon creation
+- #1433 Added Submitter column in Sample's analyses listing
 - #1422 Notify user with failing addresses when emailing of results reports
 - #1420 Allow to detach a partition from its primary sample
 - #1410 Email API

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -529,6 +529,19 @@ schema = BikaFolderSchema.copy() + Schema((
         ),
     ),
     BooleanField(
+        "AutoreceiveSamples",
+        schemata="Sampling",
+        default=False,
+        widget=BooleanWidget(
+            label=_("Auto-receive samples"),
+            description=_(
+                "Select to receive the samples automatically when created by "
+                "lab personnel and sampling workflow is disabled. Samples "
+                "created by client contacts won't be received automatically"
+            ),
+        ),
+    ),
+    BooleanField(
         'ShowPartitions',
         schemata="Appearance",
         default=False,

--- a/bika/lims/workflow/analysisrequest/events.py
+++ b/bika/lims/workflow/analysisrequest/events.py
@@ -48,14 +48,10 @@ def after_no_sampling_workflow(analysis_request):
     """
     setup = api.get_setup()
     if setup.getAutoreceiveSamples():
-        # Auto-receive samples is enabled. Receive the sample automatically,
-        # but only if the current user is a laboratory contact
-        user = api.get_current_user()
-        contact = api.get_user_contact(user, contact_types=["LabContact"])
-        if contact:
-            # Note that if current user does not have privileges to receive,
-            # the sample won't be transitioned, even if we call do_action_for
-            do_action_for(analysis_request, "receive")
+        # Auto-receive samples is enabled. Note transition to "received" state
+        # will only take place if the current user has enough privileges (this
+        # is handled by do_action_for already).
+        do_action_for(analysis_request, "receive")
 
 
 def after_reject(analysis_request):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

By default, the samples need to be received by lab personnel after they are created in the system. Quite often, lab personnel would like the samples that are created by themselves to be automatically received.

## Current behavior before PR

Samples created by lab personnel cannot be auto-received upon creation

## Desired behavior after PR is merged

Samples created by lab personnel can be auto-received upon creation

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
