### PR TITLE
Fix non-saving checkbox values for manual Interims in Analysis Services

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Changelog
 
 **Fixed**
 
+- #1443 Fix non-saving checkbox values for manual Interims in Analysis Services
 - #1426 Render HTML Texts in Info Popups correctly
 - #1423 Use the value set for ui_item property when displaying ReferenceWidget
 - #1425 Fix adapter priority for widget visibility

--- a/bika/lims/browser/js/bika.lims.analysisservice.js
+++ b/bika/lims/browser/js/bika.lims.analysisservice.js
@@ -577,20 +577,23 @@
       rows = field.find("tr.records_row_InterimFields");
       interims = [];
       $.each(rows, function(index, row) {
-        var values;
+        var inputs, values;
         values = {};
-        $.each($(row).find("td input"), function(index, input) {
+        inputs = row.querySelectorAll("td input");
+        $.each(inputs, function(index, input) {
           var key, value;
           key = this.name.split(":")[0].split(".")[1];
           value = input.value;
           if (input.type === "checkbox") {
             value = input.checked;
           }
-          return values[key] = value;
+          values[key] = value;
+          return true;
         });
         if (values.keyword !== "") {
-          return interims.push(values);
+          interims.push(values);
         }
+        return true;
       });
       return interims;
     };
@@ -634,18 +637,15 @@
           key = this.name.split(":")[0].split(".")[1];
           value = interim[key];
           if (input.type === "checkbox") {
-            if (value) {
-              value = true;
-            } else {
-              value = false;
-            }
-            return input.checked = value;
+            input.checked = value;
+            input.value = "on";
           } else {
             if (!value) {
               value = "";
             }
-            return input.value = value;
+            input.value = value;
           }
+          return true;
         });
       });
     };
@@ -848,7 +848,7 @@
           catalog_name: "bika_setup_catalog",
           page_size: 0,
           UID: calculation_uid,
-          is_active: true,
+          active_state: true,
           sort_on: "sortable_title"
         }
       };

--- a/bika/lims/browser/js/bika.lims.analysisservice.js
+++ b/bika/lims/browser/js/bika.lims.analysisservice.js
@@ -848,7 +848,7 @@
           catalog_name: "bika_setup_catalog",
           page_size: 0,
           UID: calculation_uid,
-          active_state: true,
+          is_active: true,
           sort_on: "sortable_title"
         }
       };

--- a/bika/lims/browser/js/coffee/bika.lims.analysisservice.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisservice.coffee
@@ -537,7 +537,8 @@ class window.AnalysisServiceEditView
     interims = []
     $.each rows, (index, row) ->
       values = {}
-      $.each $(row).find("td input"), (index, input) ->
+      inputs = row.querySelectorAll "td input"
+      $.each inputs, (index, input) ->
         # Extract the key from the element name
         # InterimFields.keyword:records:ignore_empty
         key = @name.split(":")[0].split(".")[1]
@@ -545,9 +546,18 @@ class window.AnalysisServiceEditView
         if input.type is "checkbox"
           value = input.checked
         values[key] = value
+        # N.B. coffee-script always returns the last value if not explicitly returned
+        #      and false values act as a break in $.each loops!
+        return true
+
       # Only rows with Keyword set
       if values.keyword isnt ""
         interims.push values
+
+      # N.B. coffee-script always returns the last value if not explicitly returned
+      #      and false values act as a break in $.each loops!
+      return true
+
     return interims
 
 
@@ -592,12 +602,16 @@ class window.AnalysisServiceEditView
         key = @name.split(":")[0].split(".")[1]
         value = interim[key]
         if input.type is "checkbox"
-          # transform to bool value
-          if value then value = yes else value = no
           input.checked = value
+          # N.B. if we omit the value, the field won't be set on save
+          input.value = "on"
         else
           if not value then value = ""
           input.value = value
+
+        # N.B. coffee-script always returns the last value if not explicitly returned
+        #      and false values act as a break in $.each loops!
+        return true
 
 
   flush_interims: =>

--- a/bika/lims/browser/js/coffee/bika.lims.analysisservice.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisservice.coffee
@@ -817,7 +817,7 @@ class window.AnalysisServiceEditView
         catalog_name: "bika_setup_catalog"
         page_size: 0
         UID: calculation_uid
-        active_state: true
+        is_active: true
         sort_on: "sortable_title"
 
     @ajax_submit options


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the Analysis Services JavaScript, which caused that manual interims (not coming from a Calculation) did not save.

## Current behavior before PR

Checkbox fields for `report`, `hidden` and `wide` did not safe values for interims

## Desired behavior after PR is merged

Checkbox fields for `report`, `hidden` and `wide` safe values for interims

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
