### PR TITLE
Better Ajax Loader for Sample Add Form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Changelog
 
 **Changed**
 
+- #1513 Better Ajax Loader for Sample Add Form
 - #1508 Do not try to render InstrumentQCFailuresViewlet to non-lab personnel
 - #1495 Better Remarks handling and display
 - #1502 Improved DateTime Widget

--- a/bika/lims/browser/bootstrap.py
+++ b/bika/lims/browser/bootstrap.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.LIMS is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2020 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.lims import api
+from plone.memoize.ram import cache
+from Products.Five import BrowserView
+from senaite.lims import logger
+from zope.component import getMultiAdapter
+from zope.interface import Interface
+from zope.interface import implements
+
+
+class IBootstrapView(Interface):
+    """Twitter Bootstrap View
+    """
+
+    def getColumnsClasses(view=None):
+        """A helper method to return the clases for the columns of the site
+           it should return a dict with three elements:'one', 'two', 'content'
+           Each of them should contain the classnames for the first (leftmost)
+           second (rightmost) and middle column
+        """
+
+    def getViewportValues(view=None):
+        """Determine the value of the viewport meta-tag
+        """
+
+
+def icon_cache_key(method, self, brain_or_object):
+    """Generates a cache key for the icon lookup
+
+    Includes the virtual URL to handle multiple HTTP/HTTPS domains
+    Example: http://senaite.local/clients?modified=1512033263370
+    """
+    url = api.get_url(brain_or_object)
+    modified = api.get_modification_date(brain_or_object).millis()
+    key = "{}?modified={}".format(url, modified)
+    logger.debug("Generated Cache Key: {}".format(key))
+    return key
+
+
+class BootstrapView(BrowserView):
+    """Twitter Bootstrap helper view for SENAITE LIMS
+    """
+    implements(IBootstrapView)
+
+    def __init__(self, context, request):
+        super(BrowserView, self).__init__(context, request)
+
+    @cache(icon_cache_key)
+    def get_icon_for(self, brain_or_object):
+        """Get the navigation portlet icon for the brain or object
+
+        The cache key ensures that the lookup is done only once per domain name
+        """
+        portal_types = api.get_tool("portal_types")
+        fti = portal_types.getTypeInfo(api.get_portal_type(brain_or_object))
+        icon = fti.getIcon()
+        if not icon:
+            return ""
+        # Always try to get the big icon for high-res displays
+        icon_big = icon.replace(".png", "_big.png")
+        # fall back to a default icon if the looked up icon does not exist
+        if self.context.restrictedTraverse(icon_big, None) is None:
+            icon_big = None
+        portal_url = api.get_url(api.get_portal())
+        title = api.get_title(brain_or_object)
+        html_tag = "<img title='{}' src='{}/{}' width='16' />".format(
+            title, portal_url, icon_big or icon)
+        logger.debug("Generated Icon Tag for {}: {}".format(
+            api.get_path(brain_or_object), html_tag))
+        return html_tag
+
+    def getViewportValues(self, view=None):
+        """Determine the value of the viewport meta-tag
+        """
+        values = {
+            'width': 'device-width',
+            'initial-scale': '1.0',
+        }
+
+        return ','.join('%s=%s' % (k, v) for k, v in values.items())
+
+    def getColumnsClasses(self, view=None):
+        """Determine whether a column should be shown. The left column is
+           called plone.leftcolumn; the right column is called
+           plone.rightcolumn.
+        """
+
+        plone_view = getMultiAdapter(
+            (self.context, self.request), name=u'plone')
+        portal_state = getMultiAdapter(
+            (self.context, self.request), name=u'plone_portal_state')
+
+        sl = plone_view.have_portlets('plone.leftcolumn', view=view)
+        sr = plone_view.have_portlets('plone.rightcolumn', view=view)
+
+        isRTL = portal_state.is_rtl()
+
+        # pre-fill dictionary
+        columns = dict(one="", content="", two="")
+
+        if not sl and not sr:
+            # we don't have columns, thus conten takes the whole width
+            columns['content'] = "col-md-12"
+
+        elif sl and sr:
+            # In case we have both columns, content takes 50% of the whole
+            # width and the rest 50% is spread between the columns
+            columns['one'] = "col-xs-12 col-md-2"
+            columns['content'] = "col-xs-12 col-md-8"
+            columns['two'] = "col-xs-12 col-md-2"
+
+        elif (sr and not sl) and not isRTL:
+            # We have right column and we are NOT in RTL language
+            columns['content'] = "col-xs-12 col-md-10"
+            columns['two'] = "col-xs-12 col-md-2"
+
+        elif (sl and not sr) and isRTL:
+            # We have left column and we are in RTL language
+            columns['one'] = "col-xs-12 col-md-2"
+            columns['content'] = "col-xs-12 col-md-10"
+
+        elif (sl and not sr) and not isRTL:
+            # We have left column and we are in NOT RTL language
+            columns['one'] = "col-xs-12 col-md-2"
+            columns['content'] = "col-xs-12 col-md-10"
+
+        # # append cell to each css-string
+        # for key, value in columns.items():
+        #     columns[key] = "cell " + value
+
+        return columns

