### PR TITLE
Integrated Setup and Profiles from senaite.lims

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changelog
 
 **Added**
 
+- #1536 Integrated Setup and Profiles from senaite.lims
 - #1534 Integrate browser resources from senaite.lims
 - #1529 Moved contentmenu provider into core
 - #1523 Moved Installation Screens into core

--- a/bika/lims/profiles/default/actions.xml
+++ b/bika/lims/profiles/default/actions.xml
@@ -1,26 +1,23 @@
 <?xml version="1.0"?>
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-	name="portal_actions"
-	meta_type="Plone Actions Tool"
-	purge="True">
+        name="portal_actions"
+        meta_type="Plone Actions Tool"
+        purge="True">
 
-	<action-provider name="portal_actions"/>
-
-	<!-- hide the "sharing" tab on a list of types.
-             This is here to avoid hiding the sharing tab globally -->
-
-	<object name="object" meta_type="CMF Action Category" purge="True">
-		<property name="title"/>
-		<object name="local_roles" meta_type="CMF Action" i18n:domain="plone">
-			<property name="title" i18n:translate="">Sharing</property>
-			<property name="description" i18n:translate=""/>
-			<property name="url_expr">string:${object_url}/@@sharing</property>
-			<property name="link_target"/>
-			<property name="icon_expr"/>
-			<property name="available_expr">python:here.portal_type not in ['Client', 'ClientFolder']</property>
-			<property name="permissions"/>
-			<property name="visible">False</property>
-		</object>
+  <!-- Object actions -->
+  <object name="object" meta_type="CMF Action Category" purge="True">
+    <!-- hide the "sharing" tab on a list of types.
+         This is here to avoid hiding the sharing tab globally -->
+    <object name="local_roles" meta_type="CMF Action" i18n:domain="plone">
+      <property name="title" i18n:translate="">Sharing</property>
+      <property name="description" i18n:translate=""/>
+      <property name="url_expr">string:${object_url}/@@sharing</property>
+      <property name="link_target"/>
+      <property name="icon_expr"/>
+      <property name="available_expr">python:here.portal_type not in ['Client', 'ClientFolder']</property>
+      <property name="permissions"/>
+      <property name="visible">False</property>
+    </object>
     <!-- Audit Log -->
     <object name="auditlog" meta_type="CMF Action" i18n:domain="senaite.core">
       <property name="title" i18n:translate="">Audit Log</property>
@@ -34,131 +31,75 @@
       </property>
       <property name="visible">True</property>
     </object>
-	</object>
+  </object>
 
