### PR TITLE
Date (yymmdd) support in IDs generation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1584 Date (yymmdd) support in IDs generation
 - #1582 Allow to retest analyses without the need of retraction
 - #1573 Append the type name of the current record in breadcrumbs (Client)
 - #1573 Add link "My Organization" under top-right user selection list

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -814,6 +814,7 @@ schema = BikaFolderSchema.copy() + Schema((
                 "</tr>"
                 "<tr><td>Client</td><td>{client}</td></tr>"
                 "<tr><td>Year</td><td>{year}</td></tr>"
+                "<tr><td>Date</td><td>{yymmdd}</td></tr>"
                 "<tr><td>Sample ID</td><td>{sampleId}</td></tr>"
                 "<tr><td>Sample Type</td><td>{sampleType}</td></tr>"
                 "<tr><td>Sampling Date</td><td>{samplingDate}</td></tr>"

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -35,6 +35,7 @@ from bika.lims.interfaces import IAnalysisRequestSecondary
 from bika.lims.interfaces import IIdServer
 from bika.lims.numbergenerator import INumberGenerator
 from DateTime import DateTime
+from datetime import datetime
 from Products.ATContentTypes.utils import DT2dt
 from zope.component import getAdapters
 from zope.component import getUtility
@@ -206,6 +207,7 @@ def get_variables(context, **kw):
         "id": api.get_id(context),
         "portal_type": portal_type,
         "year": get_current_year(),
+        "yymmdd": get_yymmdd(),
         "parent": api.get_parent(context),
         "seq": 0,
         "alpha": Alphanumber(0),
@@ -341,6 +343,10 @@ def get_current_year():
     """
     return DateTime().strftime("%Y")[2:]
 
+def get_yymmdd():
+    """Returns the current date in yymmdd format
+    """
+    return datetime.now().strftime("%y%m%d")
 
 def make_storage_key(portal_type, prefix=None):
     """Make a storage (dict-) key for the number generator


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request enables the support of `{yymmdd}` wildcard for IDServer.

## Current behavior before PR

`{year}` wildcard supported, but not current day

## Desired behavior after PR is merged

`{yymmdd}` wildcard supported

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