--- a/bika/lims/browser/bootstrap.zcml
+++ b/bika/lims/browser/bootstrap.zcml
@@ -9,7 +9,7 @@
   <browser:page
       name="bootstrapview"
       for="*"
-      class=".views.BootstrapView"
+      class=".bootstrap.BootstrapView"
       allowed_interface=".interfaces.IBootstrapView"
       permission="zope2.View"
       layer="bika.lims.interfaces.IBikaLIMS"/>

--- a/bika/lims/browser/bootstrap.zcml
+++ b/bika/lims/browser/bootstrap.zcml
@@ -10,7 +10,7 @@
       name="bootstrapview"
       for="*"
       class=".bootstrap.BootstrapView"
-      allowed_interface=".interfaces.IBootstrapView"
+      allowed_interface=".bootstrap.IBootstrapView"
       permission="zope2.View"
       layer="bika.lims.interfaces.IBikaLIMS"/>
 

--- a/bika/lims/browser/bootstrap.zcml
+++ b/bika/lims/browser/bootstrap.zcml
@@ -1,0 +1,17 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:cmf="http://namespaces.zope.org/cmf"
+    i18n_domain="senaite.core">
+
+  <!-- Bootstrap Helper View -->
+  <browser:page
+      name="bootstrapview"
+      for="*"
+      class=".views.BootstrapView"
+      allowed_interface=".interfaces.IBootstrapView"
+      permission="zope2.View"
+      layer="bika.lims.interfaces.IBikaLIMS"/>
+
+</configure>

--- a/bika/lims/browser/configure.zcml
+++ b/bika/lims/browser/configure.zcml
@@ -16,6 +16,7 @@
   <include file="attachment.zcml"/>
   <include file="auditlog.zcml"/>
   <include file="batchfolder.zcml"/>
+  <include file="bootstrap.zcml"/>
   <include file="calcs.zcml"/>
   <include file="clientfolder.zcml"/>
   <include file="contact.zcml"/>

--- a/bika/lims/browser/configure.zcml
+++ b/bika/lims/browser/configure.zcml
@@ -20,6 +20,7 @@
   <include file="calcs.zcml"/>
   <include file="clientfolder.zcml"/>
   <include file="contact.zcml"/>
+  <include file="controlpanel.zcml"/>
   <include file="dynamic_analysisspec.zcml"/>
   <include file="instrument.zcml"/>
   <include file="instrumentlocation.zcml"/>

--- a/bika/lims/browser/controlpanel.py
+++ b/bika/lims/browser/controlpanel.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.LIMS is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2020 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from plone.app.controlpanel.overview import OverviewControlPanel
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
+
+class SenaiteOverviewControlPanel(OverviewControlPanel):
+    template = ViewPageTemplateFile(
+        "templates/plone.app.controlpanel.overview.pt")

--- a/bika/lims/browser/controlpanel.zcml
+++ b/bika/lims/browser/controlpanel.zcml
@@ -1,0 +1,18 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:cmf="http://namespaces.zope.org/cmf"
+    i18n_domain="senaite.core">
+
+  <include package="plone.app.controlpanel" file="permissions.zcml" />
+
+  <!-- Controlpanel View -->
+  <browser:page
+      name="overview-controlpanel"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      class=".views.SenaiteOverviewControlPanel"
+      permission="plone.app.controlpanel.Overview"
+      layer="bika.lims.interfaces.IBikaLIMS"/>
+
+</configure>

