### PR TITLE
Fix Wrong url in client's analyses profiles listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Changelog
 
 **Fixed**
 
+- #1595 Fix Wrong url in client's analyses profiles listing
 - #1593 Fix Out-of-range alert icon is shown to users w/o "View Results" privileges
 - #1592 Fix Publisher user cannot publish samples
 - #1591 Fix User can assign a contact from another client while creating a Sample

--- a/bika/lims/browser/client/views/analysisprofiles.py
+++ b/bika/lims/browser/client/views/analysisprofiles.py
@@ -53,7 +53,7 @@ class ClientAnalysisProfilesView(BikaListingView):
         self.columns = {
             'title': {'title': _('Title'),
                       'index': 'sortable_title',
-                      'replace_url': 'absolute_url'},
+                      'replace_url': 'getURL'},
             'Description': {'title': _('Description'),
                             'index': 'description'},
             'getProfileKey': {'title': _('Profile Key')},


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the links of the Analyses Profiles from inside Client to work properly.

## Current behavior before PR

The links from Client's Analysis Profiles listing point to `http://localhost/senaite/bika_setup_catalog`

## Desired behavior after PR is merged

The links from Client's Analysis Profiles listing point to the right url

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
