### PR TITLE
Sample rejection during registration is not generating Rejection report/pdf

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,7 @@ Changelog
 
 **Fixed**
 
+- #1552 Rejection on registration is neither generating rejection pdf nor email
 - #1550 Fix Uncaught TypeError in combogrid
 - #1542 Fix sporadical errors when contacts do not have a valid email address
 - #1540 Fix flushing CCEmail fields in Sample Add Form

--- a/bika/lims/api/mail.py
+++ b/bika/lims/api/mail.py
@@ -74,7 +74,7 @@ def parse_email_address(address):
     :type address: basestring
     :returns: Tuple of (name, email)
     """
-    if not isinstance(address, basestring):
+    if not isinstance(address, six.string_types):
         raise ValueError("Expected a string, got {}".format(type(address)))
     return parseaddr(address)
 

--- a/bika/lims/api/mail.py
+++ b/bika/lims/api/mail.py
@@ -21,6 +21,7 @@
 import mimetypes
 import os
 import re
+import six
 import socket
 from email import encoders
 from email.header import Header
@@ -176,7 +177,7 @@ def compose_email(from_addr, to_addr, subj, body, attachments=[], **kw):
     """Compose a RFC 2822 MIME message
 
     :param from_address: Email from address
-    :param to_address: List of email or (name, email) pairs
+    :param to_address: An email or a list of emails
     :param subject: Email subject
     :param body: Email body
     :param attachments: List of email attachments
@@ -184,7 +185,9 @@ def compose_email(from_addr, to_addr, subj, body, attachments=[], **kw):
     """
     _preamble = "This is a multi-part message in MIME format.\n"
     _from = to_email_address(from_addr)
-    _to = to_email_address(to_addr)
+    if isinstance(to_addr, six.string_types):
+        to_addr = [to_addr]
+    _to = map(to_email_address, to_addr)
     _subject = to_email_subject(subj)
     _body = to_email_body_text(body, **kw)
 
@@ -193,7 +196,7 @@ def compose_email(from_addr, to_addr, subj, body, attachments=[], **kw):
     mime_msg.preamble = _preamble
     mime_msg["Subject"] = _subject
     mime_msg["From"] = _from
-    mime_msg["To"] = _to
+    mime_msg["To"] = ", ".join(_to)
     mime_msg.attach(_body)
 
     # Attach attachments

--- a/bika/lims/api/mail.py
+++ b/bika/lims/api/mail.py
@@ -18,10 +18,10 @@
 # Copyright 2018-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import io
 import mimetypes
 import os
 import re
-import six
 import socket
 from email import encoders
 from email.header import Header
@@ -35,9 +35,16 @@ from smtplib import SMTPException
 from string import Template
 from StringIO import StringIO
 
+import six
+
 from bika.lims import api
 from bika.lims import logger
 from Products.CMFPlone.utils import safe_unicode
+
+try:
+    file_types = (file, io.IOBase)
+except NameError:
+    file_types = (io.IOBase,)
 
 # RFC 2822 local-part: dot-atom or quoted-string
 # characters allowed in atom: A-Za-z0-9!#$%&'*+-/=?^_`{|}~
@@ -86,7 +93,7 @@ def to_email_subject(subject):
     :type subject: basestring
     :returns: Encoded email subject header
     """
-    if not isinstance(subject, basestring):
+    if not isinstance(subject, six.string_types):
         raise TypeError("Expected string, got '{}'".format(type(subject)))
     return Header(s=safe_unicode(subject), charset="utf8")
 
@@ -110,7 +117,7 @@ def to_email_attachment(filedata, filename="", **kw):
     taken from the keyword arguments.
 
     :param filedata: File, file path, filedata
-    :type filedata: FileIO, MIMEBase, basestring
+    :type filedata: FileIO, MIMEBase, str
     :param filename: Filename to use
     :type filename: str
     :returns: MIME Attachment
@@ -130,7 +137,7 @@ def to_email_attachment(filedata, filename="", **kw):
         # return immediately
         return filedata
     # Handle file/StringIO
-    elif isinstance(filedata, (file, StringIO)):
+    elif isinstance(filedata, (file_types, StringIO)):
         data = filedata.read()
     # Handle file paths
     if is_file(filedata):
@@ -139,7 +146,7 @@ def to_email_attachment(filedata, filename="", **kw):
             # read the filedata from the filepath
             data = f.read()
     # Handle raw filedata
-    elif isinstance(filedata, basestring):
+    elif isinstance(filedata, six.string_types):
         data = filedata
 
     # Set MIME type from keyword arguments or guess it from the filename
@@ -161,10 +168,10 @@ def is_valid_email_address(address):
     Code taken from `CMFDefault.utils.checkEmailAddress`
 
     :param address: The email address to check
