### PR TITLE
Improve memory consumption of upgrade steop

### DIFF
--- a/src/senaite/core/upgrade/v02_00_000.py
+++ b/src/senaite/core/upgrade/v02_00_000.py
@@ -844,6 +844,7 @@ def migrate_resultsinterpretations_inline_images(portal):
         obj = api.get_object(brain)
         if num and num % 1000 == 0:
             logger.info("Processed {}/{}".format(num, count))
+            transaction.commit()
         rid = obj.getResultsInterpretationDepts()
         for ri in rid:
             html = ri.get("richtext")
@@ -864,6 +865,7 @@ def migrate_resultsinterpretations_inline_images(portal):
                     .format(obj.getId(), src, link))
                 obj._p_changed = True
             ri["richtext"] = html
+        obj._p_deactivate()
 
     transaction.commit()
     logger.info("Migrating results interpretation image links ... [DONE]")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR improves the overall memory consumption of the upgrade step `migrate_resultsinterpretations_inline_images`.

## Current behavior before PR

Process might be killed during upgrade by OOM.

## Desired behavior after PR is merged

Process does not over-consume available memory

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
