### PR TITLE
Some values are not properly rendered in services listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Fixed**
 
+- #1581 Fix Some values are not properly rendered in services listing
 - #1575 Fix Uncertainties are displayed although result is below Detection Limit
 - #1572 Fix Unable to get the previous status when duplicated in review history
 - #1570 Fix Date time picker does not translates well to current language

--- a/bika/lims/controlpanel/bika_analysisservices.py
+++ b/bika/lims/controlpanel/bika_analysisservices.py
@@ -382,7 +382,6 @@ class AnalysisServicesView(BikaListingView):
             item["MaxTimeAllowed"] = self.format_maxtime(maxtime)
 
         # Price
-        import pdb;pdb.set_trace()
         item["Price"] = self.format_price(obj.Price)
 
         # Duplicate Variation

--- a/bika/lims/controlpanel/bika_analysisservices.py
+++ b/bika/lims/controlpanel/bika_analysisservices.py
@@ -228,7 +228,6 @@ class AnalysisServicesView(BikaListingView):
             ("Department", {
                 "title": _("Department"),
                 "toggle": False,
-                "attr": "getDepartment.Title",
                 "sortable": self.can_sort}),
             ("Unit", {
                 "title": _("Unit"),
@@ -356,7 +355,7 @@ class AnalysisServicesView(BikaListingView):
         category = obj.getCategory()
         if category:
             title = category.Title()
-            url = category.absolute_url()
+            url = api.get_url(category)
             item["Category"] = title
             item["replace"]["Category"] = get_link(url, value=title)
 
@@ -364,7 +363,7 @@ class AnalysisServicesView(BikaListingView):
         calculation = obj.getCalculation()
         if calculation:
             title = calculation.Title()
-            url = calculation.absolute_url()
+            url = api.get_url(calculation)
             item["Calculation"] = title
             item["replace"]["Calculation"] = get_link(url, value=title)
 
@@ -383,6 +382,7 @@ class AnalysisServicesView(BikaListingView):
             item["MaxTimeAllowed"] = self.format_maxtime(maxtime)
 
         # Price
+        import pdb;pdb.set_trace()
         item["Price"] = self.format_price(obj.Price)
 
         # Duplicate Variation
@@ -390,6 +390,13 @@ class AnalysisServicesView(BikaListingView):
         if dup_variation:
             item["DuplicateVariation"] = self.format_duplication_variation(
                 dup_variation)
+
+        # Department
+        department = obj.getDepartment()
+        if department:
+            title = api.get_title(department)
+            url = api.get_url(department)
+            item["replace"]["Department"] = get_link(url, title)
 
         # Unit
         unit = obj.getUnit()

--- a/bika/lims/controlpanel/bika_analysisservices.py
+++ b/bika/lims/controlpanel/bika_analysisservices.py
@@ -211,7 +211,7 @@ class AnalysisServicesView(BikaListingView):
             ("Title", {
                 "title": _("Service"),
                 "index": "sortable_title",
-                "replace_url": "absolute_url",
+                "replace_url": "getURL",
                 "sortable": self.can_sort}),
             ("Keyword", {
                 "title": _("Keyword"),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`setup_catalog` does not contain the metadata fields `getDepartment` and `absolute_url` since a long time ago, but the services listing is relying on them still. This Pull Request makes the Department to be displayed in services listing, as well as the valid url of each service.

## Current behavior before PR

Some column values are not properly rendered in services listing

## Desired behavior after PR is merged

Column values are properly rendered in services listing

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
