### PR TITLE
Links to partitions for Internal Use are displayed in partitions viewlet

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,7 @@ Changelog
 
 **Fixed**
 
+- #1511 Links to partitions for Internal Use are displayed in partitions viewlet
 - #1505 Manage Analyses Form re-applies partitioned Analyses back to the Root
 - #1503 Avoid duplicate CSS IDs in multi-column Add form
 - #1501 Fix Attribute Error in Reference Sample Popup

--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -237,6 +237,16 @@ class AnalysesView(BikaListingView):
         super(AnalysesView, self).before_render()
         self.request.set("disable_plone.rightcolumn", 1)
 
+    @property
+    @viewcache.memoize
+    def show_partitions(self):
+        """Returns whether the partitions must be displayed or not
+        """
+        if api.get_current_client():
+            # Current user is a client contact
+            return api.get_setup().getShowPartitions()
+        return True
+
     @viewcache.memoize
     def analysis_remarks_enabled(self):
         """Check if analysis remarks are enabled
@@ -1183,6 +1193,10 @@ class AnalysesView(BikaListingView):
 
         sample_id = analysis_brain.getRequestID
         if sample_id != api.get_id(self.context):
+            if not self.show_partitions:
+                # Do not display the link
+                return
+
             part_url = analysis_brain.getRequestURL
             url = get_link(part_url, value=sample_id, **{"class": "small"})
             title = item["replace"].get("Service") or item["Service"]

--- a/bika/lims/browser/viewlets/analysisrequest.py
+++ b/bika/lims/browser/viewlets/analysisrequest.py
@@ -43,11 +43,20 @@ class PrimaryAnalysisRequestViewlet(ViewletBase):
     def get_partitions(self):
         """Returns whether this viewlet is visible or not
         """
+        partitions = []
+
         # If current user is a client contact, rely on Setup's ShowPartitions
-        if api.get_current_client():
+        client = api.get_current_client()
+        if client:
             if not api.get_setup().getShowPartitions():
-                return []
-        return self.context.getDescendants()
+                return partitions
+
+        partitions = self.context.getDescendants()
+        if client:
+            # Do not display partitions for Internal use
+            return filter(lambda part: not part.getInternalUse(), partitions)
+
+        return partitions
 
 
 class PartitionAnalysisRequestViewlet(ViewletBase):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Links to partitions for Internal Use are displayed in Sample's partition viewlet, and below analyses (in analyses listing) as well when the current user is a client contact. This Pull Request ensures the links are not rendered when the partitions are labeled for Internal Use.

## Current behavior before PR

Links to partitions for Internal Use are displayed in Sample's partition viewlet, and below analyses (in analyses listing) as well

## Desired behavior after PR is merged

Links to partitions for internal use are not displayed neither in the viewlet nor in analyses listing

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
