### PR TITLE
Fix `TypeError` exception when no interims are set in calculation

### DIFF
--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -493,8 +493,8 @@ class FormulaValidator:
         instance = kwargs["instance"]
         request = api.get_request()
         form = request.form
-        interim_fields = form.get("InterimFields")
-        translate = getToolByName(instance, 'translation_service').translate
+        interim_fields = form.get("InterimFields", [])
+        translate = getToolByName(instance, "translation_service").translate
         catalog = api.get_tool(SETUP_CATALOG)
         interim_keywords = filter(None, map(
             lambda i: i.get("keyword"), interim_fields))


### PR DESCRIPTION

## Description of the issue/feature this PR addresses

This PR is complementary to https://github.com/senaite/senaite.core/pull/1754

## Current behavior before PR

Type Error occurred when no interims were set in calculation:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.ATContentTypes.tool.factory, line 498, in __call__
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module Products.CMFFormController.FSControllerPageTemplate, line 92, in __call__
  Module Products.CMFFormController.BaseControllerPageTemplate, line 27, in _call
  Module Products.CMFFormController.FormController, line 385, in validate
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.CMFFormController.FSControllerValidator, line 57, in __call__
  Module Products.CMFFormController.Script, line 145, in __call__
  Module Products.CMFCore.FSPythonScript, line 133, in __call__
  Module Shared.DC.Scripts.Bindings, line 335, in __call__
  Module Shared.DC.Scripts.Bindings, line 372, in _bindAndExec
  Module Products.PythonScripts.PythonScript, line 351, in _exec
  Module script, line 6, in validate_base
   - <FSControllerValidator at /senaite/validate_base used for /senaite/bika_setup/bika_calculations/portal_factory/Calculation/calculation.2021-02-03.5826943276>
   - Line 6
  Module Products.Archetypes.BaseObject, line 517, in validate
  Module Products.Archetypes.Schema, line 629, in validate
  Module Products.Archetypes.Field, line 348, in validate
  Module Products.Archetypes.Field, line 362, in validate_validators
  Module Products.validation.chain, line 137, in __call__
  Module bika.lims.validators, line 500, in __call__
TypeError: argument 2 to map() must support iteration
```

## Desired behavior after PR is merged

Empty interims are handled gracefully

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
