### PR TITLE
Analyses from Partitions do not show up when using Worksheet Template

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Changelog
 
 **Fixed**
 
+- #1604 Fix Analyses from partitions do not show up when using Worksheet Template
 - #1602 Fix Report "Analysis per Service" is always creating the same PDF file
 - #1601 Fix Wrong url in client's sample templates listing
 - #1594 Fix System does not validate values from Results Options to be different

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -416,10 +416,9 @@ def create_partition(analysis_request, request, analyses, sample_type=None,
     # here because the transition "initialize" of analyses rely on a guard,
     # so the initialization can only be performed when the sample has been
     # received (DateReceived is set)
-    ActionHandlerPool.get_instance().queue_pool()
     for analysis in partition.getAnalyses(full_objects=True):
         doActionFor(analysis, "initialize")
-    ActionHandlerPool.get_instance().resume()
+        analysis.reindexObject()
     return partition
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When a Worksheet Template is used for the creation of a worksheet (or assignment of analyses into a worksheet), the analyses that belong to partitions are not considered.

The problem was that when partitions are created automatically on reception, the analyses (moved now into their partitions) are not reindexed, so system does not find those analyses because their value for index `isSampleReceived` is `False`

## Current behavior before PR

Analyses from partitions created automatically on reception do not show up when a Worksheet Template is used.

## Desired behavior after PR is merged

All received and unassigned analyses are considered when using a Worksheet Template, regardless of the type of Sample they belong to (partition or primary).

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
