### PR TITLE
Improved result handling of multi select/choices fields

### DIFF
--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -19,19 +19,11 @@
 # Some rights reserved, see README and LICENSE.
 
 import cgi
+import json
 import math
 from decimal import Decimal
 
 from AccessControl import ClassSecurityInfo
-from DateTime import DateTime
-from Products.Archetypes.Field import DateTimeField
-from Products.Archetypes.Field import FixedPointField
-from Products.Archetypes.Field import IntegerField
-from Products.Archetypes.Field import StringField
-from Products.Archetypes.Schema import Schema
-from Products.Archetypes.references import HoldingReference
-from Products.CMFCore.permissions import View
-from Products.CMFCore.utils import getToolByName
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import deprecated
@@ -39,8 +31,8 @@ from bika.lims import logger
 from bika.lims import workflow as wf
 from bika.lims.browser.fields import HistoryAwareReferenceField
 from bika.lims.browser.fields import InterimFieldsField
-from bika.lims.browser.fields import UIDReferenceField
 from bika.lims.browser.fields import ResultRangeField
+from bika.lims.browser.fields import UIDReferenceField
 from bika.lims.browser.fields.uidreferencefield import get_backreferences
 from bika.lims.browser.widgets import RecordsWidget
 from bika.lims.config import LDL
@@ -55,6 +47,14 @@ from bika.lims.utils.analysis import format_numeric_result
 from bika.lims.utils.analysis import get_significant_digits
 from bika.lims.workflow import getTransitionActor
 from bika.lims.workflow import getTransitionDate
+from DateTime import DateTime
+from Products.Archetypes.Field import DateTimeField
+from Products.Archetypes.Field import FixedPointField
+from Products.Archetypes.Field import IntegerField
+from Products.Archetypes.Field import StringField
+from Products.Archetypes.references import HoldingReference
+from Products.Archetypes.Schema import Schema
+from Products.CMFCore.permissions import View
 
 # A link directly to the AnalysisService object used to create the analysis
 AnalysisService = UIDReferenceField(

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -455,6 +455,10 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         # Always update ResultCapture date when this field is modified
         self.setResultCaptureDate(DateTime())
 
+        # Handle list results
+        if isinstance(value, (list, tuple)):
+            value = json.dumps(value)
+
         # Ensure result integrity regards to None, empty and 0 values
         val = str("" if not value and value != 0 else value).strip()
 
@@ -892,11 +896,11 @@ class AbstractAnalysis(AbstractBaseAnalysis):
 
             # Result might be a string with multiple options e.g. "['2', '1']"
             try:
-                raw_result = eval(result)
+                raw_result = json.loads(result)
                 texts = map(lambda r: values_texts.get(str(r)), raw_result)
                 texts = filter(None, texts)
                 return "<br/>".join(texts)
-            except:
+            except (ValueError, TypeError):
                 pass
 
         # 3. If the result is not floatable, return it without being formatted


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR improves the result handling of multi select/choices fields which was introduced in https://github.com/senaite/senaite.core/pull/1642


## Current behavior before PR

List result was parsed via `eval`

## Desired behavior after PR is merged

List result is parsed via `json.dumps` and `json.loads`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
