### PR TITLE
Fix upgrade step for 1.3.4

### DIFF
--- a/bika/lims/upgrade/v01_03_004.py
+++ b/bika/lims/upgrade/v01_03_004.py
@@ -213,9 +213,10 @@ def update_dynamic_analysisspecs(portal):
 
         # Unset/set the specification
         logger.info("Updating specification '{}' of smaple '{}'".format(
-            spec.Title(), sample.getId()))
-        sample.setAnalysisSpec(None)
-        sample.setAnalysisSpec(spec)
+            spec.Title(), obj.getId()))
+
+        obj.setSpecification(None)
+        obj.setSpecification(spec)
 
     logger.info("Updating specifications with dynamic results ranges [DONE]")
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes wrong variables in the 1.3.4 upgrade step: `update_dynamic_analysisspecs`.

## Current behavior before PR

Upgrade step was failing

## Desired behavior after PR is merged

Upgrade step work

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
