### PR TITLE
Fix KeyError in Sample Type Listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ Changelog
 
 **Fixed**
 
+- #1494 Fix KeyError in Sample Type Listing
 - #1477 Sample edit form - some selection widgets empty
 - #1478 Clients default CC E-Mails missing in Add Sample
 - #1479 Fixed too many redirects error: Labclerks viewing verified worksheets

--- a/bika/lims/controlpanel/bika_sampletypes.py
+++ b/bika/lims/controlpanel/bika_sampletypes.py
@@ -152,9 +152,9 @@ class SampleTypesView(BikaListingView):
 
         retention_period = obj.getRetentionPeriod()
         if retention_period:
-            hours = retention_period["hours"]
-            minutes = retention_period["minutes"]
-            days = retention_period["days"]
+            hours = retention_period.get("hours", "0")
+            minutes = retention_period.get("minutes", "0")
+            days = retention_period.get("days", "0")
             item["RetentionPeriod"] = _("hours: {} minutes: {} days: {}"
                                         .format(hours, minutes, days))
         else:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a KeyError when some subfields of the retention period are omitted.

Traceback:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module senaite.core.listing.view, line 222, in __call__
  Module senaite.core.listing.ajax, line 101, in handle_subpath
  Module senaite.core.listing.decorators, line 63, in wrapper
  Module senaite.core.listing.decorators, line 50, in wrapper
  Module senaite.core.listing.decorators, line 100, in wrapper
  Module senaite.core.listing.ajax, line 533, in ajax_folderitems
  Module senaite.core.listing.decorators, line 88, in wrapper
  Module senaite.core.listing.ajax, line 305, in get_folderitems
  Module senaite.core.listing.view, line 837, in folderitems
  Module bika.lims, line 224, in wrapper
  Module senaite.core.listing.view, line 1143, in _folderitems
  Module bika.lims.controlpanel.bika_sampletypes, line 157, in folderitem
KeyError: 'minutes'
```

## Current behavior before PR

Traceback occurs when not all values of the retention period were set

## Desired behavior after PR is merged

No traceback happens and omitted fields default to 0

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
