### PR TITLE
Integrated upgrade step notification events

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1773 Integrated upgrade step notification events
 - #1772 Sample dispatch workflow
 - #1771 Fix RecordsWidget does not store hidden fields in Add form
 - #1768 Added api for measurements with physical quantities

--- a/src/senaite/core/events/__init__.py
+++ b/src/senaite/core/events/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from senaite.core.events.upgrade import BeforeUpgradeStepEvent  # noqa
+from senaite.core.events.upgrade import AfterUpgradeStepEvent  # noqa

--- a/src/senaite/core/events/upgrade.py
+++ b/src/senaite/core/events/upgrade.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from zope.interface import Interface
+from zope.interface import implements
+
+
+class IBeforeUpgradeStepEvent(Interface):
+    """An event fired before the upgrade step started
+    """
+
+
+class IAfterUpgradeStepEvent(Interface):
+    """An event fired after the upgrade step completed
+    """
+
+
+class BeforeUpgradeStepEvent(object):
+    implements(IBeforeUpgradeStepEvent)
+
+    def __init__(self, context):
+        self.context = context
+
+
+class AfterUpgradeStepEvent(object):
+    implements(IAfterUpgradeStepEvent)
+
+    def __init__(self, context):
+        self.context = context

--- a/src/senaite/core/upgrade/__init__.py
+++ b/src/senaite/core/upgrade/__init__.py
@@ -19,6 +19,9 @@
 # Some rights reserved, see README and LICENSE.
 
 from Products.CMFCore.utils import getToolByName
+from senaite.core.events import AfterUpgradeStepEvent
+from senaite.core.events import BeforeUpgradeStepEvent
+from zope.event import notify
 
 
 def upgradestep(upgrade_product, version):
@@ -30,6 +33,11 @@ def upgradestep(upgrade_product, version):
             product = qi.get(upgrade_product)
             if product:
                 setattr(product, "installedversion", version)
-            return fn(context, *args)
+            # notify before upgrade step event
+            notify(BeforeUpgradeStepEvent(context))
+            # run upgrade step
+            fn(context, *args)
+            # notify after upgrade step event
+            notify(AfterUpgradeStepEvent(context))
         return wrap_func_args
     return wrap_func


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR integrates upgrade step notification events into `senaite.core`.
This allows add-ons to rund upgrade steps after the `senaite.core` upgrade machinery run to e.g. update the navigation etc.

## Current behavior before PR

Upgrade step of senaite.core did not send events

## Desired behavior after PR is merged

Upgrade step machinery of senaite.core sends the following events:

- `BeforeUpgradeStepEvent`
- `AfterUpgradeStepEvent`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
