### PR TITLE
Allow to set toolbar logo CSS styles via registry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1782 Allow to set toolbar logo CSS styles via registry
 - #1778 Added Datamanager Adapters for Analysis and Sample
 - #1777 Allow to re-add cancelled/rejected/retracted analyses to a sample
 - #1777 Fix APIError when a retest analysis source was removed from a sample

--- a/src/senaite/core/browser/viewlets/templates/toolbar.pt
+++ b/src/senaite/core/browser/viewlets/templates/toolbar.pt
@@ -9,7 +9,7 @@
 
   <!-- Navbar Brand Icon -->
   <a class="navbar-brand" href="#" tal:attributes="href portal_state/portal_url">
-    <img alt="SENAITE" height="15px" tal:attributes="src view/get_toolbar_logo" />
+    <img tal:attributes="src python:view.get_toolbar_logo();style python:view.get_toolbar_styles()" />
   </a>
 
   <!-- Navbar Toggle Button -->

--- a/src/senaite/core/browser/viewlets/toolbar.py
+++ b/src/senaite/core/browser/viewlets/toolbar.py
@@ -78,16 +78,23 @@ class ToolbarViewletManager(OrderedViewletManager):
 
     def get_toolbar_logo(self):
         registry = getUtility(IRegistry)
-        settings = registry.forInterface(
-            ISiteSchema, prefix="senaite", check=False)
         portal_url = self.portal_state.portal_url()
         try:
-            logo = settings.toolbar_logo
+            logo = registry["senaite.toolbar_logo"]
         except AttributeError:
             logo = LOGO
         if not logo:
             logo = LOGO
         return portal_url + logo
+
+    def get_toolbar_styles(self):
+        registry = getUtility(IRegistry)
+        try:
+            styles = registry["senaite.toolbar_logo_styles"]
+        except AttributeError:
+            return "height:15px;"
+        css = map(lambda style: "{}:{};".format(*style), styles.items())
+        return " ".join(css)
 
     def get_lims_setup_url(self):
         portal_url = self.portal_state.portal().absolute_url()

--- a/src/senaite/core/profiles/default/registry.xml
+++ b/src/senaite/core/profiles/default/registry.xml
@@ -22,6 +22,19 @@
     <value>/++plone++senaite.core.static/images/senaite.svg</value>
   </record>
 
+  <!-- Toolbar CSS Styles -->
+  <record name="senaite.toolbar_logo_styles" interface="Products.CMFPlone.interfaces.controlpanel.ISiteSchema" field="toolbar_logo_styles">
+    <field type="plone.registry.field.Dict">
+      <title>Toolbar CSS</title>
+      <description>CSS styles for the toolbar logo</description>
+      <key_type type="plone.registry.field.ASCIILine" />
+      <value_type type="plone.registry.field.ASCIILine" />
+    </field>
+    <value>
+      <element key="height">15px</element>
+    </value>
+  </record>
+
   <!-- Types to display in navigation -->
   <record name="plone.displayed_types" interface="Products.CMFPlone.interfaces.controlpanel.INavigationSchema" field="displayed_types">
     <field type="plone.registry.field.Tuple">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds a registry record named `toolbar_logo_styles` to set inline CSS styles to the toolbar logo

## Current behavior before PR

toolbar logo always set to 15px height

## Desired behavior after PR is merged

toolbar logo use registry settings to set inline CSS styles

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
