### PR TITLE
Use the polyfill for the `cmp` builtin function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1742 Use the polyfill for the `cmp` builtin function
 - #1741 Use six to check text data types
 - #1739 Migrated samples folder to Dexterity
 - #1738 Resolve attachment images by UID

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -47,6 +47,7 @@ from Products.CMFPlone.utils import _createObjectByType
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from senaite.core.p3compat import cmp
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getAdapters
 from zope.component import queryAdapter

--- a/src/bika/lims/browser/contact.py
+++ b/src/bika/lims/browser/contact.py
@@ -35,6 +35,7 @@ from plone.protect import CheckAuthenticator
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from senaite.core.p3compat import cmp
 
 
 class ContactLoginDetailsView(BrowserView):

--- a/src/bika/lims/browser/sampletype.py
+++ b/src/bika/lims/browser/sampletype.py
@@ -23,6 +23,7 @@ from operator import itemgetter
 
 import plone.protect
 from Products.CMFCore.utils import getToolByName
+from senaite.core.p3compat import cmp
 
 
 class get_sampletypes(object):

--- a/src/bika/lims/browser/widgets/addresswidget.py
+++ b/src/bika/lims/browser/widgets/addresswidget.py
@@ -25,6 +25,7 @@ from Products.CMFCore.utils import getToolByName
 from senaite.core.locales import COUNTRIES
 from senaite.core.locales import DISTRICTS
 from senaite.core.locales import STATES
+from senaite.core.p3compat import cmp
 
 
 class AddressWidget(TypesWidget):

--- a/src/bika/lims/browser/worksheet/ajax.py
+++ b/src/bika/lims/browser/worksheet/ajax.py
@@ -28,6 +28,7 @@ from bika.lims.api.security import check_permission
 from Products.Archetypes.config import REFERENCE_CATALOG
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
+from senaite.core.p3compat import cmp
 
 
 class AttachAnalyses(BrowserView):

--- a/src/bika/lims/browser/worksheet/views/printview.py
+++ b/src/bika/lims/browser/worksheet/views/printview.py
@@ -39,6 +39,7 @@ from bika.lims.utils import formatDecimalMark
 from bika.lims.utils import format_supsub
 from bika.lims.utils import to_utf8
 from bika.lims.utils.analysis import format_uncertainty
+from senaite.core.p3compat import cmp
 
 
 class PrintView(BrowserView):
@@ -551,7 +552,7 @@ class PrintView(BrowserView):
             data['name'] = to_utf8(client.getName())
         return data
 
-    def _flush_pdf():
+    def _flush_pdf(self):
         """ Generates a PDF using the current layout as the template and
             returns the chunk of bytes.
         """

--- a/src/bika/lims/browser/worksheet/views/results.py
+++ b/src/bika/lims/browser/worksheet/views/results.py
@@ -24,6 +24,7 @@ from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from plone.app.layout.globals.interfaces import IViewView
 from plone.memoize import view
+from senaite.core.p3compat import cmp
 from zope.interface import implements
 
 from bika.lims import api

--- a/src/bika/lims/browser/worksheettemplate.py
+++ b/src/bika/lims/browser/worksheettemplate.py
@@ -20,6 +20,7 @@
 
 from Products.CMFCore.utils import getToolByName
 from Products.Archetypes.utils import DisplayList
+from senaite.core.p3compat import cmp
 from bika.lims.browser import BrowserView
 from bika.lims.browser.widgets.serviceswidget import ServicesView
 import json

--- a/src/bika/lims/config.py
+++ b/src/bika/lims/config.py
@@ -20,6 +20,7 @@
 
 from bika.lims import bikaMessageFactory as _
 from Products.Archetypes.public import DisplayList
+from senaite.core.p3compat import cmp
 from zope.i18n.locales import locales
 
 # Implicit module imports used by others

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -54,6 +54,7 @@ from Products.Archetypes.Widget import StringWidget
 from Products.CMFCore.permissions import View
 from Products.CMFCore.utils import getToolByName
 from senaite.core.browser.fields.records import RecordsField
+from senaite.core.p3compat import cmp
 from zope.interface import implements
 
 # Anywhere that there just isn't space for unpredictably long names,

--- a/src/bika/lims/content/analysisservice.py
+++ b/src/bika/lims/content/analysisservice.py
@@ -44,6 +44,7 @@ from Products.Archetypes.public import Schema
 from Products.Archetypes.public import SelectionWidget
 from Products.Archetypes.public import registerType
 from Products.CMFCore.utils import getToolByName
