### PR TITLE
Fix Published results tab is not displayed to Client contacts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Fixed**
 
+- #1629 Fix Published results tab is not displayed to Client contacts
 - #1628 Fix instrument import for analyses with result options
 - #1625 Fix assignment of analyses via worksheet template when Worksheet is full
 - #1617 Fix writing methods on read when reindexing services

--- a/bika/lims/profiles/default/types/AnalysisRequest.xml
+++ b/bika/lims/profiles/default/types/AnalysisRequest.xml
@@ -71,7 +71,7 @@
          url_expr="string:${object_url}/published_results"
          i18n:attributes="title"
          visible="True">
-     <permission value="senaite.core: View Results"/>
+     <permission value="View"/>
  </action>
 
  <action title="Invoice"

--- a/bika/lims/upgrade/v01_03_005.py
+++ b/bika/lims/upgrade/v01_03_005.py
@@ -50,6 +50,10 @@ def upgrade(tool):
     # https://github.com/senaite/senaite.core/pull/1617
     remove_duplicate_methods_in_services(portal)
 
+    # Published results tab is not displayed to client contacts
+    # https://github.com/senaite/senaite.core/pull/1629
+    fix_published_results_permission(portal)
+
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
 
@@ -74,3 +78,14 @@ def remove_duplicate_methods_in_services(portal):
         obj.reindexObject()
 
     logger.info("Remove duplicate methods from services [DONE]")
+
+
+def fix_published_results_permission(portal):
+    """Resets the permissions for action 'published_results' from
+    AnalysisRequest portal type to 'View'
+    """
+    ti = portal.portal_types.getTypeInfo("AnalysisRequest")
+    for action in ti.listActions():
+        if action.id == "published_results":
+            action.permissions = ("View", )
+            break


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fixes a permission issue of the "published_results" action from AnalysisRequest portal type

## Current behavior before PR

"Published results" tab from inside Sample view is not displayed to client contacts.

## Desired behavior after PR is merged

"Published results" tab from inside Sample view is displayed to client contacts.
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
