### PR TITLE
Remove IDServer persistent utility

### DIFF
--- a/src/bika/lims/controlpanel/bika_idserver.py
+++ b/src/bika/lims/controlpanel/bika_idserver.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+# BBB: Registered as a persistent component!
+# -> see componentregistry.xml
+# remove after 2.0.0rc3
+class bika_idserver(object):
+    pass

--- a/src/bika/lims/profiles/default/componentregistry.xml
+++ b/src/bika/lims/profiles/default/componentregistry.xml
@@ -2,7 +2,9 @@
 <componentregistry>
   <utilities>
 
+    <!-- remove after 2.0.0rc3 -->
     <utility
+      remove="True"
       component="bika.lims.controlpanel.bika_idserver.bika_idserver"
       interface="bika.lims.interfaces.IIdServer"
       provides="bika.lims.interfaces.IIdServer"/>

--- a/src/senaite/core/upgrade/v02_00_000.py
+++ b/src/senaite/core/upgrade/v02_00_000.py
@@ -169,6 +169,9 @@ def upgrade(tool):
     # run import steps located in bika.lims profiles
     _run_import_step(portal, "rolemap", profile="profile-bika.lims:default")
     _run_import_step(portal, "typeinfo", profile="profile-bika.lims:default")
+    # https://github.com/senaite/senaite.core/pull/1730
+    _run_import_step(
+        portal, "componentregistry", profile="profile-bika.lims:default")
 
     add_dexterity_setup_items(portal)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the persistent utility `bika.lims.controlpanel.bika_idserver.bika_idserver`

## Current behavior before PR

Traceback happens on Plone upgrade:

```
PicklingError: Can't pickle <class 'bika.lims.controlpanel.bika_idserver.bika_idserver'>: import of module bika.lims.controlpanel.bika_idserver failed
grmpf....
```

## Desired behavior after PR is merged

No traceback on upgrade
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