+from senaite.core.p3compat import cmp
 from zope.interface import implements
 
 Methods = UIDReferenceField(

--- a/src/bika/lims/content/bikasetup.py
+++ b/src/bika/lims/content/bikasetup.py
@@ -60,6 +60,7 @@ from Products.CMFCore.utils import getToolByName
 from senaite.core.browser.fields.records import RecordsField
 from senaite.core.interfaces import IHideActionsMenu
 from senaite.core.locales import COUNTRIES
+from senaite.core.p3compat import cmp
 from zope.component import getUtility
 from zope.interface import implements
 

--- a/src/bika/lims/content/contact.py
+++ b/src/bika/lims/content/contact.py
@@ -37,6 +37,7 @@ from Products.Archetypes import atapi
 from Products.Archetypes.utils import DisplayList
 from Products.CMFCore.permissions import ModifyPortalContent
 from Products.CMFPlone.utils import safe_unicode
+from senaite.core.p3compat import cmp
 from zope.interface import implements
 
 ACTIVE_STATES = ["active"]

--- a/src/bika/lims/content/container.py
+++ b/src/bika/lims/content/container.py
@@ -33,6 +33,7 @@ from bika.lims.config import PROJECTNAME
 from bika.lims.content.bikaschema import BikaSchema
 from bika.lims.interfaces import IDeactivable
 from magnitude import mg
+from senaite.core.p3compat import cmp
 from zope.interface import implements
 
 schema = BikaSchema.copy() + Schema((

--- a/src/bika/lims/content/instrument.py
+++ b/src/bika/lims/content/instrument.py
@@ -65,6 +65,7 @@ from Products.ATContentTypes.content import schemata
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from senaite.core.browser.fields.records import RecordsField
+from senaite.core.p3compat import cmp
 from zope.interface import implements
 
 schema = BikaFolderSchema.copy() + BikaSchema.copy() + Schema((

--- a/src/bika/lims/content/preservation.py
+++ b/src/bika/lims/content/preservation.py
@@ -32,6 +32,7 @@ from bika.lims.browser.widgets import DurationWidget
 from bika.lims.config import PROJECTNAME, PRESERVATION_CATEGORIES
 from bika.lims.content.bikaschema import BikaSchema
 from bika.lims.interfaces import IDeactivable
+from senaite.core.p3compat import cmp
 from zope.interface import implements
 
 schema = BikaSchema.copy() + Schema((

--- a/src/bika/lims/content/referencesample.py
+++ b/src/bika/lims/content/referencesample.py
@@ -46,6 +46,7 @@ from bika.lims.interfaces import IReferenceSample, IAnalysisService, \
 from bika.lims.utils import sortable_title, tmpID
 from bika.lims.utils import to_unicode as _u
 from bika.lims.utils import to_utf8
+from senaite.core.p3compat import cmp
 from zope.interface import implements
 import sys, time
 

--- a/src/bika/lims/content/worksheet.py
+++ b/src/bika/lims/content/worksheet.py
@@ -64,6 +64,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import _createObjectByType
 from Products.CMFPlone.utils import safe_unicode
 from senaite.core.browser.fields.records import RecordsField
+from senaite.core.p3compat import cmp
 from senaite.core.workflow import ANALYSIS_WORKFLOW
 from zope.interface import implements
 

--- a/src/bika/lims/content/worksheettemplate.py
+++ b/src/bika/lims/content/worksheettemplate.py
@@ -44,6 +44,7 @@ from Products.Archetypes.public import StringWidget
 from Products.Archetypes.public import registerType
 from Products.Archetypes.references import HoldingReference
 from senaite.core.browser.fields.records import RecordsField
+from senaite.core.p3compat import cmp
 from zope.interface import implements
 
 schema = BikaSchema.copy() + Schema((

--- a/src/bika/lims/utils/__init__.py
+++ b/src/bika/lims/utils/__init__.py
@@ -47,6 +47,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFCore.WorkflowCore import WorkflowException
 from Products.CMFPlone.utils import safe_unicode
 from Products.DCWorkflow.events import AfterTransitionEvent
+from senaite.core.p3compat import cmp
 from weasyprint import CSS
 from weasyprint import HTML
 from weasyprint import default_url_fetcher

--- a/src/bika/lims/vocabularies/__init__.py
+++ b/src/bika/lims/vocabularies/__init__.py
@@ -29,6 +29,7 @@ from Products.CMFCore.utils import getToolByName
 from zope.interface import implements
 from pkg_resources import resource_filename
 from plone.resource.utils import iterDirectoriesOfType
+from senaite.core.p3compat import cmp
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary

--- a/src/senaite/core/browser/controlpanel/setupview.py
+++ b/src/senaite/core/browser/controlpanel/setupview.py
@@ -24,6 +24,7 @@ from plone.memoize.instance import memoize
 from plone.memoize.view import memoize_contextless
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from senaite.core.p3compat import cmp
 from zope.component import getMultiAdapter
 
 

--- a/src/senaite/core/exportimport/dataimport.py
+++ b/src/senaite/core/exportimport/dataimport.py
@@ -35,6 +35,7 @@ from senaite.core.exportimport import instruments
 from senaite.core.exportimport.instruments import \
     get_instrument_import_interfaces
 from senaite.core.exportimport.load_setup_data import LoadSetupData
+from senaite.core.p3compat import cmp
 from zope.component import getAdapters
 from zope.interface import implements
 

--- a/src/senaite/core/exportimport/instruments/foss/fiastar/fiastar.py
+++ b/src/senaite/core/exportimport/instruments/foss/fiastar/fiastar.py
@@ -24,6 +24,7 @@ from bika.lims.browser import BrowserView
 from DateTime import DateTime
 from Products.CMFCore.utils import getToolByName
 from plone.i18n.normalizer.interfaces import IIDNormalizer
+from senaite.core.p3compat import cmp
 from zope.component import getUtility
 from bika.lims import bikaMessageFactory as _
 from bika.lims.utils import t

--- a/src/senaite/core/exportimport/instruments/varian/vistapro/icp.py
+++ b/src/senaite/core/exportimport/instruments/varian/vistapro/icp.py
@@ -35,6 +35,7 @@ from senaite.core.exportimport.instruments.utils import \
      get_instrument_import_ar_allowed_states)
 from senaite.core.exportimport.instruments.resultsimport import \
     InstrumentCSVResultsFileParser, AnalysisResultsImporter
+from senaite.core.p3compat import cmp
 from bika.lims import bikaMessageFactory as _
 import json
 import traceback

--- a/src/senaite/core/locales/__init__.py
+++ b/src/senaite/core/locales/__init__.py
@@ -20,6 +20,7 @@
 
 from bika.lims.browser import BrowserView
 from operator import itemgetter
+from senaite.core.p3compat import cmp
 import json
 import plone
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures all `cmp` calls use the polyfill function from `senaite.core.p3compat`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
