### PR TITLE
Fix Traceback on Dynamic Analysis Specs Edit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Changelog
 
 **Fixed**
 
+- #1606 Fix Traceback on Dynamic Analysis Specs Edit
 - #1605 Fix Retests are not displayed in Worksheet's print view
 - #1604 Fix Analyses from partitions do not show up when using Worksheet Template
 - #1602 Fix Report "Analysis per Service" is always creating the same PDF file

--- a/bika/lims/content/dynamic_analysisspec.py
+++ b/bika/lims/content/dynamic_analysisspec.py
@@ -28,6 +28,7 @@ from openpyxl.shared.exc import InvalidFileException
 from plone.dexterity.content import Item
 from plone.namedfile import field as namedfile
 from plone.supermodel import model
+from z3c.form.interfaces import NOT_CHANGED
 from zope.interface import Invalid
 from zope.interface import implementer
 from zope.interface import invariant
@@ -52,6 +53,9 @@ class IDynamicAnalysisSpec(model.Schema):
     def validate_sepecs_file(data):
         """Checks the Excel file contains the required header columns
         """
+        # return immediately if not changed
+        if data.specs_file == NOT_CHANGED:
+            return True
         fd = StringIO(data.specs_file.data)
         try:
             xls = load_workbook(fd)

--- a/bika/lims/controlpanel/dynamic_analysisspecs.py
+++ b/bika/lims/controlpanel/dynamic_analysisspecs.py
@@ -21,8 +21,10 @@
 import collections
 
 from bika.lims import _
+from bika.lims import api
 from bika.lims.catalog import SETUP_CATALOG
 from bika.lims.permissions import AddAnalysisSpec
+from bika.lims.utils import get_link
 from plone.dexterity.content import Container
 from plone.supermodel import model
 from senaite.core.listing import ListingView
@@ -123,6 +125,8 @@ class DynamicAnalysisSpecsView(ListingView):
             the template
         :index: current index of the item
         """
+        item["replace"]["Title"] = get_link(
+            api.get_url(obj), value=api.get_title(obj))
         return item
 
 

--- a/bika/lims/controlpanel/dynamic_analysisspecs.py
+++ b/bika/lims/controlpanel/dynamic_analysisspecs.py
@@ -75,7 +75,7 @@ class DynamicAnalysisSpecsView(ListingView):
         self.columns = collections.OrderedDict((
             ("Title", {
                 "title": _("Title"),
-                "replace_url": "absolute_url",
+                "replace_url": "getURL",
                 "index": "sortable_title"}),
             ("Description", {
                 "title": _("Description"),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an `Invalid` file Traceback when modifying an existing Dynamic Analysis Spec without changing the existing Excel.

## Current behavior before PR

Invalid File Traceback raised

## Desired behavior after PR is merged

No Traceback after edit

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
