### PR TITLE
Avoid unnecessary Price recalculations in Sample Add Form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Changelog
 
 **Changed**
 
+- #1539 Avoid unnecessary Price recalculations in Sample Add Form
 - #1532 Updated jQuery Barcode to version 2.2.0
 - #1513 Better Ajax Loader for Sample Add Form
 - #1508 Do not try to render InstrumentQCFailuresViewlet to non-lab personnel

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -104,7 +104,7 @@
       $("body").on("click", "img.copybutton", this.on_copy_button_click);
 
       /* internal events */
-      $(this).on("form:changed", this.debounce(this.recalculate_records));
+      $(this).on("form:changed", this.debounce(this.recalculate_records, 1500));
       $(this).on("services:changed", this.debounce(this.recalculate_prices, 3000));
       $(this).on("data:updated", this.debounce(this.update_form));
       $(this).on("data:updated", this.debounce(this.hide_all_service_info));

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -104,10 +104,10 @@
       $("body").on("click", "img.copybutton", this.on_copy_button_click);
 
       /* internal events */
-      $(this).on("form:changed", this.debounce(this.recalculate_records, 500));
-      $(this).on("data:updated", this.debounce(this.recalculate_prices, 3000));
-      $(this).on("data:updated", this.debounce(this.update_form, 300));
-      $(this).on("data:updated", this.debounce(this.hide_all_service_info, 300));
+      $(this).on("form:changed", this.debounce(this.recalculate_records));
+      $(this).on("services:changed", this.debounce(this.recalculate_prices, 3000));
+      $(this).on("data:updated", this.debounce(this.update_form));
+      $(this).on("data:updated", this.debounce(this.hide_all_service_info));
       $(this).on("ajax:start", this.on_ajax_start);
       return $(this).on("ajax:end", this.on_ajax_end);
     };
@@ -135,7 +135,7 @@
         } else if (execAsap) {
           func.apply(obj, args);
         }
-        return timeout = setTimeout(delayed, threshold || 100);
+        return timeout = setTimeout(delayed, threshold || 300);
       };
     };
 
@@ -645,11 +645,15 @@
       var el, poc;
       console.debug("*** set_service::AR=" + arnum + " UID=" + uid + " checked=" + checked);
       el = $("td[fieldname='Analyses-" + arnum + "'] #cb_" + arnum + "_" + uid);
+      if (el.is(":checked") === checked) {
+        return;
+      }
       el.prop("checked", checked);
       poc = el.closest("tr[poc]").attr("poc");
       if (this.is_poc_expanded(poc)) {
-        return el.closest("tr").addClass("visible");
+        el.closest("tr").addClass("visible");
       }
+      return $(this).trigger("services:changed");
     };
 
     AnalysisRequestAdd.prototype.set_service_spec = function(arnum, uid, spec) {
@@ -1006,7 +1010,8 @@
       $el = $(el);
       uid = $el.val();
       console.debug("°°° on_analysis_click::UID=" + uid + " checked=" + checked + "°°°");
-      return $(me).trigger("form:changed");
+      $(me).trigger("form:changed");
+      return $(me).trigger("services:changed");
     };
 
     AnalysisRequestAdd.prototype.on_service_listing_header_click = function(event) {
@@ -1114,7 +1119,7 @@
         console.debug("-> Copy checkbox field");
         $el = $(el);
         checked = $el.prop("checked");
-        return $.each((function() {
+        $.each((function() {
           results1 = [];
           for (var j = 1; 1 <= ar_count ? j <= ar_count : j >= ar_count; 1 <= ar_count ? j++ : j--){ results1.push(j); }
           return results1;
@@ -1127,6 +1132,9 @@
           _el = $(_td).find("input[type=checkbox]")[index];
           return $(_el).prop("checked", checked);
         });
+        if ($el.hasClass("analysisservice-cb")) {
+          return $(me).trigger("services:changed");
+        }
       });
       $td1.find("select").each(function(index, el) {
         var j, results1;

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -97,13 +97,13 @@ class window.AnalysisRequestAdd
     ### internal events ###
 
     # handle value changes in the form
-    $(this).on "form:changed", @debounce @recalculate_records, 500
-    # recalculate prices after data changed
-    $(this).on "data:updated", @debounce @recalculate_prices, 3000
+    $(this).on "form:changed", @debounce @recalculate_records
+    # recalculate prices after services changed
+    $(this).on "services:changed", @debounce @recalculate_prices, 3000
     # update form from records after the data changed
-    $(this).on "data:updated", @debounce @update_form, 300
+    $(this).on "data:updated", @debounce @update_form
     # hide open service info after data changed
-    $(this).on "data:updated", @debounce @hide_all_service_info, 300
+    $(this).on "data:updated", @debounce @hide_all_service_info
     # handle Ajax events
     $(this).on "ajax:start", @on_ajax_start
     $(this).on "ajax:end", @on_ajax_end
@@ -116,7 +116,7 @@ class window.AnalysisRequestAdd
     ###
     timeout = null
 
-    (args...) ->
+    return (args...) ->
       obj = this
       delayed = ->
         func.apply(obj, args) unless execAsap
@@ -125,7 +125,7 @@ class window.AnalysisRequestAdd
         clearTimeout(timeout)
       else if (execAsap)
         func.apply(obj, args)
-      timeout = setTimeout delayed, threshold || 100
+      timeout = setTimeout(delayed, threshold || 300)
 
 
   template_dialog: (template_id, context, buttons) =>
@@ -650,6 +650,9 @@ class window.AnalysisRequestAdd
     console.debug "*** set_service::AR=#{arnum} UID=#{uid} checked=#{checked}"
     # get the service checkbox element
     el = $("td[fieldname='Analyses-#{arnum}'] #cb_#{arnum}_#{uid}")
+    # avoid unneccessary event triggers if the checkbox status is unchanged
+    if el.is(":checked") == checked
+      return
     # select the checkbox
     el.prop "checked", checked
     # get the point of capture of this element
@@ -657,6 +660,8 @@ class window.AnalysisRequestAdd
     # make the element visible if the categories are visible
     if @is_poc_expanded poc
       el.closest("tr").addClass "visible"
+    # trigger event for price recalculation
+    $(@).trigger "services:changed"
 
 
   set_service_spec: (arnum, uid, spec) =>
@@ -1048,6 +1053,8 @@ class window.AnalysisRequestAdd
 
     # trigger form:changed event
     $(me).trigger "form:changed"
+    # trigger event for price recalculation
+    $(me).trigger "services:changed"
 
 
   on_service_listing_header_click: (event) =>
@@ -1169,6 +1176,9 @@ class window.AnalysisRequestAdd
         _td = $tr.find("td[arnum=#{arnum}]")
         _el = $(_td).find("input[type=checkbox]")[index]
         $(_el).prop "checked", checked
+      # trigger event for price recalculation
+      if $el.hasClass "analysisservice-cb"
+        $(me).trigger "services:changed"
 
     # Copy <select> fields
     $td1.find("select").each (index, el) ->

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -97,7 +97,7 @@ class window.AnalysisRequestAdd
     ### internal events ###
 
     # handle value changes in the form
-    $(this).on "form:changed", @debounce @recalculate_records
+    $(this).on "form:changed", @debounce @recalculate_records, 1500
     # recalculate prices after services changed
     $(this).on "services:changed", @debounce @recalculate_prices, 3000
     # update form from records after the data changed


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR improves the performance of the Sample Add form when Prices are displayed

## Current behavior before PR

Prices are recalculated for every change

## Desired behavior after PR is merged

Prices are only recalculated when Analyses, Analysis Profiles or an Analysis Template changed.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
