### PR TITLE
Content rules control panel templates styled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #1726 Content rules control panel templates styled
 - #1720 Fix UnicodeDecodeError for Instrument Import Log View
 - #1719 Service/Method/Calculation relationship handling
 - #1717 Port workflow definitions to senaite namespace

--- a/src/senaite/core/browser/configure.zcml
+++ b/src/senaite/core/browser/configure.zcml
@@ -18,6 +18,7 @@
   <include package=".bootstrap"/>
   <include package=".content"/>
   <include package=".contentmenu"/>
+  <include package=".contentrules"/>
   <include package=".controlpanel"/>
   <include package=".dashboard"/>
   <include package=".dexterity"/>

--- a/src/senaite/core/browser/contentrules/configure.zcml
+++ b/src/senaite/core/browser/contentrules/configure.zcml
@@ -1,0 +1,16 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    i18n_domain="senaite.core">
+
+  <!-- Manage elements in a rul -->
+  <browser:page
+      name="manage-elements"
+      for="plone.contentrules.rule.interfaces.IRule"
+      class=".elements.ManageElements"
+      permission="plone.app.contentrules.ManageContentRules"
+      layer="senaite.core.interfaces.ISenaiteCore"
+      />
+
+</configure>

--- a/src/senaite/core/browser/contentrules/configure.zcml
+++ b/src/senaite/core/browser/contentrules/configure.zcml
@@ -4,6 +4,16 @@
     xmlns:plone="http://namespaces.plone.org/plone"
     i18n_domain="senaite.core">
 
+  <!-- Content rules control panel -->
+  <browser:page
+      for="Products.CMFCore.interfaces.ISiteRoot"
+      name="rules-controlpanel"
+      class=".controlpanel.ContentRulesControlPanel"
+      permission="plone.app.contentrules.ManageContentRules"
+      allowed_attributes="template"
+      layer="senaite.core.interfaces.ISenaiteCore"
+      />
+
   <!-- Manage elements in a rul -->
   <browser:page
       name="manage-elements"

--- a/src/senaite/core/browser/contentrules/controlpanel.py
+++ b/src/senaite/core/browser/contentrules/controlpanel.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+from plone.app.contentrules.browser.controlpanel import \
+    ContentRulesControlPanel as Base
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
+
+class ContentRulesControlPanel(Base):
+    """Manage rules in a the global rules container
+    """
+    template = ViewPageTemplateFile("templates/controlpanel.pt")

--- a/src/senaite/core/browser/contentrules/elements.py
+++ b/src/senaite/core/browser/contentrules/elements.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+
+from plone.app.contentrules.browser.elements import ManageElements as Base
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
+
+class ManageElements(Base):
+    """Manage elements in a rule
+    """
+    template = ViewPageTemplateFile('templates/manage-elements.pt')

--- a/src/senaite/core/browser/contentrules/templates/controlpanel.pt
+++ b/src/senaite/core/browser/contentrules/templates/controlpanel.pt
@@ -11,6 +11,13 @@
     <div metal:fill-slot="prefs_configlet_main"
          tal:define="rules view/registeredRules">
 
+      <!-- Link back to controlpanel -->
+      <a id="setup-link" class="link-parent"
+         tal:attributes="href string:$portal_url/@@overview-controlpanel"
+         i18n:translate="">
+        Site Setup
+      </a>
+
       <h1 class="documentFirstHeading"
           i18n:translate="title_manage_contentrules">Content Rules</h1>
 

