### PR TITLE
Improved Generic Setup Content Structure Export/Import

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #1678 Improved Generic Setup Content Structure Export/Import
 - #1676 New Field "Department ID" added to Departments
 - #1675 Fix error when setting WS template layout
 - #1674 Fix error in sample view when ccemails is None

--- a/src/senaite/core/exportimport/genericsetup/adapters.py
+++ b/src/senaite/core/exportimport/genericsetup/adapters.py
@@ -221,11 +221,14 @@ class DXNamedFileFieldNodeAdapter(ATBlobFileFieldNodeAdapter):
         """Set the field value
         """
         # logger.info("Set: {} -> {}".format(self.field.getName(), value))
+        data = value
+        if not data:
+            logger.error("Can not set empty file contents")
+            return
         filename = kw.get("filename", "")
         contentType = kw.get("mimetype") or kw.get("content_type")
-        value = self.field._type(data=value,
-                                 contentType=contentType,
-                                 filename=filename)
+        value = self.field._type(
+            data=data, contentType=contentType, filename=filename)
         self.field.set(self.context, value)
 
 

--- a/src/senaite/core/exportimport/genericsetup/adapters.py
+++ b/src/senaite/core/exportimport/genericsetup/adapters.py
@@ -27,6 +27,7 @@ from bika.lims import logger
 from bika.lims.interfaces.field import IUIDReferenceField
 from DateTime import DateTime
 from plone.app.blob.interfaces import IBlobField
+from plone.app.textfield.interfaces import IRichText
 from plone.dexterity.interfaces import IDexterityContent
 from plone.namedfile.interfaces import INamedField
 from Products.Archetypes.interfaces import IBaseObject
@@ -84,10 +85,9 @@ class ATFieldNodeAdapter(NodeAdapterBase):
             # Always handle the value as unicode
             return json.dumps(safe_unicode(value))
         except TypeError:
-            logger.warning(
-                "ParseError: '{}.{} ('{}') -> {}' is not JSON serializable!"
-                .format(self.context.getId(), self.field.getName(),
-                        self.field.type, repr(value)))
+            logger.error(
+                "ParseError: '{}.{} ('{}')' is not JSON serializable!".format(
+                    self.context.getId(), self.field.getName(), repr(value)))
             return ""
 
     def parse_json_value(self, value):
@@ -299,3 +299,25 @@ class ATRecordFieldNodeAdapter(ATFieldNodeAdapter):
     """Import/Export Records Fields
     """
     adapts(IBaseObject, IRecordField, ISetupEnviron)
+
+
+class ATRichTextFieldNodeAdapter(ATFieldNodeAdapter):
+    """Node im- and exporter for AT RichText fields.
+    """
+    implements(IFieldNode)
+    adapts(IBaseObject, IRichText, ISetupEnviron)
+
+    def get_field_value(self):
+        """Get the field value
+        """
+        value = self.field.get(self.context)
+        if not value:
+            return ""
+        return value.raw
+
+
+class DXRichTextFieldNodeAdapter(ATRichTextFieldNodeAdapter):
+    """Node im- and exporter for AT RichText fields.
+    """
+    implements(IFieldNode)
+    adapts(IDexterityContent, IRichText, ISetupEnviron)

--- a/src/senaite/core/exportimport/genericsetup/configure.zcml
+++ b/src/senaite/core/exportimport/genericsetup/configure.zcml
@@ -10,7 +10,8 @@
             Products.CMFCore.exportimport.properties.exportSiteProperties
       <adapter factory=".structure.SenaiteSiteXMLAdapter"/>
   -->
-  <adapter factory=".structure.ContentXMLAdapter"/>
+  <adapter factory=".structure.ATContentXMLAdapter"/>
+  <adapter factory=".structure.DXContentXMLAdapter"/>
 
   <!-- Field Adapters
        Know how to Import/Export field values

--- a/src/senaite/core/exportimport/genericsetup/configure.zcml
+++ b/src/senaite/core/exportimport/genericsetup/configure.zcml
@@ -13,17 +13,24 @@
   <adapter factory=".structure.ATContentXMLAdapter"/>
   <adapter factory=".structure.DXContentXMLAdapter"/>
 
