### PR TITLE
User might accidentally assign a contact from another client while creating a Sample

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Changelog
 
 **Fixed**
 
+- #1591 Fix User can assign a contact from another client while creating a Sample
 - #1585 Fix wrong label and description for `ShowPartitions` setting from setup
 - #1583 Fix traceback in services listing in ARTemplate view
 - #1581 Fix Some values are not properly rendered in services listing

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1627,6 +1627,16 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             # Re-add the Contact
             required_fields["Contact"] = contact
 
+            # Check if the contact belongs to the selected client
+            contact_obj = api.get_object(contact, None)
+            if not contact_obj:
+                fielderrors["Contact"] = _("No valid contact")
+            else:
+                parent_uid = api.get_uid(api.get_parent(contact_obj))
+                if parent_uid != record.get("Client"):
+                    msg = _("Contact does not belong to the selected client")
+                    fielderrors["Contact"] = msg
+
             # Missing required fields
             missing = [f for f in required_fields if not record.get(f, None)]
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

User might be able to accidentally assign a contact from another client if he/she goes fast enough when selecting the Contact in Add Sample form. This Pull Request addresses this shortcoming by validating the selected contact belongs to the Client just before creating the Sample.

## Current behavior before PR

User might accidentally assign a contact from another client while creating a Sample

## Desired behavior after PR is merged

User cannot assign a contact from another client while creating a Sample

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
