### PR TITLE
Make attachments viewlet to rely on permissions, not on statuses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #1711 Make attachments viewlet to rely on permissions, not on statuses
 - #1709 Remove "attachment_due" status from Worksheet and Sample
 - #1709 Consolidated Attachment Options to a single Option
 - #1708 Remove auto versioning for Analysis Services

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -962,6 +962,7 @@ class AnalysesView(BikaListingView):
         if not self.has_permission(ViewResults, obj):
             return
 
+        attachments_names = []
         attachments_html = []
         analysis = self.get_object(obj)
         for at in analysis.getAttachment():
@@ -969,9 +970,11 @@ class AnalysesView(BikaListingView):
             url = "{}/at_download/AttachmentFile".format(api.get_url(at))
             link = get_link(url, at_file.filename, tabindex="-1")
             attachments_html.append(link)
+            attachments_names.append(at_file.filename)
 
         if attachments_html:
             item["replace"]["Attachments"] = "<br/>".join(attachments_html)
+            item["Attachments"] = ", ".join(attachments_names)
 
         elif analysis.getAttachmentRequired():
             img = get_image("warning.png", title=_("Attachment required"))

--- a/src/bika/lims/browser/worksheet/ajax.py
+++ b/src/bika/lims/browser/worksheet/ajax.py
@@ -24,12 +24,13 @@ from operator import itemgetter
 import plone
 import plone.protect
 from bika.lims import FieldEditAnalysisResult
-from bika.lims.api import security
+from bika.lims.api.security import check_permission
 from Products.Archetypes.config import REFERENCE_CATALOG
 from Products.CMFCore.utils import getToolByName
+from Products.Five.browser import BrowserView
 
 
-class AttachAnalyses():
+class AttachAnalyses(BrowserView):
     """ In attachment add form,
         the analyses dropdown combo uses this as source.
         Form is handled by the worksheet ManageResults code
@@ -37,7 +38,7 @@ class AttachAnalyses():
     def __init__(self, context, request):
         self.context = context
         self.request = request
-        
+
     def __call__(self):
         plone.protect.CheckAuthenticator(self.request)
         searchTerm = 'searchTerm' in self.request and self.request['searchTerm'].lower() or ''
@@ -56,7 +57,7 @@ class AttachAnalyses():
         rows = []
         for analysis in analyses:
             # Skip analyses that cannot be edited (attachment not permitted)
-            if not security.check_permission(FieldEditAnalysisResult, analysis):
+            if not check_permission(FieldEditAnalysisResult, analysis):
                 continue
             parent = analysis.getParentTitle()
             rows.append({'analysis_uid': analysis.UID(),
@@ -92,7 +93,7 @@ class AttachAnalyses():
         return json.dumps(ret)
 
 
-class SetAnalyst():
+class SetAnalyst(BrowserView):
     """The Analysis dropdown sets worksheet.Analyst immediately
     """
 
@@ -101,7 +102,6 @@ class SetAnalyst():
         self.request = request
 
     def __call__(self):
-        rc = getToolByName(self.context, REFERENCE_CATALOG)
         mtool = getToolByName(self, 'portal_membership')
         plone.protect.CheckAuthenticator(self.request)
         plone.protect.PostOnly(self.request)
@@ -113,7 +113,7 @@ class SetAnalyst():
         self.context.setAnalyst(value)
 
 
-class SetInstrument():
+class SetInstrument(BrowserView):
     """The Instrument dropdown sets worksheet.Instrument immediately
     """
 

--- a/src/bika/lims/browser/worksheet/ajax.py
+++ b/src/bika/lims/browser/worksheet/ajax.py
@@ -23,10 +23,10 @@ from operator import itemgetter
 
 import plone
 import plone.protect
+from bika.lims import FieldEditAnalysisResult
+from bika.lims.api import security
 from Products.Archetypes.config import REFERENCE_CATALOG
 from Products.CMFCore.utils import getToolByName
-
-from bika.lims.workflow import getCurrentState
 
 
 class AttachAnalyses():
@@ -45,7 +45,6 @@ class AttachAnalyses():
         nr_rows = self.request['rows']
         sord = self.request['sord']
         sidx = self.request['sidx']
-        attachable_states = ('assigned', 'unassigned', 'to_be_verified')
         analysis_to_slot = {}
         for s in self.context.getLayout():
             analysis_to_slot[s['analysis_uid']] = int(s['position'])
@@ -56,8 +55,8 @@ class AttachAnalyses():
                 analyses.append(i)
         rows = []
         for analysis in analyses:
-            review_state = getCurrentState(analysis)
-            if review_state not in attachable_states:
+            # Skip analyses that cannot be edited (attachment not permitted)
+            if not security.check_permission(FieldEditAnalysisResult, analysis):
                 continue
             parent = analysis.getParentTitle()
             rows.append({'analysis_uid': analysis.UID(),

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -977,6 +977,10 @@ schema = BikaSchema.copy() + Schema((
         relationship='AnalysisRequestAttachment',
         mode="rw",
         read_permission=View,
+        # Te addition and removal of attachments is governed by the specific
+        # permissions "Add Sample Attachment" and "Delete Sample Attachment",
+        # so we assume here that the write permission is the less restrictive
+        # "ModifyPortalContent"
         write_permission=ModifyPortalContent,
         widget=ComputedWidget(
             visible={

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -977,7 +977,7 @@ schema = BikaSchema.copy() + Schema((
         relationship='AnalysisRequestAttachment',
         mode="rw",
         read_permission=View,
-        # Te addition and removal of attachments is governed by the specific
+        # The addition and removal of attachments is governed by the specific
         # permissions "Add Sample Attachment" and "Delete Sample Attachment",
         # so we assume here that the write permission is the less restrictive
         # "ModifyPortalContent"

--- a/src/bika/lims/content/worksheet.py
+++ b/src/bika/lims/content/worksheet.py
@@ -1137,16 +1137,6 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
             return ws.absolute_url_path()
         return ''
 
-    def getWorksheetServices(self):
-        """get list of analysis services present on this worksheet
-        """
-        services = []
-        for analysis in self.getAnalyses():
-            service = analysis.getAnalysisService()
-            if service and service not in services:
-                services.append(service)
-        return services
-
     def getQCAnalyses(self):
         """
         Return the Quality Control analyses.

--- a/src/bika/lims/permissions.py
+++ b/src/bika/lims/permissions.py
@@ -125,6 +125,7 @@ TransitionRemoveWorksheet = "senaite.core: Transition: Remove Worksheet"
 SampleAddAttachment = "senaite.core: Sample: Add Attachment"
 SampleEditAttachment = "senaite.core: Sample: Edit Attachment"
 SampleDeleteAttachment = "senaite.core: Sample: Delete Attachment"
+WorksheetAddAttachment = "senaite.core: Worksheet: Add Attachment"
 
 
 # Field Permissions

--- a/src/bika/lims/permissions.py
+++ b/src/bika/lims/permissions.py
@@ -119,6 +119,14 @@ TransitionRejectWorksheet = "senaite.core: Transition: Reject Worksheet"
 TransitionRemoveWorksheet = "senaite.core: Transition: Remove Worksheet"
 
 
+# Type-specific permissions
+# =========================
+# Sample (Analysis Request)
+SampleAddAttachment = "senaite.core: Sample: Add Attachment"
+SampleEditAttachment = "senaite.core: Sample: Edit Attachment"
+SampleDeleteAttachment = "senaite.core: Sample: Delete Attachment"
+
+
 # Field Permissions
 # =================
 # Field permissions (Analysis Request)

--- a/src/bika/lims/permissions.py
+++ b/src/bika/lims/permissions.py
@@ -121,10 +121,14 @@ TransitionRemoveWorksheet = "senaite.core: Transition: Remove Worksheet"
 
 # Type-specific permissions
 # =========================
-# Sample (Analysis Request)
+# Makes "Add Attachment" section from sample context visible
 SampleAddAttachment = "senaite.core: Sample: Add Attachment"
+# Allows to edit "Type", "Keywords" and "Report Option" from attachments, even
+# for those attachment assigned to an analysis
 SampleEditAttachment = "senaite.core: Sample: Edit Attachment"
+# Displays the "Delete" checkbox
 SampleDeleteAttachment = "senaite.core: Sample: Delete Attachment"
+# Makes "Add Attachment" section from worksheet context visible
 WorksheetAddAttachment = "senaite.core: Worksheet: Add Attachment"
 
 
@@ -167,6 +171,8 @@ FieldEditTemplate = "senaite.core: Field: Edit Template"
 
 # Field permissions (Analysis and alike)
 FieldEditAnalysisHidden = "senaite.core: Field: Edit Analysis Hidden"
+# Allows the edition of the result from an Analysis, as well as the assignment,
+# edition or removal of attachment.
 FieldEditAnalysisResult = "senaite.core: Field: Edit Analysis Result"
 FieldEditAnalysisRemarks = "senaite.core: Field: Edit Analysis Remarks"
 

--- a/src/bika/lims/permissions.zcml
+++ b/src/bika/lims/permissions.zcml
@@ -90,6 +90,12 @@
   <permission id="senaite.core.permissions.TransitionRejectWorksheet" title="senaite.core: Transition: Reject Worksheet"/>
   <permission id="senaite.core.permissions.TransitionRemoveWorksheet" title="senaite.core: Transition: Remove Worksheet"/>
 