-  <!-- Field Adapters
+  <!-- AT Field Adapters
        Know how to Import/Export field values
   -->
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.ATFieldNodeAdapter"/>
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.ATTextFieldNodeAdapter"/>
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.ATFileFieldNodeAdapter"/>
-  <adapter provides=".interfaces.IFieldNode" factory=".adapters.BlobFileFieldNodeAdapter"/>
+  <adapter provides=".interfaces.IFieldNode" factory=".adapters.ATBlobFileFieldNodeAdapter"/>
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.ATDateTimeFieldNodeAdapter"/>
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.ATReferenceFieldNodeAdapter"/>
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.ATUIDReferenceFieldNodeAdapter"/>
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.ATRecordFieldNodeAdapter"/>
+
+  <!-- DX Field Adapters
+       Know how to Import/Export field values
+  -->
+  <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXFieldNodeAdapter"/>
+  <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXNamedFileFieldNodeAdapter"/>
+  <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXDateTimeFieldNodeAdapter"/>
 
   <class class="senaite.core.browser.fields.record.RecordField">
     <implements interface=".interfaces.IRecordField" />

--- a/src/senaite/core/exportimport/genericsetup/configure.zcml
+++ b/src/senaite/core/exportimport/genericsetup/configure.zcml
@@ -25,6 +25,7 @@
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.ATReferenceFieldNodeAdapter"/>
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.ATUIDReferenceFieldNodeAdapter"/>
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.ATRecordFieldNodeAdapter"/>
+  <adapter provides=".interfaces.IFieldNode" factory=".adapters.ATRichTextFieldNodeAdapter"/>
 
   <!-- DX Field Adapters
        Know how to Import/Export field values
@@ -32,6 +33,7 @@
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXFieldNodeAdapter"/>
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXNamedFileFieldNodeAdapter"/>
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXDateTimeFieldNodeAdapter"/>
+  <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXRichTextFieldNodeAdapter"/>
 
   <class class="senaite.core.browser.fields.record.RecordField">
     <implements interface=".interfaces.IRecordField" />

--- a/src/senaite/core/exportimport/genericsetup/configure.zcml
+++ b/src/senaite/core/exportimport/genericsetup/configure.zcml
@@ -11,7 +11,8 @@
       <adapter factory=".structure.SenaiteSiteXMLAdapter"/>
   -->
   <adapter factory=".structure.ATContentXMLAdapter"/>
-  <adapter factory=".structure.DXContentXMLAdapter"/>
+  <adapter factory=".structure.DXContainerXMLAdapter"/>
+  <adapter factory=".structure.DXItemXMLAdapter"/>
 
   <!-- AT Field Adapters
        Know how to Import/Export field values

--- a/src/senaite/core/exportimport/genericsetup/structure.py
+++ b/src/senaite/core/exportimport/genericsetup/structure.py
@@ -470,10 +470,13 @@ def create_or_get(parent, id, uid, portal_type):
     else:
         # Create DX Content Slug
         factory = getUtility(IFactory, fti.factory)
-        obj = factory(uid)
+        tmp_id = str(uid)
+        obj = factory(tmp_id)
         if hasattr(obj, "_setPortalTypeName"):
             obj._setPortalTypeName(fti.getId())
         notify(ObjectCreatedEvent(obj))
+        parent._setObject(tmp_id, obj)
+        obj = parent._getOb(api.get_id(obj))
 
     return obj
 

--- a/src/senaite/core/exportimport/genericsetup/structure.py
+++ b/src/senaite/core/exportimport/genericsetup/structure.py
@@ -33,6 +33,7 @@ from Products.CMFPlone.utils import safe_unicode
 from Products.GenericSetup.interfaces import IBody
 from Products.GenericSetup.interfaces import INode
 from Products.GenericSetup.interfaces import ISetupEnviron
+from Products.GenericSetup.utils import I18NURI
 from Products.GenericSetup.utils import ObjectManagerHelpers
 from Products.GenericSetup.utils import XMLAdapterBase
 from zope.component import adapts
@@ -218,6 +219,18 @@ class ContentXMLAdapter(SenaiteSiteXMLAdapter):
 
     def __init__(self, context, environ):
         super(ContentXMLAdapter, self).__init__(context, environ)
