### PR TITLE
List all multi-reports for samples, where the current sample is contained

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,7 +32,7 @@ Changelog
 - #1466 Support for "readonly" and "hidden" visibility modes in ReferenceWidget
 
 **Changed**
-
+- #1555 List all multi-reports for samples, where the current sample is contained
 - #1543 Sort navigation child-nodes alphabetically
 - #1539 Avoid unnecessary Price recalculations in Sample Add Form
 - #1532 Updated jQuery Barcode to version 2.2.0

--- a/bika/lims/browser/analysisrequest/published_results.py
+++ b/bika/lims/browser/analysisrequest/published_results.py
@@ -18,135 +18,48 @@
 # Copyright 2018-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from Products.CMFCore.utils import getToolByName
 from bika.lims import api
-from bika.lims import bikaMessageFactory as _
-from bika.lims.browser.bika_listing import BikaListingView
-from bika.lims.utils import t
+from bika.lims.browser.publish.reports_listing import ReportsListingView
 
 
-class AnalysisRequestPublishedResults(BikaListingView):
+class AnalysisRequestPublishedResults(ReportsListingView):
     """View of published results
-
-    Prints the list of pdf files with each publication dates, the user
-    responsible of that publication, the emails of the addressees (and/or)
-    client contact names with the publication mode used (pdf, email, etc.)
     """
-    # I took IViewView away, because transitions selected in the edit-bar
-    # cause errors due to wrong context, when invoked from this view, and I
-    # don't know why.
-    # implements(IViewView)
 
     def __init__(self, context, request):
         super(AnalysisRequestPublishedResults, self).__init__(context, request)
