### PR TITLE
Cannot override behavior of Batch folder when using `before_render`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Changelog
 
 **Fixed**
 
+- #1467 Cannot override behavior of Batch folder when using `before_render`
+
 
 **Security**
 

--- a/bika/lims/browser/batchfolder.py
+++ b/bika/lims/browser/batchfolder.py
@@ -112,10 +112,10 @@ class BatchFolderContentsView(BikaListingView):
             },
         ]
 
-    def before_render(self):
+    def update(self):
         """Before template render hook
         """
-        super(BatchFolderContentsView, self).before_render()
+        super(BatchFolderContentsView, self).update()
 
         if self.context.portal_type == "BatchFolder":
             self.request.set("disable_border", 1)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`senaite.core`'s BatchFolder is used as the "root" listing view for batches listings. Nevertheless, it overrides the function `before_render`. As a result, some of the changes made in subscriber adapters from another add-ons are omitted. For instance, trying to modify `context_actions` via subscriber adapters won't have any effect because after the call, the value is overriden in BatchFolder.

This Pull Request, moves the logic for `before_render` from the base class "BatchFolder" to the function `update`.

## Current behavior before PR

Cannot override some behavior (e.g., `context_actions`) of BatchFolder listing by using subscriber adapters.

## Desired behavior after PR is merged

Can override behavior of BatchFolder listoing by using subscriber adapters.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
