### PR TITLE
Remove `notifyModified` method from analyses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2.0.0 (unreleased)
+------------------
+
+- #1731 Remove `notifyModified` method from analyses
+
+
 2.0.0rc3 (2021-01-08)
 ---------------------
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@
 from setuptools import setup
 from setuptools import find_packages
 
-version = "2.0.0rc3"
+version = "2.0.0"
 
 setup(
     name="senaite.core",

--- a/src/senaite/core/upgrade/v02_00_000.py
+++ b/src/senaite/core/upgrade/v02_00_000.py
@@ -234,6 +234,7 @@ def upgrade(tool):
     delete_reflexrulefolder(portal)
 
     # Removes the method `notifiyModified` from analyses
+    # https://github.com/senaite/senaite.core/pull/1731
     remove_collective_indexing_notify_modified(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))

--- a/src/senaite/core/upgrade/v02_00_000.py
+++ b/src/senaite/core/upgrade/v02_00_000.py
@@ -769,8 +769,8 @@ def remove_collective_indexing_notify_modified(portal):
             del od["notifyModified"]
             obj._p_changed = 1
             obj.reindexObject()
-            transaction.commit()
             cleaned += 1
-    logger.info("Cleaned {} Analyes".format(cleaned))
 
+    logger.info("Cleaned {} Analyes, committing transaction.".format(cleaned))
+    transaction.commit()
     logger.info("Remove `notifyModified` method from Analyses ... [DONE]")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the `notifyModified` method from Analyses.
This method is an artifact from `collective.indexing`, which were not correctly removed:

https://github.com/plone/collective.indexing/blob/master/src/collective/indexing/indexer.py#L50

```python
# used instead of a lambda as ZODB dump does not know how to serialize those
def notifyModified(*args):
    pass

def reindex(obj, attributes=None):
    op = getDispatcher(obj, 'reindex')
    if op is not None:
        # prevent update of modification date during deferred reindexing
        od = obj.__dict__
        if not 'notifyModified' in od:
            od['notifyModified'] = notifyModified
        op(obj, attributes or [])
        if 'notifyModified' in od:
            del od['notifyModified']
```

This method object is pickled into the state of the object which causes this traceback when `collective.indexing` is removed:

```
Traceback (innermost last):
    Module ZServer.ZPublisher.Publish, line 151, in publish
    Module ZServer.ZPublisher.Publish, line 393, in commit
    Module transaction._manager, line 257, in commit
    Module transaction._manager, line 135, in commit
    Module transaction._transaction, line 282, in commit
    Module transaction._transaction, line 273, in commit
    Module transaction._transaction, line 465, in _commitResources
    Module transaction._transaction, line 439, in _commitResources
    Module ZODB.Connection, line 489, in commit
    Module ZODB.Connection, line 997, in savepoint
    Module ZODB.Connection, line 546, in _commit
    Module ZODB.Connection, line 578, in _store_objects
    Module ZODB.serialize, line 430, in serialize
    Module ZODB.serialize, line 439, in _dump
PicklingError: Can't pickle <class 'collective.indexing.indexer.notifyModified'>: import of module collective.indexing.indexer failed
```

## Current behavior before PR

Traceback happens in listings when `collective.indexing` is not present

## Desired behavior after PR is merged

No traceback happens when `collective.indexing` is not present anymore

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
