### PR TITLE
Error when viewing a Sample w/o Batch as client contact

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,7 @@ Changelog
 
 **Fixed**
 
+- #1510 Error when viewing a Sample w/o Batch as client contact
 - #1505 Manage Analyses Form re-applies partitioned Analyses back to the Root
 - #1503 Avoid duplicate CSS IDs in multi-column Add form
 - #1501 Fix Attribute Error in Reference Sample Popup

--- a/bika/lims/adapters/widgetvisibility.py
+++ b/bika/lims/adapters/widgetvisibility.py
@@ -106,7 +106,7 @@ class BatchFieldVisibility(SenaiteATWidgetVisibility):
                 # is assigned to does not have a client assigned (e.g., the
                 # batch was assigned by lab personnel), hide this field
                 batch = self.context.getBatch()
-                if batch.getClient() != client:
+                if batch and batch.getClient() != client:
                     return "invisible"
 
         return default


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Error arises in Sample View when the sample does not have a Batch assigned and current user is a client contact.

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.analysisrequest.view, line 62, in __call__
  Module bika.lims.browser.header_table, line 83, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 173, in render
  Module chameleon.zpt.template, line 306, in render
  Module chameleon.template, line 209, in render
  Module chameleon.template, line 187, in render
  Module 64a1bd307477a7bad19adec76209dda5.py, line 186, in render
  Module bika.lims.browser.header_table, line 274, in
get_fields_grouped_by_location
  Module bika.lims.browser.header_table, line 260, in get_field_visibility_mode
  Module bika.lims.monkey.Widget, line 75, in isVisible
  Module bika.lims.adapters.widgetvisibility, line 44, in __call__
  Module bika.lims.adapters.widgetvisibility, line 109, in isVisible
AttributeError: 'NoneType' object has no attribute 'getClient'

 - Expression: "python:view.get_fields_grouped_by_location()"
 - Filename:   ... senaite.core/bika/lims/browser/templates/header_table.pt
 - Location:   (line 15: col 22)
 - Source:     ... ine="dummy python:view.get_fields_grouped_by_location();
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  repeat: {...} (0)
               template: <ViewPageTemplateFile - at 0x7f65c3927e90>
               views: <ViewMapper - at 0x7f65c1c7e6d0>
               modules: <instance - at 0x7f65d616dcf8>
               args: <tuple - at 0x7f65d8559050>
               here: <ImplicitAcquisitionWrapper H2O-0008 at 0x7f65c2c58460>
               wrapped_repeat: <SafeMapping - at 0x7f65c2d9cfc8>
               user: <ImplicitAcquisitionWrapper - at 0x7f65c2c58d20>
               nothing: <NoneType - at 0x557afb93b1a0>
               container: <ImplicitAcquisitionWrapper H2O-0008 at
0x7f65c2c58460>
               request: <instance - at 0x7f65c92c5e18>
               traverse_subpath: <list - at 0x7f65c9b323f8>
               default: <object - at 0x7f65d852fbf0>
               context: <ImplicitAcquisitionWrapper H2O-0008 at 0x7f65c2c58460>
               view: <HeaderTableView None at 0x7f65c1c7e250>
               translate: <function translate at 0x7f65c20e7140>
               root: <ImplicitAcquisitionWrapper Zope at 0x7f65c26677d0>
               options: {...} (0)
               loop: {...} (0)
               target_language: en
```

## Current behavior before PR

Error in sample view when current user is a client contact and sample has no batch assigned

## Desired behavior after PR is merged

No traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
