### PR TITLE
Disable ++resource++jquery-ui-themes/sunburst/jqueryui.css

### DIFF
--- a/bika/lims/profiles/default/cssregistry.xml
+++ b/bika/lims/profiles/default/cssregistry.xml
@@ -34,14 +34,6 @@
     rendering="link"
     insert-after="*"/>
 
-  <!-- Overwrite default jqueryui.css -->
-  <stylesheet
-    id="++resource++jquery-ui-themes/sunburst/jqueryui.css"
-    media="screen"
-    rel="stylesheet"
-    rendering="link"
-    insert-after="*"/>
-
   <!-- Activate CSS stylesheets we need -->
   <stylesheet
     id="++resource++plone.app.jquerytools.overlays.css"
@@ -103,5 +95,8 @@
   <stylesheet
     id="++resource++plone.app.discussion.stylesheets/discussion.css"
     enabled="0"/>
+  <stylesheet
+    id="++resource++jquery-ui-themes/sunburst/jqueryui.css"
+    enable="0"/>
 
 </object>

--- a/bika/lims/profiles/default/cssregistry.xml
+++ b/bika/lims/profiles/default/cssregistry.xml
@@ -97,6 +97,6 @@
     enabled="0"/>
   <stylesheet
     id="++resource++jquery-ui-themes/sunburst/jqueryui.css"
-    enable="0"/>
+    enabled="0"/>
 
 </object>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the css registration of `++resource++jquery-ui-themes/sunburst/jqueryui.css`, because it is already cooked into `collective.js.jqueryui`.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