--- a/bika/lims/browser/controlpanel.zcml
+++ b/bika/lims/browser/controlpanel.zcml
@@ -11,7 +11,7 @@
   <browser:page
       name="overview-controlpanel"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
-      class=".views.SenaiteOverviewControlPanel"
+      class=".controlpanel.SenaiteOverviewControlPanel"
       permission="plone.app.controlpanel.Overview"
       layer="bika.lims.interfaces.IBikaLIMS"/>
 

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -1250,9 +1250,10 @@
       var button;
       console.debug("°°° on_ajax_start °°°");
       button = $("input[name=save_button]");
-      return button.prop({
+      button.prop({
         "disabled": true
       });
+      return button[0].value = _("Loading ...");
     };
 
     AnalysisRequestAdd.prototype.on_ajax_end = function() {
@@ -1263,9 +1264,10 @@
       var button;
       console.debug("°°° on_ajax_end °°°");
       button = $("input[name=save_button]");
-      return button.prop({
+      button.prop({
         "disabled": false
       });
+      return button[0].value = _("Save");
     };
 
     AnalysisRequestAdd.prototype.on_form_submit = function(event, callback) {

--- a/bika/lims/browser/js/bika.lims.site.js
+++ b/bika/lims/browser/js/bika.lims.site.js
@@ -8,9 +8,6 @@
 
   window.SiteView = (function() {
     function SiteView() {
-      this.on_ajax_error = bind(this.on_ajax_error, this);
-      this.on_ajax_end = bind(this.on_ajax_end, this);
-      this.on_ajax_start = bind(this.on_ajax_start, this);
       this.on_service_info_click = bind(this.on_service_info_click, this);
       this.on_reference_definition_list_change = bind(this.on_reference_definition_list_change, this);
       this.on_numeric_field_keypress = bind(this.on_numeric_field_keypress, this);
@@ -20,8 +17,6 @@
       this.on_autocomplete_keydown = bind(this.on_autocomplete_keydown, this);
       this.on_date_range_end_change = bind(this.on_date_range_end_change, this);
       this.on_date_range_start_change = bind(this.on_date_range_start_change, this);
-      this.stop_spinner = bind(this.stop_spinner, this);
-      this.start_spinner = bind(this.start_spinner, this);
       this.notify_in_panel = bind(this.notify_in_panel, this);
       this.notificationPanel = bind(this.notificationPanel, this);
       this.set_cookie = bind(this.set_cookie, this);
@@ -35,7 +30,6 @@
       this.get_portal_url = bind(this.get_portal_url, this);
       this.init_referencedefinition = bind(this.init_referencedefinition, this);
       this.init_datepickers = bind(this.init_datepickers, this);
-      this.init_spinner = bind(this.init_spinner, this);
       this.init_client_add_overlay = bind(this.init_client_add_overlay, this);
       this.bind_eventhandler = bind(this.bind_eventhandler, this);
       this.load = bind(this.load, this);
@@ -45,7 +39,6 @@
       console.debug("SiteView::load");
       jarn.i18n.loadCatalog('senaite.core');
       this._ = window.jarn.i18n.MessageFactory("senaite.core");
-      this.init_spinner();
       this.init_client_add_overlay();
       this.init_datepickers();
       this.init_referencedefinition();
@@ -74,9 +67,17 @@
       $("body").on("change", ".date_range_start", this.on_date_range_start_change);
       $("body").on("change", ".date_range_end", this.on_date_range_end_change);
       $("body").on("click", "a.service_info", this.on_service_info_click);
-      $(document).on("ajaxStart", this.on_ajax_start);
-      $(document).on("ajaxStop", this.on_ajax_end);
-      return $(document).on("ajaxError", this.on_ajax_error);
+      return $(document).on({
+        ajaxStart: function() {
+          $("body").addClass("loading");
+        },
+        ajaxStop: function() {
+          $("body").removeClass("loading");
+        },
+        ajaxError: function() {
+          $("body").removeClass("loading");
+        }
+      });
     };
 
     SiteView.prototype.init_client_add_overlay = function() {
@@ -100,20 +101,6 @@
           onClose: function() {}
         }
       });
-    };
-
-    SiteView.prototype.init_spinner = function() {
-
-      /*
-       * Initialize Spinner Overlay
-       */
-      console.debug("SiteView::init_spinner");
-      $(document).unbind('ajaxStart');
-      $(document).unbind('ajaxStop');
-      $('#ajax-spinner').remove();
-      this.counter = 0;
-      this.spinner = $("<div id='bika-spinner'><img src='" + (this.get_portal_url()) + "/spinner.gif' alt=''/></div>");
-      return this.spinner.appendTo('body').hide();
     };
 
     SiteView.prototype.init_datepickers = function() {
@@ -356,39 +343,6 @@
       });
     };
 
-    SiteView.prototype.start_spinner = function() {
-
-      /*
-       * Start Spinner Overlay
-       */
-      console.debug("SiteView::start_spinner");
-      this.counter++;
-      this.timer = setTimeout(((function(_this) {
-        return function() {
-          if (_this.counter > 0) {
-            _this.spinner.show('fast');
-          }
-        };
-      })(this)), 500);
-    };
-
-    SiteView.prototype.stop_spinner = function() {
-
-      /*
-       * Stop Spinner Overlay
-       */
-      console.debug("SiteView::stop_spinner");
-      this.counter--;
-      if (this.counter < 0) {
-        this.counter = 0;
-      }
-      if (this.counter === 0) {
-        clearTimeout(this.timer);
-        this.spinner.stop();
-        this.spinner.hide();
-      }
-    };
-
 
     /* EVENT HANDLER */
 
@@ -601,34 +555,6 @@
         }
       });
       return $(el).click();
