### PR TITLE
Fix assignment of analyses via worksheet template when full (ported from #1625)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc2 (unreleased)
 ---------------------
 
+- #1626 Fix assignment of analyses via worksheet template when Worksheet is full
 - #1620 Add Results Interpretation Templates
 - #1621 Fix instrument import for analyses with result options
 - #1618 Better style for DX form based field errors


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Ported from #1625

When a worksheet is full and a worksheet template is assigned, the system omits those analyses for which there is no slot pre-assigned slot (based on the sample they belong to), but must assign the analyses that belong to a sample with an assigned slot.

## Current behavior before PR

Erratic behavior when re-assigning a Worksheet Template to a Worksheet. Sometimes analyses are assigned correctly for pre-existing samples and sometimes not.

## Desired behavior after PR is merged

No erratic behavior. If there is a slot available for any of the unassigned analyses, the analysis is assigned.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
