### PR TITLE
Do not force available workflow transitions in batches listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Changelog
 
 **Changed**
 
+- #1577 Do not force available workflow transitions in batches listing
 - #1573 Do not display top-level "Clients" folder to non-lab users
 
 **Fixed**

--- a/bika/lims/browser/batchfolder.py
+++ b/bika/lims/browser/batchfolder.py
@@ -96,18 +96,18 @@ class BatchFolderContentsView(BikaListingView):
                 "id": "default",
                 "contentFilter": {"review_state": "open"},
                 "title": _("Open"),
-                "transitions": [{"id": "close"}, {"id": "cancel"}],
+                "transitions": [],
                 "columns": self.columns.keys(),
             }, {
                 "id": "closed",
                 "contentFilter": {"review_state": "closed"},
                 "title": _("Closed"),
-                "transitions": [{"id": "open"}],
+                "transitions": [],
                 "columns": self.columns.keys(),
             }, {
                 "id": "cancelled",
                 "title": _("Cancelled"),
-                "transitions": [{"id": "reinstate"}],
+                "transitions": [],
                 "contentFilter": {"is_active": False},
                 "columns": self.columns.keys(),
             }, {


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The batches listing defines the allowed transitions to be performed against selected batches when a given filter is selected.

Available transitions for any given object are bound to its workflow definition and current user privileges. Forcing the available transitions makes other add-ons with the batch workflow customized to also tweak these values for new transitions to be displayed.

## Current behavior before PR

Transitions are filtered in batches listing

## Desired behavior after PR is merged

Transitions in batches listing are retrieved directly from workflow

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
