### PR TITLE
Fix traceback from log when rendering stickers preview

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,7 @@ Changelog
 
 **Fixed**
 
+- #1533 Fix traceback from log when rendering stickers preview
 - #1525 Fix error when creating partitions with analyst user
 - #1522 Fix sporadical timeout issue when adding new samples/remarks
 - #1506 Changes via manage results don't get applied to partitions

--- a/bika/lims/browser/templates/stickers_preview.pt
+++ b/bika/lims/browser/templates/stickers_preview.pt
@@ -273,10 +273,8 @@
           </tal:tick>
         </div>
         <tal:stickers repeat="item view/items">
-          <tal:sticker define="item_id python:item.getId()">
-            <div class='sticker'
-                 tal:content='structure python:view.renderItem(item)'></div>
-          </tal:sticker>
+          <div class='sticker'
+               tal:content='structure python:view.renderItem(item)'></div>
         </tal:stickers>
       </div>
     </div>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The following traceback is displayed in the logs:

```
2020-02-12 19:56:30 ERROR Zope.SiteErrorLog 1581533790.770.737304526271
http://localhost:9090/senaite/analysisrequests/sticker
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.stickers, line 110, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 173, in render
  Module chameleon.zpt.template, line 306, in render
  Module chameleon.template, line 209, in render
  Module chameleon.template, line 187, in render
  Module d402a41447f69cd9d5f4e48a0edd52e6.py, line 827, in render
  Module senaite.core.supermodel.model, line 138, in __getattr__
  Module senaite.core.supermodel.model, line 185, in get
  Module senaite.core.supermodel.model, line 171, in get_field
  Module senaite.core.supermodel.model, line 276, in instance
  Module senaite.core.supermodel.model, line 285, in brain
  Module senaite.core.supermodel.model, line 323, in get_brain_by_uid
ValueError: No results found for UID '1aa9f10c4d3d4e0b8ebb7ad339e6257f'

 - Expression: "python:item.getId()"
 - Filename:   ... ite.core/bika/lims/browser/templates/stickers_preview.pt
 - Location:   (line 276: col 39)
 - Source:     ... sticker define="item_id python:item.getId()">
```

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
