### PR TITLE
Hide unit display after fields in manage analyses listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1815 Hide unit display after fields in manage analyses listing
 - #1811 Datagrid field and widget for Dexterity types
 - #1810 Revert changes of PR #1767
 - #1806 Added base structure to implement custom dexterity fields and widgets

--- a/src/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/src/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -74,7 +74,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
                 "title": _("Service"),
                 "index": "sortable_title",
                 "sortable": False}),
-            ("Unit", {
+            ("ResultUnit", {
                 "title": _("Unit"),
                 "sortable": False}),
             ("Hidden", {
@@ -235,7 +235,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
         spec = rr.get(keyword, ResultsRangeDict())
 
         item["Title"] = obj.Title()
-        item["Unit"] = obj.getUnit()
+        item["ResultUnit"] = obj.getUnit()
         item["Price"] = price
         item["before"]["Price"] = self.get_currency_symbol()
         item["allow_edit"] = self.get_editable_columns(obj)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a display in sample manage analyses view that showed the unit after each input field.

The issue is actually located in `senaite.app.listing`:

https://github.com/senaite/senaite.app.listing/blob/2.x/webpack/app/components/TableCell.coffee#L447

this code displays always the unit after an editable field when a folderitem contains a key `Unit`.


<img width="1704" alt="CL-BL-21-0023 — SENAITE LIMS 2021-06-20 13-51-01" src="https://user-images.githubusercontent.com/713193/122672975-a5334180-d1ce-11eb-80df-4930c3faac7f.png">



## Current behavior before PR

Unit displayed after each editable field in sample manage analyses view


## Desired behavior after PR is merged

No unit displayed after each editable field in sample manage analyses view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
