### PR TITLE
Fix error in sample view when ccemails is none

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #1674 Fix error in sample view when ccemails is None
 - #1672 Fix error when adding blank/reference samples to worksheets
 - #1669 Fix Generic Setup Content Importer
 - #1666 Added adapter to extend listing_searchable_text index

--- a/src/bika/lims/browser/analysisrequest/__init__.py
+++ b/src/bika/lims/browser/analysisrequest/__init__.py
@@ -142,6 +142,8 @@ class mailto_link_from_ccemails(object):
 
     def __call__(self, field):
         ccemails = field.get(self.context)
+        if not ccemails:
+            return ""
         addresses = ccemails.split(",")
         ret = []
         for address in addresses:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an error when CC Emails have been set to the value `None`

## Current behavior before PR

Traceback occurs:

```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module bika.lims.browser.analysisrequest.view, line 43, in __call__
  Module bika.lims.browser.header_table, line 84, in __call__
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 367, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 307, in render
  Module chameleon.template, line 214, in render
  Module chameleon.template, line 192, in render
  Module d468864369ccc03380d9845d80fe9cc5, line 238, in render
  Module zope.tales.pythonexpr, line 73, in __call__
   - __traceback_info__: (view.get_fields_grouped_by_location())
  Module <string>, line 1, in <module>
  Module bika.lims.browser.header_table, line 288, in get_fields_grouped_by_location
  Module bika.lims.browser.header_table, line 223, in render_field_view
  Module bika.lims.browser.analysisrequest, line 145, in __call__
AttributeError: 'NoneType' object has no attribute 'split'
```

## Desired behavior after PR is merged

CCEMails field renders w/o a value 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
