### PR TITLE
Fix dynamic analysis specification listing error for empty excel columns (1.3.x)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
+- #1825 Fix TypeError when creating Dynamic Analysis Specifications
 - #1825 Fix dynamic analysis specification listing error for empty excel columns
 - #1822 API support for supermodel objects
 - #1818 Fix rejection report is attached as a ".bin" file in notification email

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
+- #1825 Fix dynamic analysis specification listing error for empty excel columns
 - #1822 API support for supermodel objects
 - #1818 Fix rejection report is attached as a ".bin" file in notification email
 - #1816 Fix duplicated rejection reasons in rejection viewlet (sample view)

--- a/bika/lims/browser/dynamic_analysisspec.py
+++ b/bika/lims/browser/dynamic_analysisspec.py
@@ -20,6 +20,8 @@
 
 import collections
 
+import six
+
 from bika.lims import _
 from bika.lims import api
 from senaite.core.listing.view import ListingView
@@ -68,7 +70,7 @@ class DynamicAnalysisSpecView(ListingView):
     def before_render(self):
         super(DynamicAnalysisSpecView, self).before_render()
 
-    def make_empty_item(self, **kw):
+    def make_empty_item(self, record):
         """Create a new empty item
         """
         item = {
@@ -80,11 +82,18 @@ class DynamicAnalysisSpecView(ListingView):
             "disabled": False,
             "state_class": "state-active",
         }
-        item.update(**kw)
+        for k, v in record.items():
+            # ensure keyword dictionary keys contains only strings
+            if not self.is_string(k):
+                continue
+            item[k] = v
         return item
+
+    def is_string(self, value):
+        return isinstance(value, six.string_types)
 
     def folderitems(self):
         items = []
         for record in self.specs:
-            items.append(self.make_empty_item(**record))
+            items.append(self.make_empty_item(record))
         return items

--- a/bika/lims/content/dynamic_analysisspec.py
+++ b/bika/lims/content/dynamic_analysisspec.py
@@ -65,9 +65,11 @@ class IDynamicAnalysisSpec(model.Schema):
                 "Please upload an Excel spreadsheet with at least "
                 "the following columns defined: '{}'"
                 .format(", ".join(REQUIRED_COLUMNS))))
+
         try:
-            header = map(lambda c: c.value, xls.worksheets[0].rows[0])
-        except IndexError:
+            header_row = xls.worksheets[0].rows.next()
+            header = map(lambda c: c.value, header_row)
+        except (IndexError, AttributeError):
             raise Invalid(
                 _("First sheet does not contain a valid column definition"))
         for col in REQUIRED_COLUMNS:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #1820 to 1.3.x and also fixes a TypeError when creating a Dynamic Analysis Specification because of [#1803](#1803 Updated openpyxl to latest Python 2.x compatible version)

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module plone.z3cform.layout, line 66, in __call__
  Module plone.z3cform.layout, line 50, in update
  Module plone.dexterity.browser.add, line 118, in update
  Module plone.z3cform.fieldsets.extensible, line 59, in update
  Module plone.z3cform.patch, line 30, in GroupForm_update
  Module z3c.form.group, line 145, in update
  Module plone.app.z3cform.csrf, line 21, in execute
  Module z3c.form.action, line 98, in execute
  Module z3c.form.button, line 315, in __call__
  Module z3c.form.button, line 170, in __call__
  Module plone.dexterity.browser.add, line 97, in handleAdd
  Module z3c.form.group, line 98, in extractData
  Module z3c.form.form, line 148, in extractData
  Module z3c.form.field, line 324, in extract
  Module z3c.form.field, line 216, in validate
  Module z3c.form.validator, line 201, in validate
  Module z3c.form.validator, line 206, in validateObject
  Module zope.interface.interface, line 590, in validateInvariants
  Module bika.lims.content.dynamic_analysisspec, line 69, in validate_sepecs_file
TypeError: 'generator' object has no attribute '__getitem__'
```

## Desired behavior after PR is merged

No error

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