-    };
-
-    SiteView.prototype.on_ajax_start = function(event) {
-
-      /*
-       * Eventhandler if an global Ajax Request started
-       */
-      console.debug("°°° SiteView::on_ajax_start °°°");
-      return this.start_spinner();
-    };
-
-    SiteView.prototype.on_ajax_end = function(event) {
-
-      /*
-       * Eventhandler if an global Ajax Request ended
-       */
-      console.debug("°°° SiteView::on_ajax_end °°°");
-      return this.stop_spinner();
-    };
-
-    SiteView.prototype.on_ajax_error = function(event, jqxhr, settings, thrownError) {
-
-      /*
-       * Eventhandler if an global Ajax Request error
-       */
-      console.debug("°°° SiteView::on_ajax_error °°°");
-      this.stop_spinner();
-      return this.log("Error at " + settings.url + ": " + thrownError);
     };
 
     return SiteView;

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -1273,6 +1273,7 @@ class window.AnalysisRequestAdd
     # deactivate the button
     button = $("input[name=save_button]")
     button.prop "disabled": yes
+    button[0].value = _("Loading ...")
 
 
   on_ajax_end: =>
@@ -1284,6 +1285,7 @@ class window.AnalysisRequestAdd
     # reactivate the button
     button = $("input[name=save_button]")
     button.prop "disabled": no
+    button[0].value = _("Save")
 
 
   # Note: Context of callback bound to this object

--- a/bika/lims/browser/js/coffee/bika.lims.site.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.site.coffee
@@ -12,9 +12,6 @@ class window.SiteView
     jarn.i18n.loadCatalog 'senaite.core'
     @_ = window.jarn.i18n.MessageFactory("senaite.core")
 
-    # initialze the loading spinner
-    @init_spinner()
-
     # initialze the client add overlay
     @init_client_add_overlay()
 
@@ -78,10 +75,17 @@ class window.SiteView
 
     $("body").on "click", "a.service_info", @on_service_info_click
 
-    # handle Ajax events
-    $(document).on "ajaxStart", @on_ajax_start
-    $(document).on "ajaxStop", @on_ajax_end
-    $(document).on "ajaxError", @on_ajax_error
+    # Show loader on Ajax events
+    $(document).on
+      ajaxStart: ->
+        $("body").addClass "loading"
+        return
+      ajaxStop: ->
+        $("body").removeClass "loading"
+        return
+      ajaxError: ->
+        $("body").removeClass "loading"
+        return
 
 
   init_client_add_overlay: =>
@@ -106,25 +110,6 @@ class window.SiteView
         onClose: ->
           # here is where we'd populate the form controls, if we cared to.
           return
-
-
-  init_spinner: =>
-    ###
-     * Initialize Spinner Overlay
-    ###
-    console.debug "SiteView::init_spinner"
-
-    # unbind default Plone loader
-    $(document).unbind 'ajaxStart'
-    $(document).unbind 'ajaxStop'
-    $('#ajax-spinner').remove()
-
-    # counter of active spinners
-    @counter = 0
-
-    # crate a spinner and append it to the body
-    @spinner = $("<div id='bika-spinner'><img src='#{@get_portal_url()}/spinner.gif' alt=''/></div>")
-    @spinner.appendTo('body').hide()
 
 
   init_datepickers: =>
