### PR TITLE
Fix UnicodeDecodeError in Analyses Listing Instruments Vocabulary

### DIFF
--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -464,7 +464,7 @@ class AnalysesView(ListingView):
         vocab = []
         for instrument in instruments:
             uid = api.get_uid(instrument)
-            title = api.get_title(instrument)
+            title = api.safe_unicode(api.get_title(instrument))
             # append all valid instruments
             if instrument.isValid():
                 vocab.append({
@@ -474,14 +474,14 @@ class AnalysesView(ListingView):
             elif is_qc:
                 # Is a QC analysis, include instrument also if is not valid
                 if instrument.isOutOfDate():
-                    title = _("{} (Out of date)".format(title))
+                    title = _(u"{} (Out of date)".format(title))
                 vocab.append({
                     "ResultValue": uid,
                     "ResultText": title,
                 })
             elif instrument.isOutOfDate():
                 # disable out of date instruments
-                title = _("{} (Out of date)".format(title))
+                title = _(u"{} (Out of date)".format(title))
                 vocab.append({
                     "disabled": True,
                     "ResultValue": None,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a UnicodeDecodeError in Analyses Listing

## Current behavior before PR

Traceback occurs for instruments containing unicode characters:

```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module senaite.app.listing.view, line 215, in __call__
  Module senaite.app.listing.ajax, line 108, in handle_subpath
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 533, in ajax_folderitems
  Module senaite.app.listing.decorators, line 88, in wrapper
  Module senaite.app.listing.ajax, line 312, in get_folderitems
  Module bika.lims.browser.analyses.view, line 620, in folderitems
  Module senaite.app.listing.view, line 898, in folderitems
  Module bika.lims.browser.analyses.view, line 577, in folderitem
  Module bika.lims.browser.analyses.view, line 931, in _folder_item_instrument
  Module bika.lims.browser.analyses.view, line 484, in get_instruments_vocabulary
  Module zope.i18nmessageid.message, line 112, in __call__
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 7: ordinal not in range(128)
```

## Desired behavior after PR is merged

Instrument names displayed correct

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
