### PR TITLE
Adapter hook for confirmation when creating a Sample

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
+- #1802 Adapter for Add sample form confirmation
 - #1781 Exclude invalid samples from dashboard's not-printed indicator
 - #1774 Fix Lab clerk can edit items from setup folder
 - #1763 Remove final states from dashboard

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1569,7 +1569,6 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         """Returns a dict when user confirmation is required for the creation of
         samples. Returns None otherwise
         """
-        import pdb;pdb.set_trace()
         if self.request.form.get("confirmed") == "1":
             # User pressed the "yes" button in the confirmation pane already
             return None

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -45,6 +45,7 @@ from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
 from bika.lims.api.analysisservice import get_calculation_dependencies_for
 from bika.lims.api.analysisservice import get_service_dependencies_for
+from bika.lims.interfaces import IAddSampleConfirmation
 from bika.lims.interfaces import IAddSampleFieldsFlush
 from bika.lims.interfaces import IAddSampleObjectInfo
 from bika.lims.interfaces import IGetDefaultFieldValueARAddHook
@@ -1564,9 +1565,30 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
         return prices
 
+    def check_confirmation(self):
+        """Returns a dict when user confirmation is required for the creation of
+        samples. Returns None otherwise
+        """
+        import pdb;pdb.set_trace()
+        if self.request.form.get("confirmed") == "1":
+            # User pressed the "yes" button in the confirmation pane already
+            return None
+
+        # Find out if there is a confirmation adapter available
+        adapter = queryAdapter(self.request, IAddSampleConfirmation)
+        if not adapter:
+            return None
+
+        # Extract records from the request and call the adapter
+        records = self.get_records()
+        return adapter.check_confirmation(records)
+
     def ajax_submit(self):
         """Submit & create the ARs
         """
+        confirmation = self.check_confirmation()
+        if confirmation:
+            return {"confirmation": confirmation}
 
         # Get AR required fields (including extended fields)
         fields = self.get_ar_fields()

--- a/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -214,6 +214,18 @@
         </table>
       </script>
 
+      <!-- Confirmation Template -->
+      <script id="confirm-template" type="text/x-handlebars-template">
+        <div title="Confirm" i18n:attributes="title">
+          <p i18n:translate="">
+            {{message}}
+          </p>
+          <p i18n:translate="">
+            Do you want to continue?
+          </p>
+        </div>
+      </script>
+
     </metal:block>
   </head>
 
@@ -603,6 +615,9 @@
                name="save_button"
                i18n:attributes="value"
                value="Save"/>
+
+        <input type="hidden" id="confirmed" name="confirmed" value="0"/>
+
       </form>
       <!-- /ADD Form -->
 

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -1315,11 +1315,12 @@
        * Eventhandler for the form submit button.
        * Extracts and submits all form data asynchronous.
        */
-      var base_url, me;
+      var base_url, me, portal_url;
       console.debug("°°° on_form_submit °°°");
       event.preventDefault();
       me = this;
       base_url = me.get_base_url();
+      portal_url = me.get_portal_url();
       $("div.error").removeClass("error");
       $("div.fieldErrorBox").text("");
       return this.ajax_post_form("submit").done(function(data) {
@@ -1332,7 +1333,7 @@
          *   This includes GET params for printing labels, so that we do not
          *   have to care about this here.
          */
-        var ars, destination, errorbox, field, fieldname, message, msg, parent, q, stickertemplate;
+        var ars, destination, dialog, errorbox, field, fieldname, message, msg, parent, q, stickertemplate;
         if (data['errors']) {
           msg = data.errors.message;
           if (msg !== "") {
@@ -1357,6 +1358,17 @@
           stickertemplate = data['stickertemplate'];
           q = '/sticker?autoprint=1&template=' + stickertemplate + '&items=' + ars.join(',');
           return window.location.replace(destination + q);
+        } else if (data['confirmation']) {
+          dialog = me.template_dialog("confirm-template", data.confirmation);
+          return dialog.on("yes", function() {
+            destination = data.confirmation["destination"];
+            if (destination) {
+              return window.location.replace(portal_url + '/' + destination);
+            } else {
+              $("input[name=confirmed]").val("1");
+              return $("input[name=save_button]").trigger("click");
+            }
+          });
         } else {
           return window.location.replace(base_url);
         }

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -1343,6 +1343,9 @@ class window.AnalysisRequestAdd
     # get the right base url
     base_url = me.get_base_url()
 
+    # the poral url
+    portal_url = me.get_portal_url()
+
     # remove all errors
     $("div.error").removeClass("error")
     $("div.fieldErrorBox").text("")
@@ -1382,6 +1385,19 @@ class window.AnalysisRequestAdd
         stickertemplate = data['stickertemplate']
         q = '/sticker?autoprint=1&template=' + stickertemplate + '&items=' + ars.join(',')
         window.location.replace destination + q
+
+      else if data['confirmation']
+        dialog = me.template_dialog "confirm-template", data.confirmation
+        dialog.on "yes", ->
+          destination = data.confirmation["destination"]
+          if destination
+            # Redirect user
+            window.location.replace portal_url + '/' + destination
+          else
+            # Re-submit
+            $("input[name=confirmed]").val "1"
+            $("input[name=save_button]").trigger "click"
+
       else
         window.location.replace base_url
 

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -981,6 +981,17 @@ class IAddSampleObjectInfo(Interface):
         """
 
 
+class IAddSampleConfirmation(Interface):
+    """Marker interface for confirmation Add Sample form confirmation
+    """
+
+    def check_confirmation(self, records):
+        """Returns a dict when user confirmation is required for the creation
+        of samples when the Save button from Add Sample form is pressed. Returns
+        None otherwise
+        """
+
+
 class IClientAwareMixin(Interface):
     """Marker interface for objects that can be bound to a Client, either
     because they can be added inside a Client folder or because it can be


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes possible to add an adapter to force the user to confirm before the samples are created when Sample's add form "Save" button is clicked. For instance, we might want the system to check first for duplicates in the system before a new sample is created based on the data (client sample id, profile, etc.) entered by user.

An adapter that checks for duplicates based on the ClientSampleID and DateSampled, might look as follows:

```python

class AddSampleConfirmation(object):
    """An adapter for the confirmation of sample creation in Add form
    """
    implements(IAddSampleConfirmation)

    def __init__(self, request):
        self.request = request

    def check_confirmation(self, records):
        # Check if a sample for the given date of collection and client sample id exists already
        field_names = ["ClientSampleID", "DateSampled"]
        
        for record in records:
            field_values = map(lambda name: record.get(name), field_names)
            if not all(field_values):
                continue

            date_sampled = api.to_date(field_values[2])
            date_sampled = date_sampled.strftime("%Y-%m-%d")
            date_from = "{} 00:00".format(date_sampled)
            date_to = "{} 23:59".format(date_sampled)
            query = {
                "getClientSampleID": field_values[0],
                "getDateSampled": {
                    "query": [date_from, date_to],
                    "range": "min:max",
                }
            }
            brains = api.search(query, CATALOG_ANALYSIS_REQUEST_LISTING)
            if brains:
                samp_id = api.get_id(brains[0])
                samp_ids.append(samp_id)

        confirmation = None
        if samp_ids:
            samp_ids = ", ".join(samp_ids)
            confirmation = {
                "message": "Potential duplicates found: {}".format(samp_ids)
            }
        return confirmation
```

## Current behavior before PR

Is not possible to prompt the user for confirmation on Sample submission

## Desired behavior after PR is merged

Possible to prompt the user for confirmation on Sample submission when some criteria are met

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