+  # Object-specific permissions
+  # ---------------------------
+  # Sample (Analysis Request)
+  <permission id="senaite.core.permissions.SampleAddAttachment" title="senaite.core: Sample: Add Attachment"/>
+  <permission id="senaite.core.permissions.SampleEditAttachment" title="senaite.core: Sample: Edit Attachment"/>
+  <permission id="senaite.core.permissions.SampleDeleteAttachment" title="senaite.core: Sample: Delete Attachment"/>
 
   # Field Permissions
   # -----------------

--- a/src/bika/lims/permissions.zcml
+++ b/src/bika/lims/permissions.zcml
@@ -92,10 +92,10 @@
 
   # Object-specific permissions
   # ---------------------------
-  # Sample (Analysis Request)
   <permission id="senaite.core.permissions.SampleAddAttachment" title="senaite.core: Sample: Add Attachment"/>
   <permission id="senaite.core.permissions.SampleEditAttachment" title="senaite.core: Sample: Edit Attachment"/>
   <permission id="senaite.core.permissions.SampleDeleteAttachment" title="senaite.core: Sample: Delete Attachment"/>
+  <permission id="senaite.core.permissions.WorksheetAddAttachment" title="senaite.core: Worksheet: Add Attachment"/>
 
   # Field Permissions
   # -----------------

--- a/src/bika/lims/profiles/default/rolemap.xml
+++ b/src/bika/lims/profiles/default/rolemap.xml
@@ -494,6 +494,25 @@
       <role name="Manager"/>
     </permission>
 
+    <!-- Type-specific permissions -->
+    <permission name="senaite.core: Sample: Add Attachment" acquire="False">
+      <role name="Analyst"/>
+      <role name="LabClerk"/>
+      <role name="LabManager"/>
+      <role name="Manager"/>
+    </permission>
+    <permission name="senaite.core: Sample: Edit Attachment" acquire="False">
+      <role name="Analyst"/>
+      <role name="LabClerk"/>
+      <role name="LabManager"/>
+      <role name="Manager"/>
+    </permission>
+    <permission name="senaite.core: Sample: Delete Attachment" acquire="False">
+      <role name="Analyst"/>
+      <role name="LabClerk"/>
+      <role name="LabManager"/>
+      <role name="Manager"/>
+    </permission>
 
     <!-- Field permissions -->
     <!-- Field permissions (Analysis Request) -->

--- a/src/bika/lims/profiles/default/rolemap.xml
+++ b/src/bika/lims/profiles/default/rolemap.xml
@@ -513,6 +513,11 @@
       <role name="LabManager"/>
       <role name="Manager"/>
     </permission>
+    <permission name="senaite.core: Worksheet: Add Attachment" acquire="False">
+      <role name="Analyst"/>
+      <role name="LabManager"/>
+      <role name="Manager"/>
+    </permission>
 
     <!-- Field permissions -->
     <!-- Field permissions (Analysis Request) -->

--- a/src/bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
+++ b/src/bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
@@ -744,7 +744,11 @@
 
     <!-- Hide the 'Manage Analyses' tab -->
     <permission-map name="senaite.core: Add Analysis" acquired="False"/>
-    <permission-map name="senaite.core: Add Attachment" acquired="True"/>
+    <permission-map name="senaite.core: Add Attachment" acquired="False">
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Publisher</permission-role>
+    </permission-map>
     <!-- Hide the 'Manage Results' tab -->
     <permission-map name="senaite.core: Edit Field Results" acquired="False"/>
     <permission-map name="senaite.core: Edit Results" acquired="False"/>
@@ -826,7 +830,7 @@
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
     <!-- Hide the 'Manage Analyses' tab -->
     <permission-map name="senaite.core: Add Analysis" acquired="False"/>
-    <permission-map name="senaite.core: Add Attachment" acquired="True"/>
+    <permission-map name="senaite.core: Add Attachment" acquired="False"/>
     <!-- Hide the 'Manage Results' tab -->
     <permission-map name="senaite.core: Edit Field Results" acquired="False"/>
     <permission-map name="senaite.core: Edit Results" acquired="False"/>

--- a/src/bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
+++ b/src/bika/lims/profiles/default/workflows/bika_ar_workflow/definition.xml
@@ -32,7 +32,6 @@
   <permission>senaite.core: Transition: Schedule Sampling</permission>
 
   <permission>senaite.core: Add Analysis</permission>
-  <permission>senaite.core: Add Attachment</permission>
   <permission>senaite.core: Edit Field Results</permission>
   <permission>senaite.core: Edit Results</permission>
   <permission>senaite.core: Manage Invoices</permission>
@@ -41,6 +40,11 @@
   <permission>Add portal content</permission>
   <permission>Modify portal content</permission>
   <permission>View</permission>
+
+  <!-- Type-specific permissions -->
+  <permission>senaite.core: Sample: Add Attachment</permission>
+  <permission>senaite.core: Sample: Edit Attachment</permission>
+  <permission>senaite.core: Sample: Delete Attachment</permission>
 
   <!-- Field-specific permissions
   Are meant to be used for "read_permission" and "write_permission" in fields.
@@ -105,7 +109,6 @@
       <permission-role>SamplingCoordinator</permission-role>
     </permission-map>
 
-
     <!-- MANAGED PERMISSIONS -->
     <!-- Permissions for Transitions (must match with exit transitions) -->
     <permission-map name="senaite.core: Transition: Cancel Analysis Request" acquired="False"/>
@@ -121,7 +124,6 @@
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
 
     <permission-map name="senaite.core: Add Analysis" acquired="True"/>
-    <permission-map name="senaite.core: Add Attachment" acquired="True"/>
     <permission-map name="senaite.core: Edit Field Results" acquired="True"/>
     <permission-map name="senaite.core: Edit Results" acquired="True"/>
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
@@ -129,6 +131,12 @@
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
+
+    <!-- Type-specific permissions -->
+    <permission-map name="senaite.core: Sample: Add Attachment" acquired="True"/>
+    <permission-map name="senaite.core: Sample: Edit Attachment" acquired="True"/>
+    <permission-map name="senaite.core: Sample: Delete Attachment" acquired="True"/>
+
     <!-- Field Permissions
          NOTE: This field-specific permissions for "sample_registered" apply to
          Analysis Request Add form! -->
@@ -214,7 +222,6 @@
       <!-- Roles with this permission not granted by default in rolemap -->
       <permission-role>Sampler</permission-role>
     </permission-map>
-    <permission-map name="senaite.core: Add Attachment" acquired="True"/>
     <permission-map name="senaite.core: Edit Field Results" acquired="True"/>
     <permission-map name="senaite.core: Edit Results" acquired="False"/>
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
@@ -222,6 +229,21 @@
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
+
+    <!-- Type-specific permissions -->
+    <permission-map name="senaite.core: Sample: Add Attachment" acquired="True">
+      <permission-role>Sampler</permission-role>
+      <permission-role>SamplingCoordinator</permission-role>
+    </permission-map>
+    <permission-map name="senaite.core: Sample: Edit Attachment" acquired="True">
+      <permission-role>Sampler</permission-role>
+      <permission-role>SamplingCoordinator</permission-role>
+    </permission-map>
+    <permission-map name="senaite.core: Sample: Delete Attachment" acquired="True">
+      <permission-role>Sampler</permission-role>
+      <permission-role>SamplingCoordinator</permission-role>
+    </permission-map>
+
     <!-- Field Permissions -->
     <permission-map name="senaite.core: Field: Edit Batch" acquired="True"/>
     <permission-map name="senaite.core: Field: Edit Client Order Number" acquired="True"/>
@@ -311,7 +333,6 @@
       <!-- Roles with this permission not granted by default in rolemap -->
       <permission-role>Sampler</permission-role>
     </permission-map>
-    <permission-map name="senaite.core: Add Attachment" acquired="True"/>
     <permission-map name="senaite.core: Edit Field Results" acquired="True"/>
     <permission-map name="senaite.core: Edit Results" acquired="False"/>
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
@@ -319,6 +340,21 @@
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
+
+    <!-- Type-specific permissions -->
+    <permission-map name="senaite.core: Sample: Add Attachment" acquired="True">
+      <permission-role>Sampler</permission-role>
+      <permission-role>SamplingCoordinator</permission-role>
+    </permission-map>
+    <permission-map name="senaite.core: Sample: Edit Attachment" acquired="True">
+      <permission-role>Sampler</permission-role>
+      <permission-role>SamplingCoordinator</permission-role>
+    </permission-map>
+    <permission-map name="senaite.core: Sample: Delete Attachment" acquired="True">
+      <permission-role>Sampler</permission-role>
+      <permission-role>SamplingCoordinator</permission-role>
+    </permission-map>
+
     <!-- Field Permissions -->
     <permission-map name="senaite.core: Field: Edit Batch" acquired="True"/>
     <permission-map name="senaite.core: Field: Edit Client Order Number" acquired="True"/>
@@ -398,7 +434,6 @@
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
 
     <permission-map name="senaite.core: Add Analysis" acquired="True"/>
