### PR TITLE
Allow multi-choice in results entry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc2 (unreleased)
 ---------------------
 
+- #1642 Allow multi-choice in results entry
 - #1640 Fix AttributeError on Worksheet Template assignment
 - #1638 Fix "Published results" tab is not displayed to Client contacts
 - #1637 Fix "Page not Found" Error for migrated SENAITE Contents with File/Image Fields

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -768,6 +768,10 @@ class AnalysesView(BikaListingView):
         item["CaptureDate"] = capture_date_str
         item["result_captured"] = capture_date_str
         item["string_result"] = False
+        item["multichoice_result"] = False
+
+        # Get the analysis object
+        obj = self.get_object(analysis_brain)
 
         # Edit mode enabled of this Analysis
         if self.is_analysis_edition_allowed(analysis_brain):
@@ -783,9 +787,14 @@ class AnalysesView(BikaListingView):
             if choices:
                 # N.B.we copy here the list to avoid persistent changes
                 choices = copy(choices)
-                # By default set empty as the default selected choice
-                choices.insert(0, dict(ResultValue="", ResultText=""))
+                if obj.getMultiChoice():
+                    # Render this field as a multi-choice
+                    item["multichoice_result"] = True
+                else:
+                    # By default set empty as the default selected choice
+                    choices.insert(0, dict(ResultValue="", ResultText=""))
                 item["choices"]["Result"] = choices
+
             else:
                 # If not choices, set whether the result must be floatable
                 obj = self.get_object(analysis_brain)
@@ -794,7 +803,6 @@ class AnalysesView(BikaListingView):
         if not result:
             return
 
-        obj = self.get_object(analysis_brain)
         formatted_result = obj.getFormattedResult(
             sciformat=int(self.scinot), decimalmark=self.dmk)
         item["formatted_result"] = formatted_result

--- a/src/bika/lims/browser/worksheet/views/referencesamples.py
+++ b/src/bika/lims/browser/worksheet/views/referencesamples.py
@@ -73,7 +73,7 @@ class ReferenceSamplesView(BikaListingView):
                 "sortable": False}),
             ("SupportedServices", {
                 "title": _("Supported Services"),
-                "type": "multiselect",
+                "type": "multichoice",
                 "sortable": False}),
             ("Position", {
                 "title": _("Position"),

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -879,11 +879,29 @@ class AbstractAnalysis(AbstractBaseAnalysis):
 
         choices = self.getResultOptions()
 
-        # 2. Print ResultText of matching ResulOptions
-        match = [x['ResultText'] for x in choices
-                 if str(x['ResultValue']) == str(result)]
-        if match:
-            return match[0]
+        # 2. Print ResultText of matching ResultOptions
+        if choices and not self.getMultiChoice():
+            # Result contains a single result option
+            match = [x['ResultText'] for x in choices
+                     if str(x['ResultValue']) == str(result)]
+            if match:
+                return match[0]
+
+        elif choices:
+            # Result is a string with multiple options e.g. "['2', '1']"
+            raw_result = []
+            try:
+                raw_result = eval(result)
+            except:
+                # Nothing to catch here
+                pass
+
+            values_texts = dict(map(
+                lambda c: (c["ResultValue"], c["ResultText"]), choices
+            ))
+            texts = map(lambda r: values_texts.get(r), raw_result)
+            texts = filter(None, texts)
+            return "<br/>".join(texts)
 
         # 3. If the result is not floatable, return it without being formatted
         try:

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -600,6 +600,21 @@ ResultOptions = RecordsField(
     )
 )
 
+# Allow/disallow the capture of multiple choices for this analysis
+MultiChoice = BooleanField(
+    "MultiChoice",
+    schemata="Result Options",
+    default=False,
+    widget=BooleanWidget(
+        label=_("Multiple choice"),
+        description=_(
+            "Enable this option to allow the capture of multiple result "
+            "options for this analysis. A multi-choices component will be "
+            "displayed in results entry"
+        )
+    )
+)
+
 # Allow/disallow the capture of text as the result of the analysis
 StringResult = BooleanField(
     "StringResult",
@@ -732,6 +747,7 @@ schema = BikaSchema.copy() + Schema((
     PrecisionFromUncertainty,
     AllowManualUncertainty,
     ResultOptions,
+    MultiChoice,
     Hidden,
     SelfVerification,
     NumberOfRequiredVerifications,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Requires https://github.com/senaite/senaite.app.listing/pull/32**

This Pull Request allows to configure Services so a multiple-choice selection is displayed in results entry.

## Current behavior before PR

No multi-choice result entry available

## Desired behavior after PR is merged

Multi-choice result entry available

![Captura de 2020-10-07 19-16-24](https://user-images.githubusercontent.com/832627/95365273-34fbbe80-08d2-11eb-863e-f369e139488e.png)

![Captura de 2020-10-07 19-19-21](https://user-images.githubusercontent.com/832627/95365324-45ac3480-08d2-11eb-8cc4-83068ee7ac17.png)

![Captura de 2020-10-07 19-20-09](https://user-images.githubusercontent.com/832627/95365330-48a72500-08d2-11eb-9260-62da7c273283.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
