### PR TITLE
Use six.moves.urllib instead of urllib2/urllib

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
-- #1744 Use six.urllib instead of urllib/urllib2 (p3-compat)
+- #1744 Use six.moves.urllib instead of urllib/urllib2 (p3-compat)
 - #1741 Use six to check text data types
 - #1739 Migrated samples folder to Dexterity
 - #1738 Resolve attachment images by UID

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1744 Use six.urllib instead of urllib/urllib2 (p3-compat)
 - #1741 Use six to check text data types
 - #1739 Migrated samples folder to Dexterity
 - #1738 Resolve attachment images by UID

--- a/src/bika/lims/utils/__init__.py
+++ b/src/bika/lims/utils/__init__.py
@@ -22,9 +22,9 @@ import mimetypes
 import os
 import re
 import tempfile
-import urllib2
 from email import Encoders
 from email.MIMEBase import MIMEBase
+from six.moves.urllib.request import urlopen
 from time import time
 
 from AccessControl import ModuleSecurityInfo
@@ -417,7 +417,7 @@ def createPdf(htmlreport, outfile=None, css=None, images={}):
     if css:
         if css.startswith("http://") or css.startswith("https://"):
             # Download css file in temp dir
-            u = urllib2.urlopen(css)
+            u = urlopen(css)
             _cssfile = tempfile.mktemp(suffix='.css')
             localFile = open(_cssfile, 'w')
             localFile.write(u.read())


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request replaces calls to `urllib2` or `urllib` by calls to `six.moves.urllib.?`.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
