### PR TITLE
Support html messages on Add sample custom confirmation dialog (2.x)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- #1824 Support html messages on Add sample custom confirmation dialog
 - #1821 API support for supermodel objects
 - #1820 Fix dynamic analysis specification listing error for empty excel columns
 - #1819 Fix rejection report is attached as a ".bin" file in notification email

--- a/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -217,9 +217,14 @@
       <!-- Confirmation Template -->
       <script id="confirm-template" type="text/x-handlebars-template">
         <div title="Confirm" i18n:attributes="title">
+          {{#if message}}
           <p i18n:translate="">
             {{message}}
           </p>
+          {{/if}}
+          {{#if html_message}}
+          {{{html_message}}}
+          {{/if}}
           <p i18n:translate="">
             Do you want to continue?
           </p>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #1812 to 2.x

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
