### PR TITLE
Sample's header table fields are not validated on submit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #1687 Fix Sample's header table fields are not validated on submit
 - #1683 Fix Attribute Error when creating invoice PDF
 - #1681 Allow input of date ranges between +- 150 years
 - #1678 Improved Generic Setup Content Structure Export/Import

--- a/src/bika/lims/browser/header_table.py
+++ b/src/bika/lims/browser/header_table.py
@@ -69,19 +69,16 @@ class HeaderTableView(BrowserView):
                 if value is None:
                     continue
 
+                # Keep track of field-values
+                field_values.update({field: value})
+
                 # Cache the field value in the request
                 self.request[field.getName()] = value
 
                 # Validate the field values
                 err = field.validate(value, self.context)
                 if err:
-                    # Clear field values and add the error
                     errors.update({field.getName(): err})
-                    field_values = {}
-
-                elif not errors:
-                    # Only update the field value if no errors
-                    field_values.update({field: value})
 
             if errors:
                 self.request["errors"] = errors
@@ -99,6 +96,7 @@ class HeaderTableView(BrowserView):
                 # notify object edited event
                 event.notify(ObjectEditedEvent(self.context))
                 self.context.plone_utils.addPortalMessage(message, "info")
+
         return self.template()
 
     def get_field_value(self, field, form):

--- a/src/bika/lims/browser/header_table.py
+++ b/src/bika/lims/browser/header_table.py
@@ -120,10 +120,6 @@ class HeaderTableView(BrowserView):
         # other fields
         return form[fieldname]
 
-    def is_valid(self, field, value):
-        invalid = field.validate(value, self.context)
-        return invalid is None
-
     @viewcache.memoize
     def is_primary_with_partitions(self):
         """Check if the Sample is a primary with partitions

--- a/src/bika/lims/browser/templates/header_table.pt
+++ b/src/bika/lims/browser/templates/header_table.pt
@@ -17,7 +17,8 @@
                 root_sample python:view.is_primary_with_partitions();
                 dummy python:view.get_fields_grouped_by_location();
                 prominent python:dummy[0];
-                sublists python:dummy[1]"
+                sublists python:dummy[1];
+                errors python:request.get('errors',{})"
     tal:condition="sublists">
     <form method="post" name="header_form">
       <input type="hidden" name="header_table_submitted" value="1" />
@@ -33,8 +34,7 @@
                            editable python:mode=='edit';
                            primary_bound python:getattr(field, 'primary_bound', False);
                            widget python:field.widget;
-                           accessor python:field.getAccessor(context);
-                           errors python:{};">
+                           accessor python:field.getAccessor(context);">
             <td class="active label">
               <span tal:replace="python:widget.label"/>
               <!-- Display a notification icon if the field is primary bound
@@ -78,8 +78,7 @@
                                editable python:mode=='edit';
                                primary_bound python:getattr(field, 'primary_bound', False);
                                widget python:field.widget;
-                               accessor python:field.getAccessor(context);
-                               errors python:{};">
+                               accessor python:field.getAccessor(context);">
                 <td tal:attributes="class python:row_nr%2 and 'key odd active label' or 'key even active label'">
                   <span tal:replace="python:widget.label"/>
                   <!-- Display a notification icon if the field is primary bound


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
This Pull Request validates the values submitted for fields displayed in Sample's edit view and displays a message if errors are found.

## Current behavior before PR

The values for fields displayed in the Sample's edit view (header table) are not validated on submit

## Desired behavior after PR is merged

The values for fields displayed in the Sample's edit view (header table) are validated on submit

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
