### PR TITLE
Allow to set worksheet analysis remarks in a modal popup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
- #1792 Allow to set worksheet analysis remarks in a modal popup
+- #1792 Allow to set worksheet analysis remarks in a modal popup
 - #1790 Allow multi PDF report downloads
 - #1791 Uncatalog object before renaming
 - #1785 Moved listing context actions to separate viewlets

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+ #1792 Allow to set worksheet analysis remarks in a modal popup
 - #1790 Allow multi PDF report downloads
 - #1791 Uncatalog object before renaming
 - #1785 Moved listing context actions to separate viewlets

--- a/src/bika/lims/browser/worksheet/views/analyses.py
+++ b/src/bika/lims/browser/worksheet/views/analyses.py
@@ -123,11 +123,21 @@ class AnalysesView(BaseView):
                 "type": "remarks"
             }
 
+        self.set_analysis_remarks_modal = {
+            "id": "modal_set_analysis_remarks",
+            "title": _("Set remarks"),
+            "url": "{}/set_analysis_remarks_modal".format(
+                api.get_url(self.context)),
+            "css_class": "btn btn-outline-secondary",
+            "help": _("Set remarks for selected analyses")
+        }
+
         self.review_states = [
             {
                 "id": "default",
                 "title": _("All"),
                 "contentFilter": {},
+                "custom_transitions": [self.set_analysis_remarks_modal],
                 "columns": self.columns.keys(),
             },
         ]

--- a/src/bika/lims/browser/worksheet/views/analyses.py
+++ b/src/bika/lims/browser/worksheet/views/analyses.py
@@ -24,15 +24,17 @@ from operator import itemgetter
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
+from bika.lims.api.security import check_permission
 from bika.lims.browser.analyses import AnalysesView as BaseView
+from bika.lims.interfaces import IDuplicateAnalysis
+from bika.lims.interfaces import IReferenceAnalysis
+from bika.lims.interfaces import IRoutineAnalysis
+from bika.lims.permissions import FieldEditAnalysisRemarks
 from bika.lims.utils import get_image
 from bika.lims.utils import t
 from bika.lims.utils import to_int
 from plone.memoize import view
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from bika.lims.interfaces import IRoutineAnalysis
-from bika.lims.interfaces import IReferenceAnalysis
-from bika.lims.interfaces import IDuplicateAnalysis
 
 
 class AnalysesView(BaseView):
@@ -137,10 +139,27 @@ class AnalysesView(BaseView):
                 "id": "default",
                 "title": _("All"),
                 "contentFilter": {},
-                "custom_transitions": [self.set_analysis_remarks_modal],
+                "custom_transitions": [],
                 "columns": self.columns.keys(),
             },
         ]
+
+    def before_render(self):
+        super(AnalysesView, self).before_render()
+
+        if self.show_analysis_remarks_transition():
+            for state in self.review_states:
+                state["custom_transitions"] = [self.set_analysis_remarks_modal]
+
+    def show_analysis_remarks_transition(self):
+        """Check if the analysis remarks transitions should be rendered
+
+        XXX: Convert maybe better to a real WF transition with a guard
+        """
+        for analysis in self.context.getAnalyses():
+            if check_permission(FieldEditAnalysisRemarks, analysis):
+                return True
+        return False
 
     @view.memoize
     def is_analysis_remarks_enabled(self):

--- a/src/senaite/core/browser/configure.zcml
+++ b/src/senaite/core/browser/configure.zcml
@@ -28,6 +28,7 @@
   <include package=".install"/>
   <include package=".login"/>
   <include package=".main_template"/>
+  <include package=".modals"/>
   <include package=".portlets"/>
   <include package=".samples"/>
   <include package=".viewlets"/>

--- a/src/senaite/core/browser/modals/__init__.py
+++ b/src/senaite/core/browser/modals/__init__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+import collections
+
+import six
+from bika.lims import api
+from Products.Five.browser import BrowserView
+
+
+class Modal(BrowserView):
+    """Base Class for Modals
+    """
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+        self.uids = self.get_uids_from_request()
+
+    def get_uids_from_request(self):
+        """Returns a list of uids from the request
+        """
+        uids = self.request.get("uids", "")
+        if isinstance(uids, six.string_types):
+            uids = uids.split(",")
+        unique_uids = collections.OrderedDict().fromkeys(uids).keys()
+        return filter(api.is_uid, unique_uids)

--- a/src/senaite/core/browser/modals/configure.zcml
+++ b/src/senaite/core/browser/modals/configure.zcml
@@ -1,0 +1,15 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    i18n_domain="senaite.core">
+
+  <browser:page
+      name="set_analysis_remarks_modal"
+      for="bika.lims.interfaces.IWorksheet"
+      class=".remarks.SetAnalysisRemarksModal"
+      permission="senaite.core.permissions.FieldEditAnalysisRemarks"
+      layer="senaite.core.interfaces.ISenaiteCore"
+      />
+
+</configure>

