### PR TITLE
Support result options entry for interim values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #1609 Support result options entry for interim values
 - #1598 Added "modified" index in Sample's (AnalysisRequest) catalog
 - #1596 Allow to hide actions menu by using new marker interface IHideActionsMenu
 - #1588 Dynamic Analysis Specs: Lookup dynamic spec only when the specification is set

--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -809,6 +809,9 @@ class AnalysesView(BikaListingView):
         # of interims the analysis has already assigned.
         interim_fields = analysis_brain.getInterimFields or list()
 
+        # Copy to prevent to avoid persistent changes
+        interim_fields = copy(interim_fields)
+
         for interim_field in interim_fields:
             interim_keyword = interim_field.get('keyword', '')
             if not interim_keyword:
@@ -833,22 +836,23 @@ class AnalysesView(BikaListingView):
                 interim_title = interim_field.get('title')
                 self.interim_columns[interim_keyword] = interim_title
 
-            # Does a results list needs to be rendered?
-            interim_choices = interim_field.get("choices")
-            if interim_choices:
-                headers = ["ResultValue", "ResultText"]
-                choices = interim_choices.split("|") or []
-                choices = dict(map(lambda it: it.split(":"), choices))
-                dlist = map(lambda it: dict(zip(headers, it)), choices.items())
-                if dlist:
-                    item["choices"] = {}
-                    item["choices"][interim_keyword] = dlist
+            # Does interim's results list needs to be rendered?
+            choices = interim_field.get("choices")
+            if choices:
+                # Get the {value:text} dict
+                choices = choices.split("|")
+                choices = dict(map(lambda ch: ch.strip().split(":"), choices))
 
-                    # Display the text instead of the value
-                    val = choices.get(interim_value)
-                    if val:
-                        interim_field['value'] = val
-                        item[interim_keyword]=interim_field
+                # Generate the display list
+                # [{"ResultValue": value, "ResultText": text},]
+                headers = ["ResultValue", "ResultText"]
+                d_list = map(lambda it: dict(zip(headers, it)), choices.items())
+                item.setdefault("choices", {})[interim_keyword] = d_list
+
+                # Display the text instead of the value
+                val = choices.get(interim_value, "")
+                interim_field["value"] = val
+                item[interim_keyword] = interim_field
 
         item['interimfields'] = interim_fields
         self.interim_fields[analysis_brain.UID] = interim_fields

--- a/bika/lims/browser/analyses/view.py
+++ b/bika/lims/browser/analyses/view.py
@@ -630,6 +630,7 @@ class AnalysesView(BikaListingView):
                     "ajax": True,
                 }
 
+
         if self.allow_edit:
             new_states = []
             for state in self.review_states:
@@ -831,6 +832,23 @@ class AnalysesView(BikaListingView):
             if not interim_hidden:
                 interim_title = interim_field.get('title')
                 self.interim_columns[interim_keyword] = interim_title
+
+            # Does a results list needs to be rendered?
+            interim_choices = interim_field.get("choices")
+            if interim_choices:
+                headers = ["ResultValue", "ResultText"]
+                choices = interim_choices.split("|") or []
+                choices = dict(map(lambda it: it.split(":"), choices))
+                dlist = map(lambda it: dict(zip(headers, it)), choices.items())
+                if dlist:
+                    item["choices"] = {}
+                    item["choices"][interim_keyword] = dlist
+
+                    # Display the text instead of the value
+                    val = choices.get(interim_value)
+                    if val:
+                        interim_field['value'] = val
+                        item[interim_keyword]=interim_field
 
         item['interimfields'] = interim_fields
         self.interim_fields[analysis_brain.UID] = interim_fields

--- a/bika/lims/browser/fields/interimfieldsfield.py
+++ b/bika/lims/browser/fields/interimfieldsfield.py
@@ -66,6 +66,7 @@ class InterimFieldsField(RecordsField):
             'title': 'interimfieldsvalidator',
             'value': 'interimfieldsvalidator',
             'unit': 'interimfieldsvalidator',
+            'choices': 'interimfieldsvalidator'
         },
     })
     security = ClassSecurityInfo()

--- a/bika/lims/browser/fields/interimfieldsfield.py
+++ b/bika/lims/browser/fields/interimfieldsfield.py
@@ -35,12 +35,13 @@ class InterimFieldsField(RecordsField):
         'minimalSize': 0,
         'maximalSize': 9999,
         'type': 'InterimFields',
-        'subfields': ('keyword', 'title', 'value', 'unit', 'report', 'hidden', 'wide'),
+        'subfields': ('keyword', 'title', 'value', 'choices', 'unit', 'report', 'hidden', 'wide'),
         'required_subfields': ('keyword', 'title'),
         'subfield_labels': {
             'keyword': _('Keyword'),
             'title': _('Field Title'),
             'value': _('Default value'),
+            'choices': _('Choices'),
             'unit': _('Unit'),
             'report': _('Report'),
             'hidden': _('Hidden Field'),
@@ -49,6 +50,7 @@ class InterimFieldsField(RecordsField):
         'subfield_types': {
             'hidden': 'boolean',
             'value': 'float',
+            'choices': 'string',
             'wide': 'boolean',
             'report': 'boolean',
         },
@@ -56,6 +58,7 @@ class InterimFieldsField(RecordsField):
             'keyword': 20,
             'title': 20,
             'value': 10,
+            'choices': 30,
             'unit': 10,
         },
         'subfield_validators': {


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request allows the user to configure interims so a results option list will be displayed in the analyses results entry views:

Before submit:

![Captura de 2020-07-25 13-02-03](https://user-images.githubusercontent.com/832627/88455697-c3d27080-ce77-11ea-86a9-3d20265f0d6a.png)

After submit (with linked calculation):


![Captura de 2020-07-25 13-02-29](https://user-images.githubusercontent.com/832627/88455703-d8166d80-ce77-11ea-8254-193615ffe4d2.png)



## Current behavior before PR

Options list not supported for interim values

## Desired behavior after PR is merged

Options list supported for interim values

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
