### PR TITLE
Report "Analysis per Service" is always creating the same PDF file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Changelog
 
 **Fixed**
 
+- #1602 Fix Report "Analysis per Service" is always creating the same PDF file
 - #1594 Fix System does not validate values from Results Options to be different
 - #1596 Fix Reports page shows the Display/State/Add menu
 - #1595 Fix Wrong url in client's analyses profiles listing

--- a/bika/lims/browser/reports/selection_macros/__init__.py
+++ b/bika/lims/browser/reports/selection_macros/__init__.py
@@ -436,7 +436,7 @@ class SelectionMacrosView(BrowserView):
 
     @ram.cache(_cache_key_select_state)
     def select_state_analysis(self, workflow_id, field_id, field_title, style=None):
-        return self._select_state(workflow_id, field_title, field_title, style)
+        return self._select_state(workflow_id, field_id, field_title, style)
 
     def parse_state(self, request, workflow_id, field_id, field_title):
         val = request.form.get(field_id, "")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1599

## Current behavior before PR

The "Analysis per Service" report is always creating the same PDF file no matter what was chosen in the drop down field of "Analysis State".

## Desired behavior after PR is merged

The items from "Analysis per Service" report get filtered by the status selected in the "Analysis State" drop-down.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
