### PR TITLE
Use functools.reduce instead of reduce

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
-- #1647 Use functools.reduce instead of reduce (p3-compat)
+- #1747 Use functools.reduce instead of reduce (p3-compat)
 - #1746 Use six.moves.urllib.parse instead of parse (p3-compat)
 - #1744 Use six.moves.urllib instead of urllib/urllib2 (p3-compat)
 - #1743 Replace print statement by print() function (py3-compat)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1647 Use functools.reduce instead of reduce (p3-compat)
 - #1746 Use six.moves.urllib.parse instead of parse (p3-compat)
 - #1744 Use six.moves.urllib instead of urllib/urllib2 (p3-compat)
 - #1743 Replace print statement by print() function (py3-compat)

--- a/src/bika/lims/browser/publish/emailview.py
+++ b/src/bika/lims/browser/publish/emailview.py
@@ -18,6 +18,7 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import functools
 import inspect
 import itertools
 from collections import OrderedDict
@@ -668,8 +669,8 @@ class EmailView(BrowserView):
 
         # Calculate the total size of the given objects starting with an
         # initial size of 0
-        return reduce(lambda x, y: x + y,
-                      map(self.get_filesize, iterate(files)), 0)
+        return functools.reduce(lambda x, y: x + y,
+                                map(self.get_filesize, iterate(files)), 0)
 
     def get_object_by_uid(self, uid):
         """Get the object by UID

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 import base64
+import functools
 import re
 import sys
 from decimal import Decimal
@@ -1694,7 +1695,7 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
         billable_profiles = filter(
             lambda pr: pr.getUseAnalysisProfilePrice(), profiles)
         # All services contained in the billable profiles
-        billable_profile_services = reduce(lambda a, b: a+b, map(
+        billable_profile_services = functools.reduce(lambda a, b: a+b, map(
             lambda profile: profile.getService(), billable_profiles), [])
         # Keywords of the contained services
         billable_service_keys = map(


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Use `functools.reduce` instead of `reduce`

https://docs.python.org/2/library/functools.html#functools.reduce
https://docs.python.org/3/library/functools.html#functools.reduce

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
