### PR TITLE
Fix Error when invalidating a sample with contained retests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc2 (unreleased)
 ---------------------
 
+- #1650 Fix Error when invalidating a sample with contained retests
 - #1646 Allow multi-select in results entry
 - #1645 Allow translation of path bar items
 - #1643 Setup View Filter

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -300,6 +300,9 @@ def create_retest(ar):
     # Copy the analyses from the source
     intermediate_states = ['retracted', 'reflexed']
     for an in ar.getAnalyses(full_objects=True):
+        # skip retests
+        if an.isRetest():
+            continue
         if (api.get_workflow_status_of(an) in intermediate_states):
             # Exclude intermediate analyses
             continue


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an error when a sample with contained retests is invalidated

## Traceback

```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module bika.lims.browser.workflow, line 143, in __call__
  Module bika.lims.browser.workflow.analysisrequest, line 156, in __call__
  Module bika.lims.browser.workflow, line 173, in do_action
  Module bika.lims.workflow, line 128, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 252, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 537, in _invokeWithNotification
AttributeError: 'BadRequest' object has no attribute ‚with_traceback'
```

## Current behavior before PR

Error occurs after invalidating a sample with retests


## Desired behavior after PR is merged

Retests are skipped after invalidating a sample -> no error occurs

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
