### PR TITLE
Out-of-range alert icon is shown to users w/o "View Results" privileges

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Changelog
 
 **Fixed**
 
+- #1593 Fix Out-of-range alert icon is shown to users w/o "View Results" privileges
 - #1591 Fix User can assign a contact from another client while creating a Sample
 - #1585 Fix wrong label and description for `ShowPartitions` setting from setup
 - #1583 Fix traceback in services listing in ARTemplate view

--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -1036,6 +1036,11 @@ class AnalysesView(BikaListingView):
     def _folder_item_out_of_range(self, analysis_brain, item):
         """Displays an icon if result is out of range
         """
+        if not self.has_permission(ViewResults, analysis_brain):
+            # Users without permissions to see the result should not be able
+            # to see if the result is out of range naither
+            return
+
         analysis = self.get_object(analysis_brain)
         out_range, out_shoulders = is_out_of_range(analysis)
         if out_range:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

With this Pull Request, the icon for out-of-range result is not displayed in analyses listings if the user does not have the "View Results" permission

Related issue: https://github.com/senaite/senaite.core/issues/1590

## Current behavior before PR

User w/o "View Results" permission cannot see the results (an hourglass icon is displayed), but can see if those results are out of range (an out-of-range icon is displayed)

## Desired behavior after PR is merged

out-of-range icon is never displayed to users without "View Results" permission

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
