### PR TITLE
Allow to retest analyses without the need of retraction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1582 Allow to retest analyses without the need of retraction
 - #1573 Append the type name of the current record in breadcrumbs (Client)
 - #1573 Add link "My Organization" under top-right user selection list
 

--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -151,7 +151,7 @@ class AnalysesView(BikaListingView):
                 "ajax": True,
                 "sortable": False}),
             ("retested", {
-                "title": _("Retested"),
+                "title": _("Retest"),
                 "type": "boolean",
                 "sortable": False}),
             ("Attachments", {

--- a/bika/lims/catalog/indexers/baseanalysis.py
+++ b/bika/lims/catalog/indexers/baseanalysis.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 from Products.CMFPlone.utils import safe_callable
+from bika.lims import api
 from bika.lims.catalog.indexers import sortable_sortkey_title
 from bika.lims.interfaces import IBaseAnalysis
 from plone.indexer import indexer
@@ -29,4 +30,4 @@ def sortable_title(instance):
     title = sortable_sortkey_title(instance)
     if safe_callable(title):
         title = title()
-    return title
+    return "{}-{}".format(title, api.get_id(instance))

--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -437,10 +437,10 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         raise NotImplementedError("getDependents is not implemented.")
 
     @security.public
-    def getDependencies(self, retracted=False):
+    def getDependencies(self, with_retests=False):
         """Return a list of siblings who we depend on to calculate our result.
-        :param retracted: If false retracted/rejected analyses are dismissed
-        :type retracted: bool
+        :param with_retests: If false, siblings with retests are dismissed
+        :type with_retests: bool
         :return: Analyses the current analysis depends on
         :rtype: list of IAnalysis
         """

--- a/bika/lims/content/abstractroutineanalysis.py
+++ b/bika/lims/content/abstractroutineanalysis.py
@@ -340,23 +340,23 @@ class AbstractRoutineAnalysis(AbstractAnalysis, ClientAwareMixin):
         return results_range
 
     @security.public
-    def getSiblings(self, retracted=False):
+    def getSiblings(self, with_retests=False):
         """
         Return the siblings analyses, using the parent to which the current
         analysis belongs to as the source
-        :param retracted: If false, retracted/rejected siblings are dismissed
-        :type retracted: bool
+        :param with_retests: If false, siblings with retests are dismissed
+        :type with_retests: bool
         :return: list of siblings for this analysis
         :rtype: list of IAnalysis
         """
         raise NotImplementedError("getSiblings is not implemented.")
 
     @security.public
-    def getDependents(self, retracted=False):
+    def getDependents(self, with_retests=False):
         """
         Returns a list of siblings who depend on us to calculate their result.
-        :param retracted: If false, retracted/rejected dependents are dismissed
-        :type retracted: bool
+        :param with_retests: If false, dependents with retests are dismissed
+        :type with_retests: bool
         :return: Analyses the current analysis depends on
         :rtype: list of IAnalysis
         """
@@ -373,15 +373,15 @@ class AbstractRoutineAnalysis(AbstractAnalysis, ClientAwareMixin):
             services = api.search(query, "bika_setup_catalog")
             return len(services) > 0
 
-        siblings = self.getSiblings(retracted=retracted)
+        siblings = self.getSiblings(with_retests=with_retests)
         return filter(lambda sib: is_dependent(sib), siblings)
 
     @security.public
-    def getDependencies(self, retracted=False):
+    def getDependencies(self, with_retests=False):
         """
         Return a list of siblings who we depend on to calculate our result.
-        :param retracted: If false retracted/rejected dependencies are dismissed
-        :type retracted: bool
+        :param with_retests: If false, dependencies with retests are dismissed
+        :type with_retests: bool
         :return: Analyses the current analysis depends on
         :rtype: list of IAnalysis
         """
@@ -396,10 +396,10 @@ class AbstractRoutineAnalysis(AbstractAnalysis, ClientAwareMixin):
             return []
 
         dependencies = []
-        for sibling in self.getSiblings(retracted=retracted):
+        for sibling in self.getSiblings(with_retests=with_retests):
             # We get all analyses that depend on me, also if retracted (maybe
             # I am one of those that are retracted!)
-            deps = map(api.get_uid, sibling.getDependents(retracted=True))
+            deps = map(api.get_uid, sibling.getDependents(with_retests=True))
             if self.UID() in deps:
                 dependencies.append(sibling)
         return dependencies

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -40,12 +40,12 @@ class Analysis(AbstractRoutineAnalysis):
     schema = schema
 
     @security.public
-    def getSiblings(self, retracted=False):
+    def getSiblings(self, with_retests=False):
         """
         Returns the list of analyses of the Analysis Request to which this
         analysis belongs to, but with the current analysis excluded.
-        :param retracted: If false, retracted/rejected siblings are dismissed
-        :type retracted: bool
+        :param with_retests: If false, siblings with retests are dismissed
+        :type with_retests: bool
         :return: list of siblings for this analysis
         :rtype: list of IAnalysis
         """
@@ -60,7 +60,7 @@ class Analysis(AbstractRoutineAnalysis):
                 # Exclude me from the list
                 continue
 
-            if not retracted:
+            if not with_retests:
                 if api.get_workflow_status_of(sibling) in retracted_states:
                     # Exclude retracted analyses
                     continue

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -64,6 +64,9 @@ class Analysis(AbstractRoutineAnalysis):
                 if api.get_workflow_status_of(sibling) in retracted_states:
                     # Exclude retracted analyses
                     continue
+                elif sibling.getRetest():
+                    # Exclude analyses with a retest
+                    continue
 
             siblings.append(sibling)
 

--- a/bika/lims/content/duplicateanalysis.py
+++ b/bika/lims/content/duplicateanalysis.py
@@ -80,13 +80,13 @@ class DuplicateAnalysis(AbstractRoutineAnalysis):
         return self.aq_parent
 
     @security.public
-    def getSiblings(self, retracted=False):
+    def getSiblings(self, with_retests=False):
         """
         Return the list of duplicate analyses that share the same Request and
         are included in the same Worksheet as the current analysis. The current
         duplicate is excluded from the list.
-        :param retracted: If false, retracted/rejected siblings are dismissed
-        :type retracted: bool
+        :param with_retests: If false, siblings with retests are dismissed
+        :type with_retests: bool
         :return: list of siblings for this analysis
         :rtype: list of IAnalysis
         """
@@ -113,7 +113,7 @@ class DuplicateAnalysis(AbstractRoutineAnalysis):
                 # analysis request I belong to
                 continue
 
-            if not retracted:
+            if not with_retests:
 
                 if in_state(analysis, retracted_states):
                     # Exclude retracted analyses

--- a/bika/lims/content/duplicateanalysis.py
+++ b/bika/lims/content/duplicateanalysis.py
@@ -113,9 +113,15 @@ class DuplicateAnalysis(AbstractRoutineAnalysis):
                 # analysis request I belong to
                 continue
 
-            if retracted is False and in_state(analysis, retracted_states):
-                # Exclude retracted analyses
-                continue
+            if not retracted:
+
+                if in_state(analysis, retracted_states):
+                    # Exclude retracted analyses
+                    continue
+
+                elif analysis.getRetest():
+                    # Exclude analyses with a retest
+                    continue
 
             siblings.append(analysis)
 

--- a/bika/lims/content/referenceanalysis.py
+++ b/bika/lims/content/referenceanalysis.py
@@ -180,7 +180,7 @@ class ReferenceAnalysis(AbstractAnalysis):
         """
         return []
 
-    def getDependents(self, with_retests=False):
+    def getDependents(self, with_retests=False, recursive=False):
         """It doesn't make sense for a ReferenceAnalysis to use
         dependents, since them are only used in calculations for
         routine analyses

--- a/bika/lims/content/referenceanalysis.py
+++ b/bika/lims/content/referenceanalysis.py
@@ -173,14 +173,14 @@ class ReferenceAnalysis(AbstractAnalysis):
             return ins.absolute_url_path()
         return ''
 
-    def getDependencies(self, retracted=False):
+    def getDependencies(self, with_retests=False):
         """It doesn't make sense for a ReferenceAnalysis to use
         dependencies, since them are only used in calculations for
         routine analyses
         """
         return []
 
-    def getDependents(self, retracted=False):
+    def getDependents(self, with_retests=False):
         """It doesn't make sense for a ReferenceAnalysis to use
         dependents, since them are only used in calculations for
         routine analyses

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -896,16 +896,6 @@ class IWorkflowActionUIDsAdapter(IWorkflowActionAdapter):
     """
 
 
-class IRetested(Interface):
-    """Marker interface for retested objects
-    """
-
-
-class IRetest(Interface):
-    """Marker interface for retests
-    """
-
-
 class IVerified(Interface):
     """Marker interface for verified objects
     """

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -896,6 +896,16 @@ class IWorkflowActionUIDsAdapter(IWorkflowActionAdapter):
     """
 
 
+class IRetested(Interface):
+    """Marker interface for retested objects
+    """
+
+
+class IRetest(Interface):
+    """Marker interface for retests
+    """
+
+
 class IVerified(Interface):
     """Marker interface for verified objects
     """

--- a/bika/lims/permissions.py
+++ b/bika/lims/permissions.py
@@ -97,6 +97,7 @@ TransitionClose = "senaite.core: Transition: Close"
 TransitionReopen = "senaite.core: Transition: Reopen"
 
 # Transition permissions (Analysis and alike)
+TransitionRetest = "senaite.core: Transition: Retest"
 TransitionRetract = "senaite.core: Transition: Retract"
 TransitionVerify = "senaite.core: Transition: Verify"
 TransitionAssignAnalysis = "senaite.core: Transition: Assign Analysis"

--- a/bika/lims/permissions.zcml
+++ b/bika/lims/permissions.zcml
@@ -69,6 +69,7 @@
   <permission id="senaite.core.permissions.TransitionReopen" title="senaite.core: Transition: Reopen"/>
 
   # Transition Permissions (Analysis and alike)
+  <permission id="senaite.core.permissions.TransitionRetest" title="senaite.core: Transition: Retest"/>
   <permission id="senaite.core.permissions.TransitionRetract" title="senaite.core: Transition: Retract"/>
   <permission id="senaite.core.permissions.TransitionVerify" title="senaite.core: Transition: Verify"/>
   <permission id="senaite.core.permissions.TransitionAssignAnalysis" title="senaite.core: Transition: Assign Analysis"/>

--- a/bika/lims/profiles/default/rolemap.xml
+++ b/bika/lims/profiles/default/rolemap.xml
@@ -395,6 +395,10 @@
     </permission>
 
     <!-- Transition permissions (Analysis and alike) -->
+    <permission name="senaite.core: Transition: Retest" acquire="False">
+      <role name="LabManager"/>
+      <role name="Manager"/>
+    </permission>
     <permission name="senaite.core: Transition: Retract" acquire="False">
       <role name="LabManager"/>
       <role name="Manager"/>

--- a/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
@@ -10,6 +10,7 @@
 
   <permission>senaite.core: Transition: Assign Analysis</permission>
   <permission>senaite.core: Transition: Unassign Analysis</permission>
+  <permission>senaite.core: Transition: Retest</permission>
   <permission>senaite.core: Transition: Retract</permission>
   <permission>senaite.core: Transition: Verify</permission>
   <permission>senaite.core: View Results</permission>
@@ -287,6 +288,7 @@
     <!-- TRANSITIONS -->
     <exit-transition transition_id="multi_verify" />
     <exit-transition transition_id="verify" />
+    <exit-transition transition_id="retest" />
     <exit-transition transition_id="retract" />
     <exit-transition transition_id="reject" />
     <!-- /TRANSITIONS -->
@@ -311,6 +313,8 @@
       <permission-role>RegulatoryInspector</permission-role>
       <permission-role>Verifier</permission-role>
     </permission-map>
+
+    <permission-map name="senaite.core: Transition: Retest" acquired="True" />
 
     <permission-map name="senaite.core: Transition: Retract" acquired="False">
       <permission-role>Analyst</permission-role>
@@ -617,6 +621,21 @@
       <guard-permission>senaite.core: Edit Results</guard-permission>
       <guard-permission>senaite.core: Edit Field Results</guard-permission>
       <guard-expression>python:here.guard_handler("submit")</guard-expression>
+    </guard>
+  </transition>
+
+  <!-- Transition: retest
+  Current analysis is transitioned to "verified" status and a new copy of the
+  same analysis is created. The initial state of the copy is "unassigned",
+  unless the original analysis was assigned to a worksheet. In such case, the
+  copy is transitioned to "assigned" state too. -->
+  <transition transition_id="retest" title="Retest" new_state="verified"
+              trigger="USER" before_script="" after_script=""
+              i18n:attributes="title">
+    <action url="" category="workflow" icon="">Retest</action>
+    <guard>
+      <guard-permission>senaite.core: Transition: Retest</guard-permission>
+      <guard-expression>python:here.guard_handler("retest")</guard-expression>
     </guard>
   </transition>
 

--- a/bika/lims/tests/doctests/WorkflowAnalysisRetest.rst
+++ b/bika/lims/tests/doctests/WorkflowAnalysisRetest.rst
@@ -1,0 +1,298 @@
+Analysis retest guard and event
+===============================
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t WorkflowAnalysisRetest
+
+
+Test Setup
+----------
+
+Needed Imports:
+
+    >>> from AccessControl.PermissionRole import rolesForPermissionOn
+    >>> from bika.lims import api
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+    >>> from bika.lims.workflow import isTransitionAllowed
+    >>> from DateTime import DateTime
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+
+Functional Helpers:
+
+    >>> def new_ar(services):
+    ...     values = {
+    ...         'Client': client.UID(),
+    ...         'Contact': contact.UID(),
+    ...         'DateSampled': date_now,
+    ...         'SampleType': sampletype.UID()}
+    ...     service_uids = map(api.get_uid, services)
+    ...     ar = create_analysisrequest(client, request, values, service_uids)
+    ...     transitioned = do_action_for(ar, "receive")
+    ...     return ar
+
+    >>> def try_transition(object, transition_id, target_state_id):
+    ...      success = do_action_for(object, transition_id)[0]
+    ...      state = api.get_workflow_status_of(object)
+    ...      return success and state == target_state_id
+
+    >>> def submit_analyses(ar):
+    ...     for analysis in ar.getAnalyses(full_objects=True):
+    ...         analysis.setResult(13)
+    ...         do_action_for(analysis, "submit")
+
+    >>> def get_roles_for_permission(permission, context):
+    ...     allowed = set(rolesForPermissionOn(permission, context))
+    ...     return sorted(allowed)
+
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = portal.bika_setup
+    >>> date_now = DateTime().strftime("%Y-%m-%d")
+
+We need to create some basic objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
+    >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH", MemberDiscountApplies=True)
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(setup.bika_sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.bika_departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = api.create(setup.bika_analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> Cu = api.create(setup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID(), Accredited=True)
+    >>> Fe = api.create(setup.bika_analysisservices, "AnalysisService", title="Iron", Keyword="Fe", Price="10", Category=category.UID())
+    >>> Au = api.create(setup.bika_analysisservices, "AnalysisService", title="Gold", Keyword="Au", Price="20", Category=category.UID())
+
+
+Retest transition and guard basic constraints
+---------------------------------------------
+
+Create an Analysis Request and submit results:
+
+    >>> ar = new_ar([Cu, Fe, Au])
+
+We cannot retest analyses if no results have been submitted yet:
+
+    >>> analyses = ar.getAnalyses(full_objects=True)
+    >>> analysis = analyses[0]
+    >>> isTransitionAllowed(analysis, "retest")
+    False
+    >>> submit_analyses(ar)
+
+The `retest` transition can be done now, cause the status of the analysis is
+`to_be_verified`:
+
+    >>> api.get_workflow_status_of(analysis)
+    'to_be_verified'
+
+    >>> isTransitionAllowed(analysis, "retest")
+    True
+
+When a `retest` transition is performed, a copy of the original analysis is
+created (the "retest") and the original analysis is transitioned to `verified`:
+
+    >>> analysis = analyses[0]
+    >>> try_transition(analysis, "retest", "verified")
+    True
+    >>> api.get_workflow_status_of(analysis)
+    'verified'
+
+    >>> analyses = ar.getAnalyses(full_objects=True)
+    >>> sorted(map(api.get_workflow_status_of, analyses))
+    ['to_be_verified', 'to_be_verified', 'unassigned', 'verified']
+
+Since there is one new analysis (the "retest") in `unassigned` status, the
+Analysis Request is transitioned to `sample_received`:
+
+    >>> api.get_workflow_status_of(ar)
+    'sample_received'
+
+The "retest" is a copy of original analysis:
+
+    >>> retest = filter(lambda an: api.get_workflow_status_of(an) == "unassigned", analyses)[0]
+    >>> analysis.getRetest() == retest
+    True
+    >>> retest.getRetestOf() == analysis
+    True
+    >>> retest.getKeyword() == analysis.getKeyword()
+    True
+
+But it does not keep the result:
+
+    >>> not retest.getResult()
+    True
+
+And Result capture date is None:
+
+    >>> not retest.getResultCaptureDate()
+    True
+
+If I submit a result for the "retest":
+
+    >>> retest.setResult(analysis.getResult())
+    >>> try_transition(retest, "submit", "to_be_verified")
+    True
+
+The status of both the analysis and the Analysis Request is "to_be_verified":
+
+    >>> api.get_workflow_status_of(retest)
+    'to_be_verified'
+    >>> api.get_workflow_status_of(ar)
+    'to_be_verified'
+
+And I can even ask for a retest of the retest:
+
+    >>> try_transition(retest, "retest", "verified")
+    True
+    >>> api.get_workflow_status_of(retest)
+    'verified'
+
+A new "retest" in `unassigned` state is created and the sample rolls back to
+`sample_received` status:
+
+    >>> analyses = ar.getAnalyses(full_objects=True)
+    >>> sorted(map(api.get_workflow_status_of, analyses))
+    ['to_be_verified', 'to_be_verified', 'unassigned', 'verified', 'verified']
+    >>> api.get_workflow_status_of(ar)
+    'sample_received'
+
+Auto-rollback of Worksheet on analysis retest
+---------------------------------------------
+
+The retesting of an analysis from a Worksheet that is in "to_be_verified" state
+causes the worksheet to rollback to "open" state.
+
+Create an Analysis Request and submit results:
+
+    >>> ar = new_ar([Cu, Fe, Au])
+
+Create a new Worksheet, assign all analyses and submit:
+
+    >>> ws = api.create(portal.worksheets, "Worksheet")
+    >>> for analysis in ar.getAnalyses(full_objects=True):
+    ...     ws.addAnalysis(analysis)
+    >>> submit_analyses(ar)
+
+The state for both the Analysis Request and Worksheet is "to_be_verified":
+
+    >>> api.get_workflow_status_of(ar)
+    'to_be_verified'
+    >>> api.get_workflow_status_of(ws)
+    'to_be_verified'
+
+Retest one analysis:
+
+    >>> analysis = ws.getAnalyses()[0]
+    >>> try_transition(analysis, "retest", "verified")
+    True
+
+A rollback of the state of Analysis Request and Worksheet takes place:
+
+    >>> api.get_workflow_status_of(ar)
+    'sample_received'
+    >>> api.get_workflow_status_of(ws)
+    'open'
+
+And both contain an additional analysis:
+
+    >>> len(ar.getAnalyses())
+    4
+    >>> len(ws.getAnalyses())
+    4
+
+The state of this additional analysis, the "retest", is `assigned`:
+
+    >>> analyses = ar.getAnalyses(full_objects=True)
+    >>> retest = filter(lambda an: api.get_workflow_status_of(an) == "assigned", analyses)[0]
+    >>> retest.getKeyword() == analysis.getKeyword()
+    True
+    >>> retest in ws.getAnalyses()
+    True
+
+
+Retest of an analysis with dependents
+-------------------------------------
+
+Retesting an analysis that depends on other analyses (dependents), forces the
+dependents to be retested too:
+
+Prepare a calculation that depends on `Cu` and assign it to `Fe` analysis:
+
+    >>> calc_fe = api.create(setup.bika_calculations, 'Calculation', title='Calc for Fe')
+    >>> calc_fe.setFormula("[Cu]*10")
+    >>> Fe.setCalculation(calc_fe)
+
+Prepare a calculation that depends on `Fe` and assign it to `Au` analysis:
+
+    >>> calc_au = api.create(setup.bika_calculations, 'Calculation', title='Calc for Au')
+    >>> calc_au.setFormula("([Fe])/2")
+    >>> Au.setCalculation(calc_au)
+
+Create an Analysis Request:
+
+    >>> ar = new_ar([Cu, Fe, Au])
+    >>> analyses = ar.getAnalyses(full_objects=True)
+    >>> cu_analysis = filter(lambda an: an.getKeyword()=="Cu", analyses)[0]
+    >>> fe_analysis = filter(lambda an: an.getKeyword()=="Fe", analyses)[0]
+    >>> au_analysis = filter(lambda an: an.getKeyword()=="Au", analyses)[0]
+
+TODO This should not be like this, but the calculation is performed by
+`ajaxCalculateAnalysisEntry`. The calculation logic must be moved to
+'api.analysis.calculate`:
+
+    >>> cu_analysis.setResult(20)
+    >>> fe_analysis.setResult(12)
+    >>> au_analysis.setResult(10)
+
+Submit `Au` analysis and the rest will follow:
+
+    >>> try_transition(au_analysis, "submit", "to_be_verified")
+    True
+    >>> api.get_workflow_status_of(au_analysis)
+    'to_be_verified'
+    >>> api.get_workflow_status_of(fe_analysis)
+    'to_be_verified'
+    >>> api.get_workflow_status_of(cu_analysis)
+    'to_be_verified'
+    >>> api.get_workflow_status_of(ar)
+    'to_be_verified'
+
+If I retest `Fe`, `Au` analysis is transitioned to verified and retested too:
+
+    >>> try_transition(fe_analysis, "retest", "verified")
+    True
+    >>> api.get_workflow_status_of(fe_analysis)
+    'verified'
+    >>> api.get_workflow_status_of(au_analysis)
+    'verified'
+
+As well as `Cu` analysis, that is a dependency of `Fe`:
+
+    >>> api.get_workflow_status_of(cu_analysis)
+    'verified'
+
+Hence, three new "retests" are generated in accordance:
+
+    >>> analyses = ar.getAnalyses(full_objects=True)
+    >>> len(analyses)
+    6
+    >>> au_analyses = filter(lambda an: an.getKeyword()=="Au", analyses)
+    >>> sorted(map(api.get_workflow_status_of, au_analyses))
+    ['unassigned', 'verified']
+    >>> fe_analyses = filter(lambda an: an.getKeyword()=="Fe", analyses)
+    >>> sorted(map(api.get_workflow_status_of, fe_analyses))
+    ['unassigned', 'verified']
+    >>> cu_analyses = filter(lambda an: an.getKeyword()=="Cu", analyses)
+    >>> sorted(map(api.get_workflow_status_of, cu_analyses))
+    ['unassigned', 'verified']
+
+And the current state of the Analysis Request is `sample_received` now:
+
+    >>> api.get_workflow_status_of(ar)
+    'sample_received'

--- a/bika/lims/tests/doctests/WorkflowAnalysisRetest.rst
+++ b/bika/lims/tests/doctests/WorkflowAnalysisRetest.rst
@@ -68,7 +68,7 @@ We need to create some basic objects for the test:
     >>> Cu = api.create(setup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID(), Accredited=True)
     >>> Fe = api.create(setup.bika_analysisservices, "AnalysisService", title="Iron", Keyword="Fe", Price="10", Category=category.UID())
     >>> Au = api.create(setup.bika_analysisservices, "AnalysisService", title="Gold", Keyword="Au", Price="20", Category=category.UID())
-
+    >>> setup.setSelfVerificationEnabled(True)
 
 Retest transition and guard basic constraints
 ---------------------------------------------

--- a/bika/lims/utils/analysis.py
+++ b/bika/lims/utils/analysis.py
@@ -30,8 +30,7 @@ from archetypes.schemaextender.interfaces import IExtensionField
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims.interfaces import IAnalysisService
-from bika.lims.interfaces import IRetest
-from bika.lims.interfaces import IRetested
+from bika.lims.interfaces.analysis import IRequestAnalysis
 from bika.lims.utils import formatDecimalMark
 from bika.lims.utils import to_unicode
 
@@ -630,6 +629,9 @@ def get_method_instrument_constraints(context, uids):
 def create_retest(analysis):
     """Creates a retest of the given analysis
     """
+    if not IRequestAnalysis.providedBy(analysis):
+        raise ValueError("Type not supported: {}".format(repr(type(analysis))))
+
     # Support multiple retests by prefixing keyword with *-0, *-1, etc.
     parent = api.get_parent(analysis)
     keyword = analysis.getKeyword()
@@ -649,10 +651,6 @@ def create_retest(analysis):
     worksheet = analysis.getWorksheet()
     if worksheet:
         worksheet.addAnalysis(retest)
-
-    # Apply marker interfaces
-    IRetested.providedBy(analysis)
-    IRetest.providedBy(retest)
 
     retest.reindexObject()
     return retest

--- a/bika/lims/utils/analysis.py
+++ b/bika/lims/utils/analysis.py
@@ -27,8 +27,11 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import _createObjectByType
 from archetypes.schemaextender.interfaces import IExtensionField
 
+from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims.interfaces import IAnalysisService
+from bika.lims.interfaces import IRetest
+from bika.lims.interfaces import IRetested
 from bika.lims.utils import formatDecimalMark
 from bika.lims.utils import to_unicode
 
@@ -622,3 +625,34 @@ def get_method_instrument_constraints(context, uids):
             constraints[auid][muid] = targ
             cached_servs[cachedkey][suid][muid] = targ
     return constraints
+
+
+def create_retest(analysis):
+    """Creates a retest of the given analysis
+    """
+    # Support multiple retests by prefixing keyword with *-0, *-1, etc.
+    parent = api.get_parent(analysis)
+    keyword = analysis.getKeyword()
+
+    # Get only those analyses with same keyword as original
+    analyses = parent.getAnalyses(full_objects=True)
+    analyses = filter(lambda an: an.getKeyword() == keyword, analyses)
+    new_id = '{}-{}'.format(keyword, len(analyses))
+
+    # Create a copy of the original analysis
+    an_uid = api.get_uid(analysis)
+    retest = create_analysis(parent, analysis, id=new_id, RetestOf=an_uid)
+    retest.setResult("")
+    retest.setResultCaptureDate(None)
+
+    # Add the retest to the same worksheet, if any
+    worksheet = analysis.getWorksheet()
+    if worksheet:
+        worksheet.addAnalysis(retest)
+
+    # Apply marker interfaces
+    IRetested.providedBy(analysis)
+    IRetest.providedBy(retest)
+
+    retest.reindexObject()
+    return retest

--- a/bika/lims/workflow/analysis/events.py
+++ b/bika/lims/workflow/analysis/events.py
@@ -167,30 +167,8 @@ def after_retract(analysis):
     # Retract our dependencies (analyses this analysis depends on)
     promote_to_dependencies(analysis, "retract")
 
-    # Rename the analysis to make way for it's successor.
-    # Support multiple retractions by renaming to *-0, *-1, etc
-    parent = analysis.aq_parent
-    keyword = analysis.getKeyword()
-
-    # Get only those that are analyses and with same keyword as the original
-    analyses = parent.getAnalyses(full_objects=True)
-    analyses = filter(lambda an: an.getKeyword() == keyword, analyses)
-    # TODO This needs to get managed by Id server in a nearly future!
-    new_id = '{}-{}'.format(keyword, len(analyses))
-
-    # Create a copy of the retracted analysis
-    an_uid = api.get_uid(analysis)
-    new_analysis = create_analysis(parent, analysis, id=new_id, RetestOf=an_uid)
-    new_analysis.setResult("")
-    new_analysis.setResultCaptureDate(None)
-    new_analysis.reindexObject()
-    logger.info("Retest for {} ({}) created: {}".format(
-        keyword, api.get_id(analysis), api.get_id(new_analysis)))
-
-    # Assign the new analysis to this same worksheet, if any.
-    worksheet = analysis.getWorksheet()
-    if worksheet:
-        worksheet.addAnalysis(new_analysis)
+    # Create the retest
+    create_retest(analysis)
 
     # Try to rollback the Analysis Request
     if IRequestAnalysis.providedBy(analysis):

--- a/bika/lims/workflow/analysis/guards.py
+++ b/bika/lims/workflow/analysis/guards.py
@@ -254,7 +254,7 @@ def guard_retest(analysis):
         return True
 
     # Cannot retest if all dependencies have been verified
-    if all(map(lambda an: IVerified.providedBy(an), dependencies))
+    if all(map(lambda an: IVerified.providedBy(an), dependencies)):
         return False
 
     return True

--- a/bika/lims/workflow/analysis/guards.py
+++ b/bika/lims/workflow/analysis/guards.py
@@ -242,6 +242,24 @@ def guard_retract(analysis):
     return True
 
 
+def guard_retest(analysis):
+    """Return whether the transition "retest" can be performed or not
+    """
+    # Cannot retest if there are dependents that cannot be retested
+    if not is_transition_allowed(analysis.getDependents(), "retest"):
+        return False
+
+    dependencies = analysis.getDependencies()
+    if not dependencies:
+        return True
+
+    # Cannot retest if all dependencies have been verified
+    if all(map(lambda an: IVerified.providedBy(an), dependencies))
+        return False
+
+    return True
+
+
 def guard_reject(analysis):
     """Return whether the transition "reject" can be performed or not
     """

--- a/bika/lims/workflow/analysis/guards.py
+++ b/bika/lims/workflow/analysis/guards.py
@@ -242,19 +242,16 @@ def guard_retract(analysis):
     return True
 
 
-def guard_retest(analysis):
+def guard_retest(analysis, check_dependents=True):
     """Return whether the transition "retest" can be performed or not
     """
-    # Cannot retest if there are dependents that cannot be retested
-    if not is_transition_allowed(analysis.getDependents(), "retest"):
+    # Retest transition does an automatic verify transition, so the analysis
+    # should be verifiable first
+    if not is_transition_allowed(analysis, "verify"):
         return False
 
-    dependencies = analysis.getDependencies()
-    if not dependencies:
-        return True
-
-    # Cannot retest if all dependencies have been verified
-    if all(map(lambda an: IVerified.providedBy(an), dependencies)):
+    # Cannot retest if there are dependents that cannot be retested
+    if not is_transition_allowed(analysis.getDependents(), "retest"):
         return False
 
     return True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

At the moment, retests can only be created by retracting the analysis. This is fine for when the analysis had a wrong result and the labman wants to discard the result and the analyst to perform the same test again.

Nevertheless, for some tests, a confirmative test is required when the first result, although "valid", is considered as non-conclusive. In such case, the "retract" transition is missleading.

This Pull Request adds a "retest" transition that is only available when the analysis is in "to_be_verified" status. When triggered, the current analysis is transitioned to "verified" status, but a retest is created at the same time. Therefore, the sample ends-up with two "valid" analyses for same keyword.

## Current behavior before PR

User has to retract an analysis in order to generate a retest

## Desired behavior after PR is merged

User can retest an analysis without the need of retraction

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
