### PR TITLE
Allow to set instruments from method edit view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Changed**
 
+- #1607 Allow to set instruments from method edit view
 - #1588 Dynamic Analysis Specs: Hide compliance viewlets
 - #1579 Remove classic mode in folderitems
 - #1577 Do not force available workflow transitions in batches listing

--- a/bika/lims/browser/js/bika.lims.method.js
+++ b/bika/lims/browser/js/bika.lims.method.js
@@ -2,46 +2,6 @@
  * Controller class for Method's Edit view
  */
 function MethodEditView() {
-
     var that = this;
-
-    /**
-     * Entry-point method for MethodEditView
-     */
-    that.load = function() {
-
-        loadInstruments();
-
-        $('#ManualEntryOfResults').change(function() {
-            if ($('#_AvailableInstruments option').length == 0
-                && $(this).is(':checked') == false) {
-                $(this).prop('checked', true);
-                return;
-            }
-        });
-
-    }
-
-    /**
-     * Loads the selected instruments for the current method. Merges the
-     * items from the Available Instrument multiselect with the
-     * Instruments multiselect element. If no instrument is linked to the
-     * method, selects and disables the Manual Entry of Results checkbox
-     */
-    function loadInstruments() {
-        $('#archetypes-fieldname-_AvailableInstruments').hide();
-        $('#_Instruments').prop('disabled', true);
-        $('#_Instruments').css('width', '250px');
-        $('#_Instruments option').prop('selected', true);
-        if ($('#_Instruments option').length == 0) {
-            $('#ManualEntryOfResults').prop('checked', true);
-        }
-        $('#_AvailableInstruments option').each(function() {
-            var uid = $(this).val();
-            if ($('#_Instruments option[value="'+uid+'"]').length == 0) {
-                $(this).css('color', '#8f8f8f');
-                $(this).appendTo('#_Instruments');
-            }
-        });
-    }
+    that.load = function() {}
 }

--- a/bika/lims/browser/methodfolder.py
+++ b/bika/lims/browser/methodfolder.py
@@ -147,7 +147,7 @@ class MethodFolderContentsView(BikaListingView):
         else:
             item["Calculation"] = ""
 
-        manual_entry_of_results_allowed = obj.isManualEntryOfResults()
+        manual_entry_of_results_allowed = obj.getManualEntryOfResults()
         item["ManualEntry"] = manual_entry_of_results_allowed
         item["replace"]["ManualEntry"] = " "
         if manual_entry_of_results_allowed:

--- a/bika/lims/content/method.py
+++ b/bika/lims/content/method.py
@@ -232,5 +232,10 @@ class Method(BaseFolder):
         items = [(i.UID, i.Title) for i in bsc(query)]
         return DisplayList(list(items))
 
+    def isManualEntryOfResults(self):
+        """BBB
+        """
+        return self.getManualEntryOfResults()
+
 
 registerType(Method, PROJECTNAME)

--- a/bika/lims/content/method.py
+++ b/bika/lims/content/method.py
@@ -88,9 +88,7 @@ schema = BikaSchema.copy() + Schema((
             visible=True,
             label=_("Instruments"),
             description=_(
-                "The selected instruments have support for this method. "
-                "Use the Instrument edit view to assign "
-                "the method to a specific instrument"),
+                "Select the supported Instruments for this Method."),
         )
     ),
 

--- a/bika/lims/content/method.py
+++ b/bika/lims/content/method.py
@@ -22,30 +22,27 @@ from AccessControl import ClassSecurityInfo
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.fields import UIDReferenceField
+from bika.lims.browser.widgets import ReferenceWidget
 from bika.lims.config import PROJECTNAME
 from bika.lims.content.bikaschema import BikaSchema
 from bika.lims.interfaces import IDeactivable
 from bika.lims.interfaces import IHaveInstrument
 from bika.lims.interfaces import IMethod
 from plone.app.blob.field import FileField as BlobFileField
+from Products.Archetypes.atapi import InAndOutWidget
 from Products.Archetypes.public import BaseFolder
 from Products.Archetypes.public import BooleanField
 from Products.Archetypes.public import BooleanWidget
-from Products.Archetypes.public import ComputedField
 from Products.Archetypes.public import FileWidget
 from Products.Archetypes.public import LinesField
-from Products.Archetypes.public import MultiSelectionWidget
 from Products.Archetypes.public import Schema
 from Products.Archetypes.public import StringField
 from Products.Archetypes.public import StringWidget
 from Products.Archetypes.public import TextAreaWidget
 from Products.Archetypes.public import TextField
-from bika.lims.browser.widgets import ReferenceWidget
 from Products.Archetypes.public import registerType
 from Products.Archetypes.utils import DisplayList
-from Products.CMFCore.utils import getToolByName
 from zope.interface import implements
