### PR TITLE
Adapter hook for confirmation when creating a Sample (2.x)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1804 Adapter hook for confirmation when creating a Sample
 - #1801 Updated openpyxl to latest Python 2.x compatible version
 - #1797 Fix Auto Import Log View and ID generation
 - #1795 Do not overwrite worksheet remarks per default

--- a/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -214,6 +214,18 @@
         </table>
       </script>
 
+      <!-- Confirmation Template -->
+      <script id="confirm-template" type="text/x-handlebars-template">
+        <div title="Confirm" i18n:attributes="title">
+          <p i18n:translate="">
+            {{message}}
+          </p>
+          <p i18n:translate="">
+            Do you want to continue?
+          </p>
+        </div>
+      </script>
+
     </metal:block>
   </head>
 
@@ -570,6 +582,9 @@
                name="save_button"
                i18n:attributes="value"
                value="Save"/>
+
+        <input type="hidden" id="confirmed" name="confirmed" value="0"/>
+
       </form>
       <!-- /ADD Form -->
 

--- a/src/bika/lims/interfaces/__init__.py
+++ b/src/bika/lims/interfaces/__init__.py
@@ -1000,6 +1000,17 @@ class IAddSampleObjectInfo(Interface):
         """
 
 
+class IAddSampleConfirmation(Interface):
+    """Marker interface for confirmation Add Sample form confirmation
+    """
+
+    def check_confirmation(self, records):
+        """Returns a dict when user confirmation is required for the creation
+        of samples when the Save button from Add Sample form is pressed. Returns
+        None otherwise
+        """
+
+
 class IClientAwareMixin(Interface):
     """Marker interface for objects that can be bound to a Client, either
     because they can be added inside a Client folder or because it can be

--- a/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
@@ -1266,11 +1266,12 @@
        * Eventhandler for the form submit button.
        * Extracts and submits all form data asynchronous.
        */
-      var base_url, me;
+      var base_url, me, portal_url;
       console.debug("°°° on_form_submit °°°");
       event.preventDefault();
       me = this;
       base_url = me.get_base_url();
+      portal_url = me.get_portal_url();
       $("div.error").removeClass("error");
       $("div.fieldErrorBox").text("");
       return this.ajax_post_form("submit").done(function(data) {
@@ -1283,7 +1284,7 @@
          *   This includes GET params for printing labels, so that we do not
          *   have to care about this here.
          */
-        var ars, destination, errorbox, field, fieldname, message, msg, parent, q, stickertemplate;
+        var ars, destination, dialog, errorbox, field, fieldname, message, msg, parent, q, stickertemplate;
         if (data['errors']) {
           msg = data.errors.message;
           if (msg !== "") {
@@ -1308,6 +1309,17 @@
           stickertemplate = data['stickertemplate'];
           q = '/sticker?autoprint=1&template=' + stickertemplate + '&items=' + ars.join(',');
           return window.location.replace(destination + q);
+        } else if (data['confirmation']) {
+          dialog = me.template_dialog("confirm-template", data.confirmation);
+          return dialog.on("yes", function() {
+            destination = data.confirmation["destination"];
+            if (destination) {
+              return window.location.replace(portal_url + '/' + destination);
+            } else {
+              $("input[name=confirmed]").val("1");
+              return $("input[name=save_button]").trigger("click");
+            }
+          });
         } else {
           return window.location.replace(base_url);
         }

--- a/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -1290,6 +1290,9 @@ class window.AnalysisRequestAdd
     # get the right base url
     base_url = me.get_base_url()
 
+    # the poral url
+    portal_url = me.get_portal_url()
+
     # remove all errors
     $("div.error").removeClass("error")
     $("div.fieldErrorBox").text("")
@@ -1329,6 +1332,19 @@ class window.AnalysisRequestAdd
         stickertemplate = data['stickertemplate']
         q = '/sticker?autoprint=1&template=' + stickertemplate + '&items=' + ars.join(',')
         window.location.replace destination + q
+
+      else if data['confirmation']
+        dialog = me.template_dialog "confirm-template", data.confirmation
+        dialog.on "yes", ->
+          destination = data.confirmation["destination"]
+          if destination
+            # Redirect user
+            window.location.replace portal_url + '/' + destination
+          else
+            # Re-submit
+            $("input[name=confirmed]").val "1"
+            $("input[name=save_button]").trigger "click"
+
       else
         window.location.replace base_url
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #1802 to 2.x

## Current behavior before PR

Is not possible to prompt the user for confirmation on Sample submission

## Desired behavior after PR is merged

Possible to prompt the user for confirmation on Sample submission when some criteria are met

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
