### PR TITLE
Fix Lab clerk can edit items from setup folder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,10 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
+- #1774 Fix Lab clerk can edit items from setup folder
 - #1763 Remove final states from dashboard
-- #1756 Fix:'View' tab not displayed after saving the batch
-- #1737 Fix: formatDateQuery does not add the timezone for queries
+- #1756 Fix 'View' tab not displayed after saving the batch
+- #1737 Fix formatDateQuery does not add the timezone for queries
 - #1707 Fix sporadic persistent changes with interims
 - #1704 Add "User name" and "User groups" columns in Lab Contacts list
 - #1704 Fix Cannot override behavior of LabContacts folder on `before_render`

--- a/bika/lims/browser/controlpanel.py
+++ b/bika/lims/browser/controlpanel.py
@@ -24,9 +24,11 @@ from bika.lims.utils import t
 from plone.app.controlpanel.overview import OverviewControlPanel
 from plone.memoize.volatile import cache
 from plone.memoize.volatile import store_on_context
+from Products.CMFCore.permissions import ModifyPortalContent
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims import api
+from bika.lims.api.security import check_permission
 
 
 def modified_cache_key(method, self, brain_or_object):
@@ -66,6 +68,11 @@ class SetupView(BrowserView):
         """Returns the Senaite Setup Object
         """
         return api.get_setup()
+
+    def can_edit_setup(self):
+        """Checks if the current user has manager rights for Setup view
+        """
+        return check_permission(ModifyPortalContent, self.setup)
 
     @cache(modified_cache_key, store_on_context)
     def get_icon_url(self, brain):

--- a/bika/lims/browser/templates/setupview.pt
+++ b/bika/lims/browser/templates/setupview.pt
@@ -29,7 +29,8 @@
       <div class="row">
 
         <!-- The setup item -->
-        <tal:setup tal:define="setup python:view.setup">
+        <tal:setup tal:define="setup python:view.setup"
+                   tal:condition="python:view.can_edit_setup()">
           <div class="col-xs-12 col-sm-6 col-md-4 col-lg-3">
             <a class="tile setup text-capitalized"
                tal:attributes="href setup/absolute_url">

--- a/bika/lims/profiles/default/rolemap.xml
+++ b/bika/lims/profiles/default/rolemap.xml
@@ -143,13 +143,11 @@
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add AnalysisCategory" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add AnalysisProfile" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
@@ -161,19 +159,16 @@
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add AnalysisService" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add AnalysisSpec" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add ARTemplate" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
@@ -186,7 +181,6 @@
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add AttachmentType" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
@@ -198,13 +192,11 @@
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add BatchLabel" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add Calculation" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
@@ -215,37 +207,31 @@
       <role name="Manager"/>
     </permission>
     <permission name="senaite.core: Add Container" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add ContainerType" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add Department" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add Instrument" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add InstrumentLocation" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add InstrumentType" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
@@ -262,19 +248,16 @@
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add LabProduct" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add Manufacturer" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add Method" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
@@ -291,7 +274,6 @@
       <role name="Manager"/>
     </permission>
     <permission name="senaite.core: Add ReferenceDefinition" acquire="False">
-      <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
@@ -301,61 +283,51 @@
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add SampleCondition" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add SampleMatrix" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add SamplePoint" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add SampleType" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add SamplingDeviation" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add StorageLocation" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add SubGroup" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add Supplier" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add SupplyOrder" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
     <permission name="senaite.core: Add WorksheetTemplate" acquire="False">
-      <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>

--- a/bika/lims/profiles/default/workflows/senaite_clients_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_clients_workflow/definition.xml
@@ -57,7 +57,12 @@
       <permission-role>SamplingCoordinator</permission-role>
       <permission-role>Verifier</permission-role>
     </permission-map>
-    <permission-map name="Modify portal content" acquired="True"/>
+    <permission-map name="Modify portal content" acquired="False">
+      <permission-role>LabClerk</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
     <permission-map name="View" acquired="False">
       <permission-role>Analyst</permission-role>
       <permission-role>LabClerk</permission-role>

--- a/bika/lims/profiles/default/workflows/senaite_clients_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_clients_workflow/definition.xml
@@ -57,12 +57,7 @@
       <permission-role>SamplingCoordinator</permission-role>
       <permission-role>Verifier</permission-role>
     </permission-map>
-    <permission-map name="Modify portal content" acquired="False">
-      <permission-role>LabClerk</permission-role>
-      <permission-role>LabManager</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>Owner</permission-role>
-    </permission-map>
+    <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="False">
       <permission-role>Analyst</permission-role>
       <permission-role>LabClerk</permission-role>