--- a/src/senaite/core/browser/contentrules/templates/controlpanel.pt
+++ b/src/senaite/core/browser/contentrules/templates/controlpanel.pt
@@ -1,0 +1,190 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      lang="en"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      metal:use-macro="here/prefs_main_template/macros/master"
+      i18n:domain="plone">
+
+  <body>
+
+    <div metal:fill-slot="prefs_configlet_main"
+         tal:define="rules view/registeredRules">
+
+      <h1 class="documentFirstHeading"
+          i18n:translate="title_manage_contentrules">Content Rules</h1>
+
+      <p i18n:translate="description-contentrules-controlpanel" class="documentDescription">
+        Use the form below to define, change or remove content rules. Rules
+        will automatically perform actions on content when certain triggers
+        take place. After defining rules, you may want to go to a folder
+        to assign them, using the "rules" item in the actions menu.
+      </p>
+
+      <div id="translated-text" style="display:none">
+        <span id="trns_form_error" i18n:translate="">
+          There was an error saving content rules.
+        </span>
+        <span id="trns_form_success" i18n:translate="">
+          Content rule settings updated.
+        </span>
+      </div>
+
+      <!-- Disable globally -->
+      <div class="mb-4" id="fieldset-global">
+        <form name="ruleSettings" method="POST"
+              tal:attributes="action string:${context/absolute_url}/@@rules-controlpanel">
+          <span tal:replace="structure context/@@authenticator/authenticator"/>
+          <div class="field">
+            <input type="hidden" name="global_disable:boolean:default" value="" />
+            <input type="checkbox"
+                   id="rules_disable_globally"
+                   name="global_disable:boolean"
+                   value="True"
+                   tal:attributes="checked python:view.globally_disabled() and 'checked' or None" />
+            <label for="rules_disable_globally" i18n:translate="">Disable globally</label>
+            <div class="formHelp" i18n:translate="">
+              Whether or not content rules should be disabled globally. If this is selected,
+              no rules will be executed anywhere in the portal.
+            </div>
+          </div>
+
+          <div class="formControls">
+            <input type="submit"
+                   name="form.button.SaveSettings"
+                   class="btn btn-primary"
+                   value="Save"
+                   i18n:attributes="value label_save;" />
+          </div>
+        </form>
+      </div>
+
+      <!-- rules -->
+      <fieldset id="fieldset-rules"
+                tal:define="rules rules|view/registeredRules;
+                    add_url string:${context/absolute_url}/+rule/plone.ContentRule;">
+        <legend id="fieldsetlegend-rules" i18n:translate="legend-contentrules">Content rules</legend>
+
+        <!-- table filters (disabled) -->
+        <div class="filters" tal:condition="python:False">
+          <span class="type-filters">
+            <span i18n:translate="">Filter:</span>
+            <span class="filter-option"
+                  tal:repeat="rule view/ruleTypesToShow">
+              <input id="all" type="checkbox"
+                     tal:attributes="id rule/id"
+              />
+              <label
+                for="all"
+                tal:attributes="for rule/id"
+                tal:content="rule/title">
+                All</label>
+            </span>
+          </span>
+          <span class="state-filters" tal:condition="rules">
+            <span class="filter-option"
+                  tal:repeat="state view/statesToShow">
+              <input id="all" type="checkbox"
+                     tal:attributes="id state/id"
+              />
+              <label
+                for="all"
+                tal:attributes="for state/id"
+                tal:content="state/title">
+                All</label>
+            </span>
+          </span>
+        </div>
+
+        <div id="rules_table_form"
+             metal:define-macro="rules_table_form">
+          <table class="table table-striped"
+                 tal:condition="rules">
+            <thead>
+              <tr>
+                <th i18n:translate="label_contentrules_rule_listing">content rule</th>
+                <th i18n:translate="label_contentrules_rule_event">event</th>
+                <th i18n:translate="label_contentrules_rule_enabled">enabled</th>
+                <th >&nbsp;</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tal:rules repeat="rule view/registeredRules">
+                <tr tal:define="oddrow repeat/rule/odd"
+                    tal:attributes="class python:(oddrow and 'even ' or 'odd ') + rule['row_class'];">
+                  <td>
+                    <dl>
+                      <dt>
+                        <a tal:attributes="href string:${context/absolute_url}/++rule++${rule/id}/@@manage-elements">
+                          <span tal:replace="rule/title">Rule Title</span>
+                        </a>
+                      </dt>
+                      <dd tal:content="rule/description">
+                        Rule Description.
+                      </dd>
+                    </dl>
+                  </td>
+                  <td>
+                    <span class="trigger"
+                          tal:content="rule/trigger"
+                          i18n:translate="">trigger</span>
+                  </td>
+                  <td class="checker"
+                      tal:define="enabled rule/enabled;
+                                  assigned rule/assigned;">
+                    <!-- rule enabled -->
+                    <i class="fas fa-check"
+                       tal:condition="python:enabled and assigned"
+                       i18n:attributes="title label_contentrules_rule_enabled;"
+                       title="active"></i>
+                    <!-- rule not enabled and not assigned -->
+                    <i class="fas fa-times"
+                       tal:condition="python:not enabled"
+                       i18n:attributes="title"
+                       title="inactive"></i>
+                    <!-- rule enabled but not assigned -->
+                    <i class="fas fa-ban"
+                       tal:condition="python:not assigned and enabled"
+                       i18n:attributes="title"
+                       title="unassigned"></i>
+                  </td>
+                  <td>
+                    <form style="display: inline" method="POST"
+                          tal:attributes="action string:${context/absolute_url}/@@rules-controlpanel">
+                      <span tal:replace="structure context/@@authenticator/authenticator"/>
+                      <input type="hidden"
+                             name="rule-id"
+                             tal:attributes="value rule/id">
+                      <input class="btn btn-sm btn-primary" type="submit" value="Enable"
+                             name="form.button.EnableRule"
+                             tal:attributes="data-value rule/id;
+                                    data-url string:$portal_url/@@contentrule-enable"
+                             i18n:attributes="value label_enable;" />
+                      <input class="btn btn-sm btn-secondary" type="submit" value="Disable"
+                             name="form.button.DisableRule"
+                             tal:attributes="data-value rule/id;
+                                    data-url string:$portal_url/@@contentrule-disable"
+                             i18n:attributes="value label_disable;" />
+                      <input class="btn btn-sm btn-danger" type="submit" value="Delete"
+                             tal:attributes="data-value rule/id;
+                                    data-url string:$portal_url/@@contentrule-delete"
+                             name="form.button.DeleteRule"
+                             i18n:attributes="value label_delete;" />
+                    </form>
+                  </td>
+                </tr>
+              </tal:rules>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- add rule -->
+        <a id="#addcontentrule" tal:attributes="href add_url"
+           class="btn btn-primary"
+           i18n:translate="label_contentrule_add">Add content rule</a>
+      </fieldset>
+
+    </div>
+  </body>
+</html>
+

