### PR TITLE
Use six to check text data types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1741 Use six to check text data types
 - #1739 Migrated samples folder to Dexterity
 - #1738 Resolve attachment images by UID
 - #1734 Allow to drag&drop images in tinymce

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -754,7 +754,7 @@ def get_workflows_for(brain_or_object):
     :rtype: tuple
     """
     workflow = ploneapi.portal.get_tool("portal_workflow")
-    if isinstance(brain_or_object, basestring):
+    if isinstance(brain_or_object, six.string_types):
         return workflow.getChainFor(brain_or_object)
     obj = get_object(brain_or_object)
     return workflow.getChainFor(obj)
@@ -861,7 +861,7 @@ def get_catalogs_for(brain_or_object, default="portal_catalog"):
     if is_object(brain_or_object):
         catalogs = archetype_tool.getCatalogsByType(
             get_portal_type(brain_or_object))
-    if isinstance(brain_or_object, basestring):
+    if isinstance(brain_or_object, six.string_types):
         catalogs = archetype_tool.getCatalogsByType(brain_or_object)
 
     if not catalogs:
@@ -894,7 +894,7 @@ def do_transition_for(brain_or_object, transition):
     :type brain_or_object: ATContentType/DexterityContentType/CatalogBrain
     :returns: The object where the transtion was performed
     """
-    if not isinstance(transition, basestring):
+    if not isinstance(transition, six.string_types):
         fail("Transition type needs to be string, got '%s'" % type(transition))
     obj = get_object(brain_or_object)
     try:
@@ -1000,7 +1000,7 @@ def get_user(user_or_username):
     user = None
     if isinstance(user_or_username, MemberData):
         user = user_or_username
-    if isinstance(user_or_username, basestring):
+    if isinstance(user_or_username, six.string_types):
         user = get_member_by_login_name(get_portal(), user_or_username, False)
     return user
 
@@ -1149,7 +1149,7 @@ def normalize_id(string):
     :returns: Normalized ID
     :rtype: str
     """
-    if not isinstance(string, basestring):
+    if not isinstance(string, six.string_types):
         fail("Type of argument must be string, found '{}'"
              .format(type(string)))
     # get the id nomalizer utility
@@ -1165,7 +1165,7 @@ def normalize_filename(string):
     :returns: Normalized ID
     :rtype: str
     """
-    if not isinstance(string, basestring):
+    if not isinstance(string, six.string_types):
         fail("Type of argument must be string, found '{}'"
              .format(type(string)))
     # get the file nomalizer utility
@@ -1183,7 +1183,7 @@ def is_uid(uid, validate=False):
     :return: True if a valid uid
     :rtype: bool
     """
-    if not isinstance(uid, basestring):
+    if not isinstance(uid, six.string_types):
         return False
     if uid == '0':
         return True
@@ -1363,14 +1363,14 @@ def to_display_list(pairs, sort_by="key", allow_empty=True):
     """
     dl = DisplayList()
 
-    if isinstance(pairs, basestring):
+    if isinstance(pairs, six.string_types):
         pairs = [pairs, pairs]
     for pair in pairs:
         # pairs is a list of lists -> add each pair
         if isinstance(pair, (tuple, list)):
             dl.add(*pair)
         # pairs is just a single pair -> add it and stop
-        if isinstance(pair, basestring):
+        if isinstance(pair, six.string_types):
             dl.add(*pairs)
             break
 

--- a/src/bika/lims/api/security.py
+++ b/src/bika/lims/api/security.py
@@ -18,6 +18,7 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import six
 from AccessControl import getSecurityManager
 from AccessControl.Permission import Permission
 from bika.lims import api
@@ -219,7 +220,7 @@ def grant_local_roles_for(brain_or_object, roles, user=None):
     user_id = get_user_id(user)
     obj = api.get_object(brain_or_object)
 
-    if isinstance(roles, basestring):
+    if isinstance(roles, six.string_types):
         roles = [roles]
 
     obj.manage_addLocalRoles(user_id, roles)
@@ -240,7 +241,7 @@ def revoke_local_roles_for(brain_or_object, roles, user=None):
     valid_roles = get_valid_roles_for(obj)
     to_grant = list(get_local_roles_for(obj))
 