@@ -364,42 +349,6 @@ class window.SiteView
     return
 
 
-  start_spinner: =>
-    ###
-     * Start Spinner Overlay
-    ###
-    console.debug "SiteView::start_spinner"
-
-    # increase the counter
-    @counter++
-
-    @timer = setTimeout (=>
-      if @counter > 0
-        @spinner.show 'fast'
-      return
-    ), 500
-
-    return
-
-
-  stop_spinner: =>
-    ###
-     * Stop Spinner Overlay
-    ###
-    console.debug "SiteView::stop_spinner"
-
-    # decrease the counter
-    @counter--
-
-    if @counter < 0
-      @counter = 0
-    if @counter == 0
-      clearTimeout @timer
-      @spinner.stop()
-      @spinner.hide()
-    return
-
-
   ### EVENT HANDLER ###
 
   on_date_range_start_change: (event) =>
@@ -626,35 +575,3 @@ class window.SiteView
 
     # workaround un-understandable overlay api
     $(el).click()
-
-
-  on_ajax_start: (event) =>
-    ###
-     * Eventhandler if an global Ajax Request started
-    ###
-    console.debug "°°° SiteView::on_ajax_start °°°"
-
-    # start the loading spinner
-    @start_spinner()
-
-
-  on_ajax_end: (event) =>
-    ###
-     * Eventhandler if an global Ajax Request ended
-    ###
-    console.debug "°°° SiteView::on_ajax_end °°°"
-
-    # stop the loading spinner
-    @stop_spinner()
-
-
-  on_ajax_error: (event, jqxhr, settings, thrownError) =>
-    ###
-     * Eventhandler if an global Ajax Request error
-    ###
-    console.debug "°°° SiteView::on_ajax_error °°°"
-
-    # stop the loading spinner
-    @stop_spinner()
-
-    @log "Error at #{settings.url}: #{thrownError}"

