### PR TITLE
Manage Analyses Form re-applies partitioned Analyses back to the Root Sample

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ Changelog
 
 **Fixed**
 
+- #1505 Manage Analyses Form re-applies partitioned Analyses back to the Root
 - #1503 Avoid duplicate CSS IDs in multi-column Add form
 - #1501 Fix Attribute Error in Reference Sample Popup
 - #1493 jsonapi.read omits `include_methods` when a single parameter is used

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changelog
 
 **Added**
 
+- #1505 Display partition link in analyses listing
 - #1491 Enable Audit-logging for Dexterity Contents
 - #1489 Support Multiple Catalogs for Dexterity Contents
 - #1481 Filter Templates field when Sample Type is selected in Sample Add form

--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -563,6 +563,8 @@ class AnalysesView(BikaListingView):
         self._folder_item_detection_limits(obj, item)
         # Fill Specifications
         self._folder_item_specifications(obj, item)
+        # Fill Partition
+        self._folder_item_partition(obj, item)
         # Fill Due Date and icon if late/overdue
         self._folder_item_duedate(obj, item)
         # Fill verification criteria
@@ -1171,6 +1173,20 @@ class AnalysesView(BikaListingView):
         if full_obj.getAccredited():
             img = get_image("accredited.png", title=t(_("Accredited")))
             self._append_html_element(item, "Service", img)
+
+    def _folder_item_partition(self, analysis_brain, item):
+        """Adds an anchor to the partition if the current analysis is from a
+        partition that does not match with the current context
+        """
+        if not IAnalysisRequest.providedBy(self.context):
+            return
+
+        sample_id = analysis_brain.getRequestID
+        if sample_id != api.get_id(self.context):
+            part_url = analysis_brain.getRequestURL
+            url = get_link(part_url, value=sample_id, **{"class": "small"})
+            title = item["replace"].get("Service") or item["Service"]
+            item["replace"]["Service"] = "{}<br/>{}".format(title, url)
 
     def _folder_item_report_visibility(self, analysis_brain, item):
         """Set if the hidden field can be edited (enabled/disabled)

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -60,7 +60,6 @@ class AnalysisRequestAnalysesView(BikaListingView):
         self.show_select_all_checkbox = False
         self.pagesize = 999999
         self.show_search = True
-        self.fetch_transitions_on_select = False
 
         self.categories = []
         self.selected = []

--- a/bika/lims/browser/fields/aranalysesfield.py
+++ b/bika/lims/browser/fields/aranalysesfield.py
@@ -82,7 +82,7 @@ class ARAnalysesField(ObjectField):
 
         # Do the search against the catalog
         query["portal_type"] = "Analysis"
-        query["getRequestUID"] = api.get_uid(instance)
+        query["getAncestorsUIDs"] = api.get_uid(instance)
         brains = catalog(query)
         if full_objects:
             return map(api.get_object, brains)

--- a/bika/lims/browser/fields/aranalysesfield.py
+++ b/bika/lims/browser/fields/aranalysesfield.py
@@ -103,17 +103,6 @@ class ARAnalysesField(ObjectField):
         # Current assigned analyses
         analyses = instance.objectValues("Analysis")
 
-        # Submitted analyses must be retained
-        submitted = filter(lambda an: ISubmitted.providedBy(an), analyses)
-
-        # Prevent removing all analyses
-        #
-        # N.B.: Submitted analyses are rendered disabled in the HTML form.
-        #       Therefore, their UIDs are not included in the submitted UIDs.
-        if not items and not submitted:
-            logger.warn("Not allowed to remove all Analyses from AR.")
-            return []
-
         # Bail out if the items is not a list type
         if not isinstance(items, (list, tuple)):
             raise TypeError(
@@ -181,7 +170,7 @@ class ARAnalysesField(ObjectField):
                 continue
 
             # Skip non-open Analyses
-            if analysis in submitted:
+            if ISubmitted.providedBy(analysis):
                 continue
 
             # Remember assigned attachments

--- a/bika/lims/browser/fields/aranalysesfield.py
+++ b/bika/lims/browser/fields/aranalysesfield.py
@@ -141,8 +141,6 @@ class ARAnalysesField(ObjectField):
             prices = dict()
 
         # Add analyses
-        # The returned analyses can contain either newly created analyses or
-        # analyses from partitions and/or ancestors
         new_analyses = map(lambda service:
                            self.add_analysis(instance, service, prices, hidden),
                            services)

--- a/bika/lims/browser/fields/aranalysesfield.py
+++ b/bika/lims/browser/fields/aranalysesfield.py
@@ -104,6 +104,9 @@ class ARAnalysesField(ObjectField):
         :type hidden: list
         :returns: list of new assigned Analyses
         """
