### PR TITLE
Publisher user cannot publish samples

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Changelog
 
 **Fixed**
 
+- #1592 Fix Publisher user cannot publish samples
 - #1591 Fix User can assign a contact from another client while creating a Sample
 - #1585 Fix wrong label and description for `ShowPartitions` setting from setup
 - #1583 Fix traceback in services listing in ARTemplate view

--- a/bika/lims/profiles/default/rolemap.xml
+++ b/bika/lims/profiles/default/rolemap.xml
@@ -798,6 +798,7 @@
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
+      <role name="Publisher"/>
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Manage Invoices" acquire="False">

--- a/bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
@@ -38,6 +38,7 @@
   <permission>senaite.core: Manage Invoices</permission>
   <permission>senaite.core: View Results</permission>
   <permission>Access contents information</permission>
+  <permission>Add portal content</permission>
   <permission>Modify portal content</permission>
   <permission>View</permission>
 
@@ -662,6 +663,10 @@
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
     <permission-map name="senaite.core: View Results" acquired="True"/>
     <permission-map name="Access contents information" acquired="True"/>
+    <permission-map name="Add portal content" acquired="True">
+      <!-- Publisher role must be able to add ARReports -->
+      <permission-role>Publisher</permission-role>
+    </permission-map>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
     <!-- Field Permissions -->
@@ -832,6 +837,10 @@
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
     <permission-map name="senaite.core: View Results" acquired="True"/>
     <permission-map name="Access contents information" acquired="True"/>
+    <permission-map name="Add portal content" acquired="True">
+      <!-- Publisher role must be able to add ARReports -->
+      <permission-role>Publisher</permission-role>
+    </permission-map>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
     <!-- Field Permissions (all readonly) -->

--- a/bika/lims/profiles/default/workflows/senaite_clientcontact_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_clientcontact_workflow/definition.xml
@@ -50,6 +50,7 @@
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>Owner</permission-role>
+      <permission-role>Publisher</permission-role>
     </permission-map>
   </state>
 

--- a/bika/lims/profiles/default/workflows/senaite_labcontact_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_labcontact_workflow/definition.xml
@@ -55,6 +55,7 @@
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>Publisher</permission-role>
     </permission-map>
   </state>
 

--- a/bika/lims/tests/doctests/Permissions.rst
+++ b/bika/lims/tests/doctests/Permissions.rst
@@ -257,7 +257,7 @@ Exactly these roles have should have a `View` permission::
     ['Authenticated']
 
     >>> get_roles_for_permission("View", labcontact)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabClerk', 'LabManager', 'Manager', 'Publisher']
 
 Exactly these roles have should have the `Access contents information` permission::
 
@@ -388,7 +388,7 @@ Client they belong to:
 Exactly these roles should have a `View` permission for client contact object:
 
     >>> get_roles_for_permission("View", contact)
-    ['LabClerk', 'LabManager', 'Manager', 'Owner']
+    ['LabClerk', 'LabManager', 'Manager', 'Owner', 'Publisher']
 
 Exactly these roles have should have the `Access contents information` permission::
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes users with role `Publisher` to be able to publish samples.

https://github.com/senaite/senaite.core/issues/1589

## Current behavior before PR

Users with role `Publisher` cannot publish samples

## Desired behavior after PR is merged

Users with role `Publisher` can publish samples

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
