### PR TITLE
Render Analysis Remarks in Listings as HTML

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Changed**
 
+- #1451 Render Analysis Remarks in Listings as HTML
 - #1445 Allow formatted HTML in the other rejection reasons
 - #1428 Publish verified partitions
 - #1429 Add2: Do not set template values on already filled fields

--- a/bika/lims/api/__init__.py
+++ b/bika/lims/api/__init__.py
@@ -1376,3 +1376,21 @@ def to_display_list(pairs, sort_by="key", allow_empty=True):
         dl = dl.sortedByValue()
 
     return dl
+
+
+def text_to_html(text, wrap="p", encoding="utf8"):
+    """Convert `\n` sequences in the text to HTML `\n`
+
+    :param text: Plain text to convert
+    :param wrap: Toggle to wrap the text in a
+    :returns: HTML converted and encoded text
+    """
+    # handle text internally as unicode
+    text = safe_unicode(text)
+    # replace newline characters with HTML entities
+    html = text.replace("\n", "<br/>")
+    if wrap:
+        html = u"<{tag}>{html}</{tag}>".format(
+            tag=wrap, html=html)
+    # return encoded html
+    return html.encode(encoding)

--- a/bika/lims/api/__init__.py
+++ b/bika/lims/api/__init__.py
@@ -1385,6 +1385,8 @@ def text_to_html(text, wrap="p", encoding="utf8"):
     :param wrap: Toggle to wrap the text in a
     :returns: HTML converted and encoded text
     """
+    if not text:
+        return ""
     # handle text internally as unicode
     text = safe_unicode(text)
     # replace newline characters with HTML entities

--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -1212,11 +1212,14 @@ class AnalysesView(BikaListingView):
         """
 
         if self.analysis_remarks_enabled():
-            remarks = analysis_brain.getRemarks
-            item["Remarks"] = api.text_to_html(remarks)
+            item["Remarks"] = analysis_brain.getRemarks
 
         if self.is_analysis_edition_allowed(analysis_brain):
             item["allow_edit"].extend(["Remarks"])
+        else:
+            # render HTMLified text in readonly mode
+            item["Remarks"] = api.text_to_html(
+                analysis_brain.getRemarks, wrap=None)
 
     def _append_html_element(self, item, element, html, glue="&nbsp;",
                              after=True):

--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -1212,7 +1212,8 @@ class AnalysesView(BikaListingView):
         """
 
         if self.analysis_remarks_enabled():
-            item["Remarks"] = analysis_brain.getRemarks
+            remarks = analysis_brain.getRemarks
+            item["Remarks"] = api.text_to_html(remarks)
 
         if self.is_analysis_edition_allowed(analysis_brain):
             item["allow_edit"].extend(["Remarks"])

--- a/bika/lims/tests/doctests/API.rst
+++ b/bika/lims/tests/doctests/API.rst
@@ -1601,3 +1601,34 @@ It can be sorted either by key or by value:
 
     >>> api.to_display_list(pairs, sort_by="value")
     <DisplayList [('b', 10), ('a', 100), ('', '')] at ...>
+
+
+Converting a text to HTML
+-------------------------
+
+This function converts newline (`\n`) escape sequences in plain text to `<br/>`
+tags for HTML rendering.
+
+The function can handle plain texts:
+
+    >>> text = "First\r\nSecond\r\nThird"
+    >>> api.text_to_html(text)
+    '<p>First\r<br/>Second\r<br/>Third</p>'
+
+Unicodes texts work as well:
+
+    >>> text = u"Ä\r\nÖ\r\nÜ"
+    >>> api.text_to_html(text)
+    '<p>\xc3\x83\xc2\x84\r<br/>\xc3\x83\xc2\x96\r<br/>\xc3\x83\xc2\x9c</p>'
+
+The outer `<p>` wrap can be also omitted:
+
+    >>> text = "One\r\nTwo"
+    >>> api.text_to_html(text, wrap=None)
+    'One\r<br/>Two'
+
+Or changed to another tag:
+
+    >>> text = "One\r\nTwo"
+    >>> api.text_to_html(text, wrap="div")
+    '<div>One\r<br/>Two</div>'

--- a/bika/lims/tests/doctests/API.rst
+++ b/bika/lims/tests/doctests/API.rst
@@ -1632,3 +1632,9 @@ Or changed to another tag:
     >>> text = "One\r\nTwo"
     >>> api.text_to_html(text, wrap="div")
     '<div>One\r<br/>Two</div>'
+
+Empty strings are returned unchanged:
+
+    >>> text = ""
+    >>> api.text_to_html(text, wrap="div")
+    ''


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the formatting for analysis remarks, so that newlines are properly displayed

## Current behavior before PR

Newlines not shown in Analysis Remarks field

<img width="433" alt="S19-24883 — LISCON LIMS 2019-10-07 13-33-13" src="https://user-images.githubusercontent.com/713193/66308295-0f2a8b00-e907-11e9-913f-4f1adc2ea36d.png">

## Desired behavior after PR is merged

Newlines and HTML shown in Analysis Remarks field

<img width="402" alt="S19-24883 — LISCON LIMS 2019-10-07 13-34-57" src="https://user-images.githubusercontent.com/713193/66308371-46993780-e907-11e9-8b5e-3567965d581e.png">



--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
