### PR TITLE
Allow to override datepicker's dateformat via locales

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- #1830 Fix datepicker's dateformat cannot be overwritten via locales
+- #1830 Allow to override datepicker's dateformat via locales
 
 2.0.0 (2021-07-26)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-
+- #1830 Fix datepicker's dateformat cannot be overwritten via locales
 
 2.0.0 (2021-07-26)
 ------------------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,8 +1,8 @@
 [buildout]
 index = https://pypi.org/simple/
-extends = https://dist.plone.org/release/5.2.3/versions.cfg
+extends = https://dist.plone.org/release/5.2.4/versions.cfg
 find-links =
-    https://dist.plone.org/release/5.2.3/
+    https://dist.plone.org/release/5.2.4/
     https://dist.plone.org/thirdparty/
 
 parts =

--- a/src/bika/lims/browser/__init__.py
+++ b/src/bika/lims/browser/__init__.py
@@ -63,7 +63,10 @@ def get_date(context, value):
         request = api.get_request()
         format = translate(
             key, domain="senaite.core", mapping={}, context=request)
-        # TODO: Is this replacement below strictly necessary?
+        # The variables at locales .po files (e.g. "date_format_short") take
+        # into consideration the translation service tool and therefore, their
+        # format is like "${d}/${m}/${Y}". We need to "convert" this format
+        # to %-like.
         return format.replace(r"${", '%').replace('}', '')
 
     # Try with prioritized formats

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/datetimewidget.js
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/datetimewidget.js
@@ -14,14 +14,13 @@ document.addEventListener("DOMContentLoaded", () => {
   var dt_fmt = _t(dt_fmt_string);
 
   if (dt_fmt != dt_fmt_string) {
-    dt_fmt = dt_fmt.replaceAll(/[${}]/gi, "");
+    date_format = dt_fmt.replaceAll(/[${}]/gi, "");
   }
 
   var config = Object.assign(dt_config, tp_config);
 
   $('[datepicker="1"]').datepicker(
     Object.assign(config, {
-      dateFormat: "yy-mm-dd",
       changeMonth: true,
       changeYear: true,
       yearRange: "-150:+150",


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that the date_format of datepickers is rendered in accordance with a custom "senaite.core.po" locale that overwrites the default one. To overwrite core locales with a custom one, `plone.recipe.zope2instance` has been used: https://github.com/plone/plone.recipe.zope2instance#locales

## Current behavior before PR

Cannot overwrite the date_format for datepickers set by default in core's locales

## Desired behavior after PR is merged

Can overwrite the date_format for datepickers set by default in core's locales

## Screenshots

![Captura de 2021-07-28 14-04-00](https://user-images.githubusercontent.com/832627/127319219-dc3fb1a1-f820-4982-8214-d49577134997.png)

![Captura de 2021-07-28 14-04-11](https://user-images.githubusercontent.com/832627/127319241-0adfdc63-e28b-4742-855f-4a9a98ea38d1.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
