### PR TITLE
Client contacts can create samples without contact

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Fixed**
 
+- #1563 Fix Client Contacts can create Samples without Contact
 - #1560 Fix missing Add Dynamic Analysis Specifications Button for Lab Managers
 
 

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -818,10 +818,16 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         """Returns the client info of an object
         """
         info = self.get_base_info(obj)
+
+        # Set the default contact, but only if empty. The Contact field is
+        # flushed each time the Client changes, so we can assume that if there
+        # is a selected contact, it belongs to current client already
         default_contact = self.get_default_contact(client=obj)
         if default_contact:
+            contact_info = self.get_contact_info(default_contact)
+            contact_info.update({"if_empty": True})
             info["field_values"].update({
-                "Contact": self.get_contact_info(default_contact),
+                "Contact": contact_info
             })
 
         # Set default CC Email field


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When a Client contact adds a Sample, the system defaults the Contact field with the contact the current user is assigned to. System does not allow him/her to change the Contact field, and this might end up without value.

Linked issue: https://github.com/senaite/senaite.core/issues/1562

## Current behavior before PR

Client contact cannot change the contact from the Sample in Add form

## Desired behavior after PR is merged

Client contact can change the contact from the Sample in Add form

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
