### PR TITLE
Fix missing Add Dynamic Analysis Specifications Button for Lab Managers

### DIFF
--- a/bika/lims/controlpanel/dynamic_analysisspecs.py
+++ b/bika/lims/controlpanel/dynamic_analysisspecs.py
@@ -22,6 +22,7 @@ import collections
 
 from bika.lims import _
 from bika.lims.catalog import SETUP_CATALOG
+from bika.lims.permissions import AddAnalysisSpec
 from plone.dexterity.content import Container
 from plone.supermodel import model
 from senaite.core.listing import ListingView
@@ -56,7 +57,7 @@ class DynamicAnalysisSpecsView(ListingView):
         self.context_actions = {
             _("Add"): {
                 "url": "++add++DynamicAnalysisSpec",
-                "permission": "cmf.AddPortalContent",
+                "permission": AddAnalysisSpec,
                 "icon": "++resource++bika.lims.images/add.png"}
             }
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the add permission for dynamic analysisspecs for LabManagers

## Current behavior before PR

No "Add" button is displayed in Dynamic Analysisspecs for Lab Managers

## Desired behavior after PR is merged

"Add" button is displayed in Dynamic Analysisspecs for Lab Managers

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
