### PR TITLE
Sample dispatch workflow

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1772 Sample dispatch workflow
 - #1771 Fix RecordsWidget does not store hidden fields in Add form
 - #1768 Added api for measurements with physical quantities
 - #1767 Disallow results entry when sample modification is not allowed

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -22,6 +22,7 @@ import re
 from collections import OrderedDict
 from datetime import datetime
 from datetime import timedelta
+from itertools import groupby
 
 import six
 
@@ -794,6 +795,11 @@ def get_previous_worfklow_status_of(brain_or_object, skip=None, default=None):
 
     skip = isinstance(skip, (list, tuple)) and skip or []
     history = get_review_history(brain_or_object)
+
+    # Remove consecutive duplicates, some transitions might happen more than
+    # once consecutively (e.g. publish)
+    history = map(lambda i: i[0], groupby(history))
+
     for num, item in enumerate(history):
         # skip the current history entry
         if num == 0:

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -781,6 +781,30 @@ def get_workflow_status_of(brain_or_object, state_var="review_state"):
     return workflow.getInfoFor(ob=obj, name=state_var, default='')
 
 
+def get_previous_worfklow_status_of(brain_or_object, skip=None, default=None):
+    """Get the previous workflow status of the object
+
+    :param brain_or_object: A single catalog brain or content object
+    :type brain_or_object: ATContentType/DexterityContentType/CatalogBrain
+    :param skip: Workflow states to skip
+    :type skip: tuple/list
+    :returns: status
+    :rtype: str
+    """
+
+    skip = isinstance(skip, (list, tuple)) and skip or []
+    history = get_review_history(brain_or_object)
+    for num, item in enumerate(history):
+        # skip the current history entry
+        if num == 0:
+            continue
+        status = item.get("review_state")
+        if status in skip:
+            continue
+        return status
+    return default
+
+
 def get_creation_date(brain_or_object):
     """Get the creation date of the brain or object
 

--- a/src/bika/lims/api/snapshot.py
+++ b/src/bika/lims/api/snapshot.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 import json
+
 import six
 
 from bika.lims import _
@@ -35,6 +36,7 @@ from senaite.app.supermodel import SuperModel
 from zope.annotation.interfaces import IAnnotatable
 from zope.annotation.interfaces import IAnnotations
 from zope.interface import alsoProvides
+from zope.interface import noLongerProvides
 
 SNAPSHOT_STORAGE = "senaite.core.snapshots"
 
@@ -318,6 +320,18 @@ def take_snapshot(obj, store=True, **kw):
     alsoProvides(obj, IAuditable)
 
     return snapshot
+
+
+def pause_snapshots_for(obj):
+    """Pause snapshots for the given object
+    """
+    alsoProvides(obj, IDoNotSupportSnapshots)
+
+
+def resume_snapshots_for(obj):
+    """Resume snapshots for the given object
+    """
+    noLongerProvides(obj, IDoNotSupportSnapshots)
 
 
 def compare_snapshots(snapshot_a, snapshot_b, raw=False):

--- a/src/bika/lims/permissions.py
+++ b/src/bika/lims/permissions.py
@@ -112,6 +112,8 @@ TransitionReceiveSample = "senaite.core: Transition: Receive Sample"
 TransitionRejectSample = "senaite.core: Transition: Reject Sample"
 TransitionSampleSample = "senaite.core: Transition: Sample Sample"
 TransitionScheduleSampling = "senaite.core: Transition: Schedule Sampling"
+TransitionDispatchSample = "senaite.core: Transition: Dispatch Sample"
+TransitionRestoreSample = "senaite.core: Transition: Restore Sample"
 
 # Transition permissions (Worksheet)
 TransitionRejectWorksheet = "senaite.core: Transition: Reject Worksheet"

--- a/src/bika/lims/permissions.zcml
+++ b/src/bika/lims/permissions.zcml
@@ -84,6 +84,8 @@
   <permission id="senaite.core.permissions.TransitionRejectSample" title="senaite.core: Transition: Reject Sample"/>
   <permission id="senaite.core.permissions.TransitionSampleSample" title="senaite.core: Transition: Sample Sample"/>
   <permission id="senaite.core.permissions.TransitionScheduleSampling" title="senaite.core: Transition: Schedule Sampling"/>
+  <permission id="senaite.core.permissions.TransitionDispatchSample" title="senaite.core: Transition: Dispatch Sample"/>
+  <permission id="senaite.core.permissions.TransitionRestoreSample" title="senaite.core: Transition: Restore Sample"/>
 
   # Transition Permissions (Worksheet)
   <permission id="senaite.core.permissions.TransitionRejectWorksheet" title="senaite.core: Transition: Reject Worksheet"/>

--- a/src/bika/lims/profiles/default/rolemap.xml
+++ b/src/bika/lims/profiles/default/rolemap.xml
@@ -478,6 +478,14 @@
       <role name="Manager"/>
       <role name="SamplingCoordinator"/>
     </permission>
+    <permission name="senaite.core: Transition: Dispatch Sample" acquire="False">
+      <role name="LabManager"/>
+      <role name="Manager"/>
+    </permission>
+    <permission name="senaite.core: Transition: Restore Sample" acquire="False">
+      <role name="LabManager"/>
+      <role name="Manager"/>
+    </permission>
 
     <!-- Transition permissions (Worksheet) -->
     <permission name="senaite.core: Transition: Reject Worksheet" acquire="False">

--- a/src/bika/lims/workflow/__init__.py
+++ b/src/bika/lims/workflow/__init__.py
@@ -35,7 +35,6 @@ from bika.lims.jsonapi import get_include_fields
 from bika.lims.utils import changeWorkflowState  # noqa
 from bika.lims.utils import t
 from bika.lims.workflow.indexes import ACTIONS_TO_INDEXES
-from itertools import groupby
 from Products.Archetypes.config import UID_CATALOG
 from Products.CMFCore.utils import getToolByName
 from Products.CMFCore.WorkflowCore import WorkflowException
@@ -267,23 +266,6 @@ def get_review_history_statuses(instance, reverse=False):
     """
     review_history = getReviewHistory(instance, reverse=reverse)
     return map(lambda event: event["review_state"], review_history)
