### PR TITLE
Display Client tabs in Sample Points listing

### DIFF
--- a/bika/lims/browser/client/views/samplepoints.py
+++ b/bika/lims/browser/client/views/samplepoints.py
@@ -24,4 +24,10 @@ from bika.lims.controlpanel.bika_samplepoints import SamplePointsView
 class ClientSamplePointsView(SamplePointsView):
     """This is displayed in the "Sample Points" tab on each client
     """
-    pass
+
+    def before_render(self):
+        """Before template render hook
+        """
+        # Display the Client's tab bar at the top
+        if "disable_border" in self.request:
+            del(self.request["disable_border"])


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Display the Client tabs in Sample Points listing

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
