### PR TITLE
Added client sampleid to worksheet printview

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Added**
 
+- #1612 Add Client sample ID to worksheet template printview
 - #1609 Support result options entry for interim values
 - #1598 Added "modified" index in Sample's (AnalysisRequest) catalog
 - #1596 Allow to hide actions menu by using new marker interface IHideActionsMenu

--- a/bika/lims/browser/worksheet/views/printview.py
+++ b/bika/lims/browser/worksheet/views/printview.py
@@ -472,6 +472,7 @@ class PrintView(BrowserView):
                         sample.getDateSampled(), long_format=True),
                     'date_received': self.ulocalized_time(
                         sample.getDateReceived(), long_format=0),
+                    'client_sampleid': sample.getClientSampleID(),
                     }
 
             if sample.portal_type == "ReferenceSample":


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1612

## Current behavior before PR

Worksheet templates print does not show "client sample id"

## Desired behavior after PR is merged

Worksheet templates print view should include "client sample id" option

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
