### PR TITLE
Move time calculation into cache key function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1776 Move time calculation into cache key function
 - #1773 Integrated upgrade step notification events
 - #1772 Sample dispatch workflow
 - #1771 Fix RecordsWidget does not store hidden fields in Add form

--- a/src/senaite/core/browser/globals/theme.py
+++ b/src/senaite/core/browser/globals/theme.py
@@ -45,11 +45,10 @@ from .interfaces import ISenaiteTheme
 IMG_TAG = Template("""<img src="$src" $attr />""")
 
 ICON_BASE_URL = "++plone++senaite.core.static/assets/icons"
-ICON_CACHE_TIME = time.time() // 86400  # 1 day
 
 
 def icon_cache_key(method, instance):
-    return ICON_CACHE_TIME
+    return time.time() // 86400  # 1 day
 
 
 @implementer(ITraversable)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the time calculation of the icon cache key

## Current behavior before PR

cache time calculation at module level

## Desired behavior after PR is merged

cache time calculation in function

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
