### PR TITLE
Fix interims with choices are not displayed in listings after a while

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #1696 Fix interims with choices are not displayed in listings after a while
 - #1695 Fix form submission for required multi-reference fields
 - #1693 Fix Datepicker localization
 - #1691 Fix immediate logout when timeout exceeds 32 bit integer value

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -820,7 +820,8 @@ class AnalysesView(BikaListingView):
 
         # Set interim fields. Note we add the key 'formatted_value' to the list
         # of interims the analysis has already assigned.
-        interim_fields = analysis_brain.getInterimFields or list()
+        analysis_obj = self.get_object(analysis_brain)
+        interim_fields = analysis_obj.getInterimFields() or list()
 
         # Copy to prevent to avoid persistent changes
         interim_fields = copy(interim_fields)

--- a/src/bika/lims/catalog/analysis_catalog.py
+++ b/src/bika/lims/catalog/analysis_catalog.py
@@ -80,7 +80,6 @@ _columns_list = [
     "getUnit",
     "getKeyword",
     "getCategoryTitle",
-    "getInterimFields",
     "getRemarks",
     "getRetestOfUID",
     "getDateSampled",


### PR DESCRIPTION
# Description of the issue/feature this PR addresses

When a value is set to an interim with choices, the listing initially displays the value correctly because remains in `senaite.app.listing` cache, but as soon as the list is filtered or the page refreshed, the value is not displayed anymore. Listing grabs the interims from the brain directly (`getInterimFields` metadata column), but even that `set_field` endpoint from `senaite.app.listing` stores the value and reindexes the analysis object, the value of the metadata field remains unchanged.

This metadata column is only used in analysis listing and we already wake-up the analysis object to grab other properties while rendering the list, so there is no advantage at all of having this metadata column.

Also, the fact that interims field is stored as a dict requires special care when storing/updating this value in ZODB. Again, because of the limited use of it, the complexity it entails is not worth.

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR

Values of interims with choices are not displayed in listings after save and on refresh

## Desired behavior after PR is merged

Values of interims with choices are displayed correctly after save and on refresh

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
