### PR TITLE
Unable to get the previous status when duplicated in review history

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Fixed**
 
+- #1572 Fix Unable to get the previous status when duplicated in review history
 - #1570 Fix Date time picker does not translates well to current language
 - #1571 Fix Cannot reject Sample when contact has no email set
 - #1568 Fix Traceback when rendering sticker `Code_39_2ix1i`

--- a/bika/lims/workflow/__init__.py
+++ b/bika/lims/workflow/__init__.py
@@ -34,6 +34,7 @@ from bika.lims.jsonapi import get_include_fields
 from bika.lims.utils import changeWorkflowState  # noqa
 from bika.lims.utils import t
 from bika.lims.workflow.indexes import ACTIONS_TO_INDEXES
+from itertools import groupby
 from Products.Archetypes.config import UID_CATALOG
 from Products.CMFCore.utils import getToolByName
 from Products.CMFCore.WorkflowCore import WorkflowException
@@ -276,6 +277,9 @@ def get_prev_status_from_history(instance, status=None):
     target = status or api.get_workflow_status_of(instance)
     history = getReviewHistory(instance, reverse=True)
     history = map(lambda event: event["review_state"], history)
+    # Remove consecutive duplicates
+    history = map(lambda i: i[0], groupby(history))
+
     if target not in history or history.index(target) == len(history)-1:
         return None
     return history[history.index(target)+1]


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The function `get_prev_status_from_history` gets the review history of a given object, do a reverse of the list and then keeps iterating through the fetched status until a match against the passed-in value is found. In such case, it returns the next status (since the list was reversed, it actually returns the status reached by the object previously in time). Nevertheless, if the status is repeated in the list consecutively, the function always return the same passed-in status.

This Pull Request address the situation, so even if the object has a given status consecutively duplicated in its review_history, the function returns the status the object had before.

## Current behavior before PR

Given an object with a review history with following statuses (sorted from older to newest):

```python
["sample_received", "to_be_verified", "verified", "published", "published"]
```
The following returns "published", whilst it should return "verified":

```python
wf.get_prev_status_from_history(obj, "published") == "published"
True
```

## Desired behavior after PR is merged


Given an object with a review history with following statuses (sorted from older to newest):

```python
["sample_received", "to_be_verified", "verified", "published", "published"]
```
The following returns "verified"

```python
wf.get_prev_status_from_history(obj, "published") == "verified"
True
```

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