+        if items is None:
+            items = []
+
         # Bail out if the items is not a list type
         if not isinstance(items, (list, tuple)):
             raise TypeError(

--- a/bika/lims/browser/fields/aranalysesfield.py
+++ b/bika/lims/browser/fields/aranalysesfield.py
@@ -22,22 +22,22 @@ import itertools
 
 from AccessControl import ClassSecurityInfo
 from AccessControl import Unauthorized
+from Products.Archetypes.Registry import registerField
+from Products.Archetypes.public import Field
+from Products.Archetypes.public import ObjectField
+from Products.CMFCore.utils import getToolByName
+from zope.interface import implements
+
 from bika.lims import api
 from bika.lims import logger
 from bika.lims.api.security import check_permission
 from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
-from bika.lims.interfaces import IAnalysis, ISubmitted
-from bika.lims.interfaces import IAnalysisService
 from bika.lims.interfaces import IARAnalysesField
-from bika.lims.interfaces import IBaseAnalysis
+from bika.lims.interfaces import IAnalysis
+from bika.lims.interfaces import IAnalysisService
+from bika.lims.interfaces import ISubmitted
 from bika.lims.permissions import AddAnalysis
 from bika.lims.utils.analysis import create_analysis
-from Products.Archetypes.public import Field
-from Products.Archetypes.public import ObjectField
-from Products.Archetypes.Registry import registerField
-from Products.Archetypes.utils import shasattr
-from Products.CMFCore.utils import getToolByName
-from zope.interface import implements
 
 """Field to manage Analyses on ARs
 
@@ -100,9 +100,6 @@ class ARAnalysesField(ObjectField):
         :type hidden: list
         :returns: list of new assigned Analyses
         """
-        # Current assigned analyses
-        analyses = instance.objectValues("Analysis")
-
         # Bail out if the items is not a list type
         if not isinstance(items, (list, tuple)):
             raise TypeError(
@@ -153,7 +150,8 @@ class ARAnalysesField(ObjectField):
         # Remove analyses
         # Since Manage Analyses view displays the analyses from partitions, we
         # also need to take them into consideration here. Analyses from
-        # ancestors can be omitted
+        # ancestors can be omitted.
+        analyses = instance.objectValues("Analysis")
         analyses.extend(self.get_analyses_from_descendants(instance))
 
         # Service UIDs

--- a/bika/lims/monkey/zcatalog.py
+++ b/bika/lims/monkey/zcatalog.py
@@ -33,32 +33,15 @@ def searchResults(self, REQUEST=None, used=None, **kw):
             and self.id == CATALOG_ANALYSIS_LISTING:
 
         # Fetch all analyses that have the request UID passed in as an ancestor,
-        # cause we want Primary ARs to always display the analyses from their
-        # derived ARs (if result is not empty)
-
+        # cause we want for Samples to always return the contained analyses plus
+        # those contained in partitions
         request = REQUEST.copy()
         orig_uid = request.get('getRequestUID')
-
-        # If a list of request uid, retrieve them sequentially to make the
-        # masking process easier
-        if isinstance(orig_uid, list):
-            results = list()
-            for uid in orig_uid:
-                request['getRequestUID'] = [uid]
-                results += self.searchResults(REQUEST=request, used=used, **kw)
-            return results
 
         # Get all analyses, those from descendant ARs included
         del request['getRequestUID']
         request['getAncestorsUIDs'] = orig_uid
-        results = self.searchResults(REQUEST=request, used=used, **kw)
-
-        # Masking
-        primary = filter(lambda an: an.getParentUID == orig_uid, results)
-        derived = filter(lambda an: an.getParentUID != orig_uid, results)
-        derived_keys = map(lambda an: an.getKeyword, derived)
-        results = filter(lambda an: an.getKeyword not in derived_keys, primary)
-        return results + derived
+        return self.searchResults(REQUEST=request, used=used, **kw)
 
     # Normal search
     return self._catalog.searchResults(REQUEST, used, **kw)

--- a/bika/lims/tests/doctests/ARAnalysesField.rst
+++ b/bika/lims/tests/doctests/ARAnalysesField.rst
@@ -269,32 +269,15 @@ We expect to have just the `PH` Analysis again:
     >>> ar.objectValues("Analysis")
     [<Analysis at /plone/clients/client-1/water-0001/PH>]
 
-Removing all Analyses is prevented, because it can not be empty:
-
-    >>> new_analyses = field.set(ar, [])
-    >>> ar.objectValues("Analysis")
-    [<Analysis at /plone/clients/client-1/water-0001/PH>]
-
 The field can also handle UIDs of Analyses Services:
 
     >>> service_uids = map(api.get_uid, all_services)
     >>> new_analyses = field.set(ar, service_uids)
 
-We expect again to have the `CA` and `MG` Analyses as well:
-
-    >>> sorted(new_analyses, key=methodcaller('getId'))
-    [<Analysis at /plone/clients/client-1/water-0001/CA>, <Analysis at /plone/clients/client-1/water-0001/MG>]
-
-And all the three Analyses in total:
+We expect again to have all the three Analyses:
 
     >>> sorted(ar.objectValues("Analysis"), key=methodcaller("getId"))
     [<Analysis at /plone/clients/client-1/water-0001/CA>, <Analysis at /plone/clients/client-1/water-0001/MG>, <Analysis at /plone/clients/client-1/water-0001/PH>]
-
-Set again only the `PH` Analysis:
-
-    >>> new_analyses = field.set(ar, [analysisservice1])
-    >>> ar.objectValues("Analysis")
-    [<Analysis at /plone/clients/client-1/water-0001/PH>]
 
 The field should also handle catalog brains:
 

--- a/bika/lims/tests/doctests/ARAnalysesFieldWithPartitions.rst
+++ b/bika/lims/tests/doctests/ARAnalysesFieldWithPartitions.rst
@@ -66,6 +66,7 @@ Create some basic objects for the test:
     >>> Cu = api.create(setup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID(), Accredited=True)
     >>> Fe = api.create(setup.bika_analysisservices, "AnalysisService", title="Iron", Keyword="Fe", Price="10", Category=category.UID())
     >>> Au = api.create(setup.bika_analysisservices, "AnalysisService", title="Gold", Keyword="Au", Price="20", Category=category.UID())
+    >>> Mg = api.create(setup.bika_analysisservices, "AnalysisService", title="Magnesium", Keyword="Mg", Price="20", Category=category.UID())
 
 
 Creation of a Sample with a Partition
@@ -285,5 +286,84 @@ while the function returns None:
     True
     >>> sample.objectValues("Analysis")
     []
+    >>> partition.objectValues("Analysis")
+    [<Analysis at /plone/clients/client-1/W-0001-P01/Cu>, <Analysis at /plone/clients/client-1/W-0001-P01/Fe>, <Analysis at /plone/clients/client-1/W-0001-P01/Au>]
+
+
+Set analyses
+------------
+
+If we try to set same analyses as before to the root sample, nothing happens
+because the analyses are already there:
+
+    >>> field.set(sample, [Cu, Fe, Au])
+    []
+
+The analyses still belong to the partition though:
+
+    >>> sample.objectValues("Analysis")
+    []
+    >>> partition.objectValues("Analysis")
+    [<Analysis at /plone/clients/client-1/W-0001-P01/Cu>, <Analysis at /plone/clients/client-1/W-0001-P01/Fe>, <Analysis at /plone/clients/client-1/W-0001-P01/Au>]
+
+Same result if I set the analyses to the partition:
+
+    >>> field.set(partition, [Cu, Fe, Au])
+    []
+    >>> sample.objectValues("Analysis")
+    []
+    >>> partition.objectValues("Analysis")
+    [<Analysis at /plone/clients/client-1/W-0001-P01/Cu>, <Analysis at /plone/clients/client-1/W-0001-P01/Fe>, <Analysis at /plone/clients/client-1/W-0001-P01/Au>]
+
+If I add a new analysis in the list, the analysis is successfully added:
+
+    >>> field.set(sample, [Cu, Fe, Au, Mg])
+    [<Analysis at /plone/clients/client-1/W-0001/Mg>]
+    >>> sample.objectValues("Analysis")
+    [<Analysis at /plone/clients/client-1/W-0001/Mg>]
+
+And the partition keeps its own analyses:
+
+    >>> partition.objectValues("Analysis")
+    [<Analysis at /plone/clients/client-1/W-0001-P01/Cu>, <Analysis at /plone/clients/client-1/W-0001-P01/Fe>, <Analysis at /plone/clients/client-1/W-0001-P01/Au>]
+
+Apply the changes:
+
+    >>> transaction.commit()
+
+If I set the same analyses to the partition, I don't get any result:
+
+    >>> field.set(partition, [Cu, Fe, Au, Mg])
+    []
+
+but, the `Mg` analysis has been moved into the partition:
+
+    >>> sample.objectValues("Analysis")
+    []
+    >>> partition.objectValues("Analysis")
+    [<Analysis at /plone/clients/client-1/W-0001-P01/Cu>, <Analysis at /plone/clients/client-1/W-0001-P01/Fe>, <Analysis at /plone/clients/client-1/W-0001-P01/Au>, <Analysis at /plone/clients/client-1/W-0001-P01/Mg>]
+
+To remove `Mg` analysis, pass the list without `Mg`:
+
+    >>> field.set(sample, [Cu, Fe, Au])
+    []
+
+The analysis `Mg` has been removed, although it belonged to the partition:
+
+    >>> sample.objectValues("Analysis")
+    []
+    >>> partition.objectValues("Analysis")
+    [<Analysis at /plone/clients/client-1/W-0001-P01/Cu>, <Analysis at /plone/clients/client-1/W-0001-P01/Fe>, <Analysis at /plone/clients/client-1/W-0001-P01/Au>]
+
+But if I add a new analysis to the primary and I try to remove it from the
+partition, nothing will happen:
+
+    >>> field.set(sample, [Cu, Fe, Au, Mg])
+    [<Analysis at /plone/clients/client-1/W-0001/Mg>]
+
+    >>> field.set(partition, [Cu, Fe, Au])
+    []
+    >>> sample.objectValues("Analysis")
+    [<Analysis at /plone/clients/client-1/W-0001/Mg>]
     >>> partition.objectValues("Analysis")
     [<Analysis at /plone/clients/client-1/W-0001-P01/Cu>, <Analysis at /plone/clients/client-1/W-0001-P01/Fe>, <Analysis at /plone/clients/client-1/W-0001-P01/Au>]

--- a/bika/lims/tests/doctests/ARAnalysesFieldWithPartitions.rst
+++ b/bika/lims/tests/doctests/ARAnalysesFieldWithPartitions.rst
@@ -1,0 +1,289 @@
+AR Analyses Field when using Partitions
+=======================================
+
+The setter of the ARAnalysesField takes descendants (partitions) and ancestors
+from the current instance into account to prevent inconsistencies: In a Sample
+lineage analyses from a node are always masked by same analyses in leaves. This
+can drive to inconsistencies and therefore, there is the need to keep the tree
+without duplicates.
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t ARAnalysesFieldWithPartitions
+
+Test Setup
+----------
+
+Needed imports:
+
+    >>> import transaction
+    >>> from DateTime import DateTime
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+    >>> from bika.lims import api
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.utils.analysisrequest import create_partition
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+    >>> from zope.interface import alsoProvides
+    >>> from zope.interface import noLongerProvides
+
+Functional Helpers:
+
+    >>> def new_sample(services):
+    ...     values = {
+    ...         'Client': client.UID(),
+    ...         'Contact': contact.UID(),
+    ...         'DateSampled': DateTime().strftime("%Y-%m-%d"),
+    ...         'SampleType': sampletype.UID()}
+    ...     service_uids = map(api.get_uid, services)
+    ...     ar = create_analysisrequest(client, request, values, service_uids)
+    ...     transitioned = do_action_for(ar, "receive")
+    ...     return ar
+
+    >>> def get_analysis_from(sample, service):
+    ...     service_uid = api.get_uid(service)
+    ...     for analysis in sample.getAnalyses(full_objects=True):
+    ...         if analysis.getServiceUID() == service_uid:
+    ...             return analysis
+    ...     return None
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = api.get_setup()
+
+Create some basic objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ['Manager',])
+    >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH", MemberDiscountApplies=True)
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(setup.bika_sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.bika_departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = api.create(setup.bika_analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> Cu = api.create(setup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID(), Accredited=True)
+    >>> Fe = api.create(setup.bika_analysisservices, "AnalysisService", title="Iron", Keyword="Fe", Price="10", Category=category.UID())
+    >>> Au = api.create(setup.bika_analysisservices, "AnalysisService", title="Gold", Keyword="Au", Price="20", Category=category.UID())
+
+
+Creation of a Sample with a Partition
+-------------------------------------
+
+Create a Sample and receive:
+
+    >>> sample = new_sample([Cu, Fe])
+
+Create a Partition containing of the Sample, containing the analysis `Cu`:
+
+    >>> cu = get_analysis_from(sample, Cu)
+    >>> partition = create_partition(sample, request, [cu])
+
+The analysis 'Cu' lives in the partition:
+
+    >>> cu = get_analysis_from(partition, Cu)
+    >>> api.get_parent(cu) == partition
+    True
+
+Although is also returned by the primary:
+
+    >>> cu = get_analysis_from(sample, Cu)
+    >>> api.get_parent(cu) == partition
+    True
+    >>> api.get_parent(cu) == sample
+    False
+
+
+Analyses retrieval
+------------------
+
+Get the ARAnalysesField to play with:
+
+    >>> field = sample.getField("Analyses")
+
+get_from_instance
+.................
+
+When asked for `Fe` when the primary is given, it returns the analysis, cause
+it lives in the primary:
+
+    >>> fe = field.get_from_instance(sample, Fe)
+    >>> fe.getServiceUID() == api.get_uid(Fe)
+    True
+
+But when asked for `Cu` when the primary is given, it returns None, cause it
+lives in the partition:
+
+    >>> cu = field.get_from_instance(sample, Cu)
+    >>> cu is None
+    True
+
+While it returns the analysis when the partition is used:
+
+    >>> cu = field.get_from_instance(partition, Cu)
+    >>> cu.getServiceUID() == api.get_uid(Cu)
+    True
+
+But when asking the partition for `Fe` it returns None, cause it lives in the
+ancestor:
+
+    >>> fe = field.get_from_instance(partition, Fe)
+    >>> fe is None
+    True
+
+get_from_ancestor
+.................
+
+When asked for `Fe` to primary, it returns None because there is no ancestor
+containing `Fe`:
+
+    >>> fe = field.get_from_ancestor(sample, Fe)
+    >>> fe is None
+    True
+
+But when asked for `Fe` to the partition, it returns the analysis, cause it
+it lives in an ancestor from the partition:
+
+    >>> fe = field.get_from_ancestor(partition, Fe)
+    >>> fe.getServiceUID() == api.get_uid(Fe)
+    True
+
+If I ask for `Cu`, that lives in the partition, it will return None for both:
+
+    >>> cu = field.get_from_ancestor(sample, Cu)
+    >>> cu is None
+    True
+
+    >>> cu = field.get_from_ancestor(partition, Cu)
+    >>> cu is None
+    True
+
+get_from_descendant
+...................
+
+When asked for `Fe` to primary, it returns None because there is no descendant
+containing `Fe`:
+
+    >>> fe = field.get_from_descendant(sample, Fe)
+    >>> fe is None
+    True
+
+And same with partition:
+
+    >>> fe = field.get_from_descendant(partition, Fe)
+    >>> fe is None
+    True
+
+When asked for `Cu` to primary, it returns the analysis, because it lives in a
+descendant (partition):
+
+    >>> cu = field.get_from_descendant(sample, Cu)
+    >>> cu.getServiceUID() == api.get_uid(Cu)
+    True
+
+But returns None if I ask to the partition:
+
+    >>> cu = field.get_from_descendant(partition, Cu)
+    >>> cu is None
+    True
+
+get_analyses_from_descendants
+.............................
+
+It returns the analyses contained by the descendants:
+
+    >>> field.get_analyses_from_descendants(sample)
+    [<Analysis at /plone/clients/client-1/W-0001-P01/Cu>]
+
+    >>> field.get_analyses_from_descendants(partition)
+    []
+
+
+Resolution of analyses from the Sample lineage
+----------------------------------------------
+
+resolve_analysis
+................
+
+Resolves the analysis from the sample lineage if exists:
+
+    >>> fe = field.resolve_analysis(sample, Fe)
+    >>> fe.getServiceUID() == api.get_uid(Fe)
+    True
+    >>> fe.aq_parent == sample
+    True
+
+    >>> cu = field.resolve_analysis(sample, Cu)
+    >>> cu.getServiceUID() == api.get_uid(Cu)
+    True
+    >>> cu.aq_parent == partition
+    True
+
+    >>> au = field.resolve_analysis(sample, Au)
+    >>> au is None
+    True
+
+But when we use the partition and the analysis is found in an ancestor, it
+moves the analysis into the partition:
+
+    >>> fe = field.resolve_analysis(partition, Fe)
+    >>> fe.getServiceUID() == api.get_uid(Fe)
+    True
+    >>> fe.aq_parent == partition
+    True
+    >>> sample.objectValues("Analysis")
+    []
+    >>> partition.objectValues("Analysis")
+    [<Analysis at /plone/clients/client-1/W-0001-P01/Cu>, <Analysis at /plone/clients/client-1/W-0001-P01/Fe>]
+
+
+Addition of analyses
+--------------------
+
+add_analysis
+............
+
+Setup required parameters:
+
+    >>> prices = hidden = dict()
+
+If we try to add now an analysis that already exists, either in the partition or
+in the primary, the analysis won't be added:
+
+    >>> added = field.add_analysis(sample, Fe, prices, hidden)
+    >>> added is None
+    True
+    >>> sample.objectValues("Analysis")
+    []
+
+    >>> added = field.add_analysis(partition, Fe, prices, hidden)
+    >>> added is None
+    True
+    >>> partition.objectValues("Analysis")
+    [<Analysis at /plone/clients/client-1/W-0001-P01/Cu>, <Analysis at /plone/clients/client-1/W-0001-P01/Fe>]
+
+If we add a new analysis, this will be added in the sample we are working with:
+
+    >>> au = field.add_analysis(sample, Au, prices, hidden)
+    >>> au.getServiceUID() == api.get_uid(Au)
+    True
+    >>> sample.objectValues("Analysis")
+    [<Analysis at /plone/clients/client-1/W-0001/Au>]
+    >>> partition.objectValues("Analysis")
+    [<Analysis at /plone/clients/client-1/W-0001-P01/Cu>, <Analysis at /plone/clients/client-1/W-0001-P01/Fe>]
+
+Apply the changes:
+
+    >>> transaction.commit()
+
+If I try to add an analysis that exists in an ancestor, the analysis gets moved
+while the function returns None:
+
+    >>> added = field.add_analysis(partition, Au, prices, hidden)
+    >>> added is None
+    True
+    >>> sample.objectValues("Analysis")
+    []
+    >>> partition.objectValues("Analysis")
+    [<Analysis at /plone/clients/client-1/W-0001-P01/Cu>, <Analysis at /plone/clients/client-1/W-0001-P01/Fe>, <Analysis at /plone/clients/client-1/W-0001-P01/Au>]

--- a/bika/lims/upgrade/v01_03_003.py
+++ b/bika/lims/upgrade/v01_03_003.py
@@ -341,6 +341,12 @@ def remove_cascaded_analyses_of_root_samples(portal):
                     .format(analysis_id, root_an_state,
                             api.get_id(sample), api.get_url(sample)))
 
+            # partition analysis is in invalid state
+            elif part_an_state in ["rejected", "retracted"]:
+                # -> probably the retest was automatically created in the
+                #    parent instead of the partition
+                pass
+
             # root analysis was submitted, but not the partition analysis
             elif ISubmitted.providedBy(root_an) and not ISubmitted.providedBy(part_an):
                 # -> remove the analysis from the partition

--- a/bika/lims/upgrade/v01_03_003.py
+++ b/bika/lims/upgrade/v01_03_003.py
@@ -323,11 +323,21 @@ def remove_cascaded_analyses_of_root_samples(portal):
         logger.info("Found {} Root Samples that contain cascaded Analyses"
                     .format(len(to_clean)))
 
-        # Uncomment before flight
-        # for sample, analyses in to_clean:
-        #     sample.manage_delObjects(analyses)
+        for sample, analyses in to_clean:
+            sid = api.get_id(sample)
+            for analysis in analyses:
+                an = sample[analysis]
+                state = api.get_workflow_status_of(an)
+                if state != "unassigned":
+                    # XXX What to do when assigned, rejected ... ?
+                    pass
+                logger.info("Deleting Analysis '{}' in State '{}' from '{}'"
+                            .format(analysis, state, sid))
+                # Uncomment before flight
+                # sample._delObject(analysis)
 
-    logger.info("Removing cascaded analyses from Root Samples... [DONE]")
+    logger.info("Removing cascaded analyses from {} Root Samples... [DONE]"
+                .format(len(to_clean)))
 
 
 def reindex_client_fields(portal):

--- a/bika/lims/upgrade/v01_03_003.py
+++ b/bika/lims/upgrade/v01_03_003.py
@@ -341,6 +341,12 @@ def remove_cascaded_analyses_of_root_samples(portal):
                     .format(analysis_id, root_an_state,
                             api.get_id(sample), api.get_url(sample)))
 
+            # root analysis is in invalid state
+            elif root_an_state in ["rejected", "retracted"]:
+                # -> probably the retest was automatically created in the
+                #    parent instead of the partition
+                pass
+
             # partition analysis is in invalid state
             elif part_an_state in ["rejected", "retracted"]:
                 # -> probably the retest was automatically created in the


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1504

## Current behavior before PR

Root Sample contains Analyses that are assigned to one of its partitions due to improper handling of the Sample Analyses Field

## Desired behavior after PR is merged

Root Sample contains no Analyses that are assigned to one of tis partitions and the Sample Analysis Field handles Analyses of Partitions properly 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
