### PR TITLE
Allow to extend Add Sample behavior with adapters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1462 Allow to extend Add Sample behavior with adapters
 - #1455 Added support for adapters in guard handler
 - #1436 Setting in setup for auto-reception of samples upon creation
 - #1433 Added Submitter column in Sample's analyses listing

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 
 **Added**
 
-- #1462 Allow to extend Add Sample behavior with adapters
+- #1462 Allow to extend the behavior of fields from AddSample view with adapters
 - #1455 Added support for adapters in guard handler
 - #1436 Setting in setup for auto-reception of samples upon creation
 - #1433 Added Submitter column in Sample's analyses listing

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,7 @@ Changelog
 
 **Fixed**
 
+- #1462 Autofill Client Contact in Sample Add form when current user is a client
 - #1449 sort_limit was not considered in ReferenceWidget searches
 - #1449 Fix Clients were unable to add batches
 - #1453 Fix initial IDs not starting with 1

--- a/bika/lims/adapters/addsample.py
+++ b/bika/lims/adapters/addsample.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2019 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from zope.component import adapts
+
+from bika.lims import api
+from bika.lims.interfaces import IAddSampleObjectInfo
+
+
+class AddSampleObjectInfoAdapter(object):
+    """Base implementation of an adapter for reference fields used in Sample
+    Add form
+    """
+    adapts(IAddSampleObjectInfo)
+
+    def __init__(self, context):
+        self.context = context
+
+    def get_base_info(self):
+        """Returns the basic dictionary structure for the current object
+        """
+        return {
+            "id": api.get_id(self.context),
+            "uid": api.get_uid(self.context),
+            "title": api.get_title(self.context),
+            "field_values": {},
+            "filter_queries": {},
+        }
+
+    def get_object_info(self):
+        """Returns the dict representation of the context object for its
+        correct consumption by Sample Add form.
+        See IAddSampleObjectInfo for further details
+        """
+        raise NotImplementedError("get_object_info not implemented")

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1458,6 +1458,14 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         objects = map(lambda obj: self.get_object_info(obj, key), objects)
         return filter(None, objects)
 
+    def object_info_cache_key(method, self, obj, key):
+        if obj is None:
+            raise DontCache
+        field_name = key.replace("_uid", "")
+        obj_key = api.get_cache_key(obj)
+        return "-".join([field_name, obj_key])
+
+    @cache(object_info_cache_key)
     def get_object_info(self, obj, key):
         """Returns the object info metadata for the passed in object and key
         :param obj: the object from which extract the info from

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1459,9 +1459,9 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         return filter(None, objects)
 
     def object_info_cache_key(method, self, obj, key):
-        if obj is None:
+        if obj is None or not key:
             raise DontCache
-        field_name = key.replace("_uid", "")
+        field_name = key.replace("_uid", "").lower()
         obj_key = api.get_cache_key(obj)
         return "-".join([field_name, obj_key])
 

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1145,22 +1145,6 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         info["service_uids"] = specifications.keys()
         return info
 
-    @cache(cache_key)
-    def get_container_info(self, obj):
-        """Returns the info for a Container
-        """
-        info = self.get_base_info(obj)
-        info.update({})
-        return info
-
-    @cache(cache_key)
-    def get_preservation_info(self, obj):
-        """Returns the info for a Preservation
-        """
-        info = self.get_base_info(obj)
-        info.update({})
-        return info
-
     def ajax_get_global_settings(self):
         """Returns the global Bika settings
         """
@@ -1478,9 +1462,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         func = getattr(self, func_name, None)
 
         # Get the info for each object
-        info = {}
-        if callable(func):
-            info = func(obj)
+        info = callable(func) and func(obj) or self.get_base_info(obj)
 
         # Check if there is any adapter to handle objects for this field
         for name, adapter in getAdapters((obj, ), IAddSampleObjectInfo):

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -441,6 +441,11 @@ class AnalysisRequestAddView(BrowserView):
         contacts = catalog(query)
         if len(contacts) == 1:
             return api.get_object(contacts[0])
+        elif client == api.get_current_client():
+            # Current user is a Client contact. Use current contact
+            current_user = api.get_current_user()
+            return api.get_user_contact(current_user, contact_types=["Contact"])
+
         return None
 
     def getMemberDiscountApplies(self):

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -28,7 +28,8 @@ from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
 from bika.lims.api.analysisservice import get_calculation_dependencies_for
 from bika.lims.api.analysisservice import get_service_dependencies_for
-from bika.lims.interfaces import IGetDefaultFieldValueARAddHook
+from bika.lims.interfaces import IGetDefaultFieldValueARAddHook, \
+    IAddSampleFieldFilter
 from bika.lims.utils import tmpID
 from bika.lims.utils.analysisrequest import create_analysisrequest as crar
 from bika.lims.workflow import ActionHandlerPool
@@ -42,6 +43,7 @@ from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.annotation.interfaces import IAnnotations
+from zope.component import getAdapters
 from zope.component import queryAdapter
 from zope.i18n.locales import locales
 from zope.interface import implements
@@ -845,38 +847,44 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
         # catalog queries for UI field filtering
         filter_queries = {
-            "contact": {
+            "Contact": {
                 "getParentUID": [uid]
             },
-            "cc_contact": {
+            "CCContact": {
                 "getParentUID": [uid]
             },
-            "invoice_contact": {
+            "InvoiceContact": {
                 "getParentUID": [uid]
             },
-            "samplepoint": {
+            "SamplePoint": {
                 "getClientUID": [uid, bika_samplepoints_uid],
             },
-            "artemplates": {
+            "Template": {
                 "getClientUID": [uid, bika_artemplates_uid],
             },
-            "analysisprofiles": {
+            "Profiles": {
                 "getClientUID": [uid, bika_analysisprofiles_uid],
             },
-            "analysisspecs": {
+            "Specification": {
                 "getClientUID": [uid, bika_analysisspecs_uid],
             },
-            "samplinground": {
+            "SamplingRound": {
                 "getParentUID": [uid],
             },
-            "sample": {
+            "Sample": {
                 "getClientUID": [uid],
             },
-            "batch": {
+            "Batch": {
                 "getClientUID": [uid, ""],
             }
         }
         info["filter_queries"] = filter_queries
+
+        # Maybe other add-ons have additional fields that require filtering too
+        import pdb;pdb.set_trace()
+        for name, ad in getAdapters((obj,), IAddSampleFieldFilter):
+            additional_filters = ad.get_info()
+            info["filter_queries"].update(additional_filters)
 
         return info
 

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1034,42 +1034,21 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         client = self.get_client()
         client_uid = client and api.get_uid(client) or ""
 
-        # sample matrix
-        sample_matrix = obj.getSampleMatrix()
-        sample_matrix_uid = sample_matrix and sample_matrix.UID() or ""
-        sample_matrix_title = sample_matrix and sample_matrix.Title() or ""
-
-        # container type
-        container_type = obj.getContainerType()
-        container_type_uid = container_type and container_type.UID() or ""
-        container_type_title = container_type and container_type.Title() or ""
-
-        # sample points
-        sample_points = obj.getSamplePoints()
-        sample_point_uids = map(lambda sp: sp.UID(), sample_points)
-        sample_point_titles = map(lambda sp: sp.Title(), sample_points)
-
         info.update({
             "prefix": obj.getPrefix(),
             "minimum_volume": obj.getMinimumVolume(),
             "hazardous": obj.getHazardous(),
             "retention_period": obj.getRetentionPeriod(),
-            "sample_matrix_uid": sample_matrix_uid,
-            "sample_matrix_title": sample_matrix_title,
-            "container_type_uid": container_type_uid,
-            "container_type_title": container_type_title,
-            "sample_point_uids": sample_point_uids,
-            "sample_point_titles": sample_point_titles,
         })
 
         # catalog queries for UI field filtering
         filter_queries = {
-            "samplepoint": {
+            "SamplePoint": {
                 "getSampleTypeTitles": [obj.Title(), ''],
                 "getClientUID": [client_uid, bika_samplepoints_uid],
                 "sort_order": "descending",
             },
-            "specification": {
+            "Specification": {
                 "getSampleTypeTitle": obj.Title(),
                 "getClientUID": [client_uid, bika_analysisspecs_uid],
                 "sort_order": "descending",

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -435,7 +435,7 @@ class AnalysisRequestAddView(BrowserView):
                 "query": path,
                 "depth": 1
             },
-            "incactive_state": "active",
+            "is_active": True,
         }
         contacts = catalog(query)
         if len(contacts) == 1:
@@ -804,6 +804,8 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             "title": obj.Title(),
             "description": obj.Description(),
             "url": obj.absolute_url(),
+            "field_values": {},
+            "filter_queries": {},
         }
 
         return info
@@ -817,11 +819,9 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         default_contact_info = {}
         default_contact = self.get_default_contact(client=obj)
         if default_contact:
-            default_contact_info = self.get_contact_info(default_contact)
-
-        info.update({
-            "default_contact": default_contact_info
-        })
+            info["field_values"].update({
+                "Contact": self.get_contact_info(default_contact)
+            })
 
         # UID of the client
         uid = api.get_uid(obj)

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1064,69 +1064,59 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         """
         info = self.get_base_info(obj)
 
