### PR TITLE
API support for supermodel objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 version: ~> 1.0
 language: python
-sudo: false
+os: linux
+dist: xenial
 cache:
   pip: true
   directories:
     - eggs
-matrix:
+jobs:
   fast_finish: true
   include:
     - python: "2.7"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1821 API support for supermodel objects
 - #1820 Fix dynamic analysis specification listing error for empty excel columns
 - #1819 Fix rejection report is attached as a ".bin" file in notification email
 - #1817 Fix duplicated rejection reasons in rejection viewlet (sample view)

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@
 .. image:: https://img.shields.io/pypi/v/senaite.core.svg?style=flat-square
     :target: https://pypi.python.org/pypi/senaite.core
 
-.. image:: https://img.shields.io/travis/senaite/senaite.core/master.svg?style=flat-square
-    :target: https://travis-ci.org/senaite/senaite.core
+.. image:: https://img.shields.io/travis/com/senaite/senaite.core/master.svg?style=flat-square
+    :target: https://travis-ci.com/senaite/senaite.core
 
 .. image:: https://img.shields.io/scrutinizer/g/senaite/senaite.core/2.x.svg?style=flat-square
     :target: https://scrutinizer-ci.com/g/senaite/senaite.core/?branch=2.x

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -212,6 +212,8 @@ def is_object(brain_or_object):
     """
     if is_portal(brain_or_object):
         return True
+    if is_supermodel(brain_or_object):
+        return True
     if is_at_content(brain_or_object):
         return True
     if is_dexterity_content(brain_or_object):
@@ -231,6 +233,8 @@ def get_object(brain_object_uid, default=_marker):
     """
     if is_uid(brain_object_uid):
         return get_object_by_uid(brain_object_uid)
+    elif is_supermodel(brain_object_uid):
+        return brain_object_uid.instance
     if not is_object(brain_object_uid):
         if default is _marker:
             fail("{} is not supported.".format(repr(brain_object_uid)))
@@ -260,6 +264,19 @@ def is_brain(brain_or_object):
     :rtype: bool
     """
     return ICatalogBrain.providedBy(brain_or_object)
+
+
+def is_supermodel(brain_or_object):
+    """Checks if the passed in object is a supermodel
+
+    :param brain_or_object: A single catalog brain or content object
+    :type brain_or_object: ATContentType/DexterityContentType/CatalogBrain
+    :returns: True if the object is a catalog brain
+    :rtype: bool
+    """
+    # avoid circular imports
+    from senaite.app.supermodel.interfaces import ISuperModel
+    return ISuperModel.providedBy(brain_or_object)
 
 
 def is_dexterity_content(brain_or_object):

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -30,6 +30,8 @@ so here we will assume the role of Lab Manager.
     >>> from plone.app.testing import setRoles
     >>> setRoles(portal, TEST_USER_ID, ['Manager',])
 
+    >>> from senaite.app.supermodel import SuperModel
+
 
 Getting the Portal
 ..................
@@ -134,6 +136,11 @@ The function also accepts a UID:
     >>> api.get_object(api.get_uid(brain))
     <Client at /plone/clients/client-1>
 
+And also accepts `SuperModel` objects:
+
+    >>> api.get_object(SuperModel(brain))
+    <Client at /plone/clients/client-1>
+
 And returns the portal object when UID=="0"
 
     >>> api.get_object("0")
@@ -167,6 +174,9 @@ Portal object, we can use the `is_object` function::
     True
 
     >>> api.is_object(api.get_portal())
+    True
+
+    >>> api.is_object(SuperModel(client))
     True
 
     >>> api.is_object(None)

--- a/src/senaite/core/tests/layers.py
+++ b/src/senaite/core/tests/layers.py
@@ -41,6 +41,7 @@ class BaseLayer(PloneSandboxLayer):
         import senaite.core
         import senaite.app.listing
         import senaite.app.spotlight
+        import senaite.app.supermodel
         import senaite.impress
         import senaite.lims
         import Products.TextIndexNG3
@@ -49,6 +50,7 @@ class BaseLayer(PloneSandboxLayer):
         self.loadZCML(package=senaite.core)
         self.loadZCML(package=senaite.app.listing)
         self.loadZCML(package=senaite.app.spotlight)
+        self.loadZCML(package=senaite.app.supermodel)
         self.loadZCML(package=senaite.impress)
         self.loadZCML(package=senaite.lims)
         self.loadZCML(package=Products.TextIndexNG3)
@@ -58,6 +60,7 @@ class BaseLayer(PloneSandboxLayer):
         zope.installProduct(app, "senaite.core")
         zope.installProduct(app, "senaite.app.listing")
         zope.installProduct(app, "senaite.app.spotlight")
+        zope.installProduct(app, "senaite.app.supermodel")
         zope.installProduct(app, "senaite.impress")
         zope.installProduct(app, "senaite.lims")
         zope.installProduct(app, "Products.TextIndexNG3")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the API that it supports `SuperModel` objects (`senaite.app.supermodel`)

## Current behavior before PR

`SuperModel` objects were not recognized by the API

## Desired behavior after PR is merged

`SuperModel` objects are supported by the API

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
