### PR TITLE
Add "User name" and "User groups" columns in Lab Contacts list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #1706 Add "User name" and "User groups" columns in Lab Contacts listing
 - #1702 Remove Analysis Specifications from AR Add Form
 - #1700 Better styling of header and description in content views
 - #1690 Added ContentSectionViewletManager to allow dynamic addition of sections

--- a/src/bika/lims/controlpanel/bika_labcontacts.py
+++ b/src/bika/lims/controlpanel/bika_labcontacts.py
@@ -24,6 +24,7 @@ from Products.ATContentTypes.content import schemata
 from Products.Archetypes import atapi
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
+from bika.lims.api import user as api_user
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.config import PROJECTNAME
 from bika.lims.interfaces import ILabContacts
@@ -90,6 +91,12 @@ class LabContactsView(BikaListingView):
             ("EmailAddress", {
                 "title": _("Email Address"),
                 "toggle": True}),
+            ("Username", {
+                "title": _("User name"),
+                "toggle": False}),
+            ("Groups", {
+                "title": _("User groups"),
+                "toggle": False}),
         ))
 
         self.review_states = [
@@ -154,8 +161,23 @@ class LabContactsView(BikaListingView):
         item["BusinessPhone"] = obj.getBusinessPhone()
         item["Fax"] = obj.getBusinessFax()
         item["MobilePhone"] = obj.getMobilePhone()
+        item["Username"] = obj.getUsername()
 
+        # Display the groups the user belongs to, if any
+        groups = self.get_user_groups(obj)
+        item["Groups"] = ", ".join(groups)
         return item
+
+    def get_user_groups(self, contact):
+        """Returns the groups from the contact passed-in
+        """
+        username = contact.getUsername()
+        if not username:
+            return []
+
+        skip = ["AuthenticatedUsers"]
+        groups = api_user.get_groups(username)
+        return filter(lambda g: g not in skip, sorted(groups))
 
 
 schema = ATFolderSchema.copy()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Ported from #1704 

## Current behavior before PR

No columns "User name" and "User groups" in Lab Contacts listing

## Desired behavior after PR is merged

Columns "User name" and "User groups" in Lab Contacts listing

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
