### PR TITLE
Added Auto ID Behavior for Dexterity Contents

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1441 Added Auto ID Behavior for Dexterity Contents
 - #1431 Added Submitter column in Sample's analyses listing
 - #1422 Notify user with failing addresses when emailing of results reports
 - #1420 Allow to detach a partition from its primary sample

--- a/bika/lims/configure.zcml
+++ b/bika/lims/configure.zcml
@@ -11,14 +11,6 @@
 
   <i18n:registerTranslations directory="locales" />
 
-
-  <!-- Plone behavior for Dexterity based contents -->
-  <plone:behavior
-      title="Auto-Generate ID Beahvior for Dexterity Contents"
-      description="Generates an ID with the IDServer"
-      provides="bika.lims.interfaces.IAutoGenerateID"
-      />
-
 <includeDependencies package="." />
 //  <include package="jarn.jsi18n" />
 //  <include package="plone.app.z3cform" />
@@ -50,6 +42,13 @@
   <i18n:registerTranslations directory="locales" />
 
   <cmf:registerDirectory name="skins" directory="skins" recursive="True" />
+
+  <!-- Plone behavior for Dexterity based contents -->
+  <plone:behavior
+      title="Auto-Generate ID Beahvior for Dexterity Contents"
+      description="Generates an ID with the IDServer"
+      provides="bika.lims.interfaces.IAutoGenerateID"
+      />
 
   <!-- jquery redirects here when values are entered into 'document' context (barcodes) -->
   <browser:page
@@ -97,13 +96,4 @@
       provides="bika.lims.interfaces.INumberGenerator"
       factory=".numbergenerator.NumberGenerator"
   />
-
-
-   <!-- Bika Auto generate ID behavior for Dexterity types -->
-   <plone:behavior
-        title="Auto generate ID Behavior for Dexterity contents"
-        description="Generates an ID with the IDServer"
-        provides="bika.lims.interfaces.IGenerateID"
-        />
-
 </configure>

--- a/bika/lims/configure.zcml
+++ b/bika/lims/configure.zcml
@@ -12,6 +12,13 @@
   <i18n:registerTranslations directory="locales" />
 
 
+  <!-- Plone behavior for Dexterity based contents -->
+  <plone:behavior
+      title="Auto-Generate ID Beahvior for Dexterity Contents"
+      description="Generates an ID with the IDServer"
+      provides="bika.lims.interfaces.IAutoGenerateID"
+      />
+
 <includeDependencies package="." />
 //  <include package="jarn.jsi18n" />
 //  <include package="plone.app.z3cform" />

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -28,6 +28,11 @@ class IBikaLIMS(Interface):
     """
 
 
+class IAutoGenerateID(Interface):
+    """Auto-generate ID with ID server
+    """
+
+
 class IActionHandlerPool(Interface):
     """Marker interface for the ActionHandlerPool utility
     """

--- a/bika/lims/profiles/default/types/SamplingRound.xml
+++ b/bika/lims/profiles/default/types/SamplingRound.xml
@@ -87,6 +87,7 @@
     <!-- enabled behaviors -->
     <!-- This allow references between archetypes and dexterity content types. -->
     <property name="behaviors">
+        <element value="bika.lims.interfaces.IAutoGenerateID"/>
         <element value="plone.app.referenceablebehavior.referenceable.IReferenceable" />
     </property>
 </object>

--- a/bika/lims/subscribers/configure.zcml
+++ b/bika/lims/subscribers/configure.zcml
@@ -4,6 +4,13 @@
     xmlns:i18n="http://namespaces.zope.org/i18n"
     i18n_domain="senaite.core">
 
+  <!-- ID Server: Object Added -->
+  <subscriber
+      for="bika.lims.interfaces.IAutoGenerateID
+           zope.lifecycleevent.interfaces.IObjectAddedEvent"
+      handler=".objectadded.auto_generate_id"
+      />
+
   <!-- Audit Log: Object Created -->
   <subscriber
       for="*

--- a/bika/lims/subscribers/objectadded.py
+++ b/bika/lims/subscribers/objectadded.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE
+#
+# Copyright 2018 by it's authors.
+
+from bika.lims.idserver import renameAfterCreation
+from bika.lims import logger
+
+
+def auto_generate_id(obj, event):
+    """Generate ID with the IDServer from senaite.core
+    """
+    logger.info("Auto-Generate ID for {}".format(repr(obj)))
+    renameAfterCreation(obj)

--- a/bika/lims/subscribers/samplinground.py
+++ b/bika/lims/subscribers/samplinground.py
@@ -18,21 +18,19 @@
 # Copyright 2018-2019 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from bika.lims.idserver import renameAfterCreation
 
 def SamplingRoundAddedEventHandler(instance, event):
-    """ Event fired when BikaSetup object gets modified.
-        Since Sampling Round is a dexterity object we have to change the ID by "hand"
-        Then we have to redirect the user to the ar add form
+    """Redirect user to the sample add form
     """
     if instance.portal_type != "SamplingRound":
-        print("How does this happen: type is %s should be SamplingRound" % instance.portal_type)
-        return
-    renameAfterCreation(instance)
+        raise TypeError("Expected portal type 'SamplingRound', got '{}'"
+                        .format(instance.portal_type))
+
+    # renameAfterCreation(instance)
     num_art = len(instance.ar_templates)
     destination_url = instance.aq_parent.absolute_url() + \
-                    "/portal_factory/" + \
-                    "AnalysisRequest/Request new analyses/ar_add?samplinground=" + \
-                    instance.UID() + "&ar_count=" + str(num_art)
+        "/portal_factory/" + \
+        "AnalysisRequest/Request new analyses/ar_add?samplinground=" + \
+        instance.UID() + "&ar_count=" + str(num_art)
     request = getattr(instance, 'REQUEST', None)
     request.response.redirect(destination_url)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR introduces a [Plone Behavior](https://docs.plone.org/external/plone.app.dexterity/docs/behaviors/index.html) to generate IDs for [Dexterity](https://docs.plone.org/external/plone.app.dexterity/docs/index.html) based contents.

## Usage

Add this XML into your Dexterity `profiles/default/types/<Content>.xml`:

```xml
  <!-- Dexterity behaviours for this type -->
  <property name="behaviors">
    <element value="bika.lims.interfaces.IAutoGenerateID"/>
    ...
  </property>
```

## Current behavior before PR

Dexterity contents not integrated into the ID Server machinery

## Desired behavior after PR is merged

Dexterity contents supported by the ID Server machinery

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
