### PR TITLE
Fix assignment of analyses via worksheet template when Worksheet is full

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Fixed**
 
+- #1625 Fix assignment of analyses via worksheet template when Worksheet is full
 - #1617 Fix writing methods on read when reindexing services
 
 

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -814,6 +814,12 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
             slots.append(slot)
         return slots
 
+    def get_containers_slots(self):
+        """Returns a list of tuple (container_uid, slot)
+        """
+        layout = self.getLayout()
+        return map(lambda l: (l["container_uid"], int(l["position"])), layout)
+
     def _apply_worksheet_template_routine_analyses(self, wst):
         """Add routine analyses to worksheet according to the worksheet template
         layout passed in w/o overwriting slots that are already filled.
@@ -827,116 +833,83 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         :param wst: worksheet template used as the layout
         :returns: None
         """
-        bac = api.get_tool("bika_analysis_catalog")
-        services = wst.getService()
-        wst_service_uids = [s.UID() for s in services]
+        # Get the services from the Worksheet Template
+        service_uids = wst.getRawService()
+        if not service_uids:
+            # No service uids assigned to this Worksheet Template, skip
+            logger.warn("Worksheet Template {} has no services assigned"
+                        .format(_api.get_path(wst)))
+            return
+
+        # Search for unassigned analyses
         query = {
             "portal_type": "Analysis",
-            "getServiceUID": wst_service_uids,
+            "getServiceUID": service_uids,
             "review_state": "unassigned",
             "isSampleReceived": True,
             "is_active": True,
             "sort_on": "getPrioritySortkey"
         }
-        # Filter analyses their Analysis Requests have been received
-        analyses = bac(query)
-
-        # No analyses, nothing to do
+        analyses = api.search(query, CATALOG_ANALYSIS_LISTING)
         if not analyses:
             return
 
-        # Available slots for routine analyses. Sort reverse, cause we need a
-        # stack for sequential assignment of slots
+        # Available slots for routine analyses
         available_slots = self.resolve_available_slots(wst, 'a')
         available_slots.sort(reverse=True)
 
         # If there is an instrument assigned to this Worksheet Template, take
         # only the analyses that allow this instrument into consideration.
-        instrument = wst.getInstrument()
+        instrument = wst.getRawInstrument()
 
         # If there is method assigned to the Worksheet Template, take only the
         # analyses that allow this method into consideration.
-        method = wst.getRestrictToMethod()
+        method = wst.getRawRestrictToMethod()
 
-        # This worksheet is empty?
-        num_routine_analyses = len(self.getRegularAnalyses())
+        # Map existing sample uids with slots
+        samples_slots = dict(self.get_containers_slots())
+        new_sample_uids = []
+        new_analyses = []
 
-        # Group Analyses by Analysis Requests
-        ar_analyses = dict()
-        ar_slots = dict()
-        ar_fixed_slots = dict()
+        for analysis in analyses:
+            analysis = api.get_object(analysis)
 
-        for brain in analyses:
-            obj = api.get_object(brain)
-            arid = obj.getRequestID()
-
-            if instrument and not obj.isInstrumentAllowed(instrument):
-                # Exclude those analyses for which the worksheet's template
-                # instrument is not allowed
+            if instrument and not analysis.isInstrumentAllowed(instrument):
+                # WST's Instrument does not supports this analysis
                 continue
 
-            if method and not obj.isMethodAllowed(method):
-                # Exclude those analyses for which the worksheet's template
-                # method is not allowed
+            if method and not analysis.isMethodAllowed(method):
+                # WST's method does not supports this analysis
                 continue
 
-            slot = ar_slots.get(arid, None)
+            # Get the slot where analyses from this sample are located
+            sample_uid = analysis.getRequestUID()
+            slot = samples_slots.get(sample_uid)
             if not slot:
-                # We haven't processed other analyses that belong to the same
-                # Analysis Request as the current one.
-                if len(available_slots) == 0 and num_routine_analyses == 0:
-                    # No more slots available for this worksheet/template, so
-                    # we cannot add more analyses to this WS. Also, there is no
-                    # chance to process a new analysis with an available slot.
-                    break
+                if len(available_slots) == 0:
+                    # Maybe next analysis is from a sample with a slot assigned
+                    continue
 
-                if num_routine_analyses == 0:
-                    # This worksheet is empty, but there are slots still
-                    # available, assign the next available slot to this analysis
-                    slot = available_slots.pop()
-                else:
-                    # This worksheet is not empty and there are slots still
-                    # available.
-                    slot = self.get_slot_position(obj.getRequest())
-                    if slot:
-                        # Prefixed slot position
-                        ar_fixed_slots[arid] = slot
-                        if arid not in ar_analyses:
-                            ar_analyses[arid] = list()
-                        ar_analyses[arid].append(obj)
-                        continue
+                # Pop next available slot
+                slot = available_slots.pop()
 
-                    # This worksheet does not contain any other analysis
-                    # belonging to the same Analysis Request as the current
-                    if len(available_slots) == 0:
-                        # There is the chance to process a new analysis that
-                        # belongs to an Analysis Request that is already
-                        # in this worksheet.
-                        continue
+                # Feed the samples_slots
+                samples_slots[sample_uid] = slot
+                new_sample_uids.append(sample_uid)
 
