### PR TITLE
Adding Control Reference to Worksheet causes print fail

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Changelog
 
 **Fixed**
 
+- #1474 Adding Control Reference to Worksheet causes print fail
 - #1472 Secondary samples - removal of analysis profile not possible
 - #1469 Fix Site Properties Generic Setup Export Step
 - #1467 Cannot override behavior of Batch folder when using `before_render`

--- a/bika/lims/browser/worksheet/views/printview.py
+++ b/bika/lims/browser/worksheet/views/printview.py
@@ -369,7 +369,7 @@ class PrintView(BrowserView):
                 ar = self._ar_data(arobj)
                 ar['client'] = self._client_data(arobj.aq_parent)
                 ar["sample"] = dict()
-                if IReferenceSample.providedBy(an):
+                if IReferenceSample.providedBy(arobj):
                     ar['sample'] = self._sample_data(an.getSample())
                 else:
                     ar['sample'] = self._sample_data(an.getRequest())


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1431

## Current behavior before PR

When a reference sample (e.g. control) is added to a Worksheet and the print button is pressed, the following error occurs:

```
Unable to load the template 'ar_by_column.pt':
Traceback (most recent call last):
  File "/usr/local/Plone/buildout-cache/eggs/senaite.core-1.3.1-py2.7.egg/bika/lims/browser/worksheet/views/printview.py", line 143, in renderWSTemplate
    reptemplate = embed(self)
  File "/usr/local/Plone/buildout-cache/eggs/Zope2-2.13.27-py2.7.egg/Products/Five/browser/pagetemplatefile.py", line 59, in __call__
    sourceAnnotations=getattr(debug_flags, 'sourceAnnotations', 0),
  File "/usr/local/Plone/buildout-cache/eggs/zope.pagetemplate-3.6.3-py2.7.egg/zope/pagetemplate/pagetemplate.py", line 132, in pt_render
    strictinsert=0, sourceAnnotations=sourceAnnotations
  File "/usr/local/Plone/buildout-cache/eggs/five.pt-2.2.4-py2.7.egg/five/pt/engine.py", line 98, in __call__
    return self.template.render(**kwargs)
  File "/usr/local/Plone/buildout-cache/eggs/z3c.pt-3.2.0-py2.7.egg/z3c/pt/pagetemplate.py", line 173, in render
    return base_renderer(**context)
  File "/usr/local/Plone/buildout-cache/eggs/Chameleon-3.6.2-py2.7.egg/chameleon/zpt/template.py", line 306, in render
    return super(PageTemplate, self).render(**_kw)
  File "/usr/local/Plone/buildout-cache/eggs/Chameleon-3.6.2-py2.7.egg/chameleon/template.py", line 209, in render
    raise_with_traceback(exc, tb)
  File "/usr/local/Plone/buildout-cache/eggs/Chameleon-3.6.2-py2.7.egg/chameleon/template.py", line 187, in render
    self._render(stream, econtext, rcontext)
  File "58de6ce66ce9364d2672247d11f82b6c.py", line 119, in render
  File "/usr/local/Plone/buildout-cache/eggs/senaite.core-1.3.1-py2.7.egg/bika/lims/browser/worksheet/views/printview.py", line 190, in getWorksheet
    ws = self._ws_data(self._worksheets[self._current_ws_index])
  File "/usr/local/Plone/buildout-cache/eggs/senaite.core-1.3.1-py2.7.egg/bika/lims/browser/worksheet/views/printview.py", line 253, in _ws_data
    data['ars'] = self._analyses_data(ws)
  File "/usr/local/Plone/buildout-cache/eggs/senaite.core-1.3.1-py2.7.egg/bika/lims/browser/worksheet/views/printview.py", line 375, in _analyses_data
    ar['sample'] = self._sample_data(an.getRequest())
AttributeError: getRequest

 - Expression: "python:view.getWorksheet()"
 - Filename:   ... owser/worksheet/views/../templates/print/ar_by_column.pt
 - Location:   (line 16: col 30)
 - Source:     ... ne="worksheet       python:view.getWorksheet();
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  repeat: {...} (0)
               template: 
               views: 
               modules: 
               args: 
               here: 
               wrapped_repeat: 
               user: 
               nothing: 
               container: 
               request: 
               traverse_subpath: 
               default: 
               context: 
               view: 
               translate: 
               root: 
               options: {...} (0)
               loop: {...} (0)
               target_language: 
```

## Desired behavior after PR is merged

No traceback and the worksheet print view is rendered correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