--- a/bika/lims/browser/templates/plone.app.controlpanel.overview.pt
+++ b/bika/lims/browser/templates/plone.app.controlpanel.overview.pt
@@ -1,0 +1,156 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="here/prefs_main_template/macros/master"
+      i18n:domain="plone">
+
+  <body>
+
+    <metal:override fill-slot="top_slot"
+                    tal:define="disable_column_one python:request.set('disable_plone.leftcolumn',1);
+                               disable_column_two python:request.set('disable_plone.rightcolumn',1);"/>
+
+    <div metal:fill-slot="prefs_configlet_main">
+
+      <h1 class="documentFirstHeading"
+          i18n:translate="">Site Setup</h1>
+
+      <p class="documentDescription" i18n:translate="description_control_panel">
+        Configuration area for Plone and add-on Products.
+      </p>
+
+      <dl class="portalMessage alert alert-warning"
+          tal:condition="view/upgrade_warning">
+        <dt i18n:translate="">
+          Warning
+        </dt>
+        <dd i18n:translate="">
+          The site configuration is outdated and needs to be
+          upgraded. Please
+          <a href="#"
+             tal:attributes="href string:${context/portal_url}/@@plone-upgrade"
+             title="Go to the upgrade page"
+             i18n:attributes="title;"
+             i18n:name="link_continue_with_the_upgrade"
+             i18n:translate="">
+            continue with the upgrade
+          </a>.
+        </dd>
+      </dl>
+
+      <dl class="portalMessage alert alert-warning"
+          tal:condition="view/mailhost_warning">
+        <dt i18n:translate="">
+          Warning
+        </dt>
+        <dd i18n:translate="text_no_mailhost_configured">
+          You have not configured a mail host or a site 'From'
+          address, various features including contact forms, email
+          notification and password reset will not work. Go to the
+          <tal:link i18n:name="label_mail_control_panel_link">
+            <a href=""
+               i18n:translate="text_no_mailhost_configured_control_panel_link"
+               tal:attributes="href string:${portal_url}/@@mail-controlpanel"
+            >Mail control panel</a>
+          </tal:link>
+          to fix this.
+        </dd>
+      </dl>
+
+      <dl class="portalMessage alert alrt-warning"
+          tal:condition="not:view/pil">
+        <dt i18n:translate="">
+          Warning
+        </dt>
+        <dd i18n:translate="text_no_pil_installed">
+          Warning: PIL is not installed properly, image scaling will not work.
+        </dd>
+      </dl>
+
+      <tal:category tal:repeat="category view/categories">
+        <div class="col-md-12">
+
+          <h2 tal:content="category/title"
+              i18n:translate="">Category</h2>
+
+          <div tal:define="sublists python:view.sublists(category.get('id'))">
+
+            <div tal:repeat="sublist sublists"
+                 tal:condition="sublists"
+                 class="col-md-3">
+
+              <ul class="configlets nav nav-stacked nav-pills"
+                  tal:condition="sublist">
+                <tal:actions tal:repeat="action sublist">
+                  <li tal:condition="action/visible">
+                    <a href=""
+                       tal:define="icon action/icon"
+                       tal:attributes="href action/url">
+                      <img src="" alt=""
+                           tal:condition="not:icon"
+                           tal:attributes="src string:${portal_url}/maintenance_icon.png" />
+                      <img src="" alt=""
+                           tal:condition="icon"
+                           tal:attributes="src icon;
+                                alt action/title;"
+                           i18n:attributes="alt" />
+                      <tal:title tal:content="action/title"
+                                 i18n:translate="">
+                        Title
+                      </tal:title>
+                    </a>
+                  </li>
+                </tal:actions>
+              </ul>
+            </div>
+
+            <div class="discreet help-block"
+                 tal:condition="not:sublists"
+                 i18n:translate="label_no_prefs_panels_available">
+              No preference panels available.
+            </div>
+
+          </div>
+
+        </div>
+      </tal:category>
+
+      <div class="col-md-12">
+        <h2 i18n:translate="heading_version_overview">Version Overview</h2>
+
+        <ul tal:repeat="version view/version_overview">
+          <li tal:content="version">Version</li>
+        </ul>
+
+        <!-- Production Mode -->
+        <p tal:condition="not:view/is_dev_mode"
+           class="discreet text-muted"
+           i18n:translate="description_production_mode">
+          You are running in "production mode". This is the preferred mode of
+          operation for a live Plone site, but means that some
+          configuration changes will not take effect until your server is
+          restarted or a product refreshed. If this is a development instance,
+          and you want to enable debug mode, stop the server, set 'debug-mode=on'
+          in your buildout.cfg, re-run bin/buildout and then restart the server
+          process.
+        </p>
+
+        <!-- DEV Mode -->
+        <p tal:condition="view/is_dev_mode"
+           class="discreet text-muted"
+           i18n:translate="description_debug_mode">
+          You are running in "debug mode". This mode is intended for sites that
+          are under development. This allows many configuration changes to be
+          immediately visible, but will make your site run more slowly. To turn
+          off debug mode, stop the server, set 'debug-mode=off' in your
+          buildout.cfg, re-run bin/buildout and then restart the server
+          process.
+        </p>
+      </div>
+
+    </div>
+
+  </body>
+</html>

--- a/bika/lims/skins/bika/base_properties.props
+++ b/bika/lims/skins/bika/base_properties.props
@@ -1,4 +1,4 @@
-title:string=Plone's color, font, logo and border defaults
+title:string=SENAITE Theme
 plone_skin:string=Plone Default
 
 logoName:string=logo.png

