### PR TITLE
Fix Maximum length of Choices subfield (interim) is set to 40 (ported #1653)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 
 **Fixed**
 
-- #1655 Fix Maximum length of Choices subfield (interim) is set to 40
+- #1656 Fix Maximum length of Choices subfield (interim) is set to 40
 - #1651 Fix Error when invalidating a sample with contained retests
 - #1633 Fix report section displays date pickers in Chinese
 - #1639 Fix very rare AttributeError on Worksheet Template assignment

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Fixed**
 
+- #1655 Fix Maximum length of Choices subfield (interim) is set to 40
 - #1651 Fix Error when invalidating a sample with contained retests
 - #1633 Fix report section displays date pickers in Chinese
 - #1639 Fix very rare AttributeError on Worksheet Template assignment

--- a/bika/lims/browser/fields/interimfieldsfield.py
+++ b/bika/lims/browser/fields/interimfieldsfield.py
@@ -58,8 +58,11 @@ class InterimFieldsField(RecordsField):
             'keyword': 20,
             'title': 20,
             'value': 10,
-            'choices': 30,
+            'choices': 50,
             'unit': 10,
+        },
+        "subfield_maxlength": {
+            "choices": -1,
         },
         'subfield_validators': {
             'keyword': 'interimfieldsvalidator',

--- a/bika/lims/skins/bika/bika_widgets/recordswidget.pt
+++ b/bika/lims/skins/bika/bika_widgets/recordswidget.pt
@@ -82,7 +82,9 @@
                                      or field.subfield_hidden.get(key, False) == False)">
                     <tal:block
                       define="type python:field.getSubfieldType(key);
-                              required python:key in field.required_subfields and ' required' or '';">
+                              required python:key in field.required_subfields and ' required' or '';
+                              maxlength python:field.getSubfieldMaxlength(key);
+                              maxlength python:maxlength&gt;0 and maxlength or None;">
 
                       <!-- string -->
 
@@ -98,7 +100,7 @@
                                           id string:${fieldName}-${key}-${repeat/idx/index};
                                           value python:field.getSubfieldValue(values, idx, key);
                                           size python:field.getSubfieldSize(key);
-                                          maxlength python:field.getSubfieldMaxlength(key);
+                                          maxlength maxlength|nothing;
                                           readonly python:hasattr(field, 'subfield_readonly') and field.subfield_readonly.get(key, False) or False;
                                           tabindex tabindex/next|nothing;
                                           combogrid_options python: widget.jsondumps(combogrid_options.get(key, ''))"/>
@@ -186,7 +188,7 @@
                                           id string:${fieldName}-${key}-${repeat/idx/index};
                                           value python:field.getSubfieldValue(values, idx, key);
                                           size python:field.getSubfieldSize(key);
-                                          maxlength python:field.getSubfieldMaxlength(key);
+                                          maxlength maxlength|nothing;
                                           readonly python:hasattr(field, 'subfield_readonly') and field.subfield_readonly.get(key, False) or False;
                                           tabindex tabindex/next|nothing;"/>
                       </tal:string>
@@ -205,7 +207,7 @@
                                           id string:${fieldName}-${key}-${repeat/idx/index};
                                           value python:field.getSubfieldValue(values, idx, key);
                                           size python:field.getSubfieldSize(key);
-                                          maxlength python:field.getSubfieldMaxlength(key);
+                                          maxlength maxlength|nothing;
                                           readonly python:hasattr(field, 'subfield_readonly') and field.subfield_readonly.get(key, False) or False;
                                           tabindex tabindex/next|nothing;"/>
                       </tal:string>
@@ -220,7 +222,7 @@
 								                          id string:${fieldName}-${key}-${repeat/idx/index};
 								                          value python:field.getSubfieldValue(values, idx, key);
 								                          size python:field.getSubfieldSize(key);
-								                          maxlength python:field.getSubfieldMaxlength(key);
+								                          maxlength maxlength|nothing;
 								                          tabindex tabindex/next|nothing;"/>
 					            </tal:number>
 
@@ -234,7 +236,7 @@
                                           id string:${fieldName}-${key}-${repeat/idx/index};
                                           value python:field.getSubfieldValue(values, idx, key);
                                           size python:field.getSubfieldSize(key);
-                                          maxlength python:field.getSubfieldMaxlength(key);
+                                          maxlength maxlength|nothing;
                                           tabindex tabindex/next|nothing;"/>
                       </tal:number>
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Ported from https://github.com/senaite/senaite.core/pull/1653**

The maximum length of subfield "Choices" from Interim fields is set to 40. Thus, is not possible to add a list of choices the whole length of the string is greater than 40. However, the system forces to establish a `maxlength`, because its value is always rendered in the template.

This Pull Request modifies the Records Widget, so when the subfield's `maxlength` value is lower than 1, the system does not renders such attribute. In such case, there is no length limit on the input text.

## Current behavior before PR

User cannot add choices in interim fields with a length above 40 characters

## Desired behavior after PR is merged

User can add choices in interim fields with no limit of characters length

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