+
+    def _getObjectNode(self, name, i18n=True):
+        node = self._doc.createElement(name)
+        # Attach the UID of the object as well
+        node.setAttribute("uid", api.get_uid(self.context))
+        node.setAttribute("name", self.context.getId())
+        node.setAttribute("meta_type", self.context.meta_type)
+        i18n_domain = getattr(self.context, "i18n_domain", None)
+        if i18n and i18n_domain:
+            node.setAttributeNS(I18NURI, "i18n:domain", i18n_domain)
+            self._i18n_props = ("title", "description")
+        return node
 
     def _exportNode(self):
         """Export the object as a DOM node.

--- a/src/senaite/core/exportimport/genericsetup/structure.py
+++ b/src/senaite/core/exportimport/genericsetup/structure.py
@@ -474,6 +474,8 @@ def create_or_get(parent, id, uid, portal_type):
         obj = factory(tmp_id)
         if hasattr(obj, "_setPortalTypeName"):
             obj._setPortalTypeName(fti.getId())
+        # set the old UID to maintain references
+        setattr(obj, "_plone.uuid", uid)
         notify(ObjectCreatedEvent(obj))
         parent._setObject(tmp_id, obj)
         obj = parent._getOb(api.get_id(obj))

--- a/src/senaite/core/exportimport/genericsetup/structure.py
+++ b/src/senaite/core/exportimport/genericsetup/structure.py
@@ -56,6 +56,8 @@ SKIP_TYPES = [
 
 
 class SenaiteSiteXMLAdapter(XMLAdapterBase, ObjectManagerHelpers):
+    """Adapter for the SENAITE root object (portal)
+    """
     adapts(ISenaiteSiteRoot, ISetupEnviron)
 
     def __init__(self, context, environ):

--- a/src/senaite/core/exportimport/genericsetup/structure.py
+++ b/src/senaite/core/exportimport/genericsetup/structure.py
@@ -234,10 +234,11 @@ class ATContentXMLAdapter(SenaiteSiteXMLAdapter):
     def _getObjectNode(self, name, i18n=True):
         node = self._doc.createElement(name)
         # Attach the UID of the object as well
-        node.setAttribute("uid", api.get_uid(self.context))
         node.setAttribute("id", api.get_id(self.context))
+        node.setAttribute("uid", api.get_uid(self.context))
         node.setAttribute("name", api.get_id(self.context))
         node.setAttribute("meta_type", self.context.meta_type)
+        node.setAttribute("portal_type", api.get_portal_type(self.context))
         i18n_domain = getattr(self.context, "i18n_domain", None)
         if i18n and i18n_domain:
             node.setAttributeNS(I18NURI, "i18n:domain", i18n_domain)
@@ -414,7 +415,7 @@ def create_content_slugs(parent, parent_path, context):
         # extract node attributes (see `_exportNode` method)
         child_id = child.getAttribute("name")
         child_uid = child.getAttribute("uid")
-        portal_type = child.getAttribute("meta_type")
+        portal_type = child.getAttribute("portal_type")
         # get or create object
         obj = create_or_get(parent, child_id, child_uid, portal_type)
         # handle vanished objects

--- a/src/senaite/core/exportimport/genericsetup/structure.py
+++ b/src/senaite/core/exportimport/genericsetup/structure.py
@@ -36,6 +36,7 @@ from Products.GenericSetup.interfaces import ISetupEnviron
 from Products.GenericSetup.utils import I18NURI
 from Products.GenericSetup.utils import ObjectManagerHelpers
 from Products.GenericSetup.utils import XMLAdapterBase
+from senaite.core.p3compat import cmp
 from zope.component import adapts
 from zope.component import queryMultiAdapter
 from zope.interface import alsoProvides

--- a/src/senaite/core/p3compat.py
+++ b/src/senaite/core/p3compat.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+# Python 3 compatibility module
+
+
+def cmp(a, b):
+    """Polyfill for the `cmp` builtin function
+
+    https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
+
+    The cmp() function should be treated as gone, and the __cmp__() special
+    method is no longer supported. Use __lt__() for sorting, __eq__() with
+    __hash__(), and other rich comparisons as needed. (If you really need the
+    cmp() functionality, you could use the expression (a > b) - (a < b) as the
+    equivalent for cmp(a, b).)
+    """
+    return (a > b) - (a < b)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR improves the Generic Setup Structure Import/Export for SENAITE.

## Current behavior before PR

- IDServer empty after import
- DX Types not supported
- Import overwrites existing contents by ID
- Error during import when FTI does not exist

## Desired behavior after PR is merged

- New IDs created according to the formatting for all imported contents
- DX Types (e.g. dynamic analysisspecs, resultsinterpretation templates) supported
- Import overwrites when UID matches
- Import skips objects w/o FTI

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
