### PR TITLE
Remove Analysis Specifications from AR Add Form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #1702 Remove Analysis Specifications from AR Add Form
 - #1700 Better styling of header and description in content views
 - #1690 Added ContentSectionViewletManager to allow dynamic addition of sections
 - #1698 Apply focus styling for setup view tiles when tabbing

--- a/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -486,57 +486,6 @@
                             &#9432;
                           </div>
 
-                          <tal:specifications tal:condition="python:view.is_ar_specs_allowed()">
-                            <!-- Specifications -->
-                            <div tal:define="fieldname string:Specifications-${arnum};
-                                             specifications python:view.specifications.get(arnum);
-                                             service_spec python:specifications.get(service_keyword, {})"
-                                 tal:attributes="fieldname string:${fieldname};
-                                                 uid service_uid;
-                                                 arnum arnum;
-                                                 id string:${service_uid}-${arnum}-specifications;
-                                                 class string:service-specifications ${service_uid}-specifications d-sm-flex justify-content-center;">
-                              <input type="hidden"
-                                     tal:attributes="name string:${fieldname}.uid:records;
-                                                     value string:${service_uid}"/>
-                              <input type="hidden"
-                                     tal:attributes="name string:${fieldname}.keyword:records;
-                                                     value string:${service_keyword}"/>
-                              <input type="text"
-                                     class="form-control warn_min"
-                                     size="1"
-                                     placeholder="&lt;min"
-                                     title="&lt;min"
-                                     i18n:attributes="placeholder"
-                                     tal:attributes="name string:${fieldname}.warn_min:records;
-                                                     value python:service_spec.get('warn_min');"/>
-                              <input type="text"
-                                     class="form-control min"
-                                     size="1"
-                                     placeholder="&gt;min"
-                                     title="&gt;min"
-                                     i18n:attributes="placeholder;title"
-                                     tal:attributes="name string:${fieldname}.min:records;
-                                                     value python:service_spec.get('min');"/>
-                              <input type="text"
-                                     class="form-control max"
-                                     size="1"
-                                     placeholder="&lt;max"
-                                     title="&lt;max"
-                                     i18n:attributes="placeholder;title"
-                                     tal:attributes="name string:${fieldname}.max:records;
-                                                     value python:service_spec.get('max');"/>
-                              <input type="text"
-                                     class="form-control warn_max"
-                                     size="1"
-                                     placeholder="&gt;max"
-                                     title="&gt;max"
-                                     i18n:attributes="placeholder;title"
-                                     tal:attributes="name string:${fieldname}.warn_max:records;
-                                                     value python:service_spec.get('warn_max');"/>
-                            </div>
-                          </tal:specifications>
-
                           <!-- Service Info Box -->
                           <div tal:attributes="id string:${service_uid}-info;
                                                class string:${service_uid}-info service-info;">

--- a/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
@@ -27,11 +27,9 @@
       this.on_analysis_template_changed = bind(this.on_analysis_template_changed, this);
       this.on_analysis_lock_button_click = bind(this.on_analysis_lock_button_click, this);
       this.on_analysis_details_click = bind(this.on_analysis_details_click, this);
-      this.on_analysis_specification_changed = bind(this.on_analysis_specification_changed, this);
       this.on_referencefield_value_changed = bind(this.on_referencefield_value_changed, this);
       this.hide_all_service_info = bind(this.hide_all_service_info, this);
       this.get_service = bind(this.get_service, this);
-      this.set_service_spec = bind(this.set_service_spec, this);
       this.set_service = bind(this.set_service, this);
       this.set_template = bind(this.set_template, this);
       this.get_reference_field_value = bind(this.get_reference_field_value, this);
@@ -93,10 +91,6 @@
       $("body").on("click", "tr[fieldname=InvoiceExclude] input[type='checkbox']", this.recalculate_records);
       $("body").on("click", "tr[fieldname=Analyses] input[type='checkbox']", this.on_analysis_checkbox_click);
       $("body").on("selected change", "input[type='text'].referencewidget", this.on_referencefield_value_changed);
