### PR TITLE
Show only active dynamic analysisspecs in reference widget

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #1684 Show only active dynamic analysisspecs in reference widget
 - #1683 Fix Attribute Error when creating invoice PDF
 - #1681 Allow input of date ranges between +- 150 years
 - #1678 Improved Generic Setup Content Structure Export/Import

--- a/src/bika/lims/content/analysisspec.py
+++ b/src/bika/lims/content/analysisspec.py
@@ -67,6 +67,7 @@ schema = Schema((
             showOn=True,
             catalog_name=SETUP_CATALOG,
             base_query=dict(
+                is_active=True,
                 sort_on="sortable_title",
                 sort_order="ascending"
             ),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the base query of the dynamic analysisspecs reference widget inside analysis specifications

## Current behavior before PR

Inactive dynamic analysis specs were displayed

## Desired behavior after PR is merged

Only active dynamic analysis specs are displayed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
