### PR TITLE
Fix RecordsWidget does not store hidden fields in Add form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1771 Fix RecordsWidget does not store hidden fields in Add form
 - #1768 Added api for measurements with physical quantities
 - #1767 Disallow results entry when sample modification is not allowed
 - #1755 Set markup schema to `html/text` as default for RichText fields

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/recordswidget.js
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/recordswidget.js
@@ -25,7 +25,7 @@ function recordswidget_lookups(elements){
             if ($(this).attr('name').split(".").length > 1) {
             	key = $(this).attr('name').split(".")[1].split(":")[0];
             }
-            row_nr = parseInt(this.id.split("-")[2]);
+            var row_nr = parseInt(this.id.split("-").slice(-1)[0]);
             $(this).val(ui.item[key]);
             // Set values if colModel matches recordswidget subfield name
             var colModel = $.parseJSON($(this).attr('combogrid_options')).colModel;
@@ -63,7 +63,7 @@ function recordswidget_loadEventHandlers(elements) {
                 key = $(this).attr('name').split(".")[1].split(":")[0];
             }
             var colModel = $.parseJSON($(this).attr('combogrid_options')).colModel;
-            row_nr = parseInt(this.id.split("-")[2]);
+            var row_nr = parseInt(this.id.split("-").slice(-1)[0]);
             for (var i = colModel.length - 1; i >= 0; i--) {
                 var colname = colModel[i]['columnName'];
                 if (colname != key) {


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When RecordsWidget containing a ReferenceWidgets inside is used in Sample Add form, the hidden fields (typically _uid and those defined in the colModel) are not set for the given row when the referenced object is selected. The reason is that the old-fashion js did not take into consideration that in Sample Add form, the (sample) column is injected into the fieldnames. This made the js to not be able to calculate the row number properly and therefore, not able to set the values for hidden fields.

This PR makes the js to grab the last digit of the fieldname to get the rownumber instead of picking the value at position 3.

## Current behavior before PR

Records widgets (with reference widgets on it) do not work properly in Add Sample form

## Desired behavior after PR is merged

Records widgets (with reference widgets on it) do work properly in Add Sample form

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
