### PR TITLE
Fix error when setting WS template layout

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #1675 Fix error when setting WS template layout
 - #1672 Fix error when adding blank/reference samples to worksheets
 - #1669 Fix Generic Setup Content Importer
 - #1666 Added adapter to extend listing_searchable_text index

--- a/src/bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt
+++ b/src/bika/lims/skins/bika/bika_widgets/worksheettemplatelayoutwidget.pt
@@ -125,7 +125,7 @@
 	            </td>
 	            <!-- Dropdown for Duplicate Analysis -->
 	            <td>
-		            <div id="" tal:define="num_rows repeat/row/length">
+		            <div id="" tal:define="num_rows python:repeat['row'].number()">
 			            <select name="Layout.dup:records:ignore_empty"
                           tal:attributes="style python: selected_type == 'd' and 'display:inline;;' or 'display:none;;';
                                           class string:duplicate_analysis_dropdown;


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an error that occurs after setting a WS template layout.

NOTE:
This happens only for Plone 5.2.2, because the template rendering engine changed to Chameleon which does not support `repeat/item/length` anymore.

## Current behavior before PR

Traceback occurs:

```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module Products.CMFFormController.FSControllerPageTemplate, line 92, in __call__
  Module Products.CMFFormController.BaseControllerPageTemplate, line 30, in _call
  Module Products.CMFFormController.ControllerBase, line 233, in getNext
  Module Products.CMFFormController.Actions.TraverseTo, line 38, in __call__
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.CMFFormController.FSControllerPythonScript, line 106, in __call__
  Module Products.CMFFormController.ControllerBase, line 233, in getNext
  Module Products.CMFFormController.Actions.TraverseToAction, line 81, in __call__
  Module Products.CMFFormController.Actions.TraverseTo, line 38, in __call__
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.CMFFormController.FSControllerPageTemplate, line 92, in __call__
  Module Products.CMFFormController.BaseControllerPageTemplate, line 33, in _call
  Module Shared.DC.Scripts.Bindings, line 335, in __call__
  Module Shared.DC.Scripts.Bindings, line 372, in _bindAndExec
  Module Products.CMFCore.FSPageTemplate, line 256, in _exec
  Module Products.CMFCore.FSPageTemplate, line 197, in pt_render
  Module Products.PageTemplates.PageTemplate, line 85, in pt_render
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 367, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 307, in render
  Module chameleon.template, line 214, in render
  Module chameleon.template, line 192, in render
  Module 1c07152ab142f5516dfafa1b84b319fe, line 1221, in render
  Module 1c07152ab142f5516dfafa1b84b319fe, line 1028, in render_master
  Module 511074ec2b8d96b4d200b939dc4aedd6, line 1449, in render_master
  Module 511074ec2b8d96b4d200b939dc4aedd6, line 444, in render_content
  Module 1c07152ab142f5516dfafa1b84b319fe, line 1013, in __fill_main
  Module 1c07152ab142f5516dfafa1b84b319fe, line 183, in render_main
  Module b88c3ac984cba5c67c3cb96ed97f8b74, line 529, in render_body
  Module 2d0eef6a7b4679510b7488037833c809, line 1433, in render_edit
  Module d6ab204a51373fbd6d3304a97ebcefba, line 702, in render_edit
  Module 2d0eef6a7b4679510b7488037833c809, line 1166, in __fill_widget_body
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 196, in _eval
  Module Products.PageTemplates.Expressions, line 126, in render
  Module zope.tales.tales, line 526, in length
TypeError: object of type 'listiterator' has no len()
```

## Desired behavior after PR is merged

WS template layout is rendered

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
