### PR TITLE
Date time picker does not translates well to current language

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ Changelog
 
 **Fixed**
 
-- #1580 Fix Cannot reject Sample when contact has no email set
+- #1570 Fix Date time picker does not translates well to current language
+- #1571 Fix Cannot reject Sample when contact has no email set
 - #1568 Fix Traceback when rendering sticker `Code_39_2ix1i`
 - #1567 Fix missing CCContact after adding a new Sample
 - #1566 Fix column sorting in Worksheet listing

--- a/bika/lims/skins/bika/bika_widgets/datetimewidget.js
+++ b/bika/lims/skins/bika/bika_widgets/datetimewidget.js
@@ -2,7 +2,7 @@ jQuery( function($) {
   $(document).ready(function() {
 
     var lang = jarn.i18n.currentLanguage;
-    var config = $.timepicker.regional[lang] || {};
+    var config = $.datepicker.regional[lang] || $.datepicker.regional[''];
 
     $('[datepicker="1"]').datepicker(
       Object.assign(config, {


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

jQuery date-picker widget displays years, months weeks in Chinese regardless the selected language.

It seems that `bika_widgets/datetimewidget.js` gets the widget configuration from a jQuery library.

But the gotten jQuery configuration came from **time**-picker setup dictionary instead of the **date**-picker dictionary. Hence, no name for years, weeks or months were gotten. Somehow jQuery was getting a random (or the last) configuration for year, months and weeks names.

This PR gets the `date picker` dictionary configuration from jQuery library instead the `time picker`. It also considers the situation that` jarn.i18n.currentLanguage` returns a void object. In such case, we set the default region `$.datepicker.regional['']` that seems to be 'en'.

Other background:
- Gitter discussion: https://gitter.im/senaite/Lobby?at=5cda7c26f251e60ffa7bf1b2
- PR that changed the source dictionary: https://github.com/senaite/senaite.core/commit/9e6aa2096fec1146489bf07be4e73620669260db#diff-3e421d09939848ec26f25de7ebbc75daR5
- @rockfruit 's ticket from some years ago: https://bugs.jqueryui.com/ticket/6682
- EN as default regional: https://github.com/jquery/jquery-ui/commit/450d75f912f4161c475f18f9eeb7efd307c02eae

## Current behavior before PR

jQuery date-picker widget displays month and years in Chinese even though different language and regions are selected. Note that time is in the correct format.

![image](https://user-images.githubusercontent.com/7425587/79248154-bcb0c500-7e7b-11ea-9342-a3cabb3cdef4.png)


## Desired behavior after PR is merged

Date picker uses proper date and month titles.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
