### PR TITLE
Analysts are not displayed in Worksheet listing just afer being created

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Fixed**
 
+- #1580 Fix Analysts are not displayed once created in worksheets listing
 - #1575 Fix Uncertainties are displayed although result is below Detection Limit
 - #1572 Fix Unable to get the previous status when duplicated in review history
 - #1570 Fix Date time picker does not translates well to current language

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -139,12 +139,6 @@ def printfile(portal, from_addr, to_addrs, msg):
     pass
 
 
-def _cache_key_getUsers(method, context, roles=[], allow_empty=True):
-    key = time() // (60 * 60), roles, allow_empty
-    return key
-
-
-@ram.cache(_cache_key_getUsers)
 def getUsers(context, roles, allow_empty=True):
     """ Present a DisplayList containing users in the specified
         list of roles


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request removes the cache of the function `getUsers` from `utils` module.

## Current behavior before PR

Newly created analysts are not displayed in worksheet listing for selection (e.g. for WS creation or re-assignment) until 2 hours later after they have been created

## Desired behavior after PR is merged

New analysts are displayed immediately in worksheets listing for selection

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
