### PR TITLE
Multi-select component for results entry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc2 (unreleased)
 ---------------------
 
+- #1646 Allow multi-select in results entry
 - #1643 Setup View Filter
 - #1642 Allow multi-choice in results entry
 - #1640 Fix AttributeError on Worksheet Template assignment

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -767,8 +767,6 @@ class AnalysesView(BikaListingView):
         item["Result"] = result
         item["CaptureDate"] = capture_date_str
         item["result_captured"] = capture_date_str
-        item["string_result"] = False
-        item["multichoice_result"] = False
 
         # Get the analysis object
         obj = self.get_object(analysis_brain)
@@ -783,22 +781,22 @@ class AnalysesView(BikaListingView):
                 item["allow_edit"].append("Result")
 
             # Prepare result options
-            choices = analysis_brain.getResultOptions
+            choices = obj.getResultOptions()
             if choices:
                 # N.B.we copy here the list to avoid persistent changes
                 choices = copy(choices)
-                if obj.getMultiChoice():
-                    # Render this field as a multi-choice
-                    item["multichoice_result"] = True
-                else:
+                choices_type = obj.getResultOptionsType()
+                if choices_type == "select":
                     # By default set empty as the default selected choice
                     choices.insert(0, dict(ResultValue="", ResultText=""))
                 item["choices"]["Result"] = choices
+                item["result_type"] = choices_type
+
+            elif obj.getStringResult():
+                item["result_type"] = "string"
 
             else:
-                # If not choices, set whether the result must be floatable
-                obj = self.get_object(analysis_brain)
-                item["string_result"] = obj.getStringResult()
+                item["result_type"] = "numeric"
 
         if not result:
             return

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -877,31 +877,27 @@ class AbstractAnalysis(AbstractBaseAnalysis):
                     "but not floatable: %s" % (self.id, result))
                 return formatDecimalMark(result, decimalmark=decimalmark)
 
-        choices = self.getResultOptions()
-
         # 2. Print ResultText of matching ResultOptions
-        if choices and not self.getMultiChoice():
-            # Result contains a single result option
-            match = [x['ResultText'] for x in choices
-                     if str(x['ResultValue']) == str(result)]
+        choices = self.getResultOptions()
+        if choices:
+            # Create a dict for easy mapping of result options
+            values_texts = dict(map(
+                lambda c: (str(c["ResultValue"]), c["ResultText"]), choices
+            ))
+
+            # Result might contain a single result option
+            match = values_texts.get(str(result))
             if match:
                 return match[0]
 
-        elif choices:
-            # Result is a string with multiple options e.g. "['2', '1']"
-            raw_result = []
+            # Result might be a string with multiple options e.g. "['2', '1']"
             try:
                 raw_result = eval(result)
+                texts = map(lambda r: values_texts.get(str(r)), raw_result)
+                texts = filter(None, texts)
+                return "<br/>".join(texts)
             except:
-                # Nothing to catch here
                 pass
-
-            values_texts = dict(map(
-                lambda c: (c["ResultValue"], c["ResultText"]), choices
-            ))
-            texts = map(lambda r: values_texts.get(r), raw_result)
-            texts = filter(None, texts)
-            return "<br/>".join(texts)
 
         # 3. If the result is not floatable, return it without being formatted
         try:

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -888,7 +888,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             # Result might contain a single result option
             match = values_texts.get(str(result))
             if match:
-                return match[0]
+                return match
 
             # Result might be a string with multiple options e.g. "['2', '1']"
             try:

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -603,6 +603,7 @@ ResultOptions = RecordsField(
 RESULT_OPTIONS_TYPES = (
     ("select", _("Selection list")),
     ("multiselect", _("Multiple selection")),
+    ("multiselect_duplicates", _("Multiple selection (with duplicates)")),
     ("multichoice", _("Multiple choices")),
 )
 

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -600,18 +600,24 @@ ResultOptions = RecordsField(
     )
 )
 
-# Allow/disallow the capture of multiple choices for this analysis
-MultiChoice = BooleanField(
-    "MultiChoice",
+RESULT_OPTIONS_TYPES = (
+    ("select", _("Selection list")),
+    ("multiselect", _("Multiple selection")),
+    ("multichoice", _("Multiple choices")),
+)
+
+ResultOptionsType = StringField(
+    "ResultOptionsType",
     schemata="Result Options",
-    default=False,
-    widget=BooleanWidget(
-        label=_("Multiple choice"),
+    default="select",
+    vocabulary=DisplayList(RESULT_OPTIONS_TYPES),
+    widget=SelectionWidget(
+        label=_("Result options type"),
         description=_(
-            "Enable this option to allow the capture of multiple result "
-            "options for this analysis. A multi-choices component will be "
-            "displayed in results entry"
-        )
+            "Type of control to be displayed on result entry when result "
+            "options are set"
+        ),
+        format="select",
     )
 )
 
@@ -747,7 +753,7 @@ schema = BikaSchema.copy() + Schema((
     PrecisionFromUncertainty,
     AllowManualUncertainty,
     ResultOptions,
-    MultiChoice,
+    ResultOptionsType,
     Hidden,
     SelfVerification,
     NumberOfRequiredVerifications,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Requires https://github.com/senaite/senaite.app.listing/pull/33**

This Pull Request allows to configure Services so a multiple-select is displayed in results entry.

## Current behavior before PR

No multi-select for results entry available

## Desired behavior after PR is merged

Multi-select for results entry available

![Captura de 2020-10-08 15-17-03](https://user-images.githubusercontent.com/832627/95464802-ac852880-097a-11eb-80e1-db678185798f.png)

![Captura de 2020-10-08 15-16-13](https://user-images.githubusercontent.com/832627/95464834-b3ac3680-097a-11eb-8f4a-9858b366c2b6.png)

![Captura de 2020-10-08 15-16-27](https://user-images.githubusercontent.com/832627/95464849-b9a21780-097a-11eb-86a9-9eef1dbb19d4.png)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
