### PR TITLE
Fixed Worksheet autofill of wide Iterims

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Changelog
 
 **Fixed**
 
+- #1444 Fixed Worksheet autofill of wide Iterims
 - #1426 Render HTML Texts in Info Popups correctly
 - #1423 Use the value set for ui_item property when displaying ReferenceWidget
 - #1425 Fix adapter priority for widget visibility

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -1122,13 +1122,13 @@
       empty_only = $("#wideinterims_empty").is(":checked");
       value = $("#wideinterims_value").val();
       set_value = function(input, value) {
-        var cb, tr;
-        input.value = value;
-        tr = input.closest("tr");
-        cb = tr.querySelector("input[type='checkbox']");
-        if (!cb.checked) {
-          return cb.click();
-        }
+        var evt, nativeInputValueSetter;
+        nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
+        nativeInputValueSetter.call(input, value);
+        evt = new Event('input', {
+          bubbles: true
+        });
+        return input.dispatchEvent(evt);
       };
       return $("tr td input[column_key='" + interim + "']").each(function(index, input) {
         if (empty_only) {

--- a/bika/lims/browser/js/bika.lims.worksheet.js
+++ b/bika/lims/browser/js/bika.lims.worksheet.js
@@ -1113,22 +1113,32 @@
       /*
        * Eventhandler when the wide interim apply button was clicked
        */
-      var $el, analysis, empty_only, interim;
+      var $el, analysis, empty_only, interim, set_value, value;
       console.debug("°°° WorksheetManageResultsView::on_wideinterims_apply_click °°°");
       event.preventDefault();
       $el = $(event.currentTarget);
       analysis = $("#wideinterims_analyses").val();
       interim = $("#wideinterims_interims").val();
       empty_only = $("#wideinterims_empty").is(":checked");
-      return $("tr td input[column_key='" + interim + "']").each(function(index, element) {
+      value = $("#wideinterims_value").val();
+      set_value = function(input, value) {
+        var cb, tr;
+        input.value = value;
+        tr = input.closest("tr");
+        cb = tr.querySelector("input[type='checkbox']");
+        if (!cb.checked) {
+          return cb.click();
+        }
+      };
+      return $("tr td input[column_key='" + interim + "']").each(function(index, input) {
         if (empty_only) {
           if ($(this).val() === "" || $(this).val().match(/\d+/) === "0") {
-            $(this).val($("#wideinterims_value").val());
+            set_value(input, value);
           }
         } else {
-          $(this).val($("#wideinterims_value").val());
+          set_value(input, value);
         }
-        return $(this).trigger("change");
+        return true;
       });
     };
 

--- a/bika/lims/browser/js/coffee/bika.lims.worksheet.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.worksheet.coffee
@@ -1045,14 +1045,14 @@ class window.WorksheetManageResultsView
     # N.B.: Workaround to notify the ReactJS listing component about the changed
     # values
     set_value = (input, value) ->
-      # Set the value in the input field
-      input.value = value
       # Manually select the checkbox of this row
       # https://github.com/senaite/senaite.core/issues/1202
-      tr = input.closest("tr")
-      cb = tr.querySelector("input[type='checkbox']")
-      if not cb.checked
-        cb.click()
+      # https://stackoverflow.com/questions/23892547/what-is-the-best-way-to-trigger-onchange-event-in-react-js
+      # TL;DR: React library overrides input value setter
+      nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set
+      nativeInputValueSetter.call(input, value)
+      evt = new Event('input', {bubbles: true})
+      input.dispatchEvent(evt)
 
     $("tr td input[column_key='#{interim}']").each (index, input) ->
       if empty_only

--- a/bika/lims/browser/js/coffee/bika.lims.worksheet.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.worksheet.coffee
@@ -1040,11 +1040,24 @@ class window.WorksheetManageResultsView
     analysis = $("#wideinterims_analyses").val()
     interim = $("#wideinterims_interims").val()
     empty_only = $("#wideinterims_empty").is(":checked")
+    value = $("#wideinterims_value").val()
 
-    $("tr td input[column_key='#{interim}']").each (index, element) ->
+    # N.B.: Workaround to notify the ReactJS listing component about the changed
+    # values
+    set_value = (input, value) ->
+      # Set the value in the input field
+      input.value = value
+      # Manually select the checkbox of this row
+      # https://github.com/senaite/senaite.core/issues/1202
+      tr = input.closest("tr")
+      cb = tr.querySelector("input[type='checkbox']")
+      if not cb.checked
+        cb.click()
+
+    $("tr td input[column_key='#{interim}']").each (index, input) ->
       if empty_only
         if $(this).val() == "" or $(this).val().match(/\d+/) == "0"
-          $(this).val $("#wideinterims_value").val()
+          set_value input, value
       else
-        $(this).val $("#wideinterims_value").val()
-      $(this).trigger "change"
+        set_value input, value
+      return true

--- a/bika/lims/browser/worksheet/views/results.py
+++ b/bika/lims/browser/worksheet/views/results.py
@@ -164,10 +164,6 @@ class ManageResultsView(BrowserView):
             if analysis.getKeyword() in outdict.keys():
                 continue
 
-            calculation = analysis.getCalculation()
-            if not calculation:
-                continue
-
             andict = {
                 "analysis": analysis.Title(),
                 "keyword": analysis.getKeyword(),
@@ -177,12 +173,6 @@ class ManageResultsView(BrowserView):
             # Analysis Service interim defaults
             for field in analysis.getInterimFields():
                 if field.get("wide", False):
-                    andict["interims"][field["keyword"]] = field
-
-            # Interims from calculation
-            for field in calculation.getInterimFields():
-                if field["keyword"] not in andict["interims"].keys() \
-                   and field.get("wide", False):
                     andict["interims"][field["keyword"]] = field
 
             if andict["interims"]:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1202

## Current behavior before PR

Setting wide Interims in Worksheets did not select the row for saving

## Desired behavior after PR is merged

Setting wide Interims in Worksheets selects the row for saving

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
