### PR TITLE
Display tabs in content edit view when more than one group

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
-- #1688 Display tabs in content edit view when more than one group
+- #1689 Display tabs in content edit view when more than one group
 - #1685 Remove Supply Orders
 - #1684 Show only active dynamic analysisspecs in reference widget
 - #1687 Fix Sample's header table fields are not validated on submit

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #1688 Display tabs in content edit view when more than one group
 - #1685 Remove Supply Orders
 - #1684 Show only active dynamic analysisspecs in reference widget
 - #1687 Fix Sample's header table fields are not validated on submit

--- a/src/senaite/core/browser/dexterity/templates/macros.pt
+++ b/src/senaite/core/browser/dexterity/templates/macros.pt
@@ -87,7 +87,8 @@
           <metal:block define-slot="formtop" />
 
           <!-- navigation tabs -->
-          <ul class="nav nav-tabs" role="tablist">
+          <ul class="nav nav-tabs" role="tablist"
+              tal:condition="python: has_groups and enable_form_tabbing">
 
             <!-- primary tab -->
             <li class="nav-item" role="presentation"
@@ -103,7 +104,7 @@
             </li>
 
             <!-- secondary tabs -->
-            <li tal:repeat="group groups" tal:condition="has_groups" class="nav-item" role="presentation">
+            <li tal:repeat="group groups" class="nav-item" role="presentation">
               <a tal:define="normalizeString nocall:context/@@plone/normalizeString;
                              fieldset_label group/label;
                              fieldset_name python:getattr(group, '__name__', False) or getattr(group.label, 'default', False) or fieldset_label;


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request hides the "Default" tab from content edit view when is the only form group

## Current behavior before PR

"Default" tab in content edit view is always displayed, even if only one group defined

## Desired behavior after PR is merged

"Default" tab in content edit view is displayed when there is more than one group defined

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
