### PR TITLE
Make navigation to Client view easier for client contacts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
+**Added**
+
+- #1573 Add link "My Organization" under top-right user selection list
+
+**Changed**
+
+- #1573 Do not display top-level "Clients" folder to non-lab users
+
 **Fixed**
 
 - #1572 Fix Unable to get the previous status when duplicated in review history

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1573 Append the type name of the current record in breadcrumbs (Client)
 - #1573 Add link "My Organization" under top-right user selection list
 
 **Changed**

--- a/bika/lims/browser/bootstrap/static/css/bootstrap-integration.css
+++ b/bika/lims/browser/bootstrap/static/css/bootstrap-integration.css
@@ -364,3 +364,8 @@ https://github.com/senaite/senaite.lims/pull/92 */
 #content > h1:first-of-type {
     margin-top: 0;
 }
+
+/* Do not display Clients top-folder in nav-bar when client */
+body.userrole-client div.navbar li.section-clients {
+  display:none;
+}

--- a/bika/lims/browser/bootstrap/static/css/bootstrap-integration.css
+++ b/bika/lims/browser/bootstrap/static/css/bootstrap-integration.css
@@ -364,8 +364,3 @@ https://github.com/senaite/senaite.lims/pull/92 */
 #content > h1:first-of-type {
     margin-top: 0;
 }
-
-/* Do not display Clients top-folder in nav-bar when client */
-body.userrole-client div.navbar li.section-clients {
-  display:none;
-}

--- a/bika/lims/browser/configure.zcml
+++ b/bika/lims/browser/configure.zcml
@@ -61,6 +61,14 @@
       layer="bika.lims.interfaces.IBikaLIMS"
     />
 
+  <!-- Redirect to user's org view -->
+  <browser:page
+      for="*"
+      name="my_organization"
+      class=".myorganization.MyOrganizationView"
+      permission="zope2.View"
+      layer="bika.lims.interfaces.IBikaLIMS" />
+
   <browser:page
       for="*"
       name="at_validate_field"

--- a/bika/lims/browser/myorganization.py
+++ b/bika/lims/browser/myorganization.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2020 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.lims import api
+from bika.lims.browser import BrowserView
+
+
+class MyOrganizationView(BrowserView):
+    """Redirects to the current user's organization view, if any. Otherwise,
+    falls-back to portal view
+    """
+
+    def __call__(self):
+        url = api.get_url(api.get_portal())
+        current_user = api.get_current_user()
+        contact = api.get_user_contact(current_user)
+        if contact:
+            parent = api.get_parent(contact)
+            url = api.get_url(parent)
+
+        return self.request.response.redirect(url)

--- a/bika/lims/browser/portlets/navigation.py
+++ b/bika/lims/browser/portlets/navigation.py
@@ -17,7 +17,7 @@
 #
 # Copyright 2018-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
-
+from AccessControl import Unauthorized
 from Products.CMFCore.permissions import View
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from plone.app.portlets.portlets.navigation import Renderer as BaseRenderer
@@ -52,11 +52,13 @@ class NavigationPortletRenderer(BaseRenderer):
         """Purges the items of the nav tree for which the current user does not
         have "View" permission granted
         """
-        uid = data.get("UID", "")
-        if api.is_uid(uid):
+        item = data.get("item", "")
+        if item:
             # Check if current user has "View" permission granted
-            obj = api.get_object_by_uid(uid)
-            if not check_permission(View, obj):
+            try:
+                if not check_permission(View, item):
+                    return None
+            except Unauthorized:
                 return None
 
         if "children" in data:

--- a/bika/lims/browser/portlets/navigation.py
+++ b/bika/lims/browser/portlets/navigation.py
@@ -18,8 +18,12 @@
 # Copyright 2018-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from plone.app.portlets.portlets.navigation import Renderer as BaseRenderer
+from Products.CMFCore.permissions import View
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from plone.app.portlets.portlets.navigation import Renderer as BaseRenderer
+
+from bika.lims import api
+from bika.lims.api.security import check_permission
 
 
 class NavigationPortletRenderer(BaseRenderer):
@@ -27,3 +31,37 @@ class NavigationPortletRenderer(BaseRenderer):
         "templates/plone.app.portlets.portlets.navigation.pt")
     recurse = ViewPageTemplateFile(
         "templates/plone.app.portlets.portlets.navigation_recurse.pt")
