### PR TITLE
Fix duplicated rejection reasons in rejection viewlet (sample view) (2.x)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1817 Fix duplicated rejection reasons in rejection viewlet (sample view)
 - #1815 Hide unit display after fields in manage analyses listing
 - #1811 Datagrid field and widget for Dexterity types
 - #1810 Revert changes of PR #1767

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -2333,7 +2333,10 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
         reasons = self.getRejectionReasons()
         if not reasons:
             return []
-        return reasons[0].get("selected", [])
+
+        # Return a copy of the list to avoid accidental writes
+        reasons = reasons[0].get("selected", [])[:]
+        return filter(None, reasons)
 
     def getOtherRejectionReasons(self):
         """Returns other rejection reasons custom text, if any
@@ -2341,7 +2344,7 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
         reasons = self.getRejectionReasons()
         if not reasons:
             return ""
-        return reasons[0].get("other", "")
+        return reasons[0].get("other", "").strip()
 
     def createAttachment(self, filedata, filename="", **kw):
         """Add a new attachment to the sample


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Ports #1816 to 2.x

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
