### PR TITLE
Move Service's Additional Values to Result Options schemata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 2.0.0rc2 (unreleased)
 ---------------------
 
+- #1655 Rename service's "Result Options" and "Additional Values"
+- #1655 Move service's "Additional values" to "Result Options" tab
 - #1650 Fix Error when invalidating a sample with contained retests
 - #1646 Allow multi-select in results entry
 - #1645 Allow translation of path bar items

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -591,12 +591,11 @@ ResultOptions = RecordsField(
     subfield_maxlength={'ResultValue': 5,
                         'ResultText': 255,},
     widget=RecordsWidget(
-        label=_("Result Options"),
+        label=_("Predefined results"),
         description=_(
-            "Please list all options for the analysis result if you want to "
-            "restrict it to specific options only, e.g. 'Positive', "
-            "'Negative' and 'Indeterminable'.  The option's result value must "
-            "be a number"),
+            "List of possible final results. When set, no custom result is "
+            "allowed on results entry and user has to choose from these values"
+        ),
     )
 )
 
@@ -613,10 +612,10 @@ ResultOptionsType = StringField(
     default="select",
     vocabulary=DisplayList(RESULT_OPTIONS_TYPES),
     widget=SelectionWidget(
-        label=_("Result options type"),
+        label=_("Control type"),
         description=_(
-            "Type of control to be displayed on result entry when result "
-            "options are set"
+            "Type of control to be displayed on result entry when predefined "
+            "results are set"
         ),
         format="select",
     )

--- a/src/bika/lims/content/analysisservice.py
+++ b/src/bika/lims/content/analysisservice.py
@@ -382,12 +382,14 @@ Calculation = UIDReferenceField(
 # before the calculation is performed.
 InterimFields = InterimFieldsField(
     'InterimFields',
-    schemata='Method',
+    schemata="Result Options",
     widget=RecordsWidget(
-        label=_("Additional Values"),
+        label=_("Result variables"),
         description=_(
-            "Values can be entered here which will override the defaults "
-            "specified in the Calculation Interim Fields."),
+            "Variables are displayed as additional input fields on results "
+            "entry, next to 'Result' field. If the analysis has a Calculation "
+            "assigned, the values set here override those from the Calculation "
+        ),
     )
 )
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request does the following:

- Move Service's "Additional Values" field (internally known as "InterimFields") to "Result Options" schemata
- Rename "Additional Values" field to "Result variables"
- Rename "Result Options Type" to "Control type"
- Rename "Result Options" field to "Predefined results"

## Current behavior before PR

Interim fields ("Additional Values")  have been used as a way to replace interims for calculations for a long toime, but now they have sense by their own, especially after the "choices" functionality for interims was added.

## Desired behavior after PR is merged

Make the parameterization of Services easier to understand

![Captura de 2020-10-12 15-26-43](https://user-images.githubusercontent.com/832627/95751801-66dc9e80-0c9f-11eb-93dd-12b0c4906968.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
