### PR TITLE
Added an 'extra_inline_buttons' metal slot on edit macro

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1833 Added an 'extra_inline_buttons' metal slot on edit macro
 - #1831 Added adapter for custom validation of records in Sample Add form
 - #1830 Allow to override datepicker's dateformat via locales
 

--- a/src/senaite/core/skins/senaite_templates/edit_macros.pt
+++ b/src/senaite/core/skins/senaite_templates/edit_macros.pt
@@ -225,42 +225,47 @@
                  tal:attributes="value python:(last_referer and '%s/%s' % (context.absolute_url(), template.id) not in last_referer) and last_referer or (context.getParentNode() and context.getParentNode().absolute_url())"
           />
 
-          <!-- Buttons -->
-          <metal:block define-slot="buttons"
-                       tal:define="fieldset_index python:fieldset in fieldsets and fieldsets.index(fieldset);
-                                   n_fieldsets python:len(fieldsets)">
+          <div class="mt-2">
 
-            <div class="mt-2">
-              <input tal:condition="python:fieldset_index &gt; 0"
-                    class="btn btn-sm btn-outline-secondary"
-                    type="submit"
-                    name="form.button.previous"
-                    value="Previous"
-                    i18n:attributes="value label_previous;"
-                    tal:attributes="disabled python:test(isLocked, 'disabled', None);"
-              />
-              <input tal:condition="python:not allow_tabbing and (fieldset_index &lt; n_fieldsets - 1)"
-                    class="btn btn-sm btn-outline-secondary"
-                    type="submit"
-                    name="form.button.next"
-                    value="Next"
-                    i18n:attributes="value label_next;"
-                    tal:attributes="disabled python:test(isLocked, 'disabled', None);"
-              />
-              <input class="btn btn-sm btn-primary"
-                    type="submit"
-                    name="form.button.save"
-                    value="Save"
-                    i18n:attributes="value label_save;"
-                    tal:attributes="disabled python:test(isLocked, 'disabled', None);" />
+            <!-- Buttons -->
+            <metal:block define-slot="buttons"
+                         tal:define="fieldset_index python:fieldset in fieldsets and fieldsets.index(fieldset);
+                                     n_fieldsets python:len(fieldsets)">
 
-              <input class="btn btn-sm btn-secondary"
-                    type="submit"
-                    name="form.button.cancel"
-                    value="Cancel"
-                    i18n:attributes="value label_cancel;" />
-            </div>
-          </metal:block>
+                <input tal:condition="python:fieldset_index &gt; 0"
+                      class="btn btn-sm btn-outline-secondary"
+                      type="submit"
+                      name="form.button.previous"
+                      value="Previous"
+                      i18n:attributes="value label_previous;"
+                      tal:attributes="disabled python:test(isLocked, 'disabled', None);"
+                />
+                <input tal:condition="python:not allow_tabbing and (fieldset_index &lt; n_fieldsets - 1)"
+                      class="btn btn-sm btn-outline-secondary"
+                      type="submit"
+                      name="form.button.next"
+                      value="Next"
+                      i18n:attributes="value label_next;"
+                      tal:attributes="disabled python:test(isLocked, 'disabled', None);"
+                />
+                <input class="btn btn-sm btn-primary"
+                      type="submit"
+                      name="form.button.save"
+                      value="Save"
+                      i18n:attributes="value label_save;"
+                      tal:attributes="disabled python:test(isLocked, 'disabled', None);" />
+
+                <input class="btn btn-sm btn-secondary"
+                      type="submit"
+                      name="form.button.cancel"
+                      value="Cancel"
+                      i18n:attributes="value label_cancel;" />
+            </metal:block>
+
+            <!-- Extra In-line Button Slot -->
+            <metal:block define-slot="extra_inline_buttons" />
+
+          </div>
 
           <!-- Extra Button Slot -->
           <metal:block define-slot="extra_buttons" />


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds an extra slot for buttons that have to be displayed inline in the edit macro, next to those that already exist by default. With this `extra_inline_buttons` slots, the following is possible without having to overwrite default `buttons` slot.

![Captura de 2021-08-11 16-47-46](https://user-images.githubusercontent.com/832627/129051863-60b89140-72a0-45c5-8941-d38fd0a3fb93.png)

## Current behavior before PR

There is an `extra_buttons` slot, but is rendered below default buttons

## Desired behavior after PR is merged

There is an `extra_inline_buttons` slot that is rendered next to default buttons

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
