### PR TITLE
Fix KeyError in calculation validator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1754 Fix KeyError in calculation validator
 - #1751 Fix typos and naming in import template
 - #1750 Auto logout timeout
 - #1748 Use six.StringIO instead of StringIO or cStringIO (py3-compat)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This happens when a formula is given and the interim fields have
not all required fields set:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.ATContentTypes.tool.factory, line 498, in __call__
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module Products.CMFFormController.FSControllerPageTemplate, line 92, in __call__
  Module Products.CMFFormController.BaseControllerPageTemplate, line 27, in _call
  Module Products.CMFFormController.FormController, line 385, in validate
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.CMFFormController.FSControllerValidator, line 57, in __call__
  Module Products.CMFFormController.Script, line 145, in __call__
  Module Products.CMFCore.FSPythonScript, line 133, in __call__
  Module Shared.DC.Scripts.Bindings, line 335, in __call__
  Module Shared.DC.Scripts.Bindings, line 372, in _bindAndExec
  Module Products.PythonScripts.PythonScript, line 351, in _exec
  Module script, line 6, in validate_base
   - <FSControllerValidator at /bikalims/validate_base used for /bikalims/bika_setup/bika_calculations/portal_factory/Calculation/calculation.2021-01-28.5034789518>
   - Line 6
  Module Products.Archetypes.BaseObject, line 517, in validate
  Module Products.Archetypes.Schema, line 629, in validate
  Module Products.Archetypes.Field, line 348, in validate
  Module Products.Archetypes.Field, line 362, in validate_validators
  Module Products.validation.chain, line 137, in __call__
  Module bika.lims.validators, line 501, in __call__
KeyError: 'keyword'
```

## Current behavior before PR

KeyError occurs when a new calculation is added with a title and a formula, but just one non-required field set in the interims, e.g. the unit.

## Desired behavior after PR is merged

Error message is displayed that interims have missing values

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