+
+    def createNavTree(self):
+        data = self.getNavTree()
+
+        # We only want the items from the nav tree for which current user has
+        # "View" permission granted
+        data = self.purge_nav_tree(data)
+
+        bottomLevel = self.data.bottomLevel or self.properties.getProperty('bottomLevel', 0)
+
+        if bottomLevel < 0:
+            # Special case where navigation tree depth is negative
+            # meaning that the admin does not want the listing to be displayed
+            return self.recurse([], level=1, bottomLevel=bottomLevel)
+        else:
+            return self.recurse(children=data.get('children', []), level=1, bottomLevel=bottomLevel)
+
+    def purge_nav_tree(self, data):
+        """Purges the items of the nav tree for which the current user does not
+        have "View" permission granted
+        """
+        uid = data.get("UID", "")
+        if api.is_uid(uid):
+            # Check if current user has "View" permission granted
+            obj = api.get_object_by_uid(uid)
+            if not check_permission(View, obj):
+                return None
+
+        if "children" in data:
+            children = map(self.purge_nav_tree, data["children"])
+            children = filter(None, children)
+            data["children"] = children
+
+        return data

--- a/bika/lims/browser/portlets/templates/plone.app.portlets.portlets.navigation_recurse.pt
+++ b/bika/lims/browser/portlets/templates/plone.app.portlets.portlets.navigation_recurse.pt
@@ -26,7 +26,7 @@
           tal:condition="python:bottomLevel &lt;= 0 or level &lt;= bottomLevel">
 
         <tal:level define="item_class string:senaite-state-${node/normalized_review_state};
-                           item_type_class python:'senatite-contenttype-' + normalizeString(item_type);
+                           item_type_class python:'senaite-contenttype-' + normalizeString(item_type);
                            item_class python:is_current and item_class + ' active' or item_class;">
 
           <a tal:attributes="href python:use_remote_url and item_remote_url or item_url;

--- a/bika/lims/browser/viewlets/path_bar.py
+++ b/bika/lims/browser/viewlets/path_bar.py
@@ -71,10 +71,10 @@ class PathBarViewlet(Base):
         return title
 
     def get_portal_type_title(self, obj):
-        """Returns the title of the portal type of the current context
+        """Returns the title of the portal type of the obj passed-in
         """
         portal = api.get_portal()
-        portal_type = api.get_portal_type(self.context)
+        portal_type = api.get_portal_type(obj)
         portal_type = portal.portal_types.getTypeInfo(portal_type)
         if portal_type:
             return portal_type.title

--- a/bika/lims/browser/viewlets/path_bar.py
+++ b/bika/lims/browser/viewlets/path_bar.py
@@ -18,10 +18,22 @@
 # Copyright 2018-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from plone.app.layout.viewlets.common import PathBarViewlet as Base
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from plone.app.layout.viewlets.common import PathBarViewlet as Base
+
+from bika.lims import api
 
 
 class PathBarViewlet(Base):
     index = ViewPageTemplateFile(
         "templates/plone.app.layout.viewlets.path_bar.pt")
+
+    def update(self):
+        super(PathBarViewlet, self).update()
+
+        # If current user is a Client, hide Clients folder from breadcrumbs
+        user = api.get_current_user()
+        if "Client" in user.getRoles():
+            skip = api.get_title(api.get_portal().clients)
+            self.breadcrumbs = filter(lambda b: b.get("Title") not in skip,
+                                      self.breadcrumbs)

--- a/bika/lims/browser/viewlets/path_bar.py
+++ b/bika/lims/browser/viewlets/path_bar.py
@@ -44,7 +44,11 @@ class PathBarViewlet(Base):
         hierarchy = []
         current = self.context
         while not api.is_portal(current):
-            if check_permission(View, current):
+            if api.is_object(current):
+                if check_permission(View, current):
+                    hierarchy.append(current)
+            else:
+                # Some objects (e.g. portal_registry) are not supported
                 hierarchy.append(current)
             current = current.aq_parent
         hierarchy = sorted(hierarchy, reverse=True)
@@ -54,11 +58,15 @@ class PathBarViewlet(Base):
         """Converts the object to a breadcrumb for the template consumption
         """
         return {"Title": self.get_obj_title(obj),
-                "absolute_url": api.get_url(obj)}
+                "absolute_url": self.get_obj_url(obj)}
 
     def get_obj_title(self, obj):
         """Returns the title of the object to be displayed as breadcrumb
         """
+        if not api.is_object(obj):
+            # Some objects (e.g. portal_registry) are not supported
+            return obj.Title()
+
         title = api.get_title(obj)
         if IClient.providedBy(obj.aq_parent):
             # Objects from inside Client folder are always stored directly, w/o
@@ -69,6 +77,15 @@ class PathBarViewlet(Base):
             if pt_title:
                 title = "{} ({})".format(title, _(pt_title))
         return title
+
+    def get_obj_url(self, obj):
+        """Returns the absolute url of the object passed-in
+        """
+        if not api.is_object(obj):
+            # Some objects (e.g. portal_registry) are not supported
+            return obj.absolute_url()
+
+        return api.get_url(obj)
 
     def get_portal_type_title(self, obj):
         """Returns the title of the portal type of the obj passed-in

