### PR TITLE
Support html messages on Add sample custom confirmation dialog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
+- #1812 Support html messages on Add sample custom confirmation dialog
 - #1809 Fix `modified` index is not reindexed when the object gets updated
 - #1808 Removal of ACTIONS_TO_INDEXES mapping to ensure data integrity
 - #1803 Updated openpyxl to latest Python 2.x compatible version

--- a/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -217,9 +217,14 @@
       <!-- Confirmation Template -->
       <script id="confirm-template" type="text/x-handlebars-template">
         <div title="Confirm" i18n:attributes="title">
+          {{#if message}}
           <p i18n:translate="">
             {{message}}
           </p>
+          {{/if}}
+          {{#if html_message}}
+            {{{html_message}}}
+          {{/if}}
           <p i18n:translate="">
             Do you want to continue?
           </p>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

An adapter hook for a confirmation view on Add Sample creation was added recently (#1802). This Pull Request makes possible to include html in the custom message. For instance:

![Captura de 2021-06-12 17-25-00](https://user-images.githubusercontent.com/832627/121781010-2a04d680-cba3-11eb-9581-c3d393e5ea8e.png)

(note the link that redirects the user to the stickers view)

## Current behavior before PR

The confirmation dialog always escape html characters

## Desired behavior after PR is merged

Possibility to include messages without html being escaped

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
