### PR TITLE
Support Multiple Catalogs for Dexterity Contents

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changelog
 
 **Added**
 
+- #1489 Support Multiple Catalogs for Dexterity Contents
 - #1481 Filter Templates field when Sample Type is selected in Sample Add form
 - #1483 Added Accredited symbol in Analyses listings
 - #1466 Support for "readonly" and "hidden" visibility modes in ReferenceWidget

--- a/bika/lims/catalog/catalog_multiplex_processor.py
+++ b/bika/lims/catalog/catalog_multiplex_processor.py
@@ -59,15 +59,17 @@ class CatalogMultiplexProcessor(object):
         self.index(obj, attributes)
 
     def unindex(self, obj):
+        wrapped_obj = obj
         if aq_base(obj).__class__.__name__ == "PathWrapper":
             # Could be a PathWrapper object from collective.indexing.
             obj = obj.context
 
-        if IMultiCatalogBehavior(obj, None) is None:
+        if not self.supports_multi_catalogs(obj):
             return
 
         catalogs = self.get_catalogs_for(obj)
-        url = api.get_path(obj)
+        # get the old path from the wrapped object
+        url = api.get_path(wrapped_obj)
 
         for catalog in catalogs:
             if catalog._catalog.uids.get(url, None) is not None:

--- a/bika/lims/catalog/catalog_multiplex_processor.py
+++ b/bika/lims/catalog/catalog_multiplex_processor.py
@@ -53,6 +53,10 @@ class CatalogMultiplexProcessor(object):
             # We want the intersection of the catalogs idxs
             # and the incoming list.
             indexes = set(catalog.indexes()).intersection(attributes)
+            # Skip reindexing if no indexes match
+            if attributes and not indexes:
+                continue
+            # recatalog the object
             catalog.catalog_object(obj, url, idxs=list(indexes))
 
     def reindex(self, obj, attributes=None):

--- a/bika/lims/catalog/catalog_multiplex_processor.py
+++ b/bika/lims/catalog/catalog_multiplex_processor.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+
+from Acquisition import aq_base
+from bika.lims import api
+from bika.lims import logger
+from bika.lims.config import USE_COLLECTIVE_INDEXING
+from bika.lims.interfaces import IMultiCatalogBehavior
+from zope.interface import implements
+
+if USE_COLLECTIVE_INDEXING:
+    from collective.indexing.interfaces import IIndexQueueProcessor
+
+REQUIRED_CATALOGS = [
+    "auditlog_catalog",
+]
+
+
+class CatalogMultiplexProcessor(object):
+    """A catalog multiplex processor
+    """
+    if USE_COLLECTIVE_INDEXING:
+        implements(IIndexQueueProcessor)
+
+    def get_catalogs_for(self, obj):
+        catalogs = getattr(obj, "_catalogs", [])
+        for rc in REQUIRED_CATALOGS:
+            if rc in catalogs:
+                continue
+            catalogs.append(rc)
+        return map(api.get_tool, catalogs)
+
+    def supports_multi_catalogs(self, obj):
+        """Check if the Multi Catalog Behavior is enabled
+        """
+        if IMultiCatalogBehavior(obj, None) is None:
+            return False
+        return True
+
+    def index(self, obj, attributes=None):
+        if attributes is None:
+            attributes = []
+
+        if not self.supports_multi_catalogs(obj):
+            return
+
+        catalogs = self.get_catalogs_for(obj)
+        url = api.get_path(obj)
+
+        for catalog in catalogs:
+            logger.info(
+                "CatalogMultiplexProcessor::indexObject:catalog={} url={}"
+                .format(catalog.id, url))
+            # We want the intersection of the catalogs idxs
+            # and the incoming list.
+            indexes = set(catalog.indexes()).intersection(attributes)
+            catalog.catalog_object(obj, url, idxs=list(indexes))
+
+    def reindex(self, obj, attributes=None):
+        self.index(obj, attributes)
+
+    def unindex(self, obj):
+        if aq_base(obj).__class__.__name__ == "PathWrapper":
+            # Could be a PathWrapper object from collective.indexing.
+            obj = obj.context
+
+        if IMultiCatalogBehavior(obj, None) is None:
+            return
+
+        catalogs = self.get_catalogs_for(obj)
+        url = api.get_path(obj)
+
+        for catalog in catalogs:
+            if catalog._catalog.uids.get(url, None) is not None:
+                logger.info(
+                    "CatalogMultiplexProcessor::unindex:catalog={} url={}"
+                    .format(catalog.id, url))
+                catalog.uncatalog_object(url)
+
+    def begin(self):
+        pass
+
+    def commit(self):
+        pass
+
+    def abort(self):
+        pass

--- a/bika/lims/catalog/configure.zcml
+++ b/bika/lims/catalog/configure.zcml
@@ -15,7 +15,7 @@
       zcml:condition="installed collective.indexing"
       factory=".catalog_multiplex_processor.CatalogMultiplexProcessor"
       provides="collective.indexing.indexer.IPortalCatalogQueueProcessor"
