### PR TITLE
QC Analyses listing appears empty in Sample view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,7 @@ Changelog
 
 **Fixed**
 
+- #1512 QC Analyses listing appears empty in Sample view
 - #1511 Links to partitions for Internal Use are displayed in partitions viewlet
 - #1505 Manage Analyses Form re-applies partitioned Analyses back to the Root
 - #1503 Avoid duplicate CSS IDs in multi-column Add form

--- a/bika/lims/browser/analyses/qc.py
+++ b/bika/lims/browser/analyses/qc.py
@@ -82,7 +82,7 @@ class QCAnalysesView(AnalysesView):
         self.contentFilter.update({
             "UID": qc_uids,
             "portal_type": ["DuplicateAnalysis", "ReferenceAnalysis"],
-            "sort_on": "getId"
+            "sort_on": "sortable_title"
         })
 
     def is_analysis_edition_allowed(self, analysis_brain):

--- a/bika/lims/browser/analyses/qc.py
+++ b/bika/lims/browser/analyses/qc.py
@@ -77,7 +77,6 @@ class QCAnalysesView(AnalysesView):
         """Update hook
         """
         super(AnalysesView, self).update()
-
         # Update the query with the QC Analyses uids
         qc_uids = map(api.get_uid, self.context.getQCAnalyses())
         self.contentFilter.update({
@@ -85,6 +84,13 @@ class QCAnalysesView(AnalysesView):
             "portal_type": ["DuplicateAnalysis", "ReferenceAnalysis"],
             "sort_on": "getId"
         })
+
+    def is_analysis_edition_allowed(self, analysis_brain):
+        """Overwrite this method to ensure the table is recognized as readonly
+
+        XXX: why is the super method not recognizing `self.allow_edit`?
+        """
+        return False
 
     def folderitem(self, obj, item, index):
         item = super(QCAnalysesView, self).folderitem(obj, item, index)

--- a/bika/lims/browser/analyses/qc.py
+++ b/bika/lims/browser/analyses/qc.py
@@ -50,11 +50,11 @@ class QCAnalysesView(AnalysesView):
         """
         super(AnalysesView, self).update()
 
-        # Update the query with the Sample's worksheet UIDs
-        worksheet_uids = map(api.get_uid, self.context.getWorksheets())
+        # Update the query with the QC Analyses uids
+        qc_uids = map(api.get_uid, self.context.getQCAnalyses())
         self.contentFilter.update({
+            "UID": qc_uids,
             "portal_type": ["DuplicateAnalysis", "ReferenceAnalysis"],
-            "getWorksheetUID": worksheet_uids,
             "sort_on": "getId"
         })
 

--- a/bika/lims/browser/analyses/qc.py
+++ b/bika/lims/browser/analyses/qc.py
@@ -45,19 +45,6 @@ class QCAnalysesView(AnalysesView):
         icon_path = "/++resource++bika.lims.images/referencesample.png"
         self.icon = "{}{}".format(self.portal_url, icon_path)
 
-    def update(self):
-        """Update hook
-        """
-        super(AnalysesView, self).update()
-
-        # Update the query with the QC Analyses uids
-        qc_uids = map(api.get_uid, self.context.getQCAnalyses())
-        self.contentFilter.update({
-            "UID": qc_uids,
-            "portal_type": ["DuplicateAnalysis", "ReferenceAnalysis"],
-            "sort_on": "getId"
-        })
-
         # Add Worksheet and QC Sample ID columns
         new_columns = OrderedDict((
             ("Worksheet", {
@@ -86,6 +73,18 @@ class QCAnalysesView(AnalysesView):
         for review_state in self.review_states:
             review_state.update({"columns": self.columns.keys()})
 
+    def update(self):
+        """Update hook
+        """
+        super(AnalysesView, self).update()
+
+        # Update the query with the QC Analyses uids
+        qc_uids = map(api.get_uid, self.context.getQCAnalyses())
+        self.contentFilter.update({
+            "UID": qc_uids,
+            "portal_type": ["DuplicateAnalysis", "ReferenceAnalysis"],
+            "sort_on": "getId"
+        })
 
     def folderitem(self, obj, item, index):
         item = super(QCAnalysesView, self).folderitem(obj, item, index)

--- a/bika/lims/browser/analyses/qc.py
+++ b/bika/lims/browser/analyses/qc.py
@@ -79,9 +79,13 @@ class QCAnalysesView(AnalysesView):
         if "Hidden" in self.columns:
             del(self.columns["Hidden"])
 
+        # Remove filters (Valid, Invalid, All)
+        self.review_states = [self.review_states[0]]
+
         # Apply the columns to all review_states
         for review_state in self.review_states:
             review_state.update({"columns": self.columns.keys()})
+
 
     def folderitem(self, obj, item, index):
         item = super(QCAnalysesView, self).folderitem(obj, item, index)

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -1829,10 +1829,16 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
         if not worksheet_uids:
             return []
 
-        # Get the qc analyses from these worksheets
-        portal_types = ["ReferenceAnalysis", "DuplicateAnalysis"]
-        query = dict(portal_type=portal_types, getWorksheetUID=worksheet_uids)
+        # Get reference qc analyses from these worksheets
+        query = dict(portal_type="ReferenceAnalysis",
+                     getWorksheetUID=worksheet_uids)
         qc_analyses = api.search(query, CATALOG_ANALYSIS_LISTING)
+
+        # Extend with duplicate qc analyses from these worksheets and Sample
+        query = dict(portal_type="DuplicateAnalysis",
+                     getWorksheetUID=worksheet_uids,
+                     getAncestorsUIDs=[api.get_uid(self)])
+        qc_analyses += api.search(query, CATALOG_ANALYSIS_LISTING)
 
         # Bail out analyses with a different review_state
         if review_state:

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -1810,6 +1810,8 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
         """
         # Get the Analyses UIDs of this Sample
         analyses_uids = map(api.get_uid, self.getAnalyses())
