### PR TITLE
Fix barcode is not rendered when stickers preview is called directly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
+- #1813 Fix barcode is not rendered when stickers preview is called directly
 - #1809 Fix `modified` index is not reindexed when the object gets updated
 - #1808 Removal of ACTIONS_TO_INDEXES mapping to ensure data integrity
 - #1803 Updated openpyxl to latest Python 2.x compatible version

--- a/bika/lims/browser/templates/stickers_preview.pt
+++ b/bika/lims/browser/templates/stickers_preview.pt
@@ -219,6 +219,9 @@
          pdfwindow.document.forms.topdf.submit();
        }
 
+       // Force the barcode to be rendered when page gets loaded first time
+       $("select#template").trigger("change");
+
        // If autoprint=1, render the pdf automatically
        if (location.href.indexOf("autoprint=1") != -1) {
          printPdf();


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When the stickers preview is called directly, the barcode is not rendered by default. For instance:
http://localhost:9090/senaite/clients/client19-1116/BP-00435/sticker

## Current behavior before PR

The barcode is not rendered by the default when the stickers preview is called directly

## Desired behavior after PR is merged

The barcode is rendered by default when the stickers preview is called directly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
