### PR TITLE
Dynamic Analysis Specs: Lookup dynamic specs only when specification is set and hide spec compliance viewlets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1588 Dynamic Analysis Specs: Cache range lookups
 - #1586 Allow to configure the variables for IDServer with an Adapter
 - #1584 Date (yymmdd) support in IDs generation
 - #1582 Allow to retest analyses without the need of retraction
@@ -14,6 +15,7 @@ Changelog
 
 **Changed**
 
+- #1588 Dynamic Analysis Specs: Hide compliance viewlets
 - #1579 Remove classic mode in folderitems
 - #1577 Do not force available workflow transitions in batches listing
 - #1573 Do not display top-level "Clients" folder to non-lab users

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 
 **Added**
 
-- #1588 Dynamic Analysis Specs: Cache range lookups
+- #1588 Dynamic Analysis Specs: Lookup dynamic spec only when the specification is set
 - #1586 Allow to configure the variables for IDServer with an Adapter
 - #1584 Date (yymmdd) support in IDs generation
 - #1582 Allow to retest analyses without the need of retraction

--- a/bika/lims/adapters/dynamicresultsrange.py
+++ b/bika/lims/adapters/dynamicresultsrange.py
@@ -20,6 +20,9 @@
 
 from bika.lims import api
 from bika.lims.interfaces import IDynamicResultsRange
+from plone.memoize.volatile import ATTR
+from plone.memoize.volatile import CONTAINER_FACTORY
+from plone.memoize.volatile import cache
 from zope.interface import implementer
 
 marker = object()
@@ -35,6 +38,17 @@ DEFAULT_RANGE_KEYS = [
     "maxpanic",
     "error",
 ]
+
+
+def analysis_cache_key(method, instance):
+    return instance.analysis.UID()
+
+
+def store_on_analysis(method, instance, *args, **kwargs):
+    """Volatile cache storage on the portal object
+    """
+    analysis = instance.analysis
+    return analysis.__dict__.setdefault(ATTR, CONTAINER_FACTORY())
 
 
 @implementer(IDynamicResultsRange)
@@ -152,5 +166,6 @@ class DynamicResultsRange(object):
 
         return rr
 
+    @cache(analysis_cache_key, get_cache=store_on_analysis)
     def __call__(self):
         return self.get_results_range()

--- a/bika/lims/adapters/dynamicresultsrange.py
+++ b/bika/lims/adapters/dynamicresultsrange.py
@@ -20,9 +20,6 @@
 
 from bika.lims import api
 from bika.lims.interfaces import IDynamicResultsRange
-from plone.memoize.volatile import ATTR
-from plone.memoize.volatile import CONTAINER_FACTORY
-from plone.memoize.volatile import cache
 from zope.interface import implementer
 
 marker = object()
@@ -38,20 +35,6 @@ DEFAULT_RANGE_KEYS = [
     "maxpanic",
     "error",
 ]
-
-
-def analysis_cache_key(method, instance):
-    """We cache by UID to maintain the specs even when the dynamic spec or the
-    analysis changed.
-    """
-    return instance.analysis.UID()
-
-
-def store_on_analysis(method, instance, *args, **kwargs):
-    """Volatile cache storage on the analysis object
-    """
-    analysis = instance.analysis
-    return analysis.__dict__.setdefault(ATTR, CONTAINER_FACTORY())
 
 
 @implementer(IDynamicResultsRange)
@@ -169,6 +152,5 @@ class DynamicResultsRange(object):
 
         return rr
 
-    @cache(analysis_cache_key, get_cache=store_on_analysis)
     def __call__(self):
         return self.get_results_range()

