### PR TITLE
User with "Analyst" role cannot submit analyses from worksheet

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Changelog
 
 **Fixed**
 
+- #1475 User with "Analyst" role cannot submit analyses from worksheet
 - #1474 Adding Control Reference to Worksheet causes print fail
 - #1473 Hidden settings of analysis services lost on Sample creation
 - #1472 Secondary samples - removal of analysis profile not possible

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -207,6 +207,10 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
             if method and analysis.isMethodAllowed(method):
                 analysis.setMethod(method)
 
+        # Assign the worksheet's analyst to the analysis
+        # https://github.com/senaite/senaite.core/issues/1409
+        analysis.setAnalyst(self.getAnalyst())
+
         # Transition analysis to "assigned"
         actions_pool = ActionHandlerPool.get_instance()
         actions_pool.queue_pool()

--- a/bika/lims/workflow/analysis/guards.py
+++ b/bika/lims/workflow/analysis/guards.py
@@ -18,14 +18,16 @@
 # Copyright 2018-2019 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from plone.memoize.request import cache
+
 from bika.lims import api
 from bika.lims import logger
 from bika.lims import workflow as wf
+from bika.lims.api import security
 from bika.lims.interfaces import ISubmitted
 from bika.lims.interfaces import IVerified
 from bika.lims.interfaces import IWorksheet
 from bika.lims.interfaces.analysis import IRequestAnalysis
-from plone.memoize.request import cache
 
 
 def is_worksheet_context():
@@ -140,7 +142,7 @@ def guard_submit(analysis):
             if not analyst:
                 return False
             # Cannot submit if assigned analyst is not the current user
-            if analyst != api.get_current_user().getId():
+            if analyst != security.get_user_uid():
                 return False
 
     # Cannot submit unless all dependencies are submitted or can be submitted

--- a/bika/lims/workflow/analysis/guards.py
+++ b/bika/lims/workflow/analysis/guards.py
@@ -136,10 +136,11 @@ def guard_submit(analysis):
     if not analysis.bika_setup.getAllowToSubmitNotAssigned():
         if not user_has_super_roles():
             # Cannot submit if unassigned
-            if not analysis.getAnalyst():
+            analyst = analysis.getAnalyst()
+            if not analyst:
                 return False
             # Cannot submit if assigned analyst is not the current user
-            if analysis.getAnalyst() != api.get_current_user().getId():
+            if analyst != api.get_current_user().getId():
                 return False
 
     # Cannot submit unless all dependencies are submitted or can be submitted

--- a/bika/lims/workflow/analysis/guards.py
+++ b/bika/lims/workflow/analysis/guards.py
@@ -142,7 +142,7 @@ def guard_submit(analysis):
             if not analyst:
                 return False
             # Cannot submit if assigned analyst is not the current user
-            if analyst != security.get_user_uid():
+            if analyst != security.get_user_id():
                 return False
 
     # Cannot submit unless all dependencies are submitted or can be submitted


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Assigned analyst to a given worksheet cannot submit the results, but save them only when the setting "Allow to submit results for unassigned analyses or for analyses assigned to others" from Setup is disabled.

Linked issue: https://github.com/senaite/senaite.core/issues/1409

## Current behavior before PR

Assigned analyst can save, but not submit results in worksheet

## Desired behavior after PR is merged

Assigned analyst can save and submit results in worksheet

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