-        # sample type
+        batch = obj.getBatch()
+        client = obj.getClient()
         sample_type = obj.getSampleType()
-        sample_type_uid = sample_type and sample_type.UID() or ""
-        sample_type_title = sample_type and sample_type.Title() or ""
-
-        # sample condition
         sample_condition = obj.getSampleCondition()
-        sample_condition_uid = sample_condition \
-            and sample_condition.UID() or ""
-        sample_condition_title = sample_condition \
-            and sample_condition.Title() or ""
-
-        # storage location
         storage_location = obj.getStorageLocation()
-        storage_location_uid = storage_location \
-            and storage_location.UID() or ""
-        storage_location_title = storage_location \
-            and storage_location.Title() or ""
-
-        # sample point
         sample_point = obj.getSamplePoint()
-        sample_point_uid = sample_point and sample_point.UID() or ""
-        sample_point_title = sample_point and sample_point.Title() or ""
-
-        # container type
-        container_type = sample_type and sample_type.getContainerType() or None
-        container_type_uid = container_type and container_type.UID() or ""
-        container_type_title = container_type and container_type.Title() or ""
-
-        # Sampling deviation
+        container = obj.getContainer()
         deviation = obj.getSamplingDeviation()
-        deviation_uid = deviation and deviation.UID() or ""
-        deviation_title = deviation and deviation.Title() or ""
+        preservation = obj.getPreservation()
+        specification = obj.getSpecification()
+        sample_template = obj.getTemplate()
+        profiles = obj.getProfiles() or []
+        cccontacts = obj.getCCContact() or []
+        contact = obj.getContact()
 
         info.update({
-            "sample_id": obj.getId(),
-            "batch_uid": obj.getBatchUID() or None,
-            "date_sampled": self.to_iso_date(obj.getDateSampled()),
-            "sampling_date": self.to_iso_date(obj.getSamplingDate()),
-            "sample_type_uid": sample_type_uid,
-            "sample_type_title": sample_type_title,
-            "container_type_uid": container_type_uid,
-            "container_type_title": container_type_title,
-            "sample_condition_uid": sample_condition_uid,
-            "sample_condition_title": sample_condition_title,
-            "storage_location_uid": storage_location_uid,
-            "storage_location_title": storage_location_title,
-            "sample_point_uid": sample_point_uid,
-            "sample_point_title": sample_point_title,
-            "environmental_conditions": obj.getEnvironmentalConditions(),
             "composite": obj.getComposite(),
-            "client_uid": obj.getClientUID(),
-            "client_title": obj.getClientTitle(),
-            "contact": self.get_contact_info(obj.getContact()),
-            "client_order_number": obj.getClientOrderNumber(),
-            "client_sample_id": obj.getClientSampleID(),
-            "client_reference": obj.getClientReference(),
-            "sampling_deviation_uid": deviation_uid,
-            "sampling_deviation_title": deviation_title,
-            "sampling_workflow_enabled": obj.getSamplingWorkflowEnabled(),
-            "remarks": obj.getRemarks(),
         })
+
+        # Set the fields for which we want the value to be set automatically
+        # when the primary sample is selected
+        info["field_values"].update({
+            "Client": self.to_field_value(client),
+            "Contact": self.to_field_value(contact),
+            "CCContact": map(self.to_field_value, cccontacts),
+            "CCEmails": obj.getCCEmails() or [],
+            "Batch": self.to_field_value(batch),
+            "DateSampled": {"value": self.to_iso_date(obj.getDateSampled())},
+            "SamplingDate": {"value": self.to_iso_date(obj.getSamplingDate())},
+            "SampleType": self.to_field_value(sample_type),
+            "EnvironmentalConditions": {"value": obj.getEnvironmentalConditions()},
+            "ClientSampleID": {"value": obj.getClientSampleID()},
+            "ClientReference": {"value": obj.getClientReference()},
+            "ClientOrderNumber": {"value": obj.getClientOrderNumber()},
+            "SampleCondition": self.to_field_value(sample_condition),
+            "SamplePoint": self.to_field_value(sample_point),
+            "StorageLocation": self.to_field_value(storage_location),
+            "Container": self.to_field_value(container),
+            "SamplingDeviation": self.to_field_value(deviation),
+            "Preservation": self.to_field_value(preservation),
+            "Specification": self.to_field_value(specification),
+            "Template": self.to_field_value(sample_template),
+            "Profiles": map(self.to_field_value, profiles),
+            "Composite": {"value": obj.getComposite()}
+        })
+
         return info
+
+    def to_field_value(self, obj):
+        return {
+            "uid": obj and api.get_uid(obj) or "",
+            "title": obj and api.get_title(obj) or ""
+        }
 
     @cache(cache_key)
     def get_specification_info(self, obj):
@@ -1215,6 +1205,30 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             "SampleType": [
                 "SamplePoint",
                 "Specification"
+            ],
+            "PrimarySample": [
+                "Batch"
+                "Client",
+                "Contact",
+                "CCContact",
+                "CCEmails",
+                "ClientOrderNumber",
+                "ClientReference",
+                "ClientSampleID",
+                "ContainerType",
+                "DateSampled",
+                "EnvironmentalConditions",
+                "InvoiceContact",
+                "Preservation",
+                "Profiles",
+                "SampleCondition",
+                "SamplePoint",
+                "SampleType",
+                "SamplingDate",
+                "SamplingDeviation",
+                "StorageLocation",
+                "Specification",
+                "Template",
             ]
         }
 

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -29,6 +29,7 @@ from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from plone import protect
+from plone.memoize import view as viewcache
 from plone.memoize.volatile import DontCache
 from plone.memoize.volatile import cache
 from zope.annotation.interfaces import IAnnotations
@@ -110,6 +111,8 @@ class AnalysisRequestAddView(BrowserView):
             return url
         return "{}?{}".format(url, qs)
 
+    # XXX HEADS-UP!
+    @viewcache.memoize
     def get_object_by_uid(self, uid):
         """Get the object by UID
         """
@@ -1332,7 +1335,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         template = metadata.get("template_metadata", {})
         # We don't expect more than one template, but who knows about future?
         for uid, obj_info in template.items():
-            obj = api.get_object_by_uid(uid)
+            obj = self.get_object_by_uid(uid)
             # profile from the template
             profile = obj.getAnalysisProfile()
             # add the profile to the other profiles
@@ -1377,7 +1380,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         service_metadata = metadata.get("service_metadata", {})
         profiles = metadata.get("profiles_metadata", {})
         for uid, obj_info in profiles.items():
-            obj = api.get_object_by_uid(uid)
+            obj = self.get_object_by_uid(uid)
             # get all services of this profile
             services = obj.getService()
             # get all UIDs of the profile services
@@ -1409,7 +1412,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         unmet_dependencies = {}
         services = metadata.get("service_metadata", {}).copy()
         for uid, obj_info in services.items():
-            obj = api.get_object_by_uid(uid)
+            obj = self.get_object_by_uid(uid)
             # get the dependencies of this service
             deps = get_service_dependencies_for(obj)
 

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -19,9 +19,25 @@
 # Some rights reserved, see README and LICENSE.
 
 import json
-import itertools
 from collections import OrderedDict
 from datetime import datetime
+
+from BTrees.OOBTree import OOBTree
+from DateTime import DateTime
+from Products.CMFPlone.utils import _createObjectByType
+from Products.CMFPlone.utils import safe_unicode
+from Products.Five.browser import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from plone import protect
+from plone.memoize.volatile import DontCache
+from plone.memoize.volatile import cache
+from zope.annotation.interfaces import IAnnotations
+from zope.component import adapts
+from zope.component import getAdapters
+from zope.component import queryAdapter
+from zope.i18n.locales import locales
+from zope.interface import implements
+from zope.publisher.interfaces import IPublishTraverse
 
 from bika.lims import POINTS_OF_CAPTURE
 from bika.lims import api
@@ -30,27 +46,10 @@ from bika.lims import logger
 from bika.lims.api.analysisservice import get_calculation_dependencies_for
 from bika.lims.api.analysisservice import get_service_dependencies_for
 from bika.lims.interfaces import IGetDefaultFieldValueARAddHook, \
-    IAddSampleFieldFilter, IAddSampleFieldsFlush, IAddSampleMetadata, \
-    IAddSampleObjectInfo
+    IAddSampleFieldsFlush, IAddSampleObjectInfo
 from bika.lims.utils import tmpID
 from bika.lims.utils.analysisrequest import create_analysisrequest as crar
 from bika.lims.workflow import ActionHandlerPool
