### PR TITLE
Fix KeyError when retrieving toolbar logo

### DIFF
--- a/src/senaite/core/browser/viewlets/toolbar.py
+++ b/src/senaite/core/browser/viewlets/toolbar.py
@@ -81,7 +81,7 @@ class ToolbarViewletManager(OrderedViewletManager):
         portal_url = self.portal_state.portal_url()
         try:
             logo = registry["senaite.toolbar_logo"]
-        except AttributeError:
+        except (AttributeError, KeyError):
             logo = LOGO
         if not logo:
             logo = LOGO
@@ -91,7 +91,7 @@ class ToolbarViewletManager(OrderedViewletManager):
         registry = getUtility(IRegistry)
         try:
             styles = registry["senaite.toolbar_logo_styles"]
-        except AttributeError:
+        except (AttributeError, KeyError):
             return "height:15px;"
         css = map(lambda style: "{}:{};".format(*style), styles.items())
         return " ".join(css)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a `KeyError` when accessing a not upgraded Senaite site

## Current behavior before PR

Site Error occurs:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.core.browser.dashboard.dashboard, line 203, in __call__
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module d7a38c21ca27113ce81312509ba60e88, line 1691, in render
  Module d53e829825bf71aeee90ff3d3956f7d0, line 1131, in render_master
  Module zope.contentprovider.tales, line 79, in __call__
  Module senaite.core.browser.viewlets.toolbar, line 43, in render
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 214, in render
  Module chameleon.template, line 192, in render
  Module bb035a679efce10f1e69906f0597f715, line 242, in render
  Module zope.tales.pythonexpr, line 73, in __call__
   - __traceback_info__: (view.get_toolbar_styles())
  Module <string>, line 1, in <module>
  Module senaite.core.browser.viewlets.toolbar, line 93, in get_toolbar_styles
  Module plone.registry.registry, line 42, in __getitem__
KeyError: 'senaite.toolbar_logo_styles'

 - Expression: " python:view.get_toolbar_styles("
 - Filename:   ... e/src/senaite/core/browser/viewlets/templates/toolbar.pt
 - Location:   (line 12: col 65)
 - Source:     ... lbar_logo();style python:view.get_toolbar_styles()" />
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Expression: "provider:plone.toolbar"
 - Filename:   ... te/core/browser/main_template/templates/main_template.pt
 - Location:   (line 73: col 36)
 - Source:     ... 
                                         ^
 - Expression: "here/main_template/macros/master"
 - Filename:   ... rc/senaite/core/browser/dashboard/templates/dashboard.pt
 - Location:   (line 2: col 23)
 - Source:     metal:use-macro="here/main_template/macros/master"
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  request: <WSGIRequest, URL=http://localhost:8983/senaite/senaite-dashboard>
               personal_bar: <plone.app.layout.viewlets.common.PersonalBarViewlet object at 0x7f7f09f95490>
               context_state: <Products.Five.browser.metaconfigure.ContextState object at 0x7f7f09f95310>
               attrs: {u'src': u'python:view.get_toolbar_logo()', u'style': u'python:view.get_toolbar_styles()'}
               language_selector: <senaite.core.browser.viewlets.languageselector.LanguageSelector object at 0x7f7f09f95450>
               container: <PloneSite at /senaite>
               traverse_subpath: []
               global_sections: <senaite.core.browser.viewlets.sections.GlobalSectionsViewlet object at 0x7f7f09f8ff50>
               template: <Products.Five.browser.pagetemplatefile.ViewPageTemplateFile object at 0x7f7f1246dd50>
               translate: <function translate at 0x7f7f09f90c08>
               repeat: <Products.PageTemplates.engine.RepeatDictWrapper object at 0x7f7f116c56e0>
               views: <Products.Five.browser.pagetemplatefile.ViewMapper object at 0x7f7f09f8f950>
               args: ()
               here: <PloneSite at /senaite>
               user: <PropertiedUser 'admin'>
               nothing: None
               default: <DEFAULT>
               modules: <Products.PageTemplates.ZRPythonExpr._SecureModuleImporter object at 0x7f7f284ce190>
               loop: {}
               context: <PloneSite at /senaite>
               portal_state: <Products.Five.browser.metaconfigure.PortalState object at 0x7f7f09f953d0>
               view: <Products.Five.viewlet.manager.<ViewletManager providing IToolbar> object at 0x7f7f09f8f610>
               root: <Application at >
               options: {}
               target_language: None
```

## Desired behavior after PR is merged

No site error occurs

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