-    :type address: basestring
+    :type address: str
     :returns: True if the address is a valid email
     """
-    if not isinstance(address, basestring):
+    if not isinstance(address, six.string_types):
         return False
     if not _LOCAL_RE.match(address):
         return False
@@ -210,13 +217,13 @@ def send_email(email, immediate=True):
     """Send the email via the MailHost tool
 
     :param email: Email message or string
-    :type email: Message or basestring
+    :type email: Message or str
     :param immediate: True to send the email immediately
     :type immediately: bool
     :returns: True if the email delivery was successful
     """
-    if not isinstance(email, (basestring, Message)):
-        raise TypeError("Email must be a Message or basestring")
+    if not isinstance(email, (six.string_types, Message)):
+        raise TypeError("Email must be a Message or str")
 
     try:
         mailhost = api.get_tool("MailHost")

--- a/bika/lims/browser/analysisrequest/reject_samples.py
+++ b/bika/lims/browser/analysisrequest/reject_samples.py
@@ -26,8 +26,9 @@ from bika.lims import workflow as wf
 from bika.lims.browser import BrowserView, ulocalized_time
 from bika.lims.catalog.analysisrequest_catalog import \
     CATALOG_ANALYSIS_REQUEST_LISTING
-from bika.lims.utils.analysisrequest import notify_rejection
 from plone.memoize import view
+
+from bika.lims.utils.analysisrequest import do_rejection
 
 
 class RejectSamplesView(BrowserView):
@@ -97,14 +98,14 @@ class RejectSamplesView(BrowserView):
                 obj = api.get_object_by_uid(sample_uid)
                 rejection_reasons = {
                     "other": other,
-                    "selected": reasons }
+                    "selected": reasons
+                }
                 obj.setRejectionReasons([rejection_reasons])
-                wf.doActionFor(obj, "reject")
-                processed.append(obj)
 
-                # Client needs to be notified?
-                if sample.get("notify", "") == "on":
-                    notify_rejection(obj)
+                # Reject the sample
+                notify = sample.get("notify", "") == "on"
+                do_rejection(obj, notify=notify)
+                processed.append(obj)
 
             if not processed:
                 return self.redirect(message=_("No samples were rejected"))

--- a/bika/lims/tests/doctests/API_mail.rst
+++ b/bika/lims/tests/doctests/API_mail.rst
@@ -173,7 +173,7 @@ Compose Email
 This function composes a new MIME message:
 
     >>> message = compose_email("from@senaite.com",
-    ...                         "to@senaite.com",
+    ...                         ["to@senaite.com", "to2@senaite.com"],
     ...                         "Test Émail",
     ...                         "Check out the new SENAITE website: $url",
     ...                         attachments=[filepath],
@@ -188,7 +188,7 @@ This function composes a new MIME message:
     MIME-Version: 1.0
     Subject: =?utf-8?q?Test_=C3=89mail?=
     From: from@senaite.com
-    To: to@senaite.com
+    To: to@senaite.com, to2@senaite.com
     <BLANKLINE>
     This is a multi-part message in MIME format.
     <BLANKLINE>

--- a/bika/lims/workflow/analysisrequest/events.py
+++ b/bika/lims/workflow/analysisrequest/events.py
@@ -19,12 +19,16 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims import api
+from bika.lims.api.mail import send_email
+from bika.lims.api.mail import to_email_attachment
 from bika.lims.interfaces import IAnalysisRequestPartition
 from bika.lims.interfaces import IDetachedPartition
 from bika.lims.interfaces import IReceived
 from bika.lims.interfaces import IVerified
 from bika.lims.utils import changeWorkflowState
 from bika.lims.utils.analysisrequest import create_retest
+from bika.lims.utils.analysisrequest import get_rejection_mail
+from bika.lims.utils.analysisrequest import get_rejection_pdf
 from bika.lims.workflow import doActionFor as do_action_for
 from bika.lims.workflow import get_prev_status_from_history
 from bika.lims.workflow.analysisrequest import AR_WORKFLOW_ID

--- a/bika/lims/workflow/analysisrequest/events.py
+++ b/bika/lims/workflow/analysisrequest/events.py
@@ -27,8 +27,6 @@ from bika.lims.interfaces import IReceived
 from bika.lims.interfaces import IVerified
 from bika.lims.utils import changeWorkflowState
 from bika.lims.utils.analysisrequest import create_retest
-from bika.lims.utils.analysisrequest import get_rejection_mail
-from bika.lims.utils.analysisrequest import get_rejection_pdf
 from bika.lims.workflow import doActionFor as do_action_for
 from bika.lims.workflow import get_prev_status_from_history
 from bika.lims.workflow.analysisrequest import AR_WORKFLOW_ID


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When rejection workflow is enabled and user specify the reasons of rejection while creating the Sample (Add Sample form), the sample is created and rejected straightforward, but neither the rejection pdf document nor the notification email to client contact are generated.

## Current behavior before PR

Neither rejection pdf nor notification email are generated when rejecting while creating a Sample

## Desired behavior after PR is merged

Rejection pdf and notification email are generated when rejecting while creating a Sample

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