-        self.catalog = "portal_catalog"
+
+        # get the client for the catalog query
+        client = context.getClient()
+        client_path = api.get_path(client)
+
+        # get the UID of the current context (sample)
+        sample_uid = api.get_uid(context)
+
         self.contentFilter = {
-            'portal_type': 'ARReport',
-            'path': {
-                'query': api.get_path(self.context),
-                'depth': 1,
+            "portal_type": "ARReport",
+            "path": {
+                "query": client_path,
+                "depth": 2,
             },
-            'sort_order': 'reverse'
+            # search all reports where the current sample is contained
+            "contained_sample_uids": [sample_uid],
+            "sort_on": "created",
+            "sort_order": "descending",
         }
 
-        self.context_actions = {}
-        self.show_select_column = True
-        self.show_workflow_action_buttons = False
-        self.form_id = 'published_results'
-        self.icon = self.portal_url + "/++resource++bika.lims.images/report_big.png"
-        self.title = self.context.translate(_("Published results"))
-        self.columns = {
-            'Title': {'title': _('File')},
-            'FileSize': {'title': _('Size')},
-            'Date': {'title': _('Published Date')},
-            'PublishedBy': {'title': _('Published By')},
-            'DatePrinted': {'title': _('Printed Date')},
-            'Recipients': {'title': _('Recipients')},
-        }
+        # disable the searchbox in this listing
+        self.show_search = False
+
+        # only allow the email transition at this level
         self.review_states = [
-            {'id': 'default',
-             'title': 'All',
-             'contentFilter': {},
-             'columns': ['Title',
-                         'FileSize',
-                         'Date',
-                         'PublishedBy',
-                         'DatePrinted',
-                         'Recipients']},
+            {
+                "id": "default",
+                "title": "All",
+                "contentFilter": {},
+                "columns": self.columns.keys(),
+                "custom_transitions": [
+                    self.send_email_transition,
+                ]
+            },
         ]
-
-    def __call__(self):
-        # Printing workflow enabled?
-        # If not, remove the Column
-        self.printwfenabled = self.context.bika_setup.getPrintingWorkflowEnabled()
-        printed_colname = 'DatePrinted'
-        if not self.printwfenabled and printed_colname in self.columns:
-            # Remove "Printed" columns
-            del self.columns[printed_colname]
-            tmprvs = []
-            for rs in self.review_states:
-                tmprs = rs
-                tmprs['columns'] = [c for c in rs.get('columns', []) if
-                                    c != printed_colname]
-                tmprvs.append(tmprs)
-            self.review_states = tmprvs
-
-        template = BikaListingView.__call__(self)
-        return template
-
-    def contentsMethod(self, contentFilter):
-        """
-        ARReport objects associated to the current Analysis request.
-        If the user is not a Manager or LabManager or Client, no items are
-        displayed.
-        """
-        allowedroles = ['Manager', 'LabManager', 'Client', 'LabClerk']
-        pm = getToolByName(self.context, "portal_membership")
-        member = pm.getAuthenticatedMember()
-        roles = member.getRoles()
-        allowed = [a for a in allowedroles if a in roles]
-        return self.context.objectValues('ARReport') if allowed else []
-
-    def folderitem(self, obj, item, index):
-        obj_url = obj.absolute_url()
-        pdf = obj.getPdf()
-        filesize = 0
-        title = _('Download')
-        anchor = "<a href='%s/at_download/Pdf'>%s</a>" % \
-                 (obj_url, _("Download"))
-        try:
-            filesize = pdf.get_size()
-            filesize = filesize / 1024 if filesize > 0 else 0
-        except:
-            # POSKeyError: 'No blob file'
-            # Show the record, but not the link
-            title = _('Not available')
-            anchor = title
-
-        item['Title'] = title
-        item['FileSize'] = '%sKb' % filesize
-        fmt_date = self.ulocalized_time(obj.created(), long_format=1)
-        item['Date'] = fmt_date
-        item['PublishedBy'] = self.user_fullname(obj.Creator())
-
-        if self.printwfenabled:
-            # The date when the Results Report was printed (if so)
-            item['DatePrinted'] = ''
-            fmt_date = obj.getDatePrinted() if hasattr(obj, 'getDatePrinted') else ''
-            if (fmt_date):
-                fmt_date = self.ulocalized_time(fmt_date, long_format=1)
-                item['DatePrinted'] = fmt_date
-                if obj.getDatePrinted() is None:
-                    item['after']['DatePrinted'] = ("<img src='++resource++bika.lims.images/warning.png' title='%s'/>" %
-                                                    (t(_("Has not been Printed."))))
-
-        recip = []
-        for recipient in obj.getRecipients():
-            email = recipient['EmailAddress']
-            val = recipient['Fullname']
-            if email:
-                val = "<a href='mailto:%s'>%s</a>" % (email, val)
-            recip.append(val)
-        item['replace']['Recipients'] = ', '.join(recip)
-        item['replace']['Title'] = anchor
-        return item

--- a/bika/lims/browser/analysisrequest/published_results.py
+++ b/bika/lims/browser/analysisrequest/published_results.py
@@ -42,7 +42,7 @@ class AnalysisRequestPublishedResults(ReportsListingView):
                 "query": client_path,
                 "depth": 2,
             },
-            # search all reports where the current sample is contained
+            # search all reports, where the current sample UID is included
             "report_sample_uid": [sample_uid],
             "sort_on": "created",
             "sort_order": "descending",

--- a/bika/lims/browser/analysisrequest/published_results.py
+++ b/bika/lims/browser/analysisrequest/published_results.py
@@ -43,7 +43,7 @@ class AnalysisRequestPublishedResults(ReportsListingView):
                 "depth": 2,
             },
             # search all reports, where the current sample UID is included
-            "report_sample_uid": [sample_uid],
+            "sample_uid": [sample_uid],
             "sort_on": "created",
             "sort_order": "descending",
         }

--- a/bika/lims/browser/analysisrequest/published_results.py
+++ b/bika/lims/browser/analysisrequest/published_results.py
@@ -43,7 +43,7 @@ class AnalysisRequestPublishedResults(ReportsListingView):
                 "depth": 2,
             },
             # search all reports where the current sample is contained
-            "contained_sample_uids": [sample_uid],
+            "report_sample_uid": [sample_uid],
             "sort_on": "created",
             "sort_order": "descending",
         }

--- a/bika/lims/browser/publish/configure.zcml
+++ b/bika/lims/browser/publish/configure.zcml
@@ -22,9 +22,18 @@
       layer="bika.lims.interfaces.IBikaLIMS"
       />
 
