### PR TITLE
Added Accredited symbol in Analyses listings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changelog
 
 **Added**
 
+- #1483 Added Accredited symbol in Analyses listings
 - #1466 Support for "readonly" and "hidden" visibility modes in ReferenceWidget
 
 

--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -569,6 +569,8 @@ class AnalysesView(BikaListingView):
         self._folder_item_verify_icons(obj, item)
         # Fill worksheet anchor/icon
         self._folder_item_assigned_worksheet(obj, item)
+        # Fill accredited icon
+        self._folder_item_accredited_icon(obj, item)
         # Fill reflex analysis icons
         self._folder_item_reflex_icons(obj, item)
         # Fill hidden field (report visibility)
@@ -1161,6 +1163,14 @@ class AnalysesView(BikaListingView):
         img = get_image('reflexrule.png',
                         title=t(_('It comes form a reflex rule')))
         self._append_html_element(item, 'Service', img)
+
+    def _folder_item_accredited_icon(self, analysis_brain, item):
+        """Adds an icon to the item dictionary if it is an accredited analysis
+        """
+        full_obj = self.get_object(analysis_brain)
+        if full_obj.getAccredited():
+            img = get_image("accredited.png", title=t(_("Accredited")))
+            self._append_html_element(item, "Service", img)
 
     def _folder_item_report_visibility(self, analysis_brain, item):
         """Set if the hidden field can be edited (enabled/disabled)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds the "accredited" icon next to Analyses titles in analyses listings.

Linked issue: https://github.com/senaite/senaite.core/issues/1266

## Current behavior before PR

Accredited symbol is only displayed in Analysis Service listings

## Desired behavior after PR is merged

Accredited symbol is displayed in Analyses listings too

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
