### PR TITLE
Fix LabManager cannot create Reference Definitions

### DIFF
--- a/bika/lims/profiles/default/rolemap.xml
+++ b/bika/lims/profiles/default/rolemap.xml
@@ -274,6 +274,7 @@
       <role name="Manager"/>
     </permission>
     <permission name="senaite.core: Add ReferenceDefinition" acquire="False">
+      <role name="LabManager"/>
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a permission issue introduced in https://github.com/senaite/senaite.core/pull/1774

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