-
-
-def get_prev_status_from_history(instance, status=None):
-    """Returns the previous status of the object. If status is set, returns the
-    previous status before the object reached the status passed in.
-    If instance has reached the status passed in more than once, only the last
-    one is considered.
-    """
-    target = status or api.get_workflow_status_of(instance)
-    history = getReviewHistory(instance, reverse=True)
-    history = map(lambda event: event["review_state"], history)
-    # Remove consecutive duplicates
-    history = map(lambda i: i[0], groupby(history))
-
-    if target not in history or history.index(target) == len(history)-1:
-        return None
-    return history[history.index(target)+1]
 
 
 def getReviewHistory(instance, reverse=True):

--- a/src/bika/lims/workflow/analysisrequest/events.py
+++ b/src/bika/lims/workflow/analysisrequest/events.py
@@ -28,7 +28,6 @@ from bika.lims.interfaces import IVerified
 from bika.lims.utils import changeWorkflowState
 from bika.lims.utils.analysisrequest import create_retest
 from bika.lims.workflow import doActionFor as do_action_for
-from bika.lims.workflow import get_prev_status_from_history
 from bika.lims.workflow.analysisrequest import do_action_to_analyses
 from bika.lims.workflow.analysisrequest import do_action_to_ancestors
 from bika.lims.workflow.analysisrequest import do_action_to_descendants
@@ -143,8 +142,9 @@ def after_reinstate(analysis_request):
     do_action_to_analyses(analysis_request, "reinstate")
 
     # Force the transition to previous state before the request was cancelled
