### PR TITLE
Setup View Filter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc2 (unreleased)
 ---------------------
 
+- #1643 Setup View Filter
 - #1642 Allow multi-choice in results entry
 - #1640 Fix AttributeError on Worksheet Template assignment
 - #1638 Fix "Published results" tab is not displayed to Client contacts

--- a/src/senaite/core/browser/controlpanel/templates/setupview.pt
+++ b/src/senaite/core/browser/controlpanel/templates/setupview.pt
@@ -12,13 +12,29 @@
                     tal:define="disable_column_one python:request.set('disable_plone.leftcolumn', 1);
                                 disable_column_two python:request.set('disable_plone.rightcolumn', 1);"/>
 
+    <metal:block fill-slot="senaite_legacy_js"
+                 tal:define="portal context/@@plone_portal_state/portal;">
+      <script type="text/javascript"
+              src="senaite.core.setupview.js"
+              tal:attributes="src string:${portal/absolute_url}/++plone++senaite.core.static/js/senaite.core.setupview.js"></script>
+    </metal:block>
+
     <div metal:fill-slot="prefs_configlet_main" id="lims-controlpanel">
 
       <div id="setupview" class="row">
 
+        <div class="col-sm-12 mb-4">
+          <input id="searchbox"
+                 autofocus
+                 type="text"
+                 class="form-control form-control-lg"
+                 placeholder="Type to filter ..."
+                 i18n:attributes="placeholder">
+        </div>
+
         <!-- The setup item -->
         <tal:setup tal:define="setup python:view.setup">
-          <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
+          <div class="tilewrapper col-xs-12 col-sm-6 col-md-4 col-lg-3">
             <a class="tile setup text-capitalized text-decoration-none"
                tal:attributes="href setup/absolute_url;
                                title setup/Title"
@@ -26,11 +42,11 @@
               <div class="item text-truncate">
                 <img src="#"
                      tal:replace="structure python:view.get_icon_for(setup, css_class='icon')"/>
-                <div class="title vcenter text-truncate d-inline-block"
+                <span class="title vcenter text-truncate d-inline-block"
                      i18n:translate=""
                      tal:content="setup/Title">
                   Setup Item Title
-                </div>
+                </span>
               </div>
             </a>
           </div>
@@ -38,7 +54,7 @@
 
         <!-- The other setup items -->
         <tal:tiles tal:repeat="brain view/setupitems">
-          <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
+          <div class="tilewrapper col-xs-12 col-sm-6 col-md-4 col-lg-3">
             <a class="tile text-capitalized text-decoration-none"
                tal:attributes="href brain/getURL;
                                title brain/Title"

--- a/src/senaite/core/browser/static/js/coffee/senaite.core.setupview.coffee
+++ b/src/senaite/core/browser/static/js/coffee/senaite.core.setupview.coffee
@@ -1,0 +1,81 @@
+### Please use this command to compile this file into the parent directory:
+    coffee --no-header -w -o ../ -c senaite.core.setupview.coffee
+###
+
+# DOCUMENT READY ENTRY POINT
+document.addEventListener "DOMContentLoaded", ->
+  console.debug "*** DOMContentLoaded: --> Loading Controller"
+  window.setupview_controller = new SetupViewController()
+
+class SetupViewController
+
+  constructor: ->
+
+    @on_search = @on_search.bind this
+    @on_keypress = @on_keypress.bind this
+
+    searchbox = document.getElementById "searchbox"
+    searchbox.addEventListener "input", @on_search
+    searchbox.addEventListener "keypress", @on_keypress
+
+    @first = null
+    @items = @get_items()
+
+  hide_tile: (tile) ->
+      tile.classList.add "d-none"
+
+  show_tile: (tile) ->
+      tile.classList.remove "d-none"
+
+  get_tiles: ->
+    return document.querySelectorAll("div.tilewrapper")
+
+  get_items: ->
+    nodes = document.querySelectorAll("div.tilewrapper span.title")
+    items = []
+    nodes.forEach (el) ->
+      title = el.innerText.toLowerCase()
+      items.push {title: title, el: el}
+    return items
+
+  show_all: ->
+    tiles = @get_tiles()
+    tiles.forEach (tile) =>
+      @show_tile tile
+
+  filter_items: (value) ->
+    console.log "SetupViewController::filter_items:value=", value
+    @first = null
+    if not value
+      return @show_all()
+    @items.forEach (item) =>
+      el = item.el
+      tile = el.closest "div.tilewrapper"
+      title = item.title
+      rx = RegExp(value, "gi");
+
+      if title.match rx
+        @show_tile tile
+        # remember the first matching tile
+        if @first is null
+          @first = tile
+      else
+        @hide_tile tile
+
+  navigate: (tile) ->
+    if @first is null
+      return
+    url = @first.querySelector("a").getAttribute("href")
+    return unless url
+    location.href = url
+
+  on_search: (event) ->
+    target = event.currentTarget
+    value = target.value.toLowerCase()
+    @filter_items value
+
+  on_keypress: (event) ->
+    code = event.keyCode
+    return unless code is 13
+    @navigate()
+

