### PR TITLE
Resurrect Identifier Types Class

### DIFF
--- a/bika/lims/__init__.py
+++ b/bika/lims/__init__.py
@@ -156,6 +156,7 @@ def initialize(context):
     from controlpanel.bika_containers import Containers  # noqa
     from controlpanel.bika_containertypes import ContainerTypes  # noqa
     from controlpanel.bika_departments import Departments  # noqa
+    from controlpanel.bika_identifiertypes import IdentifierTypes  # noqa
     from controlpanel.bika_instrumentlocations import InstrumentLocations  # noqa
     from controlpanel.bika_instruments import Instruments  # noqa
     from controlpanel.bika_instrumenttypes import InstrumentTypes  # noqa

--- a/bika/lims/controlpanel/bika_identifiertypes.py
+++ b/bika/lims/controlpanel/bika_identifiertypes.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# TODO: Remove in senaite.core 1.3.3
+#
+from bika.lims.config import PROJECTNAME
+from bika.lims.interfaces import IIdentifierTypes
+from plone.app.folder.folder import ATFolder
+from plone.app.folder.folder import ATFolderSchema
+from Products.Archetypes.public import registerType
+from Products.ATContentTypes.content import schemata
+from zope.interface.declarations import implements
+
+
+schema = ATFolderSchema.copy()
+
+
+class IdentifierTypes(ATFolder):
+    implements(IIdentifierTypes)
+    displayContentsTab = False
+    schema = schema
+
+
+schemata.finalizeATCTSchema(schema, folderish=True, moveDiscussion=False)
+
+registerType(IdentifierTypes, PROJECTNAME)

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -321,14 +321,12 @@ class IContainerTypes(Interface):
 
 
 class IIdentifierTypes(Interface):
-    """Marker interface for identifier types
+    """TODO: Remove in senaite.core 1.3.3
     """
 
 
 class IHaveIdentifiers(Interface):
-    """If this interface is provided by an AT object, the object will
-    automatically be given an 'Identifiers' field, which will be associated
-    with the bika_identifiertypes in site setup.
+    """TODO: Remove in senaite.core 1.3.3
     """
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes https://github.com/senaite/senaite.core/pull/1430

## Current behavior before PR

Migration step fails, because the existing `bika_identifiers` object has no registered class definition anymore:

`<persistent broken bika.lims.controlpanel.bika_identifiertypes.IdentifierTypes instance '\x00\x00\x00\x00\x00\x00\x1b\x82'>`

## Desired behavior after PR is merged

Migration step is able to remove all Identifier Types from the system.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
