### PR TITLE
Removed dependency to plone.app.iterate

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,7 @@ Changelog
 
 **Removed**
 
+- #1551 Removed dependency to plone.app.iterate
 - #1530 Removed ARImport
 - #1530 Removed stale type registrations
 - #1541 Remove add/edit options of ReferenceWidget

--- a/bika/lims/profiles/default/metadata.xml
+++ b/bika/lims/profiles/default/metadata.xml
@@ -5,7 +5,6 @@
     <dependency>profile-jarn.jsi18n:default</dependency>
     <dependency>profile-Products.ATExtensions:default</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>
-    <dependency>profile-plone.app.iterate:plone.app.iterate</dependency>
     <dependency>profile-Products.TinyMCE:TinyMCE</dependency>
     <dependency>profile-collective.js.jqueryui:default</dependency>
     <dependency>profile-Products.DataGridField:default</dependency>

--- a/bika/lims/upgrade/v01_03_003.py
+++ b/bika/lims/upgrade/v01_03_003.py
@@ -397,6 +397,8 @@ def upgrade(tool):
     # Add progress metadata column for Batches
     add_metadata(portal, BIKA_CATALOG, "getProgress", True)
 
+    uninstall_plone_app_iterate(portal)
+
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
 
@@ -901,3 +903,13 @@ def remove_arimports(portal):
 
     logger.info("Removing AR Imports folder [DONE]")
 
+
+def uninstall_plone_app_iterate(portal):
+    """Uninstall plone.app.iterate
+    """
+    qi = api.get_tool("portal_quickinstaller")
+    profile = "plone.app.iterate"
+    if qi.isProductInstalled(profile):
+        logger.info("Uninstalling '{}' ...".format(profile))
+        qi.uninstallProducts(products=[profile])
+        logger.info("Uninstalling '{}' [DONE]".format(profile))

--- a/bika/lims/upgrade/v01_03_003.py
+++ b/bika/lims/upgrade/v01_03_003.py
@@ -397,6 +397,7 @@ def upgrade(tool):
     # Add progress metadata column for Batches
     add_metadata(portal, BIKA_CATALOG, "getProgress", True)
 
+    # https://github.com/senaite/senaite.core/pull/1551
     uninstall_plone_app_iterate(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Installing `senaite.core` also installs `plone.app.iterate` which adds the actions "Checkin" and "Checkout" to the view of some types:

<img width="1321" alt="Calcium — SENAITE 2020-02-18 21-57-04" src="https://user-images.githubusercontent.com/713193/74777378-a5999080-5299-11ea-8d82-d8083064a8ae.png">


## Current behavior before PR

`senaite.core` has `plone.app.iterate` as dependecy

## Desired behavior after PR is merged

`plone.app.iterate` is no longer a dependecy

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
