### PR TITLE
Missing canton Garabito for Puntarenas province (Costa Rica)

### DIFF
--- a/bika/lims/locales/__init__.py
+++ b/bika/lims/locales/__init__.py
@@ -18665,6 +18665,7 @@ DISTRICTS = [
  ['CR', '02', 'Cant\xc3\xb3n de Jim\xc3\xa9nez'],
  ['CR', '03', 'Cant\xc3\xb3n de Hojancha'],
  ['CR', '04', 'Cant\xc3\xb3n Central de Heredia'],
+ ['CR', '07', 'Cant\xc3\xb3n de Garabito'],
  ['CR', '01', 'Cant\xc3\xb3n de Guatuso'],
  ['CR', '06', 'Cant\xc3\xb3n de Gu\xc3\xa1cimo'],
  ['CR', '01', 'Cant\xc3\xb3n de Grecia'],


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

"Cantón de Garabito" was missing for Puntarenas province (Costa Rica)

https://en.wikipedia.org/wiki/Garabito_(canton)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
