### PR TITLE
Add Form: Recalculate prices on copy

### DIFF
--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -69,7 +69,9 @@
       this.init_file_fields();
       this.get_global_settings();
       this.get_flush_settings();
-      return this.recalculate_records();
+      this.recalculate_records();
+      this.recalculate_prices();
+      return this;
     };
 
 

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -49,6 +49,12 @@ class window.AnalysisRequestAdd
     # recalculate records on load (needed for AR copies)
     @recalculate_records()
 
+    # always recalculate prices in the first run
+    @recalculate_prices()
+
+    # return a reference to the instance
+    return @
+
 
   ### METHODS ###
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a regression introduced in https://github.com/senaite/senaite.core/pull/1539 

## Current behavior before PR

Prices not recalculated when samples are copied

## Desired behavior after PR is merged

Prices recalculated when samples are copied

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
