### PR TITLE
Skip portal tools in structure import

### DIFF
--- a/bika/lims/exportimport/genericsetup/structure.py
+++ b/bika/lims/exportimport/genericsetup/structure.py
@@ -386,6 +386,14 @@ def can_export(obj):
     return True
 
 
+def can_import(obj):
+    """Decides if the object can be imported or not
+    """
+    if not api.is_object(obj):
+        return False
+    return True
+
+
 def get_id(obj):
     if api.is_portal(obj):
         return SITE_ID
@@ -397,7 +405,7 @@ def exportObjects(obj, parent_path, context):
     """
 
     if not can_export(obj):
-        logger.info("Skipping {}".format(repr(obj)))
+        logger.info("Skipping export of {}".format(repr(obj)))
         return
 
     if api.is_portal(obj):
@@ -424,6 +432,11 @@ def exportObjects(obj, parent_path, context):
 def importObjects(obj, parent_path, context):
     """ Import subobjects recursively.
     """
+
+    if not can_import(obj):
+        logger.info("Skipping import of {}".format(repr(obj)))
+        return
+
     if api.is_portal(obj):
         # explicitly instantiate the importer to avoid adapter clash of
         # Products.CMFCore.exportimport.properties.PropertiesXMLAdapter


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Skip portal tools when importing the content structure via Generic Setup

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
