### PR TITLE
Custom view/edit forms for dexterity types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #1662 Custom view/edit forms for dexterity types
 - #1660 Cleanup unused ajax endpoints for reports and js
 - #1659 Fix language in datepicker widgets
 

--- a/src/senaite/core/browser/configure.zcml
+++ b/src/senaite/core/browser/configure.zcml
@@ -20,6 +20,7 @@
   <include package=".contentmenu"/>
   <include package=".controlpanel"/>
   <include package=".dashboard"/>
+  <include package=".dexterity"/>
   <include package=".fields"/>
   <include package=".frontpage"/>
   <include package=".globals"/>

--- a/src/senaite/core/browser/dexterity/configure.zcml
+++ b/src/senaite/core/browser/dexterity/configure.zcml
@@ -1,0 +1,49 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
+    i18n_domain="plone">
+
+  <!-- Override form/field/widget macros for edit mode -->
+  <browser:page
+      name="ploneform-macros"
+      for="*"
+      class=".views.SenaiteMacros"
+      template="templates/macros.pt"
+      allowed_interface="zope.interface.common.mapping.IItemMapping"
+      permission="zope.Public"
+      layer="senaite.core.interfaces.ISenaiteFormLayer"
+      />
+
+  <!-- Override widget rendering -->
+  <browser:page
+      name="ploneform-render-widget"
+      for="z3c.form.interfaces.IWidget"
+      class=".views.SenaiteRenderWidget"
+      permission="zope.Public"
+      layer="senaite.core.interfaces.ISenaiteFormLayer"
+      />
+
+  <!-- Default view for Dexterity Items -->
+  <browser:page
+      for="plone.dexterity.interfaces.IDexterityItem"
+      name="view"
+      class=".views.SenaiteDefaultView"
+      template="templates/item.pt"
+      permission="zope2.View"
+      layer="senaite.core.interfaces.ISenaiteCore"
+      />
+
+  <!-- Defaut edit view for Dexterity Items -->
+  <browser:page
+      for="plone.dexterity.interfaces.IDexterityContent"
+      name="edit"
+      class=".views.SenaiteDefaultEditView"
+      permission="cmf.ModifyPortalContent"
+      layer="senaite.core.interfaces.ISenaiteCore"
+      />
+
+  <!-- Override the form for the standard full-page form rendering -->
+  <adapter factory=".views.form_factory" />
+
+</configure>

--- a/src/senaite/core/browser/dexterity/templates/form.pt
+++ b/src/senaite/core/browser/dexterity/templates/form.pt
@@ -1,0 +1,19 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      i18n:domain="plone"
+      metal:use-macro="context/main_template/macros/master">
+
+  <metal:block fill-slot="main">
+
+    <h1 class="documentFirstHeading"
+        tal:content="view/label | nothing" />
+
+    <div id="content-core">
+      <metal:block use-macro="context/@@ploneform-macros/titlelessform" />
+    </div>
+
+  </metal:block>
+
+</html>

--- a/src/senaite/core/browser/dexterity/templates/item.pt
+++ b/src/senaite/core/browser/dexterity/templates/item.pt
@@ -1,0 +1,31 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="context/@@main_template/macros/master"
+      i18n:domain="plone">
+  <body>
+
+    <metal:main fill-slot="content-core">
+      <metal:content-core define-macro="content-core">
+
+        <tal:block repeat="widget view/widgets/values|nothing">
+          <tal:block tal:condition="python:widget.__name__ not in ('IBasic.title', 'IBasic.description', 'title', 'description',)">
+            <tal:widget tal:replace="structure widget/@@ploneform-render-widget"/>
+          </tal:block>
+        </tal:block>
+
+        <div tal:repeat="group view/groups|nothing"
+             tal:attributes="id python:''.join((group.prefix, 'groups.', group.__name__)).replace('.', '-')">
+          <legend class="mt-2 border-top border-bottom" tal:content="group/label" />
+          <tal:block tal:repeat="widget group/widgets/values|nothing">
+            <tal:widget tal:replace="structure widget/@@ploneform-render-widget"/>
+          </tal:block>
+        </div>
+
+      </metal:content-core>
+    </metal:main>
+
+  </body>
+</html>

