### PR TITLE
Fix wrong url in client's sample templates listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Changelog
 
 **Fixed**
 
+- #1601 Fix Wrong url in client's sample templates listing
 - #1594 Fix System does not validate values from Results Options to be different
 - #1596 Fix Reports page shows the Display/State/Add menu
 - #1595 Fix Wrong url in client's analyses profiles listing

--- a/bika/lims/browser/client/views/artemplates.py
+++ b/bika/lims/browser/client/views/artemplates.py
@@ -52,7 +52,7 @@ class ClientARTemplatesView(BikaListingView):
         self.columns = {
             'title': {'title': _('Title'),
                       'index': 'sortable_title',
-                      'replace_url': 'absolute_url'},
+                      'replace_url': 'getURL'},
             'Description': {'title': _('Description'),
                             'index': 'description'},
         }


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the links of the Sample Templates listing from inside Client to work properly.

## Current behavior before PR

The links from Client's Sample Templates listing point to http://localhost/senaite/bika_setup_catalog

## Desired behavior after PR is merged

The links from Client's Sample Tempaltes listing point to the right url

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
