### PR TITLE
Fix dynamic analysis specification listing error for empty excel columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1820 Fix dynamic analysis specification listing error for empty excel columns
 - #1817 Fix duplicated rejection reasons in rejection viewlet (sample view)
 - #1815 Hide unit display after fields in manage analyses listing
 - #1811 Datagrid field and widget for Dexterity types

--- a/src/bika/lims/browser/dynamic_analysisspec.py
+++ b/src/bika/lims/browser/dynamic_analysisspec.py
@@ -20,6 +20,8 @@
 
 import collections
 
+import six
+
 from bika.lims import _
 from bika.lims import api
 from senaite.app.listing.view import ListingView
@@ -68,7 +70,7 @@ class DynamicAnalysisSpecView(ListingView):
     def before_render(self):
         super(DynamicAnalysisSpecView, self).before_render()
 
-    def make_empty_item(self, **kw):
+    def make_empty_item(self, record):
         """Create a new empty item
         """
         item = {
@@ -80,11 +82,18 @@ class DynamicAnalysisSpecView(ListingView):
             "disabled": False,
             "state_class": "state-active",
         }
-        item.update(**kw)
+        for k, v in record.items():
+            # ensure keyword dictionary keys contains only strings
+            if not self.is_string(k):
+                continue
+            item[k] = v
         return item
+
+    def is_string(self, value):
+        return isinstance(value, six.string_types)
 
     def folderitems(self):
         items = []
         for record in self.specs:
-            items.append(self.make_empty_item(**record))
+            items.append(self.make_empty_item(record))
         return items


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an error in the dynamic analysisspec listing when the excel contains empty columns

## Current behavior before PR

internal server error occurs

## Desired behavior after PR is merged

non string-type columns are filtered out from the folderitems

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
