### PR TITLE
Remove the cross-assignment of SampleType--SamplePoint

### DIFF
--- a/bika/lims/browser/client/views/samplepoints.py
+++ b/bika/lims/browser/client/views/samplepoints.py
@@ -20,64 +20,12 @@
 
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.controlpanel.bika_samplepoints import SamplePointsView
 from bika.lims.permissions import *
 from Products.CMFCore.utils import getToolByName
 
 
-class ClientSamplePointsView(BikaListingView):
+class ClientSamplePointsView(SamplePointsView):
     """This is displayed in the "Sample Points" tab on each client
     """
-
-    def __init__(self, context, request):
-        super(ClientSamplePointsView, self).__init__(context, request)
-        self.catalog = "bika_setup_catalog"
-        self.contentFilter = {
-            'portal_type': 'SamplePoint',
-            'sort_on': 'sortable_title',
-            'path': {
-                "query": "/".join(self.context.getPhysicalPath()),
-                "level": 0},
-        }
-
-        self.show_select_row = False
-        self.show_select_column = True
-        self.pagesize = 50
-        self.form_id = "SamplePoints"
-        self.icon = self.portal_url + \
-                    "/++resource++bika.lims.images/samplepoint_big.png"
-        self.title = self.context.translate(_("Sample Points"))
-        self.description = ""
-
-        self.columns = {
-            'title': {'title': _('Title'),
-                      'index': 'sortable_title',
-                      'replace_url': 'absolute_url'},
-            'Description': {'title': _('Description'),
-                            'index': 'description'},
-        }
-        self.review_states = [
-            {'id': 'default',
-             'title': _('Active'),
-             'contentFilter': {'is_active': True},
-             'transitions': [{'id': 'deactivate'}, ],
-             'columns': ['title', 'Description']},
-            {'id': 'inactive',
-             'title': _('Inactive'),
-             'contentFilter': {'is_active': False},
-             'transitions': [{'id': 'activate'}, ],
-             'columns': ['title', 'Description']},
-            {'id': 'all',
-             'title': _('All'),
-             'contentFilter': {},
-             'columns': ['title', 'Description']},
-        ]
-
-    def __call__(self):
-        mtool = getToolByName(self.context, 'portal_membership')
-        checkPermission = mtool.checkPermission
-        if checkPermission(AddSamplePoint, self.context):
-            self.context_actions[_('Add')] = \
-                {'url': 'createObject?type_name=SamplePoint',
-                 'permission': 'Add portal content',
-                 'icon': '++resource++bika.lims.images/add.png'}
-        return super(ClientSamplePointsView, self).__call__()
+    pass

--- a/bika/lims/browser/client/views/samplepoints.py
+++ b/bika/lims/browser/client/views/samplepoints.py
@@ -18,11 +18,7 @@
 # Copyright 2018-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from bika.lims import bikaMessageFactory as _
-from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.controlpanel.bika_samplepoints import SamplePointsView
-from bika.lims.permissions import *
-from Products.CMFCore.utils import getToolByName
 
 
 class ClientSamplePointsView(SamplePointsView):

--- a/bika/lims/content/samplepoint.py
+++ b/bika/lims/content/samplepoint.py
@@ -31,7 +31,6 @@ from Products.Archetypes.public import Schema
 from Products.Archetypes.public import StringField
 from Products.Archetypes.public import StringWidget
 from Products.Archetypes.public import registerType
-from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from plone.app.blob.field import FileField as BlobFileField
 from zope.interface import implements
