### PR TITLE
Compatibility with Plone 5.2.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2.0.0rc2 (unreleased)
+---------------------
+
+- #1613 Fix permission error when accessing `get_data_settings` for Plone 5.2.2
+
+
 2.0.0rc1 (2020-07-24)
 ---------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@ Changelog
 - New install screens
 
 
-1.3.4 (unreleased)
+1.3.4 (2020-08-11)
 ------------------
 
 **Added**

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.0.0rc2 (unreleased)
 ---------------------
 
-- #1613 Fix permission error when accessing `get_data_settings` for Plone 5.2.2
+- #1613 Compatibility with Plone 5.2.2
 
 
 2.0.0rc1 (2020-07-24)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,8 +1,8 @@
 [buildout]
 index = https://pypi.org/simple/
-extends = https://dist.plone.org/release/5.2-latest/versions.cfg
+extends = https://dist.plone.org/release/5.2.2/versions.cfg
 find-links =
-    https://dist.plone.org/release/5.2-latest/
+    https://dist.plone.org/release/5.2.2/
     https://dist.plone.org/thirdparty/
 
 parts =

--- a/src/bika/lims/browser/analysisrequest/templates/analysisrequests.pt
+++ b/src/bika/lims/browser/analysisrequest/templates/analysisrequests.pt
@@ -35,7 +35,7 @@
                      min="1"
                      max="99"
                      class="form-control form-control-sm"
-                     tal:attributes="value view/getDefaultAddCount|1"/>
+                     tal:attributes="value python:view.getDefaultAddCount() or 1"/>
               <span class="input-group-append">
                 <button type="submit"
                         class="btn btn-outline-secondary btn-sm">

--- a/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -243,7 +243,7 @@
                      min="1"
                      max="99"
                      class="form-control form-control-sm"
-                     tal:attributes="value view/ar_count|1"/>
+                     tal:attributes="value python:view.ar_count or 1"/>
               <span class="input-group-append">
                 <button type="submit"
                         class="btn btn-outline-secondary btn-sm">

--- a/src/bika/lims/browser/templates/header_table.pt
+++ b/src/bika/lims/browser/templates/header_table.pt
@@ -12,7 +12,9 @@
   </head>
 
   <body
-    tal:define="root_sample python:view.is_primary_with_partitions();
+    tal:define="senaite_view python:context.restrictedTraverse('@@senaite_view');
+                test nocall:senaite_view/test;
+                root_sample python:view.is_primary_with_partitions();
                 dummy python:view.get_fields_grouped_by_location();
                 prominent python:dummy[0];
                 sublists python:dummy[1]"

--- a/src/senaite/core/browser/bootstrap/bootstrap.py
+++ b/src/senaite/core/browser/bootstrap/bootstrap.py
@@ -46,6 +46,10 @@ class IBootstrapView(Interface):
         """Determine the value of the viewport meta-tag
         """
 
