### PR TITLE
Use six.StringIO instead of StringIO or cStringIO

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1748 Use six.StringIO instead of StringIO or cStringIO (py3-compat)
 - #1748 Use correct syntax for exceptions (py3-compat)
 - #1745 Use six.iteritems instead of iteritems function (py3-compat)
 - #1747 Use functools.reduce instead of reduce (p3-compat)

--- a/src/bika/lims/api/mail.py
+++ b/src/bika/lims/api/mail.py
@@ -34,9 +34,7 @@ from email.Utils import formataddr
 from email.Utils import parseaddr
 from smtplib import SMTPException
 from string import Template
-from StringIO import StringIO
-
-import six
+from six import StringIO
 
 from bika.lims import api
 from bika.lims import logger

--- a/src/bika/lims/browser/reports/productivity_analysesattachments.py
+++ b/src/bika/lims/browser/reports/productivity_analysesattachments.py
@@ -146,7 +146,7 @@ class Report(BrowserView):
 
         if self.request.get('output_format', '') == 'CSV':
             import csv
-            import StringIO
+            from six import StringIO
             import datetime
 
             fieldnames = [
@@ -157,7 +157,7 @@ class Report(BrowserView):
                 _('Size'),
                 _('Loaded'),
             ]
-            output = StringIO.StringIO()
+            output = StringIO()
             dw = csv.DictWriter(output, fieldnames=fieldnames)
             dw.writerow(dict((fn, fn) for fn in fieldnames))
             for row in datalines:

--- a/src/bika/lims/browser/reports/productivity_analysesperclient.py
+++ b/src/bika/lims/browser/reports/productivity_analysesperclient.py
@@ -18,10 +18,10 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-import StringIO
 import csv
 import datetime
 from collections import OrderedDict
+from six import StringIO
 
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims import api
@@ -162,7 +162,7 @@ class Report(BrowserView):
             'Samples',
             'Analyses',
         ]
-        output = StringIO.StringIO()
+        output = StringIO()
         dw = csv.DictWriter(output, extrasaction='ignore',
                             fieldnames=fieldnames)
         dw.writerow(dict((fn, fn) for fn in fieldnames))

--- a/src/bika/lims/browser/reports/productivity_analysesperdepartment.py
+++ b/src/bika/lims/browser/reports/productivity_analysesperdepartment.py
@@ -185,7 +185,7 @@ class Report(BrowserView):
 
         if self.request.get('output_format', '') == 'CSV':
             import csv
-            import StringIO
+            from six import StringIO
             import datetime
 
             fieldnames = [
@@ -195,7 +195,7 @@ class Report(BrowserView):
                 'Performed',
                 'Published',
             ]
-            output = StringIO.StringIO()
+            output = StringIO()
             dw = csv.DictWriter(output, extrasaction='ignore',
                                 fieldnames=fieldnames)
             dw.writerow(dict((fn, fn) for fn in fieldnames))

--- a/src/bika/lims/browser/reports/productivity_analysesperformedpertotal.py
+++ b/src/bika/lims/browser/reports/productivity_analysesperformedpertotal.py
@@ -24,6 +24,7 @@ from bika.lims import bikaMessageFactory as _
 from bika.lims.browser import BrowserView
 from bika.lims.browser.reports.selection_macros import SelectionMacrosView
 from plone.app.layout.globals.interfaces import IViewView
+from six import StringIO
 from zope.interface import implements
 
 
@@ -185,7 +186,7 @@ class Report(BrowserView):
                 'Performed',
                 'Published',
             ]
-            output = StringIO.StringIO()
+            output = StringIO()
             dw = csv.DictWriter(output, extrasaction='ignore',
                                 fieldnames=fieldnames)
             dw.writerow(dict((fn, fn) for fn in fieldnames))

--- a/src/bika/lims/browser/reports/productivity_analysespersampletype.py
+++ b/src/bika/lims/browser/reports/productivity_analysespersampletype.py
@@ -131,14 +131,14 @@ class Report(BrowserView):
 
         if self.request.get('output_format', '') == 'CSV':
             import csv
