### PR TITLE
Allow installation of senaite.core for 1.x upgrade

### DIFF
--- a/src/senaite/core/configure.zcml
+++ b/src/senaite/core/configure.zcml
@@ -41,8 +41,6 @@
       title="SENAITE CORE: Run Setup Handler"
       description="Run install handler"
       handler="senaite.core.setuphandlers.install">
-    <depends name="typeinfo"/>
-    <depends name="toolset"/>
   </genericsetup:importStep>
 
   <!-- Hidden Profiles -->

--- a/src/senaite/core/profiles/default/types.xml
+++ b/src/senaite/core/profiles/default/types.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <object name="portal_types" meta_type="Plone Types Tool">
  <property name="title">Controls available content types in senaite</property>
+ <!-- remove old AT based types -->
+ <object remove="True" name="InstrumentLocation" meta_type="Factory-based Type Information with dynamic views"/>
+ <object remove="True" name="InstrumentLocations" meta_type="Factory-based Type Information with dynamic views"/>
  <!-- Instrument Locations -->
  <object name="InstrumentLocation" meta_type="Dexterity FTI" />
  <object name="InstrumentLocations" meta_type="Dexterity FTI" />

--- a/src/senaite/core/setuphandlers.py
+++ b/src/senaite/core/setuphandlers.py
@@ -25,6 +25,7 @@ from bika.lims.setuphandlers import setup_catalog_mappings
 from bika.lims.setuphandlers import setup_core_catalogs
 from bika.lims.setuphandlers import setup_form_controller_actions
 from bika.lims.setuphandlers import setup_groups
+from Products.CMFPlone.utils import get_installer
 from senaite.core import logger
 from senaite.core.config import PROFILE_ID
 from zope.interface import implementer
@@ -89,6 +90,15 @@ def install(context):
     _run_import_step(portal, "typeinfo")
     _run_import_step(portal, "factorytool")
     _run_import_step(portal, "workflow", "profile-senaite.core:default")
+    _run_import_step(portal, "toolset", "profile-senaite.core:default")
+    _run_import_step(portal, "typeinfo", "profile-senaite.core:default")
+
+    # skip installers if already installed
+    qi = get_installer(portal)
+    profiles = ["bika.lims", "senaite.core"]
+    if any(map(lambda p: qi.is_product_installed(p), profiles)):
+        logger.info("SENAITE CORE already installed [SKIP]")
+        return
 
     # Run Installers
     setup_groups(portal)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR handles the installation procedure of `senaite.core` when upgrading the system from `1.x` versions.

## Current behavior before PR

Installation of `senaite.core` failed because of updated DX types and performed all setup steps

## Desired behavior after PR is merged

Installation of `senaite.core` succeeds and skips initial setup steps

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