+    def get_data_settings():
+        """Helper method to inject data attributes in a DOM node
+        """
+
 
 def icon_cache_key(method, self, brain_or_object, **kw):
     """Generates a cache key for the icon lookup

--- a/src/senaite/core/browser/globals/configure.zcml
+++ b/src/senaite/core/browser/globals/configure.zcml
@@ -4,6 +4,14 @@
     xmlns:zcml="http://namespaces.zope.org/zcml">
 
   <browser:page
+      name="senaite_view"
+      for="*"
+      permission="zope.Public"
+      class=".view.SenaiteView"
+      allowed_interface=".interfaces.ISenaiteView"
+      />
+
+  <browser:page
       name="senaite_theme"
       for="*"
       permission="zope.Public"

--- a/src/senaite/core/browser/globals/interfaces.py
+++ b/src/senaite/core/browser/globals/interfaces.py
@@ -21,6 +21,18 @@
 from zope.interface import Interface
 
 
+class ISenaiteView(Interface):
+    """A view that provides global utilities
+    """
+
+    def test(*args):
+        """A special function, 'test', that supports if-then expressions.
+
+        This code is taken from `RestrictedPython.Utilities`.
+        https://community.plone.org/t/plone-5-2-1-5-2-2-page-template-issues
+        """
+
+
 class ISenaiteTheme(Interface):
     """A view that provides theme specific configuration
     """

--- a/src/senaite/core/browser/globals/view.py
+++ b/src/senaite/core/browser/globals/view.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2020 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from Products.Five.browser import BrowserView
+from zope.interface import implementer
+
+from .interfaces import ISenaiteView
+
+
+@implementer(ISenaiteView)
+class SenaiteView(BrowserView):
+    """A view that provides global utilities
+    """
+
+    def test(self, *args):
+        """A special function, 'test', that supports if-then expressions.
+
+        The 'test' function accepts any number of arguments. If the first
+        argument is true, then the second argument is returned, otherwise if
+        the third argument is true, then the fourth argument is returned, and
+        so on. If there is an odd number of arguments, then the last argument
+        is returned in the case that none of the tested arguments is true,
+        otherwise None is returned.
+
+        This code is taken from `RestrictedPython.Utilities`.
+
+        Used in `main_template` to work around the following issue:
+        https://community.plone.org/t/plone-5-2-1-5-2-2-page-template-issues
+        """
+        length = len(args)
+        for i in range(1, length, 2):
+            if args[i - 1]:
+                return args[i]
+
+        if length % 2:
+            return args[-1]

--- a/src/senaite/core/browser/main_template/templates/ajax_main_template.pt
+++ b/src/senaite/core/browser/main_template/templates/ajax_main_template.pt
@@ -6,6 +6,8 @@
         xmlns:metal="http://xml.zope.org/namespaces/metal"
         xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         tal:define="senaite_theme python:context.restrictedTraverse('@@senaite_theme');
+                    senaite_view python:context.restrictedTraverse('@@senaite_view');
+                    test nocall:senaite_view/test;
                     portal_state python:context.restrictedTraverse('@@plone_portal_state');
                     context_state python:context.restrictedTraverse('@@plone_context_state');
                     plone_view python:context.restrictedTraverse('@@plone');

--- a/src/senaite/core/browser/main_template/templates/main_template.pt
+++ b/src/senaite/core/browser/main_template/templates/main_template.pt
@@ -6,6 +6,8 @@
         xmlns:metal="http://xml.zope.org/namespaces/metal"
         xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         tal:define="senaite_theme python:context.restrictedTraverse('@@senaite_theme');
+                    senaite_view python:context.restrictedTraverse('@@senaite_view');
+                    test nocall:senaite_view/test;
                     portal_state python:context.restrictedTraverse('@@plone_portal_state');
                     context_state python:context.restrictedTraverse('@@plone_context_state');
                     plone_view python:context.restrictedTraverse('@@plone');

--- a/src/senaite/core/skins/senaite_templates/edit_macros.pt
+++ b/src/senaite/core/skins/senaite_templates/edit_macros.pt
@@ -110,7 +110,7 @@
                      tal:content="python:view.getTranslatedSchemaLabel(fieldset)"
                      tal:attributes="id string:${id}-tab;
                                      href string:#${id};
-                                     class python:repeat['fieldset'].start() and 'nav-link active' or 'nav-link'"
+                                     class python:repeat['fieldset'].start and 'nav-link active' or 'nav-link'"
                      i18n:translate="">
                   </a>
                 </li>
@@ -120,7 +120,7 @@
               <tal:fieldsets repeat="fieldset fieldsets">
                 <div tal:define="id python:view.normalizeString(fieldset)"
                      tal:attributes="id string:${id};
-                                     class python:repeat['fieldset'].start() and 'tab-pane fade show active' or 'tab-pane fade'"
+                                     class python:repeat['fieldset'].start and 'tab-pane fade show active' or 'tab-pane fade'"
                      role="tabpanel">
                   <tal:fields repeat="field python:schematas[fieldset].editableFields(here, visible_only=True)">
                     <metal:fieldMacro use-macro="python:context.widget(field.getName(), mode='edit')" />


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fixtures for several issues when upgrading to Plone 5.2.2

## Current behavior before PR

Errors in Page Templates occur

## Desired behavior after PR is merged

Page templates are compatible with Plone 5.2.2

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