-from BTrees.OOBTree import OOBTree
-from DateTime import DateTime
-from plone import protect
-from plone.memoize.volatile import DontCache
-from plone.memoize.volatile import cache
-from Products.CMFPlone.utils import _createObjectByType
-from Products.CMFPlone.utils import safe_unicode
-from Products.Five.browser import BrowserView
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from zope.annotation.interfaces import IAnnotations
-from zope.component import adapts
-from zope.component import getAdapters
-from zope.component import queryAdapter
-from zope.i18n.locales import locales
-from zope.interface import implements
-from zope.publisher.interfaces import IPublishTraverse
 
 AR_CONFIGURATION_STORAGE = "bika.lims.browser.analysisrequest.manage.add"
 SKIP_FIELD_ON_COPY = ["Sample", "PrimaryAnalysisRequest", "Remarks"]

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -111,7 +111,9 @@ class AnalysisRequestAddView(BrowserView):
             return url
         return "{}?{}".format(url, qs)
 
-    # XXX HEADS-UP!
+    # N.B.: We are caching here persistent objects!
+    #       It should be safe to do this but only on the view object,
+    #       because it get recreated per request (transaction border).
     @viewcache.memoize
     def get_object_by_uid(self, uid):
         """Get the object by UID

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -815,8 +815,6 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         """Returns the client info of an object
         """
         info = self.get_base_info(obj)
-
-        default_contact_info = {}
         default_contact = self.get_default_contact(client=obj)
         if default_contact:
             info["field_values"].update({
@@ -899,20 +897,24 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
         # Note: It might get a circular dependency when calling:
         #       map(self.get_contact_info, obj.getCCContact())
-        cccontacts = {}
+        cccontacts = []
         for contact in obj.getCCContact():
             uid = api.get_uid(contact)
             fullname = contact.getFullname()
             email = contact.getEmailAddress()
-            cccontacts[uid] = {
+            cccontacts.append({
+                "uid": uid,
+                "title": fullname,
                 "fullname": fullname,
                 "email": email
-            }
+            })
 
         info.update({
             "fullname": fullname,
             "email": email,
-            "cccontacts": cccontacts,
+            "field_values": {
+                "CCContact": cccontacts
+            },
         })
 
         return info

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -881,7 +881,6 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         info["filter_queries"] = filter_queries
 
         # Maybe other add-ons have additional fields that require filtering too
-        import pdb;pdb.set_trace()
         for name, ad in getAdapters((obj,), IAddSampleFieldFilter):
             additional_filters = ad.get_info()
             info["filter_queries"].update(additional_filters)

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -254,14 +254,15 @@
       me = this;
       $(".service-lockbtn").hide();
       return $.each(records, function(arnum, record) {
-        $.each(record.primaryanalysisrequest_metadata, function(uid, sample) {
-          return me.apply_field_value(arnum, sample);
-        });
-        $.each(record.client_metadata, function(uid, client) {
-          return me.apply_field_value(arnum, client);
-        });
-        $.each(record.contact_metadata, function(uid, contact) {
-          return me.apply_field_value(arnum, contact);
+        var discard;
+        discard = ["service_metadata", "specification_metadata"];
+        $.each(record, function(name, metadata) {
+          if (indexOf.call(discard, name) >= 0 || !name.endsWith("_metadata")) {
+            return;
+          }
+          return $.each(metadata, function(uid, obj_info) {
+            return me.apply_field_value(arnum, obj_info);
+          });
         });
         $.each(record.service_metadata, function(uid, metadata) {
           var lock;
@@ -271,20 +272,9 @@
           }
           return me.set_service(arnum, uid, true);
         });
-        $.each(record.template_metadata, function(uid, template) {
-          return me.set_template(arnum, template);
-        });
         $.each(record.specification_metadata, function(uid, spec) {
           return $.each(spec.specifications, function(uid, service_spec) {
             return me.set_service_spec(arnum, uid, service_spec);
-          });
-        });
-        $.each(record.sampletype_metadata, function(uid, sampletype) {
-          return me.apply_field_value(arnum, sampletype);
-        });
-        $.each(record.additional, function(field_name, item) {
-          return $.each(item, function(uid, metadata) {
-            return me.apply_field_value(arnum, metadata);
           });
         });
         return $.each(record.unmet_dependencies, function(uid, dependencies) {
@@ -397,8 +387,10 @@
        * Applies the value for the given record, by setting values and applying
        * search filters to dependents
        */
-      var me;
+      var me, title;
       me = this;
+      title = record.title;
+      console.debug("apply_field_value: arnum=" + arnum + " record=" + title);
       me.apply_dependent_values(arnum, record);
       return me.apply_dependent_filter_queries(record, arnum);
     };

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -381,6 +381,20 @@
       return $(field_id);
     };
 
+    AnalysisRequestAdd.prototype.apply_field_filters = function(record, arnum) {
+
+      /*
+       * Apply search filters to dependendents
+       */
+      var me;
+      me = this;
+      return $.each(record.filter_queries, function(field_name, query) {
+        var field;
+        field = $("#" + field_name + ("-" + arnum));
+        return me.set_reference_field_query(field, query);
+      });
+    };
+
     AnalysisRequestAdd.prototype.flush_fields_for = function(field_name, arnum) {
 
       /*
@@ -520,11 +534,7 @@
           this.set_reference_field(field, contact_uid, contact_title);
         }
       }
-      return $.each(client.filter_queries, function(field_name, query) {
-        var field;
-        field = $("#" + field_name + ("-" + arnum));
-        return me.set_reference_field_query(field, query);
-      });
+      return me.apply_field_filters(client, arnum);
     };
 
     AnalysisRequestAdd.prototype.set_contact = function(arnum, contact) {
@@ -792,6 +802,9 @@
       uid = $el.attr("uid");
       field_name = $el.closest("tr[fieldname]").attr("fieldname");
       arnum = $el.closest("[arnum]").attr("arnum");
+      if (field_name === "Template" || field_name === "Profiles") {
+        return;
+      }
       console.debug("°°° on_referencefield_value_changed: field_name=" + field_name + " arnum=" + arnum + " °°°");
       me.flush_fields_for(field_name, arnum);
       if (!has_value) {

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -35,7 +35,6 @@
       this.set_service_spec = bind(this.set_service_spec, this);
       this.set_service = bind(this.set_service, this);
       this.set_template = bind(this.set_template, this);
-      this.set_sampletype = bind(this.set_sampletype, this);
       this.set_sample = bind(this.set_sample, this);
       this.set_reference_field = bind(this.set_reference_field, this);
       this.set_reference_field_query = bind(this.set_reference_field_query, this);
@@ -284,7 +283,7 @@
           return me.set_sample(arnum, sample);
         });
         $.each(record.sampletype_metadata, function(uid, sampletype) {
-          return me.set_sampletype(arnum, sampletype);
+          return me.apply_field_value(arnum, sampletype);
         });
         return $.each(record.unmet_dependencies, function(uid, dependencies) {
           var context, dialog, service;
@@ -423,6 +422,11 @@
       me = this;
       values_json = $.toJSON(values);
       field = $("#" + field_name + ("-" + arnum));
+      if ((values.if_empty != null) && values.if_empty === true) {
+        if (!field.val()) {
+          return;
+        }
+      }
       console.debug("apply_dependent_value: field_name=" + field_name + " field_values=" + values_json);
       if ((values.uid != null) && (values.title != null)) {
         return me.set_reference_field(field, values.uid, values.title);
@@ -630,28 +634,6 @@
       uid = sample.sampling_deviation_uid;
       title = sample.sampling_deviation_title;
       return this.set_reference_field(field, uid, title);
-    };
-
-    AnalysisRequestAdd.prototype.set_sampletype = function(arnum, sampletype) {
-
-      /*
-       * Recalculate partitions
-       * Filter Sample Points
-       */
-      var field, query, title, uid;
-      field = $("#SamplePoint-" + arnum);
-      query = sampletype.filter_queries.samplepoint;
-      this.set_reference_field_query(field, query);
-      field = $("#DefaultContainerType-" + arnum);
-      if (!field.val()) {
-        uid = sampletype.container_type_uid;
-        title = sampletype.container_type_title;
-        this.flush_reference_field(field);
-        this.set_reference_field(field, uid, title);
-      }
-      field = $("#Specification-" + arnum);
-      query = sampletype.filter_queries.specification;
-      return this.set_reference_field_query(field, query);
     };
 
     AnalysisRequestAdd.prototype.set_template = function(arnum, template) {

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -282,6 +282,11 @@
         $.each(record.sampletype_metadata, function(uid, sampletype) {
           return me.apply_field_value(arnum, sampletype);
         });
+        $.each(record.additional, function(field_name, item) {
+          return $.each(item, function(uid, metadata) {
+            return me.apply_field_value(arnum, metadata);
+          });
+        });
         return $.each(record.unmet_dependencies, function(uid, dependencies) {
           var context, dialog, service;
           service = record.service_metadata[uid];

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -254,6 +254,9 @@
       me = this;
       $(".service-lockbtn").hide();
       return $.each(records, function(arnum, record) {
+        $.each(record.primaryanalysisrequest_metadata, function(uid, sample) {
+          return me.apply_field_value(arnum, sample);
+        });
         $.each(record.client_metadata, function(uid, client) {
           return me.apply_field_value(arnum, client);
         });
@@ -275,9 +278,6 @@
           return $.each(spec.specifications, function(uid, service_spec) {
             return me.set_service_spec(arnum, uid, service_spec);
           });
-        });
-        $.each(record.sample_metadata, function(uid, sample) {
-          return me.apply_field_value(arnum, sample);
         });
         $.each(record.sampletype_metadata, function(uid, sampletype) {
           return me.apply_field_value(arnum, sampletype);
@@ -788,7 +788,7 @@
       if (uid in record.service_to_profiles) {
         profiles = record.service_to_profiles[uid];
         $.each(profiles, function(index, uid) {
-          return extra["profiles"].push(record.profile_metadata[uid]);
+          return extra["profiles"].push(record.profiles_metadata[uid]);
         });
       }
       if (uid in record.service_to_templates) {
@@ -839,7 +839,7 @@
       context["templates"] = [];
       if (uid in record.service_to_profiles) {
         profile_uid = record.service_to_profiles[uid];
-        context["profiles"].push(record.profile_metadata[profile_uid]);
+        context["profiles"].push(record.profiles_metadata[profile_uid]);
       }
       if (uid in record.service_to_templates) {
         template_uid = record.service_to_templates[uid];
@@ -962,7 +962,7 @@
       uid = $el.attr("uid");
       arnum = $el.closest("[arnum]").attr("arnum");
       record = this.records_snapshot[arnum];
-      profile_metadata = record.profile_metadata[uid];
+      profile_metadata = record.profiles_metadata[uid];
       profile_services = [];
       $.each(record.profile_to_services[uid], function(index, uid) {
         return profile_services.push(record.service_metadata[uid]);

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -29,8 +29,7 @@
       this.on_analysis_lock_button_click = bind(this.on_analysis_lock_button_click, this);
       this.on_analysis_details_click = bind(this.on_analysis_details_click, this);
       this.on_analysis_specification_changed = bind(this.on_analysis_specification_changed, this);
-      this.on_contact_changed = bind(this.on_contact_changed, this);
-      this.on_client_changed = bind(this.on_client_changed, this);
+      this.on_referencefield_value_changed = bind(this.on_referencefield_value_changed, this);
       this.hide_all_service_info = bind(this.hide_all_service_info, this);
       this.get_service = bind(this.get_service, this);
       this.set_service_spec = bind(this.set_service_spec, this);
@@ -96,8 +95,7 @@
       $("body").on("click", "tr[fieldname=Composite] input[type='checkbox']", this.recalculate_records);
       $("body").on("click", "tr[fieldname=InvoiceExclude] input[type='checkbox']", this.recalculate_records);
       $("body").on("click", "tr[fieldname=Analyses] input[type='checkbox']", this.on_analysis_checkbox_click);
-      $("body").on("selected change", "tr[fieldname=Client] input[type='text']", this.on_client_changed);
-      $("body").on("selected change", "tr[fieldname=Contact] input[type='text']", this.on_contact_changed);
+      $("body").on("selected change", "input[type='text'].referencewidget", this.on_referencefield_value_changed);
       $("body").on("change", "input.min", this.on_analysis_specification_changed);
       $("body").on("change", "input.max", this.on_analysis_specification_changed);
       $("body").on("change", "input.warn_min", this.on_analysis_specification_changed);
@@ -785,35 +783,20 @@
 
     /* EVENT HANDLER */
 
-    AnalysisRequestAdd.prototype.on_client_changed = function(event) {
+    AnalysisRequestAdd.prototype.on_referencefield_value_changed = function(event) {
 
       /*
-       * Eventhandler when the client changed (happens on Batches)
+       * Generic event handler for when a field value changes
        */
-      var $el, arnum, el, me, uid;
+      var $el, arnum, el, field_name, me, uid;
       me = this;
       el = event.currentTarget;
       $el = $(el);
       uid = $el.attr("uid");
+      field_name = $el.closest("tr[fieldname]").attr("fieldname");
       arnum = $el.closest("[arnum]").attr("arnum");
-      console.debug("°°° on_client_changed: arnum=" + arnum + " °°°");
-      me.flush_fields_for("Client", arnum);
-      return $(me).trigger("form:changed");
-    };
-
-    AnalysisRequestAdd.prototype.on_contact_changed = function(event) {
-
-      /*
-       * Eventhandler when the contact changed
-       */
-      var $el, arnum, el, me, uid;
-      me = this;
-      el = event.currentTarget;
-      $el = $(el);
-      uid = $el.attr("uid");
-      arnum = $el.closest("[arnum]").attr("arnum");
-      console.debug("°°° on_contact_changed: arnum=" + arnum + " °°°");
-      me.flush_fields_for("Contact", arnum);
+      console.debug("°°° on_field_value_changed: field_name=" + field_name + " arnum=" + arnum + " °°°");
+      me.flush_fields_for(field_name, arnum);
       return $(me).trigger("form:changed");
     };
 
@@ -954,7 +937,6 @@
       if (!has_sampletype_selected) {
         $("input[type=hidden]", $el.parent()).val("");
       }
-      me.flush_fields_for("SampleType", arnum);
       return $(me).trigger("form:changed");
     };
 

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -23,8 +23,6 @@
       this.on_analysis_profile_removed = bind(this.on_analysis_profile_removed, this);
       this.on_analysis_profile_selected = bind(this.on_analysis_profile_selected, this);
       this.on_analysis_template_changed = bind(this.on_analysis_template_changed, this);
-      this.on_specification_changed = bind(this.on_specification_changed, this);
-      this.on_sampletype_changed = bind(this.on_sampletype_changed, this);
       this.on_sample_changed = bind(this.on_sample_changed, this);
       this.on_analysis_lock_button_click = bind(this.on_analysis_lock_button_click, this);
       this.on_analysis_details_click = bind(this.on_analysis_details_click, this);
@@ -103,8 +101,6 @@
       $("body").on("click", ".service-lockbtn", this.on_analysis_lock_button_click);
       $("body").on("click", ".service-infobtn", this.on_analysis_details_click);
       $("body").on("selected change", "tr[fieldname=PrimaryAnalysisRequest] input[type='text']", this.on_sample_changed);
-      $("body").on("selected change", "tr[fieldname=SampleType] input[type='text']", this.on_sampletype_changed);
-      $("body").on("selected change", "tr[fieldname=Specification] input[type='text']", this.on_specification_changed);
       $("body").on("selected change", "tr[fieldname=Template] input[type='text']", this.on_analysis_template_changed);
       $("body").on("selected", "tr[fieldname=Profiles] input[type='text']", this.on_analysis_profile_selected);
       $("body").on("click", "tr[fieldname=Profiles] img.deletebtn", this.on_analysis_profile_removed);
@@ -788,15 +784,19 @@
       /*
        * Generic event handler for when a field value changes
        */
-      var $el, arnum, el, field_name, me, uid;
+      var $el, arnum, el, field_name, has_value, me, uid;
       me = this;
       el = event.currentTarget;
       $el = $(el);
+      has_value = $el.val();
       uid = $el.attr("uid");
       field_name = $el.closest("tr[fieldname]").attr("fieldname");
       arnum = $el.closest("[arnum]").attr("arnum");
-      console.debug("°°° on_field_value_changed: field_name=" + field_name + " arnum=" + arnum + " °°°");
+      console.debug("°°° on_referencefield_value_changed: field_name=" + field_name + " arnum=" + arnum + " °°°");
       me.flush_fields_for(field_name, arnum);
+      if (!has_value) {
+        $("input[type=hidden]", $el.parent()).val("");
+      }
       return $(me).trigger("form:changed");
     };
 
@@ -914,47 +914,6 @@
       has_sample_selected = $el.val();
       console.debug("°°° on_sample_change::UID=" + uid + " PrimaryAnalysisRequest=" + val + "°°°");
       if (!has_sample_selected) {
-        $("input[type=hidden]", $el.parent()).val("");
-      }
-      return $(me).trigger("form:changed");
-    };
-
-    AnalysisRequestAdd.prototype.on_sampletype_changed = function(event) {
-
-      /*
-       * Eventhandler when the SampleType was changed.
-       * Fires form:changed event
-       */
-      var $el, arnum, el, has_sampletype_selected, me, uid, val;
-      me = this;
-      el = event.currentTarget;
-      $el = $(el);
-      uid = $(el).attr("uid");
-      val = $el.val();
-      arnum = $el.closest("[arnum]").attr("arnum");
-      has_sampletype_selected = $el.val();
-      console.debug("°°° on_sampletype_change::UID=" + uid + " SampleType=" + val + "°°°");
-      if (!has_sampletype_selected) {
-        $("input[type=hidden]", $el.parent()).val("");
-      }
-      return $(me).trigger("form:changed");
-    };
-
-    AnalysisRequestAdd.prototype.on_specification_changed = function(event) {
-
-      /*
-       * Eventhandler when the Specification was changed.
-       */
-      var $el, arnum, el, has_specification_selected, me, uid, val;
-      me = this;
-      el = event.currentTarget;
-      $el = $(el);
-      uid = $(el).attr("uid");
-      val = $el.val();
-      arnum = $el.closest("[arnum]").attr("arnum");
-      has_specification_selected = $el.val();
-      console.debug("°°° on_specification_change::UID=" + uid + " Specification=" + val + "°°°");
-      if (!has_specification_selected) {
         $("input[type=hidden]", $el.parent()).val("");
       }
       return $(me).trigger("form:changed");

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -36,6 +36,7 @@
       this.set_template = bind(this.set_template, this);
       this.set_reference_field = bind(this.set_reference_field, this);
       this.set_reference_field_query = bind(this.set_reference_field_query, this);
+      this.reset_reference_field_query = bind(this.reset_reference_field_query, this);
       this.get_field_by_id = bind(this.get_field_by_id, this);
       this.get_fields = bind(this.get_fields, this);
       this.get_form = bind(this.get_form, this);
@@ -470,7 +471,7 @@
     AnalysisRequestAdd.prototype.flush_reference_field = function(field) {
 
       /*
-       * Empty the reference field
+       * Empty the reference field and restore the search query
        */
       var catalog_name;
       catalog_name = field.attr("catalog_name");
@@ -479,7 +480,22 @@
       }
       field.val("");
       $("input[type=hidden]", field.parent()).val("");
-      return $(".multiValued-listing", field.parent()).empty();
+      $(".multiValued-listing", field.parent()).empty();
+      return this.reset_reference_field_query(field);
+    };
+
+    AnalysisRequestAdd.prototype.reset_reference_field_query = function(field) {
+
+      /*
+       * Restores the catalog search query for the given reference field
+       */
+      var catalog_name, query;
+      catalog_name = field.attr("catalog_name");
+      if (!catalog_name) {
+        return;
+      }
+      query = $.parseJSON(field.attr("base_query"));
+      return this.set_reference_field_query(field, query);
     };
 
     AnalysisRequestAdd.prototype.set_reference_field_query = function(field, query, type) {

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -256,7 +256,7 @@
       $(".service-lockbtn").hide();
       return $.each(records, function(arnum, record) {
         var discard;
-        discard = ["service_metadata", "specification_metadata"];
+        discard = ["service_metadata", "specification_metadata", "template_metadata"];
         $.each(record, function(name, metadata) {
           if (indexOf.call(discard, name) >= 0 || !name.endsWith("_metadata")) {
             return;
@@ -272,6 +272,9 @@
             lock.show();
           }
           return me.set_service(arnum, uid, true);
+        });
+        $.each(record.template_metadata, function(uid, template) {
+          return me.set_template(arnum, template);
         });
         $.each(record.specification_metadata, function(uid, spec) {
           return $.each(spec.specifications, function(uid, service_spec) {

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -486,10 +486,8 @@
        * Filter SamplingRound
        * Filter Batch
        */
-      var contact_title, contact_uid, field, query;
-      field = $("#Contact-" + arnum);
-      query = client.filter_queries.contact;
-      this.set_reference_field_query(field, query);
+      var contact_title, contact_uid, me;
+      me = this;
       if (document.URL.indexOf("analysisrequests") > -1) {
         contact_title = client.default_contact.title;
         contact_uid = client.default_contact.uid;
@@ -497,33 +495,11 @@
           this.set_reference_field(field, contact_uid, contact_title);
         }
       }
-      field = $("#CCContact-" + arnum);
-      query = client.filter_queries.cc_contact;
-      this.set_reference_field_query(field, query);
-      field = $("#InvoiceContact-" + arnum);
-      query = client.filter_queries.invoice_contact;
-      this.set_reference_field_query(field, query);
-      field = $("#SamplePoint-" + arnum);
-      query = client.filter_queries.samplepoint;
-      this.set_reference_field_query(field, query);
-      field = $("#Template-" + arnum);
-      query = client.filter_queries.artemplates;
-      this.set_reference_field_query(field, query);
-      field = $("#Profiles-" + arnum);
-      query = client.filter_queries.analysisprofiles;
-      this.set_reference_field_query(field, query);
-      field = $("#Specification-" + arnum);
-      query = client.filter_queries.analysisspecs;
-      this.set_reference_field_query(field, query);
-      field = $("#SamplingRound-" + arnum);
-      query = client.filter_queries.samplinground;
-      this.set_reference_field_query(field, query);
-      field = $("#PrimaryAnalysisRequest-" + arnum);
-      query = client.filter_queries.sample;
-      this.set_reference_field_query(field, query);
-      field = $("#Batch-" + arnum);
-      query = client.filter_queries.batch;
-      return this.set_reference_field_query(field, query);
+      return $.each(client.filter_queries, function(field_name, query) {
+        var field;
+        field = $("#" + field_name + ("-" + arnum));
+        return me.set_reference_field_query(field, query);
+      });
     };
 
     AnalysisRequestAdd.prototype.set_contact = function(arnum, contact) {

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -248,7 +248,7 @@ class window.AnalysisRequestAdd
 
       # set client
       $.each record.client_metadata, (uid, client) ->
-        me.set_client arnum, client
+        me.apply_field_value arnum, client
 
       # set contact
       $.each record.contact_metadata, (uid, contact) ->
@@ -380,7 +380,36 @@ class window.AnalysisRequestAdd
     return $(field_id)
 
 
-  apply_field_filters: (record, arnum) ->
+  apply_field_value: (arnum, record) ->
+    ###
+     * Applies the value for the given record, by setting values and applying
+     * search filters to dependents
+    ###
+    me = this
+
+    # Set default values to dependents
+    me.apply_dependent_values arnum, record
+
+    # Apply search filters to other fields
+    me.apply_dependent_filter_queries record, arnum
+
+
+  apply_dependent_values: (arnum, record) ->
+    ###
+     * Sets default field values to dependents
+    ###
+    me = this
+    $.each record.field_values, (field_name, values) ->
+      values_json = $.toJSON values
+      field = $("#" + field_name + "-#{arnum}")
+      console.debug "set_field_values: field_name=#{field_name} field_values=#{values_json}"
+      if values.uid? and values.title?
+        me.set_reference_field field, values.uid, values.title
+      else if values.value?
+        field.val values.value
+
+
+  apply_dependent_filter_queries: (record, arnum) ->
     ###
      * Apply search filters to dependendents
     ###
@@ -514,32 +543,6 @@ class window.AnalysisRequestAdd
       div.append title
       mvl.append div
       $field.val("")
-
-
-  set_client: (arnum, client) =>
-    ###
-     * Filter Contacts
-     * Filter CCContacts
-     * Filter InvoiceContacts
-     * Filter SamplePoints
-     * Filter ARTemplates
-     * Filter Specification
-     * Filter SamplingRound
-     * Filter Batch
-    ###
-
-    me = this
-
-    # handle default contact for /analysisrequests listing
-    # https://github.com/senaite/senaite.core/issues/705
-    if document.URL.indexOf("analysisrequests") > -1
-      contact_title = client.default_contact.title
-      contact_uid = client.default_contact.uid
-      if contact_title and contact_uid
-        @set_reference_field field, contact_uid, contact_title
-
-    # Apply search filters to other fields
-    me.apply_field_filters client, arnum
 
 
   set_contact: (arnum, contact) =>

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -87,10 +87,6 @@ class window.AnalysisRequestAdd
     $("body").on "click", ".service-infobtn", @on_analysis_details_click
     # Sample changed
     $("body").on "selected change", "tr[fieldname=PrimaryAnalysisRequest] input[type='text']", @on_sample_changed
-    # SampleType changed
-    $("body").on "selected change", "tr[fieldname=SampleType] input[type='text']", @on_sampletype_changed
-    # Specification changed
-    $("body").on "selected change", "tr[fieldname=Specification] input[type='text']", @on_specification_changed
     # Analysis Template changed
     $("body").on "selected change", "tr[fieldname=Template] input[type='text']", @on_analysis_template_changed
     # Analysis Profile selected
@@ -835,14 +831,19 @@ class window.AnalysisRequestAdd
     me = this
     el = event.currentTarget
     $el = $(el)
+    has_value = $el.val()
     uid = $el.attr "uid"
     field_name = $el.closest("tr[fieldname]").attr "fieldname"
     arnum = $el.closest("[arnum]").attr "arnum"
 
-    console.debug "°°° on_field_value_changed: field_name=#{field_name} arnum=#{arnum} °°°"
+    console.debug "°°° on_referencefield_value_changed: field_name=#{field_name} arnum=#{arnum} °°°"
 
     # Flush depending fields
     me.flush_fields_for field_name, arnum
+
+    # Manually flush UID field if the field does not have a selected value
+    if not has_value
+      $("input[type=hidden]", $el.parent()).val("")
 
     # trigger form:changed event
     $(me).trigger "form:changed"
@@ -969,53 +970,6 @@ class window.AnalysisRequestAdd
 
     # deselect the sample if the field is empty
     if not has_sample_selected
-      # XXX manually flush UID field
-      $("input[type=hidden]", $el.parent()).val("")
-
-    # trigger form:changed event
-    $(me).trigger "form:changed"
-
-
-  on_sampletype_changed: (event) =>
-    ###
-     * Eventhandler when the SampleType was changed.
-     * Fires form:changed event
-    ###
-
-    me = this
-    el = event.currentTarget
-    $el = $(el)
-    uid = $(el).attr "uid"
-    val = $el.val()
-    arnum = $el.closest("[arnum]").attr "arnum"
-    has_sampletype_selected = $el.val()
-    console.debug "°°° on_sampletype_change::UID=#{uid} SampleType=#{val}°°°"
-
-    # deselect the sampletype if the field is empty
-    if not has_sampletype_selected
-      # XXX manually flush UID field
-      $("input[type=hidden]", $el.parent()).val("")
-
-    # trigger form:changed event
-    $(me).trigger "form:changed"
-
-
-  on_specification_changed: (event) =>
-    ###
-     * Eventhandler when the Specification was changed.
-    ###
-
-    me = this
-    el = event.currentTarget
-    $el = $(el)
-    uid = $(el).attr "uid"
-    val = $el.val()
-    arnum = $el.closest("[arnum]").attr "arnum"
-    has_specification_selected = $el.val()
-    console.debug "°°° on_specification_change::UID=#{uid} Specification=#{val}°°°"
-
-    # deselect the specification if the field is empty
-    if not has_specification_selected
       # XXX manually flush UID field
       $("input[type=hidden]", $el.parent()).val("")
 

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -380,6 +380,16 @@ class window.AnalysisRequestAdd
     return $(field_id)
 
 
+  apply_field_filters: (record, arnum) ->
+    ###
+     * Apply search filters to dependendents
+    ###
+    me = this
+    $.each record.filter_queries, (field_name, query) ->
+      field = $("#" + field_name + "-#{arnum}")
+      me.set_reference_field_query field, query
+
+
   flush_fields_for: (field_name, arnum) ->
     ###
      * Flush dependant fields
@@ -529,9 +539,7 @@ class window.AnalysisRequestAdd
         @set_reference_field field, contact_uid, contact_title
 
     # Apply search filters to other fields
-    $.each client.filter_queries, (field_name, query) ->
-      field = $("#" + field_name + "-#{arnum}")
-      me.set_reference_field_query field, query
+    me.apply_field_filters client, arnum
 
 
   set_contact: (arnum, contact) =>
@@ -835,6 +843,9 @@ class window.AnalysisRequestAdd
     uid = $el.attr "uid"
     field_name = $el.closest("tr[fieldname]").attr "fieldname"
     arnum = $el.closest("[arnum]").attr "arnum"
+    if field_name in ["Template", "Profiles"]
+      # These fields have it's own event handler
+      return
 
     console.debug "°°° on_referencefield_value_changed: field_name=#{field_name} arnum=#{arnum} °°°"
 

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -243,6 +243,9 @@ class window.AnalysisRequestAdd
 
     # set all values for one record (a single column in the AR Add form)
     $.each records, (arnum, record) ->
+      # set sample
+      $.each record.primaryanalysisrequest_metadata, (uid, sample) ->
+        me.apply_field_value arnum, sample
 
       # set client
       $.each record.client_metadata, (uid, client) ->
@@ -274,10 +277,6 @@ class window.AnalysisRequestAdd
       $.each record.specification_metadata, (uid, spec) ->
         $.each spec.specifications, (uid, service_spec) ->
           me.set_service_spec arnum, uid, service_spec
-
-      # set sample
-      $.each record.sample_metadata, (uid, sample) ->
-        me.apply_field_value arnum, sample
 
       # set sampletype
       $.each record.sampletype_metadata, (uid, sampletype) ->
@@ -812,7 +811,7 @@ class window.AnalysisRequestAdd
     if uid of record.service_to_profiles
       profiles = record.service_to_profiles[uid]
       $.each profiles, (index, uid) ->
-        extra["profiles"].push record.profile_metadata[uid]
+        extra["profiles"].push record.profiles_metadata[uid]
 
     # inject template info
     if uid of record.service_to_templates
@@ -862,7 +861,7 @@ class window.AnalysisRequestAdd
     # collect profiles
     if uid of record.service_to_profiles
       profile_uid = record.service_to_profiles[uid]
-      context["profiles"].push record.profile_metadata[profile_uid]
+      context["profiles"].push record.profiles_metadata[profile_uid]
 
     # collect templates
     if uid of record.service_to_templates
@@ -1007,7 +1006,7 @@ class window.AnalysisRequestAdd
     arnum = $el.closest("[arnum]").attr "arnum"
 
     record = @records_snapshot[arnum]
-    profile_metadata = record.profile_metadata[uid]
+    profile_metadata = record.profiles_metadata[uid]
     profile_services = []
 
     # prepare a list of services used by the profile with the given UID

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -283,6 +283,11 @@ class window.AnalysisRequestAdd
       $.each record.sampletype_metadata, (uid, sampletype) ->
         me.apply_field_value arnum, sampletype
 
+      # set additional records
+      $.each record.additional, (field_name, item) ->
+        $.each item, (uid, metadata) ->
+          me.apply_field_value arnum, metadata
+
       # handle unmet dependencies, one at a time
       $.each record.unmet_dependencies, (uid, dependencies) ->
         service = record.service_metadata[uid]

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -245,7 +245,7 @@ class window.AnalysisRequestAdd
     $.each records, (arnum, record) ->
 
       # Apply the values generically, but those to be handled differently
-      discard = ["service_metadata", "specification_metadata"]
+      discard = ["service_metadata", "specification_metadata", "template_metadata"]
       $.each record, (name, metadata) ->
         # Discard those fields that will be handled differently and those that
         # do not contain explicit object metadata (e.g service_to_specification)
@@ -267,6 +267,10 @@ class window.AnalysisRequestAdd
 
         # select the service
         me.set_service arnum, uid, yes
+
+      # set template
+      $.each record.template_metadata, (uid, template) ->
+        me.set_template arnum, template
 
       # set specification
       $.each record.specification_metadata, (uid, spec) ->

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -73,10 +73,9 @@ class window.AnalysisRequestAdd
     $("body").on "click", "tr[fieldname=InvoiceExclude] input[type='checkbox']", @recalculate_records
     # Analysis Checkbox clicked
     $("body").on "click", "tr[fieldname=Analyses] input[type='checkbox']", @on_analysis_checkbox_click
-    # Client changed
-    $("body").on "selected change", "tr[fieldname=Client] input[type='text']", @on_client_changed
-    # Contact changed
-    $("body").on "selected change", "tr[fieldname=Contact] input[type='text']", @on_contact_changed
+    # Generic onchange event handler for reference fields
+    $("body").on "selected change" , "input[type='text'].referencewidget", @on_referencefield_value_changed
+
     # Analysis Specification changed
     $("body").on "change", "input.min", @on_analysis_specification_changed
     $("body").on "change", "input.max", @on_analysis_specification_changed
@@ -829,41 +828,21 @@ class window.AnalysisRequestAdd
 
   ### EVENT HANDLER ###
 
-  on_client_changed: (event) =>
+  on_referencefield_value_changed: (event) =>
     ###
-     * Eventhandler when the client changed (happens on Batches)
+     * Generic event handler for when a field value changes
     ###
-
     me = this
     el = event.currentTarget
     $el = $(el)
     uid = $el.attr "uid"
+    field_name = $el.closest("tr[fieldname]").attr "fieldname"
     arnum = $el.closest("[arnum]").attr "arnum"
 
-    console.debug "°°° on_client_changed: arnum=#{arnum} °°°"
+    console.debug "°°° on_field_value_changed: field_name=#{field_name} arnum=#{arnum} °°°"
 
-    # Flush client depending fields
-    me.flush_fields_for "Client", arnum
-
-    # trigger form:changed event
-    $(me).trigger "form:changed"
-
-
-  on_contact_changed: (event) =>
-    ###
-     * Eventhandler when the contact changed
-    ###
-
-    me = this
-    el = event.currentTarget
-    $el = $(el)
-    uid = $el.attr "uid"
-    arnum = $el.closest("[arnum]").attr "arnum"
-
-    console.debug "°°° on_contact_changed: arnum=#{arnum} °°°"
-
-    # Flush contact depending fields
-    me.flush_fields_for "Contact", arnum
+    # Flush depending fields
+    me.flush_fields_for field_name, arnum
 
     # trigger form:changed event
     $(me).trigger "form:changed"
@@ -1016,9 +995,6 @@ class window.AnalysisRequestAdd
     if not has_sampletype_selected
       # XXX manually flush UID field
       $("input[type=hidden]", $el.parent()).val("")
-
-    # Flush sampletype depending fields
-    me.flush_fields_for "SampleType", arnum
 
     # trigger form:changed event
     $(me).trigger "form:changed"

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -283,7 +283,7 @@ class window.AnalysisRequestAdd
 
       # set sampletype
       $.each record.sampletype_metadata, (uid, sampletype) ->
-        me.set_sampletype arnum, sampletype
+        me.apply_field_value arnum, sampletype
 
       # handle unmet dependencies, one at a time
       $.each record.unmet_dependencies, (uid, dependencies) ->
@@ -418,6 +418,12 @@ class window.AnalysisRequestAdd
     me = this
     values_json = $.toJSON values
     field = $("#" + field_name + "-#{arnum}")
+
+    if values.if_empty? and values.if_empty is true
+      # Set the value if the field is empty only
+      if not field.val()
+        return
+
     console.debug "apply_dependent_value: field_name=#{field_name} field_values=#{values_json}"
 
     if values.uid? and values.title?
@@ -660,32 +666,6 @@ class window.AnalysisRequestAdd
     uid = sample.sampling_deviation_uid
     title = sample.sampling_deviation_title
     @set_reference_field field, uid, title
-
-
-  set_sampletype: (arnum, sampletype) =>
-    ###
-     * Recalculate partitions
-     * Filter Sample Points
-    ###
-
-    # restrict the sample points
-    field = $("#SamplePoint-#{arnum}")
-    query = sampletype.filter_queries.samplepoint
-    @set_reference_field_query field, query
-
-    # set the default container
-    field = $("#DefaultContainerType-#{arnum}")
-    # apply default container if the field is empty
-    if not field.val()
-      uid = sampletype.container_type_uid
-      title = sampletype.container_type_title
-      @flush_reference_field field
-      @set_reference_field field, uid, title
-
-    # restrict the specifications
-    field = $("#Specification-#{arnum}")
-    query = sampletype.filter_queries.specification
-    @set_reference_field_query field, query
 
 
   set_template: (arnum, template) =>

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -495,10 +495,7 @@ class window.AnalysisRequestAdd
      * Filter Batch
     ###
 
-    # filter Contacts
-    field = $("#Contact-#{arnum}")
-    query = client.filter_queries.contact
-    @set_reference_field_query field, query
+    me = this
 
     # handle default contact for /analysisrequests listing
     # https://github.com/senaite/senaite.core/issues/705
@@ -508,51 +505,10 @@ class window.AnalysisRequestAdd
       if contact_title and contact_uid
         @set_reference_field field, contact_uid, contact_title
 
-    # filter CCContacts
-    field = $("#CCContact-#{arnum}")
-    query = client.filter_queries.cc_contact
-    @set_reference_field_query field, query
-
-    # filter InvoiceContact
-    # XXX Where is this field?
-    field = $("#InvoiceContact-#{arnum}")
-    query = client.filter_queries.invoice_contact
-    @set_reference_field_query field, query
-
-    # filter Sample Points
-    field = $("#SamplePoint-#{arnum}")
-    query = client.filter_queries.samplepoint
-    @set_reference_field_query field, query
-
-    # filter AR Templates
-    field = $("#Template-#{arnum}")
-    query = client.filter_queries.artemplates
-    @set_reference_field_query field, query
-
-    # filter Analysis Profiles
-    field = $("#Profiles-#{arnum}")
-    query = client.filter_queries.analysisprofiles
-    @set_reference_field_query field, query
-
-    # filter Analysis Specs
-    field = $("#Specification-#{arnum}")
-    query = client.filter_queries.analysisspecs
-    @set_reference_field_query field, query
-
-    # filter Samplinground
-    field = $("#SamplingRound-#{arnum}")
-    query = client.filter_queries.samplinground
-    @set_reference_field_query field, query
-
-    # filter Sample
-    field = $("#PrimaryAnalysisRequest-#{arnum}")
-    query = client.filter_queries.sample
-    @set_reference_field_query field, query
-
-    # filter Batch
-    field = $("#Batch-#{arnum}")
-    query = client.filter_queries.batch
-    @set_reference_field_query field, query
+    # Apply search filters to other fields
+    $.each client.filter_queries, (field_name, query) ->
+      field = $("#" + field_name + "-#{arnum}")
+      me.set_reference_field_query field, query
 
 
   set_contact: (arnum, contact) =>

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -243,17 +243,14 @@ class window.AnalysisRequestAdd
 
     # set all values for one record (a single column in the AR Add form)
     $.each records, (arnum, record) ->
-      # set sample
-      $.each record.primaryanalysisrequest_metadata, (uid, sample) ->
-        me.apply_field_value arnum, sample
 
-      # set client
-      $.each record.client_metadata, (uid, client) ->
-        me.apply_field_value arnum, client
-
-      # set contact
-      $.each record.contact_metadata, (uid, contact) ->
-        me.apply_field_value arnum, contact
+      # Apply the values generically, but those to be handled differently
+      discard = ["service_metadata", "specification_metadata"]
+      $.each record, (name, metadata) ->
+        if name in discard or !name.endsWith("_metadata")
+          return
+        $.each metadata, (uid, obj_info) ->
+          me.apply_field_value arnum, obj_info
 
       # set services
       $.each record.service_metadata, (uid, metadata) ->
@@ -269,23 +266,10 @@ class window.AnalysisRequestAdd
         # select the service
         me.set_service arnum, uid, yes
 
-      # set template
-      $.each record.template_metadata, (uid, template) ->
-        me.set_template arnum, template
-
       # set specification
       $.each record.specification_metadata, (uid, spec) ->
         $.each spec.specifications, (uid, service_spec) ->
           me.set_service_spec arnum, uid, service_spec
-
-      # set sampletype
-      $.each record.sampletype_metadata, (uid, sampletype) ->
-        me.apply_field_value arnum, sampletype
-
-      # set additional records
-      $.each record.additional, (field_name, item) ->
-        $.each item, (uid, metadata) ->
-          me.apply_field_value arnum, metadata
 
       # handle unmet dependencies, one at a time
       $.each record.unmet_dependencies, (uid, dependencies) ->
@@ -396,6 +380,8 @@ class window.AnalysisRequestAdd
      * search filters to dependents
     ###
     me = this
+    title = record.title
+    console.debug "apply_field_value: arnum=#{arnum} record=#{title}"
 
     # Set default values to dependents
     me.apply_dependent_values arnum, record

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -247,6 +247,8 @@ class window.AnalysisRequestAdd
       # Apply the values generically, but those to be handled differently
       discard = ["service_metadata", "specification_metadata"]
       $.each record, (name, metadata) ->
+        # Discard those fields that will be handled differently and those that
+        # do not contain explicit object metadata (e.g service_to_specification)
         if name in discard or !name.endsWith("_metadata")
           return
         $.each metadata, (uid, obj_info) ->

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -457,7 +457,7 @@ class window.AnalysisRequestAdd
 
   flush_reference_field: (field) ->
     ###
-     * Empty the reference field
+     * Empty the reference field and restore the search query
     ###
 
     catalog_name = field.attr "catalog_name"
@@ -468,6 +468,17 @@ class window.AnalysisRequestAdd
     $("input[type=hidden]", field.parent()).val("")
     $(".multiValued-listing", field.parent()).empty()
 
+    # restore the original search query
+    @reset_reference_field_query field
+
+  reset_reference_field_query: (field) =>
+    ###
+     * Restores the catalog search query for the given reference field
+    ###
+    catalog_name = field.attr "catalog_name"
+    return unless catalog_name
+    query = $.parseJSON field.attr "base_query"
+    @set_reference_field_query field, query
 
   set_reference_field_query: (field, query, type="base_query") =>
     ###

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -85,8 +85,6 @@ class window.AnalysisRequestAdd
     $("body").on "click", ".service-lockbtn", @on_analysis_lock_button_click
     # Analysis info button clicked
     $("body").on "click", ".service-infobtn", @on_analysis_details_click
-    # Sample changed
-    $("body").on "selected change", "tr[fieldname=PrimaryAnalysisRequest] input[type='text']", @on_sample_changed
     # Analysis Template changed
     $("body").on "selected change", "tr[fieldname=Template] input[type='text']", @on_analysis_template_changed
     # Analysis Profile selected
@@ -279,7 +277,7 @@ class window.AnalysisRequestAdd
 
       # set sample
       $.each record.sample_metadata, (uid, sample) ->
-        me.set_sample arnum, sample
+        me.apply_field_value arnum, sample
 
       # set sampletype
       $.each record.sampletype_metadata, (uid, sampletype) ->
@@ -432,13 +430,14 @@ class window.AnalysisRequestAdd
 
     else if values.value?
       # This is a normal input field
-      field.val values.value
+      if typeof values.value == "boolean"
+        field.prop "checked", values.value
+      else
+        field.val values.value
 
     else if typeIsArray values
       # This is a multi field (e.g. CCContact)
       $.each values, (index, item) ->
-        item_json = $.toJSON item
-        console.debug "#{item_json}"
         me.apply_dependent_value arnum, field_name, item
 
 
@@ -576,96 +575,6 @@ class window.AnalysisRequestAdd
       div.append title
       mvl.append div
       $field.val("")
-
-
-  set_sample: (arnum, sample) =>
-    ###
-     * Apply the sample data to all fields of arnum
-    ###
-
-    # set the client
-    field = $("#Client-#{arnum}")
-    uid = sample.client_uid
-    title = sample.client_title
-    @set_reference_field field, uid, title
-
-    # set the client contact
-    field = $("#Contact-#{arnum}")
-    contact = sample.contact
-    uid = contact.uid
-    fullname = contact.fullname
-    @set_reference_field field, uid, fullname
-    @apply_field_value(arnum, contact)
-
-    # set the sampling date
-    field = $("#SamplingDate-#{arnum}")
-    value = sample.sampling_date
-    field.val value
-
-    # set the date sampled
-    field = $("#DateSampled-#{arnum}")
-    value = sample.date_sampled
-    field.val value
-
-    # set the sample type (required)
-    field = $("#SampleType-#{arnum}")
-    uid = sample.sample_type_uid
-    title = sample.sample_type_title
-    @set_reference_field field, uid, title
-
-    # set environmental conditions
-    field = $("#EnvironmentalConditions-#{arnum}")
-    value = sample.environmental_conditions
-    field.val value
-
-    # set client sample ID
-    field = $("#ClientSampleID-#{arnum}")
-    value = sample.client_sample_id
-    field.val value
-
-    # set client reference
-    field = $("#ClientReference-#{arnum}")
-    value = sample.client_reference
-    field.val value
-
-    # set the client order number
-    field = $("#ClientOrderNumber-#{arnum}")
-    value = sample.client_order_number
-    field.val value
-
-    # set composite
-    field = $("#Composite-#{arnum}")
-    field.prop "checked", sample.composite
-
-    # set the sample condition
-    field = $("#SampleCondition-#{arnum}")
-    uid = sample.sample_condition_uid
-    title = sample.sample_condition_title
-    @set_reference_field field, uid, title
-
-    # set the sample point
-    field = $("#SamplePoint-#{arnum}")
-    uid = sample.sample_point_uid
-    title = sample.sample_point_title
-    @set_reference_field field, uid, title
-
-    # set the storage location
-    field = $("#StorageLocation-#{arnum}")
-    uid = sample.storage_location_uid
-    title = sample.storage_location_title
-    @set_reference_field field, uid, title
-
-    # set the default container type
-    field = $("#DefaultContainerType-#{arnum}")
-    uid = sample.container_type_uid
-    title = sample.container_type_title
-    @set_reference_field field, uid, title
-
-    # set the sampling deviation
-    field = $("#SamplingDeviation-#{arnum}")
-    uid = sample.sampling_deviation_uid
-    title = sample.sampling_deviation_title
-    @set_reference_field field, uid, title
 
 
   set_template: (arnum, template) =>
@@ -960,29 +869,6 @@ class window.AnalysisRequestAdd
         $(@).dialog "close"
 
     dialog = @template_dialog "service-dependant-template", context, buttons
-
-
-  on_sample_changed: (event) =>
-    ###
-     * Eventhandler when the Sample was changed.
-    ###
-
-    me = this
-    el = event.currentTarget
-    $el = $(el)
-    uid = $(el).attr "uid"
-    val = $el.val()
-    arnum = $el.closest("[arnum]").attr "arnum"
-    has_sample_selected = $el.val()
-    console.debug "°°° on_sample_change::UID=#{uid} PrimaryAnalysisRequest=#{val}°°°"
-
-    # deselect the sample if the field is empty
-    if not has_sample_selected
-      # XXX manually flush UID field
-      $("input[type=hidden]", $el.parent()).val("")
-
-    # trigger form:changed event
-    $(me).trigger "form:changed"
 
 
   on_analysis_template_changed: (event) =>

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -1001,3 +1001,8 @@ class IAddSampleMetadata(Interface):
              },
         }
         """