--- a/bika/lims/profiles/default/actions.xml
+++ b/bika/lims/profiles/default/actions.xml
@@ -33,6 +33,36 @@
     </object>
   </object>
 
+  <!-- User actions -->
+  <object name="user" meta_type="CMF Action Category">
+    <!-- Hide User Dashboard -->
+    <object name="dashboard" meta_type="CMF Action" i18n:domain="plone">
+      <property name="title" i18n:translate="">Dashboard</property>
+      <property name="description" i18n:translate=""></property>
+      <property name="url_expr">string:${portal_url}/dashboard</property>
+      <property name="link_target"></property>
+      <property name="icon_expr"></property>
+      <property name="available_expr">python:member is not None</property>
+      <property name="permissions">
+        <element value="Portlets: Manage own portlets"/>
+      </property>
+      <property name="visible">False</property>
+    </object>
+
+    <!-- My Organization link -->
+    <object name="my_organization" meta_type="CMF Action" i18n:domain="plone">
+      <property name="title" i18n:translate="">My Organization</property>
+      <property name="description"/>
+      <property name="url_expr">string:${portal_url}/my_organization</property>
+      <property name="link_target"/>
+      <property name="icon_expr"/>
+      <property name="available_expr">python:member and "Client" in member.getRoles()</property>
+      <property name="permissions"/>
+      <property name="visible">True</property>
+    </object>
+  </object>
+
+
   <!-- Folder Buttons -->
   <object name="folder_buttons">
     <object name="copy">

--- a/bika/lims/profiles/default/actions.xml
+++ b/bika/lims/profiles/default/actions.xml
@@ -50,8 +50,9 @@
     </object>
 
     <!-- My Organization link -->
-    <object name="my_organization" meta_type="CMF Action" i18n:domain="plone">
-      <property name="title" i18n:translate="">My Organization</property>
+    <object name="my_organization" meta_type="CMF Action" i18n:domain="plone"
+      insert-before="logout">
+      <property name="title" i18n:translate="">My organization</property>
       <property name="description"/>
       <property name="url_expr">string:${portal_url}/my_organization</property>
       <property name="link_target"/>

--- a/bika/lims/profiles/default/workflows/senaite_client_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_client_workflow/definition.xml
@@ -41,50 +41,11 @@
     <permission-map name="senaite.core: Transition: Deactivate" acquired="True" />
 
     <!-- Plone's permissions -->
-    <permission-map name="Access contents information" acquired="False">
-      <!-- Same as in rolemap.xml, but without Client -->
-      <permission-role>Analyst</permission-role>
-      <permission-role>LabClerk</permission-role>
-      <permission-role>LabManager</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>Owner</permission-role>
-      <permission-role>Preserver</permission-role>
-      <permission-role>Publisher</permission-role>
-      <permission-role>RegulatoryInspector</permission-role>
-      <permission-role>Sampler</permission-role>
-      <permission-role>SamplingCoordinator</permission-role>
-      <permission-role>Verifier</permission-role>
-    </permission-map>
+    <permission-map name="Access contents information" acquired="True" />
     <permission-map name="Delete objects" acquired="True" />