-                    # Assign the next available slot
-                    slot = available_slots.pop()
+            # Keep track of the analyses to add
+            new_analyses.append((analysis, sample_uid))
 
-            ar_slots[arid] = slot
-            if arid not in ar_analyses:
-                ar_analyses[arid] = list()
-            ar_analyses[arid].append(obj)
+        # Re-sort slots for new samples to display them in natural order
+        new_slots = map(lambda s: samples_slots.get(s), new_sample_uids)
+        sorted_slots = zip(sorted(new_sample_uids), sorted(new_slots))
+        for sample_id, slot in sorted_slots:
+            samples_slots[sample_uid] = slot
 
-        # Sort the analysis requests by sortable_title, so the ARs will appear
-        # sorted in natural order. Since we will add the analysis with the
-        # exact slot where they have to be displayed, we need to sort the slots
-        # too and assign them to each group of analyses in natural order
-        sorted_ar_ids = sorted(ar_analyses.keys())
-        slots = sorted(ar_slots.values(), reverse=True)
-
-        # Add regular analyses
-        for ar_id in sorted_ar_ids:
-            slot = ar_fixed_slots.get(ar_id, None)
-            if not slot:
-                slot = slots.pop()
-            ar_ans = ar_analyses[ar_id]
-            for ar_an in ar_ans:
-                self.addAnalysis(ar_an, slot)
+        # Add analyses to the worksheet
+        for analysis, sample_uid in new_analyses:
+            slot = samples_slots[sample_uid]
+            self.addAnalysis(analysis, slot)
 
     def _apply_worksheet_template_duplicate_analyses(self, wst):
         """Add duplicate analyses to worksheet according to the worksheet template

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -838,7 +838,7 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         if not service_uids:
             # No service uids assigned to this Worksheet Template, skip
             logger.warn("Worksheet Template {} has no services assigned"
-                        .format(_api.get_path(wst)))
+                        .format(api.get_path(wst)))
             return
 
         # Search for unassigned analyses

--- a/bika/lims/tests/doctests/WorksheetApplyTemplate.rst
+++ b/bika/lims/tests/doctests/WorksheetApplyTemplate.rst
@@ -459,3 +459,153 @@ as the rest of the slots:
     >>> ref9_uids = [ref.UID() for ref in ref9]
     >>> [ref for ref in ref9_uids if ref not in refs_uids]
     []
+
+Reject any remaining analyses awaiting for assignment:
+
+    >>> query = {"portal_type": "Analysis", "review_state": "unassigned"}
+    >>> objs = map(api.get_object, api.search(query, "bika_analysis_catalog"))
+    >>> sucess = map(lambda obj: doActionFor(obj, "reject"), objs)
+
+
+WorksheetTemplate assignment to a non-empty Worksheet
+=====================================================
+
+Worksheet Template can also be used when the worksheet is not empty.
+The template has slots available for routine analyses in positions 1, 2 and 4:
+
+    >>> layout = template.getLayout()
+    >>> slots = filter(lambda p: p["type"] == "a", layout)
+    >>> sorted(map(lambda p: int(p.get("pos")), slots))
+    [1, 2, 4]
+
+Create 3 samples with 'Cu' analyses:
+
+    >>> service_uids = [Cu]
+    >>> samples = map(lambda i: create_analysisrequest(client, request, values, service_uids), range(3))
+    >>> success = map(lambda s: doActionFor(s, "receive"), samples)
+
+Create a worksheet and apply the template:
+
+    >>> worksheet = api.create(portal.worksheets, "Worksheet")
+    >>> worksheet.applyWorksheetTemplate(template)
+
+The Sample from first slot contains 1 analysis only (Cu):
+
+    >>> first = worksheet.get_container_at(1)
+    >>> first_analyses = worksheet.get_analyses_at(1)
+    >>> len(first_analyses)
+    1
+
+    >>> first_analyses[0].getKeyword()
+    'Cu'
+
+    >>> first_analyses[0].getRequest() == first
+    True
+
+Add "Fe" analysis to the sample from first slot and re-assign the worksheet:
+
+    >>> cu = first.getAnalyses(full_objects=True)[0]
+    >>> first.setAnalyses([cu, Fe])
+    >>> worksheet.applyWorksheetTemplate(template)
+
+The first slot, booked for the first Sample, contains now 'Fe':
+
+    >>> first_analyses = worksheet.get_analyses_at(1)
+    >>> len(first_analyses)
+    2
+
+    >>> map(lambda a: a.getKeyword(), first_analyses)
+    ['Cu', 'Fe']
+
+    >>> map(lambda a: a.getRequest() == first, first_analyses)
+    [True, True]
+
+Add "Fe" analysis to the third Sample (slot #4) and re-assign the worksheet:
+
+    >>> third = worksheet.get_container_at(4)
+    >>> cu = third.getAnalyses(full_objects=True)[0]
+    >>> third.setAnalyses([cu, Fe])
+    >>> worksheet.applyWorksheetTemplate(template)
+
+The fourth slot contains now 'Fe' too:
+
+    >>> third_analyses = worksheet.get_analyses_at(4)
+    >>> len(third_analyses)
+    2
+
+    >>> map(lambda a: a.getKeyword(), third_analyses)
+    ['Cu', 'Fe']
+
+    >>> map(lambda a: a.getRequest() == third, third_analyses)
+    [True, True]
+
+Create now 5 more samples:
+
+    >>> service_uids = [Cu]
+    >>> samples = map(lambda i: create_analysisrequest(client, request, values, service_uids), range(3))
+    >>> success = map(lambda s: doActionFor(s, "receive"), samples)
+
+And reassign the template to the worksheet:
+
+    >>> worksheet.applyWorksheetTemplate(template)
+
+None of these new samples have been added:
+
+    >>> new_samp_uids = map(api.get_uid, samples)
+    >>> container_uids = map(lambda l: l["container_uid"], worksheet.getLayout())
+    >>> [u for u in new_samp_uids if u in container_uids]
+    []
+
+Add "Fe" analysis to the second Sample and re-assign the worksheet:
+
+    >>> second = worksheet.get_container_at(2)
+    >>> cu = second.getAnalyses(full_objects=True)[0]
+    >>> second.setAnalyses([cu, Fe])
+    >>> worksheet.applyWorksheetTemplate(template)
+
+The second slot contains now 'Fe' too:
+
+    >>> second_analyses = worksheet.get_analyses_at(2)
+    >>> len(second_analyses)
+    2
+
+    >>> map(lambda a: a.getKeyword(), second_analyses)
+    ['Cu', 'Fe']
+
+    >>> map(lambda a: a.getRequest() == second, second_analyses)
+    [True, True]
+
+While none of the analyses from new samples have been added:
+
+    >>> container_uids = map(lambda l: l["container_uid"], worksheet.getLayout())
+    >>> [u for u in new_samp_uids if u in container_uids]
+    []
+
+Reject any remaining analyses awaiting for assignment:
+
+    >>> query = {"portal_type": "Analysis", "review_state": "unassigned"}
+    >>> objs = map(api.get_object, api.search(query, "bika_analysis_catalog"))
+    >>> sucess = map(lambda obj: doActionFor(obj, "reject"), objs)
+
+
+WorksheetTemplate assignment keeps Sample natural order
+=======================================================
+
+Analyses are grabbed by using their priority sort key, but samples are sorted
+in natural order in the slots.
+
+Create and receive 3 samples:
+
+    >>> service_uids = [Cu]
+    >>> samples = map(lambda i: create_analysisrequest(client, request, values, service_uids), range(3))
+    >>> success = map(lambda s: doActionFor(s, "receive"), samples)
+
+Create a worksheet and apply the template:
+
+    >>> worksheet = api.create(portal.worksheets, "Worksheet")
+    >>> worksheet.applyWorksheetTemplate(template)
+
+Slots follows the natural order of the samples:
+
+    >>> map(lambda s: worksheet.get_slot_position(s), samples)
+    [1, 2, 4]

--- a/bika/lims/tests/doctests/WorksheetApplyTemplate.rst
+++ b/bika/lims/tests/doctests/WorksheetApplyTemplate.rst
@@ -609,3 +609,38 @@ Slots follows the natural order of the samples:
 
     >>> map(lambda s: worksheet.get_slot_position(s), samples)
     [1, 2, 4]
+
+
+Assignment of a WorksheetTemplate with no services
+==================================================
+
+Create a Worksheet Template without services assigned:
+
+    >>> service_uids = []
+    >>> layout = [
+    ...     {'pos': '1', 'type': 'a',
+    ...      'blank_ref': '',
+    ...      'control_ref': '',
+    ...      'dup': ''},
+    ...     {'pos': '2', 'type': 'a',
+    ...      'blank_ref': '',
+    ...      'control_ref': '',
+    ...      'dup': ''},
+    ... ]
+    >>> empty_template = api.create(bikasetup.bika_worksheettemplates, "WorksheetTemplate", title="WS Template Empty Test", Layout=layout, Service=service_uids)
+
+Create and receive 2 samples:
+
+    >>> service_uids = [Cu]
+    >>> samples = map(lambda i: create_analysisrequest(client, request, values, service_uids), range(2))
+    >>> success = map(lambda s: doActionFor(s, "receive"), samples)
+
+Create a Worksheet and assign the template:
+
+    >>> worksheet = api.create(portal.worksheets, "Worksheet")
+    >>> worksheet.applyWorksheetTemplate(empty_template)
+
+Worksheet remains empty:
+
+    >>> worksheet.getAnalyses()
+    []


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When a worksheet is full and a worksheet template is assigned, the system omits those analyses for which there is no slot pre-assigned slot (based on the sample they belong to), but must assign the analyses that belong to a sample with an assigned slot.

## Current behavior before PR

Erratic behavior when re-assigning a Worksheet Template to a Worksheet. Sometimes analyses are assigned correctly for pre-existing samples and sometimes not.

## Desired behavior after PR is merged

No erratic behavior. If there is a slot available for any of the unassigned analyses, the analysis is assigned.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
