### PR TITLE
Added missing datamanager registration for reference analyses

### DIFF
--- a/src/senaite/core/datamanagers/__init__.py
+++ b/src/senaite/core/datamanagers/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from AccessControl import Unauthorized
-from bika.lims import api
 from bika.lims.api.security import check_permission
 from Products.CMFCore.permissions import ModifyPortalContent
 from Products.CMFCore.permissions import View

--- a/src/senaite/core/datamanagers/configure.zcml
+++ b/src/senaite/core/datamanagers/configure.zcml
@@ -7,4 +7,7 @@
   <!-- Data Manager for Analyses -->
   <adapter factory=".analysis.RoutineAnalysisDataManager" />
 
+  <!-- Data Manager for Reference Analyses -->
+  <adapter factory=".analysis.ReferenceAnalysisDataManager" />
+
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds a missing adapter registration for reference analyses.

Also see: https://github.com/senaite/senaite.core/pull/1778

## Current behavior before PR

No suitable datamanager adapter found for reference analyses

## Desired behavior after PR is merged

Datamanager adapter registered for reference analyses

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
