### PR TITLE
Readonly Transactions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1732 Readonly Transactions
 - #1731 Remove `notifyModified` method from analyses
 
 

--- a/src/senaite/core/browser/form/ajax.py
+++ b/src/senaite/core/browser/form/ajax.py
@@ -22,6 +22,7 @@ import json
 
 from bika.lims.browser import BrowserView
 from bika.lims.decorators import returns_json
+from senaite.core.decorators import readonly_transaction
 from senaite.core.interfaces import IAjaxEditForm
 from zope.component import queryMultiAdapter
 
@@ -135,12 +136,15 @@ The `message` should be an i18n message factory and are translated with
 
 class FormView(BrowserView):
     """Form View
+
+    NOTE: No persistent operations are allowed!
     """
 
     @property
     def adapter(self):
         return queryMultiAdapter((self.context, self.request), IAjaxEditForm)
 
+    @readonly_transaction
     @returns_json
     def initialized(self):
         data = self.get_json()
@@ -150,6 +154,7 @@ class FormView(BrowserView):
             return {}
         return self.adapter.initialized(data)
 
+    @readonly_transaction
     @returns_json
     def modified(self):
         data = self.get_json()

--- a/src/senaite/core/decorators/__init__.py
+++ b/src/senaite/core/decorators/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+from functools import wraps
+
+import transaction
+from senaite.core import logger
+
+
+def readonly_transaction(func):
+    """Decorator to doom the current transaction
+
+    https://transaction.readthedocs.io/en/latest/doom.html#dooming-transactions
+    """
+    @wraps(func)
+    def decorator(self, *args, **kwargs):
+        logger.info("*** READONLY TRANSACTION: '{}.{}' ***".
+                    format(self.__class__.__name__, self.__name__))
+        tx = transaction.get()
+        tx.doom()
+        return func(self, *args, **kwargs)
+    return decorator


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds a `readonly_transactions` decorator that dooms transactions:
https://transaction.readthedocs.io/en/latest/doom.html#dooming-transactions

## Current behavior before PR

Multiple Ajax POST requests produce DatabaseConflict Errors, because for every request a `transaction.commit` is done:
https://github.com/zopefoundation/ZServer/blob/master/src/ZServer/ZPublisher/Publish.py#L151

```
2021-01-10 22:25:47 ERROR Zope.SiteErrorLog 1610313947.140.106835736318 http://localhost:8080/senaite/bika_setup/bika_artemplates/portal_factory/ARTemplate/artemplate.2021-01-10.6704519281/table_ar_template_analyses/folderitems
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 151, in publish
  Module ZServer.ZPublisher.Publish, line 393, in commit
  Module transaction._manager, line 257, in commit
  Module transaction._manager, line 135, in commit
  Module transaction._transaction, line 282, in commit
  Module transaction._transaction, line 273, in commit
  Module transaction._transaction, line 465, in _commitResources
  Module transaction._transaction, line 442, in _commitResources
  Module ZODB.Connection, line 692, in tpc_vote
  Module ZEO.ClientStorage, line 752, in tpc_vote
  Module ZEO.asyncio.client, line 764, in call
  Module ZEO.asyncio.client, line 743, in call
  Module ZEO.asyncio.client, line 756, in wait_for_result
  Module concurrent.futures._base, line 462, in result
  Module concurrent.futures._base, line 414, in __get_result
ConflictError: database conflict error (oid 0x083228ca, class BTrees.IOBTree.IOBucket, serial this txn started with 0x03dd4025ba9e1e66 2021-01-10 21:25:43.738512, serial currently committed 0x03dd4025bfe7a000 2021-01-10 21:25:44.977684)
```



## Desired behavior after PR is merged

Ajax requests that should be readonly can `doom` the transaction to mitigate these conflict errors

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
