### PR TITLE
Fix TypeError when retracting analysis with ExtendedField

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,7 @@ Changelog
 
 **Fixed**
 
+- #1556 Fix TypeError when retracting analyses with ExtendedField
 - #1552 Rejection on registration is neither generating rejection pdf nor email
 - #1550 Fix Uncaught TypeError in combogrid
 - #1542 Fix sporadical errors when contacts do not have a valid email address

--- a/bika/lims/utils/analysis.py
+++ b/bika/lims/utils/analysis.py
@@ -25,6 +25,8 @@ import zope.event
 from Products.Archetypes.event import ObjectInitializedEvent
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import _createObjectByType
+from archetypes.schemaextender.interfaces import IExtensionField
+
 from bika.lims import bikaMessageFactory as _
 from bika.lims.interfaces import IAnalysisService
 from bika.lims.utils import formatDecimalMark
@@ -74,9 +76,14 @@ def copy_analysis_field_values(source, analysis, **kwargs):
             # to give the value. We have realized that in some cases using
             # 'set' when the value is a string, it saves the value
             # as unicode instead of plain string.
-            mutator_name = analysis.getField(fieldname).mutator
-            mutator = getattr(analysis, mutator_name)
-            mutator(value)
+            field = analysis.getField(fieldname)
+            if IExtensionField.providedBy(field):
+                # SchemaExtender fields don't auto-generate the accessor/mutator
+                field.set(analysis, value)
+            else:
+                mutator_name = field.mutator
+                mutator = getattr(analysis, mutator_name)
+                mutator(value)
 
 
 def create_analysis(context, source, **kwargs):


### PR DESCRIPTION
##  Description of the issue/feature this PR addresses

SchemaExtender fields don't auto-generate the accessor/mutator methods, so an error is raised when trying to retract a given analysis with an ExtendedField because the system tries to copy the field values to the retest.

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.workflow, line 143, in __call__
  Module bika.lims.browser.workflow, line 154, in __call__
  Module bika.lims.browser.workflow, line 173, in do_action
  Module bika.lims.workflow, line 127, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 241, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 552, in _invokeWithNotification
  Module Products.DCWorkflow.DCWorkflow, line 282, in doActionFor
  Module Products.DCWorkflow.DCWorkflow, line 421, in _changeStateOf
  Module Products.DCWorkflow.DCWorkflow, line 531, in _executeTransition
  Module zope.event, line 31, in notify
  Module zope.component.event, line 24, in dispatch
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module zope.component.event, line 32, in objectEventNotify
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module bika.lims.workflow, line 197, in AfterTransitionEventHandler
  Module bika.lims.workflow, line 172, in call_workflow_event
  Module bika.lims.workflow.analysisrequest.events, line 77, in after_retract
  Module bika.lims.workflow.analysisrequest, line 52, in do_action_to_analyses
  Module bika.lims.workflow, line 127, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 241, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 552, in _invokeWithNotification
  Module Products.DCWorkflow.DCWorkflow, line 282, in doActionFor
  Module Products.DCWorkflow.DCWorkflow, line 421, in _changeStateOf
  Module Products.DCWorkflow.DCWorkflow, line 531, in _executeTransition
  Module zope.event, line 31, in notify
  Module zope.component.event, line 24, in dispatch
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module zope.component.event, line 32, in objectEventNotify
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module bika.lims.workflow, line 197, in AfterTransitionEventHandler
  Module bika.lims.workflow, line 172, in call_workflow_event
  Module bika.lims.workflow.analysis.events, line 144, in after_retract
  Module bika.lims.utils.analysis, line 95, in create_analysis
  Module bika.lims.utils.analysis, line 78, in copy_analysis_field_values
TypeError: getattr(): attribute name must be string
```

## Desired behavior after PR is merged

No error. The retest is created and the value for the extended field kept in the retest.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
