### PR TITLE
Fix language in datepicker widgets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
-- no changes yet
+- #1659 Fix language in datepicker widgets
 
 
 2.0.0rc2 (2020-10-13)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1633

## Current behavior before PR

Non Archetype field datepickers in custom templates and dexterity contents appear in wrong language

## Desired behavior after PR is merged

Datepickers in custom templates and dexterity contents appear in correct language

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
