### PR TITLE
Fix Published results tab is not displayed to Client contacts (ported from #1629)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc2 (unreleased)
 ---------------------
 
+- #1638 Fix "Published results" tab is not displayed to Client contacts
 - #1637 Fix "Page not Found" Error for migrated SENAITE Contents with File/Image Fields
 - #1635 Sidebar toggle
 - #1632 Reorganize JS/CSS modules

--- a/src/bika/lims/profiles/default/types/AnalysisRequest.xml
+++ b/src/bika/lims/profiles/default/types/AnalysisRequest.xml
@@ -61,7 +61,7 @@
          url_expr="string:${object_url}/published_results"
          i18n:attributes="title"
          visible="True">
-     <permission value="senaite.core: View Results"/>
+     <permission value="View"/>
  </action>
 
  <action title="Invoice"

--- a/src/senaite/core/upgrade/v02_00_000.py
+++ b/src/senaite/core/upgrade/v02_00_000.py
@@ -73,6 +73,10 @@ def upgrade(tool):
     setup.runImportStepFromProfile(profile, "workflow")
     add_dexterity_setup_items(portal)
 
+    # Published results tab is not displayed to client contacts
+    # https://github.com/senaite/senaite.core/pull/1638
+    fix_published_results_permission(portal)
+
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
 
@@ -125,3 +129,14 @@ def install_senaite_core(portal):
         logger.info("Installing '{}' ...".format(p))
         qi.installProduct(p)
     logger.info("Installing SENAITE CORE 2.x [DONE]")
+
+
+def fix_published_results_permission(portal):
+    """Resets the permissions for action 'published_results' from
+    AnalysisRequest portal type to 'View'
+    """
+    ti = portal.portal_types.getTypeInfo("AnalysisRequest")
+    for action in ti.listActions():
+        if action.id == "published_results":
+            action.permissions = ("View", )
+            break


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Ported from #1629**
Fixes a permission issue of the "published_results" action from AnalysisRequest portal type

## Current behavior before PR

"Published results" tab from inside Sample view is not displayed to client contacts.

## Desired behavior after PR is merged

"Published results" tab from inside Sample view is displayed to client contacts.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
