### PR TITLE
Fix missing CCContact after adding a new Sample

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Fixed**
 
+- #1567 Fix missing CCContact after adding a new Sample
 - #1563 Fix Client Contacts can create Samples without Contact
 - #1560 Fix missing Add Dynamic Analysis Specifications Button for Lab Managers
 

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -34,6 +34,7 @@
       this.set_service_spec = bind(this.set_service_spec, this);
       this.set_service = bind(this.set_service, this);
       this.set_template = bind(this.set_template, this);
+      this.get_reference_field_value = bind(this.get_reference_field_value, this);
       this.set_reference_field = bind(this.set_reference_field, this);
       this.set_reference_field_query = bind(this.set_reference_field_query, this);
       this.reset_reference_field_query = bind(this.reset_reference_field_query, this);
@@ -590,6 +591,28 @@
       }
     };
 
+    AnalysisRequestAdd.prototype.get_reference_field_value = function(field) {
+
+      /*
+       * Return the value of a single/multi reference field
+       */
+      var $field, $parent, multivalued, ref, uids;
+      $field = $(field);
+      if ($field.attr("multivalued") === void 0) {
+        return [];
+      }
+      multivalued = $field.attr("multivalued") === "1";
+      if (!multivalued) {
+        return [$field.val()];
+      }
+      $parent = field.closest("div.field");
+      uids = (ref = $("input[type=hidden]", $parent)) != null ? ref.val() : void 0;
+      if (!uids) {
+        return [];
+      }
+      return uids.split(",");
+    };
+
     AnalysisRequestAdd.prototype.set_template = function(arnum, template) {
 
       /*
@@ -756,7 +779,7 @@
       me = this;
       el = event.currentTarget;
       $el = $(el);
-      has_value = $el.val();
+      has_value = this.get_reference_field_value($el);
       uid = $el.attr("uid");
       field_name = $el.closest("tr[fieldname]").attr("fieldname");
       arnum = $el.closest("[arnum]").attr("arnum");

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -590,6 +590,27 @@ class window.AnalysisRequestAdd
       $field.val("")
 
 
+  get_reference_field_value: (field) =>
+    ###
+     * Return the value of a single/multi reference field
+    ###
+    $field = $(field)
+    if $field.attr("multivalued") is undefined
+      return []
+
+    multivalued = $field.attr("multivalued") == "1"
+
+    if not multivalued
+      return [$field.val()]
+
+    $parent = field.closest("div.field")
+    uids = $("input[type=hidden]", $parent)?.val()
+    if not uids
+      return []
+
+    return uids.split(",")
+
+
   set_template: (arnum, template) =>
     ###
      * Apply the template data to all fields of arnum
@@ -763,7 +784,7 @@ class window.AnalysisRequestAdd
     me = this
     el = event.currentTarget
     $el = $(el)
-    has_value = $el.val()
+    has_value = @get_reference_field_value $el
     uid = $el.attr "uid"
     field_name = $el.closest("tr[fieldname]").attr "fieldname"
     arnum = $el.closest("[arnum]").attr "arnum"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1561

## Current behavior before PR

CCContact was missing after adding a new Sample.
Furthermore, the selected CCContact(s) were not deselectable

## Desired behavior after PR is merged

CCContacts can be added/removed in Sample Add form and are stored after save

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
