### PR TITLE
Added support for adapters in guard handler

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1455 Added support for adapters in guard handler
 - #1436 Setting in setup for auto-reception of samples upon creation
 - #1433 Added Submitter column in Sample's analyses listing
 - #1441 Added Auto ID Behavior for Dexterity Contents

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -959,3 +959,7 @@ class IDetachedPartition(Interface):
 class IGuardAdapter(Interface):
     """Marker interface for guard adapters
     """
+
+    def guard(self, transition):
+        """Return False if you want to block the transition
+        """

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -954,3 +954,8 @@ class IInternalUse(Interface):
 class IDetachedPartition(Interface):
     """Marker interface for samples that have been detached from its primary
     """
+
+
+class IGuardAdapter(Interface):
+    """Marker interface for guard adapters
+    """

--- a/bika/lims/workflow/__init__.py
+++ b/bika/lims/workflow/__init__.py
@@ -391,7 +391,7 @@ def guard_handler(instance, transition_id):
     # If adapters are found, core's guard will only be evaluated if, and only
     # if, ALL "pre-guards" return True
     for name, ad in getAdapters((instance,), IGuardAdapter):
-        if not ad.guard(transition_id):
+        if ad.guard(transition_id) is False:
             return False
 
     clazz_name = instance.portal_type

--- a/bika/lims/workflow/__init__.py
+++ b/bika/lims/workflow/__init__.py
@@ -388,13 +388,10 @@ def guard_handler(instance, transition_id):
     if not instance:
         return True
 
-    # Find out if there are adapters registered for this type
-    adapters = map(lambda ad: ad[1], getAdapters((instance,), IGuardAdapter))
-
     # If adapters are found, core's guard will only be evaluated if, and only
     # if, ALL "pre-guards" return True
-    for ad in adapters:
-        if hasattr(ad, "pre_guard") and not ad.pre_guard(transition_id):
+    for name, ad in getAdapters((instance,), IGuardAdapter):
+        if not ad.guard(transition_id):
             return False
 
     clazz_name = instance.portal_type
@@ -411,12 +408,6 @@ def guard_handler(instance, transition_id):
 
     if not guard(instance):
         return False
-
-    # "post-guards" are only evaluated if core's guard returns True. For the
-    # guard to return True, all post_guards must return True too.
-    for ad in adapters:
-        if hasattr(ad, "post_guard") and not ad.post_guard(transition_id):
-            return False
 
     return True
 

--- a/bika/lims/workflow/__init__.py
+++ b/bika/lims/workflow/__init__.py
@@ -406,10 +406,7 @@ def guard_handler(instance, transition_id):
     if not guard:
         return True
 
-    if not guard(instance):
-        return False
-
-    return True
+    return guard(instance)
 
 
 def _load_wf_module(module_relative_name):


### PR DESCRIPTION
##  Description of the issue/feature this PR addresses

This Pull Request allows to adapt the behavior of core's guard handler. 

### Use case

Imagine you want to be more restrictive regarding the verification of results in such a way that you only want the transition `verify` to be available if the submitted result is in-range. For this to work, you'd need to change the guard expresion from the workflow definition in your add-on, reimport workflows.xml, and update role mappings for pre-existing objects. This improvement makes the task far easier:

1. Create a new adapter in your add-on:

```py
from bika.lims.api.analysis import is_out_of_range
from bika.lims.interfaces import IGuardAdapter

class AnalysisGuardAdapter(object):
    implements(IGuardAdapter)

    def __init__(self, context):
        self.context = context

    def guard(self, action):
        """Returns False if action is verify and result is not in range
        """
        if action == "verify":
            return not is_out_of_range(self.context)[0]
        return True
```
2. Register the adapter:

```xml
  <adapter
    name="my.addon.analysis_guard"
    for="bika.lims.interfaces.IAnalysis"
    factory=".adapters.AnalysisGuardAdapter"
    provides="bika.lims.interfaces.IGuardAdapter"
  />
```
## Current behavior before PR

No support for adapters in guard handler

## Desired behavior after PR is merged

Support for adapters in guard_handler

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
