### PR TITLE
Fix "+Add" buttons are not visible to client users in samples/batches

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1840 Fix "+Add" buttons are not visible to client users in samples/batches
 - #1839 Allow sample partitions in submitted states
 - #1836 Redirect client users to their organization page on login
 - #1836 Cleanup `allow_module` and remove obsolete Script Python file

--- a/src/senaite/core/browser/viewlets/add_samples.py
+++ b/src/senaite/core/browser/viewlets/add_samples.py
@@ -17,7 +17,8 @@ class AddSamplesViewlet(ViewletBase):
         """
         if not ISamplesView.providedBy(self.view):
             return False
-        if not api.security.check_permission(AddAnalysisRequest, self.context):
+        container = self.get_samples_container()
+        if not api.security.check_permission(AddAnalysisRequest, container):
             return False
         return True
 
@@ -30,7 +31,13 @@ class AddSamplesViewlet(ViewletBase):
     def get_add_url(self):
         """Return the sample add URL
         """
-        return "{}/ar_add".format(api.get_url(self.context))
+        container = self.get_samples_container()
+        return "{}/ar_add".format(api.get_url(container))
+
+    def get_samples_container(self):
+        """Returns the container object where new samples will be added
+        """
+        return api.get_current_client() or self.context
 
     @property
     @memoize

--- a/src/senaite/core/browser/viewlets/listings.py
+++ b/src/senaite/core/browser/viewlets/listings.py
@@ -96,13 +96,15 @@ class ListingTableActionsViewlet(ViewletBase):
     def get_context_actions(self, **kw):
         """Get the defined ccontex actions of the listing view
         """
+        portal = api.get_portal()
+        portal_url = api.get_url(portal)
         actions = getattr(self.view, "context_actions", {})
         for k, v in actions.items():
             url = v.get("url")
             if not url:
                 continue
-            context_url = api.get_url(self.context)
-            if not url.startswith(context_url):
+            if not url.startswith(portal_url):
+                context_url = api.get_url(self.context)
                 url = "{}/{}".format(context_url, url)
             default_perm = k == "Add" and DEFAULT_ADD_PERM or DEFAULT_PERM
             perm = v.get("permission", default_perm)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The context action buttons "+Add" are not rendered in general samples and batches listings when the current user is a client

## Current behavior before PR

`+Add` button not rendered in general samples and batches listings when current user is a client

## Desired behavior after PR is merged

`+Add` button rendered in general samples and batches listings when current user is a client

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
