### PR TITLE
Fixed indexing of partitions and missing metadata generation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1753 Fixed indexing of partitions and missing metadata generation
 - #1751 Fix typos and naming in import template
 - #1750 Auto logout timeout
 - #1748 Use six.StringIO instead of StringIO or cStringIO (py3-compat)

--- a/src/bika/lims/catalog/indexers/__init__.py
+++ b/src/bika/lims/catalog/indexers/__init__.py
@@ -82,9 +82,15 @@ def get_metadata_for(instance, catalog):
     try:
         return catalog.getMetadataForUID(path)
     except KeyError:
-        logger.warn("Cannot get metadata from {}. Path not found: {}"
-                    .format(catalog.id, path))
-        return {}
+        logger.info("Generating catalog metadata for '{}' manually"
+                    .format(path))
+        metadata = {}
+        for key in catalog.schema():
+            attr = getattr(instance, key, None)
+            if callable(attr):
+                attr = attr()
+            metadata[key] = attr
+        return metadata
 
 
 def get_searchable_text_tokens(instance, catalog_name,

--- a/src/bika/lims/catalog/indexers/analysisrequest.py
+++ b/src/bika/lims/catalog/indexers/analysisrequest.py
@@ -18,17 +18,12 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-import six
-
 from bika.lims import api
 from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
-from bika.lims.catalog.indexers import get_metadata_for
-from bika.lims.interfaces import IAnalysisRequest
 from bika.lims.catalog.indexers import get_searchable_text_tokens
+from bika.lims.interfaces import IAnalysisRequest
 from bika.lims.interfaces import IBikaCatalogAnalysisRequestListing
-from bika.lims.interfaces import IListingSearchableTextProvider
 from plone.indexer import indexer
-from zope.component import getAdapters
 
 
 @indexer(IAnalysisRequest)
@@ -66,7 +61,7 @@ def listing_searchable_text(instance):
         tokens = get_searchable_text_tokens(descendant, catalog)
         entries.update(tokens)
 
-    return u" ".join(tokens)
+    return u" ".join(list(entries))
 
 
 @indexer(IAnalysisRequest)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the indexing of sample partitions and missing metadata generation.

## Current behavior before PR

- Sample partitions not in catalog
- metadata empty for some samples

## Desired behavior after PR is merged

- Sample partitions in catalog
- Metadata manually generated when empty

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
