### PR TITLE
Support Dexterity Contents in Catalog Indexers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Changelog
 
 **Changed**
 
+- #1488 Support Dexterity Contents in Catalog Indexers
 - #1486 Clean-up of indexes and metadata from `setup_catalog`
 
 **Removed**

--- a/bika/lims/catalog/indexers/__init__.py
+++ b/bika/lims/catalog/indexers/__init__.py
@@ -18,19 +18,18 @@
 # Copyright 2018-2019 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from Products.Archetypes.interfaces import IBaseObject
-from Products.CMFPlone.CatalogTool import sortable_title as plone_sortable_title
-from Products.CMFPlone.utils import safe_callable
-from plone.indexer import indexer
-
 from bika.lims import api
 from bika.lims import logger
-from bika.lims.api import safe_getattr
 from bika.lims.catalog.bika_catalog import BIKA_CATALOG
 from bika.lims.interfaces import IBikaCatalog
+from plone.indexer import indexer
+from Products.CMFCore.interfaces import IContentish
+from Products.CMFPlone.CatalogTool import \
+    sortable_title as plone_sortable_title
+from Products.CMFPlone.utils import safe_callable
 
 
-@indexer(IBaseObject)
+@indexer(IContentish)
 def is_active(instance):
     """Returns False if the status of the instance is 'cancelled' or 'inactive'.
     Otherwise returns True
@@ -38,7 +37,7 @@ def is_active(instance):
     return api.is_active(instance)
 
 
-@indexer(IBaseObject)
+@indexer(IContentish)
 def sortable_title(instance):
     """Uses the default Plone sortable_text index lower-case
     """
@@ -62,7 +61,7 @@ def sortable_sortkey_title(instance):
     return "{:010.3f}{}".format(sort_key, title)
 
 
-@indexer(IBaseObject, IBikaCatalog)
+@indexer(IContentish, IBikaCatalog)
 def listing_searchable_text(instance):
     """ Retrieves all the values of metadata columns in the catalog for
     wildcard searches

--- a/bika/lims/catalog/indexers/bikasetup.py
+++ b/bika/lims/catalog/indexers/bikasetup.py
@@ -17,8 +17,6 @@
 #
 # Copyright 2018-2019 by it's authors.
 # Some rights reserved, see README and LICENSE.
-from Products.Archetypes.interfaces import IBaseObject
-from plone.indexer import indexer
 
 from bika.lims import api
 from bika.lims.catalog.bikasetup_catalog import SETUP_CATALOG
@@ -31,6 +29,8 @@ from bika.lims.interfaces import IHaveInstrument
 from bika.lims.interfaces import IHavePrice
 from bika.lims.interfaces import IInstrument
 from bika.lims.interfaces import ISampleTypeAwareMixin
+from plone.indexer import indexer
+from Products.CMFCore.interfaces import IContentish
 
 
 @indexer(ISampleTypeAwareMixin, IBikaSetupCatalog)
@@ -38,8 +38,8 @@ def sampletype_uid(instance):
     """Returns the list of SampleType UIDs the instance is assigned to
 
     This is a KeywordIndex, so it will be indexed as a list, even if only one
-    SampleType can be assigned to the instance. Moreover, if the instance has no
-    SampleType assigned, it returns a tuple with a None value. This allows
+    SampleType can be assigned to the instance. Moreover, if the instance has
+    no SampleType assigned, it returns a tuple with a None value. This allows
     searches for `MissingValue` entries too.
     """
     sample_type = instance.getSampleType()
@@ -62,9 +62,9 @@ def method_available_uid(instance):
     """Returns a list of Method UIDs that are available for this instance
 
     If the instance (AnalysisService) has InstrumentEntryOfResults set to True,
-    it returns the methods available from the instruments capable to perform the
-    service, as well as the methods set manually to the analysis. Otherwise, it
-    returns the methods assigned manually only.
+    it returns the methods available from the instruments capable to perform
+    the service, as well as the methods set manually to the analysis.
+    Otherwise, it returns the methods assigned manually only.
 
     If the instance has no available method assigned, it returns a tuple with
     a None value. This allows searches for `MissingValue` entries too.
@@ -128,7 +128,7 @@ def point_of_capture(instance):
     return instance.getPointOfCapture()
 
 
-@indexer(IBaseObject, IBikaSetupCatalog)
+@indexer(IContentish, IBikaSetupCatalog)
 def listing_searchable_text(instance):
     """ Retrieves all the values of metadata columns in the catalog for
     wildcard searches


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Support Dexterity contents in custom Indexers

## Current behavior before PR

Indexers adapt `Products.Archetypes.interfaces.IBaseObject`

## Desired behavior after PR is merged

Indexers adapt `Products.CMFCore.interfaces.IContentish`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
