### PR TITLE
Cannot override behavior of LabContacts folder when using `before_render` and added `Roles` column

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 
 **Fixed**
 
-- #1704 Fix Cannot override behavior of LabContacts folder when using `before_render`
+- #1704 Fix Cannot override behavior of LabContacts folder on `before_render`
 - #1680 Fix Selected instrument is not assigned to analyses in Worksheet
 - #1673 Fix Samples not sorted in natural order when Worksheet Template is used
 - #1656 Fix Maximum length of Choices subfield (interim) is set to 40
@@ -24,7 +24,7 @@ Changelog
 
 **Added**
 
-- #1704 Add the User Roles column in Lab Contacts list
+- #1704 Add "User name" and "User groups" columns in Lab Contacts list
 - #1612 Add Client sample ID to worksheet template printview
 - #1609 Support result options entry for interim values
 - #1598 Added "modified" index in Sample's (AnalysisRequest) catalog

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Fixed**
 
+- #1704 Fix Cannot override behavior of LabContacts folder when using `before_render`
 - #1680 Fix Selected instrument is not assigned to analyses in Worksheet
 - #1673 Fix Samples not sorted in natural order when Worksheet Template is used
 - #1656 Fix Maximum length of Choices subfield (interim) is set to 40
@@ -23,6 +24,7 @@ Changelog
 
 **Added**
 
+- #1704 Add the User Roles column in Lab Contacts list
 - #1612 Add Client sample ID to worksheet template printview
 - #1609 Support result options entry for interim values
 - #1598 Added "modified" index in Sample's (AnalysisRequest) catalog

--- a/bika/lims/controlpanel/bika_labcontacts.py
+++ b/bika/lims/controlpanel/bika_labcontacts.py
@@ -112,9 +112,11 @@ class LabContactsView(BikaListingView):
             },
         ]
 
-    def before_render(self):
+    def update(self):
         """Before template render hook
         """
+        super(LabContactsView, self).update()
+
         # Don't allow any context actions
         self.request.set("disable_border", 1)
 

--- a/bika/lims/controlpanel/bika_labcontacts.py
+++ b/bika/lims/controlpanel/bika_labcontacts.py
@@ -22,17 +22,19 @@ import collections
 
 from Products.ATContentTypes.content import schemata
 from Products.Archetypes import atapi
+from plone.app.folder.folder import ATFolder
+from plone.app.folder.folder import ATFolderSchema
+from zope.interface.declarations import implements
+
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
+from bika.lims.api import user as api_user
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.config import PROJECTNAME
 from bika.lims.interfaces import ILabContacts
 from bika.lims.permissions import AddLabContact
 from bika.lims.utils import get_email_link
 from bika.lims.utils import get_link
-from plone.app.folder.folder import ATFolder
-from plone.app.folder.folder import ATFolderSchema
-from zope.interface.declarations import implements
 
 
 # TODO: Separate content and view into own modules!
@@ -169,11 +171,11 @@ class LabContactsView(BikaListingView):
         if user is None:
             roles = ''
         else:
-            ignored_roles = ['Authenticated', 'Member']
+            ignored_roles = ["AuthenticatedUsers"]
             roles = filter(lambda r: r not in ignored_roles,
-                           user.getRoles())
+                           api_user.get_groups(user))
 
-        item["UserRoles"] = ','.join(roles)
+        item["UserRoles"] = ', '.join(sorted(roles))
         return item
 
 

--- a/bika/lims/controlpanel/bika_labcontacts.py
+++ b/bika/lims/controlpanel/bika_labcontacts.py
@@ -91,8 +91,11 @@ class LabContactsView(BikaListingView):
             ("EmailAddress", {
                 "title": _("Email Address"),
                 "toggle": True}),
-            ("UserRoles", {
-                "title": _("User Roles"),
+            ("Username", {
+                "title": _("User name"),
+                "toggle": True}),
+            ("Groups", {
+                "title": _("User groups"),
                 "toggle": True}),
         ))
 
@@ -166,17 +169,23 @@ class LabContactsView(BikaListingView):
         item["BusinessPhone"] = obj.getBusinessPhone()
         item["Fax"] = obj.getBusinessFax()
         item["MobilePhone"] = obj.getMobilePhone()
+        item["Username"] = obj.getUsername()
 
-        user = api.get_user(obj.getUsername())
-        if user is None:
-            roles = ''
-        else:
-            ignored_roles = ["AuthenticatedUsers"]
-            roles = filter(lambda r: r not in ignored_roles,
-                           api_user.get_groups(user))
-
-        item["UserRoles"] = ', '.join(sorted(roles))
+        # Display the groups the user belongs to, if any
+        groups = self.get_user_groups(obj)
+        item["Groups"] = ", ".join(groups)
         return item
+
+    def get_user_groups(self, contact):
+        """Returns the groups from the contact passed-in
+        """
+        username = contact.getUsername()
+        if not username:
+            return []
+
+        skip = ["AuthenticatedUsers"]
+        groups = api_user.get_groups(username)
+        return filter(lambda g: g not in skip, sorted(groups))
 
 
 schema = ATFolderSchema.copy()

--- a/bika/lims/controlpanel/bika_labcontacts.py
+++ b/bika/lims/controlpanel/bika_labcontacts.py
@@ -89,6 +89,9 @@ class LabContactsView(BikaListingView):
             ("EmailAddress", {
                 "title": _("Email Address"),
                 "toggle": True}),
+            ("UserRoles", {
+                "title": _("User Roles"),
+                "toggle": True}),
         ))
 
         self.review_states = [
@@ -162,6 +165,15 @@ class LabContactsView(BikaListingView):
         item["Fax"] = obj.getBusinessFax()
         item["MobilePhone"] = obj.getMobilePhone()
 
+        user = api.get_user(obj.getUsername())
+        if user is None:
+            roles = ''
+        else:
+            ignored_roles = ['Authenticated', 'Member']
+            roles = filter(lambda r: r not in ignored_roles,
+                           user.getRoles())
+
+        item["UserRoles"] = ','.join(roles)
         return item
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`senaite.core`'s LabContacts is used as the "root" listing view for lab contacts listings. Nevertheless, it overrides the function `before_render`. As a result, some changes made in subscriber adapters from another add-ons are omitted. For instance, trying to modify `context_actions` via subscriber adapters won't have any effect because after the call, the value is overridden in LabContacts folder.

It also adds a new column to display the user roles assigned to each contact

This Pull Request, moves the logic for `before_render` from the base class "LabContacts" to the function `update`.

## Current behavior before PR

Cannot override some behavior (e.g., `context_actions`) of LabContacts listing by using subscriber adapters.

## Desired behavior after PR is merged

Can override behavior of LabContacts listing by using subscriber adapters.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