-    if isinstance(roles, basestring):
+    if isinstance(roles, six.string_types):
         roles = [roles]
 
     for role in roles:
@@ -286,7 +287,7 @@ def grant_permission_for(brain_or_object, permission, roles, acquire=0):
     valid_roles = get_valid_roles_for(obj)
     to_grant = list(get_roles_for_permission(permission, obj))
 
-    if isinstance(roles, basestring):
+    if isinstance(roles, six.string_types):
         roles = [roles]
 
     for role in roles:
@@ -313,7 +314,7 @@ def revoke_permission_for(brain_or_object, permission, roles, acquire=0):
     valid_roles = get_valid_roles_for(obj)
     to_grant = list(get_roles_for_permission(permission, obj))
 
-    if isinstance(roles, basestring):
+    if isinstance(roles, six.string_types):
         roles = [roles]
 
     for role in roles:
@@ -338,7 +339,7 @@ def manage_permission_for(brain_or_object, permission, roles, acquire=0):
     """
     obj = api.get_object(brain_or_object)
 
-    if isinstance(roles, basestring):
+    if isinstance(roles, six.string_types):
         roles = [roles]
 
     for item in obj.ac_inherited_permissions(1):

--- a/src/bika/lims/api/snapshot.py
+++ b/src/bika/lims/api/snapshot.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 import json
+import six
 
 from bika.lims import _
 from bika.lims import api
@@ -393,7 +394,7 @@ def _process_value(value):
     if not value:
         value = _("Not set")
     # handle strings
-    elif isinstance(value, basestring):
+    elif isinstance(value, six.string_types):
         # XXX: bad data, e.g. in AS Method field
         if value == "None":
             value = _("Not set")

--- a/src/bika/lims/api/user.py
+++ b/src/bika/lims/api/user.py
@@ -18,6 +18,8 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import six
+
 from AccessControl import getSecurityManager
 from bika.lims.api import get_portal
 from bika.lims.api import get_tool
@@ -38,7 +40,7 @@ def get_user(user=None):
     elif isinstance(user, MemberData):
         # MemberData wrapped user -> get the user object
         user = user.getUser()
-    elif isinstance(user, basestring):
+    elif isinstance(user, six.string_types):
         # User ID -> get the user
         user = get_member_by_login_name(get_portal(), user, False)
         if user:
@@ -65,7 +67,7 @@ def get_group(group):
     :returns: Group
     """
     portal_groups = get_tool("portal_groups")
-    if isinstance(group, basestring):
+    if isinstance(group, six.string_types):
         group = portal_groups.getGroupById(group)
     elif isinstance(group, GroupData):
         group = group
@@ -93,7 +95,7 @@ def add_group(group, user=None):
     if user is None:
         raise ValueError("User '{}' not found".format(repr(user)))
 
-    if isinstance(group, basestring):
+    if isinstance(group, six.string_types):
         group = [group]
     elif isinstance(group, GroupData):
         group = [group]
@@ -115,7 +117,7 @@ def del_group(group, user=None):
     if user is None:
         raise ValueError("User '{}' not found".format(repr(user)))
 
-    if isinstance(group, basestring):
+    if isinstance(group, six.string_types):
         group = [group]
     elif isinstance(group, GroupData):
         group = [group]

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -19,6 +19,8 @@
 # Some rights reserved, see README and LICENSE.
 
 import json
+import six
+
 from collections import OrderedDict
 from datetime import datetime
 
@@ -762,7 +764,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         value = record.get(key, None)
         if value is None:
             return []
-        if isinstance(value, basestring):
+        if isinstance(value, six.string_types):
             value = value.split(",")
         return filter(lambda uid: uid, value)
 

--- a/src/bika/lims/browser/analysisrequest/reject_samples.py
+++ b/src/bika/lims/browser/analysisrequest/reject_samples.py
@@ -18,6 +18,8 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import six
+
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
@@ -126,7 +128,7 @@ class RejectSamplesView(BrowserView):
         """Returns a list of objects coming from the "uids" request parameter
         """
         uids = self.request.form.get("uids", "")
-        if isinstance(uids, basestring):
+        if isinstance(uids, six.string_types):
             uids = uids.split(",")
 
         uids = list(set(uids))

