### PR TITLE
Fix writing methods on read when reindexing services

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc2 (unreleased)
 ---------------------
 
+- #1616 Fix writing instrument methods on read when reindexing services
 - #1613 Compatibility with Plone 5.2.2
 
 

--- a/src/bika/lims/content/analysisservice.py
+++ b/src/bika/lims/content/analysisservice.py
@@ -496,7 +496,8 @@ class AnalysisService(AbstractBaseAnalysis):
         Returns the UIDs of the available methods. it is used as a
         vocabulary to fill the selection list of 'Methods' field.
         """
-        method_uids = self.getRawMethods()
+        # N.B. we return a copy of the list to avoid accidental writes
+        method_uids = map(lambda x: x, self.getRawMethods())
         if self.getInstrumentEntryOfResults():
             for instrument in self.getInstruments():
                 method_uids.extend(instrument.getRawMethods())

--- a/src/bika/lims/content/analysisservice.py
+++ b/src/bika/lims/content/analysisservice.py
@@ -497,7 +497,7 @@ class AnalysisService(AbstractBaseAnalysis):
         vocabulary to fill the selection list of 'Methods' field.
         """
         # N.B. we return a copy of the list to avoid accidental writes
-        method_uids = map(lambda x: x, self.getRawMethods())
+        method_uids = self.getRawMethods()[:]
         if self.getInstrumentEntryOfResults():
             for instrument in self.getInstruments():
                 method_uids.extend(instrument.getRawMethods())

--- a/src/senaite/core/upgrade/configure.zcml
+++ b/src/senaite/core/upgrade/configure.zcml
@@ -8,7 +8,7 @@
        source="1.3.4"
        destination="2.0.0"
        handler="senaite.core.upgrade.v02_00_000.upgrade"
-       profile="bika.lims:default"/>
+       profile="senaite.core:default"/>
 
    <genericsetup:upgradeStep
        title="Upgrade to SENAITE.CORE 1.3.4"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR resolves an issue for analysis services that instrument methods are extended to the methods field on reindex

## Current behavior before PR

Instrument methods are extended to the methods field of services on reindex

## Desired behavior after PR is merged

Instrument methods are not written to the service methods on reindex

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
