### PR TITLE
Fix bad Dexterity FTI type names

### DIFF
--- a/src/senaite/core/profiles/default/types/InterpretationTemplate.xml
+++ b/src/senaite/core/profiles/default/types/InterpretationTemplate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<object name="DynamicAnalysisSpec" meta_type="Dexterity FTI"
+<object name="InterpretationTemplate" meta_type="Dexterity FTI"
         i18n:domain="senaite.core"
         xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 

--- a/src/senaite/core/profiles/default/types/InterpretationTemplates.xml
+++ b/src/senaite/core/profiles/default/types/InterpretationTemplates.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<object name="DynamicAnalysisSpecs" meta_type="Dexterity FTI"
+<object name="InterpretationTemplates" meta_type="Dexterity FTI"
         i18n:domain="senaite.core"
         xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Wrong object names in profile/default/types

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
