### PR TITLE
New Field "Department ID" added to Departments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #1676 New Field "Department ID" added to Departments
 - #1675 Fix error when setting WS template layout
 - #1674 Fix error in sample view when ccemails is None
 - #1672 Fix error when adding blank/reference samples to worksheets

--- a/src/bika/lims/catalog/indexers/bikasetup.py
+++ b/src/bika/lims/catalog/indexers/bikasetup.py
@@ -121,6 +121,14 @@ def department_title(instance):
     return to_keywords_list(department, api.get_title)
 
 
+@indexer(IHaveDepartment, IBikaSetupCatalog)
+def department_id(instance):
+    """Returns the ID of the Department the instance is assigned to
+    """
+    department = instance.getDepartment()
+    return to_keywords_list(department, lambda dep: dep.getDepartmentID())
+
+
 @indexer(IAnalysisService, IBikaSetupCatalog)
 def point_of_capture(instance):
     """Returns the point of capture of the instance

--- a/src/bika/lims/catalog/indexers/configure.zcml
+++ b/src/bika/lims/catalog/indexers/configure.zcml
@@ -13,6 +13,7 @@
 
   <!-- bika_setup Catalog Index adapters -->
   <adapter name="category_uid" factory=".bikasetup.category_uid"/>
+  <adapter name="department_id" factory=".bikasetup.department_id"/>
   <adapter name="department_title" factory=".bikasetup.department_title"/>
   <adapter name="department_uid" factory=".bikasetup.department_uid"/>
   <adapter name="instrument_title" factory=".bikasetup.instrument_title"/>

--- a/src/bika/lims/content/department.py
+++ b/src/bika/lims/content/department.py
@@ -26,6 +26,7 @@ from bika.lims.config import PROJECTNAME
 from bika.lims.content.bikaschema import BikaSchema
 from bika.lims.interfaces import IDeactivable
 from bika.lims.interfaces import IDepartment
+from bika.lims.interfaces import IHaveDepartment
 from Products.Archetypes.public import BaseContent
 from Products.Archetypes.public import ReferenceField
 from Products.Archetypes.public import Schema
@@ -80,7 +81,7 @@ schema["description"].schemata = "default"
 
 
 class Department(BaseContent):
-    implements(IDepartment, IDeactivable)
+    implements(IDepartment, IHaveDepartment, IDeactivable)
     security = ClassSecurityInfo()
     displayContentsTab = False
     schema = schema
@@ -90,6 +91,13 @@ class Department(BaseContent):
     def _renameAfterCreation(self, check_auto_id=False):
         from bika.lims.idserver import renameAfterCreation
         renameAfterCreation(self)
+
+    def getDepartment(self):
+        """Used in catalog indexer
+
+        see: bika.lims.catalog.indexers.bikasetup.py
+        """
+        return self
 
 
 registerType(Department, PROJECTNAME)

--- a/src/bika/lims/content/department.py
+++ b/src/bika/lims/content/department.py
@@ -37,7 +37,7 @@ from zope.interface import implements
 
 DeapartmentID = StringField(
     "DepartmentID",
-    required=0,
+    required=1,
     searchable=True,
     validators=("uniquefieldvalidator", "standard_id_validator"),
     widget=StringWidget(

--- a/src/bika/lims/content/department.py
+++ b/src/bika/lims/content/department.py
@@ -19,13 +19,6 @@
 # Some rights reserved, see README and LICENSE.
 
 from AccessControl import ClassSecurityInfo
-from Products.Archetypes.public import BaseContent
-from Products.Archetypes.public import ReferenceField
-from Products.Archetypes.public import Schema
-from Products.Archetypes.public import registerType
-from Products.Archetypes.references import HoldingReference
-from zope.interface import implements
-
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.widgets import ReferenceWidget
 from bika.lims.catalog.bikasetup_catalog import SETUP_CATALOG
@@ -33,11 +26,30 @@ from bika.lims.config import PROJECTNAME
 from bika.lims.content.bikaschema import BikaSchema
 from bika.lims.interfaces import IDeactivable
 from bika.lims.interfaces import IDepartment
+from Products.Archetypes.public import BaseContent
+from Products.Archetypes.public import ReferenceField
+from Products.Archetypes.public import Schema
+from Products.Archetypes.public import StringField
+from Products.Archetypes.public import StringWidget
+from Products.Archetypes.public import registerType
+from Products.Archetypes.references import HoldingReference
+from zope.interface import implements
+
+DeapartmentID = StringField(
+    "DepartmentID",
+    required=0,
+    searchable=True,
+    validators=("uniquefieldvalidator", "standard_id_validator"),
+    widget=StringWidget(
+        label=_("Department ID"),
+        description=_("Unique Department ID that identifies the department"),
+    ),
+)
 
 Manager = ReferenceField(
-    'Manager',
+    "Manager",
     required=1,
-    allowed_types=('LabContact',),
+    allowed_types=("LabContact", ),
     referenceClass=HoldingReference,
     relationship="DepartmentLabContact",
     widget=ReferenceWidget(
@@ -57,12 +69,14 @@ Manager = ReferenceField(
     ),
 )
 
+
 schema = BikaSchema.copy() + Schema((
+    DeapartmentID,
     Manager,
 ))
 
-schema['description'].widget.visible = True
-schema['description'].schemata = 'default'
+schema["description"].widget.visible = True
+schema["description"].schemata = "default"
 
 
 class Department(BaseContent):

--- a/src/bika/lims/controlpanel/bika_departments.py
+++ b/src/bika/lims/controlpanel/bika_departments.py
@@ -71,6 +71,10 @@ class DepartmentsView(BikaListingView):
         self.pagesize = 25
 
         self.columns = collections.OrderedDict((
+            ("DepartmentID", {
+                "title": _("Department ID"),
+                "index": "department_id",
+                "toggle": False}),
             ("Title", {
                 "title": _("Department"),
                 "index": "sortable_title"}),
@@ -123,6 +127,12 @@ class DepartmentsView(BikaListingView):
         description = obj.Description()
         url = obj.absolute_url()
 
+        # Department ID
+        department_id = obj.getDepartmentID()
+        item["DepartmentID"] = department_id
+        item["replace"]["DepartmentID"] = get_link(url, value=department_id)
+
+        # Department Title
         item["replace"]["Title"] = get_link(url, value=title)
         item["Description"] = description
 

--- a/src/bika/lims/controlpanel/bika_departments.py
+++ b/src/bika/lims/controlpanel/bika_departments.py
@@ -22,7 +22,6 @@ import collections
 
 from Products.ATContentTypes.content import schemata
 from Products.Archetypes import atapi
-from Products.Archetypes.utils import DisplayList
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.bika_listing import BikaListingView

--- a/src/bika/lims/controlpanel/bika_departments.py
+++ b/src/bika/lims/controlpanel/bika_departments.py
@@ -71,13 +71,13 @@ class DepartmentsView(BikaListingView):
         self.pagesize = 25
 
         self.columns = collections.OrderedDict((
+            ("Title", {
+                "title": _("Department"),
+                "index": "sortable_title"}),
             ("DepartmentID", {
                 "title": _("Department ID"),
                 "index": "department_id",
                 "toggle": False}),
-            ("Title", {
-                "title": _("Department"),
-                "index": "sortable_title"}),
             ("Description", {
                 "title": _("Description"),
                 "index": "Description",
@@ -127,14 +127,14 @@ class DepartmentsView(BikaListingView):
         description = obj.Description()
         url = obj.absolute_url()
 
+        # Department Title
+        item["replace"]["Title"] = get_link(url, value=title)
+        item["Description"] = description
+
         # Department ID
         department_id = obj.getDepartmentID()
         item["DepartmentID"] = department_id
         item["replace"]["DepartmentID"] = get_link(url, value=department_id)
-
-        # Department Title
-        item["replace"]["Title"] = get_link(url, value=title)
-        item["Description"] = description
 
         item["Manager"] = ""
         item["ManagerPhone"] = ""

--- a/src/bika/lims/setuphandlers.py
+++ b/src/bika/lims/setuphandlers.py
@@ -169,6 +169,7 @@ INDEXES = (
     ("bika_setup_catalog", "created", "", "DateIndex"),
     ("bika_setup_catalog", "department_title", "", "KeywordIndex"),
     ("bika_setup_catalog", "department_uid", "", "KeywordIndex"),
+    ("bika_setup_catalog", "department_id", "", "KeywordIndex"),
     ("bika_setup_catalog", "getClientUID", "", "FieldIndex"),
     ("bika_setup_catalog", "getId", "", "FieldIndex"),
     ("bika_setup_catalog", "getKeyword", "", "FieldIndex"),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds an additional field "DepartmentID" to the Department Type.
This can be used in future to identify the department uniquely for filtering and ID mixins.

## Current behavior before PR

No unique department ID field existent

## Desired behavior after PR is merged

Unique Department ID Field added

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
