### PR TITLE
Allow formatted HTML in the other rejection reasons

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Changed**
 
+- #1445 Allow formatted HTML in the other rejection reasons
 - #1428 Publish verified partitions
 - #1429 Add2: Do not set template values on already filled fields
 - #1427 Improved performance of Sample header table rendering

--- a/bika/lims/browser/viewlets/templates/rejected_ar_viewlet.pt
+++ b/bika/lims/browser/viewlets/templates/rejected_ar_viewlet.pt
@@ -20,7 +20,7 @@
       <p tal:define="other_reasons python:sample.getOtherRejectionReasons()"
          tal:condition="other_reasons">
         <span i18n:translate="">Other reasons: </span>
-        <span tal:content="other_reasons"></span>
+        <span tal:content="structure other_reasons"></span>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR allows to use HTML tags like `<br>` to structure the custom rejection reasons

## Current behavior before PR

No HTML formatting possible in other rejection reasons

## Desired behavior after PR is merged

HTML formatting possible in other rejection reasons

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
