### PR TITLE
Fix wrong label and description for `ShowPartitions` setting from setup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Changelog
 
 **Fixed**
 
+- #1585 Fix wrong label and description for `ShowPartitions` setting from setup
 - #1583 Fix traceback in services listing in ARTemplate view
 - #1581 Fix Some values are not properly rendered in services listing
 - #1580 Fix Analysts are not displayed once created in worksheets listing

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -532,12 +532,11 @@ schema = BikaFolderSchema.copy() + Schema((
         schemata="Appearance",
         default=False,
         widget=BooleanWidget(
-            label=_("Display sample partitions to clients"),
+            label=_("Enable Sample Partitioning"),
             description=_(
-                "Select to show sample partitions to client contacts. "
-                "If deactivated, partitions won't be included in listings "
-                "and no info message with links to the primary sample will "
-                "be displayed to client contacts.")
+                "Select to enable the partitioning module. An additional "
+                "transition 'Create Partitions' will be available for samples "
+                "in received status")
         ),
     ),
     BooleanField(


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Label was wrong in setup > ShowPartitions field.

The sample partitioning module is enabled when this setting is checked

## Current behavior before PR

Wrong label/description

## Desired behavior after PR is merged

Correct label/description

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