--- a/src/bika/lims/browser/auditlog.py
+++ b/src/bika/lims/browser/auditlog.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 import collections
+import six
 
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
@@ -170,7 +171,7 @@ class AuditLogView(ListingView):
     def translate_state(self, s):
         """Translate the given state string
         """
-        if not isinstance(s, basestring):
+        if not isinstance(s, six.string_types):
             return s
         s = s.capitalize().replace("_", " ")
         return t(_(s))

--- a/src/bika/lims/browser/fields/uidreferencefield.py
+++ b/src/bika/lims/browser/fields/uidreferencefield.py
@@ -18,6 +18,8 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import six
+
 from AccessControl import ClassSecurityInfo
 from Products.Archetypes.Field import Field, StringField
 from bika.lims import logger
@@ -209,7 +211,7 @@ class UIDReferenceField(StringField):
         # current set UIDs
         raw = self.getRaw(context) or []
         # handle single reference fields
-        if isinstance(raw, basestring):
+        if isinstance(raw, six.string_types):
             raw = [raw, ]
         cur = set(raw)
         # UIDs to be set

--- a/src/bika/lims/browser/partition_magic.py
+++ b/src/bika/lims/browser/partition_magic.py
@@ -18,6 +18,8 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import six
+
 from collections import OrderedDict
 from collections import defaultdict
 
@@ -169,7 +171,7 @@ class PartitionMagicView(BrowserView):
         if not uids:
             # check for the `items` parammeter
             uids = self.request.form.get("items", "")
-        if isinstance(uids, basestring):
+        if isinstance(uids, six.string_types):
             uids = uids.split(",")
         unique_uids = OrderedDict().fromkeys(uids).keys()
         return filter(None, map(self.get_object_by_uid, unique_uids))

--- a/src/bika/lims/browser/workflow/__init__.py
+++ b/src/bika/lims/browser/workflow/__init__.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 import collections
+import six
 import time
 
 from bika.lims import api
@@ -68,7 +69,7 @@ class RequestContextAware(object):
         """Returns a list of uids from the request
         """
         uids = self.request.get("uids", "")
-        if isinstance(uids, basestring):
+        if isinstance(uids, six.string_types):
             uids = uids.split(",")
         unique_uids = collections.OrderedDict().fromkeys(uids).keys()
         return filter(api.is_uid, unique_uids)

--- a/src/bika/lims/catalog/indexers/auditlog.py
+++ b/src/bika/lims/catalog/indexers/auditlog.py
@@ -20,6 +20,7 @@
 
 import itertools
 import re
+import six
 
 from bika.lims import api
 from bika.lims.api.snapshot import get_last_snapshot
@@ -151,7 +152,7 @@ def listing_searchable_text(instance):
             map(append, value)
         elif isinstance(value, (dict)):
             map(append, value.items())
-        elif isinstance(value, basestring):
+        elif isinstance(value, six.string_types):
             # convert unicode to UTF8
             if isinstance(value, unicode):
                 value = api.safe_unicode(value).encode("utf8")

--- a/src/bika/lims/content/client.py
+++ b/src/bika/lims/content/client.py
@@ -18,6 +18,8 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import six
+
 from AccessControl import ClassSecurityInfo
 from AccessControl import Unauthorized
 from Products.ATContentTypes.content import schemata
