### PR TITLE
Fix Text of interim choices is not displayed correctly on readonly mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc2 (unreleased)
 ---------------------
 
+- #1654 Fix Text of interim choices is not displayed correctly on readonly mode
 - #1650 Fix Error when invalidating a sample with contained retests
 - #1646 Allow multi-select in results entry
 - #1645 Allow translation of path bar items

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -862,9 +862,14 @@ class AnalysesView(BikaListingView):
                 d_list = map(lambda it: dict(zip(headers, it)), choices.items())
                 item.setdefault("choices", {})[interim_keyword] = d_list
 
-                # Display the text instead of the value
-                val = choices.get(interim_value, "")
-                interim_field["value"] = val
+                # Set the text as the formatted value
+                text = choices.get(interim_value, "")
+                interim_field["formatted_value"] = text
+
+                if not is_editable:
+                    # Display the text instead of the value
+                    interim_field["value"] = text
+
                 item[interim_keyword] = interim_field
 
         item['interimfields'] = interim_fields


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When an interim field of type "choices" is used, the result is not displayed properly in read-only mode, when user cannot edit the analysis result.

## Current behavior before PR

Interim's choice result is not displayed properly on read-only mode

## Desired behavior after PR is merged

Interim's choice result is displayed properly on read-only mode

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
