### PR TITLE
Fixed wrong placement of ajax timeout option

### DIFF
--- a/bika/lims/browser/js/coffee/bika_widgets/remarkswidget.coffee
+++ b/bika/lims/browser/js/coffee/bika_widgets/remarkswidget.coffee
@@ -158,15 +158,10 @@ class window.RemarksWidgetView
       url: @get_portal_url() + "/@@API/update"
       data:
         obj_uid: widget.attr('data-uid')
-        timeout: 600000  # 10 minutes timeout
     options.data[fieldname] = value
     @ajax_submit options
     .done (data) ->
       return deferred.resolveWith this, [[]]
-    .fail (request, status, error) ->
-      msg = _("Sorry, an error occured: #{status}")
-      window.bika.lims.portalMessage msg
-      window.scroll 0, 0
     return deferred.promise()
 
   ### EVENT HANDLERS ###
@@ -213,13 +208,18 @@ class window.RemarksWidgetView
     options.context ?= this
     options.dataType ?= "json"
     options.data ?= {}
+    options.timeout ?= 600000  # 10 minutes timeout
 
     console.debug ">>> ajax_submit::options=", options
 
     $(this).trigger "ajax:submit:start"
     done = ->
       $(this).trigger "ajax:submit:end"
-    return $.ajax(options).done done
+    fail = (request, status, error) ->
+      msg = _("Sorry, an error occured: #{status}")
+      window.bika.lims.portalMessage msg
+      window.scroll 0, 0
+    return $.ajax(options).done(done).fail(fail)
 
   get_portal_url: =>
     ###

--- a/bika/lims/skins/bika/bika_widgets/remarkswidget.js
+++ b/bika/lims/skins/bika/bika_widgets/remarkswidget.js
@@ -206,18 +206,12 @@
       options = {
         url: this.get_portal_url() + "/@@API/update",
         data: {
-          obj_uid: widget.attr('data-uid'),
-          timeout: 600000
+          obj_uid: widget.attr('data-uid')
         }
       };
       options.data[fieldname] = value;
       this.ajax_submit(options).done(function(data) {
         return deferred.resolveWith(this, [[]]);
-      }).fail(function(request, status, error) {
-        var msg;
-        msg = _("Sorry, an error occured: " + status);
-        window.bika.lims.portalMessage(msg);
-        return window.scroll(0, 0);
       });
       return deferred.promise();
     };
@@ -266,7 +260,7 @@
        *    jQuery ajax options
        * @returns {Deferred} XHR request
        */
-      var done;
+      var done, fail;
       console.debug("°°° ajax_submit °°°");
       if (options == null) {
         options = {};
@@ -286,12 +280,21 @@
       if (options.data == null) {
         options.data = {};
       }
+      if (options.timeout == null) {
+        options.timeout = 600000;
+      }
       console.debug(">>> ajax_submit::options=", options);
       $(this).trigger("ajax:submit:start");
       done = function() {
         return $(this).trigger("ajax:submit:end");
       };
-      return $.ajax(options).done(done);
+      fail = function(request, status, error) {
+        var msg;
+        msg = _("Sorry, an error occured: " + status);
+        window.bika.lims.portalMessage(msg);
+        return window.scroll(0, 0);
+      };
+      return $.ajax(options).done(done).fail(fail);
     };
 
     RemarksWidgetView.prototype.get_portal_url = function() {


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fix regression introduced in https://github.com/senaite/senaite.core/pull/1522 by placing the  jQuery ajax timout option at the wrong place

## Current behavior before PR

Traceback occurs:
```
Traceback (most recent call last):
  File "/Users/rbartl/.buildout/eggs/plone.jsonapi.core-0.6-py2.7.egg/plone/jsonapi/core/browser/decorators.py", line 24, in decorator
    return f(*args, **kwargs)
  File "/Users/rbartl/.buildout/eggs/plone.jsonapi.core-0.6-py2.7.egg/plone/jsonapi/core/browser/api.py", line 60, in to_json
    return self.dispatch()
  File "/Users/rbartl/.buildout/eggs/plone.jsonapi.core-0.6-py2.7.egg/plone/jsonapi/core/browser/api.py", line 54, in dispatch
    return router(self.context, self.request, path)
  File "/Users/rbartl/.buildout/eggs/plone.jsonapi.core-0.6-py2.7.egg/plone/jsonapi/core/browser/router.py", line 138, in __call__
    return self.view_functions[endpoint](context, request, **values)
  File "/Users/rbartl/develop/ridingbytes/bechem/bechem.lims/src/senaite.core/bika/lims/jsonapi/update.py", line 162, in update
    raise BadRequest("The following request fields were not used: %s.  Request aborted." % self.unused)
BadRequest: The following request fields were not used: ['timeout'].  Request aborted.
```

## Desired behavior after PR is merged

No traceback occurs


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
