### PR TITLE
Fix error when invalidating a sample with contained retests (ported from #1650)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Fixed**
 
+- #1651 Fix Error when invalidating a sample with contained retests
 - #1633 Fix report section displays date pickers in Chinese
 - #1639 Fix very rare AttributeError on Worksheet Template assignment
 - #1629 Fix Published results tab is not displayed to Client contacts

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -300,6 +300,9 @@ def create_retest(ar):
     # Copy the analyses from the source
     intermediate_states = ['retracted', 'reflexed']
     for an in ar.getAnalyses(full_objects=True):
+        # skip retests
+        if an.isRetest():
+            continue
         if (api.get_workflow_status_of(an) in intermediate_states):
             # Exclude intermediate analyses
             continue


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Ported from #1650 
This PR fixes an error when a sample with contained retests is invalidated

## Traceback

```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module bika.lims.browser.workflow, line 143, in __call__
  Module bika.lims.browser.workflow.analysisrequest, line 156, in __call__
  Module bika.lims.browser.workflow, line 173, in do_action
  Module bika.lims.workflow, line 128, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 252, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 537, in _invokeWithNotification
AttributeError: 'BadRequest' object has no attribute ‚with_traceback'
```

## Current behavior before PR

Error occurs after invalidating a sample with retests


## Desired behavior after PR is merged

Retests are skipped after invalidating a sample -> no error occurs

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
