### PR TITLE
1.3.x: AS's not reindexed after a Categoy is modified

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Changelog
 - #1628 Fix instrument import for analyses with result options
 - #1625 Fix assignment of analyses via worksheet template when Worksheet is full
 - #1617 Fix writing methods on read when reindexing services
+- #1798 Fix reindexing of AnalysisServices after AnalysisCategories modified 
 
 
 1.3.4 (2020-08-11)

--- a/bika/lims/subscribers/objectmodified.py
+++ b/bika/lims/subscribers/objectmodified.py
@@ -22,6 +22,7 @@ from Products.CMFCore.utils import getToolByName
 
 from bika.lims import api
 from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
+from bika.lims.catalog import SETUP_CATALOG
 
 
 def ObjectModifiedEventHandler(obj, event):
@@ -39,8 +40,7 @@ def ObjectModifiedEventHandler(obj, event):
         backrefs = obj.getBackReferences('MethodCalculation')
         for i, target in enumerate(backrefs):
             target = uc(UID=target.UID())[0].getObject()
-            pr.save(obj=target, comment="Calculation updated to version %s" %
-                (version_id + 1,))
+            pr.save(obj=target, comment="Calculation updated to version %s" % (version_id + 1,))
             reference_versions = getattr(target, 'reference_versions', {})
             reference_versions[obj.UID()] = version_id + 1
             target.reference_versions = reference_versions
@@ -62,9 +62,17 @@ def ObjectModifiedEventHandler(obj, event):
     elif obj.portal_type == 'AnalysisCategory':
         # If the analysis category's Title is modified, we must
         # re-index all services and analyses that refer to this title.
+
+        # AnalysisServices
+        query = dict(getCategoryUID=obj.UID())
+        brains = api.search(query, SETUP_CATALOG)
+        for brain in brains:
+            obj = api.get_object(brain)
+            obj.reindexObject(idxs=['getCategoryTitle'])
+
+        # Analyses
         query = dict(getCategoryUID=obj.UID())
         brains = api.search(query, CATALOG_ANALYSIS_LISTING)
         for brain in brains:
             obj = api.get_object(brain)
             obj.reindexObject(idxs=['getCategoryTitle'])
-


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
AnalysisServices in an AnalysisCategory are not reindexed after the AC is modified. This results in the AC not appearing in on the Add Sample page.

Linked issue: https://github.com/senaite/senaite.core/issues/1798

## Current behavior before PR
After modifying an AC, that Category no longer appears on the ar_add view

## Desired behavior after PR is merged
After modifying an AC, that Category and it's ASs does appear on the ar_add view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
