### PR TITLE
Fix column sorting in Worksheet listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Fixed**
 
+- #1566 Fix column sorting in Worksheet listing
 - #1563 Fix Client Contacts can create Samples without Contact
 - #1560 Fix missing Add Dynamic Analysis Specifications Button for Lab Managers
 

--- a/bika/lims/browser/worksheet/views/folder.py
+++ b/bika/lims/browser/worksheet/views/folder.py
@@ -94,6 +94,7 @@ class FolderView(BikaListingView):
 
         self.columns = collections.OrderedDict((
             ("Progress", {
+               "index": "getProgressPercentage",
                "title": _("Progress")}),
             ("Title", {
                 "title": _("Worksheet"),
@@ -104,12 +105,16 @@ class FolderView(BikaListingView):
             ("Template", {
                 "title": _("Template"),
                 "attr": "getWorksheetTemplateTitle",
+                "index": "getWorksheetTemplateTitle",
                 "replace_url": "getWorksheetTemplateURL"}),
             ("NumRegularSamples", {
+                "index": "getNumberOfRegularSamples",
                 "title": _("Samples")}),
             ("NumQCAnalyses", {
+                "index": "getNumberOfQCAnalyses",
                 "title": _("QC Analyses")}),
             ("NumRegularAnalyses", {
+                "index": "getNumberOfRegularAnalyses",
                 "title": _("Routine Analyses")}),
             ("CreationDate", {
                 "title": _("Created"),

--- a/bika/lims/browser/worksheet/views/folder.py
+++ b/bika/lims/browser/worksheet/views/folder.py
@@ -93,8 +93,7 @@ class FolderView(BikaListingView):
             })
 
         self.columns = collections.OrderedDict((
-            ("Progress", {
-               "index": "getProgressPercentage",
+            ("getProgressPercentage", {
                "title": _("Progress")}),
             ("Title", {
                 "title": _("Worksheet"),
@@ -102,19 +101,14 @@ class FolderView(BikaListingView):
             ("Analyst", {
                 "title": _("Analyst"),
                 "index": "getAnalyst"}),
-            ("Template", {
+            ("getWorksheetTemplateTitle", {
                 "title": _("Template"),
-                "attr": "getWorksheetTemplateTitle",
-                "index": "getWorksheetTemplateTitle",
                 "replace_url": "getWorksheetTemplateURL"}),
-            ("NumRegularSamples", {
-                "index": "getNumberOfRegularSamples",
+            ("getNumberOfRegularSamples", {
                 "title": _("Samples")}),
-            ("NumQCAnalyses", {
-                "index": "getNumberOfQCAnalyses",
+            ("getNumberOfQCAnalyses", {
                 "title": _("QC Analyses")}),
-            ("NumRegularAnalyses", {
-                "index": "getNumberOfRegularAnalyses",
+            ("getNumberOfRegularAnalyses", {
                 "title": _("Routine Analyses")}),
             ("CreationDate", {
                 "title": _("Created"),
@@ -314,15 +308,19 @@ class FolderView(BikaListingView):
         item["replace"]["Title"] = get_link(title_link, value=title)
 
         # Total QC Analyses
-        item["NumQCAnalyses"] = str(obj.getNumberOfQCAnalyses)
+        item["getNumberOfQCAnalyses"] = str(
+            obj.getNumberOfQCAnalyses)
         # Total Routine Analyses
-        item["NumRegularAnalyses"] = str(obj.getNumberOfRegularAnalyses)
+        item["getNumberOfRegularAnalyses"] = str(
+            obj.getNumberOfRegularAnalyses)
         # Total Number of Samples
-        item["NumRegularSamples"] = str(obj.getNumberOfRegularSamples)
+        item["getNumberOfRegularSamples"] = str(
+            obj.getNumberOfRegularSamples)
 
         # Progress
-        progress_perc = obj.getProgressPercentage
-        item["replace"]["Progress"] = get_progress_bar_html(progress_perc)
+        progress = obj.getProgressPercentage
+        progress_bar_html = get_progress_bar_html(progress)
+        item["replace"]["getProgressPercentage"] = progress_bar_html
 
         review_state = item["review_state"]
         if self.can_reassign and review_state == "open":


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Several columns from the worksheet listing table sort wrong

## Current behavior before PR

Columns with dysfunctional sortings:

- Progress
- Template
- Samples
- QC Analyses
- Routine Analyses


## Desired behavior after PR is merged

All columns sort correctly in the listing table


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