-    <permission-map name="senaite.core: Add Attachment" acquired="True"/>
     <permission-map name="senaite.core: Edit Field Results" acquired="True"/>
     <permission-map name="senaite.core: Edit Results" acquired="False"/>
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
@@ -406,6 +441,12 @@
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
+
+    <!-- Type-specific permissions -->
+    <permission-map name="senaite.core: Sample: Add Attachment" acquired="True"/>
+    <permission-map name="senaite.core: Sample: Edit Attachment" acquired="True"/>
+    <permission-map name="senaite.core: Sample: Delete Attachment" acquired="True"/>
+
     <!-- Field Permissions -->
     <permission-map name="senaite.core: Field: Edit Batch" acquired="True"/>
     <permission-map name="senaite.core: Field: Edit Client Order Number" acquired="True"/>
@@ -485,7 +526,6 @@
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
 
     <permission-map name="senaite.core: Add Analysis" acquired="True"/>
-    <permission-map name="senaite.core: Add Attachment" acquired="True"/>
     <permission-map name="senaite.core: Edit Field Results" acquired="True"/>
     <permission-map name="senaite.core: Edit Results" acquired="True"/>
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
@@ -493,6 +533,12 @@
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
+
+    <!-- Type-specific permissions -->
+    <permission-map name="senaite.core: Sample: Add Attachment" acquired="True"/>
+    <permission-map name="senaite.core: Sample: Edit Attachment" acquired="True"/>
+    <permission-map name="senaite.core: Sample: Delete Attachment" acquired="True"/>
+
     <!-- Field Permissions -->
     <permission-map name="senaite.core: Field: Edit Batch" acquired="True"/>
     <permission-map name="senaite.core: Field: Edit Client Order Number" acquired="True"/>
@@ -573,7 +619,6 @@
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="senaite.core: Add Attachment" acquired="True"/>
     <permission-map name="senaite.core: Edit Field Results" acquired="False"/>
     <permission-map name="senaite.core: Edit Results" acquired="False"/>
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
@@ -585,6 +630,12 @@
     </permission-map>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
+
+    <!-- Type-specific permissions -->
+    <permission-map name="senaite.core: Sample: Add Attachment" acquired="True"/>
+    <permission-map name="senaite.core: Sample: Edit Attachment" acquired="True"/>
+    <permission-map name="senaite.core: Sample: Delete Attachment" acquired="True"/>
+
     <!-- Field Permissions -->
     <permission-map name="senaite.core: Field: Edit Batch" acquired="True"/>
     <permission-map name="senaite.core: Field: Edit Client Order Number" acquired="True"/>
@@ -661,7 +712,6 @@
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
 
     <permission-map name="senaite.core: Add Analysis" acquired="True"/>
-    <permission-map name="senaite.core: Add Attachment" acquired="True"/>
     <permission-map name="senaite.core: Edit Field Results" acquired="True"/>
     <permission-map name="senaite.core: Edit Results" acquired="True"/>
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
@@ -669,6 +719,12 @@
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
+
+    <!-- Type-specific permissions -->
+    <permission-map name="senaite.core: Sample: Add Attachment" acquired="True"/>
+    <permission-map name="senaite.core: Sample: Edit Attachment" acquired="True"/>
+    <permission-map name="senaite.core: Sample: Delete Attachment" acquired="True"/>
+
     <!-- Field Permissions -->
     <permission-map name="senaite.core: Field: Edit Batch" acquired="True"/>
     <permission-map name="senaite.core: Field: Edit Client Order Number" acquired="True"/>
@@ -744,11 +800,6 @@
 
     <!-- Hide the 'Manage Analyses' tab -->
     <permission-map name="senaite.core: Add Analysis" acquired="False"/>
-    <permission-map name="senaite.core: Add Attachment" acquired="False">
-      <permission-role>LabManager</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>Publisher</permission-role>
-    </permission-map>
     <!-- Hide the 'Manage Results' tab -->
     <permission-map name="senaite.core: Edit Field Results" acquired="False"/>
     <permission-map name="senaite.core: Edit Results" acquired="False"/>
@@ -761,6 +812,20 @@
     </permission-map>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
+
+    <!-- Type-specific permissions -->
+    <permission-map name="senaite.core: Sample: Add Attachment" acquired="False">
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Publisher</permission-role>
+    </permission-map>
+    <permission-map name="senaite.core: Sample: Edit Attachment" acquired="False">
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Publisher</permission-role>
+    </permission-map>
+    <permission-map name="senaite.core: Sample: Delete Attachment" acquired="False"/>
+
     <!-- Field Permissions (all readonly) -->
     <permission-map name="senaite.core: Field: Edit Batch" acquired="False"/>
     <permission-map name="senaite.core: Field: Edit Client Order Number" acquired="False"/>
@@ -830,7 +895,6 @@
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
     <!-- Hide the 'Manage Analyses' tab -->
     <permission-map name="senaite.core: Add Analysis" acquired="False"/>
-    <permission-map name="senaite.core: Add Attachment" acquired="False"/>
     <!-- Hide the 'Manage Results' tab -->
     <permission-map name="senaite.core: Edit Field Results" acquired="False"/>
     <permission-map name="senaite.core: Edit Results" acquired="False"/>
@@ -839,6 +903,18 @@
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
+
+    <!-- Type-specific permissions -->
+    <permission-map name="senaite.core: Sample: Add Attachment" acquired="False">
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="senaite.core: Sample: Edit Attachment" acquired="False">
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="senaite.core: Sample: Delete Attachment" acquired="False"/>
+
     <!-- Field Permissions (all readonly) -->
     <permission-map name="senaite.core: Field: Edit Batch" acquired="False"/>
     <permission-map name="senaite.core: Field: Edit Client Order Number" acquired="False"/>
@@ -905,7 +981,6 @@
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
     <!-- Hide the 'Manage Analyses' tab -->
     <permission-map name="senaite.core: Add Analysis" acquired="False"/>
-    <permission-map name="senaite.core: Add Attachment" acquired="True"/>
     <!-- Hide the 'Manage Results' tab -->
     <permission-map name="senaite.core: Edit Field Results" acquired="False"/>
     <permission-map name="senaite.core: Edit Results" acquired="False"/>
@@ -914,6 +989,12 @@
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
+
+    <!-- Type-specific permissions -->
+    <permission-map name="senaite.core: Sample: Add Attachment" acquired="False"/>
+    <permission-map name="senaite.core: Sample: Edit Attachment" acquired="False"/>
+    <permission-map name="senaite.core: Sample: Delete Attachment" acquired="False"/>
+
     <!-- Field Permissions (all readonly) -->
     <permission-map name="senaite.core: Field: Edit Batch" acquired="False"/>
     <permission-map name="senaite.core: Field: Edit Client Order Number" acquired="False"/>
@@ -979,7 +1060,6 @@
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
     <!-- Hide the 'Manage Analyses' tab -->
     <permission-map name="senaite.core: Add Analysis" acquired="False"/>
-    <permission-map name="senaite.core: Add Attachment" acquired="True"/>
     <!-- Hide the 'Manage Results' tab -->
     <permission-map name="senaite.core: Edit Field Results" acquired="False"/>
     <permission-map name="senaite.core: Edit Results" acquired="False"/>
@@ -988,6 +1068,12 @@
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
+
+    <!-- Type-specific permissions -->
+    <permission-map name="senaite.core: Sample: Add Attachment" acquired="False"/>
+    <permission-map name="senaite.core: Sample: Edit Attachment" acquired="False"/>
+    <permission-map name="senaite.core: Sample: Delete Attachment" acquired="False"/>
+
     <!-- Field Permissions (all readonly) -->
     <permission-map name="senaite.core: Field: Edit Batch" acquired="False"/>
     <permission-map name="senaite.core: Field: Edit Client Order Number" acquired="False"/>
@@ -1058,7 +1144,6 @@
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
     <!-- Hide the 'Manage Analyses' tab -->
     <permission-map name="senaite.core: Add Analysis" acquired="False"/>
-    <permission-map name="senaite.core: Add Attachment" acquired="True"/>
     <!-- Hide the 'Manage Results' tab -->
     <permission-map name="senaite.core: Edit Field Results" acquired="False"/>
     <permission-map name="senaite.core: Edit Results" acquired="False"/>
@@ -1067,6 +1152,12 @@
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
+
+    <!-- Type-specific permissions -->
+    <permission-map name="senaite.core: Sample: Add Attachment" acquired="False"/>
+    <permission-map name="senaite.core: Sample: Edit Attachment" acquired="False"/>
+    <permission-map name="senaite.core: Sample: Delete Attachment" acquired="False"/>
+
     <!-- Field Permissions (all readonly) -->
     <permission-map name="senaite.core: Field: Edit Batch" acquired="False"/>
     <permission-map name="senaite.core: Field: Edit Client Order Number" acquired="False"/>

--- a/src/bika/lims/profiles/default/workflows/bika_worksheet_workflow/definition.xml
+++ b/src/bika/lims/profiles/default/workflows/bika_worksheet_workflow/definition.xml
@@ -8,7 +8,6 @@
              manager_bypass="False"
              i18n:domain="senaite.core">
 
-  <permission>senaite.core: Add Attachment</permission>
   <permission>senaite.core: Transition: Assign Analysis</permission>
   <permission>senaite.core: Edit Worksheet</permission>
   <permission>senaite.core: Transition: Retract</permission>
