### PR TITLE
Fix duplicated rejection reasons in rejection viewlet (sample view)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
+- #1816 Fix duplicated rejection reasons in rejection viewlet (sample view)
 - #1814 Fix inconsistent behavior of Add sample form confirmation actions
 - #1813 Fix barcode is not rendered when stickers preview is called directly
 - #1812 Support html messages on Add sample custom confirmation dialog

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2301,7 +2301,10 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
         reasons = self.getRejectionReasons()
         if not reasons:
             return []
-        return reasons[0].get("selected", [])
+
+        # Return a copy of the list to avoid accidental writes
+        reasons = reasons[0].get("selected", [])[:]
+        return filter(None, reasons)
 
     def getOtherRejectionReasons(self):
         """Returns other rejection reasons custom text, if any
@@ -2309,7 +2312,7 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
         reasons = self.getRejectionReasons()
         if not reasons:
             return ""
-        return reasons[0].get("other", "")
+        return reasons[0].get("other", "").strip()
 
     def createAttachment(self, filedata, filename="", **kw):
         """Add a new attachment to the sample


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request prevents accidental writes while retrieving Rejection Reasons from the Sample.

## Current behavior before PR

The "selected" rejection reasons displayed in the rejection viewlet seem to grow automatically with those "other" reasons:

![Captura de 2021-06-22 21-32-36](https://user-images.githubusercontent.com/832627/122988012-8e911400-d3a1-11eb-90a2-7b1aa66fa986.png)

## Desired behavior after PR is merged

No accidental writes while retrieving Rejection Reasons from the Sample

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
