### PR TITLE
Fix initial IDs not starting with 1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,7 @@ Changelog
 
 **Fixed**
 
+- #1453 Fix initial IDs not starting with 1
 - #1447 New Client contact has access to last client's Sample only
 - #1446 Parameter `group` in `contact._addUserToGroup` was not considered
 - #1444 Fixed Worksheet autofill of wide Iterims

--- a/bika/lims/browser/idserver/configure.zcml
+++ b/bika/lims/browser/idserver/configure.zcml
@@ -20,13 +20,4 @@
       layer="bika.lims.interfaces.IBikaLIMS"
       />
 
-  <browser:page
-      for="*"
-      name="ng_flush"
-      class="bika.lims.browser.idserver.view.IDServerView"
-      attribute="flush"
-      permission="cmf.ManagePortal"
-      layer="bika.lims.interfaces.IBikaLIMS"
-      />
-
 </configure>

--- a/bika/lims/browser/idserver/templates/numbergenerator.pt
+++ b/bika/lims/browser/idserver/templates/numbergenerator.pt
@@ -55,20 +55,12 @@
           </div>
         </tal:numbers>
 
-
         <input class="btn btn-primary btn-sm allowMultiSubmit"
                type="submit"
                name="seed"
                i18n:attributes="value"
                value="Seed"/>
 
-        <!-- enable via the dev-tools if you know what you are doing... -->
-        <input class="btn btn-danger btn-sm allowMultiSubmit"
-               type="submit"
-               disabled="disabled"
-               name="flush"
-               i18n:attributes="value"
-               value="Reset Numbers"/>
       </form>
 
     </div>

--- a/bika/lims/browser/idserver/view.py
+++ b/bika/lims/browser/idserver/view.py
@@ -78,13 +78,6 @@ class IDServerView(BrowserView):
                     message = _("Seeding key {} to {}".format(key, value))
                 self.add_status_message(message, "info")
 
-        # Handle "Flush" action
-        if form.get("flush", False):
-            message = _("Flushed Number Storage")
-            self.add_status_message(message, "warning")
-            self.flush()
-            return self.template()
-
         return self.template()
 
     def get_id_template_for(self, key):
@@ -129,10 +122,3 @@ class IDServerView(BrowserView):
 
         new_seq = self.set_seed(prefix, seed)
         return 'IDServerView: "%s" seeded to %s' % (prefix, new_seq)
-
-    def flush(self):
-        """ Flush the storage
-        """
-        number_generator = getUtility(INumberGenerator)
-        number_generator.flush()
-        return "IDServerView: Number storage flushed!"

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -346,7 +346,8 @@ def search_by_prefix(portal_type, prefix):
     """Returns brains which share the same portal_type and ID prefix
     """
     catalog = api.get_tool("uid_catalog")
-    brains = catalog({"portal_type": portal_type})
+    # Search all brains because the portal_type might also be an interface
+    brains = catalog({})
     # Filter brains with the same ID prefix
     return filter(lambda brain: api.get_id(brain).startswith(prefix), brains)
 
@@ -456,7 +457,11 @@ def get_generated_number(context, config, variables, **kw):
     if key not in number_generator:
         max_num = 0
         existing = get_ids_with_prefix(portal_type, prefix)
-        numbers = map(lambda id: get_seq_number_from_id(id, id_template, prefix), existing)
+        # filter out the current temporary ID
+        temp_id = api.get_id(context)
+        existing = filter(lambda id: id != temp_id, existing)
+        numbers = map(lambda id: get_seq_number_from_id(
+            id, id_template, prefix), existing)
         # figure out the highest number in the sequence
         if numbers:
             max_num = max(numbers)

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -454,7 +454,7 @@ def get_generated_number(context, config, variables, **kw):
     key = make_storage_key(portal_type, prefix)
 
     # Handle flushed storage
-    if key not in number_generator:
+    if len(number_generator.keys()) == 0:
         max_num = 0
         existing = get_ids_with_prefix(portal_type, prefix)
         # filter out the current temporary ID

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -342,24 +342,6 @@ def get_current_year():
     return DateTime().strftime("%Y")[2:]
 
 
-def search_by_prefix(portal_type, prefix):
-    """Returns brains which share the same portal_type and ID prefix
-    """
-    catalog = api.get_tool("uid_catalog")
-    # Search all brains because the portal_type might also be an interface
-    brains = catalog({})
-    # Filter brains with the same ID prefix
-    return filter(lambda brain: api.get_id(brain).startswith(prefix), brains)
-
-
-def get_ids_with_prefix(portal_type, prefix):
-    """Return a list of ids sharing the same portal type and prefix
-    """
-    brains = search_by_prefix(portal_type, prefix)
-    ids = map(api.get_id, brains)
-    return ids
-
-
 def make_storage_key(portal_type, prefix=None):
     """Make a storage (dict-) key for the number generator
     """
