### PR TITLE
Remove `senaite.instruments` dependency for instrument import form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Removed**
 
+- #1482 Remove `senaite.instruments` dependency for instrument import form
 - #1478 Remove AcquireFieldDefaults (was used for CCEmails field only)
 
 **Fixed**

--- a/bika/lims/exportimport/dataimport.py
+++ b/bika/lims/exportimport/dataimport.py
@@ -119,23 +119,15 @@ class ajaxGetImportTemplate(BrowserView):
 
     def __call__(self):
         plone.protect.CheckAuthenticator(self.request)
-        exim = self.request.get('exim')
-        core_instrument = self.is_exim_in_core(exim)
-        exim = exim.replace(".", "/")
+        exim = self.request.get('exim').replace(".", "/")
         # If a specific template for this instrument doesn't exist yet,
         # use the default template for instrument results file import located
         # at bika/lims/exportimport/instruments/instrument.pt
-        # if exim.startswith('senaite/instruments'):
-        if core_instrument:
-            instrpath = os.path.join("exportimport", "instruments")
-            templates_dir = resource_filename("bika.lims", instrpath)
-            fname = "%s/%s_import.pt" % (templates_dir, exim)
-        else:
-            instrpath = '/'.join(exim.split('/')[2:-2])
-            templates_dir = resource_filename("senaite.instruments", instrpath)
-            fname = "{}/{}_import.pt".format(templates_dir, exim.split('/')[-1])
+        instrpath = os.path.join("exportimport", "instruments")
+        templates_dir = resource_filename("bika.lims", instrpath)
+        fname = "%s/%s_import.pt" % (templates_dir, exim)
         if os.path.isfile(fname):
-            return ViewPageTemplateFile(fname)(self)
+            return ViewPageTemplateFile("instruments/%s_import.pt" % exim)(self)
         else:
             return ViewPageTemplateFile("instruments/instrument.pt")(self)
 
@@ -151,14 +143,6 @@ class ajaxGetImportTemplate(BrowserView):
             items.append((item.getKeyword, item.Title))
         items.sort(lambda x, y: cmp(x[1].lower(), y[1].lower()))
         return DisplayList(list(items))
-
-    def is_exim_in_core(self, exim):
-        portal_tool = plone.api.portal.get_tool('portal_setup')
-        profiles = portal_tool.listProfileInfo()
-        for profile in profiles:
-            if exim.startswith(profile['product']):
-                return False
-        return True
 
 
 class ajaxGetImportInterfaces(BrowserView):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request removes the dependency of `senaite.instruments` for when an instrument interface is added in another add-on. See the linked issue for further details.

@mikejmets , I've undone some of the changes you did in https://github.com/senaite/senaite.core/pull/1349 . Better use a named adapter or similar to handle templates from `senaite.instruments` rather than forcing the user to manually install `senaite.instruments` add-on to make their own to work. This said, I think that at some point, the whole `dataimport.py` and machinery behind (including the import form rendering through ajax) should be revisited/refactored.

Linked issue: https://github.com/senaite/senaite.core/issues/1415

## Current behavior before PR

Error when adding an instrument import interface in a custom add-on if `senaite.instruments` is not installed.

## Desired behavior after PR is merged

No error when adding an instrument import interface in a custom add-on.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
