### PR TITLE
Fix Uncaught TypeError in combogrid

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,7 @@ Changelog
 
 **Fixed**
 
+- #1550 Fix Uncaught TypeError in combogrid
 - #1542 Fix sporadical errors when contacts do not have a valid email address
 - #1540 Fix flushing CCEmail fields in Sample Add Form
 - #1533 Fix traceback from log when rendering stickers preview

--- a/bika/lims/browser/js/thirdparty/jquery/jquery.ui.combogrid-1.6.3.js
+++ b/bika/lims/browser/js/thirdparty/jquery/jquery.ui.combogrid-1.6.3.js
@@ -326,7 +326,7 @@ $.widget( "cg.combogrid", {
 						$( document ).one( 'mousedown', function( event ) {
 							if ( event.target !== self.element[ 0 ] &&
 								event.target !== menuElement &&
-								!$.ui.contains( menuElement, event.target ) ) {
+								!$.contains( menuElement, event.target ) ) {
 								self.close();
 							}
 						});


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This happens when someone clicks the left/right arrows in the combogrid widget:

jquery.ui.combogrid-1.6.3.js:329 Uncaught TypeError: $.ui.contains is not a function
    at HTMLDocument.<anonymous> (jquery.ui.combogrid-1.6.3.js:329)
    at HTMLDocument.e (jquery-2.2.4.min.js:3)
    at HTMLDocument.dispatch (jquery-2.2.4.min.js:3)
    at HTMLDocument.r.handle (jquery-2.2.4.min.js:3)

## Current behavior before PR

Type Error occurs when clicking left/right arrows in combogrid widget

## Desired behavior after PR is merged

No Type Error occurs when clicking left/right arrows in combogrid widget

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
