### PR TITLE
Uncertainties are displayed although result is below Detection Limit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #1575 Fix Uncertainties are displayed although result is below Detection Limit
 - #1572 Fix Unable to get the previous status when duplicated in review history
 - #1570 Fix Date time picker does not translates well to current language
 - #1571 Fix Cannot reject Sample when contact has no email set

--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -985,8 +985,8 @@ class AnalysesView(BikaListingView):
                                        sciformat=int(self.scinot))
         if formatted:
             item["Uncertainty"] = formatted
-        else:
-            item["Uncertainty"] = obj.getUncertainty(result)
+            item["before"]["Uncertainty"] = "± "
+            item["after"]["Uncertainty"] = obj.getUnit()
 
         if self.is_uncertainty_edition_allowed(analysis_brain):
             item["allow_edit"].append("Uncertainty")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

In Analyses listings, the uncertainties are displayed even if the result is below (or above) the Detection Limit. Also, units and +- symbol are not displayed.

## Current behavior before PR

![Captura de 2020-04-26 23-56-14](https://user-images.githubusercontent.com/832627/80321375-e6270480-881c-11ea-89f6-0c986f749994.png)

## Desired behavior after PR is merged

![Captura de 2020-04-26 23-56-36](https://user-images.githubusercontent.com/832627/80321369-e0312380-881c-11ea-958c-8721e7f4ee37.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