@@ -16,29 +15,19 @@
   <permission>senaite.core: Transition: Remove Worksheet</permission>
   <permission>senaite.core: Transition: Unassign Analysis</permission>
   <permission>senaite.core: View Results</permission>
+  <permission>senaite.core: Worksheet: Add Attachment</permission>
   <permission>Modify portal content</permission>
 
+  <!-- STATE: Open -->
   <state state_id="open" title="Open" i18n:attributes="title">
     <exit-transition transition_id="submit" />
     <exit-transition transition_id="remove" />
-    <permission-map name="senaite.core: Transition: Reject Worksheet" acquired="False"/>
-    <permission-map name="senaite.core: Transition: Remove Worksheet" acquired="True"/>
-    <permission-map name="senaite.core: Add Attachment" acquired="False">
-      <permission-role>Analyst</permission-role>
-      <permission-role>LabClerk</permission-role>
-      <permission-role>LabManager</permission-role>
-      <permission-role>Manager</permission-role>
-    </permission-map>
-    <permission-map name="senaite.core: Transition: Assign Analysis" acquired="True"/>
     <permission-map name="senaite.core: Edit Worksheet" acquired="False">
       <permission-role>Analyst</permission-role>
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="senaite.core: Transition: Retract" acquired="False">
-    </permission-map>
-    <permission-map name="senaite.core: Transition: Unassign Analysis" acquired="True"/>
     <permission-map name="senaite.core: View Results" acquired="False">
       <permission-role>Analyst</permission-role>
       <permission-role>LabClerk</permission-role>
@@ -51,17 +40,25 @@
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
     </permission-map>
-  </state>
 
+    <!-- Transitions -->
+    <permission-map name="senaite.core: Transition: Assign Analysis" acquired="True"/>
+    <permission-map name="senaite.core: Transition: Reject Worksheet" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Remove Worksheet" acquired="True"/>
+    <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Unassign Analysis" acquired="True"/>
+
+    <!-- Type-specific permissions -->
+    <permission-map name="senaite.core: Worksheet: Add Attachment" acquired="True"/>
+
+  </state>
+  <!-- /STATE: Open -->
+
+
+  <!-- STATE: Rejected -->
   <state state_id="rejected" title="Rejected" i18n:attributes="title">
     <exit-transition transition_id="" />
-    <permission-map name="senaite.core: Transition: Reject Worksheet" acquired="False"/>
-    <permission-map name="senaite.core: Transition: Remove Worksheet" acquired="False"/>
-    <permission-map name="senaite.core: Add Attachment" acquired="False"/>
-    <permission-map name="senaite.core: Transition: Assign Analysis" acquired="False"/>
     <permission-map name="senaite.core: Edit Worksheet" acquired="False"/>
-    <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
-    <permission-map name="senaite.core: Transition: Unassign Analysis" acquired="False"/>
     <permission-map name="senaite.core: View Results" acquired="False">
       <permission-role>Analyst</permission-role>
       <permission-role>LabClerk</permission-role>
@@ -71,29 +68,31 @@
     <permission-map name="Modify portal content" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-  </state>
 
+    <!-- Transitions -->
+    <permission-map name="senaite.core: Transition: Assign Analysis" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Reject Worksheet" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Remove Worksheet" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Unassign Analysis" acquired="False"/>
+
+    <!-- Type-specific permissions -->
+    <permission-map name="senaite.core: Worksheet: Add Attachment" acquired="False"/>
+
+  </state>
+  <!-- /STATE: Rejected -->
+
+
+  <!-- STATE: To be verified -->
   <state state_id="to_be_verified" title="To be verified" i18n:attributes="title">
     <exit-transition transition_id="verify" />
     <exit-transition transition_id="retract" />
     <exit-transition transition_id="reject" />
     <exit-transition transition_id="rollback_to_open" />
-    <permission-map name="senaite.core: Transition: Reject Worksheet" acquired="True"/>
-    <permission-map name="senaite.core: Transition: Remove Worksheet" acquired="False"/>
-    <permission-map name="senaite.core: Add Attachment" acquired="False">
-      <permission-role>LabManager</permission-role>
-      <permission-role>Manager</permission-role>
-    </permission-map>
-    <permission-map name="senaite.core: Transition: Assign Analysis" acquired="True"/>
     <permission-map name="senaite.core: Edit Worksheet" acquired="False">
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="senaite.core: Transition: Retract" acquired="False">
-      <permission-role>LabManager</permission-role>
-      <permission-role>Manager</permission-role>
-    </permission-map>
-    <permission-map name="senaite.core: Transition: Unassign Analysis" acquired="True"/>
     <permission-map name="senaite.core: View Results" acquired="False">
       <permission-role>Analyst</permission-role>
       <permission-role>LabClerk</permission-role>
@@ -106,20 +105,23 @@
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
     </permission-map>
-  </state>
 
+    <!-- Transitions -->
+    <permission-map name="senaite.core: Transition: Assign Analysis" acquired="True"/>
+    <permission-map name="senaite.core: Transition: Reject Worksheet" acquired="True"/>
+    <permission-map name="senaite.core: Transition: Remove Worksheet" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Retract" acquired="True"/>
+    <permission-map name="senaite.core: Transition: Unassign Analysis" acquired="True"/>
+
+    <!-- Type-specific permissions -->
+    <permission-map name="senaite.core: Worksheet: Add Attachment" acquired="False"/>
+  </state>
+  <!-- /STATE: To be verified -->
+
+  <!-- STATE: Verified -->
   <state state_id="verified" title="Verified" i18n:attributes="title">
     <exit-transition transition_id="retract" />
-    <permission-map name="senaite.core: Transition: Reject Worksheet" acquired="False"/>
-    <permission-map name="senaite.core: Transition: Remove Worksheet" acquired="False"/>
-    <permission-map name="senaite.core: Add Attachment" acquired="False"/>
-    <permission-map name="senaite.core: Transition: Assign Analysis" acquired="False"/>
     <permission-map name="senaite.core: Edit Worksheet" acquired="False"/>
-    <permission-map name="senaite.core: Transition: Retract" acquired="False">
-      <permission-role>LabManager</permission-role>
-      <permission-role>Manager</permission-role>
-    </permission-map>
-    <permission-map name="senaite.core: Transition: Unassign Analysis" acquired="False"/>
     <permission-map name="senaite.core: View Results" acquired="False">
       <permission-role>Analyst</permission-role>
       <permission-role>LabClerk</permission-role>
@@ -132,7 +134,18 @@
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
     </permission-map>
+
+    <!-- Transitions -->
+    <permission-map name="senaite.core: Transition: Assign Analysis" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Reject Worksheet" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Remove Worksheet" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Retract" acquired="True"/>
+    <permission-map name="senaite.core: Transition: Unassign Analysis" acquired="False"/>
+
+    <!-- Type-specific permissions -->
+    <permission-map name="senaite.core: Worksheet: Add Attachment" acquired="False"/>
   </state>
+  <!-- /STATE: Verified -->
 
   <transition transition_id="reject" title="Reject" new_state="rejected" trigger="USER" before_script="" after_script="" i18n:attributes="title">
     <action url="" category="workflow" icon="">Reject</action>

--- a/src/bika/lims/profiles/default/workflows/bika_worksheet_workflow/definition.xml
+++ b/src/bika/lims/profiles/default/workflows/bika_worksheet_workflow/definition.xml
@@ -57,14 +57,10 @@
     <exit-transition transition_id="" />
     <permission-map name="senaite.core: Transition: Reject Worksheet" acquired="False"/>
     <permission-map name="senaite.core: Transition: Remove Worksheet" acquired="False"/>
-    <permission-map name="senaite.core: Add Attachment" acquired="False">
-      <permission-role>Manager</permission-role>
-    </permission-map>
+    <permission-map name="senaite.core: Add Attachment" acquired="False"/>
     <permission-map name="senaite.core: Transition: Assign Analysis" acquired="False"/>
-    <permission-map name="senaite.core: Edit Worksheet" acquired="False">
-    </permission-map>
-    <permission-map name="senaite.core: Transition: Retract" acquired="False">
-    </permission-map>
+    <permission-map name="senaite.core: Edit Worksheet" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
     <permission-map name="senaite.core: Transition: Unassign Analysis" acquired="False"/>
     <permission-map name="senaite.core: View Results" acquired="False">
       <permission-role>Analyst</permission-role>
@@ -85,15 +81,11 @@
     <permission-map name="senaite.core: Transition: Reject Worksheet" acquired="True"/>
     <permission-map name="senaite.core: Transition: Remove Worksheet" acquired="False"/>
     <permission-map name="senaite.core: Add Attachment" acquired="False">
-      <permission-role>Analyst</permission-role>
-      <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
     </permission-map>
     <permission-map name="senaite.core: Transition: Assign Analysis" acquired="True"/>
     <permission-map name="senaite.core: Edit Worksheet" acquired="False">
-      <permission-role>Analyst</permission-role>
-      <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
     </permission-map>
@@ -120,17 +112,9 @@
     <exit-transition transition_id="retract" />
     <permission-map name="senaite.core: Transition: Reject Worksheet" acquired="False"/>
     <permission-map name="senaite.core: Transition: Remove Worksheet" acquired="False"/>
