### PR TITLE
Fix missing error percentage calculation for reference samples

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,7 @@ Changelog
 
 **Fixed**
 
+- #1452 Fix missing error percentage calculation for reference samples
 - #1447 New Client contact has access to last client's Sample only
 - #1446 Parameter `group` in `contact._addUserToGroup` was not considered
 - #1444 Fixed Worksheet autofill of wide Iterims

--- a/bika/lims/browser/referencesample.py
+++ b/bika/lims/browser/referencesample.py
@@ -348,6 +348,7 @@ class ReferenceResultsView(BikaListingView):
         item["result"] = ref_result.get("result")
         item["min"] = ref_result.get("min")
         item["max"] = ref_result.get("max")
+        item["error"] = ref_result.get("error")
 
         # Icons
         after_icons = ""

--- a/bika/lims/browser/widgets/referenceresultswidget.py
+++ b/bika/lims/browser/widgets/referenceresultswidget.py
@@ -47,8 +47,6 @@ class ReferenceResultsView(BikaListingView):
         }
         self.context_actions = {}
 
-
-        self.show_column_toggles = False
         self.show_select_column = True
         self.show_select_all_checkbox = True
         self.pagesize = 999999
@@ -162,6 +160,7 @@ class ReferenceResultsView(BikaListingView):
         item["result"] = rr.get("result", "")
         item["min"] = rr.get("min", "")
         item["max"] = rr.get("max", "")
+        item["error"] = rr.get("error", "")
 
         # Icons
         after_icons = ""
@@ -224,8 +223,15 @@ class ReferenceResultsWidget(TypesWidget):
 
             # If neither min nor max have been set, assume we only accept a
             # discrete result (like if % of error was 0).
+            s_err = self._get_spec_value(form, uid, "error")
             s_min = self._get_spec_value(form, uid, "min", result)
             s_max = self._get_spec_value(form, uid, "max", result)
+
+            # If an error percentage was given, calculate the min/max from the
+            # error percentage
+            if s_err:
+                s_min = float(result) * (1 - float(s_err)/100)
+                s_max = float(result) * (1 + float(s_err)/100)
 
             service = api.get_object_by_uid(uid)
             values[uid] = {
@@ -233,7 +239,8 @@ class ReferenceResultsWidget(TypesWidget):
                 "uid": uid,
                 "result": result,
                 "min": s_min,
-                "max": s_max
+                "max": s_max,
+                "error": s_err
             }
 
         return values.values(), {}

--- a/bika/lims/content/analysisspec.py
+++ b/bika/lims/content/analysisspec.py
@@ -221,6 +221,7 @@ class ResultsRangeDict(dict):
         super(ResultsRangeDict, self).__init__(*arg, **kw)
         self["min"] = self.min
         self["max"] = self.max
+        self["error"] = self.error
         self["warn_min"] = self.warn_min
         self["warn_max"] = self.warn_max
         self["min_operator"] = self.min_operator
@@ -233,6 +234,10 @@ class ResultsRangeDict(dict):
     @property
     def max(self):
         return self.get("max", '')
+
+    @property
+    def error(self):
+        return self.get("error", '')
 
     @property
     def warn_min(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the Permitted Error % calculation for Reference Samples.

## Current behavior before PR

Min/Max values are always set to the expected Result, even if the permitted Error % was set.

## Desired behavior after PR is merged

Min/Max values are calculated from the permitted Error %

<img width="1581" alt="Water Reference — SENAITE 2019-10-09 21-50-32" src="https://user-images.githubusercontent.com/713193/66515157-d8a76880-eade-11e9-9791-9bf129d865e8.png">


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
