### PR TITLE
Pin CSSSelect to < 0.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
         # https://pypi.org/project/more-itertools/
         'more-itertools<6.0.0',
         # cssselect2 0.3.0 does not support Python 2.x anymore
-        'cssselect<0.3.0',
+        'cssselect2<0.3.0',
     ],
     extras_require={
         'test': [

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,9 @@ setup(
         # https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst#622-2020-01-02
         'Pillow<7.0.0',
         # https://pypi.org/project/more-itertools/
-        'more-itertools<6.0.0'
+        'more-itertools<6.0.0',
+        # cssselect2 0.3.0 does not support Python 2.x anymore
+        'cssselect<0.3.0',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR

Setup/Scrutinizer fails because cssselect 0.3.0 is not compatible with Python 2.x anymore 

## Desired behavior after PR is merged

Pin cssselect to < 0.3.0

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
