### PR TITLE
Doctests for the Worksheet Template assignment with methods/instruments

### DIFF
--- a/bika/lims/tests/doctests/WorksheetApplyTemplate.rst
+++ b/bika/lims/tests/doctests/WorksheetApplyTemplate.rst
@@ -644,3 +644,176 @@ Worksheet remains empty:
 
     >>> worksheet.getAnalyses()
     []
+
+
+Assignment of Worksheet Template with Instrument
+==================================================
+
+When a Worksheet Template has an instrument assigned, only analyses that can be
+performed with that same instrument are added in the worksheet.
+
+Create a new Instrument:
+
+    >>> instr_type = api.create(bikasetup.bika_instrumenttypes, "InstrumentType", title="Temp instrument type")
+    >>> manufacturer = api.create(bikasetup.bika_manufacturers, "Manufacturer", title="Temp manufacturer")
+    >>> supplier = api.create(bikasetup.bika_suppliers, "Supplier", title="Temp supplier")
+    >>> instrument = api.create(bikasetup.bika_instruments,
+    ...                         "Instrument",
+    ...                         title="Temp Instrument",
+    ...                         Manufacturer=manufacturer,
+    ...                         Supplier=supplier,
+    ...                         InstrumentType=instr_type)
+
+Create a Worksheet Template and assign the instrument:
+
+    >>> service_uids = [Cu]
+    >>> layout = [
+    ...     {'pos': '1', 'type': 'a',
+    ...      'blank_ref': '',
+    ...      'control_ref': '',
+    ...      'dup': ''},
+    ...     {'pos': '2', 'type': 'a',
+    ...      'blank_ref': '',
+    ...      'control_ref': '',
+    ...      'dup': ''},
+    ... ]
+    >>> instr_template = api.create(bikasetup.bika_worksheettemplates,
+    ...                             "WorksheetTemplate",
+    ...                             title="WS Template with instrument",
+    ...                             Layout=layout,
+    ...                             Instrument=instrument,
+    ...                             Service=service_uids)
+
+Create and receive 2 samples:
+
+    >>> service_uids = [Cu]
+    >>> samples = map(lambda i: create_analysisrequest(client, request, values, service_uids), range(2))
+    >>> success = map(lambda s: doActionFor(s, "receive"), samples)
+
+Create a Worksheet and assign the template:
+
+    >>> worksheet = api.create(portal.worksheets, "Worksheet")
+    >>> worksheet.applyWorksheetTemplate(instr_template)
+
+Worksheet remains empty because the instrument is not allowed for `Cu` service:
+
+    >>> worksheet.getAnalyses()
+    []
+
+Assign the Instrument to the `Cu` service:
+
+    >>> Cu.setInstrumentEntryOfResults(True)
+    >>> Cu.setInstruments([instrument,])
+
+Re-assign the worksheet template:
+
+    >>> worksheet.applyWorksheetTemplate(instr_template)
+
+Worksheet still remains empty, because the analyses were created before the
+assignment of Instrument to the the `Cu` service:
+
+    >>> worksheet.getAnalyses()
+    []
+
+Create a 2 more samples:
+
+    >>> service_uids = [Cu]
+    >>> samples = map(lambda i: create_analysisrequest(client, request, values, service_uids), range(2))
+    >>> success = map(lambda s: doActionFor(s, "receive"), samples)
+
+Re-assign the worksheet template and the worksheet now contains the two
+analyses from the new samples we've created:
+
+    >>> worksheet.applyWorksheetTemplate(instr_template)
+    >>> ws_analyses = worksheet.getAnalyses()
+    >>> len(ws_analyses)
+    2
+
+    >>> all(map(lambda a: a.getRequest() in samples, ws_analyses))
+    True
+
+Unassign instrument from `Cu` service:
+
+    >>> Cu.setInstrumentEntryOfResults(False)
+    >>> Cu.setInstruments([])
+
+Reject any remaining analyses awaiting for assignment:
+
+    >>> query = {"portal_type": "Analysis", "review_state": "unassigned"}
+    >>> objs = map(api.get_object, api.search(query, "bika_analysis_catalog"))
+    >>> success = map(lambda obj: doActionFor(obj, "reject"), objs)
+
+
+Assignment of Worksheet Template with Method
+============================================
+
+When a Worksheet Template has a method assigned, only analyses that can be
+performed with that same method are added in the worksheet.
+
+Create a new Method:
+
+    >>> method = api.create(portal.methods, "Method", title="Temp method")
+
+Create a Worksheet Template and assign the method:
+
+    >>> service_uids = [Cu]
+    >>> layout = [
+    ...     {'pos': '1', 'type': 'a',
+    ...      'blank_ref': '',
+    ...      'control_ref': '',
+    ...      'dup': ''},
+    ...     {'pos': '2', 'type': 'a',
+    ...      'blank_ref': '',
+    ...      'control_ref': '',
+    ...      'dup': ''},
+    ... ]
+    >>> method_template = api.create(bikasetup.bika_worksheettemplates,
+    ...                              "WorksheetTemplate",
+    ...                              title="WS Template with instrument",
+    ...                              Layout=layout,
+    ...                              RestrictToMethod=method,
+    ...                              Service=service_uids)
+
+Create and receive 2 samples:
+
+    >>> service_uids = [Cu]
+    >>> samples = map(lambda i: create_analysisrequest(client, request, values, service_uids), range(2))
+    >>> success = map(lambda s: doActionFor(s, "receive"), samples)
+
+Create a Worksheet and assign the template:
+
+    >>> worksheet = api.create(portal.worksheets, "Worksheet")
+    >>> worksheet.applyWorksheetTemplate(method_template)
+
+Worksheet remains empty because the method is not allowed for `Cu` service:
+
+    >>> worksheet.getAnalyses()
+    []
+
+Assign the Method to the `Cu` service:
+
+    >>> Cu.setMethods([method, ])
+
+Re-assign the worksheet template:
+
+    >>> worksheet.applyWorksheetTemplate(method_template)
+
+The worksheet now contains the two analyses:
+
+    >>> worksheet.applyWorksheetTemplate(method_template)
+    >>> ws_analyses = worksheet.getAnalyses()
+    >>> len(ws_analyses)
+    2
+
+    >>> all(map(lambda a: a.getRequest() in samples, ws_analyses))
+    True
+
+Unassign method from `Cu` service:
+
+    >>> Cu.setMethods([])
+
+Reject any remaining analyses awaiting for assignment:
+
+    >>> query = {"portal_type": "Analysis", "review_state": "unassigned"}
+    >>> objs = map(api.get_object, api.search(query, "bika_analysis_catalog"))
+    >>> success = map(lambda obj: doActionFor(obj, "reject"), objs)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds two doctests:

- Assignment of Worksheet Template with Instrument
- Assignment of Worksheet Template with Method

## Current behavior before PR

No doctests for the assignment of Worksheet Template with instrument or method

## Desired behavior after PR is merged

More doctests

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
