### PR TITLE
Wrong version in upgrade step 1.3.3

### DIFF
--- a/bika/lims/upgrade/v01_03_003.py
+++ b/bika/lims/upgrade/v01_03_003.py
@@ -23,7 +23,7 @@ from bika.lims.config import PROJECTNAME as product
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
 
-version = "2.0.0"  # Remember version number in metadata.xml and setup.py
+version = "1.3.3"  # Remember version number in metadata.xml and setup.py
 profile = "profile-{0}:default".format(product)
 
 


### PR DESCRIPTION
Change version from 2.0.0 to 1.3.3

## Description of the issue/feature this PR addresses

Wrong version after upgrade to 1.3.3

## Current behavior before PR

Although Senaite was upgraded without inconveniences, the destination version is wrong.

## Desired behavior after PR is merged

Correct version after upgrade.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