--- a/src/senaite/core/browser/contentrules/templates/manage-elements.pt
+++ b/src/senaite/core/browser/contentrules/templates/manage-elements.pt
@@ -1,0 +1,331 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      lang="en"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      metal:use-macro="here/prefs_main_template/macros/master"
+      i18n:domain="plone">
+
+  <body>
+
+    <div metal:fill-slot="prefs_configlet_main">
+
+      <h1 class="documentFirstHeading"
+          i18n:translate="title_edit_contentrule">Edit content rule</h1>
+
+      <a href=""
+         class="link-parent"
+         tal:attributes="href string:${portal_url}/@@rules-controlpanel"
+         i18n:translate="go_to_contentrules_management">
+        Up to rule management
+      </a>
+
+      <p i18n:translate="contentrules_description_execution"
+         class="documentDescription">
+        Rules execute when a triggering event occurs. Rule actions will only
+        be invoked if all the rule's conditions are met. You can add new
+        actions and conditions using the buttons below.
+      </p>
+
+      <!-- conditions panel -->
+      <div class="font-weight-bold text-muted" i18n:translate="if_all_conditions_met">
+        If all of the following conditions are met:
+      </div>
+      <a name="condition"></a>
+      <div class="border rounded p-2" id="configure-conditions" tal:define="conditions view/conditions">
+        <!-- no conditions message -->
+        <div tal:condition="not:conditions" class="alert alert-warning">
+          <strong>Info</strong>
+          <span i18n:translate="">
+            There is not any additional condition checked on this rule.
+          </span>
+        </div>
+
+        <form tal:attributes="action view/view_url" method="post"
+              tal:define="auth_token context/@@authenticator/token"
+              tal:repeat="condition conditions">
+          <span tal:replace="structure context/@@authenticator/authenticator"></span>
+          <a tal:attributes="name string:condition++${condition/idx}"></a>
+          <input type="hidden" name="element_id:int" tal:attributes="value condition/idx" />
+          <div class="rule-element">
+            <div class="rule-operations">
+              <a tal:attributes="href string:${condition/editview}?_authenticator=${auth_token}"
+                 class="btn btn-sm btn-primary"
+                 tal:condition="condition/editview" i18n:translate="label_edit">Edit</a>
+              <input type="submit"
+                     name="form.button.DeleteCondition"
+                     value="Remove"
+                     class="btn btn-sm btn-danger"
+                     i18n:attributes="value label_remove;"
+              />
+              <input tal:attributes="disabled python:condition['first'] and 'disabled' or None"
+                     type="submit"
+                     name="form.button.MoveConditionUp"
+                     value="&uarr;"
+                     class="btn btn-sm btn-secondary"
+              />
+              <input tal:attributes="disabled python:condition['last'] and 'disabled' or None"
+                     type="submit"
+                     name="form.button.MoveConditionDown"
+                     value="&darr;"
+                     class="btn btn-sm btn-secondary"
+              />
+            </div>
+
+            <div class="my-3 alert alert-info">
+              <strong tal:content="condition/title" i18n:translate="">Transition was publish.</strong>
+              <span tal:content="condition/summary">
+                Something happened
+              </span>
+            </div>
+          </div>
+        </form>
+
+        <!-- conditions select -->
+        <form tal:attributes="action string:${view/base_url}/+condition" method="get"
+              id="add-condition">
+          <span tal:replace="structure context/@@authenticator/authenticator"></span>
+
+          <div class="input-group mb-3">
+            <span class="input-group-prepend">
+              <label i18n:translate="contentrules_add_condition"
+                    class="input-group-text"
+                    for="contentrules-add-condition">
+                Add condition
+              </label>
+            </span>
+            <select class="custom-select" name=":action" size="1" id="contentrules-add-condition">
+              <tal:block repeat="condition view/addable_conditions">
+                <option tal:attributes="value condition/addview"
+                        i18n:translate=""
+                        tal:content="condition/title" />
+              </tal:block>
+            </select>
+            <div class="input-group-append">
+              <input class="btn btn-sm btn-primary"
+                    type="submit"
+                    name="form.button.AddCondition"
+                    value="Add"
+                    i18n:attributes="value label_add;" />
+            </div>
+          </div>
+        </form>
+      </div> <!-- /conditions panel -->
+
+
+      <!-- actions panel -->
+      <div class="font-weight-bold text-muted mt-4" i18n:translate="contentrules_perform_actions">
+        Perform the following actions:
+      </div>
+      <div class="border rounded p-2" id="configure-actions" tal:define="actions view/actions">
+        <a name="action"></a>
+        <div tal:condition="not:actions" class="alert alert-warning">
+          <strong>Warning</strong>
+          <span i18n:translate="">
+            There is not any action performed by this rule.
+            Click on Add button to setup an action.
+          </span>
+        </div>
+        <form tal:attributes="action view/view_url" method="post"
+              tal:define="auth_token context/@@authenticator/token"
+              tal:repeat="action actions">
+          <span tal:replace="structure context/@@authenticator/authenticator"></span>
+          <a tal:attributes="name string:action++${action/idx}"></a>
+          <input type="hidden" name="element_id:int" tal:attributes="value action/idx" />
+          <div class="rule-element">
+            <div class="rule-operations">
+              <a tal:attributes="href string:${action/editview}?_authenticator=${auth_token}" class="pat-plone-modal"
+                 tal:condition="action/editview">
+                <input type="submit"
+                       name="form.button.EditAction"
+                       value="Edit"
+                       class="btn btn-sm btn-primary"
+                       i18n:attributes="value label_edit;"
+                />
+              </a>
+              <input type="submit"
+                     name="form.button.DeleteAction"
+                     value="Remove"
+                     class="btn btn-sm btn-danger"
+                     i18n:attributes="value label_remove;"
+              />
+              <input tal:attributes="disabled python:action['first'] and 'disabled' or None"
+                     type="submit"
+                     name="form.button.MoveActionUp"
+                     value="&uarr;"
+                     class="btn btn-sm btn-secondary"
+              />
+              <input tal:attributes="disabled python:action['last'] and 'disabled' or None"
+                     type="submit"
+                     name="form.button.MoveActionDown"
+                     value="&darr;"
+                     class="btn btn-sm btn-secondary"
+              />
+            </div>
+
+            <div class="my-3 alert alert-info">
+              <strong tal:content="action/title"
+                      i18n:translate="">Move to folder</strong>
+              <span tal:content="action/summary">
+                Something happened
+              </span>
+            </div>
+          </div>
+        </form>
+
+        <!-- action select -->
+        <form tal:attributes="action string:${view/base_url}/+action" method="get"
+              id="add-action">
+          <span tal:replace="structure context/@@authenticator/authenticator"></span>
+
+          <div class="input-group mb-3">
+            <span class="input-group-prepend">
+              <label i18n:translate="contentrules_add_action"
+                     class="input-group-text"
+                     for="contentrules-add-action">
+                Add action
+              </label>
+            </span>
+            <select class="custom-select" name=":action" size="1" id="contentrules-add-action">
+              <tal:block repeat="action view/addable_actions">
+                <option tal:attributes="value action/addview"
+                        i18n:translate=""
+                        tal:content="action/title"></option>
+              </tal:block>
+            </select>
+            <div class="input-group-append">
+              <input class="btn btn-sm btn-primary"
+                     type="submit"
+                     name="form.button.AddAction"
+                     value="Add"
+                     i18n:attributes="value label_add;" />
+            </div>
+          </div>
+        </form>
+      </div>
+
+      <!-- assignments -->
+      <tal:assignments define="assignments view/assignments">
+        <div class="font-weight-bold text-muted mt-4" i18n:translate="label_contentrules_rule_assignments">
+          Assignments
+        </div>
+        <div class="" id="manage-assignments">
+          <tal:noassignments condition="not:assignments">
+            <div class="portalMessage warning">
+              <strong i18n:translate="">This rule is not assigned to any location</strong>
+
+              <tal:enabled condition="view/rule_enabled">
+                <span i18n:translate="">
+                  The rule is enabled but will perform nothing since it is not assigned anywhere.
+                </span>
+                <br />
+                <span i18n:translate="">
+                  Go to the folder where you want the rule to apply, or at the site root,
+                  click on 'rule' tab, and then locally setup the rules.
+                </span>
+                <form  tal:attributes="action view/view_url" method="post">
+                  <span tal:replace="structure context/@@authenticator/authenticator"/>
+                  <label i18n:translate="contentrules_assignments_shortcuts">Shortcuts:</label>
+                  <input type="submit"
+                         class="btn btn-sm btn-primary"
+                         value="Apply rule on the whole site"
+                         name="form.button.ApplyOnWholeSite"
+                         i18n:attributes="value" />
+                </form>
+              </tal:enabled>
+            </div>
+
+          </tal:noassignments>
+          <tal:assignments condition="nocall:assignments">
+            <div class="alert alert-dark">
+              <strong>Info</strong>
+              <span
+                i18n:translate="description_contentrules_rule_assignments">
+                This rule is assigned to the following locations:
+              </span>
+              <tal:items repeat="assignment assignments">
+                <a tal:attributes="href string:${assignment/url}/@@manage-content-rules"
+                   tal:content="assignment/title" />
+              </tal:items>
+            </div>
+          </tal:assignments>
+        </div>
+      </tal:assignments>
+
+      <!-- edit rule -->
+      <div class="font-weight-bold text-muted mt-4" i18n:translate="">Configure rule</div>
+      <div class="border rounded p-2" id="configure-rule">
+        <form tal:attributes="action view/view_url" method="post">
+          <span tal:replace="structure context/@@authenticator/authenticator"></span>
+
+          <div class="form-group">
+            <label for="form.title" i18n:translate="label_title">Title</label>
+            <input class="form-control"
+                   id="form.title" type="text" width="50" name="title"
+                   tal:attributes="value request/ruleTitle | view/rule_title"/>
+            <small class="form-text text-muted" i18n:translate="description_contentrule_title">
+              Please set a descriptive title for the rule.
+            </small>
+          </div>
+
+          <div class="form-group">
+            <label for="form.description" i18n:translate="label_description">Description</label>
+            <textarea id="form.description"
+                      class="form-control"
+                      name="description"
+                      tal:content="request/ruleDescription | view/rule_description ">
+            </textarea>
+            <small class="form-text text-muted" i18n:translate="contentrules_description_description">
+              Enter a short description of the rule and its purpose.
+            </small>
+          </div>
+
+          <div class="form-group">
+            <label i18n:translate="label_rule_event_trigger">
+              Event trigger: <span i18n:name="trigger" tal:content="view/rule_event"></span>
+            </label>
+            <small class="form-text text-muted" i18n:translate="contentrules_description_trigger">
+              The rule will execute when the following event occurs.
+            </small>
+          </div>
+
+          <div class="form-group custom-control custom-switch">
+            <input class="custom-control-input"
+                   type="checkbox" id="stop" name="stopExecuting"
+                   tal:attributes="checked view/rule_stop"/>
+            <label class="custom-control-label" for="stop" i18n:translate="contentrules_description_stop">
+              Stop evaluating content rules after this rule completes
+            </label>
+          </div>
+
+          <div class="form-group custom-control custom-switch">
+            <input class="custom-control-input"
+                   type="checkbox" id="cascading" name="cascading"
+                   tal:attributes="checked view/rule_cascading"/>
+            <label class="custom-control-label" for="cascading" i18n:translate="contentrules_description_cascading">
+              The actions executed by this rule can trigger other rules
+            </label>
+          </div>
+
+          <div class="form-group custom-control custom-switch">
+            <input class="custom-control-input"
+                   type="checkbox" id="enabled" name="enabled"
+                   tal:attributes="checked view/rule_enabled"/>
+            <label class="custom-control-label" for="enabled" i18n:translate="">
+              Enabled
+            </label>
+          </div>
+
+          <div class="formControls">
+            <input class="btn btn-primary"
+                   type="submit"
+                   name="form.button.Save"
+                   value="Save"
+                   i18n:attributes="value label_save;" />
+          </div>
+        </form>
+      </div>
+
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the styles for the content rules control panel views.

## Current behavior before PR

Content rules not editable, because they were styled as alert boxes and usable with JS only

## Desired behavior after PR is merged

Content rules are editable and styled with Bootstrap 4 markup. They are editable w/o JS

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
