### PR TITLE
Allow unassign transition for cancelled/rejected/retracted analyses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,7 @@ Changelog
 
 **Fixed**
 
+- #1461 Allow unassign transition for cancelled/rejected/retracted analyses
 - #1449 sort_limit was not considered in ReferenceWidget searches
 - #1449 Fix Clients were unable to add batches
 - #1453 Fix initial IDs not starting with 1

--- a/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
@@ -394,7 +394,7 @@
   <state state_id="rejected" title="Rejected" i18n:attributes="title">
 
     <!-- TRANSITIONS -->
-    <exit-transition transition_id="" />
+    <exit-transition transition_id="unassign" />
     <!-- /TRANSITIONS -->
 
     <!-- Only allow modification of fields explicitly granted

--- a/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
@@ -244,6 +244,7 @@
 
     <!-- TRANSITIONS -->
     <exit-transition transition_id="reinstate" />
+    <exit-transition transition_id="unassign" />
     <!-- /TRANSITIONS -->
 
     <!-- Only allow modification of fields explicitly granted

--- a/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
@@ -349,7 +349,7 @@
   <state state_id="retracted" title="Retracted" i18n:attributes="title">
 
     <!-- TRANSITIONS -->
-    <exit-transition transition_id="" />
+    <exit-transition transition_id="unassign" />
     <!-- /TRANSITIONS -->
 
     <!-- Only allow modification of fields explicitly granted

--- a/bika/lims/upgrade/v01_03_002.py
+++ b/bika/lims/upgrade/v01_03_002.py
@@ -54,6 +54,7 @@ def upgrade(tool):
     # Mixed permissions for transitions in client workflow (#1419)
     # Allow to detach a partition from its primary sample (#1420)
     # Allow clients to create batches (#1450)
+    # Allow unassign transition for cancelled/rejected/retracted analyses #1461
     setup.runImportStepFromProfile(profile, "workflow")
 
     # Allow to detach a partition from its primary sample (#1420)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When assigned analyses are cancelled/rejected/retracted, they remain in the Worksheet.
If these were the only Analyses in the Worksheet, the Worksheet is stuck in Open state  

## Current behavior before PR

Analyses in the states `cancelled`, `rejected` or `retracted` can not be removed from worksheets which keeps the worksheet stuck in open state.

## Desired behavior after PR is merged

Analyses in the states `cancelled`, `rejected` or `retracted` can be removed from worksheets. The worksheet can be removed afterwards.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
