### PR TITLE
Fix Attribute Error when creating invoice PDF

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #1683 Fix Attribute Error when creating invoice PDF
 - #1681 Allow input of date ranges between +- 150 years
 - #1678 Improved Generic Setup Content Structure Export/Import
 - #1676 New Field "Department ID" added to Departments

--- a/src/bika/lims/browser/analysisrequest/invoice.py
+++ b/src/bika/lims/browser/analysisrequest/invoice.py
@@ -179,12 +179,11 @@ class InvoiceCreate(InvoicePrintView):
         sample = self.context
         # create first the invoice so that we have a unique invoice ID
         invoice = sample.createInvoice(None)
-        # check if an invoice PDF was already created
-        if invoice.getInvoicePDF() is None:
-            # create then the PDF with the new invoice ID
-            pdf = self.create_pdf()
-            # set it to the invoice object
-            invoice.setInvoicePDF(pdf)
+        # create then the PDF with the invoice ID
+        pdf = self.create_pdf()
+        # set it to the invoice object
+        invoice.setInvoicePDF(pdf)
+        # set message and redirect back
         self.add_status_message(_("Invoice {} created").format(
             api.get_id(invoice)))
         self.request.response.redirect(

--- a/src/bika/lims/browser/analysisrequest/templates/invoice_content.pt
+++ b/src/bika/lims/browser/analysisrequest/templates/invoice_content.pt
@@ -49,6 +49,17 @@
             </span>
           </td>
         </tr>
+        <!-- Invoice Date -->
+        <tr>
+          <td>
+            <label i18n:translate="">Invoice Date</label>
+          </td>
+          <td>
+            <span tal:condition="nocall:invoice">
+              <span tal:content="python:view.to_localized_time(invoice.getInvoiceDate())"/>
+            </span>
+          </td>
+        </tr>
         <!-- Client Reference -->
         <tr>
           <td>

--- a/src/bika/lims/browser/analysisrequest/templates/invoice_content.pt
+++ b/src/bika/lims/browser/analysisrequest/templates/invoice_content.pt
@@ -1,11 +1,11 @@
 <div id="invoice"
   i18n:domain="senaite.core"
-  tal:define="sample view/sample;
-              invoice sample/Invoice;">
+  tal:define="sample nocall:view/sample;
+              invoice nocall:sample/Invoice;">
 
   <tal:css>
     <style type="text/css">
-     #invoice { font-size: 9pt; }
+     #invoice { font-size: 9pt; font-family: Helvetica, Arial, Sans-Serif; }
      #invoice table { border: none; }
      #invoice table tr { background-color: transparent; }
      #invoice table th { border-style: solid none; }
@@ -14,7 +14,12 @@
     </style>
   </tal:css>
 
-  <h1 i18n:translate="">Invoice</h1>
+  <h1>
+    <span tal:omit-tag="" i18n:translate="">Invoice</span>
+    <span tal:replace="invoice/getId|default">
+      <span tal:omit-tag="" i18n:translate="">Proforma (Not yet invoiced)</span>
+    </span>
+  </h1>
 
   <!-- Invoice Header -->
   <div class="row">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an attribute error that occurred when an invoice PDF was created.
Furthermore, the generated Invoice ID was not correctly displayed in the PDF 

## Current behavior before PR

- Attribute error occurred on Invoice PDF creation:

```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module bika.lims.browser.analysisrequest.invoice, line 182, in __call__
AttributeError: 'InvoiceCreate' object has no attribute 'aq_parent'
```

- Invoice ID was not correctly displayed in the PDF

## Desired behavior after PR is merged

- Invoice PDF creates w/o errors
- Invoice ID correctly set

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
