### PR TITLE
New Client contact has access to last Sample only

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Changelog
 
 **Fixed**
 
+- #1447 New Client contact has access to last client's Sample only
 - #1446 Parameter `group` in `contact._addUserToGroup` was not considered
 - #1444 Fixed Worksheet autofill of wide Iterims
 - #1443 Fix non-saving checkbox values for manual Interims in Analysis Services

--- a/bika/lims/content/contact.py
+++ b/bika/lims/content/contact.py
@@ -329,8 +329,8 @@ class Contact(Person):
         """Reindex object security after user linking
         """
         if hasattr(aq_base(obj), "objectValues"):
-            for obj in obj.objectValues():
-                self._recursive_reindex_object_security(obj)
+            for child_obj in obj.objectValues():
+                self._recursive_reindex_object_security(child_obj)
 
         logger.debug("Reindexing object security for {}".format(repr(obj)))
         obj.reindexObjectSecurity()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When a new client contact is created and new user created/linked, the new user can only see the last sample that was created for that client. The reason is that, although local roles for each client and descendants were correctly set, only the first sample was reindexed because the value `obj` was overriden in the loop.

## Current behavior before PR

New user linked to client contact can only see the last sample from the client

## Desired behavior after PR is merged

New user linked to client contact can see all samples from the client

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
