### PR TITLE
Added Datamanager Adapters for Analysis and Sample

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1778 Added Datamanager Adapters for Analysis and Sample
 - #1773 Integrated upgrade step notification events
 - #1772 Sample dispatch workflow
 - #1771 Fix RecordsWidget does not store hidden fields in Add form

--- a/src/senaite/core/configure.zcml
+++ b/src/senaite/core/configure.zcml
@@ -13,6 +13,7 @@
   <!-- package includes -->
   <include package=".adapters" />
   <include package=".browser" />
+  <include package=".datamanagers" />
   <include package=".exportimport" />
   <include package=".locales" />
   <include package=".upgrade" />

--- a/src/senaite/core/datamanagers/__init__.py
+++ b/src/senaite/core/datamanagers/__init__.py
@@ -17,22 +17,16 @@ class DataManager(object):
         self.context = context
 
     def get(self, name):
-        if not self.can_access():
-            raise Unauthorized("You are not allowed to access {}".format(
-                api.get_id(self.context)))
-        return getattr(self.context, name)
+        raise NotImplementedError("Must be implemented by subclass")
 
     def query(self, name, default=None):
-        if not self.can_access():
-            raise Unauthorized("You are not allowed to access {}".format(
-                api.get_id(self.context)))
-        return getattr(self.context, name, default)
+        try:
+            return self.get(name)
+        except AttributeError:
+            return default
 
     def set(self, name, value):
-        if not self.can_access():
-            raise Unauthorized("You are not allowed to modify {}".format(
-                api.get_id(self.context)))
-        return setattr(self.context, name, value)
+        raise NotImplementedError("Must be implemented by subclass")
 
     def can_access(self):
         return check_permission(View, self.context)

--- a/src/senaite/core/datamanagers/__init__.py
+++ b/src/senaite/core/datamanagers/__init__.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+from AccessControl import Unauthorized
+from bika.lims import api
+from bika.lims.api.security import check_permission
+from Products.CMFCore.permissions import ModifyPortalContent
+from Products.CMFCore.permissions import View
+from senaite.core.interfaces.datamanager import IDataManager
+from zope.interface import implementer
+
+
+@implementer(IDataManager)
+class DataManager(object):
+    """Data manager base class."""
+
+    def __init__(self, context):
+        self.context = context
+
+    def get(self, name):
+        if not self.can_access():
+            raise Unauthorized("You are not allowed to access {}".format(
+                api.get_id(self.context)))
+        return getattr(self.context, name)
+
+    def query(self, name, default=None):
+        if not self.can_access():
+            raise Unauthorized("You are not allowed to access {}".format(
+                api.get_id(self.context)))
+        return getattr(self.context, name, default)
+
+    def set(self, name, value):
+        if not self.can_access():
+            raise Unauthorized("You are not allowed to modify {}".format(
+                api.get_id(self.context)))
+        return setattr(self.context, name, value)
+
+    def can_access(self):
+        return check_permission(View, self.context)
+
+    def can_write(self):
+        return check_permission(ModifyPortalContent, self.context)

