### PR TITLE
2.x: AS's not reindexed after a Categoy is modified #1798 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,7 @@ Changelog
 - #1733 Allow results interpretation in sample received state
 - #1732 Readonly Transactions
 - #1731 Remove `notifyModified` method from analyses
+- #1798 Reindex AnalysisServices in an AnalysisCategory after that AC is modified
 
 
 2.0.0rc3 (2021-01-08)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
AnalysisServices in an AnalysisCategory are not reindexed after the AC is modified. This results in the AC not appearing in on the Add Sample page.

Linked issue: https://github.com/senaite/senaite.core/issues/1798

## Current behavior before PR
After modifying an AC, that Category no longer appears on the ar_add view

## Desired behavior after PR is merged
After modifying an AC, that Category and it's ASs does appear on the ar_add view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
