### PR TITLE
Added adapter for custom validation of records in Sample Add form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1831 Added adapter for custom validation of records in Sample Add form
 - #1830 Allow to override datepicker's dateformat via locales
 
 2.0.0 (2021-07-26)

--- a/src/bika/lims/interfaces/__init__.py
+++ b/src/bika/lims/interfaces/__init__.py
@@ -1011,6 +1011,18 @@ class IAddSampleConfirmation(Interface):
         """
 
 
+class IAddSampleRecordsValidator(Interface):
+    """Marker interface for Add Sample Records validators
+    """
+
+    def validate(self, records):
+        """Returns None if all records are valid. Returns an error dict like
+        follows otherwise, so the error messages it contains is displayed at
+        the top of the Add Sample form view.
+            {"message": "", "fielderrors": {}}
+        """
+
+
 class IClientAwareMixin(Interface):
     """Marker interface for objects that can be bound to a Client, either
     because they can be added inside a Client folder or because it can be


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the addition of custom validators for Add sample form records possible. Possibilities for these validators are endless. For instance, one may want a custom validator that checks if the value of a given field is consistent with the value of another field. Or one might want to ensure that the values entered for same field and two different records are always different, or the value set for a given field matches with the current time of the day (morning, evening, etc.).

Below, an example of an adapter that acts as a validator of Add Sample field records. It basically checks the volume entered is below the value set for the selected Sample Type.

```python

from bika.lims import api
from bika.lims import senaiteMessageFactory as _s
from bika.lims.interfaces import IAddSampleRecordsValidator
from my.lims import messageFactory as _
from zope.interface import implementer
from senaite.core.api import measure as mapi


@implementer(IAddSampleRecordsValidator)
class RecordsValidator(object):
    """Add Sample form records validator
    """

    def __init__(self, request):
        self.request = request

    def validate(self, records):
        """Returns None if all records are valid. Returns an error dict like
        follows otherwise, so the error messages it contains is displayed at
        the top of the Add Sample form view.
            {"message": "", "fielderrors": {}}
        """
        message = ""
        field_errors = {}
        for num, record in enumerate(records):

            # Check if volume is correct based on the selected sample type
            err = self.validate_minimum_volume(record)
            if err:
                field_errors["Volume-{}".format(num)] = err

        if any([message, field_errors]):
            return {
                "message": message,
                "fielderrors": field_errors
            }

    def validate_minimum_volume(self, record):
        """Validates the Volume set in the record is above the minimum volume
        required for the selected sample type
        """
        error = None

        # Retrieve volume and min_volume here
        volume = self.get_volume(record)
        min_volume = self.get_minimum_volume(record)

        # Compare
        if volume < min_volume:
            error = _("Volume is below {}").format(min_volume)
            if not volume_str:
                error = _s("Field '{}' is required".format("Volume"))

        # Return the error (if any)
        return error
```

And we register the adapter accordingly:

```xml
  <!-- Validator of records on Add Sample form -->
  <adapter
      for="my.lims.interfaces.IMyLimsLayer"
      provides="bika.lims.interfaces.IAddSampleRecordsValidator"
      factory=".addsample.RecordsValidator"
      name="my.lims.adapter.addsample.recordsvalidator" />
```

## Current behavior before PR

Not possible to validate Add Sample records on submit

## Desired behavior after PR is merged

Possible to validate Add Sample records on submit

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