-    <permission-map name="List folder contents" acquired="False">
-      <!-- Same as in rolemap.xml, but without Client -->
-      <permission-role>Analyst</permission-role>
-      <permission-role>LabClerk</permission-role>
-      <permission-role>LabManager</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>Owner</permission-role>
-      <permission-role>Preserver</permission-role>
-      <permission-role>Publisher</permission-role>
-      <permission-role>RegulatoryInspector</permission-role>
-      <permission-role>Sampler</permission-role>
-      <permission-role>SamplingCoordinator</permission-role>
-      <permission-role>Verifier</permission-role>
-    </permission-map>
+    <permission-map name="List folder contents" acquired="True"/>
     <permission-map name="Modify portal content" acquired="True"/>
-    <permission-map name="View" acquired="False">
-      <!-- Same as in rolemap.xml, but without Client -->
-      <permission-role>Analyst</permission-role>
-      <permission-role>LabClerk</permission-role>
-      <permission-role>LabManager</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>Owner</permission-role>
-      <permission-role>Preserver</permission-role>
-      <permission-role>Publisher</permission-role>
-      <permission-role>RegulatoryInspector</permission-role>
-      <permission-role>Sampler</permission-role>
-      <permission-role>SamplingCoordinator</permission-role>
-      <permission-role>Verifier</permission-role>
-    </permission-map>
+    <permission-map name="View" acquired="True"/>
   </state>
 
   <!-- State: inactive

--- a/bika/lims/profiles/default/workflows/senaite_clients_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_clients_workflow/definition.xml
@@ -29,16 +29,47 @@
   <state state_id="active" title="Active" i18n:attributes="title">
     <exit-transition transition_id="" />
     <!-- PLONE Permissions -->
+    <!-- Only Lab Personnel can access to clients folder -->
     <permission-map name="Access contents information" acquired="False">
-      <permission-role>Authenticated</permission-role>
+      <permission-role>Analyst</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Preserver</permission-role>
+      <permission-role>Publisher</permission-role>
+      <permission-role>RegulatoryInspector</permission-role>
+      <permission-role>Sampler</permission-role>
+      <permission-role>SamplingCoordinator</permission-role>
+      <permission-role>Verifier</permission-role>
     </permission-map>
     <permission-map name="Delete objects" acquired="False" />
     <permission-map name="List folder contents" acquired="False">
-      <permission-role>Authenticated</permission-role>
+      <permission-role>Analyst</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Preserver</permission-role>
+      <permission-role>Publisher</permission-role>
+      <permission-role>RegulatoryInspector</permission-role>
+      <permission-role>Sampler</permission-role>
+      <permission-role>SamplingCoordinator</permission-role>
+      <permission-role>Verifier</permission-role>
     </permission-map>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="False">
-      <permission-role>Authenticated</permission-role>
+      <permission-role>Analyst</permission-role>
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+      <permission-role>Preserver</permission-role>
+      <permission-role>Publisher</permission-role>
+      <permission-role>RegulatoryInspector</permission-role>
+      <permission-role>Sampler</permission-role>
+      <permission-role>SamplingCoordinator</permission-role>
+      <permission-role>Verifier</permission-role>
     </permission-map>
   </state>
 

--- a/bika/lims/tests/doctests/Permissions.rst
+++ b/bika/lims/tests/doctests/Permissions.rst
@@ -375,7 +375,7 @@ Test Permissions
 Exactly these roles have should have a `View` permission for clients folder::
 
     >>> get_roles_for_permission("View", clients)
-    ['Authenticated']
+    ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Owner', 'Preserver', 'Publisher', 'RegulatoryInspector', 'Sampler', 'SamplingCoordinator', 'Verifier']
 
 Exactly these roles should have a `View` permission for client object. Note that
 permissions for Client role are not granted, but for Owner. Lab Contacts are
@@ -393,7 +393,7 @@ Exactly these roles should have a `View` permission for client contact object:
 Exactly these roles have should have the `Access contents information` permission::
 
     >>> get_roles_for_permission("Access contents information", clients)