--- a/bika/lims/skins/bika/main_template.pt
+++ b/bika/lims/skins/bika/main_template.pt
@@ -1,0 +1,206 @@
+<metal:page define-macro="master"><tal:doctype tal:replace="structure string:&lt;!DOCTYPE html&gt;" />
+  <html xmlns="http://www.w3.org/1999/xhtml"
+        tal:define="portal_state context/@@plone_portal_state;
+                    context_state context/@@plone_context_state;
+                    plone_view context/@@plone;
+                    lang portal_state/language;
+                    view nocall:view | nocall: plone_view;
+                    dummy python: plone_view.mark_view(view);
+                    portal_url portal_state/portal_url;
+                    checkPermission nocall: context/portal_membership/checkPermission;
+                    site_properties context/portal_properties/site_properties;
+                    ajax_load request/ajax_load | nothing;
+                    ajax_include_head request/ajax_include_head | nothing;
+                    dummy python:request.RESPONSE.setHeader('X-UA-Compatible', 'IE=edge,chrome=1');
+                    bootstrapview nocall:context/@@bootstrapview"
+        tal:attributes="lang lang;">
+
+    <metal:cache use-macro="context/global_cache_settings/macros/cacheheaders">
+      Get the global cache headers located in global_cache_settings.
+    </metal:cache>
+
+    <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+      <meta charset="utf-8">
+      <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+      <metal:baseslot define-slot="base">
+        <base tal:attributes="href plone_view/renderBase" /><!--[if lt IE 7]></base><![endif]-->
+      </metal:baseslot>
+
+      <tal:notajax tal:condition="python:not ajax_load or ajax_include_head">
+        <div tal:replace="structure provider:plone.htmlhead" />
+        <link tal:replace="structure provider:plone.htmlhead.links" />
+
+        <tal:comment replace="nothing">
+          Various slots where you can insert elements in the header from a template.
+        </tal:comment>
+        <metal:topslot define-slot="top_slot" />
+        <metal:headslot define-slot="head_slot" />
+        <metal:styleslot define-slot="style_slot" />
+        <metal:javascriptslot define-slot="javascript_head_slot" />
+
+        <meta name="viewport"
+              tal:define="viewportvalues bootstrapview/getViewportValues"
+              tal:attributes="content viewportvalues"
+              content="width=device-width, initial-scale=0.6666, maximum-scale=1.0, minimum-scale=0.6666" />
+        <meta name="generator" content="Plone - http://plone.org" />
+      </tal:notajax>
+    </head>
+
+    <body tal:define="isRTL portal_state/is_rtl;
+                      sl python:plone_view.have_portlets('plone.leftcolumn', view);
+                      sr python:plone_view.have_portlets('plone.rightcolumn', view);
+                      body_class python:plone_view.bodyClass(template, view);
+                      classes python:bootstrapview.getColumnsClasses(view)"
+          tal:attributes="class body_class;
+                          dir python: isRTL and 'rtl' or 'ltr';
+                          data-portal-url portal_url;
+                          data-base-url context/absolute_url">
+
+      <!-- Ajax Loader -->
+      <div id="loader" i18n-translate="">Loading...</div>
+
+      <div id="visual-portal-wrapper" class="container-fluid">
+        <div class="row">
+          <div class="col-md-12">
+
+            <header tal:condition="not:ajax_load">
+              <div id="portal-header-wrapper">
+                <div tal:replace="structure provider:plone.portaltop" />
+              </div>
+            </header>
+          </div>
+        </div>
+
+        <div id="portal-columns" class="row">
+
+          <tal:notajax tal:condition="not:ajax_load">
+            <div id="portal-column-one"
+                 class="col-md-2"
+                 metal:define-slot="column_one_slot"
+                 tal:condition="sl"
+                 tal:attributes="class classes/one">
+              <metal:portlets define-slot="portlets_one_slot">
+                <tal:block replace="structure provider:plone.leftcolumn" />
+              </metal:portlets>
+            </div>
+          </tal:notajax>
+
+          <div id="portal-column-content" class="col-md-8"
+               tal:attributes="class classes/content">
+
+            <div id="viewlet-above-content" tal:content="structure provider:plone.abovecontent" tal:condition="not:ajax_load" />
+
+            <div class="row">
+              <div class="col-md-12">
+                <metal:block define-slot="content">
+                  <div metal:define-macro="content"
+                       tal:define="show_border context/@@plone/showEditableBorder; show_border python:show_border and not ajax_load"
+                       tal:attributes="class python:show_border and 'documentEditable' or ''">
+
+                    <div class="row">
+                      <div class="col-md-12">
+                        <div id="editing-bar"
+                             tal:condition="show_border"
+                             tal:content="structure provider:plone.contentviews" />
+                      </div>
+                    </div>
+
+                    <div class="row">
+                      <div class="col-md-12">
+                        <div metal:use-macro="context/global_statusmessage/macros/portal_message">
+                          Status message
+                        </div>
+                      </div>
+                    </div>
+
+                    <div class="row">
+                      <div class="col-md-12">
+                        <metal:slot define-slot="body">
+                          <div id="content">
+
+                            <metal:header define-slot="header" tal:content="nothing">
+                              Visual Header
+                            </metal:header>
+
+                            <metal:bodytext define-slot="main">
+
+                              <div id="viewlet-above-content-title" tal:content="structure provider:plone.abovecontenttitle" tal:condition="not:ajax_load" />
+                              <metal:title define-slot="content-title">
+                                <metal:comment tal:content="nothing">
+                                  If you write a custom title always use
+                                  <h1 class="documentFirstHeading"></h1> for it
+                                </metal:comment>
+                                <h1 metal:use-macro="context/kss_generic_macros/macros/generic_title_view">
+                                  Generic KSS Title. Is rendered with class="documentFirstHeading".
+                                </h1>
+                              </metal:title>
+                              <div id="viewlet-below-content-title" tal:content="structure provider:plone.belowcontenttitle" tal:condition="not:ajax_load" />
+
+                              <metal:description define-slot="content-description">
+                                <metal:comment tal:content="nothing">
+                                  If you write a custom description always use
+                                  <div class="documentDescription"></div> for it
+                                </metal:comment>
+                                <div metal:use-macro="context/kss_generic_macros/macros/generic_description_view">
+                                  Generic KSS Description. Is rendered with class="documentDescription".
+                                </div>
+                              </metal:description>
+
+                              <div id="viewlet-above-content-body" tal:content="structure provider:plone.abovecontentbody" tal:condition="not:ajax_load" />
+                              <div id="content-core">
+                                <metal:text define-slot="content-core" tal:content="nothing">
+                                  Page body text
+                                </metal:text>
+                              </div>
+                              <div id="viewlet-below-content-body" tal:content="structure provider:plone.belowcontentbody" tal:condition="not:ajax_load" />
+
+                            </metal:bodytext>
+                          </div>
+                        </metal:slot>
+
+                        <metal:sub define-slot="sub" tal:content="nothing">
+                          This slot is here for backwards compatibility only.
+                          Don't use it in your custom templates.
+                        </metal:sub>
+                      </div>
+                    </div>
+                  </div>
+                </metal:block>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-12">
+                <div id="viewlet-below-content" tal:content="structure provider:plone.belowcontent" tal:condition="not:ajax_load" />
+              </div>
+            </div>
+          </div>
+
+          <tal:notajax tal:condition="not:ajax_load">
+            <div id="portal-column-two"
+                 class="col-md-2"
+                 metal:define-slot="column_two_slot"
+                 tal:condition="sr"
+                 tal:attributes="class classes/two">
+              <metal:portlets define-slot="portlets_two_slot">
+                <tal:block replace="structure provider:plone.rightcolumn" />
+              </metal:portlets>
+            </div>
+          </tal:notajax>
+        </div>
+
+        <div class="row">
+          <div class="col-md-12">
+            <footer tal:condition="not:ajax_load">
+              <div id="portal-footer-wrapper">
+                <div tal:replace="structure provider:plone.portalfooter" />
+              </div>
+            </footer>
+          </div>
+        </div>
+      </div>
+
+    </body>
+  </html>
+</metal:page>