-	<object name="portal_tabs" meta_type="CMF Action Category" purge="True">
-		<property name="title"/>
-		<object name="index_html" meta_type="CMF Action" i18n:domain="plone">
-			<property name="title" i18n:translate="">Home</property>
-			<property name="description" i18n:translate=""/>
-			<property name="url_expr">string:${globals_view/navigationRootUrl}</property>
-			<property name="link_target"/>
-			<property name="icon_expr"/>
-			<property name="available_expr"/>
-			<property name="permissions">
-				<element value="View"/>
-			</property>
-			<property name="visible">False</property>
-		</object>
-		<object name="front-page" meta_type="CMF Action" i18n:domain="plone">
-			<property name="title" i18n:translate="">Home</property>
-			<property name="description" i18n:translate=""/>
-			<property name="url_expr">string:${globals_view/navigationRootUrl}</property>
-			<property name="link_target"/>
-			<property name="icon_expr"/>
-			<property name="available_expr"/>
-			<property name="permissions">
-				<element value="View"/>
-			</property>
-			<property name="visible">False</property>
-		</object>
-		<object name="analysisrequests" meta_type="CMF Action" i18n:domain="plone">
-			<property name="title" i18n:translate="">Samples</property>
-			<property name="description" i18n:translate=""/>
-			<property name="url_expr">string:$portal_url/analysisrequests</property>
-			<property name="link_target"/>
-			<property name="icon_expr"/>
-			<property name="available_expr"/>
-			<property name="permissions">
-				<element value="senaite.core: Manage Analysis Requests"/>
-			</property>
-			<property name="visible">False</property>
-		</object>
-		<object name="worksheets" meta_type="CMF Action" i18n:domain="plone">
-			<property name="title" i18n:translate="">Worksheets</property>
-			<property name="description" i18n:translate=""/>
-			<property name="url_expr">string:$portal_url/worksheets</property>
-			<property name="link_target"/>
-			<property name="icon_expr"/>
-			<property name="available_expr"/>
-			<property name="permissions">
-				<element value="senaite.core: Manage Worksheets"/>
-			</property>
-			<property name="visible">False</property>
-		</object>
-		<object name="suppliers" meta_type="CMF Action" i18n:domain="plone">
-			<property name="title" i18n:translate="">Suppliers</property>
-			<property name="description" i18n:translate=""/>
-			<property name="url_expr">string:$portal_url/suppliers</property>
-			<property name="link_target"/>
-			<property name="icon_expr"/>
-			<property name="available_expr"/>
-			<property name="permissions">
-				<element value="senaite.core: Manage Reference Suppliers"/>
-			</property>
-			<property name="visible">False</property>
-		</object>
-		<object name="referencesamples" meta_type="CMF Action" i18n:domain="plone">
-			<property name="title" i18n:translate="">Reference Samples</property>
-			<property name="description" i18n:translate=""/>
-			<property name="url_expr">string:$portal_url/referencesamples</property>
-			<property name="link_target"/>
-			<property name="icon_expr"/>
-			<property name="available_expr"/>
-			<property name="permissions">
-				<element value="senaite.core: Manage Reference"/>
-			</property>
-			<property name="visible">False</property>
-		</object>
-		<object name="extracts" meta_type="CMF Action" i18n:domain="plone">
-			<property name="title" i18n:translate="">Extracts</property>
-			<property name="description" i18n:translate=""/>
-			<property name="url_expr">string:$portal_url/extracts</property>
-			<property name="link_target"/>
-			<property name="icon_expr"/>
-			<property name="available_expr"/>
-			<property name="permissions">
-				<element value="List portal members"/>
-			</property>
-			<property name="visible">False</property>
-		</object>
-		<object name="reset_services" meta_type="CMF Action" i18n:domain="plone">
-			<property name="title" i18n:translate="">Prices</property>
-			<property name="description" i18n:translate=""/>
-			<property name="url_expr">string:$portal_url/setanalyses</property>
-			<property name="link_target"/>
-			<property name="icon_expr"/>
-			<property name="available_expr"/>
-			<property name="permissions">
-				<element value="List portal members"/>
-			</property>
-			<property name="visible">False</property>
-		</object>
-		<object name="reports" meta_type="CMF Action" i18n:domain="plone">
-			<property name="title" i18n:translate="">Report</property>
-			<property name="description" i18n:translate=""/>
-			<property name="url_expr">string:$portal_url/reports</property>
-			<property name="link_target"/>
-			<property name="icon_expr"/>
-			<property name="available_expr"/>
-			<property name="permissions">
-				<element value="List portal members"/>
-			</property>
-			<property name="visible">True</property>
-		</object>
-		<object name="import" meta_type="CMF Action" i18n:domain="plone">
-			<property name="title" i18n:translate="">Import</property>
-			<property name="description" i18n:translate=""/>
-			<property name="url_expr">string:$portal_url/import</property>
-			<property name="link_target"/>
-			<property name="icon_expr"/>
-			<property name="available_expr"/>
-			<property name="permissions">
-				<element value="senaite.core: Import Instrument Results"/>
-			</property>
-			<property name="visible">True</property>
-		</object>
-    <!-- Search -->
+  <!-- Folder Buttons -->
+  <object name="folder_buttons">
+    <object name="copy">
+      <property name="visible">False</property>
+    </object>
+    <object name="cut">
+      <property name="visible">False</property>
+    </object>
+    <object name="paste">
+      <property name="visible">False</property>
+    </object>
+    <object name="delete">
+      <property name="visible">False</property>
+    </object>
+    <object name="rename">
+      <property name="visible">False</property>
+    </object>
+  </object>
+
+  <!-- Object Buttons -->
+  <object name="object_buttons">
+    <object name="copy">
+      <property name="visible">False</property>
+    </object>
+    <object name="cut">
+      <property name="visible">False</property>
+    </object>
+    <object name="paste">
+      <property name="visible">False</property>
+    </object>
+    <object name="delete">
+      <property name="visible">False</property>
+    </object>
+    <object name="rename">
+      <property name="visible">False</property>
+    </object>
+  </object>
+
+  <!-- Portal Tabs (Located in the upper right button) -->
+  <object name="portal_tabs" meta_type="CMF Action Category" purge="True">
+    <!-- Reports -->
+    <object name="reports" meta_type="CMF Action" i18n:domain="plone">
+      <property name="title" i18n:translate="">Report</property>
+      <property name="description" i18n:translate=""/>
+      <property name="url_expr">string:$portal_url/reports</property>
+      <property name="link_target"/>
+      <property name="icon_expr"/>
+      <property name="available_expr"/>
+      <property name="permissions">
+        <element value="senaite.core: Manage Analysis Requests"/>
+      </property>
+      <property name="visible">True</property>
+    </object>
+    <!-- Import -->
+    <object name="import" meta_type="CMF Action" i18n:domain="plone">
+      <property name="title" i18n:translate="">Import</property>
+      <property name="description" i18n:translate=""/>
+      <property name="url_expr">string:$portal_url/import</property>
+      <property name="link_target"/>
+      <property name="icon_expr"/>
+      <property name="available_expr"/>
+      <property name="permissions">
+        <element value="senaite.core: Import Instrument Results"/>
+      </property>
+      <property name="visible">True</property>
+    </object>
+    <!-- Spotlight Search View -->
     <object name="spotlight_search" meta_type="CMF Action" i18n:domain="plone">
       <property name="title" i18n:translate="">Search</property>
       <property name="description" i18n:translate=""/>
