### PR TITLE
Allow translation of path bar items 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc2 (unreleased)
 ---------------------
 
+- #1645 Allow translation of path bar items
 - #1643 Setup View Filter
 - #1642 Allow multi-choice in results entry
 - #1640 Fix AttributeError on Worksheet Template assignment

--- a/src/senaite/core/browser/viewlets/path_bar.py
+++ b/src/senaite/core/browser/viewlets/path_bar.py
@@ -56,7 +56,7 @@ class PathBarViewlet(Base):
     def to_breadcrumb(self, obj):
         """Converts the object to a breadcrumb for the template consumption
         """
-        return {"Title": self.get_obj_title(obj),
+        return {"Title": _(self.get_obj_title(obj)),
                 "absolute_url": self.get_obj_url(obj)}
 
     def get_obj_title(self, obj):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The path bar (breadcrumbs menu) shows the current path from the portal root by concatenating the object titles.
Some object titles, e.g. Clients, Batches etc., are translated. While these items show up correctly in the navigation, they do now show up translated in the path bar.

## Current behavior before PR

Path bar items not translated

<img width="849" alt="Samples — LIMS 2020-10-08 14-34-45" src="https://user-images.githubusercontent.com/713193/95459122-7b552a00-0973-11eb-8c0f-242f1ae9dbe0.png">


## Desired behavior after PR is merged

Path bar items translated

<img width="849" alt="Samples — LIMS 2020-10-08 14-35-55" src="https://user-images.githubusercontent.com/713193/95459212-9d4eac80-0973-11eb-8c58-dd80d1ecd401.png">



--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