-    prev_status = get_prev_status_from_history(analysis_request, "cancelled")
-    changeWorkflowState(analysis_request, SAMPLE_WORKFLOW, prev_status,
+    skip = ["cancelled"]
+    prev = api.get_previous_worfklow_status_of(analysis_request, skip=skip)
+    changeWorkflowState(analysis_request, SAMPLE_WORKFLOW, prev,
                         action="reinstate")
     analysis_request.reindexObject()
 

--- a/src/bika/lims/workflow/analysisrequest/guards.py
+++ b/src/bika/lims/workflow/analysisrequest/guards.py
@@ -231,3 +231,20 @@ def guard_detach(analysis_request):
     """
     # Detach transition can only be done to partitions
     return analysis_request.isPartition()
+
+
+def guard_dispatch(sample):
+    """Checks if the dispatch transition is allowed
+
+    We prevent dispatching when one analysis is assigned to a worksheet.
+    """
+    for analysis in sample.getAnalyses():
+        if api.get_workflow_status_of(analysis) == "assigned":
+            return False
+    return True
+
+
+def guard_restore(sample):
+    """Checks if the restore transition is allowed
+    """
+    return True

--- a/src/senaite/core/adapters/configure.zcml
+++ b/src/senaite/core/adapters/configure.zcml
@@ -11,4 +11,16 @@
        https://github.com/plone/plone.app.blob/issues/54 -->
   <adapter factory=".fileupload.BlobbableFileUpload" />
 
+  <!-- Sample: "dispatch"
+  Note this applies wide, cause at the moment, this action only exists
+  for Analysis Requests and we always want this adapter to be in charge,
+  regardless of the context (Analysis Requests listing, Client folder, etc.) -->
+  <adapter
+    name="workflow_action_dispatch"
+    for="*
+         zope.publisher.interfaces.browser.IBrowserRequest"
+    factory=".sample.WorkflowActionDispatchAdapter"
+    provides="bika.lims.interfaces.IWorkflowActionAdapter"
+    permission="zope.Public" />
+
 </configure>

--- a/src/senaite/core/adapters/sample.py
+++ b/src/senaite/core/adapters/sample.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+from bika.lims import api
+from bika.lims.browser.workflow import RequestContextAware
+from bika.lims.interfaces import IWorkflowActionUIDsAdapter
+from zope.interface import implementer
+
+
+@implementer(IWorkflowActionUIDsAdapter)
+class WorkflowActionDispatchAdapter(RequestContextAware):
+    """Adapter in charge of Sample "dispatch" action
+    """
+
+    def __call__(self, action, uids):
+        """Redirects the user to the dispatch form
+        """
+        url = "{}/dispatch_samples?uids={}".format(
+            api.get_url(self.context), ",".join(uids))
+        return self.redirect(redirect_url=url)

--- a/src/senaite/core/browser/samples/configure.zcml
+++ b/src/senaite/core/browser/samples/configure.zcml
@@ -16,7 +16,7 @@
       for="*"
       name="dispatch_samples"
       class=".dispatch_samples.DispatchSamplesView"
-      permission="senaite.core.permissions.TransitionDispatchSample"
+      permission="zope2.View"
       layer="senaite.core.interfaces.ISenaiteCore" />
 
 </configure>

--- a/src/senaite/core/browser/samples/configure.zcml
+++ b/src/senaite/core/browser/samples/configure.zcml
@@ -16,7 +16,7 @@
       for="*"
       name="dispatch_samples"
       class=".dispatch_samples.DispatchSamplesView"
-      permission="zope2.View"
+      permission="senaite.core.permissions.TransitionDispatchSample"
       layer="senaite.core.interfaces.ISenaiteCore" />
 
 </configure>

--- a/src/senaite/core/browser/samples/configure.zcml
+++ b/src/senaite/core/browser/samples/configure.zcml
@@ -11,4 +11,12 @@
       layer="senaite.core.interfaces.ISenaiteCore"
   />
 
+  <!-- Dispatch samples -->
+  <browser:page
+      for="*"
+      name="dispatch_samples"
+      class=".dispatch_samples.DispatchSamplesView"
+      permission="senaite.core.permissions.TransitionDispatchSample"
+      layer="senaite.core.interfaces.ISenaiteCore" />
+
 </configure>

--- a/src/senaite/core/browser/samples/dispatch_samples.py
+++ b/src/senaite/core/browser/samples/dispatch_samples.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+
+import collections
+
+from bika.lims import api
+from bika.lims import senaiteMessageFactory as _
+from bika.lims.browser import BrowserView
+from bika.lims.interfaces import IAnalysisRequest
+from Products.CMFCore.WorkflowCore import WorkflowException
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from senaite.core import logger
+
+
+class DispatchSamplesView(BrowserView):
+    """Action URL for the sample "dispatch" transition
+    """
+    template = ViewPageTemplateFile("templates/dispatch_samples.pt")
+
+    def __init__(self, context, request):
+        super(DispatchSamplesView, self).__init__(context, request)
+        self.context = context
+        self.request = request
+        self.portal = api.get_portal()
+        self.back_url = api.get_url(self.context)
+
+    def __call__(self):
+        form = self.request.form
+
+        # Form submit toggle
+        form_submitted = form.get("submitted", False)
+        form_dispatch = form.get("button_dispatch", False)
+        form_cancel = form.get("button_cancel", False)
+
+        # Handle book out
+        if form_submitted and form_dispatch:
+            logger.info("*** DISPATCH ***")
+            comment = form.get("comment", "")
+            if not comment:
+                return self.redirect(
+                    redirect_url=self.request.getHeader("http_referer"),
+                    message=_("Please specify a reason"), level="error")
+            samples = self.get_samples()
+
+            for sample in samples:
+                self.dispatch(sample, comment)
+            return self.redirect()
+
+        # Handle cancel
+        if form_submitted and form_cancel:
+            return self.redirect(message=_("Cancelled"))
+        return self.template()
+
+    def dispatch(self, sample, comment):
+        """Dispatch the sample
+        """
+        wf = api.get_tool("portal_workflow")
+        try:
+            wf.doActionFor(sample, "dispatch", comment=comment)
+            return True
+        except WorkflowException:
+            return False
+
+    def get_samples(self):
+        """Extract the samples from the request UIDs
+
+        This might be either a samples container or a sample context
+        """
+
+        # fetch objects from request
+        objs = self.get_objects_from_request()
+
+        samples = []
+        for obj in objs:
+            # when coming from the samples listing
+            if IAnalysisRequest.providedBy(obj):
+                samples.append(obj)
+
+        if samples:
+            return list(set(samples))
+
+        # when coming from the WF menu inside a sample
+        if IAnalysisRequest.providedBy(self.context):
+            return [self.context]
+
+    def get_title(self, obj):
+        """Return the object title as unicode
+        """
+        title = api.get_title(obj)
+        return api.safe_unicode(title)
+
+    def get_samples_data(self):
+        """Returns a list of containers that can be moved
+        """
+        for obj in self.get_samples():
+            obj = api.get_object(obj)
+            yield {
+                "obj": obj,
+                "id": api.get_id(obj),
+                "uid": api.get_uid(obj),
+                "title": self.get_title(obj),
+                "url": api.get_url(obj),
+                "sample_type": obj.getSampleTypeTitle(),
+            }
+
+    def get_objects_from_request(self):
+        """Returns a list of objects coming from the "uids" request parameter
+        """
+        unique_uids = self.get_uids_from_request()
+        return filter(None, map(self.get_object_by_uid, unique_uids))
+
+    def get_uids_from_request(self):
+        """Return a list of uids from the request
+        """
+        uids = self.request.form.get("uids", "")
+        if isinstance(uids, basestring):
+            uids = uids.split(",")
+        unique_uids = collections.OrderedDict().fromkeys(uids).keys()
+        return filter(api.is_uid, unique_uids)
+
+    def get_object_by_uid(self, uid):
+        """Get the object by UID
+        """
+        logger.debug("get_object_by_uid::UID={}".format(uid))
+        obj = api.get_object_by_uid(uid, None)
+        if obj is None:
+            logger.warn("!! No object found for UID #{} !!")
+        return obj
+
+    def redirect(self, redirect_url=None, message=None, level="info"):
+        """Redirect with a message
+        """
+        if redirect_url is None:
+            redirect_url = self.back_url
+        if message is not None:
+            self.add_status_message(message, level)
+        return self.request.response.redirect(redirect_url)
+
+    def add_status_message(self, message, level="info"):
+        """Set a portal status message
+        """
+        return self.context.plone_utils.addPortalMessage(message, level)

--- a/src/senaite/core/browser/samples/dispatch_samples.py
+++ b/src/senaite/core/browser/samples/dispatch_samples.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import collections
+import six
 
 from bika.lims import api
 from bika.lims import senaiteMessageFactory as _
@@ -134,7 +135,7 @@ class DispatchSamplesView(BrowserView):
         """Return a list of uids from the request
         """
         uids = self.request.form.get("uids", "")
-        if isinstance(uids, basestring):
+        if isinstance(uids, six.string_types):
             uids = uids.split(",")
         unique_uids = collections.OrderedDict().fromkeys(uids).keys()
         return filter(api.is_uid, unique_uids)

--- a/src/senaite/core/browser/samples/templates/dispatch_samples.pt
+++ b/src/senaite/core/browser/samples/templates/dispatch_samples.pt
@@ -1,0 +1,97 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="senaite.storage">
+  <head>
+    <metal:block fill-slot="senaite_legacy_resources"
+                 tal:define="portal context/@@plone_portal_state/portal;">
+    </metal:block>
+  </head>
+  <body>
+
+    <!-- Title -->
+    <metal:title fill-slot="content-title">
+      <h1 i18n:translate="">
+        Dispatch samples
+      </h1>
+    </metal:title>
+
+    <!-- Description -->
+    <metal:description fill-slot="content-description">
+      <p i18n:translate="">
+        <a tal:attributes="href view/back_url"
+           i18n:name="back_link"
+           i18n:translate="">
+          &larr; Back
+        </a>
+      </p>
+    </metal:description>
+
+    <!-- Content -->
+    <metal:core fill-slot="content-core">
+      <div id="dispatch-samples-view"
+           class="row"
+           tal:define="portal context/@@plone_portal_state/portal;">
+
+        <div class="col-sm-12">
+          <form class="form rowlike"
+                id="dispatch_samples_form"
+                name="dispatch_samples_form"
+                method="POST">
+
+            <!-- Hidden Fields -->
+            <input type="hidden" name="submitted" value="1"/>
+            <input tal:replace="structure context/@@authenticator/authenticator"/>
+
+            <div i18n:translate="" class="mb-3 text-secondary">
+              The following sample(s) will be dispatched
+            </div>
+
+            <ul class="list mb-3" tal:repeat="sample view/get_samples_data">
+              <li class="list-item">
+                <input type="hidden" name="uids:list" tal:attributes="value sample/uid"/>
+                <div class="list-group-item-heading">
+                  <a href="#"
+                     tal:attributes="href sample/url">
+                  <span tal:content="sample/title"/>
+                  <small>(<span tal:replace="sample/sample_type">)</small>
+                </div>
+              </li>
+            </ul>
+
+            <div class="mb-3 field">
+              <label for="sample-dispatch-coment">Comment</label>
+              <span class="required"></span>
+              <textarea name="comment"
+                        class="form-control"
+                        id="sample-dispatch-coment"
+                        placeholder=""
+                        style="height: 150px"></textarea>
+              <small i18n:translate="" class="form-text text-muted">
+                Please write a comment where the listed sample(s) are dispatched
+              </small>
+            </div>
+
+            <!-- Form Controls -->
+            <div>
+              <input class="btn btn-primary btn-sm"
+                     type="submit"
+                     name="button_dispatch"
+                     i18n:attributes="value"
+                     value="Dispatch"/>
+              <input class="btn btn-secondary btn-sm"
+                     type="submit"
+                     name="button_cancel"
+                     i18n:attributes="value"
+                     value="Cancel"/>
+            </div>
+
+          </form>
+        </div>
+
+      </div>
+    </metal:core>
+
+  </body>
+</html>

--- a/src/senaite/core/browser/samples/templates/dispatch_samples.pt
+++ b/src/senaite/core/browser/samples/templates/dispatch_samples.pt
@@ -2,7 +2,7 @@
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       metal:use-macro="here/main_template/macros/master"
-      i18n:domain="senaite.storage">
+      i18n:domain="senaite.core">
   <head>
     <metal:block fill-slot="senaite_legacy_resources"
                  tal:define="portal context/@@plone_portal_state/portal;">

--- a/src/senaite/core/browser/viewlets/configure.zcml
+++ b/src/senaite/core/browser/viewlets/configure.zcml
@@ -264,4 +264,14 @@
       layer="senaite.core.interfaces.ISenaiteCore"
       permission="zope2.View" />
 
+  <!-- Sample dispatched viewlet -->
+  <browser:viewlet
+      for="bika.lims.interfaces.IAnalysisRequest"
+      name="ssample_dispatched"
+      class=".sample_dispatched.SampleDispatchedViewlet"
+      manager="plone.app.layout.viewlets.interfaces.IAboveContent"
+      template="templates/sample_dispatched_viewlet.pt"
+      permission="zope2.View"
+      layer="senaite.core.interfaces.ISenaiteCore" />
+
 </configure>

--- a/src/senaite/core/browser/viewlets/sample_dispatched.py
+++ b/src/senaite/core/browser/viewlets/sample_dispatched.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+from bika.lims import api
+from bika.lims.browser import ulocalized_time
+from plone.app.layout.viewlets import ViewletBase
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
+
+class SampleDispatchedViewlet(ViewletBase):
+    """Print a viewlet showing the WF history comment
+    """
+    template = ViewPageTemplateFile("templates/sample_dispatched_viewlet.pt")
+
+    def __init__(self, context, request, view, manager=None):
+        super(SampleDispatchedViewlet, self).__init__(
+            context, request, view, manager=manager)
+        self.context = context
+        self.request = request
+        self.view = view
+
+    def is_dispatched(self):
+        """Returns whether the current sample is dispatched
+        """
+        return api.get_review_status(self.context) == "dispatched"
+
+    def get_state_info(self):
+        """Returns the WF state information
+        """
+        history = api.get_review_history(self.context)
+        entry = len(history) and history[0] or {}
+        actor = entry.get("actor")
+        user = api.user.get_user(actor)
+        if user:
+            actor = user.getProperty("fullname", actor)
+        date = entry.get("time")
+        comments = entry.get("comments", "")
+
+        return {
+            "actor": actor,
+            "date": self.ulocalized_time(date, long_format=1),
+            "comments": api.safe_unicode(comments),
+        }
+
+    def index(self):
+        if self.is_dispatched():
+            return ""
+        return self.template()
+
+    def ulocalized_time(self, time, long_format=None, time_only=None):
+        return ulocalized_time(time, long_format, time_only,
+                               context=self.context, request=self.request)

--- a/src/senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt
+++ b/src/senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt
@@ -1,0 +1,23 @@
+<div tal:omit-tag=""
+     tal:condition="python: view.is_dispatched()"
+     i18n:domain="senaite.core">
+
+  <div id="portal-alert"
+       tal:define="info python:view.get_state_info()">
+    <div class="portlet-alert-item alert alert-secondary alert-dismissible">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <p class="title">
+        <strong i18n:translate="">
+          This sample has been dispatched by <span tal:replace="info/actor"/> on
+          <span tal:replace="info/date"/>
+        </strong>
+      </p>
+      <p class="description">
+        <div tal:content="structure info/comments"></div>
+      </p>
+    </div>
+  </div>
+
+</div>

--- a/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
+++ b/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
@@ -1130,7 +1130,6 @@
 
     <!-- TRANSITIONS -->
     <exit-transition transition_id="reinstate" />
-    <exit-transition transition_id="dispatch" />
     <!-- /TRANSITIONS -->
 
     <!-- PLONE PERMISSIONS -->

--- a/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
+++ b/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
@@ -30,6 +30,8 @@
   <permission>senaite.core: Transition: Retract</permission>
   <permission>senaite.core: Transition: Sample Sample</permission>
   <permission>senaite.core: Transition: Schedule Sampling</permission>
+  <permission>senaite.core: Transition: Dispatch Sample</permission>
+  <permission>senaite.core: Transition: Restore Sample</permission>
 
   <permission>senaite.core: Add Analysis</permission>
   <permission>senaite.core: Edit Field Results</permission>
@@ -501,6 +503,7 @@
     <exit-transition transition_id="submit"/>
     <exit-transition transition_id="reject" />
     <exit-transition transition_id="create_partitions" />
+    <exit-transition transition_id="dispatch" />
     <!-- /TRANSITIONS -->
 
     <!-- PLONE PERMISSIONS -->
@@ -590,6 +593,7 @@
     <exit-transition transition_id="reject" />
     <exit-transition transition_id="rollback_to_receive" />
     <exit-transition transition_id="detach" />
+    <exit-transition transition_id="dispatch" />
     <!-- /TRANSITIONS -->
 
     <permission-map name="Delete objects" acquired="False">
@@ -687,6 +691,7 @@
     <exit-transition transition_id="preserve"/>
     <exit-transition transition_id="reject" />
     <exit-transition transition_id="detach" />
+    <exit-transition transition_id="dispatch" />
     <!-- /TRANSITIONS -->
 
     <permission-map name="Delete objects" acquired="False">
@@ -774,6 +779,7 @@
     <exit-transition transition_id="invalidate" />
     <exit-transition transition_id="rollback_to_receive" />
     <exit-transition transition_id="detach" />
+    <exit-transition transition_id="dispatch" />
     <!-- /TRANSITIONS -->
 
     <permission-map name="Delete objects" acquired="False">
@@ -867,13 +873,14 @@
   <!-- /State: verified -->
 
 
-  <!-- /State: published -->
+  <!-- State: published -->
   <state state_id="published" title="Published" i18n:attributes="title">
     <description>Results published and sent to the client</description>
 
     <!-- TRANSITIONS -->
     <exit-transition transition_id="republish"/>
     <exit-transition transition_id="invalidate"/>
+    <exit-transition transition_id="dispatch" />
     <!-- /TRANSITIONS -->
 
     <permission-map name="Delete objects" acquired="False"/>
@@ -959,7 +966,7 @@
     <description>Sample was rejected</description>
 
     <!-- TRANSITIONS -->
-    <exit-transition transition_id="" />
+    <exit-transition transition_id="dispatch" />
     <!-- /TRANSITIONS -->
 
     <!-- PLONE PERMISSIONS -->
@@ -1038,7 +1045,7 @@
     <description>Published results were invalidated</description>
 
     <!-- TRANSITIONS -->
-    <exit-transition transition_id=""/>
+    <exit-transition transition_id="dispatch" />
     <!-- /TRANSITIONS -->
 
     <!-- PLONE PERMISSIONS -->
@@ -1123,6 +1130,7 @@
 
     <!-- TRANSITIONS -->
     <exit-transition transition_id="reinstate" />
+    <exit-transition transition_id="dispatch" />
     <!-- /TRANSITIONS -->
 
     <!-- PLONE PERMISSIONS -->
@@ -1194,6 +1202,84 @@
     <!-- /MANAGED PERMISSIONS -->
   </state>
   <!-- /State: cancelled -->
+
+  <!-- State: dispatched -->
+  <state state_id="dispatched" title="Dispatched" i18n:attributes="title">
+    <description>Sample is dispatched</description>
+
+    <!-- TRANSITIONS -->
+    <exit-transition transition_id="restore" />
+    <!-- /TRANSITIONS -->
+
+    <!-- PLONE PERMISSIONS -->
+    <permission-map name="Delete objects" acquired="False"/>
+    <permission-map name="Modify portal content" acquired="False"/>
+
+    <!-- MANAGED PERMISSIONS (partially readonly) -->
+    <!-- Permissions for Transitions (must match with exit transitions) -->
+    <permission-map name="senaite.core: Transition: Cancel Analysis Request" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Detach Sample Partition" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Reinstate Analysis Request" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Invalidate" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Preserve Sample" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Publish Results" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Receive Sample" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Reject Sample" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Sample Sample" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
+    <!-- Hide the 'Manage Analyses' tab -->
+    <permission-map name="senaite.core: Add Analysis" acquired="False"/>
+    <!-- Hide the 'Manage Results' tab -->
+    <permission-map name="senaite.core: Edit Field Results" acquired="False"/>
+    <permission-map name="senaite.core: Edit Results" acquired="False"/>
+    <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
+    <permission-map name="senaite.core: View Results" acquired="True"/>
+    <permission-map name="Access contents information" acquired="True"/>
+    <permission-map name="View" acquired="True"/>
+
+    <!-- Type-specific permissions -->
+    <permission-map name="senaite.core: Sample: Add Attachment" acquired="False"/>
+    <permission-map name="senaite.core: Sample: Edit Attachment" acquired="False"/>
+    <permission-map name="senaite.core: Sample: Delete Attachment" acquired="False"/>
+
+    <!-- Field Permissions (all readonly) -->
+    <permission-map name="senaite.core: Field: Edit Batch" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Client Order Number" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Client Reference" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Client Sample ID" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Client" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Composite" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Contact" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Container" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Date Preserved" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Date Received" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Date Sampled" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Environmental Conditions" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Internal Use" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Invoice Exclude" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Member Discount" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Preservation" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Preserver" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Priority" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Profiles" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Publication Specification" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Rejection Reasons" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Remarks" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Results Interpretation" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Sample Point" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Sample Type" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Sample Condition" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Sampler" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Sampling Date" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Sampling Deviation" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Scheduled Sampler" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Storage Location" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Template" acquired="False"/>
+    <permission-map name="senaite.core: Field: Edit Specification" acquired="False"/>
+    <!-- /MANAGED PERMISSIONS -->
+  </state>
+  <!-- /State: dispatched -->
 
 
   <!-- *** TRANSITIONS *** -->
@@ -1456,6 +1542,31 @@
       <guard-permission>senaite.core: Transition: Detach Sample Partition</guard-permission>
     </guard>
   </transition>
+
+  <!-- Transition: Dispatch
+       This transition applies to all received samples in all states.
+  -->
+  <transition transition_id="dispatch" title="Dispatch" new_state="dispatched" trigger="USER"
+              before_script="" after_script="" i18n:attributes="title">
+    <action url="" category="workflow" icon="">Dispatch</action>
+    <guard>
+      <guard-expression>python:here.guard_handler("dispatch")</guard-expression>
+      <guard-permission>senaite.core: Transition: Dispatch Sample</guard-permission>
+    </guard>
+  </transition>
+
+  <!-- Transition: Restore
+       This transition applies to dispatched samples and restores the sample to the previous state.
+  -->
+  <transition transition_id="restore" title="Restore" new_state="" trigger="USER"
+              before_script="" after_script="" i18n:attributes="title">
+    <action url="" category="workflow" icon="">Restore</action>
+    <guard>
+      <guard-expression>python:here.guard_handler("restore")</guard-expression>
+      <guard-permission>senaite.core: Transition: Restore Sample</guard-permission>
+    </guard>
+  </transition>
+
 
   <!-- *** VARIABLES *** -->
 

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -732,6 +732,29 @@ Reactivate the client::
     'active'
 
 
+Getting the previous Workflow Status of an Object
+........................................
+
+
+This function gives the last worflow state of an object:
+
+    >>> api.get_workflow_status_of(client)
+    'active'
+
+    >>> api.get_previous_worfklow_status_of(client)
+    'inactive'
+
+Specific states can be skipped:
+
+    >>> api.get_previous_worfklow_status_of(client, skip=['inactive'])
+    'active'
+
+A default value can be set in case no previous state was found:
+
+    >>> api.get_previous_worfklow_status_of(client, skip=['active' ,'inactive'], default='notfound')
+    'notfound'
+
+
 Getting the available transitions for an object
 ...............................................
 

--- a/src/senaite/core/tests/doctests/API_snapshot.rst
+++ b/src/senaite/core/tests/doctests/API_snapshot.rst
@@ -25,6 +25,13 @@ Needed Imports:
     >>> from plone.app.testing import TEST_USER_ID
     >>> from plone.app.testing import TEST_USER_PASSWORD
 
+    >>> from zope.lifecycleevent import modified
+    >>> from zope.component.globalregistry import getGlobalSiteManager
+    >>> from zope.lifecycleevent.interfaces import IObjectModifiedEvent
+    >>> from bika.lims.subscribers.auditlog import ObjectModifiedEventHandler
+    >>> from zope.interface import Interface
+
+
 Functional Helpers:
 
     >>> def start_server():
@@ -46,6 +53,14 @@ Functional Helpers:
     ...     if len(ans) != 1:
     ...         return None
     ...     return ans[0]
+
+    >>> def register_event_subscribers():
+    ...     gsm = getGlobalSiteManager()
+    ...     gsm.registerHandler(ObjectModifiedEventHandler, (Interface, IObjectModifiedEvent))
+
+    >>> def unregister_event_subscribers():
+    ...     gsm = getGlobalSiteManager()
+    ...     gsm.unregisterHandler(ObjectModifiedEventHandler, (Interface, IObjectModifiedEvent))
 
 
 Environment Setup
@@ -304,3 +319,51 @@ First we edit the sample to get a new snapshot:
    >>> last_diff = compare_last_two_snapshots(sample, raw=False)
    >>> last_diff
    {u'CCEmails': [('Not set', 'rb@ridingbytes.com')]}
+
+
+Pause and Resume Snapshots
+..........................
+
+
+Register event subscribers:
+
+    >>> register_event_subscribers()
+
+Pausing the snapshots will disable snapshots for a given object:
+
+    >>> pause_snapshots_for(sample)
+
+The object no longer supports snapshots now:
+
+    >>> supports_snapshots(sample)
+    False
+
+Object modification events create then no snapshots anymore:
+
+    >>> get_version(sample)
+    4
+
+    >>> modified(sample)
+
+    >>> get_version(sample)
+    4
+
+Resuming the snapshots will enable snapshots for a given object:
+
+    >>> resume_snapshots_for(sample)
+
+The object supports snapshots again:
+
+    >>> supports_snapshots(sample)
+    True
+
+Object modification events create new snapshots again:
+
+    >>> modified(sample)
+
+    >>> get_version(sample)
+    5
+
+Unregister event subscribers:
+
+    >>> unregister_event_subscribers()

--- a/src/senaite/core/tests/doctests/WorkflowSampleDispatch.rst
+++ b/src/senaite/core/tests/doctests/WorkflowSampleDispatch.rst
@@ -1,0 +1,205 @@
+Analysis Request cancel guard and event
+---------------------------------------
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t WorkflowSampleDispatch
+
+Test Setup
+..........
+
+Needed Imports:
+
+    >>> from AccessControl.PermissionRole import rolesForPermissionOn
+    >>> from bika.lims import api
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.utils.analysisrequest import create_partition
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+    >>> from bika.lims.workflow import isTransitionAllowed
+    >>> from bika.lims.workflow import getAllowedTransitions
+    >>> from DateTime import DateTime
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+
+Functional Helpers:
+
+    >>> def start_server():
+    ...     from Testing.ZopeTestCase.utils import startZServer
+    ...     ip, port = startZServer()
+    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
+
+    >>> def timestamp(format="%Y-%m-%d"):
+    ...     return DateTime().strftime(format)
+
+    >>> def start_server():
+    ...     from Testing.ZopeTestCase.utils import startZServer
+    ...     ip, port = startZServer()
+    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
+
+    >>> def new_sample(services, client, contact, sampletype):
+    ...     values = {
+    ...         'Client': client.UID(),
+    ...         'Contact': contact.UID(),
+    ...         'DateSampled': date_now,
+    ...         'SampleType': sampletype.UID()}
+    ...     service_uids = map(api.get_uid, services)
+    ...     sample = create_analysisrequest(client, request, values, service_uids)
+    ...     return sample
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = api.get_setup()
+    >>> date_now = DateTime().strftime("%Y-%m-%d")
+    >>> date_future = (DateTime() + 5).strftime("%Y-%m-%d")
+
+We need to create some basic objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
+    >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH", MemberDiscountApplies=True)
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(setup.bika_sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.bika_departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = api.create(setup.bika_analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> Cu = api.create(setup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID(), Accredited=True)
+    >>> Fe = api.create(setup.bika_analysisservices, "AnalysisService", title="Iron", Keyword="Fe", Price="10", Category=category.UID())
+    >>> Au = api.create(setup.bika_analysisservices, "AnalysisService", title="Gold", Keyword="Au", Price="20", Category=category.UID())
+
+
+Dispatch transition and guard basic constraints
+...............................................
+
+Create a new sample:
+
+    >>> sample = new_sample([Cu, Fe, Au], client, contact, sampletype)
+    >>> api.get_workflow_status_of(sample)
+    'sample_due'
+
+Because the sample is not yet received, it cannot be dispatched:
+
+    >>> "restore" in getAllowedTransitions(sample)
+    False
+
+Receive the sample:
+
+    >>> transitioned = do_action_for(sample, "receive")
+    >>> api.get_workflow_status_of(sample)
+    'sample_received'
+
+Now the sample can be dispatched:
+
+    >>> transitioned = do_action_for(sample, "dispatch")
+    >>> api.get_workflow_status_of(sample)
+    'dispatched'
+
+At this point, only "restore" transition is possible:
+
+    >>> getAllowedTransitions(sample)
+    ['restore']
+
+When the sample is restored, the status becomes the previous before the dispatch
+took place:
+
+    >>> transitioned = do_action_for(sample, "restore")
+    >>> api.get_workflow_status_of(sample)
+    'sample_received'
+
+Dispatching can be done again now:
+
+    >>> transitioned = do_action_for(sample, "dispatch")
+    >>> api.get_workflow_status_of(sample)
+    'dispatched'
+
+And restoring as well:
+
+    >>> transitioned = do_action_for(sample, "restore")
+    >>> api.get_workflow_status_of(sample)
+    'sample_received'
+
+However, if the sample analyses are assinged, we prevent dispatching:
+
+    >>> analyses = sample.getAnalyses(full_objects=True)
+    >>> map(api.get_workflow_status_of, analyses)
+    ['unassigned', 'unassigned', 'unassigned']
+    >>> analysis = analyses[0]
+    >>> worksheet = api.create(portal.worksheets, "Worksheet")
+    >>> worksheet.addAnalysis(analysis)
+    >>> api.get_workflow_status_of(analysis)
+    'assigned'
+    >>> isTransitionAllowed(sample, "dispatch")
+    False
+
+Unassign analysis from the worksheet again:
+
+    >>> worksheet.removeAnalysis(analysis)
+    >>> isTransitionAllowed(sample, "dispatch")
+    True
+
+Partitions can be dispatched as well:
+
+    >>> partition1 = create_partition(sample, request, [analyses[0]])
+    >>> api.get_workflow_status_of(partition1)
+    'sample_received'
+    >>> isTransitionAllowed(partition1, "dispatch")
+    True
+
+    >>> partition2 = create_partition(sample, request, [analyses[1]])
+    >>> api.get_workflow_status_of(partition2)
+    'sample_received'
+    >>> isTransitionAllowed(partition2, "dispatch")
+    True
+
+
+Dispatching the first partition leaves the root sample and the other partition
+unchanged:
+
+    >>> transitioned = do_action_for(partition1, "dispatch")
+    >>> api.get_workflow_status_of(partition1)
+    'dispatched'
+
+    >>> api.get_workflow_status_of(partition2)
+    'sample_received'
+
+    >>> api.get_workflow_status_of(sample)
+    'sample_received'
+
+But when both partitions are dispatched, the root sample will be set to
+dispatched as well:
+
+    >>> transitioned = do_action_for(partition2, "dispatch")
+    >>> api.get_workflow_status_of(partition2)
+    'dispatched'
+
+    >>> api.get_workflow_status_of(partition1)
+    'dispatched'
+
+    >>> api.get_workflow_status_of(sample)
+    'dispatched'
+
+
+Restoring the root sample will restore all partitions as well:
+
+    >>> transitioned = do_action_for(sample, "restore")
+    >>> api.get_workflow_status_of(sample)
+    'sample_received'
+
+    >>> api.get_workflow_status_of(partition1)
+    'sample_received'
+
+    >>> api.get_workflow_status_of(partition2)
+    'sample_received'
+
+Dispatching the root sample will dispatch all partitions as well:
+
+    >>> transitioned = do_action_for(sample, "dispatch")
+    >>> api.get_workflow_status_of(sample)
+    'dispatched'
+
+    >>> api.get_workflow_status_of(partition1)
+    'dispatched'
+
+    >>> api.get_workflow_status_of(partition2)
+    'dispatched'


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds a new workflow transition `dispatch` to samples, which allows to put samples/partitions in `dispatched` state with leaving a comment.

The `dispatch` transition is possible for all received sample states, as long as their analyses are not assigned to worksheets.

## Current behavior before PR

No dispatch workflow for samples

## Desired behavior after PR is merged

Dispatch workflow for samples

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
