### PR TITLE
Fix bad order in breadcrumbs

### DIFF
--- a/bika/lims/browser/viewlets/path_bar.py
+++ b/bika/lims/browser/viewlets/path_bar.py
@@ -17,6 +17,7 @@
 #
 # Copyright 2018-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
+
 from Products.CMFCore.permissions import View
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from plone.app.layout.viewlets.common import PathBarViewlet as Base
@@ -51,7 +52,7 @@ class PathBarViewlet(Base):
                 # Some objects (e.g. portal_registry) are not supported
                 hierarchy.append(current)
             current = current.aq_parent
-        hierarchy = sorted(hierarchy, reverse=True)
+        hierarchy = reversed(hierarchy)
         return map(self.to_breadcrumb, hierarchy)
 
     def to_breadcrumb(self, obj):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Breadcrumbs were sorted, instead of reversed :speak_no_evil: 

## Current behavior before PR

Breadcrumbs bar is not sorted properly

## Desired behavior after PR is merged

Breadcrumbs bar is sorted properly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
