### PR TITLE
Avoid duplicate CSS IDs in multi-column Add form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ Changelog
 
 **Fixed**
 
+- #1503 Avoid duplicate CSS IDs in multi-column Add form
 - #1501 Fix Attribute Error in Reference Sample Popup
 - #1493 jsonapi.read omits `include_methods` when a single parameter is used
 - #1494 Fix KeyError in Sample Type Listing

--- a/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -458,7 +458,6 @@
                                    style="height:auto;"
                                    tal:attributes="name string:${fieldname}:list;
                                                    value string:${service_uid};
-                                                   id string:cb_${service_uid};
                                                    class string:analysisservice-cb analysisservice-cb-${arnum};
                                                    alt service_title;
                                                    checked python:checked and 'checked' or '';"/>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the CSS ID for Analyses in the Add form

## Current behavior before PR

When more than 1 column is displayed, the Analyses input fields have the same CSS ID

## Desired behavior after PR is merged

The Analyses input fields have no CSS ID anymore

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
