### PR TITLE
Fix sporadical errors when contacts do not have a valid email address

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,7 @@ Changelog
 
 **Fixed**
 
+- #1542 Fix sporadical errors when contacts do not have a valid email address
 - #1540 Fix flushing CCEmail fields in Sample Add Form
 - #1533 Fix traceback from log when rendering stickers preview
 - #1525 Fix error when creating partitions with analyst user

--- a/bika/lims/content/person.py
+++ b/bika/lims/content/person.py
@@ -101,6 +101,7 @@ schema = BikaSchema.copy() + Schema((
         widget=StringWidget(
             label=_("Email Address"),
         ),
+        validators=("isEmail", )
     ),
 
     StringField(


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

User can set invalid email addresses for `Contact`, `LabContact` and other types that inherit from `Person` content type. This leads to sporadic errors in views or templates that expect valid email address format.

## Current behavior before PR

User can assign invalid email addresses in "Email address" field from contacts

## Desired behavior after PR is merged

User cannot assign invalid email addresses in "Email address" field from contacts

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
