### PR TITLE
Fixed legacy remarks parsing

### DIFF
--- a/bika/lims/browser/fields/remarksfield.py
+++ b/bika/lims/browser/fields/remarksfield.py
@@ -245,7 +245,7 @@ class RemarksField(ObjectField):
             line = line.strip()
 
             # split the line into date, user and content
-            groups = re.findall(r"(.*) \((.*)\)\n(.*)", line, re.DOTALL)
+            groups = re.findall(r"([A-Za-z]{3}, \d{1,2} [A-Za-z]{3} \d{2,4} \d{2}:\d{2}:\d{2} \+\d{4}) \((.*?)\)\n(.*)", line, re.DOTALL)  # noqa
 
             # we should have one tuple in the list
             if len(groups) != 1:

--- a/bika/lims/browser/fields/remarksfield.py
+++ b/bika/lims/browser/fields/remarksfield.py
@@ -238,25 +238,26 @@ class RemarksField(ObjectField):
         # === Tue, 28 Jan 2020 06:53:58 +0100 (admin)\nThis is a Test
         lines = re.split(r"(===) ([A-Za-z]{3}, \d{1,2} [A-Za-z]{3} \d{2,4} \d{2}:\d{2}:\d{2} [+-]{1}\d{4}) \((.*?)\)", text)  # noqa
 
-        entry = None
+        record = None
         records = []
 
-        # group into remark entries of date, user-id and content
+        # group into remark records of date, user-id and content
         for line in lines:
-            # start a new remarks entry when the marker was found
+            # start a new remarks record when the marker was found
             if line == "===":
-                entry = []
+                record = []
                 # immediately append the new entry to the records
-                records.append(entry)
+                records.append(record)
                 # skip the marker entry
                 continue
 
             # append the line to the entry until the next marker is found
             # -> this also skips the empty first line
-            if entry is not None:
-                entry.append(line)
+            if record is not None:
+                record.append(line)
 
         remarks = []
+
         for record in records:
             # each record must contain the date, user-id and text
             # -> we invalidate the whole parsing if this is not given

--- a/bika/lims/browser/fields/remarksfield.py
+++ b/bika/lims/browser/fields/remarksfield.py
@@ -230,47 +230,53 @@ class RemarksField(ObjectField):
 
         return remarks
 
-    def _parse_legacy_remarks(self, remarks):
-        """Parse legacy remarks
+    def _parse_legacy_remarks(self, text):
+        """Parse legacy remarks from the text
         """
+
+        # split legacy remarks on the complete delimiter, e.g.:
+        # === Tue, 28 Jan 2020 06:53:58 +0100 (admin)\nThis is a Test
+        lines = re.split(r"(===) ([A-Za-z]{3}, \d{1,2} [A-Za-z]{3} \d{2,4} \d{2}:\d{2}:\d{2} [+-]{1}\d{4}) \((.*?)\)", text)  # noqa
+
+        entry = None
         records = []
-        # split legacy remarks on the "===" delimiter into lines
-        lines = remarks.split("===")
+
+        # group into remark entries of date, user-id and content
         for line in lines:
-            # skip empty lines
-            if line == "":
+            # start a new remarks entry when the marker was found
+            if line == "===":
+                entry = []
+                # immediately append the new entry to the records
+                records.append(entry)
+                # skip the marker entry
                 continue
 
-            # strip leading and trailing whitespaces
-            line = line.strip()
+            # append the line to the entry until the next marker is found
+            # -> this also skips the empty first line
+            if entry is not None:
+                entry.append(line)
 
-            # split the line into date, user and content
-            groups = re.findall(r"([A-Za-z]{3}, \d{1,2} [A-Za-z]{3} \d{2,4} \d{2}:\d{2}:\d{2} \+\d{4}) \((.*?)\)\n(.*)", line, re.DOTALL)  # noqa
-
-            # we should have one tuple in the list
-            if len(groups) != 1:
-                continue
-
-            group = groups[0]
-
-            # cancel the whole parsing
-            if len(group) != 3:
+        remarks = []
+        for record in records:
+            # each record must contain the date, user-id and text
+            # -> we invalidate the whole parsing if this is not given
+            if len(record) != 3:
                 return None
 
-            created, userid, content = group
+            created, userid, content = record
 
             # try to get the full name of the user id
             fullname = self._get_fullname_from_user_id(userid)
 
-            # append the record
-            records.append({
-                "created": created,
-                "user_id": userid,
-                "user_name": fullname,
-                "content": content,
+            # append a remarks record
+            remarks.append({
+               "created": created,
+               "user_id": userid,
+               "user_name": fullname,
+               "content": content,
             })
 
-        return records
+        return remarks
 
     def _get_fullname_from_user_id(self, userid, default=""):
         """Try the fullname of the user

--- a/bika/lims/browser/fields/remarksfield.py
+++ b/bika/lims/browser/fields/remarksfield.py
@@ -268,6 +268,9 @@ class RemarksField(ObjectField):
             # try to get the full name of the user id
             fullname = self._get_fullname_from_user_id(userid)
 
+            # strip off leading and trailing escape sequences from the content
+            content = content.strip("\n\r\t")
+
             # append a remarks record
             remarks.append({
                "created": created,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the legacy remarks parser which was introduced in this PR https://github.com/senaite/senaite.core/pull/1495

## Current behavior before PR

Legacy remarks might get parsed wrong when they contain braces in the text.

## Desired behavior after PR is merged

Legacy remarks get parsed correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
