### PR TITLE
Missing index in setup_handlers

### DIFF
--- a/bika/lims/setuphandlers.py
+++ b/bika/lims/setuphandlers.py
@@ -160,6 +160,7 @@ INDEXES = (
     ("bika_catalog", "review_state", "", "FieldIndex"),
     ("bika_catalog", "sortable_title", "", "FieldIndex"),
     ("bika_catalog", "title", "", "FieldIndex"),
+    ("bika_catalog", "listing_searchable_text", "", "TextIndexNG3"),
 
     ("bika_setup_catalog", "Creator", "", "FieldIndex"),
     ("bika_setup_catalog", "Description", "", "ZCTextIndex"),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Missing index in setuphandlers

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
