### PR TITLE
Show navigation controlpanel

### DIFF
--- a/src/senaite/core/profiles/default/controlpanel.xml
+++ b/src/senaite/core/profiles/default/controlpanel.xml
@@ -102,11 +102,11 @@
     <permission>Set own properties</permission>
   </configlet>
 
-  <!-- Navigation (hidden) -->
+  <!-- Navigation -->
   <configlet title="Navigation" action_id="NavigationSettings" appId="Plone"
              category="plone-general" condition_expr=""
              icon_expr="string:$portal_url/navigation_icon.png"
-             url_expr="string:${portal_url}/@@navigation-controlpanel" visible="False">
+             url_expr="string:${portal_url}/@@navigation-controlpanel" visible="True">
     <permission>Plone Site Setup: Navigation</permission>
   </configlet>
 

--- a/src/senaite/core/profiles/default/registry.xml
+++ b/src/senaite/core/profiles/default/registry.xml
@@ -101,29 +101,12 @@
       <element>de</element>
       <element>en</element>
       <element>es</element>
-    </value>
-  </record>
-  <record name="plone.available_languages" interface="plone.i18n.interfaces.ILanguageSchema" field="available_languages">
-    <field type="plone.registry.field.List">
-      <default>
-        <element>en</element>
-      </default>
-      <description xmlns:ns0="http://xml.zope.org/namespaces/i18n" ns0:domain="plone" ns0:translate="description_available_languages">The languages in which the site should be translatable.</description>
-      <missing_value/>
-      <title xmlns:ns0="http://xml.zope.org/namespaces/i18n" ns0:domain="plone" ns0:translate="heading_available_languages">Available languages</title>
-      <value_type type="plone.registry.field.Choice">
-        <vocabulary>plone.app.vocabularies.AvailableContentLanguages</vocabulary>
-      </value_type>
-    </field>
-    <value>
-      <element>de</element>
-      <element>en</element>
-      <element>es</element>
       <element>pl</element>
       <element>th</element>
       <element>zh</element>
     </value>
   </record>
+
   <!-- Use language cookie (required to display the language menu) -->
   <record name="plone.use_cookie_negotiation" interface="plone.i18n.interfaces.ILanguageSchema" field="use_cookie_negotiation">
     <field type="plone.registry.field.Bool">
@@ -134,7 +117,6 @@
     </field>
     <value>True</value>
   </record>
-
 
   <!-- Dashboard panels visibility -->
   <record name="senaite.core.dashboard_panels_visibility">
@@ -155,6 +137,5 @@
       <element key="worksheets">null</element>
     </value>
   </record>
-
 
 </registry>

--- a/src/senaite/core/upgrade/v02_00_000.py
+++ b/src/senaite/core/upgrade/v02_00_000.py
@@ -164,6 +164,7 @@ def upgrade(tool):
     setup.runImportStepFromProfile(profile, "browserlayer")
     setup.runImportStepFromProfile(profile, "viewlets")
     setup.runImportStepFromProfile(profile, "repositorytool")
+    setup.runImportStepFromProfile(profile, "registry")
     # run import steps located in bika.lims profiles
     _run_import_step(portal, "rolemap", profile="profile-bika.lims:default")
     _run_import_step(portal, "typeinfo", profile="profile-bika.lims:default")

--- a/src/senaite/core/upgrade/v02_00_000.py
+++ b/src/senaite/core/upgrade/v02_00_000.py
@@ -164,7 +164,8 @@ def upgrade(tool):
     setup.runImportStepFromProfile(profile, "browserlayer")
     setup.runImportStepFromProfile(profile, "viewlets")
     setup.runImportStepFromProfile(profile, "repositorytool")
-    setup.runImportStepFromProfile(profile, "registry")
+    setup.runImportStepFromProfile(profile, "controlpanel")
+    setup.runImportStepFromProfile(profile, "plone.app.registry")
     # run import steps located in bika.lims profiles
     _run_import_step(portal, "rolemap", profile="profile-bika.lims:default")
     _run_import_step(portal, "typeinfo", profile="profile-bika.lims:default")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR enables the navigation controlpanel in the site-setup

## Current behavior before PR

Navigation controlpanel hidden

## Desired behavior after PR is merged

Navigation controlpanel displayed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
