### PR TITLE
Fix traceback for instrument qc view

### DIFF
--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -519,6 +519,18 @@ class AnalysesView(ListingView):
     def append_partition_filters(self):
         """Append additional review state filters for partitions
         """
+
+        # view is used for instrument QC view as well
+        if not IAnalysisRequest.providedBy(self.context):
+            return
+
+        # check if the sample has partitions
+        partitions = self.context.getDescendants()
+
+        # root partition w/o partitions
+        if not partitions:
+            return
+
         new_states = []
         valid_states = [
             "registered",
@@ -528,6 +540,7 @@ class AnalysesView(ListingView):
             "verified",
             "published",
         ]
+
         if self.context.isRootAncestor():
             root_id = api.get_id(self.context)
             new_states.append({
@@ -544,7 +557,7 @@ class AnalysesView(ListingView):
                 "columns": self.columns.keys(),
             })
 
-        for partition in self.context.getDescendants():
+        for partition in partitions:
             part_id = api.get_id(partition)
             new_states.append({
                 "id": part_id,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a side-effect caused by https://github.com/senaite/senaite.core/pull/1839

## Current behavior before PR

Traceback raised when opening instruments QC results view:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module bika.lims.browser.instrument, line 499, in __call__
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 215, in render
  Module chameleon.template, line 192, in render
  Module 77c39e8be12cb6738df381571317cf3c, line 527, in render
  Module 9ec37ac45052cd221ea40db274ec08ab, line 1449, in render_master
  Module 9ec37ac45052cd221ea40db274ec08ab, line 407, in render_content
  Module 77c39e8be12cb6738df381571317cf3c, line 451, in __fill_content_core
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module bika.lims.browser.instrument, line 506, in get_analyses_table_view
  Module bika.lims.browser.analyses.view, line 243, in update
  Module bika.lims.browser.analyses.view, line 531, in append_partition_filters
AttributeError: 'RequestContainer' object has no attribute 'isRootAncestor'
```

## Desired behavior after PR is merged

No traceback occurs on instrument qc results view
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