+
+
+class IAddSampleObjectInfo(Interface):
+    """Marker interface for objects metadata mapping
+    """

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -963,16 +963,6 @@ class IGuardAdapter(Interface):
         """
 
 
-class IAddSampleFieldFilter(Interface):
-    """Marker interface for field filters for Add Sample form
-    """
-
-    def get_info(self):
-        """Returns a dict where the key is the name of the field to be filtered
-        and the value is a dict with the search criteria
-        """
-
-
 class IAddSampleFieldsFlush(Interface):
     """Marker interface for field dependencies flush for Add Sample form
     """
@@ -983,26 +973,33 @@ class IAddSampleFieldsFlush(Interface):
         """
 
 
-class IAddSampleMetadata(Interface):
-    """Marker interface for additional fields that need to be taken into
-    account in recalculation of metadata from Add Sample form
-    """
-
-    def get_metadata(self, record):
-        """Returns a dict where the key is the fieldname (e.g. Batch) and the
-        value is another dict where the key is the UID of the object and the
-        value is its metadata representation as a dict:
-
-        {Batch: {
-             <uid>: {
-                 "id": <batch_id>,
-                 "title", <batch_title>,
-                 ...
-             },
-        }
-        """
-
-
 class IAddSampleObjectInfo(Interface):
     """Marker interface for objects metadata mapping
     """
