### PR TITLE
Updated openpyxl to latest Python 2.x compatible version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1801 Updated openpyxl to latest Python 2.x compatible version
 - #1795 Do not overwrite worksheet remarks per default
 - #1794 Generate proper IDs for analysis attachments on instrument results import
 - #1792 Allow to set worksheet analysis remarks in a modal popup

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
     install_requires=[
         "collective.monkeypatcher",
         "magnitude",
-        "openpyxl==1.5.8",
         "plone.api",
         "plone.app.dexterity",
         "plone.app.iterate",
@@ -91,6 +90,8 @@ setup(
         "archetypes.schemaextender",
         # SENAITE
         "senaite.lims",
+        # openpyxl >= 3.0.0 does not support Python 2.x anymore
+        "openpyxl<3.0.0",
     ],
     extras_require={
         "test": [

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,8 @@ setup(
         "senaite.lims",
         # openpyxl >= 3.0.0 does not support Python 2.x anymore
         "openpyxl<3.0.0",
+        # Werkzeug >= 2.0.0 does not support Python 2.x anymore
+        "Werkzeug<2.0.0",
     ],
     extras_require={
         "test": [

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
         # SENAITE
         "senaite.lims",
         # openpyxl >= 3.0.0 does not support Python 2.x anymore
-        "openpyxl<3.0.0",
+        "openpyxl==2.6.4",
         # Werkzeug >= 2.0.0 does not support Python 2.x anymore
         "Werkzeug<2.0.0",
     ],

--- a/src/bika/lims/content/dynamic_analysisspec.py
+++ b/src/bika/lims/content/dynamic_analysisspec.py
@@ -24,7 +24,7 @@ from six import StringIO
 from bika.lims import _
 from bika.lims.catalog import SETUP_CATALOG
 from openpyxl.reader.excel import load_workbook
-from openpyxl.shared.exc import InvalidFileException
+from openpyxl.utils.exceptions import InvalidFileException
 from plone.dexterity.content import Item
 from plone.namedfile import field as namedfile
 from plone.supermodel import model

--- a/src/bika/lims/content/dynamic_analysisspec.py
+++ b/src/bika/lims/content/dynamic_analysisspec.py
@@ -101,10 +101,15 @@ class DynamicAnalysisSpec(Item):
         return sheets[0]
 
     def get_header(self):
+        header = []
         ps = self.get_primary_sheet()
         if ps is None:
-            return []
-        return map(lambda cell: cell.value, ps.rows[0])
+            return header
+        for num, row in enumerate(ps.rows):
+            if num > 0:
+                break
+            header = [cell.value for cell in row]
+        return header
 
     def get_specs(self):
         ps = self.get_primary_sheet()

--- a/src/senaite/core/exportimport/load_setup_data.py
+++ b/src/senaite/core/exportimport/load_setup_data.py
@@ -111,7 +111,7 @@ class LoadSetupData(BrowserView):
         adapters = [[name, adapter]
                     for name, adapter
                     in list(getAdapters((self.context, ), ISetupDataImporter))]
-        for sheetname in workbook.get_sheet_names():
+        for sheetname in workbook.sheetnames:
             transaction.savepoint()
             ad_name = sheetname.replace(" ", "_")
             if ad_name in [a[0] for a in adapters]:

--- a/src/senaite/core/exportimport/setupdata/__init__.py
+++ b/src/senaite/core/exportimport/setupdata/__init__.py
@@ -101,7 +101,10 @@ class WorksheetImporter:
         self.context = lsd.context
         self.workbook = workbook
         self.sheetname = self.__class__.__name__.replace("_", " ")
-        self.worksheet = workbook.get_sheet_by_name(self.sheetname)
+        try:
+            self.worksheet = workbook[self.sheetname]
+        except KeyError:
+            self.worksheet = None
         self.dataset_project = dataset_project
         self.dataset_name = dataset_name
         if self.worksheet:
@@ -470,7 +473,7 @@ class Lab_Contacts(WorksheetImporter):
 
         # Now we have the lab contacts registered, try to assign the managers
         # to each department if required
-        sheet = self.workbook.get_sheet_by_name("Lab Departments")
+        sheet = self.workbook["Lab Departments"]
         bsc = getToolByName(self.context, 'bika_setup_catalog')
         for row in self.get_rows(3, sheet):
             if row['title'] and row['LabContact_Username']:
@@ -1355,7 +1358,7 @@ class Calculations(WorksheetImporter):
     def get_interim_fields(self):
         # preload Calculation Interim Fields sheet
         sheetname = 'Calculation Interim Fields'
-        worksheet = self.workbook.get_sheet_by_name(sheetname)
+        worksheet = self.workbook[sheetname]
         if not worksheet:
             return
         self.interim_fields = {}
@@ -1407,7 +1410,7 @@ class Calculations(WorksheetImporter):
 
         # Now we have the calculations registered, try to assign default calcs
         # to methods
-        sheet = self.workbook.get_sheet_by_name("Methods")
+        sheet = self.workbook["Methods"]
         bsc = getToolByName(self.context, 'bika_setup_catalog')
         for row in self.get_rows(3, sheet):
             if row.get('title', '') and row.get('Calculation_title', ''):
@@ -1424,7 +1427,7 @@ class Analysis_Services(WorksheetImporter):
     def load_interim_fields(self):
         # preload AnalysisService InterimFields sheet
         sheetname = 'AnalysisService InterimFields'
-        worksheet = self.workbook.get_sheet_by_name(sheetname)
+        worksheet = self.workbook[sheetname]
         if not worksheet:
             return
         self.service_interims = {}
@@ -1443,7 +1446,7 @@ class Analysis_Services(WorksheetImporter):
     def load_result_options(self):
         bsc = getToolByName(self.context, 'bika_setup_catalog')
         sheetname = 'AnalysisService ResultOptions'
-        worksheet = self.workbook.get_sheet_by_name(sheetname)
+        worksheet = self.workbook[sheetname]
         if not worksheet:
             return
         for row in self.get_rows(3, worksheet=worksheet):
@@ -1458,8 +1461,8 @@ class Analysis_Services(WorksheetImporter):
 
     def load_service_uncertainties(self):
         bsc = getToolByName(self.context, 'bika_setup_catalog')
-        sheetname = 'AnalysisService Uncertainties'
-        worksheet = self.workbook.get_sheet_by_name(sheetname)
+        sheetname = 'Analysis Service Uncertainties'
+        worksheet = self.workbook[sheetname]
         if not worksheet:
             return
 
@@ -1523,7 +1526,7 @@ class Analysis_Services(WorksheetImporter):
         """
         out_objects = [default_obj] if default_obj else []
         cat = getToolByName(self.context, catalog_name)
-        worksheet = self.workbook.get_sheet_by_name(sheet_name)
+        worksheet = self.workbook[sheet_name]
         if not worksheet:
             return out_objects
         for row in self.get_rows(3, worksheet=worksheet):
@@ -1737,7 +1740,7 @@ class Analysis_Profiles(WorksheetImporter):
 
     def load_analysis_profile_services(self):
         sheetname = 'Analysis Profile Services'
-        worksheet = self.workbook.get_sheet_by_name(sheetname)
+        worksheet = self.workbook[sheetname]
         self.profile_services = {}
         if not worksheet:
             return
@@ -1779,7 +1782,7 @@ class AR_Templates(WorksheetImporter):
 
     def load_artemplate_analyses(self):
         sheetname = 'AR Template Analyses'
-        worksheet = self.workbook.get_sheet_by_name(sheetname)
+        worksheet = self.workbook[sheetname]
         self.artemplate_analyses = {}
         if not worksheet:
             return
@@ -1798,7 +1801,7 @@ class AR_Templates(WorksheetImporter):
 
     def load_artemplate_partitions(self):
         sheetname = 'AR Template Partitions'
-        worksheet = self.workbook.get_sheet_by_name(sheetname)
+        worksheet = self.workbook[sheetname]
         self.artemplate_partitions = {}
         bsc = getToolByName(self.context, 'bika_setup_catalog')
         if not worksheet:
@@ -1864,10 +1867,10 @@ class Reference_Definitions(WorksheetImporter):
 
     def load_reference_definition_results(self):
         sheetname = 'Reference Definition Results'
-        worksheet = self.workbook.get_sheet_by_name(sheetname)
+        worksheet = self.workbook[sheetname]
         if not worksheet:
             sheetname = 'Reference Definition Values'
-            worksheet = self.workbook.get_sheet_by_name(sheetname)
+            worksheet = self.workbook[sheetname]
             if not worksheet:
                 return
         self.results = {}
@@ -1908,7 +1911,7 @@ class Worksheet_Templates(WorksheetImporter):
 
     def load_wst_layouts(self):
         sheetname = 'Worksheet Template Layouts'
-        worksheet = self.workbook.get_sheet_by_name(sheetname)
+        worksheet = self.workbook[sheetname]
         self.wst_layouts = {}
         if not worksheet:
             return
@@ -1927,7 +1930,7 @@ class Worksheet_Templates(WorksheetImporter):
 
     def load_wst_services(self):
         sheetname = 'Worksheet Template Services'
-        worksheet = self.workbook.get_sheet_by_name(sheetname)
+        worksheet = self.workbook[sheetname]
         self.wst_services = {}
         if not worksheet:
             return
@@ -2096,7 +2099,7 @@ class Reference_Samples(WorksheetImporter):
     def load_reference_sample_results(self, sample):
         sheetname = 'Reference Sample Results'
         if not hasattr(self, 'results_worksheet'):
-            worksheet = self.workbook.get_sheet_by_name(sheetname)
+            worksheet = self.workbook[sheetname]
             if not worksheet:
                 return
             self.results_worksheet = worksheet
@@ -2121,7 +2124,7 @@ class Reference_Samples(WorksheetImporter):
     def load_reference_analyses(self, sample):
         sheetname = 'Reference Analyses'
         if not hasattr(self, 'analyses_worksheet'):
-            worksheet = self.workbook.get_sheet_by_name(sheetname)
+            worksheet = self.workbook[sheetname]
             if not worksheet:
                 return
             self.analyses_worksheet = worksheet
@@ -2151,7 +2154,7 @@ class Reference_Samples(WorksheetImporter):
     def load_reference_analysis_interims(self, analysis):
         sheetname = 'Reference Analysis Interims'
         if not hasattr(self, 'interim_worksheet'):
-            worksheet = self.workbook.get_sheet_by_name(sheetname)
+            worksheet = self.workbook[sheetname]
             if not worksheet:
                 return
             self.interim_worksheet = worksheet
@@ -2206,7 +2209,7 @@ class Analysis_Requests(WorksheetImporter):
     def load_analyses(self, sample):
         sheetname = 'Analyses'
         if not hasattr(self, 'analyses_worksheet'):
-            worksheet = self.workbook.get_sheet_by_name(sheetname)
+            worksheet = self.workbook[sheetname]
             if not worksheet:
                 return
             self.analyses_worksheet = worksheet
@@ -2242,11 +2245,10 @@ class Analysis_Requests(WorksheetImporter):
     def load_analysis_interims(self, analysis):
         sheetname = 'Reference Analysis Interims'
         if not hasattr(self, 'interim_worksheet'):
-            worksheet = self.workbook.get_sheet_by_name(sheetname)
+            worksheet = self.workbook[sheetname]
             if not worksheet:
                 return
             self.interim_worksheet = worksheet
-        bsc = getToolByName(self.context, 'bika_setup_catalog')
         interims = []
         for row in self.get_rows(3, worksheet=self.interim_worksheet):
             if row['ReferenceAnalysis_id'] != analysis.getId():

--- a/src/senaite/core/tests/doctests/DynamicAnalysisSpec.rst
+++ b/src/senaite/core/tests/doctests/DynamicAnalysisSpec.rst
@@ -113,13 +113,13 @@ And the result ranges:
 
     >>> rr = ds.get_specs()
     >>> map(lambda r: [r.get(k) for k in header], rr)
-    [[u'Ca', u'Method A', 1, 2], [u'Ca', u'Method B', 3, 4], [u'Mg', u'Method A', 5, 6], [u'Mg', u'Method B', 7, 8]]
+    [[u'Ca', u'Method A', u'1', u'2'], [u'Ca', u'Method B', u'3', u'4'], [u'Mg', u'Method A', u'5', u'6'], [u'Mg', u'Method B', u'7', u'8']]
 
 We can also get the specs by Keyword:
 
     >>> mg_rr = ds.get_by_keyword()["Mg"]
     >>> map(lambda r: [r.get(k) for k in header], mg_rr)
-    [[u'Mg', u'Method A', 5, 6], [u'Mg', u'Method B', 7, 8]]
+    [[u'Mg', u'Method A', u'5', u'6'], [u'Mg', u'Method B', u'7', u'8']]
 
 
 Hooking in a Dynamic Analysis Specification
@@ -178,7 +178,7 @@ The specification of the `Ca` Analysis with the Method `Method A`:
 
     >>> ca_spec = ca.getResultsRange()
     >>> ca_spec["min"], ca_spec["max"]
-    (1, 2)
+    ('1', '2')
 
 Now let's change the `Ca` Analysis Method to `Method B`:
 
@@ -193,13 +193,13 @@ And get the results range again:
 
     >>> ca_spec = ca.getResultsRange()
     >>> ca_spec["min"], ca_spec["max"]
-    (3, 4)
+    ('3', '4')
 
 The same now with the `Mg` Analysis in one run:
 
     >>> mg_spec = mg.getResultsRange()
     >>> mg_spec["min"], mg_spec["max"]
-    (5, 6)
+    ('5', '6')
 
     >>> mg.setMethod(method_b)
 
@@ -210,4 +210,4 @@ Unset and set the specification again:
 
     >>> mg_spec = mg.getResultsRange()
     >>> mg_spec["min"], mg_spec["max"]
-    (7, 8)
+    ('7', '8')


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR updates `openpyxl` to the latest compatible Python 2.x version

NOTE: A change of the newer `openpyxl` version is that the returned rows of a worksheet is now a `generator` and no longer a `list`


## Current behavior before PR

openpyxl version 1.5.2 used, which fails for some Excel formats

## Desired behavior after PR is merged

openpyxl 2.x (currently 2.6.4) used, which fixes this error.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
