### PR TITLE
Fix date widget showing always 1899-12-31

### DIFF
--- a/src/senaite/core/browser/static/js/bika.lims.site.js
+++ b/src/senaite/core/browser/static/js/bika.lims.site.js
@@ -94,8 +94,7 @@
         changeYear: true,
         showWeek: true,
         yearRange: yearRange,
-        numberOfMonths: 1,
-        autoSize: true
+        numberOfMonths: 1
       });
       make_datepicker_config = function(options) {
         var default_config;

--- a/src/senaite/core/browser/static/js/coffee/bika.lims.site.coffee
+++ b/src/senaite/core/browser/static/js/coffee/bika.lims.site.coffee
@@ -104,8 +104,6 @@ class window.SiteView
       showWeek: yes
       yearRange: yearRange
       numberOfMonths: 1
-      autoSize: yes
-
 
     # returns a customizable datepicker config
     make_datepicker_config = (options) ->


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fixes invalid dates shown in datepicker widget.

This was introduced in https://github.com/senaite/senaite.core/pull/1659

## Current behavior before PR

Always the date 1899-12-31 is shown in datepicker fields

## Desired behavior after PR is merged

The selected date is shown in the datepicker field

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