--- a/src/senaite/core/browser/static/js/coffee/senaite.core.setupview.coffee
+++ b/src/senaite/core/browser/static/js/coffee/senaite.core.setupview.coffee
@@ -78,4 +78,3 @@ class SetupViewController
     code = event.keyCode
     return unless code is 13
     @navigate()
-

--- a/src/senaite/core/browser/static/js/coffee/senaite.core.setupview.coffee
+++ b/src/senaite/core/browser/static/js/coffee/senaite.core.setupview.coffee
@@ -44,7 +44,7 @@ class SetupViewController
       @show_tile tile
 
   filter_items: (value) ->
-    console.log "SetupViewController::filter_items:value=", value
+    # console.debug "SetupViewController::filter_items:value=", value
     @first = null
     if not value
       return @show_all()

--- a/src/senaite/core/browser/static/js/senaite.core.setupview.js
+++ b/src/senaite/core/browser/static/js/senaite.core.setupview.js
@@ -1,0 +1,120 @@
+
+/* Please use this command to compile this file into the parent directory:
+    coffee --no-header -w -o ../ -c senaite.core.setupview.coffee
+ */
+
+(function() {
+  var SetupViewController;
+
+  document.addEventListener("DOMContentLoaded", function() {
+    console.debug("*** DOMContentLoaded: --> Loading Controller");
+    return window.setupview_controller = new SetupViewController();
+  });
+
+  SetupViewController = (function() {
+    function SetupViewController() {
+      var searchbox;
+      this.on_search = this.on_search.bind(this);
+      this.on_keypress = this.on_keypress.bind(this);
+      searchbox = document.getElementById("searchbox");
+      searchbox.addEventListener("input", this.on_search);
+      searchbox.addEventListener("keypress", this.on_keypress);
+      this.first = null;
+      this.items = this.get_items();
+    }
+
+    SetupViewController.prototype.hide_tile = function(tile) {
+      return tile.classList.add("d-none");
+    };
+
+    SetupViewController.prototype.show_tile = function(tile) {
+      return tile.classList.remove("d-none");
+    };
+
+    SetupViewController.prototype.get_tiles = function() {
+      return document.querySelectorAll("div.tilewrapper");
+    };
+
+    SetupViewController.prototype.get_items = function() {
+      var items, nodes;
+      nodes = document.querySelectorAll("div.tilewrapper span.title");
+      items = [];
+      nodes.forEach(function(el) {
+        var title;
+        title = el.innerText.toLowerCase();
+        return items.push({
+          title: title,
+          el: el
+        });
+      });
+      return items;
+    };
+
+    SetupViewController.prototype.show_all = function() {
+      var tiles;
+      tiles = this.get_tiles();
+      return tiles.forEach((function(_this) {
+        return function(tile) {
+          return _this.show_tile(tile);
+        };
+      })(this));
+    };
+
+    SetupViewController.prototype.filter_items = function(value) {
+      console.log("SetupViewController::filter_items:value=", value);
+      this.first = null;
+      if (!value) {
+        return this.show_all();
+      }
+      return this.items.forEach((function(_this) {
+        return function(item) {
+          var el, rx, tile, title;
+          el = item.el;
+          tile = el.closest("div.tilewrapper");
+          title = item.title;
+          rx = RegExp(value, "gi");
+          if (title.match(rx)) {
+            _this.show_tile(tile);
+            if (_this.first === null) {
+              return _this.first = tile;
+            }
+          } else {
+            return _this.hide_tile(tile);
+          }
+        };
+      })(this));
+    };
+
+    SetupViewController.prototype.navigate = function(tile) {
+      var url;
+      if (this.first === null) {
+        return;
+      }
+      url = this.first.querySelector("a").getAttribute("href");
+      if (!url) {
+        return;
+      }
+      return location.href = url;
+    };
+
+    SetupViewController.prototype.on_search = function(event) {
+      var target, value;
+      target = event.currentTarget;
+      value = target.value.toLowerCase();
+      return this.filter_items(value);
+    };
+
+    SetupViewController.prototype.on_keypress = function(event) {
+      var code;
+      code = event.keyCode;
+      if (code !== 13) {
+        return;
+      }
+      return this.navigate();
+    };
+
+    return SetupViewController;
+
+  })();
+
+}).call(this);

--- a/src/senaite/core/browser/static/js/senaite.core.setupview.js
+++ b/src/senaite/core/browser/static/js/senaite.core.setupview.js
@@ -61,7 +61,6 @@
     };
 
     SetupViewController.prototype.filter_items = function(value) {
-      console.log("SetupViewController::filter_items:value=", value);
       this.first = null;
       if (!value) {
         return this.show_all();


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR was created because I am always searching in the Setup View for the right section I want to navigate.

<img width="954" alt="SENAITE LIMS 2020-10-07 23-07-46" src="https://user-images.githubusercontent.com/713193/95388094-f544cf00-08f1-11eb-9f11-20f2f3d05412.png">

## Current behavior before PR

No filter option in setupview

## Desired behavior after PR is merged

User can filter the items in setup view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