-      name="catalogmulitplex"
+      name="catalogmultiplex"
       />
 
 </configure>

--- a/bika/lims/catalog/configure.zcml
+++ b/bika/lims/catalog/configure.zcml
@@ -1,0 +1,21 @@
+<configure xmlns="http://namespaces.zope.org/zope"
+           xmlns:zcml="http://namespaces.zope.org/zcml"
+           i18n_domain="senaite.core">
+
+  <!-- Catalog Indexes -->
+  <include package=".indexers" />
+
+  <!-- N.B. `IPortalCatalogQueueProcessor` will be included in
+            `Products.CMFCore` in Plone 5 and can be removed then -->
+  <include
+      zcml:condition="installed collective.indexing"
+      package="collective.indexing" />
+
+  <utility
+      zcml:condition="installed collective.indexing"
+      factory=".catalog_multiplex_processor.CatalogMultiplexProcessor"
+      provides="collective.indexing.indexer.IPortalCatalogQueueProcessor"
+      name="catalogmulitplex"
+      />
+
+</configure>

--- a/bika/lims/config.py
+++ b/bika/lims/config.py
@@ -27,6 +27,14 @@ from zope.i18n.locales import locales
 from bika.lims.utils import t  # noqa
 from bika.lims.permissions import *  # noqa
 
+try:
+    import collective.indexing
+    collective.indexing  # noqa
+except ImportError:
+    USE_COLLECTIVE_INDEXING = False
+else:
+    USE_COLLECTIVE_INDEXING = True
+
 
 PROJECTNAME = "bika.lims"
 

--- a/bika/lims/configure.zcml
+++ b/bika/lims/configure.zcml
@@ -26,7 +26,7 @@
 
   <include package=".adapters" />
   <include package=".browser" />
-  <include package=".catalog.indexers" />
+  <include package=".catalog" />
   <include package=".content" />
   <include package=".controlpanel" />
   <include package=".exportimport" />
@@ -49,6 +49,13 @@
       title="Auto-Generate ID Beahvior for Dexterity Contents"
       description="Generates an ID with the IDServer"
       provides="bika.lims.interfaces.IAutoGenerateID"
+      />
+
+  <!-- Multicatalog Behavior for Dexterity based contents -->
+  <plone:behavior
+      title="Multi Catalog Behavior for Dexterity Contents"
+      description="Catalog Dexterity contents in multiple catalogs"
+      provides="bika.lims.interfaces.IMultiCatalogBehavior"
       />
 
   <!-- jquery redirects here when values are entered into 'document' context (barcodes) -->

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -43,6 +43,11 @@ class IAutoGenerateID(Interface):
     """
 
 
+class IMultiCatalogBehavior(Interface):
+    """Support multiple catalogs for Dexterity contents
+    """
+
+
 class IActionHandlerPool(Interface):
     """Marker interface for the ActionHandlerPool utility
     """

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,9 @@ setup(
         'senaite.impress>=1.2.0',
         # Python 2/3 compatibility library: https://six.readthedocs.io/
         'six',
+        # Needed for `IPortalCatalogQueueProcessor`, which will be included in
+        # `Products.CMFCore` in Plone 5. Remove after we are on Plone 5!
+        'collective.indexing',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR implements an `IIndexQueueProcessor` to multiplex Dexterity indexing to multiple catalogs

## Usage

Add the `bika.lims.interfaces.IMultiCatalogBehavior` to the Dexterity type config:

```xml
  <!-- Dexterity behaviours for this type -->
  <property name="behaviors">
    <element value="bika.lims.interfaces.IAutoGenerateID"/>
    <element value="bika.lims.interfaces.IMultiCatalogBehavior"/>
    <element value="plone.app.dexterity.behaviors.metadata.IBasic"/>
    <element value="plone.app.referenceablebehavior.referenceable.IReferenceable" />
  </property>
```

Add the supported catalogs into an `_catalogs` attribute of your Dexterity content:

```python
from bika.lims.catalog import SETUP_CATALOG
from plone.dexterity.content import Item
from plone.supermodel import model
from zope.interface import implementer


class IDynamicAnalysisSpec(model.Schema):
    """Dynamic Analysis Specification
    """

    specs_file = namedfile.NamedBlobFile(
        title=_(u"Specification File"),
        description=_(u"Only Excel files supported"),
        required=True)


@implementer(IDynamicAnalysisSpec)
class DynamicAnalysisSpec(Item):
    """Dynamic Analysis Specification
    """
    _catalogs = [SETUP_CATALOG]
```
The catalog multiplexer will automatically index the content in the requested catalogs.

## Current behavior before PR

Dexterity contents are only indexed in `portal_catalog`

## Desired behavior after PR is merged

Dexterity contents are indexed in `portal_catalog` **and** additional catalogs


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
