### PR TITLE
Revert changes of PR #1767

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1810 Revert changes of PR #1767
 - #1807 Removal of ACTIONS_TO_INDEXES mapping to ensure data integrity
 - #1804 Adapter hook for confirmation when creating a Sample
 - #1801 Updated openpyxl to latest Python 2.x compatible version

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -55,7 +55,6 @@ from bika.lims.utils.analysis import format_uncertainty
 from DateTime import DateTime
 from plone.memoize import view as viewcache
 from Products.Archetypes.config import REFERENCE_CATALOG
-from Products.CMFCore.permissions import ModifyPortalContent
 from Products.CMFPlone.utils import safe_unicode
 from senaite.app.listing import ListingView
 from zope.component import getAdapters
@@ -296,10 +295,6 @@ class AnalysesView(ListingView):
         if not self.context_active:
             # The current context must be active. We cannot edit analyses from
             # inside a deactivated Analysis Request, for instance
-            return False
-
-        if not self.has_permission(ModifyPortalContent, obj=self.context):
-            # skip any further checks if the sample can not be modified
             return False
 
         analysis_obj = self.get_object(analysis_brain)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The PR https://github.com/senaite/senaite.core/pull/1767 disallowed results entry of analysis results when the user has no permission for `ModifyPortalContent`.

While this serves for the purpose of dispatched samples well, it has a side-effect, that Analysts can no longer add results directly in the samples, but only over a worksheet.

A different approach need to be implemented to actually change the permissions on the Analyses after the sample is transitioned to an readonly state.

## Current behavior before PR

Analysts can not edit results of received samples

## Desired behavior after PR is merged

Analysts can edit results in received samples

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