@@ -172,17 +113,17 @@
       <property name="visible">True</property>
     </object>
     <!-- Audit Log -->
-		<object name="auditlog" meta_type="CMF Action" i18n:domain="plone">
-			<property name="title" i18n:translate="">Audit Log</property>
-			<property name="description" i18n:translate=""/>
-			<property name="url_expr">string:$portal_url/bika_setup/auditlog</property>
-			<property name="link_target"/>
-			<property name="icon_expr"/>
-			<property name="available_expr"/>
-			<property name="permissions">
-				<element value="senaite.core: View Log Tab"/>
-			</property>
-			<property name="visible">True</property>
+    <object name="auditlog" meta_type="CMF Action" i18n:domain="plone">
+      <property name="title" i18n:translate="">Audit Log</property>
+      <property name="description" i18n:translate=""/>
+      <property name="url_expr">string:$portal_url/bika_setup/auditlog</property>
+      <property name="link_target"/>
+      <property name="icon_expr"/>
+      <property name="available_expr"/>
+      <property name="permissions">
+        <element value="senaite.core: View Log Tab"/>
+      </property>
+      <property name="visible">True</property>
 		</object>
 	</object>
 </object>

--- a/bika/lims/profiles/default/portal_languages.xml
+++ b/bika/lims/profiles/default/portal_languages.xml
@@ -1,38 +1,23 @@
 <?xml version="1.0"?>
 <object>
- <default_language value="en"/>
- <use_path_negotiation value="False"/>
- <use_cookie_negotiation value="False"/>
- <set_cookie_everywhere value="False"/>
- <use_request_negotiation value="True"/>
- <use_cctld_negotiation value="False"/>
- <use_content_negotiation value="False"/>
- <use_combined_language_codes value="True"/>
- <display_flags value="False"/>
- <start_neutral value="False"/>
- <use_subdomain_negotiation value="False"/>
- <authenticated_users_only value="False"/>
- <supported_langs>
-  <element value="af"/>
-  <element value="bn"/>
-  <element value="ca"/>
-  <element value="zh"/>
-  <element value="nl"/>
-  <element value="en"/>
-  <element value="fr"/>
-  <element value="de"/>
-  <element value="el"/>
-  <element value="hi"/>
-  <element value="id"/>
-  <element value="it"/>
-  <element value="ja"/>
-  <element value="kn"/>
-  <element value="pl"/>
-  <element value="pt"/>
-  <element value="ru"/>
-  <element value="es"/>
-  <element value="ta"/>
-  <element value="uk"/>
-  <element value="ur"/>
- </supported_langs>
+  <default_language value="en"/>
+  <use_path_negotiation value="False"/>
+  <use_cookie_negotiation value="True"/>
+  <set_cookie_everywhere value="False"/>
+  <use_request_negotiation value="True"/>
+  <use_cctld_negotiation value="False"/>
+  <use_content_negotiation value="False"/>
+  <use_combined_language_codes value="True"/>
+  <display_flags value="False"/>
+  <start_neutral value="False"/>
+  <use_subdomain_negotiation value="False"/>
+  <authenticated_users_only value="False"/>
+  <supported_langs>
+    <element value="en"/>
+    <element value="es"/>
+    <element value="de"/>
+    <element value="cn"/>
+    <element value="th"/>
+    <element value="pl"/>
+  </supported_langs>
 </object>

--- a/bika/lims/profiles/default/portal_languages.xml
+++ b/bika/lims/profiles/default/portal_languages.xml
@@ -13,11 +13,11 @@
   <use_subdomain_negotiation value="False"/>
   <authenticated_users_only value="False"/>
   <supported_langs>
