### PR TITLE
Pin dependent versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,10 @@ setup(
         'more-itertools<6.0.0',
         # cssselect2 0.3.0 does not support Python 2.x anymore
         'cssselect2<0.3.0',
+        # beautifulsoup4 4.9.0 requires 'soupsieve<2.0'
+        'soupsieve<2.0.0',
+        # dependency for jsonapi
+        'simplejson',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR pins some additional versions

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
