### PR TITLE
Maximum length of Choices subfield (interim) is set to 40

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc2 (unreleased)
 ---------------------
 
+- #1653 Fix Maximum length for Choices field from Interim fields is set to 40
 - #1650 Fix Error when invalidating a sample with contained retests
 - #1646 Allow multi-select in results entry
 - #1645 Allow translation of path bar items

--- a/src/bika/lims/browser/fields/interimfieldsfield.py
+++ b/src/bika/lims/browser/fields/interimfieldsfield.py
@@ -58,8 +58,11 @@ class InterimFieldsField(RecordsField):
             "keyword": 20,
             "title": 20,
             "value": 10,
-            "choices": 30,
+            "choices": 50,
             "unit": 10,
+        },
+        "subfield_maxlength": {
+            "choices": -1,
         },
         "subfield_validators": {
             "keyword": "interimfieldsvalidator",

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/recordswidget.pt
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/recordswidget.pt
@@ -100,7 +100,7 @@
                                 id string:${fieldName}-${key}-${repeat/idx/index};
                                 value python:field.getSubfieldValue(values, idx, key);
                                 size python:field.getSubfieldSize(key);
-                                maxlength maxlength|Nothing;
+                                maxlength maxlength|nothing;
                                 readonly python:hasattr(field, 'subfield_readonly') and field.subfield_readonly.get(key, False) or False;
                                 tabindex tabindex/next|nothing;
                                 combogrid_options python: widget.jsondumps(combogrid_options.get(key, ''))"/>
@@ -188,7 +188,7 @@
                                 id string:${fieldName}-${key}-${repeat/idx/index};
                                 value python:field.getSubfieldValue(values, idx, key);
                                 size python:field.getSubfieldSize(key);
-                                maxlength maxlength|Nothing;
+                                maxlength maxlength|nothing;
                                 readonly python:hasattr(field, 'subfield_readonly') and field.subfield_readonly.get(key, False) or False;
                                 tabindex tabindex/next|nothing;"/>
                       </tal:string>
@@ -207,7 +207,7 @@
                                 id string:${fieldName}-${key}-${repeat/idx/index};
                                 value python:field.getSubfieldValue(values, idx, key);
                                 size python:field.getSubfieldSize(key);
-                                maxlength maxlength|Nothing;
+                                maxlength maxlength|nothing;
                                 readonly python:hasattr(field, 'subfield_readonly') and field.subfield_readonly.get(key, False) or False;
                                 tabindex tabindex/next|nothing;"/>
                       </tal:string>
@@ -222,7 +222,7 @@
                                  id string:${fieldName}-${key}-${repeat/idx/index};
                                  value python:field.getSubfieldValue(values, idx, key);
                                  size python:field.getSubfieldSize(key);
-                                 maxlength maxlength|Nothing;
+                                 maxlength maxlength|nothing;
                                  tabindex tabindex/next|nothing;"/>
                       </tal:number>
 
@@ -236,7 +236,7 @@
                                  id string:${fieldName}-${key}-${repeat/idx/index};
                                  value python:field.getSubfieldValue(values, idx, key);
                                  size python:field.getSubfieldSize(key);
-                                 maxlength maxlength|Nothing;
+                                 maxlength maxlength|nothing;
                                  tabindex tabindex/next|nothing;"/>
                       </tal:number>
 

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/recordswidget.pt
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/recordswidget.pt
@@ -82,7 +82,9 @@
                                      or field.subfield_hidden.get(key, False) == False)">
                     <tal:block
                       define="type python:field.getSubfieldType(key);
-                              required python:key in field.required_subfields and ' required' or '';">
+                              required python:key in field.required_subfields and ' required' or '';
+                              maxlength python:field.getSubfieldMaxlength(key);
+                              maxlength python:maxlength&gt;0 and maxlength or None;">
 
                       <!-- string -->
 
@@ -98,7 +100,7 @@
                                 id string:${fieldName}-${key}-${repeat/idx/index};
                                 value python:field.getSubfieldValue(values, idx, key);
                                 size python:field.getSubfieldSize(key);
-                                maxlength python:field.getSubfieldMaxlength(key);
+                                maxlength maxlength|Nothing;
                                 readonly python:hasattr(field, 'subfield_readonly') and field.subfield_readonly.get(key, False) or False;
                                 tabindex tabindex/next|nothing;
                                 combogrid_options python: widget.jsondumps(combogrid_options.get(key, ''))"/>
@@ -186,7 +188,7 @@
                                 id string:${fieldName}-${key}-${repeat/idx/index};
                                 value python:field.getSubfieldValue(values, idx, key);
                                 size python:field.getSubfieldSize(key);
-                                maxlength python:field.getSubfieldMaxlength(key);
+                                maxlength maxlength|Nothing;
                                 readonly python:hasattr(field, 'subfield_readonly') and field.subfield_readonly.get(key, False) or False;
                                 tabindex tabindex/next|nothing;"/>
                       </tal:string>
@@ -205,7 +207,7 @@
                                 id string:${fieldName}-${key}-${repeat/idx/index};
                                 value python:field.getSubfieldValue(values, idx, key);
                                 size python:field.getSubfieldSize(key);
-                                maxlength python:field.getSubfieldMaxlength(key);
+                                maxlength maxlength|Nothing;
                                 readonly python:hasattr(field, 'subfield_readonly') and field.subfield_readonly.get(key, False) or False;
                                 tabindex tabindex/next|nothing;"/>
                       </tal:string>
@@ -220,7 +222,7 @@
                                  id string:${fieldName}-${key}-${repeat/idx/index};
                                  value python:field.getSubfieldValue(values, idx, key);
                                  size python:field.getSubfieldSize(key);
-                                 maxlength python:field.getSubfieldMaxlength(key);
+                                 maxlength maxlength|Nothing;
                                  tabindex tabindex/next|nothing;"/>
                       </tal:number>
 
@@ -234,7 +236,7 @@
                                  id string:${fieldName}-${key}-${repeat/idx/index};
                                  value python:field.getSubfieldValue(values, idx, key);
                                  size python:field.getSubfieldSize(key);
-                                 maxlength python:field.getSubfieldMaxlength(key);
+                                 maxlength maxlength|Nothing;
                                  tabindex tabindex/next|nothing;"/>
                       </tal:number>
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The maximum length of subfield "Choices" from Interim fields is set to 40. Thus, is not possible to add a list of choices the whole length of the string is greater than 40. However, the system forces to establish a `maxlength`, because its value is always rendered in the template.

This Pull Request modifies the Records Widget, so when the subfield's `maxlength` value is lower than 1, the system does not renders such attribute. In such case, there is no length limit on the input text.

## Current behavior before PR

User cannot add choices in interim fields with a length above 40 characters

## Desired behavior after PR is merged

User can add choices in interim fields with no limit of characters length

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
