### PR TITLE
Fix 404 error on `/manage_main` (Plone 5.2.5 compatibility)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1835 Fix 404 error on `/manage_main` (Plone 5.2.5 compatibility)
 - #1834 Fix `SamplePoint` content type does not implement `ISamplePoint`
 - #1833 Added an 'extra_inline_buttons' metal slot on edit macro
 - #1831 Added adapter for custom validation of records in Sample Add form

--- a/src/bika/lims/__init__.py
+++ b/src/bika/lims/__init__.py
@@ -41,7 +41,6 @@ _ = senaiteMessageFactory
 logger = logging.getLogger("senaite.core")
 
 # XXX: Do we really need all of these in templates?
-allow_module("AccessControl")
 allow_module("bika.lims")
 allow_module("bika.lims.config")
 allow_module("bika.lims.permissions")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

System throws a 404 error when accessing to `/manage_main` endpoint (ZMI).

See https://community.plone.org/t/plone-5-2-5-released/14176/5

## Current behavior before PR

System throws a 404 error when accessing to `/manage_main` endpoint (ZMI).

## Desired behavior after PR is merged

Can access to `/manage_main` endpoint without problems

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