--- a/src/senaite/core/browser/dexterity/templates/macros.pt
+++ b/src/senaite/core/browser/dexterity/templates/macros.pt
@@ -30,16 +30,27 @@
           </dl>
         </tal:status>
 
-        <!-- Field errors -->
+        <!-- Primary Field Errors -->
         <tal:errors define="errors view/widgets/errors" condition="errors">
           <tal:error repeat="error errors">
-            <div class="field error alert alert-warning"
+            <div class="alert alert-warning"
                  tal:condition="not:nocall:error/widget"
                  tal:content="structure error/render">
               Error
             </div>
           </tal:error>
         </tal:errors>
+
+        <!-- Secondary Field Errors -->
+        <tal:groups repeat="group view/groups">
+          <tal:block tal:define="errors group/widgets/errors"
+                    tal:condition="errors"
+                    tal:repeat="error errors">
+            <div class="alert alert-warning"
+                tal:condition="not:nocall:error/widget"
+                tal:content="structure error/render"/>
+          </tal:block>
+        </tal:groups>
 
         <!-- Description -->
         <metal:description-slot define-slot="description">
@@ -77,12 +88,14 @@
 
           <!-- navigation tabs -->
           <ul class="nav nav-tabs" role="tablist">
+
             <!-- primary tab -->
-            <li class="nav-item" role="presentation">
+            <li class="nav-item" role="presentation"
+                tal:define="has_errors view/widgets/errors">
               <a tal:content="default_fieldset_label"
+                 tal:attributes="class python:has_errors and 'nav-link active text-danger' or 'nav-link active'"
                  id="default-tab"
                  href="#default"
-                 class="nav-link active"
                  data-toggle="tab"
                  role="tab">
                 Label
@@ -157,7 +170,7 @@
 
                     <!-- Error -->
                     <tal:block tal:define="errors group/widgets/errors"
-                               tal:condition="errors"
+                               tal:condition="python:False"
                                tal:repeat="error errors">
                       <div class="field error fieldErrorBox"
                            tal:condition="not:nocall:error/widget"