+        if not analyses_uids:
+            return []
 
         # Get the worksheets that contain any of these analyses
         query = dict(getAnalysesUIDs=analyses_uids)
@@ -1824,6 +1826,8 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
         """
         # Get the worksheet uids
         worksheet_uids = map(api.get_uid, self.getWorksheets())
+        if not worksheet_uids:
+            return []
 
         # Get the qc analyses from these worksheets
         portal_types = ["ReferenceAnalysis", "DuplicateAnalysis"]

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -45,6 +45,7 @@ from bika.lims.browser.widgets import SelectionWidget as BikaSelectionWidget
 from bika.lims.browser.widgets.durationwidget import DurationWidget
 from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
 from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
+from bika.lims.catalog import CATALOG_WORKSHEET_LISTING
 from bika.lims.catalog.bika_catalog import BIKA_CATALOG
 from bika.lims.config import PRIORITIES
 from bika.lims.config import PROJECTNAME
@@ -1804,59 +1805,40 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
         # noinspection PyCallingNonCallable
         return DateTime()
 
-    def getQCAnalyses(self, qctype=None, review_state=None):
-        """return the QC analyses performed in the worksheet in which, at
-        least, one sample of this AR is present.
-
-        Depending on qctype value, returns the analyses of:
-
-            - 'b': all Blank Reference Samples used in related worksheet/s
-            - 'c': all Control Reference Samples used in related worksheet/s
-            - 'd': duplicates only for samples contained in this AR
-
-        If qctype==None, returns all type of qc analyses mentioned above
+    def getWorksheets(self, full_objects=False):
+        """Returns the worksheets that contains analyses from this Sample
         """
-        qcanalyses = []
-        suids = []
-        ans = self.getAnalyses()
-        wf = getToolByName(self, 'portal_workflow')
-        for an in ans:
-            an = an.getObject()
-            if an.getServiceUID() not in suids:
-                suids.append(an.getServiceUID())
+        # Get the Analyses UIDs of this Sample
+        analyses_uids = map(api.get_uid, self.getAnalyses())
 
-        def valid_dup(wan):
-            if wan.portal_type == 'ReferenceAnalysis':
-                return False
-            an_state = wf.getInfoFor(wan, 'review_state')
-            return \
-                wan.portal_type == 'DuplicateAnalysis' \
-                and wan.getRequestID() == self.id \
-                and (review_state is None or an_state in review_state)
+        # Get the worksheets that contain any of these analyses
+        query = dict(getAnalysesUIDs=analyses_uids)
+        worksheets = api.search(query, CATALOG_WORKSHEET_LISTING)
+        if full_objects:
+            worksheets = map(api.get_object, worksheets)
+        return worksheets
 
-        def valid_ref(wan):
-            if wan.portal_type != 'ReferenceAnalysis':
-                return False
-            an_state = wf.getInfoFor(wan, 'review_state')
-            an_reftype = wan.getReferenceType()
-            return wan.getServiceUID() in suids \
-                and wan not in qcanalyses \
-                and (qctype is None or an_reftype == qctype) \
-                and (review_state is None or an_state in review_state)
+    def getQCAnalyses(self, review_state=None):
+        """Returns the Quality Control analyses assigned to worksheets that
+        contains analyses from this Sample
+        """
+        # Get the worksheet uids
+        worksheet_uids = map(api.get_uid, self.getWorksheets())
 
-        for an in ans:
-            an = an.getObject()
-            ws = an.getWorksheet()
-            if not ws:
-                continue
-            was = ws.getAnalyses()
-            for wa in was:
-                if valid_dup(wa):
-                    qcanalyses.append(wa)
-                elif valid_ref(wa):
-                    qcanalyses.append(wa)
+        # Get the qc analyses from these worksheets
+        portal_types = ["ReferenceAnalysis", "DuplicateAnalysis"]
+        query = dict(portal_type=portal_types, getWorksheetUID=worksheet_uids)
+        qc_analyses = api.search(query, CATALOG_ANALYSIS_LISTING)
 
-        return qcanalyses
+        # Bail out analyses with a different review_state
+        if review_state:
+            qc_analyses = filter(
+                lambda an: api.get_review_status(an) in review_state,
+                qc_analyses
+            )
+
+        # Return the objects
+        return map(api.get_object, qc_analyses)
 
     def isInvalid(self):
         """return if the Analysis Request has been invalidated


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When QC Analyses (controls, blanks, duplicates) are added in a worksheet, they should be listed in QC Analyses section from inside Sample view if the worksheet contains at least one analysis of the latter.

## Current behavior before PR

QC Analyses listing appears empty

## Desired behavior after PR is merged

![Captura de 2020-01-27 23-46-39](https://user-images.githubusercontent.com/832627/73220735-704cc780-415f-11ea-8ed0-90aa2fd2bda6.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