-    ['Authenticated']
+    ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Owner', 'Preserver', 'Publisher', 'RegulatoryInspector', 'Sampler', 'SamplingCoordinator', 'Verifier']
 
     >>> get_roles_for_permission("Access contents information", client)
     ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Owner', 'Preserver', 'Publisher', 'RegulatoryInspector', 'Sampler', 'SamplingCoordinator', 'Verifier']
@@ -404,7 +404,7 @@ Exactly these roles have should have the `Access contents information` permissio
 Exactly these roles have should have the `List folder contents` permission::
 
     >>> get_roles_for_permission("List folder contents", clients)
-    ['Authenticated']
+    ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Owner', 'Preserver', 'Publisher', 'RegulatoryInspector', 'Sampler', 'SamplingCoordinator', 'Verifier']
 
     >>> get_roles_for_permission("List folder contents", client)
     ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Owner', 'Preserver', 'Publisher', 'RegulatoryInspector', 'Sampler', 'SamplingCoordinator', 'Verifier']
@@ -478,8 +478,9 @@ Now we log in as the new user::
 The user can not access the clients folder yet::
 
     >>> browser.open(clients.absolute_url())
-    >>> "client-1" not in browser.contents
-    True
+    Traceback (most recent call last):
+    ...
+    Unauthorized: ...
 
     >>> browser.open(client.absolute_url())
     Traceback (most recent call last):
@@ -548,8 +549,9 @@ The user has no local owner role anymore on the client::
 The user can not access the client anymore::
 
     >>> browser.open(clients.absolute_url())
-    >>> "client-1" not in browser.contents
-    True
+    Traceback (most recent call last):
+    ...
+    Unauthorized: ...
 
     >>> browser.open(client.absolute_url())
     Traceback (most recent call last):

--- a/bika/lims/upgrade/v01_03_004.py
+++ b/bika/lims/upgrade/v01_03_004.py
@@ -51,6 +51,10 @@ def upgrade(tool):
     wf_tool = api.get_tool("portal_workflow")
     workflow = wf_tool.getWorkflowById("senaite_clients_workflow")
     workflow.updateRoleMappingsFor(portal.clients)
+    portal.clients.reindexObject()
+
+    # New link to My Organization
+    setup.runImportStepFromProfile(profile, "actions")
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True

--- a/bika/lims/upgrade/v01_03_004.py
+++ b/bika/lims/upgrade/v01_03_004.py
@@ -18,6 +18,7 @@
 # Copyright 2018-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from bika.lims import api
 from bika.lims import logger
 from bika.lims.config import PROJECTNAME as product
 from bika.lims.upgrade import upgradestep
@@ -43,5 +44,14 @@ def upgrade(tool):
 
     # -------- ADD YOUR STUFF BELOW --------
 
+    # Do not display clients folder to Clients. There is no need to do an
+    # update-role-mappings of clients, cause the permissions at client level
+    # have not changed, except that now they are acquire=1 for "active" status
+    setup.runImportStepFromProfile(profile, "workflow")
+    wf_tool = api.get_tool("portal_workflow")
+    workflow = wf_tool.getWorkflowById("senaite_clients_workflow")
+    workflow.updateRoleMappingsFor(portal.clients)
+
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
+


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request removes the "View" permission from role "Client" for top-level "clients" folder, so the link in the navigation bar is no longer displayed. An additional link "My Organization" has been added as an user_action (displayed in the user's top-right selection list). This link redirects the user to the view of the organization he/she belongs to.

![Captura de 2020-04-19 20-08-10](https://user-images.githubusercontent.com/832627/79695878-860eec00-8279-11ea-83a2-91efc92b3dde.png)

This Pull Request also appends the type name of the current object type in breadcrumbs when the parent is a Client. The reason is that all types (say Batch, Contact, etc.) are added directly inside Client folder, without specific folders for each type. Therefore, it makes sometimes difficult for user to know if is looking at, ie. a Batch or a Sample.

![Captura de 2020-04-19 21-18-06](https://user-images.githubusercontent.com/832627/79697508-7c8a8180-8283-11ea-9d19-d666d09fcb8b.png)


Linked issue: https://github.com/senaite/senaite.core/issues/1380

## Current behavior before PR

Clients folder was displayed to clients and was confusing for client users, cause they had to first go to that folder and then select their organization.

## Desired behavior after PR is merged

Client user can easily access to his/her organization view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
