### PR TITLE
Set markup schema to `html/text` as default for RichText fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1755 Set markup schema to `html/text` as default for RichText fields
 - #1754 Fix KeyError in calculation validator
 - #1753 Fixed indexing of partitions and missing metadata generation
 - #1751 Fix typos and naming in import template

--- a/src/senaite/core/setuphandlers.py
+++ b/src/senaite/core/setuphandlers.py
@@ -27,18 +27,18 @@ from bika.lims.setuphandlers import setup_core_catalogs
 from bika.lims.setuphandlers import setup_form_controller_actions
 from bika.lims.setuphandlers import setup_groups
 from plone.registry.interfaces import IRegistry
-from Products.CMFPlone.interfaces import IMarkupSchema
 from Products.CMFPlone.utils import get_installer
 from senaite.core import logger
 from senaite.core.config import PROFILE_ID
 from zope.component import getUtility
 from zope.interface import implementer
-from zope.interface.interfaces import ComponentLookupError
 
 try:
+    from Products.CMFPlone.interfaces import IMarkupSchema
     from Products.CMFPlone.interfaces import INonInstallable
 except ImportError:
     from zope.interface import Interface
+    IMarkupSchema = None
 
     class INonInstallable(Interface):
         pass
@@ -213,10 +213,10 @@ def post_install(portal_setup):
 def setup_markup_schema(portal):
     """Sets the default and allowed markup schemas for RichText widgets
     """
-    try:
-        registry = getUtility(IRegistry, context=portal)
-        settings = registry.forInterface(IMarkupSchema, prefix='plone')
-        settings.default_type = u"text/html"
-        settings.allowed_types = ("text/html", )
-    except (KeyError, ComponentLookupError):
-        pass
+    if not IMarkupSchema:
+        return
+
+    registry = getUtility(IRegistry, context=portal)
+    settings = registry.forInterface(IMarkupSchema, prefix='plone')
+    settings.default_type = u"text/html"
+    settings.allowed_types = ("text/html", )

--- a/src/senaite/core/setuphandlers.py
+++ b/src/senaite/core/setuphandlers.py
@@ -26,10 +26,14 @@ from bika.lims.setuphandlers import setup_catalog_mappings
 from bika.lims.setuphandlers import setup_core_catalogs
 from bika.lims.setuphandlers import setup_form_controller_actions
 from bika.lims.setuphandlers import setup_groups
+from plone.registry.interfaces import IRegistry
+from Products.CMFPlone.interfaces import IMarkupSchema
 from Products.CMFPlone.utils import get_installer
 from senaite.core import logger
 from senaite.core.config import PROFILE_ID
+from zope.component import getUtility
 from zope.interface import implementer
+from zope.interface.interfaces import ComponentLookupError
 
 try:
     from Products.CMFPlone.interfaces import INonInstallable
@@ -117,6 +121,9 @@ def install(context):
     setup_form_controller_actions(portal)
     setup_form_controller_more_action(portal)
 
+    # Setup markup default and allowed schemas
+    setup_markup_schema(portal)
+
     logger.info("SENAITE CORE install handler [DONE]")
 
 
@@ -201,3 +208,15 @@ def post_install(portal_setup):
     _run_import_step(portal, "skins", profile=profile_id)
 
     logger.info("SENAITE CORE post install handler [DONE]")
+
+
+def setup_markup_schema(portal):
+    """Sets the default and allowed markup schemas for RichText widgets
+    """
+    try:
+        registry = getUtility(IRegistry, context=portal)
+        settings = registry.forInterface(IMarkupSchema, prefix='plone')
+        settings.default_type = u"text/html"
+        settings.allowed_types = ("text/html", )
+    except (KeyError, ComponentLookupError):
+        pass

--- a/src/senaite/core/upgrade/v02_00_000.py
+++ b/src/senaite/core/upgrade/v02_00_000.py
@@ -37,6 +37,7 @@ from Products.CMFEditions.interfaces import IVersioned
 from senaite.core import logger
 from senaite.core.config import PROJECTNAME as product
 from senaite.core.setuphandlers import _run_import_step
+from senaite.core.setuphandlers import setup_markup_schema
 from senaite.core.upgrade import upgradestep
 from senaite.core.upgrade.utils import UpgradeUtils
 from senaite.core.upgrade.utils import catalog_object
@@ -245,6 +246,9 @@ def upgrade(tool):
 
     # Resolve attachment image URLs in results interpretations by UID
     migrate_resultsinterpretations_inline_images(portal)
+
+    # Setup markup default and allowed schemas
+    setup_markup_schema(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request establishes the markup schema `html/text` as default for RichText widgets, so the "Text format" selection list is not displayed on edition.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