+
+    def get_object_info(self):
+        """Returns the dict representation of the context object for its
+        correct consumption by Sample Add form:
+
+        {'id': <id_of_the_object>,
+         'uid': <uid_of_the_object>,
+         'title': <title_of_the_object>,
+         'filter_queries': {
+             <dependent_field_name>: {
+                 <catalog_index>: <criteria>
+             }
+         },
+         'field_values': {
+             <dependent_field_name>: {
+                <uid>: <dependent_uid>,
+                <title>: <dependent_title>
+            }
+         }
+
+        Besides the basic keys (id, uid, title), two additional keys can be
+        provided:
+        - filter_queries: contains the filter queries for other fields to be
+          applied when the value of current field changes.
+        - field_values: contains default values for other fields to be applied
+          when the value of the current field changes.
+        """

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -971,3 +971,13 @@ class IAddSampleFieldFilter(Interface):
         """Returns a dict where the key is the name of the field to be filtered
         and the value is a dict with the search criteria
         """
+
+
+class IAddSampleFieldsFlush(Interface):
+    """Marker interface for field dependencies flush for Add Sample form
+    """
+
+    def get_flush_settings(self):
+        """Returns a dict where the key is the name of the field and the value
+        is an array dependencies as field names
+        """

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -961,3 +961,13 @@ class IGuardAdapter(Interface):
     def guard(self, transition):
         """Return False if you want to block the transition
         """
