### PR TITLE
Fix error when when indexing new index listing_searchable_text (upgrade 1.3.2)

### DIFF
--- a/bika/lims/catalog/indexers/__init__.py
+++ b/bika/lims/catalog/indexers/__init__.py
@@ -85,8 +85,9 @@ def get_metadata_for(instance, catalog):
     """Returns the metadata for the given instance from the specified catalog
     """
     path = api.get_path(instance)
-    if path not in catalog.uids:
-        logger.warn("Cannot get metadata from {}: {}".format(catalog.id, path))
+    try:
+        return catalog.getMetadataForUID(path)
+    except KeyError:
+        logger.warn("Cannot get metadata from {}. Path not found: {}"
+                    .format(catalog.id, path))
         return {}
-
-    return catalog.getMetadataForUID(path)

--- a/bika/lims/catalog/indexers/__init__.py
+++ b/bika/lims/catalog/indexers/__init__.py
@@ -23,7 +23,7 @@ from Products.CMFPlone.CatalogTool import sortable_title as plone_sortable_title
 from Products.CMFPlone.utils import safe_callable
 from plone.indexer import indexer
 
-from bika.lims import api
+from bika.lims import api, logger
 from bika.lims.catalog.bika_catalog import BIKA_CATALOG
 from bika.lims.interfaces import IBikaCatalog
 
@@ -68,7 +68,7 @@ def listing_searchable_text(instance):
     """
     entries = set()
     catalog = api.get_tool(BIKA_CATALOG)
-    metadata = catalog.getMetadataForUID(api.get_path(instance))
+    metadata = get_metadata_for(instance, catalog)
     for key, brain_value in metadata.items():
         instance_value = api.safe_getattr(instance, key, None)
         parsed = api.to_searchable_text_metadata(brain_value or instance_value)
@@ -79,3 +79,14 @@ def listing_searchable_text(instance):
 
     # Concatenate all strings to one text blob
     return " ".join(entries)
+
+
+def get_metadata_for(instance, catalog):
+    """Returns the metadata for the given instance from the specified catalog
+    """
+    path = api.get_path(instance)
+    if path not in catalog.uids:
+        logger.warn("Cannot get metadata from {}: {}".format(catalog.id, path))
+        return {}
+
+    return catalog.getMetadataForUID(path)

--- a/bika/lims/catalog/indexers/analysisrequest.py
+++ b/bika/lims/catalog/indexers/analysisrequest.py
@@ -22,6 +22,7 @@ from plone.indexer import indexer
 
 from bika.lims import api
 from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
+from bika.lims.catalog.indexers import get_metadata_for
 from bika.lims.interfaces import IAnalysisRequest, \
     IBikaCatalogAnalysisRequestListing
 
@@ -51,7 +52,7 @@ def listing_searchable_text(instance):
     """
     entries = set()
     catalog = api.get_tool(CATALOG_ANALYSIS_REQUEST_LISTING)
-    metadata = catalog.getMetadataForUID(api.get_path(instance))
+    metadata = get_metadata_for(instance, catalog)
     for key, brain_value in metadata.items():
         instance_value = api.safe_getattr(instance, key, None)
         parsed = api.to_searchable_text_metadata(brain_value or instance_value)


### PR DESCRIPTION



## Description of the issue/feature this PR addresses

A traceback (see below) is rised when upgrade step 1.3.2 tries to index the new index `index listing_searchable_text` for `bika_catalog`.

## Current behavior before PR


```
2019-10-16 20:09:37 INFO senaite.core Indexing new index listing_searchable_text ...
2019-10-16 20:09:37 ERROR txng extract_content failed (senaite/batches)
Traceback (most recent call last):
  File "/home/dev/buildout-cache/eggs/zopyx.txng3.core-3.6.2-py2.7.egg/zopyx/txng3/core/index.py", line 122, in index_object
    default_language=self.languages[0])
  File "/home/dev/buildout-cache/eggs/zopyx.txng3.core-3.6.2-py2.7.egg/zopyx/txng3/core/content.py", line 123, in extract_content
    v = getattr(obj, f, None)
  File "/home/dev/buildout-cache/eggs/plone.indexer-1.0.4-py2.7.egg/plone/indexer/wrapper.py", line 63, in __getattr__
    return indexer()
  File "/home/dev/buildout-cache/eggs/plone.indexer-1.0.4-py2.7.egg/plone/indexer/delegate.py", line 20, in __call__
    return self.callable(self.context)
  File "/home/dev/zinstance/src/senaite.core/bika/lims/catalog/indexers/__init__.py", line 71, in listing_searchable_text
    metadata = catalog.getMetadataForUID(api.get_path(instance))
  File "/home/dev/buildout-cache/eggs/Products.ZCatalog-2.13.29-py2.7.egg/Products/ZCatalog/ZCatalog.py", line 533, in getMetadataForUID
    rid = self._catalog.uids[uid]
KeyError: '/senaite/batches'
```

## Desired behavior after PR is merged

No traceback and `listing_searchable_text` index is reindexed correctly.

```
2019-10-16 20:36:18 INFO senaite.core Indexing new index listing_searchable_text ...
2019-10-16 20:36:18 WARNING senaite.core Cannot get metadata from bika_catalog. Path not found: /senaite/batches
2019-10-16 24:30:05 INFO senaite.core Indexing new index listing_searchable_text [DONE]
```

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
