### PR TITLE
Use six.moves.urllib.parse instead of parse

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1746 Use six.moves.urllib.parse instead of parse (p3-compat)
 - #1744 Use six.moves.urllib instead of urllib/urllib2 (p3-compat)
 - #1743 Replace print statement by print() function (py3-compat)
 - #1741 Use six to check text data types (py3-compat)

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -22,7 +22,7 @@ import base64
 import re
 import sys
 from decimal import Decimal
-from urlparse import urljoin
+from six.moves.urllib.parse import urljoin
 
 from AccessControl import ClassSecurityInfo
 from bika.lims import api


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Replaces the calls to `parse` module by `six.moves.urllib.parse`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