+
+
+class IAddSampleFieldFilter(Interface):
+    """Marker interface for field filters for Add Sample form
+    """
+
+    def get_info(self):
+        """Returns a dict where the key is the name of the field to be filtered
+        and the value is a dict with the search criteria
+        """

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -981,3 +981,23 @@ class IAddSampleFieldsFlush(Interface):
         """Returns a dict where the key is the name of the field and the value
         is an array dependencies as field names
         """
+
+
+class IAddSampleMetadata(Interface):
+    """Marker interface for additional fields that need to be taken into
+    account in recalculation of metadata from Add Sample form
+    """
+
+    def get_metadata(self, record):
+        """Returns a dict where the key is the fieldname (e.g. Batch) and the
+        value is another dict where the key is the UID of the object and the
+        value is its metadata representation as a dict:
+
+        {Batch: {
+             <uid>: {
+                 "id": <batch_id>,
+                 "title", <batch_title>,
+                 ...
+             },
+        }
+        """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR comes with some refactoring of Add Sample logic to allow add-ons to extend/modify the behavior of the view without the need of javascript. 

### Use case/example
The following Pull Request in `senaite.health` is an example on how to modify the behavior of Sample Add form by using adapters: [Remove Add Sample view js and use field adapters instead #149](https://github.com/senaite/senaite.health/pull/149)

## Current behavior before PR

Not possible to change the behavior of Add Sample without js

## Desired behavior after PR is merged

Possible to change the behavior of Add Sample without js

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
