### PR TITLE
Allow results interpretation in sample received state

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 2.0.0 (unreleased)
 ------------------
-
+- #1733 Allow results interpretation in sample received state
 - #1731 Remove `notifyModified` method from analyses
 
 

--- a/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
+++ b/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
@@ -562,8 +562,7 @@
     <permission-map name="senaite.core: Field: Edit Publication Specification" acquired="True"/>
     <permission-map name="senaite.core: Field: Edit Rejection Reasons" acquired="True"/>
     <permission-map name="senaite.core: Field: Edit Remarks" acquired="True"/>
-    <!-- Make the field 'Results Interpretation' readonly -->
-    <permission-map name="senaite.core: Field: Edit Results Interpretation" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Results Interpretation" acquired="True"/>
     <permission-map name="senaite.core: Field: Edit Sample Point" acquired="True"/>
     <!-- Make the field 'SampleType' readonly -->
     <permission-map name="senaite.core: Field: Edit Sample Type" acquired="False"/>
@@ -846,7 +845,7 @@
     <permission-map name="senaite.core: Field: Edit Preserver" acquired="False"/>
     <permission-map name="senaite.core: Field: Edit Priority" acquired="False"/>
     <permission-map name="senaite.core: Field: Edit Profiles" acquired="False"/>
-    <!-- Allow to change the publicatoin specification -->
+    <!-- Allow to change the publication specification -->
     <permission-map name="senaite.core: Field: Edit Publication Specification" acquired="True"/>
     <permission-map name="senaite.core: Field: Edit Rejection Reasons" acquired="False"/>
     <!-- Allow to add the remarks -->


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR allows to edit the results interpretation field in received sample state

## Current behavior before PR

Results interpretation allowed first in `to_be_verified` state

## Desired behavior after PR is merged

Results interpretation allwed in `sample_received` state

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
