### PR TITLE
Allow to hide actions menu by using new marker interface IHideActionsMenu

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 
 **Added**
 
-- #1596 Allow to hide actions menu by using new marker interface IHaveNoActionsMenu
+- #1596 Allow to hide actions menu by using new marker interface IHideActionsMenu
 - #1588 Dynamic Analysis Specs: Lookup dynamic spec only when the specification is set
 - #1586 Allow to configure the variables for IDServer with an Adapter
 - #1584 Date (yymmdd) support in IDs generation

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1596 Allow to hide actions menu by using new marker interface IHaveNoActionsMenu
 - #1588 Dynamic Analysis Specs: Lookup dynamic spec only when the specification is set
 - #1586 Allow to configure the variables for IDServer with an Adapter
 - #1584 Date (yymmdd) support in IDs generation
@@ -22,6 +23,7 @@ Changelog
 
 **Fixed**
 
+- #1596 Fix Reports page shows the Display/State/Add menu
 - #1593 Fix Out-of-range alert icon is shown to users w/o "View Results" privileges
 - #1592 Fix Publisher user cannot publish samples
 - #1591 Fix User can assign a contact from another client while creating a Sample

--- a/bika/lims/browser/contentmenu.py
+++ b/bika/lims/browser/contentmenu.py
@@ -21,6 +21,7 @@
 from plone.app.contentmenu.menu import WorkflowMenu as BaseClass
 from plone.app.contentmenu.view import ContentMenuProvider
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from bika.lims.interfaces import IHaveNoActionsMenu
 from zope.component import getUtility
 from zope.browsermenu.interfaces import IBrowserMenu
 
@@ -37,6 +38,8 @@ class SenaiteContentMenuProvider(ContentMenuProvider):
     # From IContentMenuView
 
     def available(self):
+        if IHaveNoActionsMenu.providedBy(self.context):
+            return False
         return True
 
     def menu(self):

--- a/bika/lims/browser/contentmenu.py
+++ b/bika/lims/browser/contentmenu.py
@@ -21,7 +21,7 @@
 from plone.app.contentmenu.menu import WorkflowMenu as BaseClass
 from plone.app.contentmenu.view import ContentMenuProvider
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from bika.lims.interfaces import IHaveNoActionsMenu
+from bika.lims.interfaces import IHideActionsMenu
 from zope.component import getUtility
 from zope.browsermenu.interfaces import IBrowserMenu
 
@@ -38,7 +38,7 @@ class SenaiteContentMenuProvider(ContentMenuProvider):
     # From IContentMenuView
 
     def available(self):
-        if IHaveNoActionsMenu.providedBy(self.context):
+        if IHideActionsMenu.providedBy(self.context):
             return False
         return True
 

--- a/bika/lims/content/reportfolder.py
+++ b/bika/lims/content/reportfolder.py
@@ -26,13 +26,13 @@ from zope.interface import implements
 
 from bika.lims.config import PROJECTNAME
 from bika.lims.interfaces import IHaveNoBreadCrumbs
-from bika.lims.interfaces import IHaveNoActionsMenu
+from bika.lims.interfaces import IHideActionsMenu
 from bika.lims.interfaces import IReportFolder
 
 schema = ATFolderSchema.copy()
 
 class ReportFolder(ATFolder):
-    implements(IReportFolder, IHaveNoBreadCrumbs, IHaveNoActionsMenu)
+    implements(IReportFolder, IHaveNoBreadCrumbs, IHideActionsMenu)
     security = ClassSecurityInfo()
     displayContentsTab = False
     schema = schema

--- a/bika/lims/content/reportfolder.py
+++ b/bika/lims/content/reportfolder.py
@@ -19,18 +19,20 @@
 # Some rights reserved, see README and LICENSE.
 
 from AccessControl import ClassSecurityInfo
+from plone.app.folder.folder import ATFolder
+from plone.app.folder.folder import ATFolderSchema
 from Products.Archetypes.public import *
-from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t
-from bika.lims.config import PROJECTNAME
-from bika.lims.interfaces import IReportFolder, IHaveNoBreadCrumbs
-from plone.app.folder.folder import ATFolder, ATFolderSchema
 from zope.interface import implements
+
+from bika.lims.config import PROJECTNAME
+from bika.lims.interfaces import IHaveNoBreadCrumbs
+from bika.lims.interfaces import IHaveNoActionsMenu
+from bika.lims.interfaces import IReportFolder
 
 schema = ATFolderSchema.copy()
 
 class ReportFolder(ATFolder):
-    implements(IReportFolder, IHaveNoBreadCrumbs)
+    implements(IReportFolder, IHaveNoBreadCrumbs, IHaveNoActionsMenu)
     security = ClassSecurityInfo()
     displayContentsTab = False
     schema = schema

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -1093,3 +1093,8 @@ class ISamplingRoundTemplate(Interface):
     """Marker interface for a Sampling Round Template
     TODO: Legacy type. Remove after 1.3.3
     """
+
+
+class IHaveNoActionsMenu(Interface):
+    """Marker interface for content types for which actions menu must be hidden
+    """

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -1095,6 +1095,7 @@ class ISamplingRoundTemplate(Interface):
     """
 
 
-class IHaveNoActionsMenu(Interface):
-    """Marker interface for content types for which actions menu must be hidden
+class IHideActionsMenu(Interface):
+    """Marker interface that can be applied for conttents that should not
+    display the content actions menu
     """


### PR DESCRIPTION
**IMPORTANT: DO NOT MERGE INTO 2.x. Counterpart in there: https://github.com/senaite/senaite.core/commit/e03ecaa1257efdf6e3b924ea915faa1b777df85b**

## Description of the issue/feature this PR addresses

This Pull Requests adds the marker interface `IHideActionsMenu`, so the system won't render the action menu display list for those contents implementing this marker interface. This Pull Request also resolves https://github.com/senaite/senaite.core/issues/1325

## Current behavior before PR

No easy way to hide the actions menu for a given type

## Desired behavior after PR is merged

Easy way to hide actions menu for a given type

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
