### PR TITLE
Fix sporadical timeout issue when adding new samples/remarks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,7 @@ Changelog
 
 **Fixed**
 
+- #1522 Fix sporadical timeout issue when adding new samples/remarks
 - #1506 Changes via manage results don't get applied to partitions
 - #1506 Fix recursion error when getting dependencies through Calculation
 - #1506 setter from ARAnalysisField does no longer return values

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -1230,7 +1230,8 @@
         cache: false,
         dataType: 'json',
         processData: false,
-        contentType: false
+        contentType: false,
+        timeout: 600000
       };
       $.extend(ajax_options, options);
 
@@ -1239,6 +1240,11 @@
       $(me).trigger("ajax:start");
       return $.ajax(ajax_options).always(function(data) {
         return $(me).trigger("ajax:end");
+      }).fail(function(request, status, error) {
+        var msg;
+        msg = _("Sorry, an error occured: " + status);
+        window.bika.lims.portalMessage(msg);
+        return window.scroll(0, 0);
       });
     };
 

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -1250,6 +1250,7 @@ class window.AnalysisRequestAdd
       processData: false
       contentType: false
       # contentType: 'application/x-www-form-urlencoded; charset=UTF-8'
+      timeout: 600000  # 10 minutes timeout
 
     # Update Options
     $.extend(ajax_options, options)
@@ -1262,6 +1263,10 @@ class window.AnalysisRequestAdd
     $.ajax(ajax_options).always (data) ->
       # Always notify Ajax end
       $(me).trigger "ajax:end"
+    .fail (request, status, error) ->
+      msg = _("Sorry, an error occured: #{status}")
+      window.bika.lims.portalMessage msg
+      window.scroll 0, 0
 
 
   on_ajax_start: =>

--- a/bika/lims/browser/js/coffee/bika_widgets/remarkswidget.coffee
+++ b/bika/lims/browser/js/coffee/bika_widgets/remarkswidget.coffee
@@ -158,10 +158,15 @@ class window.RemarksWidgetView
       url: @get_portal_url() + "/@@API/update"
       data:
         obj_uid: widget.attr('data-uid')
+        timeout: 600000  # 10 minutes timeout
     options.data[fieldname] = value
     @ajax_submit options
     .done (data) ->
       return deferred.resolveWith this, [[]]
+    .fail (request, status, error) ->
+      msg = _("Sorry, an error occured: #{status}")
+      window.bika.lims.portalMessage msg
+      window.scroll 0, 0
     return deferred.promise()
 
   ### EVENT HANDLERS ###

--- a/bika/lims/skins/bika/bika_widgets/remarkswidget.js
+++ b/bika/lims/skins/bika/bika_widgets/remarkswidget.js
@@ -206,12 +206,18 @@
       options = {
         url: this.get_portal_url() + "/@@API/update",
         data: {
-          obj_uid: widget.attr('data-uid')
+          obj_uid: widget.attr('data-uid'),
+          timeout: 600000
         }
       };
       options.data[fieldname] = value;
       this.ajax_submit(options).done(function(data) {
         return deferred.resolveWith(this, [[]]);
+      }).fail(function(request, status, error) {
+        var msg;
+        msg = _("Sorry, an error occured: " + status);
+        window.bika.lims.portalMessage(msg);
+        return window.scroll(0, 0);
       });
       return deferred.promise();
     };


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR addresses sporadical timeout issues when adding new Samples or new Remarks. The problem occured first in FireFox 68 ESR so that either the "Save" button kept disabled or the dataset was not stored. 

Further information:

- https://stackoverflow.com/questions/24526201/ajax-does-setting-timeout-always-override-the-browsers-timeout
- https://bugzilla.mozilla.org/show_bug.cgi?id=1602154

## Current behavior before PR

Some browsers dropped silently some Ajax POST requests.

## Desired behavior after PR is merged

Ajax POST requests have now a timeout of 10 minutes. If the request failed, an error message is displayed to the user.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