--- a/bika/lims/adapters/dynamicresultsrange.py
+++ b/bika/lims/adapters/dynamicresultsrange.py
@@ -41,11 +41,14 @@ DEFAULT_RANGE_KEYS = [
 
 
 def analysis_cache_key(method, instance):
+    """We cache by UID to maintain the specs even when the dynamic spec or the
+    analysis changed.
+    """
     return instance.analysis.UID()
 
 
 def store_on_analysis(method, instance, *args, **kwargs):
-    """Volatile cache storage on the portal object
+    """Volatile cache storage on the analysis object
     """
     analysis = instance.analysis
     return analysis.__dict__.setdefault(ATTR, CONTAINER_FACTORY())

--- a/bika/lims/browser/viewlets/analysisrequest.py
+++ b/bika/lims/browser/viewlets/analysisrequest.py
@@ -97,6 +97,13 @@ class ResultsRangesOutOfDateViewlet(ViewletBase):
     specification ranges will be used instead of the new ones.
     """
 
+    def available(self):
+        spec = self.context.getSpecification()
+        if spec:
+            dynamic_spec = spec.getDynamicAnalysisSpec()
+            return not dynamic_spec
+        return True
+
     def is_specification_editable(self):
         """Returns whether the Specification field is editable or not
         """
@@ -135,6 +142,13 @@ class SpecificationNotCompliantViewlet(ViewletBase):
     existing ones via "Manage analyses" view. And results range for those
     analyses are different from the Specification initially set.
     """
+
+    def available(self):
+        spec = self.context.getSpecification()
+        if spec:
+            dynamic_spec = spec.getDynamicAnalysisSpec()
+            return not dynamic_spec
+        return True
 
     def is_specification_editable(self):
         """Returns whether the Specification field is editable or not

--- a/bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt
+++ b/bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt
@@ -1,15 +1,14 @@
 <div tal:omit-tag=""
-     tal:define="out_of_date python:view.is_results_ranges_out_of_date()"
-     tal:condition="python:out_of_date"
+     tal:condition="python:view.available()"
      i18n:domain="senaite.core">
-
-  <div class="visualClear"></div>
 
   <div id="portal-alert"
        tal:define="sample python:view.context;
                    editable python:view.is_specification_editable();
                    alert_class python: editable and 'alert-warning' or 'alert-info';
-                   alert_class python: 'portlet-alert-item alert {} alert-dismissible'.format(alert_class)">
+                   alert_class python: 'portlet-alert-item alert {} alert-dismissible'.format(alert_class);
+                   out_of_date python:view.is_results_ranges_out_of_date()"
+       tal:condition="out_of_date">
 
     <div tal:attributes="class python: alert_class">
       <button type="button" class="close" data-dismiss="alert" aria-label="Close">

--- a/bika/lims/browser/viewlets/templates/specification_non_compliant_viewlet.pt
+++ b/bika/lims/browser/viewlets/templates/specification_non_compliant_viewlet.pt
@@ -1,15 +1,14 @@
 <div tal:omit-tag=""
-     tal:define="non_compliant python:view.get_non_compliant_analyses()"
-     tal:condition="python:non_compliant"
+     tal:condition="python:view.available()"
      i18n:domain="senaite.core">
-
-  <div class="visualClear"></div>
 
   <div id="portal-alert"
        tal:define="sample python:view.context;
+                   non_compliant python:view.get_non_compliant_analyses()
                    editable python:view.is_specification_editable();
                    alert_class python: editable and 'alert-warning' or 'alert-info';
-                   alert_class python: 'portlet-alert-item alert {} alert-dismissible'.format(alert_class)">
+                   alert_class python: 'portlet-alert-item alert {} alert-dismissible'.format(alert_class)"
+       tal:condition="non_compliant">
 
     <div tal:attributes="class python: alert_class">
       <button type="button" class="close" data-dismiss="alert" aria-label="Close">

--- a/bika/lims/content/abstractroutineanalysis.py
+++ b/bika/lims/content/abstractroutineanalysis.py
@@ -43,7 +43,6 @@ from bika.lims.content.clientawaremixin import ClientAwareMixin
 from bika.lims.content.reflexrule import doReflexRuleAction
 from bika.lims.interfaces import IAnalysis
 from bika.lims.interfaces import ICancellable
-from bika.lims.interfaces import IDynamicResultsRange
 from bika.lims.interfaces import IInternalUse
 from bika.lims.interfaces import IRoutineAnalysis
 from bika.lims.interfaces.analysis import IRequestAnalysis
@@ -325,19 +324,15 @@ class AbstractRoutineAnalysis(AbstractAnalysis, ClientAwareMixin):
         """Returns the valid result range for this routine analysis
 
         A routine analysis will be considered out of range if it result falls
-        out of the range defined in "min" and "max". If there are values set for
-        "warn_min" and "warn_max", these are used to compute the shoulders in
-        both ends of the range. Thus, an analysis can be out of range, but be
-        within shoulders still.
+        out of the range defined in "min" and "max". If there are values set
+        for "warn_min" and "warn_max", these are used to compute the shoulders
+        in both ends of the range. Thus, an analysis can be out of range, but
+        be within shoulders still.
+
         :return: A dictionary with keys "min", "max", "warn_min" and "warn_max"
         :rtype: dict
         """
-        results_range = self.getField("ResultsRange").get(self)
-        # dynamic results range adapter
-        adapter = IDynamicResultsRange(self, None)
-        if adapter:
-            results_range.update(adapter())
-        return results_range
+        return self.getField("ResultsRange").get(self)
 
     @security.public
     def getSiblings(self, with_retests=False):

--- a/bika/lims/tests/doctests/DynamicAnalysisSpec.rst
+++ b/bika/lims/tests/doctests/DynamicAnalysisSpec.rst
@@ -168,6 +168,12 @@ Now we hook in our Dynamic Analysis Specification to the standard Specification:
 
     >>> specification.setDynamicAnalysisSpec(ds)
 
+
+The specification need to get unset/set again, so that the dynamic values get looked up:
+
+    >>> sample.setSpecification(None)
+    >>> sample.setSpecification(specification)
+
 The specification of the `Ca` Analysis with the Method `Method A`:
 
     >>> ca_spec = ca.getResultsRange()
@@ -177,6 +183,11 @@ The specification of the `Ca` Analysis with the Method `Method A`:
 Now let's change the `Ca` Analysis Method to `Method B`:
 
     >>> ca.setMethod(method_b)
+
+Unset and set the specification again:
+
+    >>> sample.setSpecification(None)
+    >>> sample.setSpecification(specification)
 
 And get the results range again:
 
@@ -191,6 +202,11 @@ The same now with the `Mg` Analysis in one run:
     (5, 6)
 
     >>> mg.setMethod(method_b)
+
+Unset and set the specification again:
+
+    >>> sample.setSpecification(None)
+    >>> sample.setSpecification(specification)
 
     >>> mg_spec = mg.getResultsRange()
     >>> mg_spec["min"], mg_spec["max"]


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR caches the lookup for dynamic analysis specs and hides the compliance viewlets when a dynamic analysis specification is assigned.

## Current behavior before PR

- Results range repeated multiple times
- Compliance viewlets complain about changed specifications

## Desired behavior after PR is merged

- Results range lookup cached per analysis
- No specification compliance viewlets are displayed when a dynamic analysisspecifcation is used

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
