### PR TITLE
Removed logger import from senaite.lims

### DIFF
--- a/bika/lims/browser/bootstrap/bootstrap.py
+++ b/bika/lims/browser/bootstrap/bootstrap.py
@@ -19,9 +19,9 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims import api
+from bika.lims import logger
 from plone.memoize.ram import cache
 from Products.Five import BrowserView
-from senaite.lims import logger
 from zope.component import getMultiAdapter
 from zope.interface import Interface
 from zope.interface import implements


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Removed import artefact from `senaite.lims`

## Traceback

```
  File "/home/travis/build/senaite/senaite.core/bika/lims/browser/bootstrap/bootstrap.py", line 24, in <module>

    from senaite.lims import logger

ZopeXMLConfigurationError: File "/home/travis/build/senaite/senaite.core/bika/lims/configure.zcml", line 23.2-23.32

    ZopeXMLConfigurationError: File "/home/travis/build/senaite/senaite.core/bika/lims/browser/configure.zcml", line 41.2-41.33

    ZopeXMLConfigurationError: File "/home/travis/build/senaite/senaite.core/bika/lims/browser/bootstrap/configure.zcml", line 9.2-15.46

    ImportError: No module named lims
```
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
