### PR TITLE
Disallow results entry when sample modification is not allowed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1767 Disallow results entry when sample modification is not allowed
 - #1755 Set markup schema to `html/text` as default for RichText fields
 - #1754 Fix KeyError in calculation validator
 - #1753 Fixed indexing of partitions and missing metadata generation

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -55,6 +55,7 @@ from bika.lims.utils.analysis import format_uncertainty
 from DateTime import DateTime
 from plone.memoize import view as viewcache
 from Products.Archetypes.config import REFERENCE_CATALOG
+from Products.CMFCore.permissions import ModifyPortalContent
 from Products.CMFPlone.utils import safe_unicode
 from senaite.app.listing import ListingView
 from zope.component import getAdapters
@@ -295,6 +296,10 @@ class AnalysesView(ListingView):
         if not self.context_active:
             # The current context must be active. We cannot edit analyses from
             # inside a deactivated Analysis Request, for instance
+            return False
+
+        if not self.has_permission(ModifyPortalContent, obj=self.context):
+            # skip any further checks if the sample can not be modified
             return False
 
         analysis_obj = self.get_object(analysis_brain)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR disallows analysis results entry when sample modification is not allowed

## Current behavior before PR

Results entry allowed even when `ModifyPortalContent` is not granted for the sample

## Desired behavior after PR is merged

Results entry **not** allowed when `ModifyPortalContent` is not granted for the sample

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