--- a/bika/lims/profiles/default/workflows/senaite_setup_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/senaite_setup_workflow/definition.xml
@@ -38,7 +38,6 @@
       <permission-role>Authenticated</permission-role>
     </permission-map>
     <permission-map name="Modify portal content" acquired="False">
-      <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
     </permission-map>

--- a/bika/lims/tests/doctests/API.rst
+++ b/bika/lims/tests/doctests/API.rst
@@ -874,7 +874,7 @@ for the passed in object::
     ['LabClerk', 'LabManager', 'Manager', 'Owner']
 
     >>> api.get_roles_for_permission("Modify portal content", bika_setup)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabManager', 'Manager']
 
 
 

--- a/bika/lims/tests/doctests/Permissions.rst
+++ b/bika/lims/tests/doctests/Permissions.rst
@@ -115,7 +115,7 @@ Exactly these roles have should have the `List folder contents` permission::
 Exactly these roles have should have the `Modify portal content` permission::
 
     >>> get_roles_for_permission("Modify portal content", bika_setup)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabManager', 'Manager']
 
 Exactly these roles (nobody) should have the `Delete objects` permission::
 
@@ -372,7 +372,7 @@ state of `active`::
 Test Permissions
 ................
 
-Exactly these roles have should have a `View` permission for clients folder::
+Exactly these roles should have a `View` permission for clients folder::
 
     >>> get_roles_for_permission("View", clients)
     ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Owner', 'Preserver', 'Publisher', 'RegulatoryInspector', 'Sampler', 'SamplingCoordinator', 'Verifier']

--- a/bika/lims/tests/doctests/Permissions.rst
+++ b/bika/lims/tests/doctests/Permissions.rst
@@ -278,7 +278,7 @@ Exactly these roles have should have the `List folder contents` permission::
 Exactly these roles have should have the `Modify portal content` permission::
 
     >>> get_roles_for_permission("Modify portal content", labcontacts)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabManager', 'Manager']
 
     >>> get_roles_for_permission("Modify portal content", labcontact)
     ['LabClerk', 'LabManager', 'Manager']
@@ -620,10 +620,10 @@ Exactly these roles have should have the `List folder contents` permission::
 Exactly these roles have should have the `Modify portal content` permission::
 
     >>> get_roles_for_permission("Modify portal content", instruments)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabManager', 'Manager']
 
     >>> get_roles_for_permission("Modify portal content", instrument)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabManager', 'Manager']
 
 Exactly these roles have should have the `Delete objects` permission::
 
@@ -733,10 +733,10 @@ Exactly these roles have should have the `List folder contents` permission::
 Exactly these roles have should have the `Modify portal content` permission::
 
     >>> get_roles_for_permission("Modify portal content", methods)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabManager', 'Manager']
 
     >>> get_roles_for_permission("Modify portal content", method)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabManager', 'Manager']
 
 Exactly these roles have should have the `Delete objects` permission::
 
@@ -843,10 +843,10 @@ Exactly these roles have should have the `List folder contents` permission::
 Exactly these roles have should have the `Modify portal content` permission::
 
     >>> get_roles_for_permission("Modify portal content", analysisservices)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabManager', 'Manager']
 
     >>> get_roles_for_permission("Modify portal content", analysisservice)
-    ['LabClerk', 'LabManager', 'Manager']
+    ['LabManager', 'Manager']
 
 Exactly these roles have should have the `Delete objects` permission::
 

--- a/bika/lims/upgrade/v01_03_005.py
+++ b/bika/lims/upgrade/v01_03_005.py
@@ -57,7 +57,6 @@ def upgrade(tool):
     # Add new indexes
     add_new_indexes(portal)
 
-
     # Fix writing methods on read when reindexing services
     # https://github.com/senaite/senaite.core/pull/1617
     remove_duplicate_methods_in_services(portal)

--- a/bika/lims/upgrade/v01_03_005.py
+++ b/bika/lims/upgrade/v01_03_005.py
@@ -50,9 +50,13 @@ def upgrade(tool):
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
     # -------- ADD YOUR STUFF BELOW --------
+    # Fix Lab clerk can edit items from setup folder
+    # https://github.com/senaite/senaite.core/pull/1774
+    setup.runImportStepFromProfile(profile, "rolemap")
 
     # Add new indexes
     add_new_indexes(portal)
+
 
     # Fix writing methods on read when reindexing services
     # https://github.com/senaite/senaite.core/pull/1617


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Lab Clerk role has edition permissions for site setup.

## Desired behavior after PR is merged

Lab Clerk role does not have edition permissions for site setup.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
