### PR TITLE
Fix APIError when a retest analysis source was removed from a sample

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1777 Allow to re-add cancelled/rejected/retracted analyses to a sample
+- #1777 Fix APIError when a retest analysis source was removed from a sample
 - #1773 Integrated upgrade step notification events
 - #1772 Sample dispatch workflow
 - #1771 Fix RecordsWidget does not store hidden fields in Add form

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -1112,4 +1112,8 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             return None
         if len(back_refs) > 1:
             logger.warn("Analysis {} with multiple retests".format(self.id))
-        return api.get_object_by_uid(back_refs[0])
+        retest_uid = back_refs[0]
+        retest = api.get_object_by_uid(retest_uid, default=None)
+        if retest is None:
+            logger.error("Retest with UID {} not found".format(retest_uid))
+        return retest


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue that happens when for a submitted analyses a retest was created and the original analysis removed afterwards.

## Current behavior before PR

- Retest analysis still had a reference to the original analysis
- APIError occurred when analyses were selected afterwards
- It was not possible to re-add an analysis that was previously retracted or rejected (checkbox was disabled)

## Desired behavior after PR is merged

- Retest reference is unlinked when the original analysis is removed
- Missing retest UID fails gracefully
- It is possible to re-add an analysis that was previously retracted or rejected (checkbox was disabled)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
