### PR TITLE
Fix `SamplePoint` content type does not implement `ISamplePoint`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1834 Fix `SamplePoint` content type does not implement `ISamplePoint`
 - #1833 Added an 'extra_inline_buttons' metal slot on edit macro
 - #1831 Added adapter for custom validation of records in Sample Add form
 - #1830 Allow to override datepicker's dateformat via locales

--- a/src/bika/lims/content/samplepoint.py
+++ b/src/bika/lims/content/samplepoint.py
@@ -47,6 +47,7 @@ from bika.lims.content.bikaschema import BikaSchema
 from bika.lims.content.clientawaremixin import ClientAwareMixin
 from bika.lims.content.sampletype import SampleTypeAwareMixin
 from bika.lims.interfaces import IDeactivable
+from bika.lims.interfaces import ISamplePoint
 
 schema = BikaSchema.copy() + Schema((
     CoordinateField(
@@ -131,7 +132,7 @@ schema['description'].schemata = 'default'
 
 class SamplePoint(BaseContent, HistoryAwareMixin, ClientAwareMixin,
                   SampleTypeAwareMixin):
-    implements(IDeactivable)
+    implements(ISamplePoint, IDeactivable)
     security = ClassSecurityInfo()
     displayContentsTab = False
     schema = schema


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Requests makes `SamplePoint` content type to implement `ISamplePoint` interface

## Current behavior before PR

`SamplePoint` content type does not implement `ISamplePoint`

## Desired behavior after PR is merged

`SamplePoint` content type does implement `ISamplePoint`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