-    <permission-map name="senaite.core: Add Attachment" acquired="False">
-      <permission-role>Analyst</permission-role>
-      <permission-role>LabClerk</permission-role>
-      <permission-role>LabManager</permission-role>
-      <permission-role>Manager</permission-role>
-    </permission-map>
+    <permission-map name="senaite.core: Add Attachment" acquired="False"/>
     <permission-map name="senaite.core: Transition: Assign Analysis" acquired="False"/>
-    <permission-map name="senaite.core: Edit Worksheet" acquired="False">
-      <permission-role>LabManager</permission-role>
-      <permission-role>Manager</permission-role>
-    </permission-map>
+    <permission-map name="senaite.core: Edit Worksheet" acquired="False"/>
     <permission-map name="senaite.core: Transition: Retract" acquired="False">
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>

--- a/src/senaite/core/browser/attachment/attachment.py
+++ b/src/senaite/core/browser/attachment/attachment.py
@@ -19,10 +19,11 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims import api
+from bika.lims import FieldEditAnalysisResult
 from bika.lims import logger
+from bika.lims.api import security
 from bika.lims.config import ATTACHMENT_REPORT_OPTIONS
 from bika.lims.decorators import returns_json
-from bika.lims.interfaces import IVerified
 from bika.lims.permissions import AddAttachment
 from bika.lims.permissions import EditFieldResults
 from bika.lims.permissions import EditResults
@@ -406,11 +407,12 @@ class AttachmentsView(BrowserView):
         return ATTACHMENT_REPORT_OPTIONS.items()
 
     def get_analyses(self):
-        """Returns a list of analyses from the AR
+        """Returns the list of analyses for which the current user has
+        privileges granted to add/edit/remove attachments
         """
+        perm = FieldEditAnalysisResult
         analyses = self.context.getAnalyses(full_objects=True)
-        analyses = filter(api.is_active, analyses)
-        return filter(lambda a: not IVerified.providedBy(a), analyses)
+        return filter(lambda a: security.check_permission(perm, a), analyses)
 
     def user_can_add_attachments(self):
         """Checks if the current logged in user is allowed to add attachments

--- a/src/senaite/core/browser/attachment/attachment.py
+++ b/src/senaite/core/browser/attachment/attachment.py
@@ -19,10 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims import api
-from bika.lims import EditFieldResults
-from bika.lims import EditResults
 from bika.lims import FieldEditAnalysisResult
-from bika.lims import FieldEditResultsInterpretation
 from bika.lims import logger
 from bika.lims.api import security
 from bika.lims.config import ATTACHMENT_REPORT_OPTIONS
@@ -368,8 +365,9 @@ class AttachmentsView(BrowserView):
         skip = ["cancelled", "retracted", "rejected"]
         for analysis in self.context.getAnalyses(full_objects=True):
             if api.get_review_status(analysis) in skip:
-                # Skip non-valid analyses, user can download their attachments
-                # from the analysis listing anyways
+                # Do not display attachments from invalid analyses in the
+                # attachments viewlet, user can download them from the analysis
+                # listing anyways
                 continue
 
             can_edit = security.check_permission(permission, analysis)

--- a/src/senaite/core/browser/attachment/configure.zcml
+++ b/src/senaite/core/browser/attachment/configure.zcml
@@ -20,22 +20,4 @@
       layer="senaite.core.interfaces.ISenaiteCore"
       />
 
-  <!-- Ajax exposed Attachments Methods -->
-
-  <browser:page
-      for="bika.lims.interfaces.IAnalysisRequest"
-      name="ajax_attachments_view"
-      class=".attachment.ajaxAttachmentsView"
-      permission="zope.Public"
-      layer="senaite.core.interfaces.ISenaiteCore"
-      />
-
-  <browser:page
-      for="bika.lims.interfaces.IWorksheet"
-      name="ajax_attachments_view"
-      class=".attachment.ajaxAttachmentsView"
-      permission="zope.Public"
-      layer="senaite.core.interfaces.ISenaiteCore"
-      />
-
 </configure>

--- a/src/senaite/core/browser/static/js/bika.lims.utils.attachments.js
+++ b/src/senaite/core/browser/static/js/bika.lims.utils.attachments.js
@@ -39,24 +39,6 @@
           $('#addButton').prop('disabled', true);
         }
       });
