### PR TITLE
Fix inconsistent behavior of Add sample form confirmation actions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
+- #1814 Fix inconsistent behavior of Add sample form confirmation actions
 - #1809 Fix `modified` index is not reindexed when the object gets updated
 - #1808 Removal of ACTIONS_TO_INDEXES mapping to ensure data integrity
 - #1803 Updated openpyxl to latest Python 2.x compatible version

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -1360,13 +1360,14 @@
           return window.location.replace(destination + q);
         } else if (data['confirmation']) {
           dialog = me.template_dialog("confirm-template", data.confirmation);
-          return dialog.on("yes", function() {
+          dialog.on("yes", function() {
+            $("input[name=confirmed]").val("1");
+            return $("input[name=save_button]").trigger("click");
+          });
+          return dialog.on("no", function() {
             destination = data.confirmation["destination"];
             if (destination) {
               return window.location.replace(portal_url + '/' + destination);
-            } else {
-              $("input[name=confirmed]").val("1");
-              return $("input[name=save_button]").trigger("click");
             }
           });
         } else {

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -1389,14 +1389,15 @@ class window.AnalysisRequestAdd
       else if data['confirmation']
         dialog = me.template_dialog "confirm-template", data.confirmation
         dialog.on "yes", ->
+          # Re-submit
+          $("input[name=confirmed]").val "1"
+          $("input[name=save_button]").trigger "click"
+
+        dialog.on "no", ->
+          # Don't submit and redirect user if required
           destination = data.confirmation["destination"]
           if destination
-            # Redirect user
             window.location.replace portal_url + '/' + destination
-          else
-            # Re-submit
-            $("input[name=confirmed]").val "1"
-            $("input[name=save_button]").trigger "click"
 
       else
         window.location.replace base_url


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the custom Add form confirmation pane actions to work like follows:

- If user press "yes", the form is submitted and user redirected to destination view set by default
- If user press "no", the form is not submitted. If "destination" parameter is defined, the user is redirected in accordance

## Current behavior before PR

When user press "yes" and "destination" parameter is defined, the user is redirected, but the form is not submitted

## Desired behavior after PR is merged

When user press "yes" the form is submitted in accordance. User is redirected to destination (if defined), otherwise.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