--- a/src/senaite/core/datamanagers/analysis.py
+++ b/src/senaite/core/datamanagers/analysis.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+
+from bika.lims import api
+from bika.lims.interfaces import IReferenceAnalysis
+from bika.lims.interfaces import IRoutineAnalysis
+from Products.Archetypes.utils import mapply
+from senaite.core import logger
+from senaite.core.datamanagers import DataManager
+from zope.component import adapter
+
+
+@adapter(IRoutineAnalysis)
+class RoutineAnalysisDataManager(DataManager):
+    """Data Manager for Routine Analyses
+    """
+
+    @property
+    def fields(self):
+        return api.get_fields(self.context)
+
+    def is_field_writeable(self, field):
+        """Checks if the field is writeable
+        """
+        return field.writeable(self.context)
+
+    def set(self, name, value):
+        """Set analysis field/interim value
+        """
+        # set of updated objects
+        updated_objects = set()
+
+        # schema field
+        field = self.fields.get(name)
+
+        # interims
+        interims = self.context.getInterimFields()
+        interim_keys = map(lambda i: i.get("keyword"), interims)
+
+        # schema field found
+        if field:
+            # Check the permission of the field
+            if not self.is_field_writeable(field):
+                logger.error("Field '{}' not writeable!".format(name))
+                return []
+            # get the field mutator (works only for AT content types)
+            if hasattr(field, "getMutator"):
+                mutator = field.getMutator(self.context)
+                mapply(mutator, value)
+            else:
+                # Set the value on the field directly
+                field.set(self.context, value)
+            updated_objects.add(self.context)
+
+        # interim key found
+        elif name in interim_keys:
+            # Check the permission of the field
+            interim_field = self.fields.get("InterimFields")
+            if not self.is_field_writeable(interim_field):
+                logger.error("Interim field '{}' not writeable!".format(name))
+                return []
+            for interim in interims:
+                if interim.get("keyword") == name:
+                    interim["value"] = value
+            self.context.setInterimFields(interims)
+
+        # recalculate dependent results for result and interim fields
+        if name == "Result" or name in interim_keys:
+            updated_objects.add(self.context)
+            updated_objects.update(self.recalculate_results(self.context))
+
+        # return a unified list of the updated objects
+        return list(updated_objects)
+
+    def recalculate_results(self, obj, recalculated=None):
+        """Recalculate the result of the object and its dependents
+
+        :returns: List of recalculated objects
+        """
+
+        if recalculated is None:
+            recalculated = set()
+
+        # avoid double recalculation in recursion
+        if obj in recalculated:
+            return set()
+
+        # recalculate own result
+        if obj.calculateResult(override=True):
+            # append object to the list of recalculated results
+            recalculated.add(obj)
+        # recalculate dependent analyses
+        for dep in obj.getDependents():
+            if dep.calculateResult(override=True):
+                # TODO the `calculateResult` method should return False here!
+                if dep.getResult() in ["NA", "0/0"]:
+                    continue
+                recalculated.add(dep)
+            # recalculate dependents of dependents
+            for ddep in dep.getDependents():
+                recalculated.update(
+                    self.recalculate_results(
+                        ddep, recalculated=recalculated))
+        return recalculated
+
+
+@adapter(IReferenceAnalysis)
+class ReferenceAnalysisDataManager(RoutineAnalysisDataManager):
+    """Data Manager for Reference Analyses
+    """

--- a/src/senaite/core/datamanagers/analysis.py
+++ b/src/senaite/core/datamanagers/analysis.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from AccessControl import Unauthorized
 from bika.lims import api
 from bika.lims.interfaces import IReferenceAnalysis
 from bika.lims.interfaces import IRoutineAnalysis
@@ -18,10 +19,37 @@ class RoutineAnalysisDataManager(DataManager):
     def fields(self):
         return api.get_fields(self.context)
 
+    def is_field_readable(self, field):
+        """Checks if the field is readable
+        """
+        return field.checkPermission("get", self.context)
+
     def is_field_writeable(self, field):
         """Checks if the field is writeable
         """
-        return field.writeable(self.context)
+        return field.checkPermission("set", self.context)
+
+    def get(self, name):
+        """Get analysis field
+        """
+        # schema field
+        field = self.fields.get(name)
+
+        # check if the field exists
+        if field is None:
+            raise AttributeError("Field '{}' not found".format(name))
+
+        # Check the permission of the field
+        if not self.is_field_readable(field):
+            raise Unauthorized("Field '{}' not readable!".format(name))
+
+        # return the value with the field accessor
+        if hasattr(field, "getAccessor"):
+            accessor = field.getAccessor(self.context)
+            return accessor()
+        else:
+            # Set the value on the field directly
+            return field.get(self.context)
 
     def set(self, name, value):
         """Set analysis field/interim value
@@ -76,7 +104,6 @@ class RoutineAnalysisDataManager(DataManager):
 
         :returns: List of recalculated objects
         """
-
         if recalculated is None:
             recalculated = set()
 

--- a/src/senaite/core/datamanagers/configure.zcml
+++ b/src/senaite/core/datamanagers/configure.zcml
@@ -1,0 +1,7 @@
+<configure xmlns="http://namespaces.zope.org/zope"
+           i18n_domain="senaite.core">
+
+  <!-- Data Manager for Analyses -->
+  <adapter factory=".analysis.RoutineAnalysisDataManager" />
+
+</configure>

--- a/src/senaite/core/datamanagers/configure.zcml
+++ b/src/senaite/core/datamanagers/configure.zcml
@@ -2,6 +2,9 @@
            i18n_domain="senaite.core">
 
   <!-- Data Manager for Analyses -->