-      $('.deleteAttachmentButton').live('click', function() {
-        var attachment_uid, options;
-        attachment_uid = $(this).attr('attachment_uid');
-        options = {
-          url: "@@ajax_attachments_view/delete_analysis_attachment",
-          type: 'POST',
-          success: function(responseText, statusText, xhr, $form) {
-            if (responseText === 'success') {
-              $("span[attachment_uid=" + attachment_uid + "]").remove();
-            }
-          },
-          data: {
-            'attachment_uid': attachment_uid,
-            '_authenticator': $('input[name="_authenticator"]').val()
-          }
-        };
-        $.ajax(options);
-      });
       $('#Analysis').combogrid({
         colModel: [
           {

--- a/src/senaite/core/browser/static/js/coffee/bika.lims.utils.attachments.coffee
+++ b/src/senaite/core/browser/static/js/coffee/bika.lims.utils.attachments.coffee
@@ -31,22 +31,6 @@ window.AttachmentsUtils = ->
         $('#addButton').prop 'disabled', true
       return
 
-    # This is the button next to analysis attachments in ARs and Worksheets
-    $('.deleteAttachmentButton').live 'click', ->
-      attachment_uid = $(this).attr('attachment_uid')
-      options =
-        url: "@@ajax_attachments_view/delete_analysis_attachment"
-        type: 'POST'
-        success: (responseText, statusText, xhr, $form) ->
-          if responseText == 'success'
-            $("span[attachment_uid=#{attachment_uid}]").remove()
-          return
-        data:
-          'attachment_uid': attachment_uid
-          '_authenticator': $('input[name="_authenticator"]').val()
-      $.ajax options
-      return
-
     # Dropdown grid of Analyses in attachment forms
     $('#Analysis').combogrid
       colModel: [

--- a/src/senaite/core/browser/viewlets/attachments.py
+++ b/src/senaite/core/browser/viewlets/attachments.py
@@ -46,8 +46,7 @@ class AttachmentsViewlet(ViewletBase):
         # XXX: Hack to show the viewlet only on the AR base_view
         if not any(map(url.endswith, ["base_view", "manage_results"])):
             return False
-        return self.attachments_view.user_can_add_attachments() or \
-            self.attachments_view.user_can_update_attachments()
+        return self.attachments_view.user_can_edit_attachments()
 
     def update(self):
         """Called always before render()

--- a/src/senaite/core/browser/viewlets/attachments.py
+++ b/src/senaite/core/browser/viewlets/attachments.py
@@ -21,6 +21,7 @@
 from bika.lims import AddAttachment
 from bika.lims import api
 from bika.lims import FieldEditAnalysisResult
+from bika.lims import WorksheetAddAttachment
 from bika.lims.api import security
 from plone.app.layout.viewlets.common import ViewletBase
 from plone.memoize import view
@@ -78,11 +79,12 @@ class WorksheetAttachmentsViewlet(AttachmentsViewlet):
         # XXX: Hack to show the viewlet only on the WS manage_results view
         if not self.request.getURL().endswith("manage_results"):
             return False
-        return security.check_permission(AddAttachment, self.context)
+        return security.check_permission(WorksheetAddAttachment, self.context)
 
     @view.memoize
     def get_services(self):
-        """Returns a list of AnalysisService objects present in worksheet
+        """Returns a list of dicts that represent the Analysis Services that
+        are editable and present in current Worksheet
         """
         services = set()
         for analysis in self.context.getAnalyses():
@@ -92,10 +94,13 @@ class WorksheetAttachmentsViewlet(AttachmentsViewlet):
             service = analysis.getAnalysisService()
             services.add(service)
 
+        # Return the
         services = sorted(list(services), key=lambda s: api.get_title(s))
         return map(self.get_service_info, services)
 
     def get_service_info(self, service):
+        """Returns a dict that represents an analysis service
+        """
         return {
             "uid": api.get_uid(service),
             "title": api.get_title(service),

--- a/src/senaite/core/browser/viewlets/attachments.py
+++ b/src/senaite/core/browser/viewlets/attachments.py
@@ -46,7 +46,7 @@ class AttachmentsViewlet(ViewletBase):
         # XXX: Hack to show the viewlet only on the AR base_view
         if not any(map(url.endswith, ["base_view", "manage_results"])):
             return False
-        return self.attachments_view.user_can_edit_attachments()
+        return True
 
     def update(self):
         """Called always before render()

--- a/src/senaite/core/browser/viewlets/attachments.py
+++ b/src/senaite/core/browser/viewlets/attachments.py
@@ -22,7 +22,7 @@ from bika.lims import AddAttachment
 from bika.lims import api
 from bika.lims import FieldEditAnalysisResult
 from bika.lims import WorksheetAddAttachment
-from bika.lims.api import security
+from bika.lims.api.security import check_permission
 from plone.app.layout.viewlets.common import ViewletBase
 from plone.memoize import view
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -79,7 +79,7 @@ class WorksheetAttachmentsViewlet(AttachmentsViewlet):
         # XXX: Hack to show the viewlet only on the WS manage_results view
         if not self.request.getURL().endswith("manage_results"):
             return False
-        return security.check_permission(WorksheetAddAttachment, self.context)
+        return check_permission(WorksheetAddAttachment, self.context)
 
     @view.memoize
     def get_services(self):
@@ -89,7 +89,7 @@ class WorksheetAttachmentsViewlet(AttachmentsViewlet):
         services = set()
         for analysis in self.context.getAnalyses():
             # Skip non-editable analyses
-            if not security.check_permission(FieldEditAnalysisResult, analysis):
+            if not check_permission(FieldEditAnalysisResult, analysis):
                 continue
             service = analysis.getAnalysisService()
             services.add(service)

--- a/src/senaite/core/browser/viewlets/templates/attachments.pt
+++ b/src/senaite/core/browser/viewlets/templates/attachments.pt
@@ -6,7 +6,7 @@
           class="btn btn-light dropdown-toggle mb-3"
           data-toggle="collapse"
           data-target="#ar-attachments-panel">
-    <i class="fas fa-paperclip" aria-hidden="true"></i>
+    <i class="fas fa-paperclip" aria-hidden="true"/>
     <span i18n:translate="">Attachments</span>
   </button>
 
@@ -37,12 +37,15 @@
 
     <!-- Attachments Viewlet -->
     <div class="panel-body"
-         tal:define="can_edit attachments_view/user_can_edit_attachments">
+         tal:define="can_add attachments_view/can_add_attachments;
+                     can_edit attachments_view/can_edit_attachments;
+                     can_delete attachments_view/can_delete_attachments;
+                     attachments attachments_view/get_sorted_attachments;
+                     attachment_types attachments_view/get_attachment_types;
+                     report_options attachments_view/get_attachment_report_options">
 
       <!-- Attachments List -->
-      <div id="attachments_update"
-           class="ar_attachments_list"
-           tal:define="attachments attachments_view/get_sorted_attachments">
+      <div id="attachments_update" class="ar_attachments_list">
 
         <!-- Update Attachment Form -->
         <form action="attachments_view/update"
@@ -59,16 +62,16 @@
           <table id="attachments_update_table" class="table-sm">
             <thead>
               <tr>
-                <th i18n:translate=''>Name</th>
-                <th i18n:translate=''>Type</th>
-                <th i18n:translate=''>Size</th>
-                <th i18n:translate=''>Analysis</th>
-                <th i18n:translate=''>Keywords</th>
-                <th i18n:translate=''>Report Option</th>
+                <th i18n:translate="">Name</th>
+                <th i18n:translate="">Type</th>
+                <th i18n:translate="">Size</th>
+                <th i18n:translate="">Analysis</th>
+                <th i18n:translate="">Keywords</th>
+                <th i18n:translate="">Report Option</th>
                 <!-- Please do not move this column to be the first, because the
                       :records converter will somehow offset the True/False value of
                       the checkbox by -1 (the record before will be deleted) -->
-                <th tal:condition="can_edit">Delete</th>
+                <th tal:condition="can_delete">Delete</th>
               </tr>
             </thead>
             <tbody>
@@ -76,7 +79,7 @@
 
                 <td class="attachment-link">
                   <!-- Icon and Attachment download link -->
-                  <i class="fa fa-paperclip" aria-hidden="true"></i>
+                  <i class="fa fa-paperclip" aria-hidden="true"/>
                   <a title="Click to download"
                       tal:attributes="href string:${attachment/absolute_url}/at_download/AttachmentFile"
                       tal:content="attachment/name">name</a>
@@ -89,6 +92,7 @@
                   <input type="hidden" tal:attributes="name string:order:list;
                                                        value string:${attachment/UID}"/>
                 </td>
+
                 <td class="attachment-type">
                   <!-- Attachment Type -->
                   <select name="AttachmentType"
@@ -96,25 +100,25 @@
                           tal:condition="can_edit"
                           tal:attributes="name string:attachments.AttachmentType:records;
                                           data-attachment-uid string:${attachment/UID};">
-                    <tal:item repeat="item attachments_view/get_attachment_types">
-                      <option tal:attributes="value item/UID;
+                      <option tal:repeat="item attachment_types"
+                              tal:attributes="value item/UID;
                                               selected python:item.UID==attachment['type_uid']"
-                              tal:content="item/Title">
-                        Attachment Type
-                      </option>
-                    </tal:item>
+                              tal:content="item/Title"/>
                   </select>
                   <span tal:condition="not:can_edit"
                         tal:content="attachment/type"/>
                 </td>
+
                 <td class="attachment-field-size">
                   <!-- File Size -->
                   <span class="filesize" tal:content="attachment/size"/>
                 </td>
+
                 <td class="attachment-analysis">
                   <!-- Attached to Analysis -->
                   <span class="analysis" tal:content="attachment/analysis"/>
                 </td>
+
                 <td class="attachment-keywords">
                   <!-- Attachment Keywords -->
                   <input name="AttachmentKeys"
@@ -125,6 +129,7 @@
                   <span tal:condition="not:can_edit"
                         tal:content="attachment/keywords"/>
                 </td>
+
                 <td class="attachment-report-option">
                   <!-- Attachment Report Option
                         i=Ignore in Report
@@ -135,20 +140,19 @@
                           tal:condition="can_edit"
                           tal:attributes="name string:attachments.ReportOption:records;
                                           data-attachment-uid string:${attachment/UID}">
-                    <tal:item repeat="item attachments_view/get_attachment_report_options">
-                      <option tal:attributes="value python:item[0];
-                                              selected python:item[0]==attachment['report_option']"
-                              tal:content="python: item[1]">
-                        Attachment Report Option
-                      </option>
-                    </tal:item>
+                    <option tal:repeat="item report_options"
+                            tal:attributes="value python:item[0];
+                                            selected python:item[0]==attachment['report_option']"
+                            tal:content="python: item[1]"/>
                   </select>
                   <span tal:condition="not:can_edit"
                         tal:content="attachment/report_option_value"/>
                 </td>
-                <td class="attachment-delete" tal:condition="can_edit">
 
-                  <!-- Delete Attachment -->
+                <td class="attachment-delete" tal:condition="can_delete">
+                  <!-- Delete Attachment
+                  Note that for deletion we rely on "can_edit" from attachment
+                  -->
                   <input type="checkbox"
                           tal:condition="attachment/can_edit"
                           tal:attributes="name string:attachments.delete:records:boolean;
@@ -172,7 +176,7 @@
           </div>
 
           <!-- Update attachments button.
-                This will send the values to the `attachmetns_view` endpoint. -->
+               This will send the values to the `attachmetns_view` endpoint. -->
           <input class="btn btn-secondary context"
                  id="updateButton"
                  type="submit"
@@ -187,7 +191,7 @@
 
       <!-- Add Attachments -->
       <div id="attachments_add"
-           tal:condition="can_edit"
+           tal:condition="can_add"
            class="ar_attachments_list">
 
         <!-- Add Form -->
@@ -222,12 +226,9 @@
                 <td>
                   <!-- Attachment type selection dropdown -->
                   <select name="AttachmentType" class="form-control">
-                    <tal:item repeat="item attachments_view/get_attachment_types">
-                      <option tal:attributes="value item/UID;"
-                              tal:content="item/Title">
-                        Attachment Type
-                      </option>
-                    </tal:item>
+                    <option tal:repeat="item attachment_types"
+                            tal:attributes="value item/UID;"
+                            tal:content="item/Title"/>
                   </select>
                 </td>
                 <td>
@@ -246,11 +247,11 @@
                                 disabled="disabled"
                                 tal:attributes="value python:None">
                           <span tal:omit-tag="python:True"
-                                i18n:translate="">Attach to Analysis Request</span>
+                                i18n:translate="">Attach to Sample</span>
                         </option>
                         <tal:a tal:repeat="item a_analyses">
                           <option tal:attributes="value item/UID;"
-                                  tal:content="item/Title"></option>
+                                  tal:content="item/Title"/>
                         </tal:a>
                         <tal:b tal:repeat="item b_analyses">
                           <option tal:attributes="value item/UID;">
@@ -288,12 +289,9 @@
                       r=Render in Report
                     -->
                   <select name="ReportOption" class="form-control">
-                    <tal:item repeat="item attachments_view/get_attachment_report_options">
-                      <option tal:attributes="value python:item[0];"
-                              tal:content="python: item[1]">
-                        Attachment Report Option
-                      </option>
-                    </tal:item>
+                    <option tal:repeat="item report_options"
+                            tal:attributes="value python:item[0];"
+                            tal:content="python: item[1]"/>
                   </select>
                 </td>
               </tr>

--- a/src/senaite/core/browser/viewlets/templates/attachments.pt
+++ b/src/senaite/core/browser/viewlets/templates/attachments.pt
@@ -36,7 +36,8 @@
     </style>
 
     <!-- Attachments Viewlet -->
-    <div class="panel-body">
+    <div class="panel-body"
+         tal:define="can_edit attachments_view/user_can_edit_attachments">
 
       <!-- Attachments List -->
       <div id="attachments_update"
@@ -67,12 +68,11 @@
                 <!-- Please do not move this column to be the first, because the
                       :records converter will somehow offset the True/False value of
                       the checkbox by -1 (the record before will be deleted) -->
-                <th tal:condition="attachments_view/user_can_delete_attachments">Delete</th>
+                <th tal:condition="can_edit">Delete</th>
               </tr>
             </thead>
             <tbody>
-              <tr tal:repeat="attachment attachments"
-                  tal:define="user_can_delete python:attachments_view.user_can_delete_attachments()">
+              <tr tal:repeat="attachment attachments">
 
                 <td class="attachment-link">
                   <!-- Icon and Attachment download link -->
@@ -137,7 +137,7 @@
                     </tal:item>
                   </select>
                 </td>
-                <td class="attachment-delete" tal:condition="user_can_delete">
+                <td class="attachment-delete" tal:condition="can_edit">
 
                   <!-- Delete Attachment -->
                   <input type="checkbox"

--- a/src/senaite/core/browser/viewlets/templates/attachments.pt
+++ b/src/senaite/core/browser/viewlets/templates/attachments.pt
@@ -59,19 +59,19 @@
           <input type="hidden" name="submitted" value="1"/>
           <span tal:replace="structure context/@@authenticator/authenticator"/>
 
-          <table id="attachments_update_table" class="table-sm">
+          <table id="attachments_update_table">
             <thead>
               <tr>
-                <th i18n:translate="">Name</th>
-                <th i18n:translate="">Type</th>
-                <th i18n:translate="">Size</th>
-                <th i18n:translate="">Analysis</th>
-                <th i18n:translate="">Keywords</th>
-                <th i18n:translate="">Report Option</th>
+                <th class="pr-3" i18n:translate="">Name</th>
+                <th class="pr-3" i18n:translate="">Type</th>
+                <th class="pr-3" i18n:translate="">Size</th>
+                <th class="pr-3" i18n:translate="">Analysis</th>
+                <th class="pr-3" i18n:translate="">Keywords</th>
+                <th class="pr-3" i18n:translate="">Report Option</th>
                 <!-- Please do not move this column to be the first, because the
                       :records converter will somehow offset the True/False value of
                       the checkbox by -1 (the record before will be deleted) -->
-                <th tal:condition="can_delete">Delete</th>
+                <th class="pr-3" tal:condition="can_delete">Delete</th>
               </tr>
             </thead>
             <tbody>
@@ -176,7 +176,7 @@
           </div>
 
           <!-- Update attachments button.
-               This will send the values to the `attachmetns_view` endpoint. -->
+               This will send the values to the `attachments_view` endpoint. -->
           <input class="btn btn-secondary context"
                  id="updateButton"
                  type="submit"
@@ -204,14 +204,14 @@
           <input type="hidden" name="submitted" value="1"/>
           <span tal:replace="structure context/@@authenticator/authenticator"/>
 
-          <table id="attachments_add_table" class="table-sm">
+          <table id="attachments_add_table">
             <thead>
               <tr>
-                <th i18n:translate="">Add new Attachment</th>
-                <th i18n:translate="">Type</th>
-                <th i18n:translate="">Analysis</th>
-                <th i18n:translate="">Keywords</th>
-                <th i18n:translate="">Report Option</th>
+                <th class="pr-3" i18n:translate="">Add new Attachment</th>
+                <th class="pr-3" i18n:translate="">Type</th>
+                <th class="pr-3" i18n:translate="">Analysis</th>
+                <th class="pr-3" i18n:translate="">Keywords</th>
+                <th class="pr-3" i18n:translate="">Report Option</th>
               </tr>
             </thead>
             <tbody>

--- a/src/senaite/core/browser/viewlets/templates/attachments.pt
+++ b/src/senaite/core/browser/viewlets/templates/attachments.pt
@@ -56,7 +56,7 @@
           <input type="hidden" name="submitted" value="1"/>
           <span tal:replace="structure context/@@authenticator/authenticator"/>
 
-          <table id="attachments_update_table" class="listing">
+          <table id="attachments_update_table" class="table-sm">
             <thead>
               <tr>
                 <th i18n:translate=''>Name</th>
@@ -93,31 +93,37 @@
                   <!-- Attachment Type -->
                   <select name="AttachmentType"
                           class="form-control"
+                          tal:condition="can_edit"
                           tal:attributes="name string:attachments.AttachmentType:records;
                                           data-attachment-uid string:${attachment/UID};">
                     <tal:item repeat="item attachments_view/get_attachment_types">
                       <option tal:attributes="value item/UID;
-                                              selected python:item.UID==attachment['type']"
+                                              selected python:item.UID==attachment['type_uid']"
                               tal:content="item/Title">
                         Attachment Type
                       </option>
                     </tal:item>
                   </select>
+                  <span tal:condition="not:can_edit"
+                        tal:content="attachment/type"/>
                 </td>
                 <td class="attachment-field-size">
                   <!-- File Size -->
-                  <span class="filesize" tal:content="attachment/size"></span>
+                  <span class="filesize" tal:content="attachment/size"/>
                 </td>
                 <td class="attachment-analysis">
                   <!-- Attached to Analysis -->
-                  <span class="analysis" tal:content="attachment/analysis"></span>
+                  <span class="analysis" tal:content="attachment/analysis"/>
                 </td>
                 <td class="attachment-keywords">
                   <!-- Attachment Keywords -->
                   <input name="AttachmentKeys"
                          class="form-control"
+                         tal:condition="can_edit"
                          tal:attributes="name string:attachments.AttachmentKeys:records;
                                          value attachment/keywords;"/>
+                  <span tal:condition="not:can_edit"
+                        tal:content="attachment/keywords"/>
                 </td>
                 <td class="attachment-report-option">
                   <!-- Attachment Report Option
@@ -126,6 +132,7 @@
                     -->
                   <select name="ReportOption"
                           class="form-control"
+                          tal:condition="can_edit"
                           tal:attributes="name string:attachments.ReportOption:records;
                                           data-attachment-uid string:${attachment/UID}">
                     <tal:item repeat="item attachments_view/get_attachment_report_options">
@@ -136,23 +143,26 @@
                       </option>
                     </tal:item>
                   </select>
+                  <span tal:condition="not:can_edit"
+                        tal:content="attachment/report_option_value"/>
                 </td>
                 <td class="attachment-delete" tal:condition="can_edit">
 
                   <!-- Delete Attachment -->
                   <input type="checkbox"
+                          tal:condition="attachment/can_edit"
                           tal:attributes="name string:attachments.delete:records:boolean;
                                           value python:True;"/>
-                    <input type="hidden"
-                          tal:attributes="name string:attachments.delete:records:boolean:default;
-                                          value python:False;"/>
+                  <input type="hidden"
+                        tal:attributes="name string:attachments.delete:records:boolean:default;
+                                        value python:False;"/>
                 </td>
               </tr>
             </tbody>
           </table>
 
           <!-- short usage description -->
-          <div class="formHelp discreet">
+          <div class="formHelp discreet" tal:condition="can_edit">
             <p i18n:translate="">
               Please click the update button after your changes.
             </p>
@@ -168,6 +178,7 @@
                  type="submit"
                  name="updateARAttachment"
                  value="Update Attachments"
+                 tal:condition="can_edit"
                  i18n:attributes="value"/>
 
         </form>
@@ -176,7 +187,8 @@
 
       <!-- Add Attachments -->
       <div id="attachments_add"
-            class="ar_attachments_list">
+           tal:condition="can_edit"
+           class="ar_attachments_list">
 
         <!-- Add Form -->
         <form action="attachments_view"
@@ -188,14 +200,14 @@
           <input type="hidden" name="submitted" value="1"/>
           <span tal:replace="structure context/@@authenticator/authenticator"/>
 
-          <table id="attachments_add_table" class="listing">
+          <table id="attachments_add_table" class="table-sm">
             <thead>
               <tr>
                 <th i18n:translate="">Add new Attachment</th>
                 <th i18n:translate="">Type</th>
                 <th i18n:translate="">Analysis</th>
                 <th i18n:translate="">Keywords</th>
-                <th i18n:translate=''>Report Option</th>
+                <th i18n:translate="">Report Option</th>
               </tr>
             </thead>
             <tbody>

--- a/src/senaite/core/browser/viewlets/templates/worksheet_attachments.pt
+++ b/src/senaite/core/browser/viewlets/templates/worksheet_attachments.pt
@@ -32,13 +32,13 @@
           <input type="hidden" name="submitted" value="1"/>
           <span tal:replace="structure context/@@authenticator/authenticator"/>
 
-          <table class="table-sm">
+          <table>
             <tr>
-              <th i18n:translate="">Add new Attachment</th>
-              <th i18n:translate="">Type</th>
-              <th i18n:translate="">Analysis</th>
-              <th i18n:translate="">All Analyses of Service</th>
-              <th i18n:translate="">Keywords</th>
+              <th class="pr-3" i18n:translate="">Add new Attachment</th>
+              <th class="pr-3" i18n:translate="">Type</th>
+              <th class="pr-3" i18n:translate="">Analysis</th>
+              <th class="pr-3" i18n:translate="">All Analyses of Service</th>
+              <th class="pr-3" i18n:translate="">Keywords</th>
             </tr>
             <tr>
               <td>

--- a/src/senaite/core/browser/viewlets/templates/worksheet_attachments.pt
+++ b/src/senaite/core/browser/viewlets/templates/worksheet_attachments.pt
@@ -6,7 +6,7 @@
           class="btn btn-light dropdown-toggle mb-3"
           data-toggle="collapse"
           data-target="#ws-attachments-panel">
-    <i class="fas fa-paperclip" aria-hidden="true"></i>
+    <i class="fas fa-paperclip" aria-hidden="true"/>
     <span i18n:translate="">Attachments</span>
   </button>
 
@@ -15,7 +15,9 @@
        tal:define="attachments_view python:view.get_attachments_view()">
 
     <!-- Attachments Viewlet -->
-    <div class="panel-body">
+    <div class="panel-body"
+         tal:define="attachment_types attachments_view/get_attachment_types;
+                     services view/get_services;">
 
       <!-- Add Attachments -->
       <div class="ws_attachments_add">
@@ -46,12 +48,9 @@
               </td>
               <td>
                 <select class="form-control" name="AttachmentType">
-                  <tal:item repeat="item attachments_view/get_attachment_types">
-                    <option tal:attributes="value item/UID;"
-                            tal:content="item/Title">
-                      Attachment Type
-                    </option>
-                  </tal:item>
+                  <option tal:repeat="item attachment_types"
+                          tal:attributes="value item/UID;"
+                          tal:content="item/Title"/>
                 </select>
               </td>
               <td>
@@ -67,21 +66,12 @@
                 </tal:analyses>
               </td>
               <td>
-                <tal:services
-                  tal:define="global last_uid python:None;
-                              services view/get_services" >
-                  <select class="form-control" name="Service" id="Service" condition="services">
-                    <option value='' selected></option>
-                    <tal:service tal:repeat="service services">
-                      <tal:nodups tal:condition="python:not service.UID() == last_uid">
-                        <option
-                          tal:define="global last_uid service/UID"
-                          tal:attributes="value service/UID;"
-                          tal:content="service/Title"></option>
-                      </tal:nodups>
-                    </tal:service>
-                  </select>
-                </tal:services>
+                <select class="form-control" name="Service" id="Service">
+                  <option value=""/>
+                  <option tal:repeat="service services"
+                          tal:attributes="value service/uid;"
+                          tal:content="service/title"/>
+                </select>
               </td>
               <td>
                 <input class="form-control" name="AttachmentKeys"/>

--- a/src/senaite/core/browser/viewlets/templates/worksheet_attachments.pt
+++ b/src/senaite/core/browser/viewlets/templates/worksheet_attachments.pt
@@ -32,7 +32,7 @@
           <input type="hidden" name="submitted" value="1"/>
           <span tal:replace="structure context/@@authenticator/authenticator"/>
 
-          <table class="listing">
+          <table class="table-sm">
             <tr>
               <th i18n:translate="">Add new Attachment</th>
               <th i18n:translate="">Type</th>
@@ -42,16 +42,20 @@
             </tr>
             <tr>
               <td>
-                <!-- Attachment File Upload -->
-                <input type="file" name="AttachmentFile_file"
-                       onchange="string:document.getElementById('addARButton').disabled=false"/>
+                <div class="form-group">
+                  <!-- Attachment File Upload -->
+                  <input type="file" name="AttachmentFile_file"
+                         onchange="string:document.getElementById('addARButton').disabled=false"/>
+                </div>
               </td>
               <td>
-                <select class="form-control" name="AttachmentType">
-                  <option tal:repeat="item attachment_types"
-                          tal:attributes="value item/UID;"
-                          tal:content="item/Title"/>
-                </select>
+                <div class="form-group">
+                  <select class="form-control" name="AttachmentType">
+                    <option tal:repeat="item attachment_types"
+                            tal:attributes="value item/UID;"
+                            tal:content="item/Title"/>
+                  </select>
+                </div>
               </td>
               <td>
                 <tal:analyses>
@@ -66,15 +70,19 @@
                 </tal:analyses>
               </td>
               <td>
-                <select class="form-control" name="Service" id="Service">
-                  <option value=""/>
-                  <option tal:repeat="service services"
-                          tal:attributes="value service/uid;"
-                          tal:content="service/title"/>
-                </select>
+                <div class="form-group">
+                  <select class="form-control" name="Service" id="Service">
+                    <option value=""/>
+                    <option tal:repeat="service services"
+                            tal:attributes="value service/uid;"
+                            tal:content="service/title"/>
+                  </select>
+                </div>
               </td>
               <td>
-                <input class="form-control" name="AttachmentKeys"/>
+                <div class="form-group">
+                  <input class="form-control" name="AttachmentKeys"/>
+                </div>
               </td>
             </tr>
           </table>

--- a/src/senaite/core/upgrade/v02_00_000.py
+++ b/src/senaite/core/upgrade/v02_00_000.py
@@ -123,7 +123,8 @@ def upgrade(tool):
     # https://github.com/senaite/senaite.core/pull/1638
     fix_published_results_permission(portal)
 
-    # Update workflow mappings for samples to allow profile editing
+    # Update workflow mappings for samples to allow profile editing and fix
+    # Add Attachment permission for verified and published status
     update_workflow_mappings_samples(portal)
 
     # Initialize new department ID field
@@ -220,7 +221,7 @@ def fix_published_results_permission(portal):
 
 
 def update_workflow_mappings_samples(portal):
-    """Allow to edit analysis profiles
+    """Allow to edit analysis profiles and fix AddAttachment permission
     """
     logger.info("Updating role mappings for Samples ...")
     wf_id = "bika_ar_workflow"
@@ -234,6 +235,8 @@ def update_workflow_mappings_samples(portal):
                  "attachment_due",
                  "to_be_verified",
                  "to_be_preserved",
+                 "verified",
+                 "published"
              ]}
     brains = api.search(query, CATALOG_ANALYSIS_REQUEST_LISTING)
     update_workflow_mappings_for(portal, wf_id, brains)

--- a/src/senaite/core/upgrade/v02_00_000.py
+++ b/src/senaite/core/upgrade/v02_00_000.py
@@ -114,6 +114,7 @@ def upgrade(tool):
     setup.runImportStepFromProfile(profile, "viewlets")
     setup.runImportStepFromProfile(profile, "repositorytool")
     # run import steps located in bika.lims profiles
+    _run_import_step(portal, "rolemap", profile="profile-bika.lims:default")
     _run_import_step(portal, "typeinfo", profile="profile-bika.lims:default")
     _run_import_step(portal, "workflow", profile="profile-bika.lims:default")
 
@@ -225,19 +226,7 @@ def update_workflow_mappings_samples(portal):
     """
     logger.info("Updating role mappings for Samples ...")
     wf_id = "bika_ar_workflow"
-    query = {"portal_type": "AnalysisRequest",
-             "review_state": [
-                 "sample_due",
-                 "sample_registered",
-                 "scheduled_sampling",
-                 "to_be_sampled",
-                 "sample_received",
-                 "attachment_due",
-                 "to_be_verified",
-                 "to_be_preserved",
-                 "verified",
-                 "published"
-             ]}
+    query = {"portal_type": "AnalysisRequest"}
     brains = api.search(query, CATALOG_ANALYSIS_REQUEST_LISTING)
     update_workflow_mappings_for(portal, wf_id, brains)
     logger.info("Updating role mappings for Samples [DONE]")
@@ -250,6 +239,8 @@ def update_workflow_mappings_for(portal, wf_id, brains):
     for num, brain in enumerate(brains):
         if num and num % 100 == 0:
             logger.info("Updating role mappings: {0}/{1}".format(num, total))
+        if num and num % 1000 == 0:
+            commit_transaction(portal)
         obj = api.get_object(brain)
         workflow.updateRoleMappingsFor(obj)
         obj.reindexObject(idxs=["allowedRolesAndUsers"])

--- a/src/senaite/core/upgrade/v02_00_000.py
+++ b/src/senaite/core/upgrade/v02_00_000.py
@@ -127,6 +127,7 @@ def upgrade(tool):
     # Update workflow mappings for samples to allow profile editing and fix
     # Add Attachment permission for verified and published status
     update_workflow_mappings_samples(portal)
+    update_workflow_mappings_worksheets(portal)
 
     # Initialize new department ID field
     # https://github.com/senaite/senaite.core/pull/1676
@@ -230,6 +231,17 @@ def update_workflow_mappings_samples(portal):
     brains = api.search(query, CATALOG_ANALYSIS_REQUEST_LISTING)
     update_workflow_mappings_for(portal, wf_id, brains)
     logger.info("Updating role mappings for Samples [DONE]")
+
+
+def update_workflow_mappings_worksheets(portal):
+    """Fix AddAttachment permission
+    """
+    logger.info("Updating role mappings for Worksheets ...")
+    wf_id = "bika_worksheet_workflow"
+    query = {"portal_type": "Worksheet"}
+    brains = api.search(query, CATALOG_WORKSHEET_LISTING)
+    update_workflow_mappings_for(portal, wf_id, brains)
+    logger.info("Updating role mappings for Worksheets [DONE]")
 
 
 def update_workflow_mappings_for(portal, wf_id, brains):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request modifies the way the attachments viewlet is displayed as well as the options available depending on the object to which a given attachment is associated to (sample or analysis).

Instead of relying on sample and analyses status, the viewlet now displays the suitable information based on sample and analyses permissions.

## Current behavior before PR

Attachments management viewlet is always rendered in edit mode and analysis attachments operations do not rely on analysis permissions

## Desired behavior after PR is merged

Attachments management viewlet is rendered in edit or view mode depending on the permissions for current user and context and analyses and their available operations are rendered based on the permission for the user and analysis

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