--- a/src/senaite/core/browser/modals/remarks.py
+++ b/src/senaite/core/browser/modals/remarks.py
@@ -3,7 +3,7 @@
 from bika.lims import api
 from bika.lims.api.security import check_permission
 from bika.lims.permissions import FieldEditAnalysisRemarks
-from pologgb.lims import logger
+from senaite.core import logger
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from senaite.core.browser.modals import Modal
 

--- a/src/senaite/core/browser/modals/remarks.py
+++ b/src/senaite/core/browser/modals/remarks.py
@@ -3,9 +3,11 @@
 from bika.lims import api
 from bika.lims.api.security import check_permission
 from bika.lims.permissions import FieldEditAnalysisRemarks
-from senaite.core import logger
+from Products.Archetypes.event import ObjectEditedEvent
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from senaite.core import logger
 from senaite.core.browser.modals import Modal
+from zope import event
 
 
 class SetAnalysisRemarksModal(Modal):
@@ -39,4 +41,5 @@ class SetAnalysisRemarksModal(Modal):
             remarks = "{}\n{}".format(analysis.getRemarks(), remarks)
         analysis.setRemarks(api.safe_unicode(remarks))
         analysis.reindexObject()
+        event.notify(ObjectEditedEvent(analysis))
         return True

--- a/src/senaite/core/browser/modals/remarks.py
+++ b/src/senaite/core/browser/modals/remarks.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+from bika.lims import api
+from bika.lims.api.security import check_permission
+from bika.lims.permissions import FieldEditAnalysisRemarks
+from pologgb.lims import logger
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from senaite.core.browser.modals import Modal
+
+
+class SetAnalysisRemarksModal(Modal):
+    template = ViewPageTemplateFile("templates/set_analysis_remarks.pt")
+
+    def __init__(self, context, request):
+        super(SetAnalysisRemarksModal, self).__init__(context, request)
+
+    def __call__(self):
+        if self.request.form.get("submitted", False):
+            self.handle_submit(REQUEST=self.request)
+        return self.template()
+
+    def handle_submit(self, REQUEST=None):
+        analyses = map(api.get_object_by_uid, self.uids)
+        remarks = self.request.get("remarks")
+        overwrite = self.request.form.get("overwrite") or False
+        for analysis in analyses:
+            self.set_remarks_for(analysis, remarks, overwrite=overwrite)
+
+    def set_remarks_for(self, analysis, remarks, overwrite=True):
+        """Set the remarks on the given analyses
+        """
+        logger.info("Set remarks for analysis '{}' to {}"
+                    .format(analysis.getId(), remarks))
+        if not check_permission(FieldEditAnalysisRemarks, analysis):
+            logger.warn("Not allowed to set remarks for {}"
+                        .format(analysis.getId()))
+            return False
+        if not overwrite:
+            remarks = "{}\n{}".format(analysis.getRemarks(), remarks)
+        analysis.setRemarks(api.safe_unicode(remarks))
+        analysis.reindexObject()
+        return True

--- a/src/senaite/core/browser/modals/templates/set_analysis_remarks.pt
+++ b/src/senaite/core/browser/modals/templates/set_analysis_remarks.pt
@@ -1,0 +1,42 @@
+<div class="set-analysis-remarks-modal modal-dialog modal-dialog-centered modal-dialog-scrollable">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h5 class="modal-title" i18n:translate="">Set remarks</h5>
+      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+    <div class="modal-body">
+      <form name="set-analysis-remarks-form"
+            class="form"
+            method="POST"
+            enctype="multipart/form-data"
+            tal:attributes="action string:${here/absolute_url}/set_analysis_remarks_modal">
+
+        <div class="form-group">
+          <textarea name="remarks" class="w-100 form-control"></textarea>
+          <div class="form-check text-align-left">
+            <input name="overwrite" class="form-check-input" type="checkbox" value="1" checked="checked" id="overwrite-remarks">
+            <label class="form-check-label" for="overwrite-remarks" i18n:translate="">
+              Overwrite existing remarks
+            </label>
+          </div>
+        </div>
+
+        <div class="form-group mt-2">
+          <input class="btn btn-sm btn-primary"
+                type="submit"
+                name="set_remarks"
+                i18n:attributes="value"
+                value="Set Remarks" />
+        </div>
+
+        <!-- hidden fields -->
+        <input type="hidden" name="submitted" value="1" />
+        <input tal:replace="structure context/@@authenticator/authenticator"/>
+        <input type="hidden" name="uids" value="" tal:attributes="value request/uids" />
+
+      </form>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

NOTE: This PR requires https://github.com/senaite/senaite.app.listing/pull/58

This PR registers a modal to set multiple analysis remarks in worksheets.

<img width="1552" alt="Modal Popup" src="https://user-images.githubusercontent.com/713193/112387942-baddbb80-8cf2-11eb-9280-c2e0158a60b1.png">


## Current behavior before PR

Remarks had to be set for each analysis individually

## Desired behavior after PR is merged

Remarks can be set for all analyses at once

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
