### PR TITLE
Parameter `group` in `contact._addUserToGroup` was not considered

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,7 @@ Changelog
 
 **Fixed**
 
+- #1446 Parameter `group` in `contact._addUserToGroup` was not considered
 - #1444 Fixed Worksheet autofill of wide Iterims
 - #1443 Fix non-saving checkbox values for manual Interims in Analysis Services
 - #1439 Fix global Auditlog when Analyses/Attachments were removed

--- a/bika/lims/content/contact.py
+++ b/bika/lims/content/contact.py
@@ -294,7 +294,7 @@ class Contact(Person):
         """Add user to the goup
         """
         portal_groups = api.portal.get_tool("portal_groups")
-        group = portal_groups.getGroupById('Clients')
+        group = portal_groups.getGroupById(group)
         group.addMember(username)
 
     @security.private


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The parameter `group` from function `_addUserToGroup` from `Contact` was not being used, so "Clients" was the group always assigned to the contact.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
