### PR TITLE
Changed order of setup profiles installation

### DIFF
--- a/src/senaite/core/configure.zcml
+++ b/src/senaite/core/configure.zcml
@@ -41,8 +41,6 @@
       title="SENAITE CORE: Run Setup Handler"
       description="Run install handler"
       handler="senaite.core.setuphandlers.install">
-    <depends name="typeinfo"/>
-    <depends name="toolset"/>
   </genericsetup:importStep>
 
   <!-- Hidden Profiles -->

--- a/src/senaite/core/setuphandlers.py
+++ b/src/senaite/core/setuphandlers.py
@@ -82,20 +82,22 @@ def install(context):
     logger.info("SENAITE CORE install handler [BEGIN]")
     portal = context.getSite()
 
-    # Run required import steps
+    # TODO: Remove all profiles from bika.lims package
+    # Run required import steps from bika.lims package
     _run_import_step(portal, "skins")
     _run_import_step(portal, "browserlayer")
     _run_import_step(portal, "rolemap")
     _run_import_step(portal, "typeinfo")
     _run_import_step(portal, "factorytool")
+
+    # Run required import steps from senaite.core package
     _run_import_step(portal, "workflow", "profile-senaite.core:default")
+    _run_import_step(portal, "toolset", "profile-senaite.core:default")
 
     # Run Installers
     setup_groups(portal)
     remove_default_content(portal)
     setup_core_catalogs(portal)
-    setup_content_structure(portal)
-    add_dexterity_setup_items(portal)
     setup_catalog_mappings(portal)
 
     # Run after all catalogs have been setup
@@ -104,6 +106,10 @@ def install(context):
     # Set CMF Form actions
     setup_form_controller_actions(portal)
     setup_form_controller_more_action(portal)
+
+    # Setup contents
+    setup_content_structure(portal)
+    add_dexterity_setup_items(portal)
 
     logger.info("SENAITE CORE install handler [DONE]")
 
@@ -124,6 +130,7 @@ def setup_content_structure(portal):
     """Install the base content structure
     """
     logger.info("*** Install SENAITE Content Types ***")
+    _run_import_step(portal, "typeinfo", "profile-senaite.core:default")
     _run_import_step(portal, "content")
     reindex_content_structure(portal)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the order of the setup profiles to work for fresh Senaite installations as well as for updates of 1.x -> 2.x.


## Current behavior before PR

Traceback happens when installing `senaite.core` in a `1.x` installation

```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module <string>, line 3, in installProducts
  Module AccessControl.requestmethod, line 88, in _curried
  Module Products.CMFQuickInstallerTool.QuickInstallerTool, line 713, in installProducts
  Module Products.CMFQuickInstallerTool.QuickInstallerTool, line 629, in installProduct
   - __traceback_info__: ('senaite.core',)
  Module Products.GenericSetup.tool, line 400, in runAllImportStepsFromProfile
   - __traceback_info__: profile-senaite.core:default
  Module Products.GenericSetup.tool, line 1478, in _runImportStepsFromContext
  Module Products.GenericSetup.tool, line 1290, in _doRunImportStep
   - __traceback_info__: typeinfo
  Module Products.CMFCore.exportimport.typeinfo, line 221, in importTypesTool
  Module Products.GenericSetup.utils, line 908, in importObjects
   - __traceback_info__: portal_types
  Module Products.GenericSetup.utils, line 904, in importObjects
   - __traceback_info__: types/InstrumentLocation
  Module Products.GenericSetup.utils, line 541, in _importBody
  Module Products.CMFCore.exportimport.typeinfo, line 60, in _importNode
  Module Products.GenericSetup.utils, line 773, in _initProperties
ValueError: undefined property 'add_permission'
```


## Desired behavior after PR is merged

No traceback happens when installing the `senaite.core` package in a `1.x` installation

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
