### PR TITLE
Fix UnicodeDecodeError for Instrument Import Log View

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #1720 Fix UnicodeDecodeError for Instrument Import Log View
 - #1719 Service/Method/Calculation relationship handling
 - #1717 Port workflow definitions to senaite namespace
 - #1716 Fix workflow state offset in toolbar when no dropdown is rendered

--- a/src/bika/lims/browser/instrument.py
+++ b/src/bika/lims/browser/instrument.py
@@ -742,8 +742,9 @@ class InstrumentAutoImportLogsView(AutoImportLogsView):
             "sort_order": "descending",
         }
 
+        instrument = self.context.Title()
         self.title = self.context.translate(
-            _("Auto Import Logs of %s" % self.context.Title()))
+            _(u"Auto Import Logs of %s" % api.safe_unicode(instrument)))
         self.icon = "{}/{}".format(
             self.portal_url,
             "++resource++bika.lims.images/instrumentcertification_big.png"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an `UnicodeDecodeError` when accessing the AutoImportLogs view

## Current behavior before PR

Traceback happens for instruments containing unicode chars in the title:

```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 130, in publish
  Module ZPublisher.BaseRequest, line 518, in traverse
  Module ZPublisher.BaseRequest, line 349, in traverseName
  Module plone.app.imaging.traverse, line 40, in publishTraverse
  Module plone.app.imaging.traverse, line 26, in fallback
  Module ZPublisher.BaseRequest, line 92, in publishTraverse
  Module zope.component._api, line 116, in queryMultiAdapter
  Module zope.interface.registry, line 365, in queryMultiAdapter
  Module zope.interface.adapter, line 564, in queryMultiAdapter
  Module bika.lims.browser.instrument, line 746, in __init__
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 13: ordinal not in range(128)
```


## Desired behavior after PR is merged

No traceback appears and the view is rendered

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
