### PR TITLE
Exclude invalid samples from dashboard's not-printed indicator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
+- #1780 Exclude invalid samples from dashboard's not-printed indicator
 - #1774 Fix Lab clerk can edit items from setup folder
 - #1763 Remove final states from dashboard
 - #1756 Fix 'View' tab not displayed after saving the batch

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
-- #1780 Exclude invalid samples from dashboard's not-printed indicator
+- #1781 Exclude invalid samples from dashboard's not-printed indicator
 - #1774 Fix Lab clerk can edit items from setup folder
 - #1763 Remove final states from dashboard
 - #1756 Fix 'View' tab not displayed after saving the batch

--- a/bika/lims/browser/dashboard/dashboard.py
+++ b/bika/lims/browser/dashboard/dashboard.py
@@ -432,7 +432,7 @@ class DashboardView(BrowserView):
         # Samples to be printed
         if self.context.bika_setup.getPrintingWorkflowEnabled():
             not_printed = {
-                "is_published": True,
+                "review_state": "published",
                 "getPrinted": "0",
             }
             brains = api.search(not_printed, CATALOG_ANALYSIS_REQUEST_LISTING)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The indicator from the dashboard that displays the non-yet-printed samples (when printing workflow is active) considers all samples that have been published, those that where invalidated too.

This Pull Request makes the indicator to display the count of not-yet printed samples that are currently in published status only.

## Current behavior before PR

"Not printed" indicator from dashboard includes invalidated samples

## Desired behavior after PR is merged

"Not printed" indicator from dashboard does not include invalidated samples

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
