### PR TITLE
Fix rejection report is attached as a ".bin" file in notification email

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
+- #1818 Fix rejection report is attached as a ".bin" file in notification email
 - #1816 Fix duplicated rejection reasons in rejection viewlet (sample view)
 - #1814 Fix inconsistent behavior of Add sample form confirmation actions
 - #1813 Fix barcode is not rendered when stickers preview is called directly

--- a/bika/lims/api/mail.py
+++ b/bika/lims/api/mail.py
@@ -37,6 +37,7 @@ from string import Template
 from StringIO import StringIO
 
 import six
+from plone.app.blob.field import BlobWrapper
 
 from bika.lims import api
 from bika.lims import logger
@@ -126,6 +127,7 @@ def to_email_attachment(filedata, filename="", **kw):
     data = ""
     maintype = "application"
     subtype = "octet-stream"
+    mime_type = kw.pop("mime_type", None)
 
     def is_file(s):
         try:
@@ -149,9 +151,14 @@ def to_email_attachment(filedata, filename="", **kw):
     # Handle raw filedata
     elif isinstance(filedata, six.string_types):
         data = filedata
+    # Handle wrapper for zodb blob
+    elif isinstance(filedata, BlobWrapper):
+        filename = filename or filedata.getFilename()
+        mime_type = mime_type or filedata.getContentType()
+        data = filedata.data
 
     # Set MIME type from keyword arguments or guess it from the filename
-    mime_type = kw.pop("mime_type", None) or mimetypes.guess_type(filename)[0]
+    mime_type = mime_type or mimetypes.guess_type(filename)[0]
     if mime_type is not None:
         maintype, subtype = mime_type.split("/")
 

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -491,7 +491,8 @@ def do_rejection(sample, notify=None):
 
     # Attach the PDF to the sample
     filename = "{}-rejected.pdf".format(sample_id)
-    sample.createAttachment(pdf, filename=filename)
+    attachment = sample.createAttachment(pdf, filename=filename)
+    pdf_file = attachment.getAttachmentFile()
 
     # Do we need to send a notification email?
     if notify is None:
@@ -500,7 +501,7 @@ def do_rejection(sample, notify=None):
 
     if notify:
         # Compose and send the email
-        mime_msg = get_rejection_mail(sample, pdf)
+        mime_msg = get_rejection_mail(sample, pdf_file)
         if mime_msg:
             # Send the email
             send_email(mime_msg)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the rejection report sent automatically via email is attached as a "pdf" file, with its real name

## Current behavior before PR

Rejection report sent via email on rejection is attached as a binary file (with ".bin" extension) and without a filename

## Desired behavior after PR is merged

Rejection report sent via email on rejection is attached as an application/pdf file (with ".pdf" extension) and with the real filename

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