@@ -254,7 +256,7 @@ class Client(Organisation):
         """
         if ids is None:
             ids = []
-        if isinstance(ids, basestring):
+        if isinstance(ids, six.string_types):
             ids = [ids]
 
         for id in ids:

--- a/src/bika/lims/content/instrument.py
+++ b/src/bika/lims/content/instrument.py
@@ -18,6 +18,8 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import six
+
 from datetime import date
 
 from AccessControl import ClassSecurityInfo
@@ -669,7 +671,7 @@ class Instrument(ATFolder):
         # ensure we have strings, otherwise the `getValue` method of
         # Products.Archetypes.utils will raise a TypeError
         def to_string(v):
-            if isinstance(v, basestring):
+            if isinstance(v, six.string_types):
                 return v
             return api.get_title(v)
 

--- a/src/bika/lims/fields.py
+++ b/src/bika/lims/fields.py
@@ -18,6 +18,7 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import six
 from archetypes.schemaextender.interfaces import IExtensionField
 from Products.Archetypes.public import *
 from senaite.core.browser.fields.datetime import DateTimeField
@@ -73,7 +74,7 @@ class ExtensionField(object):
             return self.getAccessor(instance)
         elif name == '_at_edit_accessor':
             return self.getEditAccessor(instance)
-        elif not isinstance(name, basestring):
+        elif not isinstance(name, six.string_types):
             raise ValueError('Bad index accessor value: %r', name)
         else:
             return getattr(instance, name)

--- a/src/bika/lims/idserver.py
+++ b/src/bika/lims/idserver.py
@@ -20,7 +20,7 @@
 
 import itertools
 import re
-
+import six
 import transaction
 from bika.lims import api
 from bika.lims import logger
@@ -295,7 +295,7 @@ def get_variables(context, **kw):
 def split(string, separator="-"):
     """ split a string on the given separator
     """
-    if not isinstance(string, basestring):
+    if not isinstance(string, six.string_types):
         return []
     return string.split(separator)
 

--- a/src/bika/lims/jsonapi/update.py
+++ b/src/bika/lims/jsonapi/update.py
@@ -25,6 +25,7 @@ from plone.jsonapi.core.interfaces import IRouteProvider
 from zExceptions import BadRequest
 from zope import interface
 import json
+import six
 import transaction
 
 
@@ -129,7 +130,7 @@ class Update(object):
         if self.request.get('obj_path', '') and not obj:
             obj_path = self.request['obj_path'].split("?")[0]
             site_path = context.portal_url.getPortalObject().getPhysicalPath()
-            if site_path and isinstance(site_path, basestring):
+            if site_path and isinstance(site_path, six.string_types):
                 site_path = site_path if site_path.startswith('/') else '/' + site_path
                 obj = context.restrictedTraverse(site_path + obj_path)
             elif site_path and len(site_path) > 1:

--- a/src/bika/lims/workflow/__init__.py
+++ b/src/bika/lims/workflow/__init__.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 import collections
+import six
 import sys
 import threading
 
@@ -431,7 +432,7 @@ def _load_wf_module(module_relative_name):
     """
     if not module_relative_name:
         return None
-    if not isinstance(module_relative_name, basestring):
+    if not isinstance(module_relative_name, six.string_types):
         return None
 
     rootmodname = __name__

--- a/src/senaite/core/browser/widgets/referencewidget.py
+++ b/src/senaite/core/browser/widgets/referencewidget.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 import json
+import six
 
 from AccessControl import ClassSecurityInfo
 from bika.lims import api
@@ -120,7 +121,7 @@ class ReferenceWidget(StringWidget):
         base_query = self.base_query
         if callable(base_query):
             base_query = base_query()
-        if base_query and isinstance(base_query, basestring):
+        if base_query and isinstance(base_query, six.string_types):
             base_query = json.loads(base_query)
 
         # portal_type: use field allowed types

--- a/src/senaite/core/exportimport/genericsetup/adapters.py
+++ b/src/senaite/core/exportimport/genericsetup/adapters.py
@@ -19,6 +19,8 @@
 # Some rights reserved, see README and LICENSE.
 
 import json
+import six
+
 from datetime import datetime
 from mimetypes import guess_type
 
@@ -182,7 +184,7 @@ class ATFileFieldNodeAdapter(ATFieldNodeAdapter):
         """
         value = self.get_field_value()
 
-        if isinstance(value, basestring):
+        if isinstance(value, six.string_types):
             return value
 
         filename = safe_unicode(value.filename) or ""

--- a/src/senaite/core/exportimport/instruments/metler/toledo/dl55.py
+++ b/src/senaite/core/exportimport/instruments/metler/toledo/dl55.py
@@ -22,6 +22,7 @@
 """
 import json
 import re
+import six
 import traceback
 
 from bika.lims import api
@@ -59,7 +60,7 @@ class MetlerToledoDL55Parser(InstrumentResultsFileParser):
                 continue
 
             # If no keyword is present, this row is skipped.
-            if len(row) < 7 or not isinstance(row[6].value, basestring):
+            if len(row) < 7 or not isinstance(row[6].value, six.string_types):
                 continue
             # keyword is stripped of non-word characters
             keyword = re.sub(r"\W", "", row[6].value)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the text data type checking compatible with Python 3
See https://six.readthedocs.io/#six.string_types

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
