### PR TITLE
Fix extremely rare AttributeError traceback on Worksheet Template assignment

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Fixed**
 
+- #1639 Fix very rare AttributeError on Worksheet Template assignment
 - #1629 Fix Published results tab is not displayed to Client contacts
 - #1628 Fix instrument import for analyses with result options
 - #1625 Fix assignment of analyses via worksheet template when Worksheet is full

--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -692,11 +692,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         :return: True if the assignment of the passed in instrument is allowed
         :rtype: bool
         """
-        if isinstance(instrument, str):
-            uid = instrument
-        else:
-            uid = instrument.UID()
-
+        uid = api.get_uid(instrument)
         return uid in self.getAllowedInstrumentUIDs()
 
     @security.public
@@ -710,11 +706,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         :return: True if the analysis can follow the method specified
         :rtype: bool
         """
-        if isinstance(method, str):
-            uid = method
-        else:
-            uid = method.UID()
-
+        uid = api.get_uid(method)
         return uid in self.getAllowedMethodUIDs()
 
     @security.public


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

An extremely rare AttributeError traceback on Worksheet Template assignment. However, a good excuse to make the code a bit more solid.

The reason was that the uid was returned as unicode (instead of str). Probably introduced because of https://github.com/senaite/senaite.core/pull/1625

```
  86             try:                                                                                    
  87                 if instrument and not analysis.isInstrumentAllowed(instrument):                     
  88                     # WST's Instrument does not supports this analysis                              
  89                     continue                                                                        
  90             except:                                                                                 
  91                 import pdb;pdb.set_trace()
(Pdb++) instrument
u'35371c1c1afe453980c35e674246a636'
(Pdb++) wst.getRawInstrument()
u'35371c1c1afe453980c35e674246a636'
(Pdb++) wst.getInstrument()
<Instrument at /senaite/bika_setup/bika_instruments/instrument-4>
```

## Current behavior before PR

```
Traceback (innermost last):

    Module ZPublisher.Publish, line 138, in publish
    Module ZPublisher.mapply, line 77, in mapply
    Module ZPublisher.Publish, line 48, in call_object
    Module bika.lims.browser.worksheet.views.add_analyses, line 130, in __call__
    Module bika.lims.browser.worksheet.views.add_analyses, line 164, in handle_submit
    Module bika.lims.content.worksheet, line 1074, in applyWorksheetTemplate
    Module bika.lims.content.worksheet, line 892, in _apply_worksheet_template_routine_analyses
    Module bika.lims.content.abstractanalysis, line 698, in isInstrumentAllowed

AttributeError: 'unicode' object has no attribute 'UID'
```

## Desired behavior after PR is merged

No traceback, analyses are assigned to the Worksheet as expected.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
