### PR TITLE
Fix traceback in services listing in ARTemplate view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Fixed**
 
+- #1583 Fix traceback in services listing in ARTemplate view
 - #1581 Fix Some values are not properly rendered in services listing
 - #1580 Fix Analysts are not displayed once created in worksheets listing
 - #1575 Fix Uncertainties are displayed although result is below Detection Limit

--- a/bika/lims/browser/widgets/artemplateanalyseswidget.py
+++ b/bika/lims/browser/widgets/artemplateanalyseswidget.py
@@ -230,11 +230,13 @@ class ARTemplateAnalysesView(BikaListingView):
         item["replace"]["Title"] = get_link(url, value=title)
         item["Price"] = self.format_price(obj.Price)
         item["allow_edit"] = self.get_editable_columns()
-        item["required"].append("Partition")
         item["choices"]["Partition"] = self.partition_choices
         item["Partition"] = partition
         item["Hidden"] = hidden
         item["selected"] = uid in self.configuration
+
+        # Make partition a required field
+        item.setdefault("required", []).append("Partition")
 
         # Add methods
         methods = obj.getMethods()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fixes a traceback in services listing from inside ARTemplate

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module senaite.core.listing.view, line 214, in __call__
  Module senaite.core.listing.ajax, line 103, in handle_subpath
  Module senaite.core.listing.decorators, line 63, in wrapper
  Module senaite.core.listing.decorators, line 50, in wrapper
  Module senaite.core.listing.decorators, line 100, in wrapper
  Module senaite.core.listing.ajax, line 528, in ajax_folderitems
  Module senaite.core.listing.decorators, line 88, in wrapper
  Module senaite.core.listing.ajax, line 307, in get_folderitems
  Module bika.lims.browser.widgets.artemplateanalyseswidget, line 200, in
folderitems
  Module senaite.core.listing.view, line 895, in folderitems
  Module bika.lims.browser.widgets.artemplateanalyseswidget, line 233, in
folderitem
KeyError: 'required'
```

## Desired behavior after PR is merged

No Traceback. Services are displayed correctly in the listing

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
