### PR TITLE
Hidden settings of analysis services lost on Sample creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Changelog
 
 **Fixed**
 
+- #1473 Hidden settings of analysis services lost on Sample creation
 - #1469 Fix Site Properties Generic Setup Export Step
 - #1467 Cannot override behavior of Batch folder when using `before_render`
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When Profiles and/or Templates are selected on Sample add form, "hidden" settings for analyses services are not populated in the newly created sample.

Linked issues:
- https://github.com/senaite/senaite.core/issues/1326
- https://github.com/senaite/senaite.core/issues/1437

## Current behavior before PR

"hidden" settings for analysis services from profiles and/or templates are not populated in sample

## Desired behavior after PR is merged

"hidden" settings for analysis services from profiles and/or templates are populated in sample

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
