### PR TITLE
Allow sample partitions in submitted states

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1839 Allow sample partitions in submitted states
 - #1836 Redirect client users to their organization page on login
 - #1836 Cleanup `allow_module` and remove obsolete Script Python file
 - #1835 Fix 404 error on `/manage_main` (Plone 5.2.5 compatibility)
@@ -11,6 +12,7 @@ Changelog
 - #1833 Added an 'extra_inline_buttons' metal slot on edit macro
 - #1831 Added adapter for custom validation of records in Sample Add form
 - #1830 Allow to override datepicker's dateformat via locales
+
 
 2.0.0 (2021-07-26)
 ------------------

--- a/src/bika/lims/browser/fields/aranalysesfield.py
+++ b/src/bika/lims/browser/fields/aranalysesfield.py
@@ -322,8 +322,11 @@ class ARAnalysesField(ObjectField):
         # Does the analysis exists in an ancestor?
         from_ancestor = self.get_from_ancestor(instance, service)
         for ancestor_analysis in from_ancestor:
-            # Move the analysis into this instance. The ancestor's
-            # analysis will be masked otherwise
+            # only move non-assigned analyses
+            state = api.get_workflow_status_of(ancestor_analysis)
+            if state != "unassigned":
+                continue
+            # Move the analysis into the partition
             analysis_id = api.get_id(ancestor_analysis)
             logger.info("Analysis {} is from an ancestor".format(analysis_id))
             cp = ancestor_analysis.aq_parent.manage_cutObjects(analysis_id)

--- a/src/bika/lims/browser/partition_magic.py
+++ b/src/bika/lims/browser/partition_magic.py
@@ -46,7 +46,6 @@ class PartitionMagicView(BrowserView):
         self.back_url = self.context.absolute_url()
         self.analyses_to_remove = dict()
 
-
     def __call__(self):
         form = self.request.form
 

--- a/src/bika/lims/browser/templates/partition_magic.pt
+++ b/src/bika/lims/browser/templates/partition_magic.pt
@@ -108,7 +108,9 @@
                   <!-- No Partitions -->
                   <tr tal:condition="python:not number_of_partitions">
                     <td>
-                      <em class="text-muted" i18n:translate="">No Partitions</em>
+                      <div class="font-italic text-muted" i18n:translate="">
+                        Please select number of partitions to create and press the preview button
+                      </div>
                     </td>
                   </tr>
                   <!-- Partitions -->

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -422,11 +422,9 @@ def create_partition(analysis_request, request, analyses, sample_type=None,
     partition.setDateReceived(ar.getDateReceived())
     partition.reindexObject(idxs="getDateReceived")
 
-    # Force partition to same status as the primary
-    status = api.get_workflow_status_of(ar)
-    changeWorkflowState(partition, SAMPLE_WORKFLOW, status)
-    if IReceived.providedBy(ar):
-        alsoProvides(partition, IReceived)
+    # Always set partition to received state
+    changeWorkflowState(partition, SAMPLE_WORKFLOW, "sample_received")
+    alsoProvides(partition, IReceived)
 
     # And initialize the analyses the partition contains. This is required
     # here because the transition "initialize" of analyses rely on a guard,

--- a/src/bika/lims/workflow/analysisrequest/guards.py
+++ b/src/bika/lims/workflow/analysisrequest/guards.py
@@ -56,6 +56,7 @@ def guard_create_partitions(analysis_request):
         return False
     return True
 
+
 def guard_submit(analysis_request):
     """Return whether the transition "submit" can be performed or not.
     Returns True if there is at least one analysis in a non-detached state and

--- a/src/bika/lims/workflow/analysisrequest/guards.py
+++ b/src/bika/lims/workflow/analysisrequest/guards.py
@@ -54,17 +54,7 @@ def guard_create_partitions(analysis_request):
     if analysis_request.isPartition():
         # Do not allow the creation of partitions from partitions
         return False
-
-    # Allow only the creation of partitions if all analyses from the Analysis
-    # Request are in unassigned state. Otherwise, we could end up with
-    # inconsistencies, because original analyses are deleted when the partition
-    # is created. Note here we exclude analyses from children (partitions).
-    analyses = analysis_request.objectValues("Analysis")
-    for analysis in analyses:
-        if api.get_workflow_status_of(analysis) != "unassigned":
-            return False
-    return analyses and True or False
-
+    return True
 
 def guard_submit(analysis_request):
     """Return whether the transition "submit" can be performed or not.

--- a/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
+++ b/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
@@ -594,6 +594,7 @@
     <exit-transition transition_id="rollback_to_receive" />
     <exit-transition transition_id="detach" />
     <exit-transition transition_id="dispatch" />
+    <exit-transition transition_id="create_partitions" />
     <!-- /TRANSITIONS -->
 
     <permission-map name="Delete objects" acquired="False">
@@ -780,6 +781,7 @@
     <exit-transition transition_id="rollback_to_receive" />
     <exit-transition transition_id="detach" />
     <exit-transition transition_id="dispatch" />
+    <exit-transition transition_id="create_partitions" />
     <!-- /TRANSITIONS -->
 
     <permission-map name="Delete objects" acquired="False">
@@ -881,6 +883,7 @@
     <exit-transition transition_id="republish"/>
     <exit-transition transition_id="invalidate"/>
     <exit-transition transition_id="dispatch" />
+    <exit-transition transition_id="create_partitions" />
     <!-- /TRANSITIONS -->
 
     <permission-map name="Delete objects" acquired="False"/>

--- a/src/senaite/core/upgrade/v02_00_001.py
+++ b/src/senaite/core/upgrade/v02_00_001.py
@@ -44,6 +44,7 @@ def upgrade(tool):
 
     # -------- ADD YOUR STUFF BELOW --------
     setup.runImportStepFromProfile(profile, "actions")
+    setup.runImportStepFromProfile(profile, "workflow")
 
     fix_types_i18n_domain(portal)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Some labs have the requirement to retain a partition in the freezer after the sample was published.
Therefore, it should be possible to create a sample partition after it was verified or published

## Current behavior before PR

Sample partitions can be only created for received samples when all of the analyses are unassigned.

## Desired behavior after PR is merged

Sample partitions can be created for `to_be_verified`, `verified` and `published` samples.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