-            import StringIO
+            from six import StringIO
             import datetime
 
             fieldnames = [
                 'Sample Type',
                 'Analyses',
             ]
-            output = StringIO.StringIO()
+            output = StringIO()
             dw = csv.DictWriter(output, extrasaction='ignore',
                                 fieldnames=fieldnames)
             dw.writerow(dict((fn, fn) for fn in fieldnames))

--- a/src/bika/lims/browser/reports/productivity_analysesperservice.py
+++ b/src/bika/lims/browser/reports/productivity_analysesperservice.py
@@ -142,14 +142,14 @@ class Report(BrowserView):
 
         if self.request.get('output_format', '') == 'CSV':
             import csv
-            import StringIO
+            from six import StringIO
             import datetime
 
             fieldnames = [
                 'Analysis Service',
                 'Analyses',
             ]
-            output = StringIO.StringIO()
+            output = StringIO()
             dw = csv.DictWriter(output, extrasaction='ignore',
                                 fieldnames=fieldnames)
             dw.writerow(dict((fn, fn) for fn in fieldnames))

--- a/src/bika/lims/browser/reports/productivity_analysestats.py
+++ b/src/bika/lims/browser/reports/productivity_analysestats.py
@@ -288,7 +288,7 @@ class Report(BrowserView):
 
         if self.request.get('output_format', '') == 'CSV':
             import csv
-            import StringIO
+            from six import StringIO
             import datetime
 
             fieldnames = [
@@ -300,7 +300,7 @@ class Report(BrowserView):
                 'Early',
                 'Average early',
             ]
-            output = StringIO.StringIO()
+            output = StringIO()
             dw = csv.DictWriter(output, extrasaction='ignore',
                                 fieldnames=fieldnames)
             dw.writerow(dict((fn, fn) for fn in fieldnames))

--- a/src/bika/lims/browser/reports/productivity_analysestats_overtime.py
+++ b/src/bika/lims/browser/reports/productivity_analysestats_overtime.py
@@ -18,10 +18,10 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-import StringIO
 import csv
 import datetime
 
+from six import StringIO
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
@@ -194,7 +194,7 @@ class Report(BrowserView):
             'Date',
             'Turnaround time (h)',
         ]
-        output = StringIO.StringIO()
+        output = StringIO()
         dw = csv.DictWriter(output, extrasaction='ignore',
                             fieldnames=fieldnames)
         dw.writerow(dict((fn, fn) for fn in fieldnames))

--- a/src/bika/lims/browser/reports/productivity_dailysamplesreceived.py
+++ b/src/bika/lims/browser/reports/productivity_dailysamplesreceived.py
@@ -101,7 +101,7 @@ class Report(BrowserView):
 
         if self.request.get('output_format', '') == 'CSV':
             import csv
-            import StringIO
+            from six import StringIO
             import datetime
 
             fieldnames = [
@@ -114,7 +114,7 @@ class Report(BrowserView):
             ]
             if self.context.bika_setup.getSamplingWorkflowEnabled():
                 fieldnames.append('SamplingDate')
-            output = StringIO.StringIO()
+            output = StringIO()
             dw = csv.DictWriter(output, fieldnames=fieldnames)
             dw.writerow(dict((fn, fn) for fn in fieldnames))
             for row in datalines:

--- a/src/bika/lims/browser/reports/productivity_dataentrydaybook.py
+++ b/src/bika/lims/browser/reports/productivity_dataentrydaybook.py
@@ -148,7 +148,7 @@ class Report(BrowserView):
 
         if self.request.get('output_format', '') == 'CSV':
             import csv
-            import StringIO
+            from six import StringIO
             import datetime
 
             fieldnames = [
@@ -167,7 +167,7 @@ class Report(BrowserView):
                 "Creator",
                 "Remarks",
             ]
-            output = StringIO.StringIO()
+            output = StringIO()
             dw = csv.DictWriter(output, extrasaction='ignore',
                                 fieldnames=fieldnames)
             dw.writerow(dict((fn, fn) for fn in fieldnames))

