### PR TITLE
Services don't get selected when a profile/template is selected in Add Sample

### DIFF
--- a/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -459,6 +459,7 @@
                                    tal:attributes="name string:${fieldname}:list;
                                                    value string:${service_uid};
                                                    class string:analysisservice-cb analysisservice-cb-${arnum};
+                                                   id string:cb_${arnum}_${service_uid};
                                                    alt service_title;
                                                    checked python:checked and 'checked' or '';"/>
                           </div>

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -644,7 +644,7 @@
        */
       var el, poc;
       console.debug("*** set_service::AR=" + arnum + " UID=" + uid + " checked=" + checked);
-      el = $("td[fieldname='Analyses-" + arnum + "'] #cb_" + uid);
+      el = $("td[fieldname='Analyses-" + arnum + "'] #cb_" + arnum + "_" + uid);
       el.prop("checked", checked);
       poc = el.closest("tr[poc]").attr("poc");
       if (this.is_poc_expanded(poc)) {

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -649,7 +649,7 @@ class window.AnalysisRequestAdd
     ###
     console.debug "*** set_service::AR=#{arnum} UID=#{uid} checked=#{checked}"
     # get the service checkbox element
-    el = $("td[fieldname='Analyses-#{arnum}'] #cb_#{uid}")
+    el = $("td[fieldname='Analyses-#{arnum}'] #cb_#{arnum}_#{uid}")
     # select the checkbox
     el.prop "checked", checked
     # get the point of capture of this element


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When a template or profile is selected in Add Sample form, the services are not automatically selected.

A regression that happened because of this change:
because of this: https://github.com/senaite/senaite.core/commit/4ad8f1f749a7757a4e526d0a42070edb714d8483#diff-7201097a937ab0b3cfadd99167de8ca5L461

The reason is that the js uses this id to check/uncheck here:
https://github.com/senaite/senaite.core/blob/master/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee#L652

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR

When a template or profile is selected in Add Sample form, the services are not automatically selected.

## Desired behavior after PR is merged

When a template or profile is selected in Add Sample form, the services are automatically selected.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
