### PR TITLE
Fix Generic Setup Content Importer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #1669 Fix Generic Setup Content Importer
 - #1666 Added adapter to extend listing_searchable_text index
 - #1665 Display Auditlog listing icon
 - #1664 Display correct icons in listings

--- a/src/senaite/core/exportimport/genericsetup/structure.py
+++ b/src/senaite/core/exportimport/genericsetup/structure.py
@@ -487,7 +487,7 @@ def import_xml(context):
     portal = context.getSite()
 
     qi = api.get_tool("portal_quickinstaller")
-    installed = qi.isProductInstalled("bika.lims")
+    installed = qi.isProductInstalled("senaite.core")
 
     if not installed:
         logger.debug("Nothing to import.")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the Generic Setup Content Importer for `2.x`

## Current behavior before PR

Tarball content import not working

## Desired behavior after PR is merged

Tarball content import working

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
