### PR TITLE
Sort navigation child-nodes alphabetically

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ Changelog
 
 **Changed**
 
+- #1543 Sort navigation child-nodes alphabetically
 - #1539 Avoid unnecessary Price recalculations in Sample Add Form
 - #1532 Updated jQuery Barcode to version 2.2.0
 - #1513 Better Ajax Loader for Sample Add Form

--- a/bika/lims/browser/portlets/templates/plone.app.portlets.portlets.navigation_recurse.pt
+++ b/bika/lims/browser/portlets/templates/plone.app.portlets.portlets.navigation_recurse.pt
@@ -50,7 +50,7 @@
           <tal:children condition="has_children">
             <ul tal:attributes="class python:'nav submenu nav-level-'+str(level)"
                 tal:condition="python: len(children) > 0 and show_children and bottomLevel and level < bottomLevel or True">
-              <span tal:replace="structure python:view.recurse(children=children, level=level+1, bottomLevel=bottomLevel)" />
+              <span tal:replace="structure python:view.recurse(children=sorted(children, key=lambda n: n.get('Title')), level=level+1, bottomLevel=bottomLevel)" />
             </ul>
           </tal:children>
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR sorts the child nodes in the portal navigation alphabetically.
Currently the Setup is the only place where this is the case.

## Current behavior before PR

Setup items in navigation portlet are sorted by object position in parent

## Desired behavior after PR is merged

Setup items in navigation portlet are sorted by their Title.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
