### PR TITLE
Resolve attachment images by UID

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1738 Resolve attachment images by UID
 - #1734 Allow to drag&drop images in tinymce
 - #1733 Allow results interpretation in sample received state
 - #1732 Readonly Transactions

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -2429,9 +2429,9 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
             attachment.setReportOption("i")
             # remove the image data base64 prefix
             html = html.replace(data_type, "")
-            # remove the base64 image data with the attachment URL
-            html = html.replace(data, "{}/AttachmentFile".format(
-                attachment.absolute_url()))
+            # remove the base64 image data with the attachment link
+            html = html.replace(data, "resolve_attachment?uid={}".format(
+                api.get_uid(attachment)))
             size = attachment.getAttachmentFile().get_size()
             logger.info("Converted {:.2f} Kb inline image for {}"
                         .format(size/1024, api.get_url(self)))

--- a/src/senaite/core/browser/attachment/configure.zcml
+++ b/src/senaite/core/browser/attachment/configure.zcml
@@ -5,6 +5,14 @@
     i18n_domain="senaite.core">
 
   <browser:page
+      for="*"
+      name="resolve_attachment"
+      class=".resolve_attachment.ResolveAttachmentView"
+      permission="zope.Public"
+      layer="senaite.core.interfaces.ISenaiteCore"
+      />
+
+  <browser:page
       for="bika.lims.interfaces.IAnalysisRequest"
       name="attachments_view"
       class=".attachment.AttachmentsView"

--- a/src/senaite/core/browser/attachment/resolve_attachment.py
+++ b/src/senaite/core/browser/attachment/resolve_attachment.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+from bika.lims import api
+from Products.Five.browser import BrowserView
+from senaite.core import logger
+
+
+class ResolveAttachmentView(BrowserView):
+    """Resolve Attachment by UID
+
+    This view is used for attachment image links to attachments
+    """
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def __call__(self):
+        uid = self.request.get("uid")
+        attachment = api.get_object_by_uid(uid, default=None)
+        if attachment is None:
+            logger.error("No attachment found for UID: '{}'".format(uid))
+            return
+        return self.download(attachment)
+
+    def get_attachment_info(self, attachment):
+        """Returns a dictionary of attachment information
+        """
+        blob = attachment.getAttachmentFile()
+
+        return {
+            "data": blob.data,
+            "content_type": blob.content_type,
+            "filename": blob.filename,
+            "last_modified": api.get_modification_date(attachment),
+        }
+
+    def download(self, attachment):
+        info = self.get_attachment_info(attachment)
+        data = info.get("data", "")
+        content_type = info.get("content_type", "application/octet-stream")
+        last_modified = info.get("last_modified")
+        response = self.request.response
+        set_header = response.setHeader
+        set_header("Content-Type", "{}".format(content_type))
+        set_header("Content-Length", len(data))
+        set_header("Last-Modified", last_modified)
+        response.write(data)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR converts images links from results interpretations to be resolved by their UID

## Current behavior before PR

The absolute attachment URL is used in the generated results interpretation HTML to link to the image data.
This breaks the image when the site is accessed via another virtual URL.

## Desired behavior after PR is merged

The attachment images are resolved by the `resolve_attachment` helper view with the UID for the attachment

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
