### PR TITLE
Support for keyword [UID] in calculation formula

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1597 Support for keyword [UID] in calculation formula
 - #1588 Dynamic Analysis Specs: Lookup dynamic spec only when the specification is set
 - #1586 Allow to configure the variables for IDServer with an Adapter
 - #1584 Date (yymmdd) support in IDs generation

--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -556,6 +556,10 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         # Calculate
         formula = calc.getMinifiedFormula()
         formula = formula.replace('[', '%(').replace(']', ')f')
+
+        # Add the UID of current object (analysis) into the mapping
+        mapping.update({"UID": api.get_uid(self)})
+        formula = formula.replace('%(UID)f', '"%(UID)s"')
         try:
             formula = eval("'%s'%%mapping" % formula,
                            {"__builtins__": None,

--- a/bika/lims/validators.py
+++ b/bika/lims/validators.py
@@ -460,6 +460,10 @@ class FormulaValidator:
             [f['keyword'] for f in interim_fields] or []
         keywords = re.compile(r"\[([^\.^\]]+)\]").findall(value)
 
+        # Exclude reserved keywords (they are always handled)
+        reserved = ("UID",)
+        keywords = filter(lambda key: key not in reserved, keywords)
+
         for keyword in keywords:
             # Check if the service keyword exists and is active.
             dep_service = bsc(getKeyword=keyword, is_active=True)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request allows to use the reserved keyword `[UID]` in formulas. Useful for when there are external calculations that require to know about the context.

## Current behavior before PR

Calculation formaul does not support `[UID]`

## Desired behavior after PR is merged

Calculation formula does support `[UID]` param

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
