### PR TITLE
Fix occasional error when labeling samples w/o report as printed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,7 @@ Changelog
 
 **Fixed**
 
+- #1454 Fix occasional error when labeling samples w/o report as printed
 - #1452 Fix missing error percentage calculation for reference samples
 - #1447 New Client contact has access to last client's Sample only
 - #1446 Parameter `group` in `contact._addUserToGroup` was not considered

--- a/bika/lims/browser/workflow/analysisrequest.py
+++ b/bika/lims/browser/workflow/analysisrequest.py
@@ -279,6 +279,8 @@ class WorkflowActionPrintSampleAdapter(WorkflowActionGenericAdapter):
             return False
         reports = sample.objectValues("ARReport")
         reports = sorted(reports, key=lambda report: report.getDatePublished())
+        if not reports:
+            return False
         last_report = reports[-1]
         if not last_report.getDatePrinted():
             last_report.setDatePrinted(DateTime())


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

In those extremely rare occasions, if any, that the system cannot retrieve the results pdf from a given sample, the system fails when trying to label multiple samples as "printed". The system was not able to retrieve the results pdf from a sample published 2y ago (several upgrades 1.2.4, 1.2.5 ... 1.3.2 happened since then). This PR does not fix the issue because of its rarity, but ensures that selecting that conflictive sample won't have any effect on the correct labeling of others as "printed".

## Current behavior before PR

```
Traceback (innermost last):

    Module ZPublisher.Publish, line 138, in publish
    Module ZPublisher.mapply, line 77, in mapply
    Module ZPublisher.Publish, line 48, in call_object
    Module bika.lims.browser.workflow, line 143, in _call_
    Module bika.lims.browser.workflow.analysisrequest, line 268, in _call_
    Module bika.lims.browser.workflow.analysisrequest, line 268, in <lambda>
    Module bika.lims.browser.workflow.analysisrequest, line 282, in set_printed_time

IndexError: list index out of range
```

## Desired behavior after PR is merged

No traceback, non-conflictive samples are labeled as "printed".

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