--- a/src/senaite/core/browser/dexterity/templates/macros.pt
+++ b/src/senaite/core/browser/dexterity/templates/macros.pt
@@ -1,0 +1,199 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      i18n:domain="plone">
+  <body>
+
+    <div class="form" metal:define-macro="form">
+
+      <metal:title-slot define-slot="title">
+        <h3 tal:condition="view/label | nothing" tal:content="view/label" />
+      </metal:title-slot>
+
+      <metal:define define-macro="titlelessform">
+
+        <!-- Status Message -->
+        <tal:status define="status view/status;
+                            has_error python:view.widgets.errors or status == getattr(view, 'formErrorsMessage', None)" condition="status">
+          <dl class="portalMessage alert error" tal:condition="has_error" role="alert">
+            <dt i18n:translate="" i18n:domain="plone">
+              Error
+            </dt>
+            <dd tal:content="status" />
+          </dl>
+          <dl class="portalMessage info" tal:condition="not:has_error" role="status">
+            <dt i18n:translate="" i18n:domain="plone">
+              Info
+            </dt>
+            <dd tal:content="status" />
+          </dl>
+        </tal:status>
+
+        <!-- Field errors -->
+        <tal:errors define="errors view/widgets/errors" condition="errors">
+          <tal:error repeat="error errors">
+            <div class="field error alert alert-warning"
+                 tal:condition="not:nocall:error/widget"
+                 tal:content="structure error/render">
+              Error
+            </div>
+          </tal:error>
+        </tal:errors>
+
+        <!-- Description -->
+        <metal:description-slot define-slot="description">
+          <p class="discreet text-secondary"
+             tal:define="description view/description | nothing"
+             tal:condition="description"
+             tal:content="structure description|default">
+            Description
+          </p>
+        </metal:description-slot>
+
+        <!-- Form -->
+        <form data-pat-autotoc="levels: legend; section: fieldset; className: autotabs"
+              class="rowlike enableUnloadProtection" action="." method="post"
+              tal:define="groups view/groups | nothing;
+                          form_name view/form_name | nothing;
+                          form_class view/css_class | string:;
+                          default_fieldset_label view/default_fieldset_label | form_name;
+                          enable_form_tabbing view/enable_form_tabbing | python:True;
+                          enable_unload_protection view/enable_unload_protection|python:True;
+                          unload_protection python:enable_unload_protection and 'pat-formunloadalert';
+                          has_groups python:bool(groups);
+                          form_tabbing python:(has_groups and enable_form_tabbing) and 'enableFormTabbing pat-autotoc' or '';
+                          show_default_label python:has_groups and default_fieldset_label and len(view.widgets);
+                          form_view_name_raw python:view.__name__ or request.getURL().split('/')[-1];
+                          form_view_name python:'-'.join(['view', 'name'] + [x for x in form_view_name_raw.split('++') if x]);
+                          "
+              tal:attributes="action view/action|request/getURL;
+                              enctype view/enctype;
+                              class python:'rowlike {0} {1} {2} kssattr-formname-{3} {4}'.format(unload_protection, form_tabbing, form_class, form_view_name_raw, form_view_name);
+                              id view/id;
+                              method view/method|string:post">
+
+          <metal:block define-slot="formtop" />
+
+          <!-- navigation tabs -->
+          <ul class="nav nav-tabs" role="tablist">
+            <!-- primary tab -->
+            <li class="nav-item" role="presentation">
+              <a tal:content="default_fieldset_label"
+                 id="default-tab"
+                 href="#default"
+                 class="nav-link active"
+                 data-toggle="tab"
+                 role="tab">
+                Label
+              </a>
+            </li>
+
+            <!-- secondary tabs -->
+            <li tal:repeat="group groups" tal:condition="has_groups" class="nav-item" role="presentation">
+              <a tal:define="normalizeString nocall:context/@@plone/normalizeString;
+                             fieldset_label group/label;
+                             fieldset_name python:getattr(group, '__name__', False) or getattr(group.label, 'default', False) or fieldset_label;
+                             fieldset_name python:normalizeString(fieldset_name);
+                             has_errors group/widgets/errors|nothing"
+                 tal:attributes="id string:${fieldset_name}-tab;
+                                 href string:#${fieldset_name};
+                                 class python:has_errors and 'nav-link text-danger' or 'nav-link'"
+                 tal:content="fieldset_label"
+                 data-toggle="tab"
+                 role="tab">
+                Label
+              </a>
+            </li>
+          </ul>
+
+          <metal:fields-slot define-slot="fields">
+
+            <input type="hidden"
+                   name="fieldset"
+                   tal:define="current_fieldset request/fieldset | python:None"
+                   tal:condition="python:has_groups and enable_form_tabbing and current_fieldset is not None"
+                   tal:attributes="value current_fieldset" />
+
+            <!-- Default fieldset -->
+            <metal:define
+              define-macro="fields"
+              tal:define="show_default_label show_default_label|nothing;
+                          has_groups has_groups|nothing">
+
+              <!-- tab content -->
+              <div class="tab-content">
+
+                <!-- Primary fieldsets -->
+                <div class="tab-pane active" id="default" role="tabpanel">
+                  <metal:define define-macro="widget_rendering">
+                    <tal:widgets repeat="widget view/widgets/values">
+                      <metal:field-slot define-slot="field">
+                        <metal:field define-macro="field">
+                          <tal:widget tal:replace="structure widget/@@ploneform-render-widget"/>
+                        </metal:field>
+                      </metal:field-slot>
+                    </tal:widgets>
+                  </metal:define>
+                </div>
+
+                <!-- Secondary fieldsets -->
+                <tal:block tal:repeat="group groups" condition="has_groups">
+                  <div class="tab-pane"
+                       role="tabpanel"
+                       tal:define="normalizeString nocall:context/@@plone/normalizeString;
+                                   fieldset_label group/label;
+                                   fieldset_name python:getattr(group, '__name__', False) or getattr(group.label, 'default', False) or fieldset_label;
+                                   fieldset_name python:normalizeString(fieldset_name);"
+                       tal:attributes="id string:${fieldset_name};
+                                       data-fieldset fieldset_name">
+
+                    <p i18n:translate=""
+                      tal:define="group_description group/description|nothing"
+                      tal:condition="group_description"
+                      tal:content="structure group_description">
+                      Description
+                    </p>
+
+                    <!-- Error -->
+                    <tal:block tal:define="errors group/widgets/errors"
+                               tal:condition="errors"
+                               tal:repeat="error errors">
+                      <div class="field error fieldErrorBox"
+                           tal:condition="not:nocall:error/widget"
+                           tal:content="structure error/render"/>
+                    </tal:block>
+
+                    <!-- Widget -->
+                    <tal:block define="view nocall:group;">
+                      <metal:block use-macro="context/@@ploneform-macros/widget_rendering" />
+                    </tal:block>
+
+                  </div>
+                </tal:block>
+              </div>
+
+            </metal:define>
+          </metal:fields-slot>
+
+          <metal:block define-slot="belowfields" />
+
+          <metal:actions-slot define-slot="actions">
+            <metal:define define-macro="actions">
+              <div class="formControls" tal:condition="view/actions/values|nothing">
+                <tal:block repeat="action view/actions/values">
+                  <input type="submit" tal:replace="structure action/render" />
+                </tal:block>
+              </div>
+            </metal:define>
+          </metal:actions-slot>
+
+          <tal:block tal:condition="view/enableCSRFProtection|nothing"
+                     tal:replace="structure context/@@authenticator/authenticator" />
+          <metal:block define-slot="formbottom" />
+
+        </form>
+      </metal:define>
+    </div>
+  </body>
+</html>

