### PR TITLE
Fix allow/disallow manual entry of analysis result based on method setting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #1718 Fix allow/disallow manual entry of analysis result based on method setting
 - #1716 Fix workflow state offset in toolbar when no dropdown is rendered
 - #1715 Updated build system to Webpack 5
 - #1714 Removed add button in auditlog listing view

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -306,6 +306,11 @@ class AnalysesView(BikaListingView):
         if not self.has_permission(FieldEditAnalysisResult, analysis_obj):
             return False
 
+        # Check if the method allows to edit the result
+        method = analysis_obj.getMethod()
+        if method and not method.getManualEntryOfResults():
+            return False
+
         # Is the instrument out of date?
         # The user can assign a result to the analysis if it does not have any
         # instrument assigned or the instrument assigned is valid.


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

With this PR the results field checks if the method allows manual entry of results as well.

## Current behavior before PR

The setting "Manual Entry of Results" was not checked

## Desired behavior after PR is merged

When the "Manual Entry of Results" is unchecked in the Method, the analysis does not allow to set a result

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
