### PR TITLE
Do not allow client user to deactivate its own client

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1841 Do not allow client user to deactivate its own client
 - #1839 Allow sample partitions in submitted states
 - #1836 Redirect client users to their organization page on login
 - #1836 Cleanup `allow_module` and remove obsolete Script Python file

--- a/docs/doctests.rst
+++ b/docs/doctests.rst
@@ -52,6 +52,7 @@ Doctests
 .. include:: ../src/senaite/core/tests/doctests/WorkflowAnalysisRequestInvalidate.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowAnalysisRequestSample.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowAnalysisRequestToBeSampled.rst
+.. include:: ../src/senaite/core/tests/doctests/WorkflowAnalysisRetest.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowAnalysisRetract.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowAnalysisSubmit.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowAnalysisUnassign.rst

--- a/src/bika/lims/workflow/client/guards.py
+++ b/src/bika/lims/workflow/client/guards.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2021 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.lims import api
+
+
+def guard_deactivate(client):
+    """Return whether the transition deactivate can be performed or not
+    """
+    # Current user cannot deactivate the client he/she belongs to
+    current_client = api.get_current_client()
+    return current_client != client

--- a/src/senaite/core/tests/doctests/BatchClientAssignment.rst
+++ b/src/senaite/core/tests/doctests/BatchClientAssignment.rst
@@ -1,4 +1,4 @@
-Analysis publication guard and event
+Batch creation and Client assignment
 ------------------------------------
 
 Running this test from the buildout directory:

--- a/src/senaite/core/tests/doctests/WorkflowAnalysisRetest.rst
+++ b/src/senaite/core/tests/doctests/WorkflowAnalysisRetest.rst
@@ -1,13 +1,13 @@
 Analysis retest guard and event
-===============================
+-------------------------------
 
 Running this test from the buildout directory:
 
-    bin/test test_textual_doctests -t WorkflowAnalysisRetest
+    bin/test -t WorkflowAnalysisRetest
 
 
 Test Setup
-----------
+..........
 
 Needed Imports:
 
@@ -71,7 +71,7 @@ We need to create some basic objects for the test:
     >>> setup.setSelfVerificationEnabled(True)
 
 Retest transition and guard basic constraints
----------------------------------------------
+.............................................
 
 Create an Analysis Request and submit results:
 
@@ -163,7 +163,7 @@ A new "retest" in `unassigned` state is created and the sample rolls back to
     'sample_received'
 
 Auto-rollback of Worksheet on analysis retest
----------------------------------------------
+.............................................
 
 The retesting of an analysis from a Worksheet that is in "to_be_verified" state
 causes the worksheet to rollback to "open" state.
@@ -217,7 +217,7 @@ The state of this additional analysis, the "retest", is `assigned`:
 
 
 Retest of an analysis with dependents
--------------------------------------
+.....................................
 
 Retesting an analysis that depends on other analyses (dependents), forces the
 dependents to be retested too:
@@ -299,7 +299,7 @@ And the current state of the Analysis Request is `sample_received` now:
 
 
 Retest of an analysis with dependencies hierarchy (recursive up)
-----------------------------------------------------------------
+................................................................
 
 Retesting an analysis with dependencies should end-up with retests for all them,
 regardless of their position in the hierarchy of dependencies. The system works
@@ -382,7 +382,7 @@ And the current state of the Analysis Request is `sample_received` now:
 
 
 Retest of an analysis with dependents hierarchy (recursive down)
-----------------------------------------------------------------
+................................................................
 
 Retesting an analysis with dependents should end-up with retests for all them,
 regardless of their position in the hierarchy of dependents. The system works


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request prevents a user belonging to a Client (via Contact) to deactivate his/her own client because of ownership privilege.

## Current behavior before PR

A client contact can deactivate the client he/she belongs to

## Desired behavior after PR is merged

A client contact cannot deactivate the client she/he belongs to

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
