### PR TITLE
Fix flushing CCEmail fields in Sample Add Form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,7 @@ Changelog
 
 **Fixed**
 
+- #1540 Fix flushing CCEmail fields in Sample Add Form
 - #1533 Fix traceback from log when rendering stickers preview
 - #1525 Fix error when creating partitions with analyst user
 - #1522 Fix sporadical timeout issue when adding new samples/remarks

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -826,7 +826,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
         # Set default CC Email field
         info["field_values"].update({
-            "CCEmails": {"value": obj.getCCEmails()}
+            "CCEmails": {"value": obj.getCCEmails(), "if_empty": True}
         })
 
         # UID of the client

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -421,7 +421,7 @@
       values_json = $.toJSON(values);
       field = $("#" + field_name + ("-" + arnum));
       if ((values.if_empty != null) && values.if_empty === true) {
-        if (field.val() !== "") {
+        if (field.val()) {
           return;
         }
       }

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -421,7 +421,7 @@
       values_json = $.toJSON(values);
       field = $("#" + field_name + ("-" + arnum));
       if ((values.if_empty != null) && values.if_empty === true) {
-        if (!field.val()) {
+        if (field.val() !== "") {
           return;
         }
       }

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -415,7 +415,7 @@ class window.AnalysisRequestAdd
 
     if values.if_empty? and values.if_empty is true
       # Set the value if the field is empty only
-      if field.val() isnt ""
+      if field.val()
         return
 
     console.debug "apply_dependent_value: field_name=#{field_name} field_values=#{values_json}"

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -415,7 +415,7 @@ class window.AnalysisRequestAdd
 
     if values.if_empty? and values.if_empty is true
       # Set the value if the field is empty only
-      if not field.val()
+      if field.val() isnt ""
         return
 
     console.debug "apply_dependent_value: field_name=#{field_name} field_values=#{values_json}"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a bug in Sample Add form, so that CCEmails are always flushed

## Current behavior before PR

It is not possible to add CC Emails in Sample Add form when the form is opened for a specific client

## Desired behavior after PR is merged

It is possible to add new CC Emails in Sample Add form and combine them with the default Emails set for this client

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
