### PR TITLE
Fix traceback when rendering sticker `Code_39_2ix1i`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Fixed**
 
+- #1568 Fix Traceback when rendering sticker `Code_39_2ix1i`
 - #1567 Fix missing CCContact after adding a new Sample
 - #1566 Fix column sorting in Worksheet listing
 - #1563 Fix Client Contacts can create Samples without Contact

--- a/bika/lims/browser/templates/stickers/Code_39_2ix1i.pt
+++ b/bika/lims/browser/templates/stickers/Code_39_2ix1i.pt
@@ -3,7 +3,8 @@
                      sample_type item/getSampleTypeTitle|nothing;
                      date_sampled python:view.ulocalized_time(item.getDateSampled());
                      client_sample_id item/getClientSampleID|nothing;
-                     hazardous item/getHazardous|nothing;">
+                     hazardous item/getHazardous|nothing;
+                     portal_url nocall:context/portal_url;">
 
 
   <!-- Sample ID -->


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a Traceback when the barcode sticker `Code_39_2ix1i` is selected.

## Current behavior before PR

```
NameError: portal_url

 - Expression: "portal_url"
 - Filename:   ... re/bika/lims/browser/templates/stickers/Code_39_2ix1i.pt
 - Location:   (line 12: col 38)
 - Source:     ... attributes="src string:${portal_url}/++resource++bika.lims.i
...
                                            ^^^^^^^^^^
```

## Desired behavior after PR is merged

No traceback. The sticker gets rendered correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
