### PR TITLE
Retests are not displayed in Worksheet's print view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Changelog
 
 **Fixed**
 
+- #1605 Fix Retests are not displayed in Worksheet's print view
 - #1602 Fix Report "Analysis per Service" is always creating the same PDF file
 - #1601 Fix Wrong url in client's sample templates listing
 - #1594 Fix System does not validate values from Results Options to be different

--- a/bika/lims/browser/worksheet/templates/print/ar_by_column.css
+++ b/bika/lims/browser/worksheet/templates/print/ar_by_column.css
@@ -36,7 +36,7 @@ div.content table tbody td {
     border:1px solid #888;
     text-align:center;
 }
-div.content table tbody td.result {
+div.content table tbody td div.result {
     padding:15px;
     text-align: center;
 }
@@ -44,16 +44,16 @@ div.content table tbody th.analyses {
     padding:20px 0 10px 0;
     font-size:1.2em;
 }
-div.content table tbody td.no-result {
+div.content table tbody td div.no-result {
     padding:0;
     border:1px solid #fff;
 }
-div.content table tbody td.no-result div {
+div.content table tbody td div.no-result {
     position:relative;
     overflow:hidden;
     padding:15px;
 }
-div.content table tbody td.no-result div:before {
+div.content table tbody div.no-result:before {
     content:'';
     display:block;
     position:absolute;
@@ -64,21 +64,24 @@ div.content table tbody td.no-result div:before {
     border: 99999px #dcdcdc solid;
     z-index: 0;
 }
-div.content table tbody td.no-result div * {
+div.content table tbody div.no-result div * {
     position: relative;
     z-index: 1;
 }
+div.content table tbody td div.repeat {
+    border-top:1px solid #888;
+}
 
 /* Pending states are shown in italics */
-div.content td.result {
+div.content td div.result {
     font-weight: normal;
     color: black;
     font-style: italic;
 }
 
 /* Verified states are shown in bold */
-div.content td.verified,
-div.content td.published {
+div.content td div.verified,
+div.content td div.published {
     font-weight: bold;
     color: black;
     font-style: normal;

--- a/bika/lims/browser/worksheet/templates/print/ar_by_column.pt
+++ b/bika/lims/browser/worksheet/templates/print/ar_by_column.pt
@@ -121,18 +121,28 @@
           <th tal:content="antitle"></th>
           <!-- (Partial) Result -->
           <tal:results tal:repeat="ar ars">
-            <tal:analysis define="analysis python:view.get_analysis_data_by_title(ar, antitle)">
-              <td tal:condition="analysis"
-                  tal:attributes="class string:${analysis/review_state} result">
-                <tal:result condition="analysis/formatted_result">
-                  <span tal:content="string:${analysis/formatted_result}">100</span>
-                  <span tal:content="string:${analysis/unit}">ml</span>
-                </tal:result>
+            <tal:analyses define="analyses python:view.get_analyses_data_by_title(ar, antitle)">
+              <td tal:condition="analyses">
+                <tal:analysis repeat="analysis analyses">
+                  <div tal:define="clazz string:${analysis/review_state};
+                                   is_first repeat/analysis/start;
+                                   clazz python: is_first and clazz or '{} repeat'.format(clazz);
+                                   clazz python: '{} result'.format(clazz);"
+                       tal:attributes="class clazz">
+                    <tal:result condition="analysis/formatted_result">
+                      <span tal:content="string:${analysis/formatted_result}">100</span>
+                      <span tal:content="string:${analysis/unit}">ml</span>
+                    </tal:result>
+                    <tal:empty_result condition="not:analysis/formatted_result">
+                      <span>&nbsp;</span>
+                    </tal:empty_result>
+                  </div>
+                </tal:analysis>
               </td>
-              <td tal:condition="not:analysis" class='no-result'>
+              <td tal:condition="not:analyses" class='no-result'>
                 <div>&nbsp;</div>
               </td>
-            </tal:analysis>
+            </tal:analyses>
           </tal:results>
         </tr>
       </tbody>

--- a/bika/lims/browser/worksheet/templates/print/ar_by_row.css
+++ b/bika/lims/browser/worksheet/templates/print/ar_by_row.css
@@ -34,16 +34,20 @@ div.content table tbody th {
     padding:0 5px 0 0;
     text-align:left;
 }
-div.content table tbody td {
+div.content table tbody td.requestid {
     padding:4px;
+}
+div.content table tbody td {
     border:1px solid #888;
 }
 div.content table tbody td.requestid {
     font-weight:bold;
 }
-div.content table tbody td.result {
-    width:90px;
+div.content table tbody td div.result,
+div.content table tbody td div.no-result {
+    width:100%;
     text-align: center;
+    padding:10px 0;
 }
 div.content table tbody th.analyses {
     padding:20px 0 10px 0;
@@ -55,16 +59,16 @@ div.content table td.requestid {
 div.content table div.barcode {
     float:none;
 }
-div.content table tbody td.no-result {
+div.content table tbody td div.no-result {
     padding:0;
     border:1px solid #fff;
 }
-div.content table tbody td.no-result div {
+div.content table tbody td div.no-result {
     position:relative;
     overflow:hidden;
     padding:30px;
 }
-div.content table tbody td.no-result div:before {
+div.content table tbody div.no-result:before {
     content:'';
     display:block;
     position:absolute;
@@ -75,21 +79,24 @@ div.content table tbody td.no-result div:before {
     border: 99999px #dcdcdc solid;
     z-index: 0;
 }
-div.content table tbody td.no-result div * {
+div.content table tbody td div.no-result div * {
     position: relative;
     z-index: 1;
 }
+div.content table tbody td div.repeat {
+    border-top:1px solid #888;
+}
 
 /* Pending states are shown in italics */
-div.content td.result {
+div.content td div.result {
     font-weight: normal;
     color: black;
     font-style: italic;
 }
 
 /* Verified states are shown in bold */
-div.content td.verified,
-div.content td.published {
+div.content td div.verified,
+div.content td div.published {
     font-weight: bold;
     color: black;
     font-style: normal;

--- a/bika/lims/browser/worksheet/templates/print/ar_by_row.pt
+++ b/bika/lims/browser/worksheet/templates/print/ar_by_row.pt
@@ -88,18 +88,28 @@
             </div>
           </td>
           <tal:results repeat="antitle anst">
-            <tal:analysis define="analysis python:view.get_analysis_data_by_title(ar, antitle)">
-              <td tal:condition="analysis"
-                  tal:attributes="class string:${analysis/review_state} result">
-                <tal:result condition="analysis/formatted_result">
-                  <span tal:content="string:${analysis/formatted_result}">100</span>
-                  <span tal:content="string:${analysis/unit}">ml</span>
-                </tal:result>
+            <tal:analyses define="analyses python:view.get_analyses_data_by_title(ar, antitle)">
+              <td tal:condition="analyses">
+                <tal:analysis repeat="analysis analyses">
+                  <div tal:define="clazz string:${analysis/review_state};
+                                   is_first repeat/analysis/start;
+                                   clazz python: is_first and clazz or '{} repeat'.format(clazz);
+                                   clazz python: '{} result'.format(clazz);"
+                       tal:attributes="class clazz">
+                    <tal:result condition="analysis/formatted_result">
+                      <span tal:content="string:${analysis/formatted_result}">100</span>
+                      <span tal:content="string:${analysis/unit}">ml</span>
+                    </tal:result>
+                    <tal:empty_result condition="not:analysis/formatted_result">
+                      <span>&nbsp;</span>
+                    </tal:empty_result>
+                  </div>
+                </tal:analysis>
               </td>
-              <td tal:condition="not:analysis" class='no-result'>
+              <td tal:condition="not:analyses" class='no-result'>
                 <div>&nbsp;</div>
               </td>
-            </tal:analysis>
+            </tal:analyses>
           </tal:results>
         </tr>
       </tbody>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Retests are not displayed in the worksheet's print view. For instance, the following worksheet:

![Captura de 2020-07-01 12-47-49](https://user-images.githubusercontent.com/832627/86235681-167e7c80-bb99-11ea-92d4-1b89efb009de.png)

has two retests of "C.neoformans" analysis for the first sample (one of the two in verified status, while the other is awaiting for result). When the "Print" button is clicked, the following is displayed:

![Captura de 2020-07-01 12-50-30](https://user-images.githubusercontent.com/832627/86235903-75dc8c80-bb99-11ea-8799-7b0209264637.png)

In this image, the field appears empty for "C neoformans", but it can display any of the three tests (no sorting at all). In any case, all three tests must be displayed,


## Desired behavior after PR is merged

System displays all analyses, retests included and sorted:

![Captura de 2020-07-01 12-42-20](https://user-images.githubusercontent.com/832627/86236062-bc31eb80-bb99-11ea-89f2-6497e60ed7b9.png)



--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