--- a/bika/lims/skins/bika/ploneCustom.css.dtml
+++ b/bika/lims/skins/bika/ploneCustom.css.dtml
@@ -1070,30 +1070,6 @@ div.LSResult {
     top:75%;
 }
 
-#bika-spinner {
-    display:none;
-    background-color: #fff;
-    background-image: url(&dtml-portal_url;/spinner.gif) center center no-repeat;
-    position: fixed;
-    width: 45px;
-    height: 45px;
-    top: 50%;
-    left: 50%;
-    margin-left: -22px; /* -1 * image width / 2 */
-    margin-top: -22px;  /* -1 * image height / 2 */
-    border:1px solid #eee;
-    border-radius:5px;
-    display: block;
-}
-
-#bika-spinner img {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    margin-left: -8px;
-    margin-top: -8px;
-}
-
 #portal-alert input,
 #portal-alert a.button {
     background-color: #436976 !important;


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The Sample Add form syncs the server data via Ajax on every field change.

<img width="1516" alt="" src="https://user-images.githubusercontent.com/713193/73611492-a7e5c480-45e2-11ea-8425-8b0689c25a7e.png">


## Current behavior before PR

The current loader is very prominent and blocks the whole UI via a modal

## Desired behavior after PR is merged

The new loader is more decent and allows to continue filling out the form

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