@@ -453,22 +435,6 @@ def get_generated_number(context, config, variables, **kw):
     # The key used for the storage
     key = make_storage_key(portal_type, prefix)
 
-    # Handle flushed storage
-    if key not in number_generator:
-        max_num = 0
-        existing = get_ids_with_prefix(portal_type, prefix)
-        # filter out the current temporary ID
-        temp_id = api.get_id(context)
-        existing = filter(lambda id: id != temp_id, existing)
-        numbers = map(lambda id: get_seq_number_from_id(
-            id, id_template, prefix), existing)
-        # figure out the highest number in the sequence
-        if numbers:
-            max_num = max(numbers)
-        # set the number generator
-        logger.info("*** SEEDING Prefix '{}' to {}".format(prefix, max_num))
-        number_generator.set_number(key, max_num)
-
     if not kw.get("dry_run", False):
         # Generate a new number
         # NOTE Even when the number exceeds the given ID sequence format,
@@ -537,8 +503,10 @@ def renameAfterCreation(obj):
     """
     # Can't rename without a subtransaction commit when using portal_factory
     transaction.savepoint(optimistic=True)
+
     # The id returned should be normalized already
     new_id = None
+
     # Checking if an adapter exists for this content type. If yes, we will
     # get new_id from adapter.
     for name, adapter in getAdapters((obj, ), IIdServer):
@@ -549,17 +517,8 @@ def renameAfterCreation(obj):
     if not new_id:
         new_id = generateUniqueId(obj)
 
-    # TODO: This is a naive check just in current folder
-    # -> this should check globally for duplicate objects with same prefix
-    # N.B. a check like `search_by_prefix` each time would probably slow things
-    # down too much!
-    # -> A solution could be to store all IDs with a certain prefix in a storage
-    parent = api.get_parent(obj)
-    if new_id in parent.objectIds():
-        # XXX We could do the check in a `while` loop and generate a new one.
-        raise KeyError("The ID {} is already taken in the path {}".format(
-            new_id, api.get_path(parent)))
     # rename the object to the new id
+    parent = api.get_parent(obj)
     parent.manage_renameObject(obj.id, new_id)
 
     return new_id

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -454,7 +454,7 @@ def get_generated_number(context, config, variables, **kw):
     key = make_storage_key(portal_type, prefix)
 
     # Handle flushed storage
-    if len(number_generator.keys()) == 0:
+    if key not in number_generator:
         max_num = 0
         existing = get_ids_with_prefix(portal_type, prefix)
         # filter out the current temporary ID

--- a/bika/lims/tests/doctests/IDServer.rst
+++ b/bika/lims/tests/doctests/IDServer.rst
@@ -230,10 +230,6 @@ Re-seed and create a new `Batch`:
     >>> batch = api.create(batches, "Batch", ClientID="RB")
     >>> batch.getId() == "BA-{}-0011".format(year)
     True
-    >>> browser.open(portal_url + '/ng_flush')
-    >>> ar = create_analysisrequest(client, request, values, service_uids)
-    >>> ar.getId()
-    'RB-20170131-water-0002'
 
 Change ID formats and use alphanumeric ids:
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When the ID Server does not find the generated key in its storage, e.g. for Sample Conditions the key `samplecondition`, it tries to handle the case when the storage was flushed and searches for all objects starting with this prefix.

Unfortunately, the temporary generated ID of the current context is there included, e.g. `samplecondition.2019-10-10.5905228809` and the sequence number returns `10` in that case.

PDB Excerpt from https://github.com/senaite/senaite.core/blob/master/bika/lims/idserver.py#L457:
```
(Pdb++) a
context = <SampleCondition at samplecondition.2019-10-10.5905228809>
config = {'prefix': 'samplecondition', 'form': 'samplecondition-{seq}', 'sequence_type': 'generated'}
variables = {'seq': 0, 'parent': <SampleConditions at /senaitelims/bika_setup/bika_sampleconditions>, 'portal_type': 'SampleCondition', 'context': <SampleCondition at /senaitelims/bika_setup/bika_sampleconditions/samplecondition.2019-10-10.5905228809>, 'year': '19', 'alpha': AAA000, 'id': 'samplecondition.2019-10-10.5905228809'}
kw = {}
(Pdb++) context.id
'samplecondition.2019-10-10.5905228809'
(Pdb++) existing
['samplecondition.2019-10-10.5905228809']
```

## Current behavior before PR

Initial IDs started with the sequence 11

## Desired behavior after PR is merged

Initial IDs start with the sequence 1

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
