### PR TITLE
'View' tab not displayed after saving the batch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
+- #1756 Fix:'View' tab not displayed after saving the batch
 - #1737 Fix: formatDateQuery does not add the timezone for queries
 - #1707 Fix sporadic persistent changes with interims
 - #1704 Add "User name" and "User groups" columns in Lab Contacts list

--- a/bika/lims/profiles/default/types/Batch.xml
+++ b/bika/lims/profiles/default/types/Batch.xml
@@ -32,7 +32,7 @@
          url_expr="string:${object_url}/base_view"
          i18n:attributes="title"
          i18n:domain="plone"
-         visible="False">
+         visible="True">
   <permission value="View"/>
  </action>
 

--- a/bika/lims/upgrade/v01_03_005.py
+++ b/bika/lims/upgrade/v01_03_005.py
@@ -54,6 +54,9 @@ def upgrade(tool):
     # https://github.com/senaite/senaite.core/pull/1629
     fix_published_results_permission(portal)
 
+    # 'View' tab not displayed after saving the batch
+    fix_batch_view_action(portal)
+
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
 
@@ -88,4 +91,14 @@ def fix_published_results_permission(portal):
     for action in ti.listActions():
         if action.id == "published_results":
             action.permissions = ("View", )
+            break
+
+
+def fix_batch_view_action(portal):
+    """Sets the 'View' action to visible for batches
+    """
+    ti = portal.portal_types.getTypeInfo("Batch")
+    for action in ti.listActions():
+        if action.id == "view":
+            action.visible = True
             break


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The Batch object only had 'Edit', 'Samples', 'Batch book' and 'Audit log' actions visible. When the batch is saved, the user is redirected to the 'View' action, but it has not a tab showing the page the user is seeing.

This situation may generate some confusion to users.

## Current behavior before PR

'View' action tab is not  visible for batches

## Desired behavior after PR is merged

'View' action tab is visible for batches.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