@@ -145,40 +144,6 @@ class SamplePoint(BaseContent, HistoryAwareMixin, ClientAwareMixin,
 
     def Title(self):
         return safe_unicode(self.getField('title').get(self)).encode('utf-8')
-
-    def setSampleTypes(self, value, **kw):
-        """ For the moment, we're manually trimming the sampletype<>samplepoint
-            relation to be equal on both sides, here.
-            It's done strangely, because it may be required to behave strangely.
-        """
-        bsc = getToolByName(self, 'bika_setup_catalog')
-        # convert value to objects
-        if value and type(value) == str:
-            value = [bsc(UID=value)[0].getObject(), ]
-        elif value and type(value) in (list, tuple) and type(value[0]) == str:
-            value = [bsc(UID=uid)[0].getObject() for uid in value if uid]
-        if not type(value) in (list, tuple):
-            value = [value, ]
-        # Find all SampleTypes that were removed
-        existing = self.Schema()['SampleTypes'].get(self)
-        removed = existing and [s for s in existing if s not in value] or []
-        added = value and [s for s in value if s not in existing] or []
-        ret = self.Schema()['SampleTypes'].set(self, value)
-
-        # finally be sure that we aren't trying to set None values here.
-        removed = [x for x in removed if x]
-        added = [x for x in added if x]
-
-        for st in removed:
-            samplepoints = st.getSamplePoints()
-            if self in samplepoints:
-                samplepoints.remove(self)
-                st.setSamplePoints(samplepoints)
-
-        for st in added:
-            st.setSamplePoints(list(st.getSamplePoints()) + [self, ])
-
-        return ret
 
 
 registerType(SamplePoint, PROJECTNAME)

--- a/bika/lims/content/sampletype.py
+++ b/bika/lims/content/sampletype.py
@@ -37,6 +37,7 @@ from bika.lims.browser.widgets import SampleTypeStickersWidget
 from bika.lims.browser.widgets.referencewidget import ReferenceWidget as brw
 from bika.lims.config import PROJECTNAME
 from bika.lims.content.bikaschema import BikaSchema
+from bika.lims.interfaces import IClient
 from bika.lims.interfaces import IDeactivable
 from bika.lims.interfaces import ISampleType
 from bika.lims.interfaces import ISampleTypeAwareMixin
@@ -265,16 +266,10 @@ class SampleType(BaseContent, HistoryAwareMixin, SampleTypeAwareMixin):
         settings = getToolByName(self, 'bika_setup')
         return settings.getDefaultSampleLifetime()
 
-    def getSamplePoints(self, preserve_context=True):
+    def getSamplePoints(self):
         """Returns the Sample Points where current Sample Type is supported
-        :param preserve_context: returns the sample points that belong to the
-        same context as the current Sample Type (e.g. client vs. setup)
         """
-        objs = self.getBackReferences("SamplePointSampleType")
-        if preserve_context:
-            path = api.get_parent_path(self)
-            objs = filter(lambda st: api.get_parent_path(st) == path, objs)
-        return objs
+        return self.getBackReferences("SamplePointSampleType")
 
     def SampleMatricesVocabulary(self):
         from bika.lims.content.samplematrix import SampleMatrices

--- a/bika/lims/content/sampletype.py
+++ b/bika/lims/content/sampletype.py
@@ -34,10 +34,8 @@ from bika.lims import logger
 from bika.lims.browser.fields import DurationField
 from bika.lims.browser.widgets import DurationWidget
 from bika.lims.browser.widgets import SampleTypeStickersWidget
-from bika.lims.browser.widgets.referencewidget import ReferenceWidget as brw
 from bika.lims.config import PROJECTNAME
 from bika.lims.content.bikaschema import BikaSchema
-from bika.lims.interfaces import IClient
 from bika.lims.interfaces import IDeactivable
 from bika.lims.interfaces import ISampleType
 from bika.lims.interfaces import ISampleTypeAwareMixin
@@ -172,13 +170,6 @@ schema = BikaSchema.copy() + Schema((
                 "per analysis service"),
         ),
     ),
