### PR TITLE
Allow input of date ranges between +- 150 years

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #1681 Allow input of date ranges between +- 150 years
 - #1678 Improved Generic Setup Content Structure Export/Import
 - #1676 New Field "Department ID" added to Departments
 - #1675 Fix error when setting WS template layout

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/datetimewidget.js
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/datetimewidget.js
@@ -15,7 +15,7 @@ document.addEventListener("DOMContentLoaded", () => {
       dateFormat: "yy-mm-dd",
       changeMonth: true,
       changeYear: true,
-      yearRange: "-50:+20"
+      yearRange: "-150:+150"
     }));
 
   $('[datetimepicker="1"]').datetimepicker(
@@ -26,19 +26,29 @@ document.addEventListener("DOMContentLoaded", () => {
       timeFormat: "HH:mm",
       changeMonth: true,
       changeYear: true,
-      yearRange: "-100:+2"
+      yearRange: "-150:+150"
     }));
 
   $('[datepicker_nofuture="1"]').on("click", function() {
-    $(this).datepicker("option", "maxDate", "0")
-      .click(function() { $(this).attr("value", ""); })
-      .focus();
+    $(this).datepicker("option", {
+      maxDate: "0",
+      changeMonth: true,
+      changeYear: true,
+      yearRange: "-150:+0"
+    })
+    .click(function() { $(this).attr("value", ""); })
+    .focus();
   });
 
   $('[datepicker_nopast="1"]').on("click", function() {
-    $(this).datepicker("option", "minDate", "0")
-      .click(function() { $(this).attr("value", ""); })
-      .focus();
+    $(this).datepicker("option", {
+      minDate: "0",
+      changeMonth: true,
+      changeYear: true,
+      yearRange: "-0:+150"
+    })
+    .click(function() { $(this).attr("value", ""); })
+    .focus();
   });
 
 });


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes allows the selection of +- 150 years in date widgets.

## Current behavior before PR

Selectable date ranges not consistent and sometimes only back to 1970

## Desired behavior after PR is merged

Selectable date ranges can be +- 150 years from today

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
