### PR TITLE
Fix Unicode Decode Error in Path Bar

### DIFF
--- a/src/senaite/core/browser/viewlets/path_bar.py
+++ b/src/senaite/core/browser/viewlets/path_bar.py
@@ -56,7 +56,8 @@ class PathBarViewlet(Base):
     def to_breadcrumb(self, obj):
         """Converts the object to a breadcrumb for the template consumption
         """
-        return {"Title": _(self.get_obj_title(obj)),
+        title = self.get_obj_title(obj)
+        return {"Title": _(api.safe_unicode(title)),
                 "absolute_url": self.get_obj_url(obj)}
 
     def get_obj_title(self, obj):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a side effect of https://github.com/senaite/senaite.core/pull/1645

## Current behavior before PR

Traceback happens when an object contains non-ascii characters

```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module Shared.DC.Scripts.Bindings, line 335, in __call__
  Module Shared.DC.Scripts.Bindings, line 372, in _bindAndExec
  Module Products.CMFCore.FSPageTemplate, line 256, in _exec
  Module Products.CMFCore.FSPageTemplate, line 197, in pt_render
  Module Products.PageTemplates.PageTemplate, line 85, in pt_render
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 367, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 307, in render
  Module chameleon.template, line 214, in render
  Module chameleon.template, line 192, in render
  Module 0b05d64486c0356cbb88ae305efa6448, line 953, in render
  Module 013bcea97944339cb3e4f65886ebf5fd, line 1397, in render_master
  Module zope.contentprovider.tales, line 76, in __call__
  Module zope.viewlet.manager, line 155, in update
  Module zope.viewlet.manager, line 161, in _updateViewlets
  Module senaite.core.browser.viewlets.path_bar, line 37, in update
  Module senaite.core.browser.viewlets.path_bar, line 54, in get_breadcrumbs
  Module senaite.core.browser.viewlets.path_bar, line 59, in to_breadcrumb
  Module zope.i18nmessageid.message, line 112, in __call__
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 22: ordinal not in range(128)
```

## Desired behavior after PR is merged

Path bar is rendered correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
