### PR TITLE
Use six.iteritems instead if iteritems function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,11 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
-- #1744 Use six.moves.urllib instead of urllib/urllib2 (p3-compat)
+- #1745 Use six.iteritems instead of iteritems function (py3-compat)
+- #1744 Use six.moves.urllib instead of urllib/urllib2 (py3-compat)
 - #1743 Replace print statement by print() function (py3-compat)
 - #1741 Use six to check text data types (py3-compat)
-- #1742 Use the polyfill for the `cmp` builtin function
+- #1742 Use the polyfill for the `cmp` builtin function (py3-compat)
 - #1741 Use six to check text data types
 - #1739 Migrated samples folder to Dexterity
 - #1738 Resolve attachment images by UID

--- a/src/bika/lims/adapters/referencewidgetvocabulary.py
+++ b/src/bika/lims/adapters/referencewidgetvocabulary.py
@@ -118,7 +118,7 @@ class DefaultReferenceWidgetVocabulary(object):
         if isinstance(data, dict):
             return {
                 self.to_utf8(key): self.to_utf8(value)
-                for key, value in data.iteritems()
+                for key, value in six.iteritems(data)
             }
 
         # if it's anything else, return it in its original form

--- a/src/bika/lims/api/snapshot.py
+++ b/src/bika/lims/api/snapshot.py
@@ -333,7 +333,7 @@ def compare_snapshots(snapshot_a, snapshot_b, raw=False):
         return {}
 
     diffs = {}
-    for key_a, value_a in snapshot_a.iteritems():
+    for key_a, value_a in six.iteritems(snapshot_a):
         # skip fieds starting with _ or __
         if key_a.startswith("_"):
             continue

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1557,7 +1557,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
             # Process valid record
             valid_record = dict()
-            for fieldname, fieldvalue in record.iteritems():
+            for fieldname, fieldvalue in six.iteritems(record):
                 # clean empty
                 if fieldvalue in ['', None]:
                     continue

--- a/src/bika/lims/browser/reports/administration_usershistory.py
+++ b/src/bika/lims/browser/reports/administration_usershistory.py
@@ -18,6 +18,8 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import six
+
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims import api
@@ -123,7 +125,7 @@ class Report(BrowserView):
             entitytype = _(entity.__class__.__name__)
 
             # Workflow states retrieval
