### PR TITLE
Do not try to render InstrumentQCFailuresViewlet to non-lab personnel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Changelog
 
 **Changed**
 
+- #1508 Do not try to render InstrumentQCFailuresViewlet to non-lab personnel
 - #1495 Better Remarks handling and display
 - #1502 Improved DateTime Widget
 - #1490 Support Dexterity Behavior Fields in API

--- a/bika/lims/browser/viewlets/configure.zcml
+++ b/bika/lims/browser/viewlets/configure.zcml
@@ -66,7 +66,7 @@
       class="bika.lims.browser.viewlets.InstrumentQCFailuresViewlet"
       manager="plone.app.layout.viewlets.interfaces.IAboveContent"
       template="templates/instrument_qc_failures_viewlet.pt"
-      permission="zope2.View"
+      permission="senaite.core.permissions.ManageBika"
       layer="bika.lims.interfaces.IBikaLIMS"
       />
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Although the viewlet `InstrumentQCFailuresViewlet` won't be displayed to non-lab personnel (because they don't have privileges to search for `Instruments` from `setup`, the system tries to render the viewlet still. This makes an `Unauthorized` error to rise up in logs and also makes the rendering of the current context slower.

## Current behavior before PR

System tries to render the viewlet `InstrumentQCFailuresViewlet` for non-lab users

## Desired behavior after PR is merged

System does not even try to render the viewlet.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