-      $("body").on("change", "input.min", this.on_analysis_specification_changed);
-      $("body").on("change", "input.max", this.on_analysis_specification_changed);
-      $("body").on("change", "input.warn_min", this.on_analysis_specification_changed);
-      $("body").on("change", "input.warn_max", this.on_analysis_specification_changed);
       $("body").on("click", ".service-lockbtn", this.on_analysis_lock_button_click);
       $("body").on("click", ".service-infobtn", this.on_analysis_details_click);
       $("body").on("selected change", "tr[fieldname=Template] input[type='text']", this.on_analysis_template_changed);
@@ -257,7 +251,7 @@
       $(".service-lockbtn").hide();
       return $.each(records, function(arnum, record) {
         var discard;
-        discard = ["service_metadata", "specification_metadata", "template_metadata"];
+        discard = ["service_metadata", "template_metadata"];
         $.each(record, function(name, metadata) {
           if (indexOf.call(discard, name) >= 0 || !name.endsWith("_metadata")) {
             return;
@@ -276,11 +270,6 @@
         });
         $.each(record.template_metadata, function(uid, template) {
           return me.set_template(arnum, template);
-        });
-        $.each(record.specification_metadata, function(uid, spec) {
-          return $.each(spec.specifications, function(uid, service_spec) {
-            return me.set_service_spec(arnum, uid, service_spec);
-          });
         });
         return $.each(record.unmet_dependencies, function(uid, dependencies) {
           var context, dialog, service;
@@ -679,24 +668,6 @@
       return $(this).trigger("services:changed");
     };
 
-    AnalysisRequestAdd.prototype.set_service_spec = function(arnum, uid, spec) {
-
-      /*
-       * Set the specification of the service
-       */
-      var el, max, min, warn_max, warn_min;
-      console.debug("*** set_service_spec::AR=" + arnum + " UID=" + uid + " spec=", spec);
-      el = $("div#" + uid + "-" + arnum + "-specifications");
-      min = $(".min", el);
-      max = $(".max", el);
-      warn_min = $(".warn_min", el);
-      warn_max = $(".warn_max", el);
-      min.val(spec.min);
-      max.val(spec.max);
-      warn_min.val(spec.warn_min);
-      return warn_max.val(spec.warn_max);
-    };
-
     AnalysisRequestAdd.prototype.get_service = function(uid) {
 
       /*
@@ -792,23 +763,12 @@
       return $(me).trigger("form:changed");
     };
 
-    AnalysisRequestAdd.prototype.on_analysis_specification_changed = function(event) {
-
-      /*
-       * Eventhandler when the specification of an analysis service changed
-       */
-      var me;
-      console.debug("°°° on_analysis_specification_changed °°°");
-      me = this;
-      return $(me).trigger("form:changed");
-    };
-
     AnalysisRequestAdd.prototype.on_analysis_details_click = function(event) {
 
       /*
        * Eventhandler when the user clicked on the info icon of a service.
        */
-      var $el, arnum, context, data, el, extra, info, profiles, record, specifications, template, templates, uid;
+      var $el, arnum, context, data, el, extra, info, profiles, record, template, templates, uid;
       el = event.currentTarget;
       $el = $(el);
       uid = $el.attr("uid");
@@ -819,8 +779,7 @@
       data = info.data("data");
       extra = {
         profiles: [],
-        templates: [],
-        specifications: []
+        templates: []
       };
       record = this.records_snapshot[arnum];
       if (uid in record.service_to_profiles) {
@@ -833,12 +792,6 @@
         templates = record.service_to_templates[uid];
         $.each(templates, function(index, uid) {
           return extra["templates"].push(record.template_metadata[uid]);
-        });
-      }
-      if (uid in record.service_to_specifications) {
-        specifications = record.service_to_specifications[uid];
-        $.each(specifications, function(index, uid) {
-          return extra["specifications"].push(record.specification_metadata[uid]);
         });
       }
       if (!data) {

--- a/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -78,11 +78,6 @@ class window.AnalysisRequestAdd
     # Generic onchange event handler for reference fields
     $("body").on "selected change" , "input[type='text'].referencewidget", @on_referencefield_value_changed
 
-    # Analysis Specification changed
-    $("body").on "change", "input.min", @on_analysis_specification_changed
-    $("body").on "change", "input.max", @on_analysis_specification_changed
-    $("body").on "change", "input.warn_min", @on_analysis_specification_changed
-    $("body").on "change", "input.warn_max", @on_analysis_specification_changed
     # Analysis lock button clicked
     $("body").on "click", ".service-lockbtn", @on_analysis_lock_button_click
     # Analysis info button clicked
@@ -247,10 +242,10 @@ class window.AnalysisRequestAdd
     $.each records, (arnum, record) ->
 
       # Apply the values generically, but those to be handled differently
-      discard = ["service_metadata", "specification_metadata", "template_metadata"]
+      discard = ["service_metadata", "template_metadata"]
       $.each record, (name, metadata) ->
         # Discard those fields that will be handled differently and those that
-        # do not contain explicit object metadata (e.g service_to_specification)
+        # do not contain explicit object metadata
         if name in discard or !name.endsWith("_metadata")
           return
         $.each metadata, (uid, obj_info) ->
@@ -273,11 +268,6 @@ class window.AnalysisRequestAdd
       # set template
       $.each record.template_metadata, (uid, template) ->
         me.set_template arnum, template
-
-      # set specification
-      $.each record.specification_metadata, (uid, spec) ->
-        $.each spec.specifications, (uid, service_spec) ->
-          me.set_service_spec arnum, uid, service_spec
 
       # handle unmet dependencies, one at a time
       $.each record.unmet_dependencies, (uid, dependencies) ->
@@ -687,26 +677,6 @@ class window.AnalysisRequestAdd
     $(@).trigger "services:changed"
 
 
-  set_service_spec: (arnum, uid, spec) =>
-    ###
-     * Set the specification of the service
-    ###
-    console.debug "*** set_service_spec::AR=#{arnum} UID=#{uid} spec=", spec
-
-    # get the service specifications
-    el = $("div##{uid}-#{arnum}-specifications")
-
-    min = $(".min", el)
-    max = $(".max", el)
-    warn_min = $(".warn_min", el)
-    warn_max = $(".warn_max", el)
-
-    min.val spec.min
-    max.val spec.max
-    warn_min.val spec.warn_min
-    warn_max.val spec.warn_max
-
-
   get_service: (uid) =>
     ###
      * Fetch the service data from server by UID
@@ -801,18 +771,6 @@ class window.AnalysisRequestAdd
     $(me).trigger "form:changed"
 
 
-  on_analysis_specification_changed: (event) =>
-    ###
-     * Eventhandler when the specification of an analysis service changed
-    ###
-    console.debug "°°° on_analysis_specification_changed °°°"
-
-    me = this
-
-    # trigger form:changed event
-    $(me).trigger "form:changed"
-
-
   on_analysis_details_click: (event) =>
     ###
      * Eventhandler when the user clicked on the info icon of a service.
@@ -833,7 +791,6 @@ class window.AnalysisRequestAdd
     extra =
       profiles: []
       templates: []
-      specifications: []
 
     # get the current snapshot record for this column
     record = @records_snapshot[arnum]
@@ -849,12 +806,6 @@ class window.AnalysisRequestAdd
       templates = record.service_to_templates[uid]
       $.each templates, (index, uid) ->
         extra["templates"].push record.template_metadata[uid]
-
-    # inject specification info
-    if uid of record.service_to_specifications
-      specifications = record.service_to_specifications[uid]
-      $.each specifications, (index, uid) ->
-        extra["specifications"].push record.specification_metadata[uid]
 
     if not data
       @get_service(uid).done (data) ->


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the min/max and warn_min/warn_max fields from the Analyses in AR Add Form.

This reduces the rendering time more than 50%.

## Current behavior before PR

For each service in each column these 4 input fields were rendered to set ranges during sample registration.

## Desired behavior after PR is merged

Individual Analysis Specifications removed from AR Add Form.

Specification ranges should be set with a single Analysis Specification Object or by the lab personell via the Manage Analyses View

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
