### PR TITLE
Fix error when adding blank/reference samples to worksheets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #1672 Fix error when adding blank/reference samples to worksheets
 - #1669 Fix Generic Setup Content Importer
 - #1666 Added adapter to extend listing_searchable_text index
 - #1665 Display Auditlog listing icon

--- a/src/bika/lims/browser/worksheet/views/referencesamples.py
+++ b/src/bika/lims/browser/worksheet/views/referencesamples.py
@@ -121,20 +121,22 @@ class ReferenceSamplesView(BikaListingView):
         """Handle form submission
         """
         form = self.request.form
-        # Selected service UIDs
+        # Selected reference/blank sample UIDs
         uids = form.get("uids")
-        # reference sample -> selected services mapping
-        supported_services = form.get("SupportedServices")
         # service -> position mapping
         positions = form.get("Position")[0]
         for uid in uids:
+            referencesample = api.get_object_by_uid(uid)
             position = positions.get(uid)
             if position == "new":
                 position = None
-            service_uids = supported_services.get(uid)
-            referencesample = api.get_object_by_uid(uid)
+            # get selected services of the reference sample
+            key = "{}.{}".format("SupportedServices", uid)
+            selected_services = form.get(key)
+            if not selected_services:
+                continue
             self.context.addReferenceAnalyses(
-                referencesample, service_uids, slot=position)
+                referencesample, selected_services, slot=position)
         redirect_url = "{}/{}".format(
             api.get_url(self.context), "manage_results")
         self.request.response.redirect(redirect_url)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1671

## Current behavior before PR

Traceback occurs when adding blank/reference samples to worksheets

## Desired behavior after PR is merged

Blanks/Reference Samples can be added to worksheets

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
