### PR TITLE
Update load_setup_data.py

### DIFF
--- a/src/senaite/core/exportimport/load_setup_data.py
+++ b/src/senaite/core/exportimport/load_setup_data.py
@@ -96,7 +96,7 @@ class LoadSetupData(BrowserView):
 
         elif 'setupfile' in form and 'file' in form and form['file'] and 'projectname' in form and form['projectname']:
                 self.dataset_project = form['projectname']
-                tmp = tempfile.mktemp()
+                tmp = tempfile.mktemp(suffix='.xlsx')
                 file_content = form['file'].read()
                 open(tmp, 'wb').write(file_content)
                 workbook = load_workbook(filename=tmp)  # , use_iterators=True)


### PR DESCRIPTION
Handle openpyxl file type read validate error on setup data import,
add valid Excel spreadsheet filename extension .xlsx to mktemp 
file creation for form upload: "InvalidFileException: openpyxl does not support  file format."

## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR

## Desired behavior after PR is merged

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