--- a/src/bika/lims/browser/reports/productivity_samplereceivedvsreported.py
+++ b/src/bika/lims/browser/reports/productivity_samplereceivedvsreported.py
@@ -117,7 +117,7 @@ class Report(BrowserView):
 
         if self.request.get('output_format', '') == 'CSV':
             import csv
-            import StringIO
+            from six import StringIO
             import datetime
 
             fieldnames = [
@@ -126,7 +126,7 @@ class Report(BrowserView):
                 'PublishedCount',
                 'RatioPercentage',
             ]
-            output = StringIO.StringIO()
+            output = StringIO()
             dw = csv.DictWriter(output, extrasaction='ignore',
                                 fieldnames=fieldnames)
             dw.writerow(dict((fn, fn) for fn in fieldnames))

--- a/src/bika/lims/content/dynamic_analysisspec.py
+++ b/src/bika/lims/content/dynamic_analysisspec.py
@@ -19,7 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 from collections import defaultdict
-from StringIO import StringIO
+from six import StringIO
 
 from bika.lims import _
 from bika.lims.catalog import SETUP_CATALOG

--- a/src/senaite/core/exportimport/instruments/foss/fiastar/fiastar.py
+++ b/src/senaite/core/exportimport/instruments/foss/fiastar/fiastar.py
@@ -29,7 +29,7 @@ from zope.component import getUtility
 from bika.lims import bikaMessageFactory as _
 from bika.lims.utils import t
 from . import FOSSFIAStarCSVParser, FOSSFIAStarImporter
-from cStringIO import StringIO
+from six import StringIO
 import json
 import traceback
 import csv

--- a/src/senaite/core/exportimport/instruments/genexpert/genexpert.py
+++ b/src/senaite/core/exportimport/instruments/genexpert/genexpert.py
@@ -20,11 +20,8 @@
 
 """ GeneXpert
 """
-import csv
 import json
 import traceback
-import types
-from cStringIO import StringIO
 from senaite.core.exportimport.instruments.resultsimport import \
     AnalysisResultsImporter, InstrumentCSVResultsFileParser
 

--- a/src/senaite/core/exportimport/instruments/nuclisens/easyq.py
+++ b/src/senaite/core/exportimport/instruments/nuclisens/easyq.py
@@ -23,7 +23,7 @@
 import csv
 import json
 import traceback
-from cStringIO import StringIO
+from six import StringIO
 import xml.etree.ElementTree as ET
 
 import types

--- a/src/senaite/core/tests/doctests/DynamicAnalysisSpec.rst
+++ b/src/senaite/core/tests/doctests/DynamicAnalysisSpec.rst
@@ -37,7 +37,7 @@ Test Setup
 Needed imports:
 
     >>> from DateTime import DateTime
-    >>> from StringIO import StringIO
+    >>> from six import StringIO
     >>> from bika.lims import api
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for

--- a/src/senaite/core/tests/doctests/InstrumentsImportInterface.rst
+++ b/src/senaite/core/tests/doctests/InstrumentsImportInterface.rst
@@ -31,7 +31,7 @@ Needed imports::
 
     >>> import os
     >>> import transaction
-    >>> import cStringIO
+    >>> from six import StringIO
     >>> from Products.CMFCore.utils import getToolByName
     >>> from bika.lims import api
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
@@ -225,7 +225,7 @@ Create an `Instrument` and assign to it the tested Import Interface::
     ...     exec('from senaite.core.exportimport.instruments.{} import Import'.format(inter[0]))
     ...     filename = os.path.join(files_path, inter[1])
     ...     data = open(filename, 'r').read()
-    ...     import_file = FileUpload(TestFile(cStringIO.StringIO(data), inter[1]))
+    ...     import_file = FileUpload(TestFile(StringIO(data), inter[1]))
     ...     request = TestRequest(form=dict(
     ...                                submitted=True,
     ...                                artoapply='received_tobeverified',


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request replaces the calls to `StringIO` or `cStringIO` modules by `six.StringIO`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