-    ComputedField(
-        'SamplePointTitle',
-        expression="[o.Title() for o in context.getSamplePoints()]",
-        widget = ComputedWidget(
-            visibile=False,
-        )
-    ),
     RecordsField(
         'AdmittedStickerTemplates',
         subfields=(
@@ -270,6 +261,11 @@ class SampleType(BaseContent, HistoryAwareMixin, SampleTypeAwareMixin):
         """Returns the Sample Points where current Sample Type is supported
         """
         return self.getBackReferences("SamplePointSampleType")
+
+    def getSamplePointTitle(self):
+        """Returns a list of Sample Point titles
+        """
+        return map(api.get_title, self.getSamplePoints())
 
     def SampleMatricesVocabulary(self):
         from bika.lims.content.samplematrix import SampleMatrices

--- a/bika/lims/controlpanel/bika_samplepoints.py
+++ b/bika/lims/controlpanel/bika_samplepoints.py
@@ -23,7 +23,6 @@ import json
 
 import plone
 from Products.ATContentTypes.content import schemata
-from Products.Archetypes import PloneMessageFactory as _p
 from Products.Archetypes import atapi
 from Products.CMFCore.permissions import ModifyPortalContent
 from Products.CMFCore.utils import getToolByName
@@ -32,7 +31,6 @@ from plone.app.folder.folder import ATFolder
 from plone.app.folder.folder import ATFolderSchema
 from zope.interface.declarations import implements
 
-from bika.lims import ManageBika
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims.api.security import check_permission

--- a/bika/lims/controlpanel/bika_samplepoints.py
+++ b/bika/lims/controlpanel/bika_samplepoints.py
@@ -138,18 +138,10 @@ class SamplePointsView(BikaListingView):
         item["Description"] = obj.Description()
 
         sample_types = obj.getSampleTypes()
-        links = map(self.resolve_link, sample_types)
+        links = map(get_link_for, sample_types)
         item["replace"]["SampleTypes"] = ", ".join(links)
 
         return item
-
-    def resolve_link(self, obj, permission=ModifyPortalContent):
-        """Generates a valid html anchor element for the obj provided if the
-        current user has the permission granted. Otherwise, returns the title
-        """
-        if check_permission(permission, obj):
-            return get_link_for(obj)
-        return api.get_title(obj)
 
 
 class ajax_SamplePoints(BrowserView):

--- a/bika/lims/controlpanel/bika_samplepoints.py
+++ b/bika/lims/controlpanel/bika_samplepoints.py
@@ -25,18 +25,24 @@ import plone
 from Products.ATContentTypes.content import schemata
 from Products.Archetypes import PloneMessageFactory as _p
 from Products.Archetypes import atapi
+from Products.CMFCore.permissions import ModifyPortalContent
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
-from bika.lims import bikaMessageFactory as _
-from bika.lims.browser import BrowserView
-from bika.lims.browser.bika_listing import BikaListingView
-from bika.lims.config import PROJECTNAME
-from bika.lims.interfaces import ISamplePoints
-from bika.lims.permissions import AddSamplePoint
-from bika.lims.utils import get_link
 from plone.app.folder.folder import ATFolder
 from plone.app.folder.folder import ATFolderSchema
 from zope.interface.declarations import implements
+
+from bika.lims import ManageBika
+from bika.lims import api
+from bika.lims import bikaMessageFactory as _
+from bika.lims.api.security import check_permission
+from bika.lims.browser import BrowserView
+from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.catalog import SETUP_CATALOG
+from bika.lims.config import PROJECTNAME
+from bika.lims.interfaces import ISamplePoints
+from bika.lims.permissions import AddSamplePoint
+from bika.lims.utils import get_link_for
 
 
 # TODO: Separate content and view into own modules!
@@ -47,11 +53,15 @@ class SamplePointsView(BikaListingView):
     def __init__(self, context, request):
         super(SamplePointsView, self).__init__(context, request)
 
-        self.catalog = "bika_setup_catalog"
+        self.catalog = SETUP_CATALOG
         self.contentFilter = {
             "portal_type": "SamplePoint",
             "sort_on": "sortable_title",
             "sort_order": "ascending",
+            "path": {
+                "query": api.get_path(self.context),
+                "depth": 1,
+            }
         }
 
         self.context_actions = {
@@ -69,7 +79,7 @@ class SamplePointsView(BikaListingView):
 
         self.show_select_row = False
         self.show_select_column = True
-        self.pagesize = 25
+        self.pagesize = 50
 
         self.columns = collections.OrderedDict((
             ("Title", {
@@ -78,10 +88,6 @@ class SamplePointsView(BikaListingView):
             ("Description", {
                 "title": _("Description"),
                 "index": "Description",
-                "toggle": True}),
-            ("Owner", {
-                "title": _p("Owner"),
-                "sortable": False,
                 "toggle": True}),
             ("getComposite", {
                 "title": _("Composite"),
@@ -130,34 +136,22 @@ class SamplePointsView(BikaListingView):
             the template
         :index: current index of the item
         """
-
-        title = obj.Title()
-        description = obj.Description()
-        url = obj.absolute_url()
-
-        item["replace"]["Title"] = get_link(url, value=title)
-        item["Description"] = description
+        item["replace"]["Title"] = get_link_for(obj)
+        item["Description"] = obj.Description()
 
         sample_types = obj.getSampleTypes()
-        if sample_types:
-            links = map(
-                lambda st: get_link(st.absolute_url(),
-                                    value=st.Title(),
-                                    css_class="link"),
-                sample_types)
-            item["replace"]["SampleTypes"] = ", ".join(links)
-        else:
-            item["SampleTypes"] = ""
-
-        parent = obj.aq_parent
-        if parent.portal_type == "Client":
-            item["Owner"] = parent.aq_parent.Title()
-            item["replace"]["Owner"] = get_link(
-                parent.absolute_url(), value=parent.getName())
-        else:
-            item["Owner"] = self.context.bika_setup.laboratory.Title()
+        links = map(self.resolve_link, sample_types)
+        item["replace"]["SampleTypes"] = ", ".join(links)
 
         return item
+
+    def resolve_link(self, obj, permission=ModifyPortalContent):
+        """Generates a valid html anchor element for the obj provided if the
+        current user has the permission granted. Otherwise, returns the title
+        """
+        if check_permission(permission, obj):
+            return get_link_for(obj)
+        return api.get_title(obj)
 
 
 class ajax_SamplePoints(BrowserView):

--- a/bika/lims/controlpanel/bika_sampletypes.py
+++ b/bika/lims/controlpanel/bika_sampletypes.py
@@ -177,20 +177,10 @@ class SampleTypesView(BikaListingView):
                                sample_points)
 
         # Display the links to the sample points
-        links = map(self.resolve_link, sample_points)
+        links = map(get_link_for, sample_points)
         item["replace"]["SamplePoints"] = ", ".join(links)
 
         return item
-
-    def resolve_link(self, obj, permission=ModifyPortalContent):
-        """Generates a valid html anchor element for the obj provided if the
-        current user has the permission granted. Otherwise, returns the title
-        """
-        if not obj:
-            return ""
-        if check_permission(permission, obj):
-            return get_link_for(obj)
-        return api.get_title(obj)
 
 
 class ajax_SampleTypes(BrowserView):

--- a/bika/lims/controlpanel/bika_sampletypes.py
+++ b/bika/lims/controlpanel/bika_sampletypes.py
@@ -165,6 +165,8 @@ class SampleTypesView(BikaListingView):
         container_type = obj.getContainerType()
         item["replace"]["ContainerType"] = get_link_for(container_type)
 
+        # Hide sample points assigned to this sample type that do not belong
+        # to the same container (Client or Setup)
         sample_points = obj.getSamplePoints()
         path = api.get_path(self.context)
         setup = api.get_setup()

--- a/bika/lims/controlpanel/bika_sampletypes.py
+++ b/bika/lims/controlpanel/bika_sampletypes.py
@@ -160,13 +160,11 @@ class SampleTypesView(BikaListingView):
                                         .format(hours, minutes, days))
 
         sample_matrix = obj.getSampleMatrix()
-        item["replace"]["SampleMatrix"] = self.resolve_link(sample_matrix)
+        item["replace"]["SampleMatrix"] = get_link_for(sample_matrix)
 
         container_type = obj.getContainerType()
-        item["replace"]["ContainerType"] = self.resolve_link(container_type)
+        item["replace"]["ContainerType"] = get_link_for(container_type)
 
-        # Hide sample points assigned to this sample type that do not belong
-        # to the same container (Client or Setup)
         sample_points = obj.getSamplePoints()
         path = api.get_path(self.context)
         setup = api.get_setup()

--- a/bika/lims/exportimport/setupdata/__init__.py
+++ b/bika/lims/exportimport/setupdata/__init__.py
@@ -1155,7 +1155,7 @@ class Sample_Types(WorksheetImporter):
             samplepoint = self.get_object(bsc, 'SamplePoint',
                                           row.get('SamplePoint_title'))
             if samplepoint:
-                obj.setSamplePoints([samplepoint, ])
+                samplepoint.setSampleType([obj, ])
             obj.unmarkCreationFlag()
             renameAfterCreation(obj)
             notify(ObjectInitializedEvent(obj))
@@ -1219,11 +1219,6 @@ class Sample_Point_Sample_Types(WorksheetImporter):
                     sampletypes.append(sampletype)
                     samplepoint.setSampleTypes(sampletypes)
 
-            if sampletype:
-                samplepoints = sampletype.getSamplePoints()
-                if samplepoint not in samplepoints:
-                    samplepoints.append(samplepoint)
-                    sampletype.setSamplePoints(samplepoints)
 
 class Storage_Locations(WorksheetImporter):
 

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -726,6 +726,8 @@ def get_link(href, value=None, **kwargs):
 def get_link_for(obj, **kwargs):
     """Returns a well-formed html anchor to the object
     """
+    if not obj:
+        return ""
     href = api.get_url(obj)
     value = api.get_title(obj)
     return get_link(href=href, value=value, **kwargs)

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -723,6 +723,14 @@ def get_link(href, value=None, **kwargs):
     return '<a href="{}" {}>{}</a>'.format(href, attr, anchor_value)
 
 
+def get_link_for(obj, **kwargs):
+    """Returns a well-formed html anchor to the object
+    """
+    href = api.get_url(obj)
+    value = api.get_title(obj)
+    return get_link(href=href, value=value, **kwargs)
+
+
 def get_email_link(email, value=None):
     """
     Returns a well-formed link to an email address. If email is None/empty,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Remove the two-ways effective relationship between Sample Type and Sample Points.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
