### PR TITLE
Fix categories don't show up automatically on Analysis Service creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
+- #1827 Fix categories don't show up automatically on Analysis Service creation
 - #1822 API support for supermodel objects
 - #1818 Fix rejection report is attached as a ".bin" file in notification email
 - #1816 Fix duplicated rejection reasons in rejection viewlet (sample view)

--- a/bika/lims/content/abstractbaseanalysis.py
+++ b/bika/lims/content/abstractbaseanalysis.py
@@ -435,8 +435,13 @@ Category = UIDReferenceField(
         checkbox_bound=0,
         label=_("Analysis Category"),
         description=_("The category the analysis service belongs to"),
-        catalog_name='bika_setup_catalog',
-        base_query={'is_active': True},
+        showOn=True,
+        catalog_name=SETUP_CATALOG,
+        base_query={
+            'is_active': True,
+            'sort_on': 'sortable_title',
+            'sort_order': 'ascending',
+        },
     )
 )
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1805

## Current behavior before PR

User is forced to type something in "Category" field in order to be able to choose an existing Category

## Desired behavior after PR is merged

The list of available categories is displayed for selection automatically when the field "Category" receives the focus

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