-
 
 schema = BikaSchema.copy() + Schema((
 
@@ -83,56 +80,30 @@ schema = BikaSchema.copy() + Schema((
         )
     ),
 
-    # The instruments linked to this method. Don't use this
-    # method, use getInstrumentUIDs() or getInstruments() instead
     LinesField(
-        "_Instruments",
-        vocabulary="getInstrumentsDisplayList",
-        widget=MultiSelectionWidget(
-            modes=("edit"),
+        "Instruments",
+        vocabulary="availableInstrumentsVocabulary",
+        accessor="getInstrumentUIDs",
+        widget=InAndOutWidget(
+            visible=True,
             label=_("Instruments"),
             description=_(
                 "The selected instruments have support for this method. "
                 "Use the Instrument edit view to assign "
                 "the method to a specific instrument"),
-        ),
-    ),
-
-    # All the instruments available in the system. Don't use this
-    # method to retrieve the instruments linked to this method, use
-    # getInstruments() or getInstrumentUIDs() instead.
-    LinesField(
-        "_AvailableInstruments",
-        vocabulary="_getAvailableInstrumentsDisplayList",
-        widget=MultiSelectionWidget(
-            modes=("edit"),
         )
     ),
 
-    # If no instrument selected, always True. Otherwise, the user will
-    # be able to set or unset the value. The behavior for this field
-    # is controlled with javascript.
+    # If no instrument selected, always True.
     BooleanField(
         "ManualEntryOfResults",
-        default=False,
+        schemata="default",
+        default=True,
         widget=BooleanWidget(
             label=_("Manual entry of results"),
             description=_("The results for the Analysis Services that use "
                           "this method can be set manually"),
-            modes=("edit"),
         )
-    ),
-
-    # Only shown in readonly view. Not in edit view
-    ComputedField(
-        "ManualEntryOfResultsViewField",
-        expression="context.isManualEntryOfResults()",
-        widget=BooleanWidget(
-            label=_("Manual entry of results"),
-            description=_("The results for the Analysis Services that use "
-                          "this method can be set manually"),
-            modes=("view"),
-        ),
     ),
 
     # Calculations associated to this method. The analyses services
@@ -190,16 +161,6 @@ class Method(BaseFolder):
         from bika.lims.idserver import renameAfterCreation
         renameAfterCreation(self)
 
-    def isManualEntryOfResults(self):
-        """Indicates if manual entry of results is allowed.
-
-        If no instrument is selected for this method, returns True. Otherwise,
-        returns False by default, but its value can be modified using the
-        ManualEntryOfResults Boolean Field
-        """
-        instruments = self.getInstruments()
-        return len(instruments) == 0 or self.getManualEntryOfResults()
-
     def getInstrument(self):
         """Instruments capable to perform this method.
         Required by IHaveInstrument
@@ -211,27 +172,66 @@ class Method(BaseFolder):
         """
         return self.getBackReferences("InstrumentMethods")
 
+    def getRawInstruments(self):
+        """List of Instrument UIDs capable to perform this method
+        """
+        return map(api.get_uid, self.getInstruments())
+
+    def setInstruments(self, value):
+        """Set the method on the selected instruments
+        """
+        # filter out empty value
+        value = filter(lambda uid: uid, value)
+
+        # handle removed instruments
+        existing = self.getInstrumentUIDs()
+        to_remove = filter(lambda uid: uid not in value, existing)
+
+        # handle all Instruments flushed
+        if not value:
+            self.setManualEntryOfResults(True)
+
+        # remove method from removed instruments
+        for uid in to_remove:
+            instrument = api.get_object_by_uid(uid)
+            methods = instrument.getMethods()
+            methods.remove(self)
+            instrument.setMethods(methods)
+
+        # add method to new added instruments
+        for uid in value:
+            instrument = api.get_object_by_uid(uid)
+            methods = instrument.getMethods()
+            if self in methods:
+                continue
+            methods.append(self)
+            instrument.setMethods(methods)
+
     def getInstrumentUIDs(self):
         """UIDs of the instruments capable to perform this method
         """
         return map(api.get_uid, self.getInstruments())
 
-    def getInstrumentsDisplayList(self):
-        """Instruments capable to perform this method
+    def setManualEntryOfResults(self, value):
+        """Allow manual entry of results
         """
-        items = [(i.UID(), i.Title()) for i in self.getInstruments()]
-        return DisplayList(list(items))
+        field = self.getField("ManualEntryOfResults")
+        if not self.getInstruments():
+            # Always true if no instrument is selected
+            field.set(self, True)
+        else:
+            field.set(self, value)
 
-    def _getAvailableInstrumentsDisplayList(self):
+    def availableInstrumentsVocabulary(self):
         """Available instruments registered in the system
-
-        Only instruments with state=active will be fetched
         """
-        bsc = getToolByName(self, "bika_setup_catalog")
-        items = [(i.UID, i.Title)
-                 for i in bsc(portal_type="Instrument",
-                              is_active=True)]
-        items.sort(lambda x, y: cmp(x[1], y[1]))
+        bsc = api.get_tool("bika_setup_catalog")
+        query = {
+            "portal_type": "Instrument",
+            "sort_on": "sortable_title",
+            "is_active": True,
+        }
+        items = [(i.UID, i.Title) for i in bsc(query)]
         return DisplayList(list(items))
 
 

--- a/bika/lims/workflow/instrument/events.py
+++ b/bika/lims/workflow/instrument/events.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+from bika.lims import api
+
+
+def after_deactivate(instrument):
+    """Function triggered after a 'deactivate' transition for the instrument
+    passed in is performed.
+    """
+
+    # remove the deactivated instrument from all assigned methods
+    for method in instrument.getMethods():
+        instruments = method.getInstruments()
+        instruments.remove(instrument)
+        instrument_uids = map(api.get_uid, instruments)
+        method.setInstruments(instrument_uids)
+        method.reindexObject()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR allows to set instruments from the method view.
Furthermore, it fixes a bug for SENAITE 2.x that in the edit view the first calculation was always selected, even if the field was unset.

## Current behavior before PR

The supported instruments for a method could be only set from inside an instrument.

## Desired behavior after PR is merged

The supported instruments for a method can be set from within the method itself.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
