### PR TITLE
Secondary samples - removal of analysis profile not possible

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Changelog
 
 **Fixed**
 
+- #1472 Secondary samples - removal of analysis profile not possible
 - #1469 Fix Site Properties Generic Setup Export Step
 - #1467 Cannot override behavior of Batch folder when using `before_render`
 

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1067,10 +1067,6 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         sample_point = obj.getSamplePoint()
         container = obj.getContainer()
         deviation = obj.getSamplingDeviation()
-        preservation = obj.getPreservation()
-        specification = obj.getSpecification()
-        sample_template = obj.getTemplate()
-        profiles = obj.getProfiles() or []
         cccontacts = obj.getCCContact() or []
         contact = obj.getContact()
 
@@ -1098,10 +1094,6 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             "StorageLocation": self.to_field_value(storage_location),
             "Container": self.to_field_value(container),
             "SamplingDeviation": self.to_field_value(deviation),
-            "Preservation": self.to_field_value(preservation),
-            "Specification": self.to_field_value(specification),
-            "Template": self.to_field_value(sample_template),
-            "Profiles": map(self.to_field_value, profiles),
             "Composite": {"value": obj.getComposite()}
         })
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When a Primary Sample is selected in Add form, some fields are automatically populated with the values coming from the Primary. Although this is the desirable behavior for most of the fields, some of the fields should remain unset to allow user to change their value at will. With this Pull Request, the values for the following fields are not set automatically when a Primary is selected:

- Profiles
- Template
- Specification
- Preservation

Linked issue: https://github.com/senaite/senaite.core/issues/1471

## Current behavior before PR

User cannot edit the profiles when a Primary is selected

## Desired behavior after PR is merged

User can edit the profiles when a Primary is selected

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
