### PR TITLE
Handle UnicodeDecodeError when generating department IDs

### DIFF
--- a/src/senaite/core/upgrade/v02_00_000.py
+++ b/src/senaite/core/upgrade/v02_00_000.py
@@ -231,6 +231,12 @@ def initialize_department_id_field(portal):
         while new_id in department_ids:
             idx += 1
             new_id = "".join(map(lambda p: p[0:idx], parts))
+        try:
+            # check if the new ID is avalid UTF8
+            new_id = new_id.decode("utf8")
+        except UnicodeDecodeError:
+            # fallback to title
+            new_id = title
         department_ids.append(new_id)
         obj.setDepartmentID(new_id)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes non-UTF8 generated department IDs in the setuphandler

## Current behavior before PR

UnicodeDecodeError raises when the department title contains unicode characters

## Desired behavior after PR is merged

The title of the department is used as fallback when the generated ID is not UTF-8 compliant

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
