### PR TITLE
Fix API create for Dexterity types (1.3.x)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
+- #1829 Fix API create for Dexterity types
 - #1827 Fix categories don't show up automatically on Analysis Service creation
 - #1825 Fix TypeError when creating Dynamic Analysis Specifications
 - #1825 Fix dynamic analysis specification listing error for empty excel columns

--- a/bika/lims/api/__init__.py
+++ b/bika/lims/api/__init__.py
@@ -130,41 +130,36 @@ def create(container, portal_type, *args, **kwargs):
     :returns: The new created object
     """
     from bika.lims.utils import tmpID
-    if kwargs.get("title") is None:
-        kwargs["title"] = "New {}".format(portal_type)
 
-    # generate a temporary ID
-    tmp_id = tmpID()
+    id = kwargs.pop("id", tmpID())
+    title = kwargs.pop("title", "New {}".format(portal_type))
 
     # get the fti
     types_tool = get_tool("portal_types")
     fti = types_tool.getTypeInfo(portal_type)
 
     if fti.product:
-        obj = _createObjectByType(portal_type, container, tmp_id)
+        obj = _createObjectByType(portal_type, container, id)
+        obj.processForm()
+        obj.edit(title=title, **kwargs)
+        modified(obj)
     else:
         # newstyle factory
         factory = getUtility(IFactory, fti.factory)
-        obj = factory(tmp_id, *args, **kwargs)
+        obj = factory(id, *args, **kwargs)
         if hasattr(obj, '_setPortalTypeName'):
             obj._setPortalTypeName(fti.getId())
+        # set the title
+        obj.title = safe_unicode(title)
+        # notify that the object was created
         notify(ObjectCreatedEvent(obj))
         # notifies ObjectWillBeAddedEvent, ObjectAddedEvent and
         # ContainerModifiedEvent
-        container._setObject(tmp_id, obj)
+        container._setObject(id, obj)
         # we get the object here with the current object id, as it might be
         # renamed already by an event handler
         obj = container._getOb(obj.getId())
 
-    # handle AT Content
-    if is_at_content(obj):
-        obj.processForm()
-
-    # Edit after processForm; processForm does AT unmarkCreationFlag.
-    obj.edit(**kwargs)
-
-    # explicit notification
-    modified(obj)
     return obj
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Requests fixes the cretion of Dexterity objects via core's API. Objects where created, but due to a silent error arising when "editing" the object, the parent was modified instead. The title of the parent was the most evident modification.

## Current behavior before PR

Can create Dexterity objects with core's API, but container is modified on edit.

## Desired behavior after PR is merged

Can create Dexterity objects with core's API while the parent object is kept unmodified

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
