### PR TITLE
Fix immediate logout when timeout exceeds 32 bit integer value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #1691 Fix immediate logout when timeout exceeds 32 bit integer value
 - #1689 Display tabs in content edit view when more than one group
 - #1682 Fix `LocationError` when editing a entry in the configuration registry
 - #1685 Remove Supply Orders

--- a/webpack/app/senaite.core.js
+++ b/webpack/app/senaite.core.js
@@ -41,9 +41,15 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Auto LogOff
   var logoff = document.body.dataset.autoLogoff || 0;
-  var logged = document.body.classList.contains('userrole-authenticated');
+  var logged = document.body.classList.contains("userrole-authenticated");
+  // Max value for setTimeout is a 32 bit integer
+  const max_timeout = 2**31 - 1;
   if (logoff > 0 && logged) {
     var logoff_ms = logoff * 60 * 1000;
+    if (logoff_ms > max_timeout) {
+      console.warn(`Setting logoff_ms to max value ${max_timeout}ms`);
+      logoff_ms = max_timeout;
+    }
     setTimeout(function() {
       location.href = window.portal_url + "/logout";
     }, logoff_ms);


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the immediate logoff execution when the timeout exceeds the maximum allowed value.

## Current behavior before PR

Logout executed immediately when the value of the calculated milliseconds exceeded a 32 Bit integer value

## Desired behavior after PR is merged

Logout milliseconds set to 32 Bit integer value if exceeded

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
