### PR TITLE
Allow multi PDF report downloads

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1790 Allow multi PDF report downloads
 - #1785 Moved listing context actions to separate viewlets
 - #1784 Dashboard fixtures: Links, colors, visibility
 - #1782 Allow to set toolbar logo CSS styles via registry

--- a/src/bika/lims/browser/publish/reports_listing.py
+++ b/src/bika/lims/browser/publish/reports_listing.py
@@ -19,7 +19,6 @@
 # Some rights reserved, see README and LICENSE.
 
 import collections
-import re
 
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _BMF
@@ -88,6 +87,18 @@ class ReportsListingView(BikaListingView):
             "help": help_publish_text,
         }
 
+        help_download_reports_text = _(
+            "Download selected reports")
+
+        self.download_reports_transition = {
+            "id": "download_reports",
+            "title": _("Download"),
+            # see senaite.core.browser.workflow
+            "url": "workflow_action?action=download_reports",
+            "css_class": "btn-outline-secondary",
+            "help": help_download_reports_text,
+        }
+
         self.columns = collections.OrderedDict((
             ("Info", {
                 "title": "",
@@ -118,6 +129,7 @@ class ReportsListingView(BikaListingView):
                 "custom_transitions": [
                     self.send_email_transition,
                     self.publish_samples_transition,
+                    self.download_reports_transition,
                 ]
             },
         ]

--- a/src/bika/lims/browser/workflow/client.py
+++ b/src/bika/lims/browser/workflow/client.py
@@ -19,13 +19,77 @@
 # Some rights reserved, see README and LICENSE.
 
 import itertools
+import tempfile
+import zipfile
 
 from bika.lims import _
 from bika.lims import api
 from bika.lims.browser.workflow import RequestContextAware
 from bika.lims.interfaces import IWorkflowActionUIDsAdapter
 from bika.lims.workflow import doActionFor
+from ZODB.POSException import POSKeyError
 from zope.interface import implements
+
+
+class WorkflowActionDownloadReportsAdapter(RequestContextAware):
+    """Adapter in charge of the client 'publish_samples' action
+    """
+    implements(IWorkflowActionUIDsAdapter)
+
+    def __call__(self, action, uids):
+        # get the selected ARReport objects
+        reports = map(api.get_object_by_uid, uids)
+
+        pdfs = []
+
+        for report in reports:
+            sample = report.getAnalysisRequest()
+            sample_id = api.get_id(sample)
+            pdf = self.get_pdf(report)
+            if pdf is None:
+                self.add_status_message(
+                    _("Could not load PDF for sample {}"
+                      .format(sample_id)), "warning")
+                continue
+            pdf.filename = "{}.pdf".format(sample_id)
+            pdfs.append(pdf)
+
+        if len(pdfs) == 1:
+            pdf = pdfs[0]
+            filename = pdf.filename
+            return self.download(pdf.data, filename, type="application/pdf")
+
+        with self.create_archive(pdfs) as archive:
+            archive_name = "Reports-{}.zip".format(self.context.getName())
+            data = archive.file.read()
+            return self.download(data, archive_name, type="application/zip")
+
+    def create_archive(self, pdfs):
+        """Create an ZIP archive with the given PDFs
+        """
+        archive = tempfile.NamedTemporaryFile(suffix=".zip")
+        with zipfile.ZipFile(archive.name, "w", zipfile.ZIP_DEFLATED) as zf:
+            for pdf in pdfs:
+                zf.writestr(pdf.filename, pdf.data)
+        return archive
+
+    def download(self, data, filename, type="application/zip"):
+        response = self.request.response
+        response.setHeader("Content-Disposition",
+                           "attachment; filename={}".format(filename))
+        response.setHeader("Content-Type", "{}; charset=utf-8".format(type))
+        response.setHeader("Content-Length", len(data))
+        response.setHeader("Cache-Control", "no-store")
+        response.setHeader("Pragma", "no-cache")
+        response.write(data)
+
+    def get_pdf(self, report):
+        """Get the report PDF
+        """
+        try:
+            return report.getPdf()
+        except (POSKeyError, TypeError):
+            return None
 
 
 class WorkflowActionPublishSamplesAdapter(RequestContextAware):

--- a/src/bika/lims/browser/workflow/configure.zcml
+++ b/src/bika/lims/browser/workflow/configure.zcml
@@ -226,4 +226,16 @@
     provides="bika.lims.interfaces.IWorkflowActionAdapter"
     permission="senaite.core.permissions.TransitionPublishResults" />
 
+  <!-- Client: "download_reports" action in the report listing
+
+  Downloads all PDFs in a single archive
+  -->
+  <adapter
+    name="workflow_action_download_reports"
+    for="bika.lims.interfaces.IClient
+         zope.publisher.interfaces.browser.IBrowserRequest"
+    factory=".client.WorkflowActionDownloadReportsAdapter"
+    provides="bika.lims.interfaces.IWorkflowActionAdapter"
+    permission="zope.Public" />
+
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR allows to select multiple report PDFs and download them at once.

<img width="1851" alt="" src="https://user-images.githubusercontent.com/713193/111650988-2234d080-8806-11eb-8c7d-f8c8b080d5cb.png">

## Current behavior before PR

Report PDFs can only be downloaded one by one

## Desired behavior after PR is merged

Multiple report PDFs are packed in one ZIP archive and downloaded

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