-  <!-- Email View -->
+  <!-- Email View on Client context -->
   <browser:page
       for="bika.lims.interfaces.IClient"
+      name="email"
+      class=".emailview.EmailView"
+      permission="senaite.core.permissions.ManageAnalysisRequests"
+      layer="bika.lims.interfaces.IBikaLIMS"
+      />
+
+  <!-- Email View on Sample context -->
+  <browser:page
+      for="bika.lims.interfaces.IAnalysisRequest"
       name="email"
       class=".emailview.EmailView"
       permission="senaite.core.permissions.ManageAnalysisRequests"

--- a/bika/lims/browser/publish/reports_listing.py
+++ b/bika/lims/browser/publish/reports_listing.py
@@ -68,7 +68,7 @@ class ReportsListingView(BikaListingView):
             "This will also publish the contained samples of the reports "
             "after the email was successfully sent.")
 
-        send_email_transition = {
+        self.send_email_transition = {
             "id": "send_email",
             "title": _("Email"),
             "url": "email",
@@ -79,7 +79,7 @@ class ReportsListingView(BikaListingView):
         help_publish_text = _(
             "Manually publish all contained samples of the selected reports.")
 
-        publish_samples_transition = {
+        self.publish_samples_transition = {
             "id": "publish_samples",
             "title": _("Publish"),
             # see senaite.core.browser.workflow
@@ -116,8 +116,8 @@ class ReportsListingView(BikaListingView):
                 "contentFilter": {},
                 "columns": self.columns.keys(),
                 "custom_transitions": [
-                    send_email_transition,
-                    publish_samples_transition,
+                    self.send_email_transition,
+                    self.publish_samples_transition,
                 ]
             },
         ]

--- a/bika/lims/catalog/indexers/arreport.py
+++ b/bika/lims/catalog/indexers/arreport.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2020 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from plone.indexer import indexer
+
+from bika.lims.interfaces import IARReport
+
+
+@indexer(IARReport)
+def contained_sample_uids(instance):
+    """Returns a list of UIDs of the contained Samples
+    """
+    return instance.getRawContainedAnalysisRequests()

--- a/bika/lims/catalog/indexers/arreport.py
+++ b/bika/lims/catalog/indexers/arreport.py
@@ -24,7 +24,7 @@ from bika.lims.interfaces import IARReport
 
 
 @indexer(IARReport)
-def report_sample_uid(instance):
+def sample_uid(instance):
     """Returns a list of UIDs of the contained Samples
     """
     return instance.getRawContainedAnalysisRequests()

--- a/bika/lims/catalog/indexers/arreport.py
+++ b/bika/lims/catalog/indexers/arreport.py
@@ -24,7 +24,7 @@ from bika.lims.interfaces import IARReport
 
 
 @indexer(IARReport)
-def contained_sample_uids(instance):
+def report_sample_uid(instance):
     """Returns a list of UIDs of the contained Samples
     """
     return instance.getRawContainedAnalysisRequests()

--- a/bika/lims/catalog/indexers/configure.zcml
+++ b/bika/lims/catalog/indexers/configure.zcml
@@ -43,6 +43,9 @@
   <adapter name="is_received" factory=".analysisrequest.is_received"/>
   <adapter name="listing_searchable_text" factory=".analysisrequest.listing_searchable_text"/>
 
+  <!-- ARReport Index Adapters -->
+  <adapter name="contained_sample_uids" factory=".arreport.contained_sample_uids"/>
+
   <!-- BaseAnalysis Index Adapters -->
   <adapter name="sortable_title" factory=".baseanalysis.sortable_title"/>
 

--- a/bika/lims/catalog/indexers/configure.zcml
+++ b/bika/lims/catalog/indexers/configure.zcml
@@ -44,7 +44,7 @@
   <adapter name="listing_searchable_text" factory=".analysisrequest.listing_searchable_text"/>
 
   <!-- ARReport Index Adapters -->
-  <adapter name="report_sample_uid" factory=".arreport.report_sample_uid"/>
+  <adapter name="sample_uid" factory=".arreport.sample_uid"/>
 
   <!-- BaseAnalysis Index Adapters -->
   <adapter name="sortable_title" factory=".baseanalysis.sortable_title"/>

--- a/bika/lims/catalog/indexers/configure.zcml
+++ b/bika/lims/catalog/indexers/configure.zcml
@@ -44,7 +44,7 @@
   <adapter name="listing_searchable_text" factory=".analysisrequest.listing_searchable_text"/>
 
   <!-- ARReport Index Adapters -->
-  <adapter name="contained_sample_uids" factory=".arreport.contained_sample_uids"/>
+  <adapter name="report_sample_uid" factory=".arreport.report_sample_uid"/>
 
   <!-- BaseAnalysis Index Adapters -->
   <adapter name="sortable_title" factory=".baseanalysis.sortable_title"/>

--- a/bika/lims/setuphandlers.py
+++ b/bika/lims/setuphandlers.py
@@ -192,7 +192,7 @@ INDEXES = (
     ("bika_setup_catalog", "title", "", "FieldIndex"),
 
     ("portal_catalog", "Analyst", "", "FieldIndex"),
-    ("portal_catalog", "report_sample_uid", "", "KeywordIndex"),
+    ("portal_catalog", "sample_uid", "", "KeywordIndex"),
 )
 
 COLUMNS = (

--- a/bika/lims/setuphandlers.py
+++ b/bika/lims/setuphandlers.py
@@ -192,6 +192,7 @@ INDEXES = (
     ("bika_setup_catalog", "title", "", "FieldIndex"),
 
     ("portal_catalog", "Analyst", "", "FieldIndex"),
+    ("portal_catalog", "contained_sample_uids", "", "KeywordIndex"),
 )
 
 COLUMNS = (

--- a/bika/lims/setuphandlers.py
+++ b/bika/lims/setuphandlers.py
@@ -192,7 +192,7 @@ INDEXES = (
     ("bika_setup_catalog", "title", "", "FieldIndex"),
 
     ("portal_catalog", "Analyst", "", "FieldIndex"),
-    ("portal_catalog", "contained_sample_uids", "", "KeywordIndex"),
+    ("portal_catalog", "report_sample_uid", "", "KeywordIndex"),
 )
 
 COLUMNS = (

--- a/bika/lims/upgrade/v01_03_003.py
+++ b/bika/lims/upgrade/v01_03_003.py
@@ -134,8 +134,8 @@ INDEXES_TO_ADD = [
     # Default listing_searchable_text index adapter for setup_catalog
     ("bika_setup_catalog", "category_uid", "KeywordIndex"),
 
-    # Allows to search ARReports where the current Sample is contained 
-    ("portal_catalog", "contained_sample_uids", "KeywordIndex"),
+    # Allows to search ARReports where the current Sample UID is included
+    ("portal_catalog", "report_sample_uid", "KeywordIndex"),
 ]
 
 INDEXES_TO_REMOVE = [

--- a/bika/lims/upgrade/v01_03_003.py
+++ b/bika/lims/upgrade/v01_03_003.py
@@ -133,6 +133,9 @@ INDEXES_TO_ADD = [
 
     # Default listing_searchable_text index adapter for setup_catalog
     ("bika_setup_catalog", "category_uid", "KeywordIndex"),
+
+    # Allows to search ARReports where the current Sample is contained 
+    ("portal_catalog", "contained_sample_uids", "KeywordIndex"),
 ]
 
 INDEXES_TO_REMOVE = [

--- a/bika/lims/upgrade/v01_03_003.py
+++ b/bika/lims/upgrade/v01_03_003.py
@@ -135,7 +135,7 @@ INDEXES_TO_ADD = [
     ("bika_setup_catalog", "category_uid", "KeywordIndex"),
 
     # Allows to search ARReports where the current Sample UID is included
-    ("portal_catalog", "report_sample_uid", "KeywordIndex"),
+    ("portal_catalog", "sample_uid", "KeywordIndex"),
 ]
 
 INDEXES_TO_REMOVE = [


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR refactors the `published_results` view for Samples to list also (multi-)reports, where the current sample is contained.

## Current behavior before PR

Reports not displayed where the current sample was just contained

## Desired behavior after PR is merged

All Reports displayed where the current sample is part of

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
