### PR TITLE
Use correct syntax for exceptions (py3-compat)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1748 Use correct syntax for exceptions (py3-compat)
 - #1745 Use six.iteritems instead of iteritems function (py3-compat)
 - #1747 Use functools.reduce instead of reduce (p3-compat)
 - #1746 Use six.moves.urllib.parse instead of parse (p3-compat)

--- a/src/bika/lims/browser/contact.py
+++ b/src/bika/lims/browser/contact.py
@@ -187,7 +187,7 @@ class ContactLoginDetailsView(BrowserView):
                 self.context.setUser(userid)
                 self.add_status_message(
                     _("User linked to this Contact"), "info")
-            except ValueError, e:
+            except ValueError as e:
                 self.add_status_message(e, "error")
         else:
             self.add_status_message(
@@ -263,7 +263,7 @@ class ContactLoginDetailsView(BrowserView):
                                    'username': username,
                                    'email': email,
                                    'fullname': username})
-        except ValueError, msg:
+        except ValueError as msg:
             return error(None, msg)
 
         # set the user to the contact

--- a/src/bika/lims/content/client.py
+++ b/src/bika/lims/content/client.py
@@ -265,8 +265,9 @@ class Client(Organisation):
                 # Ignore DeleteObjects permission check
                 continue
             if not _checkPermission(permissions.DeleteObjects, item):
-                raise Unauthorized, (
-                    "Do not have permissions to remove this object")
+                msg = "Do not have permissions to remove this object"
+                raise Unauthorized(msg)
+
         return PortalFolder.manage_delObjects(self, ids, REQUEST=REQUEST)
 
 

--- a/src/bika/lims/idserver.py
+++ b/src/bika/lims/idserver.py
@@ -503,7 +503,7 @@ def generateUniqueId(context, **kw):
     # Interpolate the ID template
     try:
         new_id = id_template.format(**variables)
-    except KeyError, e:
+    except KeyError as e:
         logger.error('KeyError: {} not in id_template {}'.format(
             e, id_template))
         raise

--- a/src/senaite/core/browser/fields/record.py
+++ b/src/senaite/core/browser/fields/record.py
@@ -153,7 +153,7 @@ class RecordField(ObjectField):
         value = None
         vocab = self.subfield_vocabularies.get(subfield, None)
         if not vocab:
-            raise AttributeError, 'no vocabulary found for %s' %subfield
+            raise AttributeError("No vocabulary found for {}".format(subfield))
 
         if isinstance(vocab, DisplayList):
             return vocab
@@ -169,10 +169,12 @@ class RecordField(ObjectField):
                     if method and callable(method):
                         value = method()
             if not isinstance(value, DisplayList):
-                raise TypeError, '%s is not a DisplayList %s' %(value, subfield)
+                msg = "{} is not a DisplayList {}".format(value, subfield)
+                raise TypeError(msg)
             return value
 
-        raise TypeError, '%s niether a StringType or a DisplayList for %s' %(vocab, subfield)
+        msg = "{} is not a string or DisplayList for {}".format(vocab, subfield)
+        raise TypeError(msg)
 
     def getViewFor(self, instance, subfield, joinWith=', '):
         """
@@ -302,17 +304,18 @@ class RecordField(ObjectField):
             current_validators = self.subfield_validators.get(subfield, ())
 
             if type(current_validators) is DictType:
-                raise NotImplementedError, 'Please use the new syntax with validation chains'
-            elif providedBy(IValidationChain, current_validators):
+                msg = "Please use the new syntax with validation chains"
+                raise NotImplementedError(msg)
+            elif IValidationChain.providedBy(current_validators):
                 validators = current_validators
-            elif providedBy(IValidator, current_validators):
+            elif IValidator.providedBy(current_validators):
                 validators = ValidationChain(chainname, validators=current_validators)
             elif type(current_validators) in (TupleType, ListType, StringType):
                 if len(current_validators):
                     # got a non empty list or string - create a chain
                     try:
                         validators = ValidationChain(chainname, validators=current_validators)
-                    except (UnknowValidatorError, FalseValidatorError), msg:
+                    except (UnknowValidatorError, FalseValidatorError) as msg:
                         log("WARNING: Disabling validation for %s/%s: %s" % (self.getName(), subfield, msg))
                         validators = ()
                 else:

--- a/src/senaite/core/tests/doctests/Listings.rst
+++ b/src/senaite/core/tests/doctests/Listings.rst
@@ -25,7 +25,7 @@ Functional Helpers:
     >>> def create_ar(client, **kw):
     ...     values = {}
     ...     services = []
-    ...     for k, v in kw.iteritems():
+    ...     for k, v in kw.items():
     ...         if k == "Services":
     ...             services = map(api.get_uid, v)
     ...         elif api.is_object(v):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request revisits the syntax for exceptions to make them compatible with py3

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
