### PR TITLE
Fix instrument import for analyses with result options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc2 (unreleased)
 ---------------------
 
+- #1621 Fix instrument import for analyses with result options
 - #1618 Better style for DX form based field errors
 - #1616 Fix writing instrument methods on read when reindexing services
 - #1613 Compatibility with Plone 5.2.2

--- a/src/senaite/core/exportimport/instruments/resultsimport.py
+++ b/src/senaite/core/exportimport/instruments/resultsimport.py
@@ -949,11 +949,15 @@ class AnalysisResultsImporter(Logger):
         # Set result if present.
         res = values.get(defresultkey, '')
         if res or res == 0 or self._override[1] == True:
-            # self.log("${object_id} result for '${analysis_keyword}': '${result}'",
-            #          mapping={"obect_id": obid,
-            #                   "analysis_keyword": acode,
-            #                   "result": str(res)})
-            # TODO incorporar per veure detall d'importacio
+
+            # handle non-floating values in result options
+            result_options = analysis.getResultOptions()
+            if result_options:
+                result_values = map(
+                    lambda r: r.get("ResultValue"), result_options)
+                if "{:.0f}".format(res) in result_values:
+                    res = int(res)
+
             analysis.setResult(res)
             if capturedate:
                 analysis.setResultCaptureDate(capturedate)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue for instrument results import, when the analysis has result options set.

## Current behavior before PR

After importing results for analyses with results options, the raw value is displayed in the results field of the analysis

## Desired behavior after PR is merged

After importing results for analyses with results options, the formatted result value is displayed in the results field of the analysis

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