+  <adapter factory=".sample.SampleDataManager" />
+
+  <!-- Data Manager for Analyses -->
   <adapter factory=".analysis.RoutineAnalysisDataManager" />
 
 </configure>

--- a/src/senaite/core/datamanagers/sample.py
+++ b/src/senaite/core/datamanagers/sample.py
@@ -28,14 +28,6 @@ class SampleDataManager(DataManager):
         """
         return field.checkPermission("set", self.context)
 
-    def query(self, name, default=None):
-        """Query sample field
-        """
-        try:
-            return self.get(name)
-        except AttributeError:
-            return default
-
     def get(self, name):
         """Get sample field
         """

--- a/src/senaite/core/datamanagers/sample.py
+++ b/src/senaite/core/datamanagers/sample.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+
+from AccessControl import Unauthorized
+from bika.lims import api
+from bika.lims.interfaces import IAnalysisRequest
+from Products.Archetypes.utils import mapply
+from senaite.core import logger
+from senaite.core.datamanagers import DataManager
+from zope.component import adapter
+
+
+@adapter(IAnalysisRequest)
+class SampleDataManager(DataManager):
+    """Data Manager for Samples
+    """
+
+    @property
+    def fields(self):
+        return api.get_fields(self.context)
+
+    def is_field_readable(self, field):
+        """Checks if the field is readable
+        """
+        return field.checkPermission("get", self.context)
+
+    def is_field_writeable(self, field):
+        """Checks if the field is writeable
+        """
+        return field.checkPermission("set", self.context)
+
+    def query(self, name, default=None):
+        """Query sample field
+        """
+        try:
+            return self.get(name)
+        except AttributeError:
+            return default
+
+    def get(self, name):
+        """Get sample field
+        """
+        # schema field
+        field = self.fields.get(name)
+
+        # check if the field exists
+        if field is None:
+            raise AttributeError("Field '{}' not found".format(name))
+
+        # Check the permission of the field
+        if not self.is_field_readable(field):
+            raise Unauthorized("Field '{}' not readable!".format(name))
+
+        # return the value with the field accessor
+        if hasattr(field, "getAccessor"):
+            accessor = field.getAccessor(self.context)
+            return accessor()
+        else:
+            # Set the value on the field directly
+            return field.get(self.context)
+
+    def set(self, name, value):
+        """Set sample field or analysis result
+        """
+        # set of updated objects
+        updated_objects = set()
+
+        # schema field
+        field = self.fields.get(name)
+
+        if field is None:
+            raise AttributeError("Field '{}' not found".format(name))
+
+        # Check the permission of the field
+        if not self.is_field_writeable(field):
+            logger.error("Field '{}' not writeable!".format(name))
+            return []
+        # get the field mutator (works only for AT content types)
+        if hasattr(field, "getMutator"):
+            mutator = field.getMutator(self.context)
+            mapply(mutator, value)
+        else:
+            # Set the value on the field directly
+            field.set(self.context, value)
+
+        updated_objects.add(self.context)
+
+        # return a unified list of the updated objects
+        return list(updated_objects)

--- a/src/senaite/core/interfaces/__init__.py
+++ b/src/senaite/core/interfaces/__init__.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 from plone.app.z3cform.interfaces import IPloneFormLayer
+from senaite.core.interfaces.datamanager import IDataManager  # noqa (convenience import)
 from zope.interface import Interface
 
 

--- a/src/senaite/core/interfaces/datamanager.py
+++ b/src/senaite/core/interfaces/datamanager.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+from zope import interface
+
+
+class NO_VALUE(object):
+    def __repr__(self):
+        return "<NO_VALUE>"
+
+
+NO_VALUE = NO_VALUE()
+
+
+class IDataManager(interface.Interface):
+    """Data manager."""
+
+    def get(name):
+        """Get the value.
+
+        If no value can be found, raise an error
+        """
+
+    def query(name, default=NO_VALUE):
+        """Query the name for its value
+
+        If no value can be found, return the default value.
+        If read is forbidden, raise an error.
+        """
+
+    def set(name, value):
+        """Set the value by name
+
+        Returns a list of updated objects
+        """
+
+    def can_read():
+        """Checks if the object is readable
+        """
+
+    def can_write():
+        """Checks if the object is writable
+        """

--- a/src/senaite/core/tests/doctests/DataManagerAnalysis.rst
+++ b/src/senaite/core/tests/doctests/DataManagerAnalysis.rst
@@ -1,0 +1,223 @@
+Analysis Data Manager
+---------------------
+
+A data manager is an object adapter to get/set/query data by a name.
+
+It is currently used for to set analyses results and interims from
+`senaite.app.listing`.
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t DataManagerAnalysis
+
+
+Test Setup
+..........
+
+Needed Imports:
+
+    >>> from operator import methodcaller
+    >>> from AccessControl.PermissionRole import rolesForPermissionOn
+    >>> from DateTime import DateTime
+    >>> from bika.lims import api
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.utils.analysisrequest import create_partition
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+    >>> from bika.lims.workflow import getAllowedTransitions
+    >>> from bika.lims.workflow import isTransitionAllowed
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+    >>> from plone.app.testing import setRoles
+
+Functional Helpers:
+
+    >>> def start_server():
+    ...     from Testing.ZopeTestCase.utils import startZServer
+    ...     ip, port = startZServer()
+    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
+
+    >>> def timestamp(format="%Y-%m-%d"):
+    ...     return DateTime().strftime(format)
+
+    >>> def start_server():
+    ...     from Testing.ZopeTestCase.utils import startZServer
+    ...     ip, port = startZServer()
+    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
+
+    >>> def new_sample(services, client, contact, sample_type, date_sampled=None):
+    ...     values = {
+    ...         'Client': api.get_uid(client),
+    ...         'Contact': api.get_uid(contact),
+    ...         'DateSampled': date_sampled or DateTime().strftime("%Y-%m-%d"),
+    ...         'SampleType': api.get_uid(sample_type),
+    ...     }
+    ...     service_uids = map(api.get_uid, services)
+    ...     sample = create_analysisrequest(client, request, values, service_uids)
+    ...     return sample
+
+    >>> def get_analysis_from(sample, service):
+    ...     service_uid = api.get_uid(service)
+    ...     for analysis in sample.getAnalyses(full_objects=True):
+    ...         if analysis.getServiceUID() == service_uid:
+    ...             return analysis
+    ...     return None
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = api.get_setup()
+
+We need to create some basic objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
+    >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH", MemberDiscountApplies=True)
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(setup.bika_sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.bika_departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = api.create(setup.bika_analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> Cu = api.create(setup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID(), Accredited=True)
+    >>> Fe = api.create(setup.bika_analysisservices, "AnalysisService", title="Iron", Keyword="Fe", Price="10", Category=category.UID())
+    >>> Au = api.create(setup.bika_analysisservices, "AnalysisService", title="Gold", Keyword="Au", Price="20", Category=category.UID())
+
+
+Using the data manager to set analysis results
+..............................................
+
+Create a new sample:
+
+    >>> sample = new_sample([Cu, Fe, Au], client, contact, sampletype)
+    >>> api.get_workflow_status_of(sample)
+    'sample_due'
+
+Receive the sample:
+
+    >>> transitioned = do_action_for(sample, "receive")
+    >>> api.get_workflow_status_of(sample)
+    'sample_received'
+
+Get the analyses from the sample:
+
+    >>> cu = get_analysis_from(sample, Cu)
+    >>> fe = get_analysis_from(sample, Fe)
+    >>> au = get_analysis_from(sample, Au)
+
+Get the data manager:
+
+    >>> from senaite.core.interfaces import IDataManager
+
+    >>> cu_dm =  IDataManager(cu)
+    >>> cu_dm
+    <senaite.core.datamanagers.analysis.RoutineAnalysisDataManager object at 0x...>
+
+Getting the value of a named attribute:
+
+    >>> cu_dm.get("Keyword")
+    u'Cu'
+
+    >>> cu_dm.get("Result")
+    u''
+
+    >>> cu_dm.get("NOTEXISTS")
+    Traceback (most recent call last):
+    ...
+    AttributeError: ...
+   
+Query a value allows to define a default value:
+
+    >>> cu_dm.query("Keyword", default=False)
+    u'Cu'
+
+    >>> cu_dm.query("Result", default=False)
+    u''
+
+    >>> cu_dm.query("NOTEXISTS", default=False)
+    False
+
+Seting a value returns a list of updated objects (important when it comes to dependency calculation):
+
+    >>> cu_dm.set("Result", 123)
+    [<Analysis at /plone/clients/client-1/W-0001/Cu>]
+
+    >>> cu_dm.get("Result")
+    u'123'
+
+
+Permission check
+................
+
+Per default, the permisisons `View` for read and `Modify portal content` for
+write operations are checked.
+
+Check if the context can be writable (per default Analyses do not grant `Modify portal content`):
+
+    >>> cu_dm.can_write()
+    False
+
+    >>> api.security.grant_permission_for(cu, "Modify portal content", ["LabManager"])
+
+    >>> cu_dm.can_write()
+    True
+
+Check if the context is readable:
+
+    >>> cu_dm.can_access()
+    True
+
+    >>> api.security.revoke_permission_for(cu, "View", [])
+
+    >>> cu_dm.can_access()
+    False
+
+
+Setting calculation interims
+............................
+
+Create a new calculation with interims:
+
+    >>> calc = api.create(setup.bika_calculations, "Calculation", title="Drying Loss Calculation")
+    >>> calc.setInterimFields([{"keyword": "SW", "title": "Weight of Sample"}, {"keyword": "DW", "title": "Dry Sample Weight"}])
+    >>> calc.setFormula("[DW]/[SW]*100")
+
+    >>> calc.getFormula()
+    '[DW]/[SW]*100'
+
+    >>> list(sorted(calc.getInterimFields(), key=lambda i: i.get("keyword")))
+    [{'keyword': 'DW', 'value': 0, 'title': 'Dry Sample Weight'}, {'keyword': 'SW', 'value': 0, 'title': 'Weight of Sample'}]
+
+Set the calculation to a new service:
+
+    >>> DRL = api.create(setup.bika_analysisservices, "AnalysisService", title="Drying Loss", Keyword="DRL", Price="50", Category=category.UID(), Accredited=True, Calculation=calc)
+
+Create a new sample:
+
+    >>> drl_sample = new_sample([DRL], client, contact, sampletype)
+
+Receive the sample:
+
+    >>> transitioned = do_action_for(drl_sample, "receive")
+
+Get the drying loss analysis:
+
+    >>> drl = get_analysis_from(drl_sample, DRL)
+
+Get the data manager
+
+    >>> drl_dm = IDataManager(drl)
+    >>> drl_dm
+    <senaite.core.datamanagers.analysis.RoutineAnalysisDataManager object at 0x...>
+
+Set the results:
+
+    >>> drl_dm.set("SW", 50)
+    [<Analysis at /plone/clients/client-1/W-0002/DRL>]
+
+    >>> drl_dm.set("DW", 10)
+    [<Analysis at /plone/clients/client-1/W-0002/DRL>]
+
+
+Check if the result was updated:
+
+    >>> drl_dm.get("Result")
+    u'20.0'

--- a/src/senaite/core/tests/doctests/DataManagerAnalysis.rst
+++ b/src/senaite/core/tests/doctests/DataManagerAnalysis.rst
@@ -114,10 +114,10 @@ Get the data manager:
 Getting the value of a named attribute:
 
     >>> cu_dm.get("Keyword")
-    u'Cu'
+    'Cu'
 
     >>> cu_dm.get("Result")
-    u''
+    ''
 
     >>> cu_dm.get("NOTEXISTS")
     Traceback (most recent call last):
@@ -127,10 +127,10 @@ Getting the value of a named attribute:
 Query a value allows to define a default value:
 
     >>> cu_dm.query("Keyword", default=False)
-    u'Cu'
+    'Cu'
 
     >>> cu_dm.query("Result", default=False)
-    u''
+    ''
 
     >>> cu_dm.query("NOTEXISTS", default=False)
     False
@@ -141,7 +141,7 @@ Seting a value returns a list of updated objects (important when it comes to dep
     [<Analysis at /plone/clients/client-1/W-0001/Cu>]
 
     >>> cu_dm.get("Result")
-    u'123'
+    '123'
 
 
 Permission check
@@ -220,4 +220,4 @@ Set the results:
 Check if the result was updated:
 
     >>> drl_dm.get("Result")
-    u'20.0'
+    '20.0'

--- a/src/senaite/core/tests/doctests/DataManagerSample.rst
+++ b/src/senaite/core/tests/doctests/DataManagerSample.rst
@@ -1,0 +1,136 @@
+Sample Data Manager
+-------------------
+
+A data manager is an object adapter to get/set/query data by a name.
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t DataManagerSample
+
+
+Test Setup
+..........
+
+Needed Imports:
+
+    >>> from operator import methodcaller
+    >>> from AccessControl.PermissionRole import rolesForPermissionOn
+    >>> from DateTime import DateTime
+    >>> from bika.lims import api
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.utils.analysisrequest import create_partition
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+    >>> from bika.lims.workflow import getAllowedTransitions
+    >>> from bika.lims.workflow import isTransitionAllowed
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+    >>> from plone.app.testing import setRoles
+
+Functional Helpers:
+
+    >>> def start_server():
+    ...     from Testing.ZopeTestCase.utils import startZServer
+    ...     ip, port = startZServer()
+    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
+
+    >>> def timestamp(format="%Y-%m-%d"):
+    ...     return DateTime().strftime(format)
+
+    >>> def start_server():
+    ...     from Testing.ZopeTestCase.utils import startZServer
+    ...     ip, port = startZServer()
+    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
+
+    >>> def new_sample(services, client, contact, sample_type, date_sampled=None):
+    ...     values = {
+    ...         'Client': api.get_uid(client),
+    ...         'Contact': api.get_uid(contact),
+    ...         'DateSampled': date_sampled or DateTime().strftime("%Y-%m-%d"),
+    ...         'SampleType': api.get_uid(sample_type),
+    ...     }
+    ...     service_uids = map(api.get_uid, services)
+    ...     sample = create_analysisrequest(client, request, values, service_uids)
+    ...     return sample
+
+    >>> def get_analysis_from(sample, service):
+    ...     service_uid = api.get_uid(service)
+    ...     for analysis in sample.getAnalyses(full_objects=True):
+    ...         if analysis.getServiceUID() == service_uid:
+    ...             return analysis
+    ...     return None
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = api.get_setup()
+
+We need to create some basic objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
+    >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH", MemberDiscountApplies=True)
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(setup.bika_sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.bika_departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = api.create(setup.bika_analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> Cu = api.create(setup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID(), Accredited=True)
+    >>> Fe = api.create(setup.bika_analysisservices, "AnalysisService", title="Iron", Keyword="Fe", Price="10", Category=category.UID())
+    >>> Au = api.create(setup.bika_analysisservices, "AnalysisService", title="Gold", Keyword="Au", Price="20", Category=category.UID())
+
+
+Using the data manager to set sample values
+...........................................
+
+Create a new sample:
+
+    >>> sample = new_sample([Cu, Fe, Au], client, contact, sampletype)
+    >>> api.get_workflow_status_of(sample)
+    'sample_due'
+
+Receive the sample:
+
+    >>> transitioned = do_action_for(sample, "receive")
+    >>> api.get_workflow_status_of(sample)
+    'sample_received'
+
+Get the data manager:
+
+    >>> from senaite.core.interfaces import IDataManager
+
+    >>> dm =  IDataManager(sample)
+    >>> dm
+    <senaite.core.datamanagers.sample.SampleDataManager object at 0x...>
+
+Set a text field:
+
+    >>> dm.set("EnvironmentalConditions", "sunny")
+    [<AnalysisRequest at /plone/clients/client-1/W-0001>]
+
+    >>> dm.get("EnvironmentalConditions")
+    'sunny'
+
+Set a bool field:
+
+    >>> dm.set("Composite", True)
+    [<AnalysisRequest at /plone/clients/client-1/W-0001>]
+
+    >>> dm.get("Composite")
+    True
+
+Set a reference field:
+
+    >>> dm.set("CCContact", [contact])
+    [<AnalysisRequest at /plone/clients/client-1/W-0001>]
+
+    >>> dm.get("CCContact")
+    [<Contact at /plone/clients/client-1/contact-1>]
+
+
+Set a date field:
+
+    >>> dm.set("DateSampled", "2000-12-31")
+    [<AnalysisRequest at /plone/clients/client-1/W-0001>]
+
+    >>> dm.get("DateSampled").strftime("%Y-%m-%d")
+    '2000-12-31'


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR introduces "Data Managers" to set/get/query data from objects.

The main purpose for data managers are to set field values from listing tables asynchronously.

## Current behavior before PR

No data managers available

## Desired behavior after PR is merged

Data managers for sample and analysis added

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
