### PR TITLE
Clean some stale indexes from analysis_catalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,7 @@ Changelog
 
 **Removed**
 
+- #1518 Removed stale indexes from `analysis_catalog`
 - #1516 Removed getResultsRange metadata from analysis_catalog
 - #1487 Dexterity Compatible Catalog Base Class
 - #1482 Remove `senaite.instruments` dependency for instrument import form

--- a/bika/lims/browser/worksheet/views/add_analyses.py
+++ b/bika/lims/browser/worksheet/views/add_analyses.py
@@ -82,7 +82,7 @@ class AddAnalysesView(BikaListingView):
             ("getClientOrderNumber", {
                 "title": _("Order"),
                 "toggle": False,
-                "index": "getClientOrderNumber"}),
+                "attr": "getClientOrderNumber"}),
             ("getRequestID", {
                 "title": _("Request ID"),
                 "attr": "getRequestID",

--- a/bika/lims/catalog/analysis_catalog.py
+++ b/bika/lims/catalog/analysis_catalog.py
@@ -39,7 +39,6 @@ _indexes_dict = {
     "getParentUID": "FieldIndex",
     "getRequestUID": "FieldIndex",
     "getDueDate": "DateIndex",
-    "getDateSampled": "DateIndex",
     "getDateReceived": "DateIndex",
     "getResultCaptureDate": "DateIndex",
     "getClientUID": "FieldIndex",
@@ -47,7 +46,6 @@ _indexes_dict = {
     # Only used in Productivity report: productivity_analysestats_overtime
     "getAnalyst": "FieldIndex",
     "getRequestID": "FieldIndex",
-    "getClientOrderNumber": "FieldIndex",
     "getKeyword": "FieldIndex",
     "getServiceUID": "FieldIndex",
     "getCategoryUID": "FieldIndex",

--- a/bika/lims/catalog/analysis_catalog.py
+++ b/bika/lims/catalog/analysis_catalog.py
@@ -44,6 +44,7 @@ _indexes_dict = {
     "getResultCaptureDate": "DateIndex",
     "getClientUID": "FieldIndex",
     "getClientTitle": "FieldIndex",
+    # Only used in Productivity report: productivity_analysestats_overtime
     "getAnalyst": "FieldIndex",
     "getRequestID": "FieldIndex",
     "getClientOrderNumber": "FieldIndex",
@@ -57,8 +58,6 @@ _indexes_dict = {
     "getReferenceAnalysesGroupID": "FieldIndex",
     "getMethodUID": "FieldIndex",
     "getInstrumentUID": "FieldIndex",
-    "getBatchUID": "FieldIndex",
-    "getAnalysisRequestPrintStatus": "FieldIndex",
     "getWorksheetUID": "FieldIndex",
     "getOriginalReflexedAnalysisUID": "FieldIndex",
     "getPrioritySortkey": "FieldIndex",

--- a/bika/lims/content/abstractroutineanalysis.py
+++ b/bika/lims/content/abstractroutineanalysis.py
@@ -329,14 +329,6 @@ class AbstractRoutineAnalysis(AbstractAnalysis, ClientAwareMixin):
             return request.getBatchUID()
 
     @security.public
-    def getAnalysisRequestPrintStatus(self):
-        """This method is used to populate catalog values
-        """
-        request = self.getRequest()
-        if request:
-            return request.getPrinted()
-
-    @security.public
     def getResultsRange(self):
         """Returns the valid result range for this routine analysis
 

--- a/bika/lims/content/abstractroutineanalysis.py
+++ b/bika/lims/content/abstractroutineanalysis.py
@@ -226,11 +226,11 @@ class AbstractRoutineAnalysis(AbstractAnalysis, ClientAwareMixin):
         return None
 
     @security.public
-    def isSampleSampled(instance):
+    def isSampleSampled(self):
         """Returns whether if the Analysis Request this analysis comes from has
         been received or not
         """
-        return instance.getDateSampled() and True or False
+        return self.getDateSampled() and True or False
 
     @security.public
     def getStartProcessDate(self):

--- a/bika/lims/content/abstractroutineanalysis.py
+++ b/bika/lims/content/abstractroutineanalysis.py
@@ -321,14 +321,6 @@ class AbstractRoutineAnalysis(AbstractAnalysis, ClientAwareMixin):
             return api.get_uid(sample_type)
 
     @security.public
-    def getBatchUID(self):
-        """This method is used to populate catalog values
-        """
-        request = self.getRequest()
-        if request:
-            return request.getBatchUID()
-
-    @security.public
     def getResultsRange(self):
         """Returns the valid result range for this routine analysis
 

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -1554,7 +1554,6 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
         original_value = self.Schema().getField('Batch').get(self)
         if original_value != value:
             self.Schema().getField('Batch').set(self, value)
-            self._reindexAnalyses(['getBatchUID'], False)
 
     def getDefaultMemberDiscount(self):
         """Compute default member discount if it applies

--- a/bika/lims/upgrade/v01_03_003.py
+++ b/bika/lims/upgrade/v01_03_003.py
@@ -28,7 +28,6 @@ from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
 from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.catalog.bikasetup_catalog import SETUP_CATALOG
 from bika.lims.config import PROJECTNAME as product
-from bika.lims.exportimport.setupdata import Analysis_Categories
 from bika.lims.interfaces import IAnalysisRequestWithPartitions
 from bika.lims.interfaces import ISubmitted
 from bika.lims.interfaces import IVerified

--- a/bika/lims/upgrade/v01_03_003.py
+++ b/bika/lims/upgrade/v01_03_003.py
@@ -24,9 +24,11 @@ from operator import itemgetter
 import transaction
 from bika.lims import api
 from bika.lims import logger
+from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
 from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.catalog.bikasetup_catalog import SETUP_CATALOG
 from bika.lims.config import PROJECTNAME as product
+from bika.lims.exportimport.setupdata import Analysis_Categories
 from bika.lims.interfaces import IAnalysisRequestWithPartitions
 from bika.lims.interfaces import ISubmitted
 from bika.lims.interfaces import IVerified
@@ -179,6 +181,10 @@ INDEXES_TO_REMOVE = [
 
     # getCategoryUID --> category_uid
     ("bika_setup_catalog", "getCategoryUID"),
+
+    # Not used anywhere
+    (CATALOG_ANALYSIS_LISTING, "getAnalysisRequestPrintStatus"),
+    (CATALOG_ANALYSIS_LISTING, "getBatchUID"),
 
 ]
 

--- a/bika/lims/upgrade/v01_03_003.py
+++ b/bika/lims/upgrade/v01_03_003.py
@@ -186,6 +186,10 @@ INDEXES_TO_REMOVE = [
     (CATALOG_ANALYSIS_LISTING, "getAnalysisRequestPrintStatus"),
     (CATALOG_ANALYSIS_LISTING, "getBatchUID"),
 
+    # Only used in Add analyses (as sortable column)
+    (CATALOG_ANALYSIS_LISTING, "getClientOrderNumber"),
+    (CATALOG_ANALYSIS_LISTING, "getDateSampled"),
+
 ]
 
 METADATA_TO_REMOVE = [

--- a/bika/lims/workflow/analysisrequest/events.py
+++ b/bika/lims/workflow/analysisrequest/events.py
@@ -171,9 +171,6 @@ def after_sample(analysis_request):
     passed in is performed
     """
     analysis_request.setDateSampled(DateTime())
-    idxs = ['getDateSampled']
-    for analysis in analysis_request.getAnalyses(full_objects=True):
-        analysis.reindexObject(idxs=idxs)
 
 
 def after_rollback_to_receive(analysis_request):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request removes some stale indexes from `analysis_catalog`:

- `getAnalysisRequestPrintStatus`
- `getBatchUID`
- `getClientOrderNumber`
- `getDateSampled`

## Current behavior before PR

Stale indexes in `analysis_catalog`

## Desired behavior after PR is merged

No stale indexes in `analysis_catalog`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
