### PR TITLE
Fix non-well formed html of default accreditation page header 

### DIFF
--- a/bika/lims/content/laboratory.py
+++ b/bika/lims/content/laboratory.py
@@ -48,7 +48,7 @@ DEFAULT_ACCREDITATION_PAGE_HEADER = """${lab_name} has been accredited as
 ${accreditation_standard} conformant by ${accreditation_body_abbr},
 ${accreditation_body_name}<br/><br/> ${accreditation_body_abbr} is the single
 national accreditation body assessing testing and calibration laboratories for
-compliance to the ISO/IEC 17025 standard.<br/></br/>\n The following analysis
+compliance to the ISO/IEC 17025 standard.<br/><br/>\n The following analysis
 services have been included in the ${accreditation_body_abbr} schedule of
 Accreditation for this Laboratory:
 """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The default string with the template text to be displayed when lab is accredited has a non-well formed element tag (`</br/>` instead of `<br/>`), causing a violation of RFC 8259 when jsonified.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
