### PR TITLE
Skip importer when no xml structure was found

### DIFF
--- a/bika/lims/exportimport/genericsetup/structure.py
+++ b/bika/lims/exportimport/genericsetup/structure.py
@@ -424,7 +424,13 @@ def exportObjects(obj, parent_path, context):
 def importObjects(obj, parent_path, context):
     """ Import subobjects recursively.
     """
-    importer = queryMultiAdapter((obj, context), IBody)
+    if api.is_portal(obj):
+        # explicitly instantiate the importer to avoid adapter clash of
+        # Products.CMFCore.exportimport.properties.PropertiesXMLAdapter
+        importer = SenaiteSiteXMLAdapter(obj, context)
+    else:
+        importer = queryMultiAdapter((obj, context), IBody)
+
     path = "%s%s" % (parent_path, get_id(obj))
     __traceback_info__ = path
     if importer:
@@ -453,7 +459,11 @@ def import_xml(context):
     installed = qi.isProductInstalled("bika.lims")
 
     if not installed:
-        logger.debug("Nothing to export.")
+        logger.debug("Nothing to import.")
+        return
+
+    if not context.readDataFile("senaite.xml"):
+        logger.debug("Nothing to import.")
         return
 
     # create content slugs for UID references


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the Senaite Structure Generic Setup Import Handler  

## Current behavior before PR

All Generic Setup handlers were called implicitly by the structure importer

## Desired behavior after PR is merged

No additional Generic Setup handlers are called when the structure importer is called

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
