### PR TITLE
Cannot reject Sample when Contact has no email set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Fixed**
 
+- #1580 Fix Cannot reject Sample when contact has no email set
 - #1568 Fix Traceback when rendering sticker `Code_39_2ix1i`
 - #1567 Fix missing CCContact after adding a new Sample
 - #1566 Fix column sorting in Worksheet listing

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -499,8 +499,9 @@ def do_rejection(sample, notify=None):
     if notify:
         # Compose and send the email
         mime_msg = get_rejection_mail(sample, pdf)
-        # Send the email
-        send_email(mime_msg)
+        if mime_msg:
+            # Send the email
+            send_email(mime_msg)
 
 
 def get_rejection_pdf(sample):
@@ -552,6 +553,11 @@ def get_rejection_mail(sample, rejection_pdf=None):
     _to = [sample.getContact()] + sample.getCCContact()
     _to = map(to_valid_email_address, _to)
     _to = filter(None, _to)
+
+    if not _to:
+        # Cannot send an e-mail without recipient!
+        logger.warn("No valid recipients for {}".format(api.get_id(sample)))
+        return None
 
     lab = api.get_setup().laboratory
     attachments = rejection_pdf and [rejection_pdf] or []


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When "Notify on Sample Rejection" option is enabled in Setup, the system sends an e-mail with the rejection reasons to the contact assigned to the sample. If the sample neither has a contact with a valid email nor CCEmail is empty, the system fails to reject because of empty recipient.

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.analysisrequest.add2, line 66, in decorator
  Module bika.lims.browser.analysisrequest.add2, line 734, in __call__
  Module bika.lims.browser.analysisrequest.add2, line 1676, in ajax_submit
  Module bika.lims.utils.analysisrequest, line 146, in create_analysisrequest
  Module bika.lims.utils.analysisrequest, line 503, in do_rejection
  Module bika.lims.api.mail, line 231, in send_email
  Module Products.MailHost.MailHost, line 231, in send
  Module Products.MailHost.MailHost, line 450, in _mungeHeaders
MailHostError: No message recipients designated
```

## Desired behavior after PR is merged

Sample is rejected, even if the contact does not have an e-mail set. The rejection of Sample while being created also works without traceback.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
