### PR TITLE
Fix: formatDateQuery does not add the timezone for queries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
+- #1737 Fix: formatDateQuery does not add the timezone for queries
 - #1707 Fix sporadic persistent changes with interims
 - #1704 Add "User name" and "User groups" columns in Lab Contacts list
 - #1704 Fix Cannot override behavior of LabContacts folder on `before_render`

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -55,6 +55,7 @@ from zope.i18n.locales import locales
 
 from bika.lims.interfaces import IClient
 from bika.lims.interfaces import IClientAwareMixin
+from bika.lims.api import to_date as api_to_date
 
 ModuleSecurityInfo('email.Utils').declarePublic('formataddr')
 allow_module('csv')
@@ -161,11 +162,18 @@ def formatDateQuery(context, date_id):
         into a date query construct
     """
     from_date = context.REQUEST.get('%s_fromdate' % date_id, None)
-    if from_date:
-        from_date = from_date + ' 00:00'
     to_date = context.REQUEST.get('%s_todate' % date_id, None)
+
+    current_timezone = DateTime().localZone()
+    if from_date:
+        from_date = ' '.join([from_date, current_timezone])
+        from_date = api_to_date(from_date)
+        from_date = from_date.earliestTime()
+
     if to_date:
-        to_date = to_date + ' 23:59'
+        to_date = ' '.join([to_date, current_timezone])
+        to_date = api_to_date(to_date)
+        to_date = to_date.latestTime()
 
     date_query = {}
     if from_date and to_date:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

SENAITE uses the function `formatDateQuery` to manipulate date ranges submitted by date filters in "old" reports.

The value from the filter is captured as a plain string containing only the date, for example "2020-12-31" or "2021-01-01".

`formatDateQuery` then adds "00:00" to the "from" filter and "23.59" to the "to" filter, without specifying the timezone.

"from" and "to" values are used to create ranged date queries in the catalog, but:

- The catalog saves date indexes in UTC format. As an example, if SENAITE is installed in a UTC-4 timezone, and the user receives a sample at `2020-12-31 21:00 (local time UTC-4)`, the value is cataloged as `2021/01/01 01:00:00 UTC`.
- When the user creates a report filtering by date, with the "FROM" parameter `2021-01-01`; the `formatDateQuery` converts it to `2021-01-01 00:00`; hence `2021-01-01 00:00 UTC`
- The query is going to return the sample received on `2020-12-31 21:00 (local time UTC-4)` but cataloged as `2021/01/01 01:00:00 UTC` in the system. Hence, the user querying for samples received from January 1st to January 31st is going to obtain the latest received samples from December.

## Current behavior before PR

Queries are done without timezone consideration.

## Desired behavior after PR is merged

Queries are done considering the timezone.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
