### PR TITLE
Uncatalog object before renaming

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1791 Uncatalog object before renaming
 - #1785 Moved listing context actions to separate viewlets
 - #1784 Dashboard fixtures: Links, colors, visibility
 - #1782 Allow to set toolbar logo CSS styles via registry

--- a/src/bika/lims/idserver.py
+++ b/src/bika/lims/idserver.py
@@ -519,6 +519,9 @@ def renameAfterCreation(obj):
     # Can't rename without a subtransaction commit when using portal_factory
     transaction.savepoint(optimistic=True)
 
+    # unindex the object
+    obj.unindexObject()
+
     # The id returned should be normalized already
     new_id = None
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR unindexes objects before renaming

## Current behavior before PR

Catalog entries with the ID before renaming stay in catalog

## Desired behavior after PR is merged

Catalog entries with old ID are not in catalog anymore

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
