### PR TITLE
Fix for results managed as strings when importing from CSV files

### DIFF
--- a/bika/lims/exportimport/instruments/resultsimport.py
+++ b/bika/lims/exportimport/instruments/resultsimport.py
@@ -954,14 +954,12 @@ class AnalysisResultsImporter(Logger):
                 # Get result values as strings
                 result_values = map(
                     lambda r: str(r.get("ResultValue")), result_options)
-                # Check whether the result is a string and transform it to number
-                if isinstance(res, str):
-                    if api.is_floatable(res):
-                        res = float(res)
-                    else:
-                        res = int(res)
+
                 # If result is floatable, only uses the int part
-                if "{:.0f}".format(res) in result_values:
+                if api.is_floatable(res):
+                    res = "{:.0f}".format(api.to_float(res))
+
+                if res in result_values:
                     res = int(res)
 
             analysis.setResult(res)

--- a/bika/lims/exportimport/instruments/resultsimport.py
+++ b/bika/lims/exportimport/instruments/resultsimport.py
@@ -951,6 +951,7 @@ class AnalysisResultsImporter(Logger):
             # handle non-floating values in result options
             result_options = analysis.getResultOptions()
             if result_options:
+                # Get result values as strings
                 result_values = map(
                     lambda r: str(r.get("ResultValue")), result_options)
                 # Check whether the result is a string and transform it to number
@@ -959,7 +960,7 @@ class AnalysisResultsImporter(Logger):
                         res = float(res)
                     else:
                         res = int(res)
-                # If result is a float
+                # If result is floatable, only uses the int part
                 if "{:.0f}".format(res) in result_values:
                     res = int(res)
 

--- a/bika/lims/exportimport/instruments/resultsimport.py
+++ b/bika/lims/exportimport/instruments/resultsimport.py
@@ -952,7 +952,14 @@ class AnalysisResultsImporter(Logger):
             result_options = analysis.getResultOptions()
             if result_options:
                 result_values = map(
-                    lambda r: r.get("ResultValue"), result_options)
+                    lambda r: str(r.get("ResultValue")), result_options)
+                # Check whether the result is a string and transform it to number
+                if isinstance(res, str):
+                    if api.is_floatable(res):
+                        res = float(res)
+                    else:
+                        res = int(res)
+                # If result is a float
                 if "{:.0f}".format(res) in result_values:
                     res = int(res)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

In case results got from a CSV file are managed as strings, the system fails on the following call: `{:.0f}".format(res)`

Also,`{:.0f}".format(res)` gets a string from an integer or decimal number, but the number is compared to a list of integers, therefore the result is always false.



## Current behavior before PR

The system fails when results are managed as strings.

## Desired behavior after PR is merged

The system does not fail.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