--- a/src/senaite/core/browser/dexterity/templates/macros.pt
+++ b/src/senaite/core/browser/dexterity/templates/macros.pt
@@ -33,7 +33,7 @@
         <!-- Primary Field Errors -->
         <tal:errors define="errors view/widgets/errors" condition="errors">
           <tal:error repeat="error errors">
-            <div class="alert alert-warning"
+            <div class="field error alert alert-warning"
                  tal:condition="not:nocall:error/widget"
                  tal:content="structure error/render">
               Error
@@ -46,7 +46,7 @@
           <tal:block tal:define="errors group/widgets/errors"
                     tal:condition="errors"
                     tal:repeat="error errors">
-            <div class="alert alert-warning"
+            <div class="field error alert alert-warning"
                 tal:condition="not:nocall:error/widget"
                 tal:content="structure error/render"/>
           </tal:block>

--- a/src/senaite/core/browser/dexterity/templates/widget.pt
+++ b/src/senaite/core/browser/dexterity/templates/widget.pt
@@ -1,0 +1,43 @@
+<div metal:define-macro="widget-wrapper"
+     i18n:domain="plone"
+     tal:define="widget nocall:context;
+                 hidden python:widget.mode == 'hidden';
+                 error widget/error;
+                 error_class python:error and ' error' or '';
+                 empty_values python: (None, '', [], ('', '', '', '00', '00', ''), ('', '', ''));
+                 empty_class python: (widget.value in empty_values) and ' empty' or '';
+	               wrapper_css_class  widget/wrapper_css_class|nothing;
+                 fieldname_class string:kssattr-fieldname-${widget/name};"
+     data-pat-inlinevalidation='{"type":"z3c.form"}'
+     tal:attributes="class string:field pat-inlinevalidation ${fieldname_class}${error_class}${empty_class} ${wrapper_css_class};
+                     data-fieldname widget/name;
+                     id string:formfield-${widget/id};">
+
+  <div for=""
+         class="horizontal font-weight-bold"
+         tal:attributes="for widget/id"
+         tal:condition="python: not hidden and widget.label">
+    <span i18n:translate="" tal:replace="widget/label">label</span>
+
+    <span class="required horizontal" title="Required"
+          tal:condition="python:widget.required and widget.mode == 'input'"
+          i18n:attributes="title title_required;">&nbsp;</span>
+  </div>
+
+  <div class="fieldErrorBox"
+       tal:content="structure error/render|nothing">
+    Error
+  </div>
+
+  <span class="formHelp text-secondary text-muted"
+        tal:define="description python: getattr(widget, 'description', widget.field.description)"
+        i18n:translate=""
+        tal:content="structure description"
+        tal:condition="python:description and not hidden">
+    field description
+  </span>
+
+  <input type="text"
+         tal:replace="structure widget/render"
+         metal:define-slot="widget" />
+</div>

