### PR TITLE
Safe removal of ARImport folder (and keep the type)

### DIFF
--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -1070,3 +1070,14 @@ class IHaveAnalysisCategory(Interface):
     def getCategoryTitle(self):
         """Returns the title of the category(ies) assigned to this instance
         """
+
+
+# Legacy types to remove after 1.3.3
+class IARImportFolder(Interface):
+    """Marker interface for a folder that contains ARImports
+    """
+
+
+class IARImport(Interface):
+    """Marker interface for an ARImport
+    """

--- a/bika/lims/upgrade/v01_03_003.py
+++ b/bika/lims/upgrade/v01_03_003.py
@@ -377,6 +377,9 @@ def upgrade(tool):
     # setup html filtering
     setup_html_filter(portal)
 
+    # Remove ARImports folder
+    remove_arimports(portal)
+
     # remove stale type regsitrations
     # https://github.com/senaite/senaite.core/pull/1530
     remove_stale_type_registrations(portal)
@@ -858,3 +861,18 @@ def fix_email_address(portal, portal_types=None, catalog_id="portal_catalog"):
                             .format(email_address))
 
     logger.info("Fixing email addresses [DONE]")
+
+
+def remove_arimports(portal):
+    """Removes arimports folder
+    """
+    logger.info("Removing AR Imports folder")
+
+    arimports = portal.get("arimports")
+    if arimports is None:
+        return
+
+    # delete de arimports folder
+    portal.manage_delObjects(arimports.getId())
+
+    logger.info("Removing AR Imports folder [DONE]")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

If the type IARImport is not kept (in bika.lims.interfaces), the only way to run the upgrade step is by typing directly the ZMI's add-on upgrade URL in the browser. And even that, there is no way later to access to the instance because the `arimports` folder is still there and the following Traceback arises:

```
2020-02-16 15:44:07 ERROR Zope.SiteErrorLog 1581882247.640.730868485071 http://localhost:9090/senaite/manage_main
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Shared.DC.Scripts.Bindings, line 322, in __call__
  Module Shared.DC.Scripts.Bindings, line 359, in _bindAndExec
  Module App.special_dtml, line 185, in _exec
  Module DocumentTemplate.DT_Let, line 77, in render
  Module DocumentTemplate.DT_In, line 647, in renderwob
  Module DocumentTemplate.DT_In, line 772, in sort_sequence
SystemError: NULL result without error in PyObject_Call
2020-02-16 15:46:24 ERROR ZODB.Connection Couldn't load state for 0x1ac2
Traceback (most recent call last):
  File "/home/senaite/buildout-cache/eggs/ZODB3-3.10.7-py2.7-linux-x86_64.egg/ZODB/Connection.py", line 860, in setstate
    self._setstate(obj)
  File "/home/senaite/buildout-cache/eggs/ZODB3-3.10.7-py2.7-linux-x86_64.egg/ZODB/Connection.py", line 914, in _setstate
    self._reader.setGhostState(obj, p)
  File "/home/senaite/buildout-cache/eggs/ZODB3-3.10.7-py2.7-linux-x86_64.egg/ZODB/serialize.py", line 612, in setGhostState
    state = self.getState(pickle)
  File "/home/senaite/buildout-cache/eggs/ZODB3-3.10.7-py2.7-linux-x86_64.egg/ZODB/serialize.py", line 605, in getState
    return unpickler.load()
  File "/home/senaite/buildout-cache/eggs/zope.interface-3.6.7-py2.7-linux-x86_64.egg/zope/interface/declarations.py", line 756, in Provides
    spec = ProvidesClass(*interfaces)
  File "/home/senaite/buildout-cache/eggs/zope.interface-3.6.7-py2.7-linux-x86_64.egg/zope/interface/declarations.py", line 659, in __init__
    Declaration.__init__(self, *(interfaces + (implementedBy(cls), )))
  File "/home/senaite/buildout-cache/eggs/zope.interface-3.6.7-py2.7-linux-x86_64.egg/zope/interface/declarations.py", line 45, in __init__
    Specification.__init__(self, _normalizeargs(interfaces))
  File "/home/senaite/buildout-cache/eggs/zope.interface-3.6.7-py2.7-linux-x86_64.egg/zope/interface/declarations.py", line 1382, in _normalizeargs
    _normalizeargs(v, output)
  File "/home/senaite/buildout-cache/eggs/zope.interface-3.6.7-py2.7-linux-x86_64.egg/zope/interface/declarations.py", line 1381, in _normalizeargs
    for v in sequence:
TypeError: 'ExtensionClass.ExtensionClass' object is not iterable
```

This PR makes the upgrade step 1.3.3 to remove the arimports folder and temporarily restores the IARImports interface

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