-            for workflowid, workflow in entity.workflow_history.iteritems():
+            for workflowid, workflow in six.iteritems(entity.workflow_history):
                 for action in workflow:
                     actiontitle = _('Created')
                     if not action['action'] or (

--- a/src/bika/lims/browser/worksheet/views/printview.py
+++ b/src/bika/lims/browser/worksheet/views/printview.py
@@ -395,7 +395,7 @@ class PrintView(BrowserView):
             ar['analyses'] = ans
             ars[reqid] = ar
 
-        ars = [a for a in ars.itervalues()]
+        ars = ars.values()
 
         # Sort analysis requests by position
         ars.sort(lambda x, y: cmp(x.get('tmp_position'), y.get('tmp_position')))

--- a/src/bika/lims/setuphandlers.py
+++ b/src/bika/lims/setuphandlers.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 import itertools
+import six
 
 from Acquisition import aq_base
 from bika.lims import api
@@ -439,7 +440,7 @@ def setup_auditlog_catalog(portal):
     catalog_id = auditlog_catalog.CATALOG_AUDITLOG
     catalog = api.get_tool(catalog_id)
 
-    for name, meta_type in auditlog_catalog._indexes.iteritems():
+    for name, meta_type in six.iteritems(auditlog_catalog._indexes):
         indexes = catalog.indexes()
         if name in indexes:
             logger.info("*** Index '%s' already in Catalog [SKIP]" % name)

--- a/src/bika/lims/utils/__init__.py
+++ b/src/bika/lims/utils/__init__.py
@@ -21,6 +21,7 @@
 import mimetypes
 import os
 import re
+import six
 import tempfile
 from email import Encoders
 from email.MIMEBase import MIMEBase
@@ -803,13 +804,14 @@ def get_strings(data):
 
     # if this is a list of values, return list of string values
     if isinstance(data, list):
-        return [get_strings(item) for item in data]
+        return map(get_strings, data)
 
     # if this is a dictionary, return dictionary of string keys and values
     if isinstance(data, dict):
+
         return {
             get_strings(key): get_strings(value)
-            for key, value in data.iteritems()
+            for key, value in six.iteritems(data)
         }
     # if it's anything else, return it in its original form
     return data
@@ -833,7 +835,7 @@ def get_unicode(data):
     if isinstance(data, dict):
         return {
             get_unicode(key): get_unicode(value)
-            for key, value in data.iteritems()
+            for key, value in six.iteritems(data)
         }
     # if it's anything else, return it in its original form
     return data

--- a/src/senaite/core/exportimport/instruments/foss/winescan/ft120.py
+++ b/src/senaite/core/exportimport/instruments/foss/winescan/ft120.py
@@ -24,6 +24,7 @@ from bika.lims import bikaMessageFactory as _
 from bika.lims.utils import t
 from . import WinescanImporter, WinescanCSVParser
 import json
+import six
 import traceback
 
 title = "FOSS - Winescan FT120"
@@ -166,7 +167,7 @@ class WinescanFT120CSVParser(WinescanCSVParser):
             # Add the results of Standard Deviation. For each acode, add
             # the Standard Result
             del values['Rep #']
-            for key, value in values.iteritems():
+            for key, value in six.iteritems(values):
                 row['Sd-%s' % key] = value
         elif is_mean:
             # Remove the # item and override with new values

--- a/src/senaite/core/exportimport/instruments/resultsimport.py
+++ b/src/senaite/core/exportimport/instruments/resultsimport.py
@@ -19,6 +19,8 @@
 # Some rights reserved, see README and LICENSE.
 
 import codecs
+import six
+
 from datetime import datetime
 from DateTime import DateTime
 from Products.CMFCore.utils import getToolByName
@@ -457,7 +459,7 @@ class AnalysisResultsImporter(Logger):
         attachments = {}
         infile = self._parser.getInputFile()
 
-        for objid, results in self._parser.getRawResults().iteritems():
+        for objid, results in six.iteritems(self._parser.getRawResults()):
             # Allowed more than one result for the same sample and analysis.
             # Needed for calibration tests
             for result in results:
@@ -531,7 +533,7 @@ class AnalysisResultsImporter(Logger):
                 capturedate = result.get('DateTime', {}).get('DateTime', None)
                 if capturedate:
                     del result['DateTime']
-                for acode, values in result.iteritems():
+                for acode, values in six.iteritems(result):
                     if acode not in acodes:
                         # Analysis keyword doesn't exist
                         continue
@@ -604,14 +606,14 @@ class AnalysisResultsImporter(Logger):
                                 "it is not assigned to a worksheet (%s)" %
                                 analysis)
 
-        for arid, acodes in importedars.iteritems():
+        for arid, acodes in six.iteritems(importedars):
             acodesmsg = ["Analysis %s" % acod for acod in acodes]
             self.log(
                     "${request_id}: ${analysis_keywords} imported sucessfully",
                     mapping={"request_id": arid,
                              "analysis_keywords": acodesmsg})
 
-        for instid, acodes in importedinsts.iteritems():
+        for instid, acodes in six.iteritems(importedinsts):
             acodesmsg = ["Analysis %s" % acod for acod in acodes]
             msg = "%s: %s %s" % (instid,
                                  ", ".join(acodesmsg),

--- a/src/senaite/core/exportimport/instruments/rochecobas/taqman/model96.py
+++ b/src/senaite/core/exportimport/instruments/rochecobas/taqman/model96.py
@@ -28,6 +28,7 @@ from senaite.core.exportimport.instruments.resultsimport import \
 from bika.lims import bikaMessageFactory as _
 from bika.lims.utils import t
 import json
+import six
 import traceback
 
 title = "Roche Cobas - Taqman - 96"
@@ -85,7 +86,7 @@ class RocheCobasTaqmanRSFParser(InstrumentResultsFileParser):
                 remarks = "".join([result, " on Order Number,", resid])
 
             rawdict = {}
-            for k, v in row.iteritems():
+            for k, v in six.iteritems(row):
                 rawdict[k] = self.parse_field(k, v)
 
             rawdict['DefaultResult'] = 'Result'


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request replaces the use of `iteritems` function by `six.iteritems`


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