--- a/src/senaite/core/browser/dexterity/views.py
+++ b/src/senaite/core/browser/dexterity/views.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+import plone.app.z3cform
+import plone.app.z3cform.interfaces
+import plone.z3cform.interfaces
+import plone.z3cform.templates
+import senaite.core.browser.dexterity
+import z3c.form.interfaces
+from plone.app.z3cform.views import Macros
+from plone.app.z3cform.views import RenderWidget
+from plone.dexterity.browser.edit import DefaultEditView
+from plone.dexterity.browser.view import DefaultView
+from senaite.core.interfaces import ISenaiteFormLayer
+from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
+
+
+def path(filepart):
+    return os.path.join(
+        os.path.dirname(senaite.core.browser.dexterity.__file__),
+        "templates",
+        filepart,
+    )
+
+
+class SenaiteMacros(Macros):
+    """Override class for templates/form.pt
+    """
+    def __init__(self, context, request):
+        super(SenaiteMacros, self).__init__(context, request)
+        self.context = context
+        self.request = request
+
+
+class SenaiteRenderWidget(RenderWidget):
+    index = ViewPageTemplateFile("templates/widget.pt")
+
+    def __init__(self, context, request):
+        super(SenaiteRenderWidget, self).__init__(context, request)
+        self.context = context
+        self.request = request
+
+
+class SenaiteDefaultView(DefaultView):
+    """The default view for Dexterity content.
+    This uses a WidgetsView and renders all widgets in display mode.
+    """
+
+    def __init__(self, context, request):
+        super(SenaiteDefaultView, self).__init__(context, request)
+        self.context = context
+        self.request = request
+
+
+class SenaiteDefaultEditView(DefaultEditView):
+    """The default edit view for Dexterity content.
+    """
+    def __init__(self, context, request):
+        super(SenaiteDefaultEditView, self).__init__(context, request)
+        self.context = context
+        self.request = request
+
+
+# Override the form for the standard full-page form rendering
+# Code taken from plone.app.z3cform.views
+
+form_factory = plone.z3cform.templates.ZopeTwoFormTemplateFactory(
+    path("form.pt"),
+    form=z3c.form.interfaces.IForm,
+    request=ISenaiteFormLayer)

--- a/src/senaite/core/interfaces/__init__.py
+++ b/src/senaite/core/interfaces/__init__.py
@@ -18,11 +18,17 @@
 # Copyright 2018-2020 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from plone.app.z3cform.interfaces import IPloneFormLayer
 from zope.interface import Interface
 
 
 class ISenaiteCore(Interface):
     """Marker interface that defines a Zope 3 browser layer.
+    """
+
+
+class ISenaiteFormLayer(IPloneFormLayer):
+    """Used to override plone.app.z3cform forms
     """
 
 

--- a/src/senaite/core/profiles/default/browserlayer.xml
+++ b/src/senaite/core/profiles/default/browserlayer.xml
@@ -2,4 +2,7 @@
 <layers>
   <layer name="senaite.core"
          interface="senaite.core.interfaces.ISenaiteCore"/>
+
+  <layer name="senaite.core.forms"
+         interface="senaite.core.interfaces.ISenaiteFormLayer"/>
 </layers>

--- a/src/senaite/core/upgrade/v02_00_000.py
+++ b/src/senaite/core/upgrade/v02_00_000.py
@@ -73,6 +73,7 @@ def upgrade(tool):
     # run import steps located in senaite.core profiles
     setup.runImportStepFromProfile(profile, "typeinfo")
     setup.runImportStepFromProfile(profile, "workflow")
+    setup.runImportStepFromProfile(profile, "browserlayer")
     # run import steps located in bika.lims profiles
     _run_import_step(portal, "typeinfo", profile="profile-bika.lims:default")
     _run_import_step(portal, "workflow", profile="profile-bika.lims:default")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR provides tabbed editing for Dexterity content types.

## Current behavior before PR

Different fieldsets were displayed on a single page

## Desired behavior after PR is merged

Different fieldsets are displayed tabbed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
