### PR TITLE
Add "modified" index in Samples (AnalysisRequest) catalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1598 Added "modified" index in Sample's (AnalysisRequest) catalog
 - #1596 Allow to hide actions menu by using new marker interface IHideActionsMenu
 - #1588 Dynamic Analysis Specs: Lookup dynamic spec only when the specification is set
 - #1586 Allow to configure the variables for IDServer with an Adapter

--- a/bika/lims/catalog/analysisrequest_catalog.py
+++ b/bika/lims/catalog/analysisrequest_catalog.py
@@ -56,6 +56,7 @@ _indexes_dict = {
     "listing_searchable_text": "TextIndexNG3",
     "isRootAncestor": "BooleanIndex",
     "is_received": "BooleanIndex",
+    "modified": "DateIndex",
 }
 # Defining the columns for this catalog
 _columns_list = [

--- a/bika/lims/upgrade/v01_03_004.py
+++ b/bika/lims/upgrade/v01_03_004.py
@@ -35,6 +35,11 @@ from bika.lims.upgrade.utils import UpgradeUtils
 version = "1.3.4"  # Remember version number in metadata.xml and setup.py
 profile = "profile-{0}:default".format(product)
 
+INDEXES_TO_ADD = [
+    # List of tuples (catalog_name, index_name, index meta type)
+    (CATALOG_ANALYSIS_REQUEST_LISTING, "modified", "DateIndex"),
+]
+
 
 @upgradestep(product, version)
 def upgrade(tool):
@@ -83,6 +88,9 @@ def upgrade(tool):
     update_workflow_mappings_contacts(portal)
     update_workflow_mappings_labcontacts(portal)
     update_workflow_mappings_samples(portal)
+
+    # Add new indexes
+    add_new_indexes(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
@@ -210,3 +218,22 @@ def update_dynamic_analysisspecs(portal):
         sample.setAnalysisSpec(spec)
 
     logger.info("Updating specifications with dynamic results ranges [DONE]")
+
+
+def add_new_indexes(portal):
+    logger.info("Adding new indexes ...")
+    for catalog_id, index_name, index_metatype in INDEXES_TO_ADD:
+        add_index(catalog_id, index_name, index_metatype)
+    logger.info("Adding new indexes ... [DONE]")
+
+
+def add_index(catalog_id, index_name, index_metatype):
+    logger.info("Adding '{}' index to '{}' ...".format(index_name, catalog_id))
+    catalog = api.get_tool(catalog_id)
+    if index_name in catalog.indexes():
+        logger.info("Index '{}' already in catalog '{}' [SKIP]"
+                    .format(index_name, catalog_id))
+        return
+    catalog.addIndex(index_name, index_metatype)
+    logger.info("Indexing new index '{}' ...".format(index_name))
+    catalog.manage_reindexIndex(index_name)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

"modified" index is required for `senaite.jsonapi` to work properly when the param `recent_modified` is used. See: https://senaitejsonapi.readthedocs.io/en/latest/api.html#parameters

## Current behavior before PR

Sample's catalog does not have `modified` index, so querying by recent modified Samples (AnalysisRequest) via `senaite.jsonapi` returns all items.

## Desired behavior after PR is merged

Param `recent_modified` from `senaite.jsonapi` works as expected when querying for `AnalysisRequest` portal type.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
