### PR TITLE
Fix Site Properties Generic Setup Export Step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Changelog
 
 **Fixed**
 
+- #1469 Fix Site Properties Generic Setup Export Step
 - #1467 Cannot override behavior of Batch folder when using `before_render`
 
 

--- a/bika/lims/exportimport/genericsetup/configure.zcml
+++ b/bika/lims/exportimport/genericsetup/configure.zcml
@@ -6,7 +6,8 @@
   <!-- XML Import/Export Adapters -->
 
   <!-- N.B. Deactivated by purpose!
-            Avoid its usage when the site properties get exported.
+            Avoid its usage when the site properties get exported:
+            Products.CMFCore.exportimport.properties.exportSiteProperties
       <adapter factory=".structure.SenaiteSiteXMLAdapter"/>
   -->
   <adapter factory=".structure.ContentXMLAdapter"/>

--- a/bika/lims/exportimport/genericsetup/configure.zcml
+++ b/bika/lims/exportimport/genericsetup/configure.zcml
@@ -4,7 +4,11 @@
     i18n_domain="senaite.core">
 
   <!-- XML Import/Export Adapters -->
-  <adapter factory=".structure.SenaiteSiteXMLAdapter"/>
+
+  <!-- N.B. Deactivated by purpose!
+            Avoid its usage when the site properties get exported.
+      <adapter factory=".structure.SenaiteSiteXMLAdapter"/>
+  -->
   <adapter factory=".structure.ContentXMLAdapter"/>
 
   <!-- Field Adapters

--- a/bika/lims/exportimport/genericsetup/structure.py
+++ b/bika/lims/exportimport/genericsetup/structure.py
@@ -400,7 +400,13 @@ def exportObjects(obj, parent_path, context):
         logger.info("Skipping {}".format(repr(obj)))
         return
 
-    exporter = queryMultiAdapter((obj, context), IBody)
+    if api.is_portal(obj):
+        # explicitly instantiate the exporter to avoid adapter clash of
+        # Products.CMFCore.exportimport.properties.PropertiesXMLAdapter
+        exporter = SenaiteSiteXMLAdapter(obj, context)
+    else:
+        exporter = queryMultiAdapter((obj, context), IBody)
+
     path = "%s%s" % (parent_path, get_id(obj))
     if exporter:
         if exporter.name:

--- a/bika/lims/upgrade/v01_03_003.py
+++ b/bika/lims/upgrade/v01_03_003.py
@@ -41,5 +41,10 @@ def upgrade(tool):
 
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
+    # -------- ADD YOUR STUFF BELOW --------
+
+    # https://github.com/senaite/senaite.core/pull/1469
+    setup.runImportStepFromProfile(profile, "propertiestool")
+
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the Site Properties Generic Setup Export Step:
`Products.CMFCore.exportimport.properties.exportSiteProperties`

This issue was introduced by the Structure Export/Import functionality of https://github.com/senaite/senaite.core/pull/1463

# Current behavior before PR

The `SenaiteSiteXMLAdapter` was called by `Products.CMFCore.exportimport.properties.exportSiteProperties` 

## Desired behavior after PR is merged

The correct adapter is called by `Products.CMFCore.exportimport.properties.exportSiteProperties`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