+    <element value="de"/>
     <element value="en"/>
     <element value="es"/>
-    <element value="de"/>
-    <element value="cn"/>
-    <element value="th"/>
     <element value="pl"/>
+    <element value="th"/>
+    <element value="zh"/>
   </supported_langs>
 </object>

--- a/bika/lims/profiles/default/portlets.xml
+++ b/bika/lims/profiles/default/portlets.xml
@@ -1,19 +1,15 @@
 <?xml version="1.0"?>
 <portlets
-    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-    i18n:domain="plone">
+  xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+  i18n:domain="plone">
 
-  <assignment
-    name="navigation"
-    category="context"
-    key="/"
-    manager="plone.leftcolumn"
-    type="portlets.Navigation"
-    visible="True">
+  <!-- Navigation Portlet -->
+  <assignment name="navigation" category="context" key="/"
+              manager="plone.leftcolumn" type="portlets.Navigation" visible="True">
     <property name="topLevel">0</property>
     <property name="currentFolderOnly">False</property>
     <property name="name">Navigation</property>
-    <property name="includeTop">True</property>
+    <property name="includeTop">False</property>
     <property name="bottomLevel">0</property>
     <property name="root"/>
   </assignment>

--- a/bika/lims/setuphandlers.py
+++ b/bika/lims/setuphandlers.py
@@ -28,6 +28,8 @@ from bika.lims.catalog import getCatalogDefinitions
 from bika.lims.catalog import setup_catalogs
 from bika.lims.catalog.catalog_utilities import addZCTextIndex
 from plone import api as ploneapi
+from plone.app.controlpanel.filter import IFilterSchema
+
 
 PROFILE_ID = "profile-bika.lims:default"
 
@@ -233,6 +235,11 @@ COLUMNS = (
     ("portal_catalog", "Analyst"),
 )
 
+ALLOWED_STYLES = [
+    "color",
+    "background-color"
+]
+
 
 def pre_install(portal_setup):
     """Runs before the first import step of the *default* profile
@@ -289,6 +296,7 @@ def setup_handler(context):
     setup_catalog_mappings(portal)
     setup_core_catalogs(portal)
     add_dexterity_setup_items(portal)
+    setup_html_filter(portal)
 
     # Setting up all LIMS catalogs defined in catalog folder
     setup_catalogs(portal, getCatalogDefinitions())
@@ -527,3 +535,17 @@ def add_dexterity_setup_items(portal):
 
     # Enable content type filtering
     ti.filter_content_types = True
+
+
+def setup_html_filter(portal):
+    """Setup HTML filtering for resultsinterpretations
+    """
+    logger.info("*** Setup HTML Filter ***")
+    # bypass the broken API from portal_transforms
+    adapter = IFilterSchema(portal)
+    style_whitelist = adapter.style_whitelist
+    for style in ALLOWED_STYLES:
+        logger.info("Allow style '{}'".format(style))
+        if style not in style_whitelist:
+            style_whitelist.append(style)
+    adapter.style_whitelist = style_whitelist

--- a/bika/lims/upgrade/v01_03_003.py
+++ b/bika/lims/upgrade/v01_03_003.py
@@ -354,6 +354,9 @@ def upgrade(tool):
     remove_stale_css(portal)
     remove_stale_javascripts(portal)
 
+    # setup portal languages
+    setup.runImportStepFromProfile(profile, "languagetool")
+
     # setup html filtering
     setup_html_filter(portal)
 

--- a/bika/lims/upgrade/v01_03_003.py
+++ b/bika/lims/upgrade/v01_03_003.py
@@ -33,6 +33,7 @@ from bika.lims.interfaces import ISubmitted
 from bika.lims.interfaces import IVerified
 from bika.lims.setuphandlers import add_dexterity_setup_items
 from bika.lims.setuphandlers import setup_form_controller_actions
+from bika.lims.setuphandlers import setup_html_filter
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
 from Products.Archetypes.config import UID_CATALOG
@@ -352,6 +353,9 @@ def upgrade(tool):
     # remove stale CSS/JS resources
     remove_stale_css(portal)
     remove_stale_javascripts(portal)
+
+    # setup html filtering
+    setup_html_filter(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is complementary to https://github.com/senaite/senaite.lims/pull/122 and integrates the profiles and setup handlers.

## Current behavior before PR

some profiles and setup handlers located in senaite.lims 

## Desired behavior after PR is merged

all profiles and setup handlers located in senaite.core

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
