### PR TITLE
Fix rejection report is attached as a ".bin" file in notification email (2.x)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1819 Fix rejection report is attached as a ".bin" file in notification email
 - #1817 Fix duplicated rejection reasons in rejection viewlet (sample view)
 - #1815 Hide unit display after fields in manage analyses listing
 - #1811 Datagrid field and widget for Dexterity types

--- a/src/bika/lims/api/mail.py
+++ b/src/bika/lims/api/mail.py
@@ -38,6 +38,7 @@ from six import StringIO
 
 from bika.lims import api
 from bika.lims import logger
+from plone.app.blob.field import BlobWrapper
 from Products.CMFPlone.utils import safe_unicode
 
 try:
@@ -124,6 +125,7 @@ def to_email_attachment(filedata, filename="", **kw):
     data = ""
     maintype = "application"
     subtype = "octet-stream"
+    mime_type = kw.pop("mime_type", None)
 
     def is_file(s):
         try:
@@ -147,9 +149,14 @@ def to_email_attachment(filedata, filename="", **kw):
     # Handle raw filedata
     elif isinstance(filedata, six.string_types):
         data = filedata
+    # Handle wrapper for zodb blob
+    elif isinstance(filedata, BlobWrapper):
+        filename = filename or filedata.getFilename()
+        mime_type = mime_type or filedata.getContentType()
+        data = filedata.data
 
     # Set MIME type from keyword arguments or guess it from the filename
-    mime_type = kw.pop("mime_type", None) or mimetypes.guess_type(filename)[0]
+    mime_type = mime_type or mimetypes.guess_type(filename)[0]
     if mime_type is not None:
         maintype, subtype = mime_type.split("/")
 

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -504,7 +504,8 @@ def do_rejection(sample, notify=None):
 
     # Attach the PDF to the sample
     filename = "{}-rejected.pdf".format(sample_id)
-    sample.createAttachment(pdf, filename=filename)
+    attachment = sample.createAttachment(pdf, filename=filename)
+    pdf_file = attachment.getAttachmentFile()
 
     # Do we need to send a notification email?
     if notify is None:
@@ -513,7 +514,7 @@ def do_rejection(sample, notify=None):
 
     if notify:
         # Compose and send the email
-        mime_msg = get_rejection_mail(sample, pdf)
+        mime_msg = get_rejection_mail(sample, pdf_file)
         if mime_msg:
             # Send the email
             send_email(mime_msg)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Ports #1818 to 2.x

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
