### PR TITLE
Fix jsonapi.read omits `include_methods` when a single parameter is used

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ Changelog
 
 **Fixed**
 
+- #1493 jsonapi.read omits `include_methods` when a single parameter is used
 - #1477 Sample edit form - some selection widgets empty
 - #1478 Clients default CC E-Mails missing in Add Sample
 - #1479 Fixed too many redirects error: Labclerks viewing verified worksheets

--- a/bika/lims/jsonapi/__init__.py
+++ b/bika/lims/jsonapi/__init__.py
@@ -25,6 +25,7 @@ from bika.lims import logger
 
 import json
 import Missing
+import six
 import sys, traceback
 
 
@@ -129,9 +130,15 @@ def load_field_values(instance, include_fields):
 def get_include_methods(request):
     """Retrieve include_methods values from the request
     """
-    methods = request.get("include_methods", "")
-    include_methods = [
-        x.strip() for x in methods.split(",") if x.strip()]
+    include_methods = []
+    if "include_methods" in request:
+        methods = request.get("include_methods", "")
+        include_methods = [
+            x.strip() for x in methods.split(",") if x.strip()]
+    if "include_methods[]" in request:
+        include_methods = request["include_methods[]"]
+        if isinstance(include_methods, six.string_types):
+            include_methods = [include_methods]
     return include_methods
 
 

--- a/bika/lims/jsonapi/__init__.py
+++ b/bika/lims/jsonapi/__init__.py
@@ -130,16 +130,15 @@ def load_field_values(instance, include_fields):
 def get_include_methods(request):
     """Retrieve include_methods values from the request
     """
-    include_methods = []
-    if "include_methods" in request:
-        methods = request.get("include_methods", "")
-        include_methods = [
-            x.strip() for x in methods.split(",") if x.strip()]
-    if "include_methods[]" in request:
-        include_methods = request["include_methods[]"]
-        if isinstance(include_methods, six.string_types):
-            include_methods = [include_methods]
-    return include_methods
+    include_methods = request.get("include_methods[]")
+    if not include_methods:
+        include_methods = request.get("include_methods", [])
+
+    if isinstance(include_methods, six.string_types):
+        include_methods = include_methods.split(",")
+        include_methods = map(lambda me: me.strip(), include_methods)
+
+    return filter(None, include_methods)
 
 
 def load_method_values(instance, include_methods):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When include_methods param is used in a read call with a single parameter (instead of a list of more than one), the jsonapi does not handle the value parameter properly and transforms it to a list of characters instead.

A call like follows:

```js
this.ajax_submit({
  url: this.get_portal_url() + "/@@API/read",
  data: {
          catalog_name: "uid_catalog",
          UID: widget.attr('data-uid'),
          include_methods: ["getSomething"],
        }
}).done(function(data) {
  return deferred.resolveWith(this, [data.objects[0]["getSomething"]]);
});
```

fails. The function `get_include_methods` returns `getSomething` instead of a list `[getSomething]`. Therefore, the function `load_method_values` tries the following calls to the instance: `g`, `e`, `t`, `S`, `o`, ...

If the call is like follows:
```javascript
this.ajax_submit({
  url: this.get_portal_url() + "/@@API/read",
  data: {
          catalog_name: "uid_catalog",
          UID: widget.attr('data-uid'),
          include_methods: ["getSomething", "getId"],
        }
}).done(function(data) {
  return deferred.resolveWith(this, [data.objects[0]["getSomething"]]);
});
```
the list is resolved properly.

## Current behavior before PR

read call fails when using `include_methods` param with a single value

## Desired behavior after PR is merged

read calls does work when using `include_methods` param with a single value

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
