### PR TITLE
Fix Auto Import Log View and ID generation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1797 Fix Auto Import Log View and ID generation
 - #1795 Do not overwrite worksheet remarks per default
 - #1794 Generate proper IDs for analysis attachments on instrument results import
 - #1792 Allow to set worksheet analysis remarks in a modal popup

--- a/src/bika/lims/browser/resultsimport/autoimportlogs.py
+++ b/src/bika/lims/browser/resultsimport/autoimportlogs.py
@@ -55,8 +55,8 @@ class AutoImportLogsView(ListingView):
                 "title": _("Interface"),
                 "sortable": False,
             }),
-            ("ImportFilename", {
-                "title": _("Imported Filename"),
+            ("ImportFile", {
+                "title": _("Imported File"),
                 "sortable": False,
             }),
             ("Results", {
@@ -92,7 +92,7 @@ class AutoImportLogsView(ListingView):
             item["replace"]["Results"] = "<code>{}</code>".format(
                 messages.replace("\n", "<br/>"))
 
-        item["ImportFilename"] = obj.getImportFilename()
+        item["ImportFile"] = obj.getImportFile()
         item["Interface"] = obj.getInterface()
 
         return item

--- a/src/bika/lims/browser/resultsimport/autoimportlogs.py
+++ b/src/bika/lims/browser/resultsimport/autoimportlogs.py
@@ -55,7 +55,7 @@ class AutoImportLogsView(ListingView):
                 "title": _("Interface"),
                 "sortable": False,
             }),
-            ("ImportFileName", {
+            ("ImportFilename", {
                 "title": _("Imported Filename"),
                 "sortable": False,
             }),

--- a/src/bika/lims/browser/resultsimport/autoimportlogs.py
+++ b/src/bika/lims/browser/resultsimport/autoimportlogs.py
@@ -22,7 +22,9 @@ from collections import OrderedDict
 
 from bika.lims import bikaMessageFactory as _
 from bika.lims.catalog import CATALOG_AUTOIMPORTLOGS_LISTING
+from bika.lims.utils import get_link_for
 from senaite.app.listing import ListingView
+from bika.lims import api
 
 
 class AutoImportLogsView(ListingView):
@@ -48,23 +50,18 @@ class AutoImportLogsView(ListingView):
             ("Instrument", {
                 "title": _("Instrument"),
                 "sortable": False,
-                "attr": "getInstrumentTitle",
-                "replace_url": "getInstrumentUrl"
             }),
             ("Interface", {
                 "title": _("Interface"),
                 "sortable": False,
-                "attr": "getInterface",
             }),
-            ("ImportFile", {
-                "title": _("Imported File"),
+            ("ImportFileName", {
+                "title": _("Imported Filename"),
                 "sortable": False,
-                "attr": "getImportedFile",
             }),
             ("Results", {
                 "title": _("Results"),
                 "sortable": False,
-                "attr": "getResults"
             })
         ))
 
@@ -78,5 +75,24 @@ class AutoImportLogsView(ListingView):
         ]
 
     def folderitem(self, obj, item, index):
-        item["ImportTime"] = obj.getLogTime.strftime("%Y-%m-%d H:%M:%S")
+        obj = api.get_object(obj)
+
+        logtime = obj.getLogTime()
+        if logtime:
+            item["ImportTime"] = self.ulocalized_time(logtime, long_format=1)
+
+        instrument = obj.getInstrument()
+        if instrument:
+            item["Instrument"] = instrument.Title()
+            item["replace"]["Instrument"] = get_link_for(instrument)
+
+        messages = obj.getResults()
+        if messages:
+            item["Results"] = messages
+            item["replace"]["Results"] = "<code>{}</code>".format(
+                messages.replace("\n", "<br/>"))
+
+        item["ImportFilename"] = obj.getImportFilename()
+        item["Interface"] = obj.getInterface()
+
         return item

--- a/src/bika/lims/content/autoimportlog.py
+++ b/src/bika/lims/content/autoimportlog.py
@@ -93,9 +93,6 @@ class AutoImportLog(BaseContent):
             return self.getInstrument().absolute_url_path()
         return None
 
-    def getImportFilename(self):
-        return self.getImportFile()
-
 
 # Activating the content type in Archetypes' internal types registry
 atapi.registerType(AutoImportLog, config.PROJECTNAME)

--- a/src/bika/lims/content/autoimportlog.py
+++ b/src/bika/lims/content/autoimportlog.py
@@ -35,7 +35,7 @@ schema = BikaSchema.copy() + atapi.Schema((
 
     # Results File that system wanted to import
     StringField(
-        "ImportedFile",
+        "ImportFile",
         default="",
     ),
 
@@ -94,7 +94,7 @@ class AutoImportLog(BaseContent):
         return None
 
     def getImportFilename(self):
-        return self.getImportedFile()
+        return self.getImportFile()
 
 
 # Activating the content type in Archetypes' internal types registry

--- a/src/bika/lims/content/autoimportlog.py
+++ b/src/bika/lims/content/autoimportlog.py
@@ -18,35 +18,51 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from zope.interface import implements
+from bika.lims import config
+from bika.lims.content.bikaschema import BikaSchema
+from bika.lims.interfaces import IAutoImportLog
+from DateTime import DateTime
 from Products.Archetypes import atapi
 from Products.Archetypes.public import BaseContent
-from bika.lims.content.bikaschema import BikaSchema
+from Products.Archetypes.public import DateTimeField
+from Products.Archetypes.public import ReferenceField
+from Products.Archetypes.public import StringField
+from Products.Archetypes.public import TextField
 from Products.Archetypes.references import HoldingReference
-from bika.lims import bikaMessageFactory as _
-from bika.lims import config
-from DateTime import DateTime
-from Products.CMFCore.utils import getToolByName
-
+from zope.interface import implements
 
 schema = BikaSchema.copy() + atapi.Schema((
+
     # Results File that system wanted to import
-    atapi.StringField('ImportedFile', default=''),
+    StringField(
+        "ImportedFile",
+        default="",
+    ),
 
-    atapi.ReferenceField('Instrument',
-                         allowed_types=('Instrument',),
-                         referenceClass=HoldingReference,
-                         relationship='InstrumentImportLogs',
-                         ),
+    ReferenceField(
+        "Instrument",
+        allowed_types=("Instrument",),
+        referenceClass=HoldingReference,
+        relationship="InstrumentImportLogs",
+    ),
 
-    atapi.StringField('Interface', default=''),
+    StringField(
+        "Interface",
+        default="",
+    ),
 
-    atapi.StringField('Results', default=''),
+    TextField(
+        "Results",
+        default="",
+    ),
 
-    atapi.DateTimeField('LogTime', default=DateTime()),
+    DateTimeField(
+        "LogTime",
+        default=DateTime(),
+    ),
 ))
 
-schema['title'].widget.visible = False
+schema["title"].widget.visible = False
 
 
 class AutoImportLog(BaseContent):
@@ -54,7 +70,13 @@ class AutoImportLog(BaseContent):
     This object will have some information/log about auto-import process
     once they are done(failed).
     """
+    implements(IAutoImportLog)
     schema = schema
+    _at_rename_after_creation = True
+
+    def _renameAfterCreation(self, check_auto_id=False):
+        from bika.lims.idserver import renameAfterCreation
+        renameAfterCreation(self)
 
     def getInstrumentUID(self):
         if self.getInstrument():
@@ -70,6 +92,9 @@ class AutoImportLog(BaseContent):
         if self.getInstrument():
             return self.getInstrument().absolute_url_path()
         return None
+
+    def getImportFilename(self):
+        return self.getImportedFile()
 
 
 # Activating the content type in Archetypes' internal types registry

--- a/src/bika/lims/interfaces/__init__.py
+++ b/src/bika/lims/interfaces/__init__.py
@@ -86,6 +86,11 @@ class IHaveNoBreadCrumbs(Interface):
     """
 
 
+class IAutoImportLog(Interface):
+    """Auto Import Log
+    """
+
+
 class IClientFolder(Interface):
     """Client folder
     """
@@ -462,9 +467,11 @@ class ILabProducts(Interface):
     """Marker interface for Lab Products
     """
 
+
 class ILabProduct(Interface):
     """Marker interface for a LabProduct
     """
+
 
 class ISamplePoint(Interface):
     """Marker interface for a Sample Point
@@ -540,9 +547,11 @@ class IWorksheetTemplates(Interface):
     """Marker interface for Worksheet Templates
     """
 
+
 class IWorksheetTemplate(Interface):
     """Marker interface for Worksheet Template
     """
+
 
 class IBikaCatalog(Interface):
     """Marker interface for bika_catalog


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the Auto Import Log View and enables ID generation by the ID server

## Current behavior before PR

- Auto Import Log contents kept temporary ID
- Auto Import Log Listing was not populated

## Desired behavior after PR is merged

- Auto Import Log Contents renamed by the ID Server
- Auto Import Log Listing displays the values correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
