### PR TITLE
Allow to configure IDServer variables with an adapter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1586 Allow to configure the variables for IDServer with an Adapter
 - #1584 Date (yymmdd) support in IDs generation
 - #1582 Allow to retest analyses without the need of retraction
 - #1573 Append the type name of the current record in breadcrumbs (Client)

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -33,12 +33,15 @@ from bika.lims.interfaces import IAnalysisRequestPartition
 from bika.lims.interfaces import IAnalysisRequestRetest
 from bika.lims.interfaces import IAnalysisRequestSecondary
 from bika.lims.interfaces import IIdServer
+from bika.lims.interfaces import IIdServerVariables
 from bika.lims.numbergenerator import INumberGenerator
 from DateTime import DateTime
 from datetime import datetime
 from Products.ATContentTypes.utils import DT2dt
 from zope.component import getAdapters
 from zope.component import getUtility
+from zope.component import queryAdapter
+
 
 AR_TYPES = [
     "AnalysisRequest",
@@ -279,6 +282,12 @@ def get_variables(context, **kw):
         variables.update({
             "clientId": context.aq_parent.getClientID(),
         })
+
+    # Look for a variables adapter
+    adapter = queryAdapter(context, IIdServerVariables)
+    if adapter:
+        vars = adapter.get_variables(**kw)
+        variables.update(vars)
 
     return variables
 

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -580,6 +580,15 @@ class IIdServer(Interface):
         """
 
 
+class IIdServerVariables(Interface):
+    """Marker interfaces for variables generator for ID Server
+    """
+
+    def get_variables(self, **kw):
+        """Returns a dict with variables
+        """
+
+
 class IReferenceWidgetVocabulary(Interface):
     """Return values for reference widgets in AR contexts
     """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Adding new variables (wildcards) for IDServer is not possible unless monkey patching `get_variables` function from `id_server`. This Pull Request allows to add new variables by making use of an adapter. Example:

```python
from datetime import datetime
from zope import interface
from bika.lims.interfaces import IIdServerVariables


class IDServerVariablesAdapter(object):
    """An adapter for the generation of Variables for ID Server
    """
    interface.implements(IIdServerVariables)

    def __init__(self, context):
        self.context = context

    def get_variables(self, **kw):
        return {
            "day_shift": self.get_day_shift()
        }

    def get_day_shift(self):
        if datetime.now().hour < 12:
            return "M"
        return "N"
```
And the adapter registration:

```xml
  <!-- Adapter that returns additional variables for ID Server -->
  <adapter
    factory=".idserver.IDServerVariablesAdapter"
    provides="bika.lims.interfaces.IIdServerVariables"
    for="*" />
```

## Current behavior before PR

Cannot extend IDServer with new variables (wildcards)

## Desired behavior after PR is merged

IDServer can be extended with new variables (wildcards) via adapters

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
