### PR TITLE
Fix instrument results import

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1844 Fix instrument results import
 - #1842 Refactor instrument results import form
 - #1841 Do not allow client user to deactivate its own client
 - #1840 Fix "+Add" buttons are not visible to client users in samples/batches

--- a/src/senaite/core/exportimport/import_results.pt
+++ b/src/senaite/core/exportimport/import_results.pt
@@ -1,19 +1,24 @@
 <div class="row" tal:define="results options/import_results">
-  <div class="col-sm-12">
+
+  <div class="col-sm-12 text-info" tal:condition="results/log">
+    <h5 i18n:translate="">Info</h5>
     <div tal:repeat="line results/log">
-      <div class="text-info" tal:content="line"></div>
+      <div tal:content="line"></div>
     </div>
   </div>
 
-  <div class="col-sm-12">
+  <div class="col-sm-12 mt-4 text-warning" tal:condition="results/warns">
+    <h5 i18n:translate="">Warnings</h5>
     <div tal:repeat="line results/warns">
-      <div class="text-warning" tal:content="line"></div>
+      <div class="" tal:content="line"></div>
     </div>
   </div>
 
-  <div class="col-sm-12">
+  <div class="col-sm-12 mt-4 text-danger" tal:condition="results/errors">
+    <h5 i18n:translate="">Errors</h5>
     <div tal:repeat="line results/errors">
-      <div class="text-danger" tal:content="line"></div>
+      <div class="" tal:content="line"></div>
     </div>
   </div>
+
 </div>

--- a/src/senaite/core/exportimport/instruments/resultsimport.py
+++ b/src/senaite/core/exportimport/instruments/resultsimport.py
@@ -19,7 +19,6 @@
 # Some rights reserved, see README and LICENSE.
 
 import codecs
-from datetime import datetime
 
 import six
 from bika.lims import api
@@ -28,7 +27,6 @@ from bika.lims import logger
 from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.idserver import renameAfterCreation
 from bika.lims.utils import t
-from DateTime import DateTime
 from Products.CMFCore.utils import getToolByName
 from senaite.core.exportimport.instruments.logger import Logger
 
@@ -925,16 +923,12 @@ class AnalysisResultsImporter(Logger):
         acode = analysis.getKeyword()
         defresultkey = values.get("DefaultResult", "")
         capturedate = None
-        # Look for timestamp
+
         if "DateTime" in values.keys():
-            try:
-                dt = values.get('DateTime')
-                capturedate = DateTime(
-                    datetime.strptime(dt, '%Y%m%d %H:%M:%S'))
-            except Exception:
-                capturedate = None
-                pass
-            del values['DateTime']
+            ts = values.get("DateTime")
+            capturedate = api.to_date(ts)
+            if capturedate is None:
+                del values["DateTime"]
 
         fields_to_reindex = []
         # get interims

--- a/src/senaite/core/exportimport/instruments/resultsimport.py
+++ b/src/senaite/core/exportimport/instruments/resultsimport.py
@@ -929,9 +929,9 @@ class AnalysisResultsImporter(Logger):
         if "DateTime" in values.keys():
             try:
                 dt = values.get('DateTime')
-                capturedate = DateTime(datetime.strptime(dt,
-                                                         '%Y%m%d %H:%M:%S'))
-            except:
+                capturedate = DateTime(
+                    datetime.strptime(dt, '%Y%m%d %H:%M:%S'))
+            except Exception:
                 capturedate = None
                 pass
             del values['DateTime']
@@ -940,7 +940,7 @@ class AnalysisResultsImporter(Logger):
         # get interims
         interimsout = []
         interims = hasattr(analysis, 'getInterimFields') \
-                   and analysis.getInterimFields() or []
+            and analysis.getInterimFields() or []
         for interim in interims:
             keyword = interim['keyword']
             title = interim['title']
@@ -1002,9 +1002,9 @@ class AnalysisResultsImporter(Logger):
             fields_to_reindex.append('Result')
 
         if (resultsaved) \
-            and values.get('Remarks', '') \
-            and analysis.portal_type == 'Analysis' \
-            and (analysis.getRemarks() != '' or self._override[1] == True):
+           and values.get('Remarks', '') \
+           and analysis.portal_type == 'Analysis' \
+           and (analysis.getRemarks() != '' or self._override[1] is True):
             analysis.setRemarks(values['Remarks'])
             fields_to_reindex.append('Remarks')
 

--- a/src/senaite/core/exportimport/instruments/resultsimport.py
+++ b/src/senaite/core/exportimport/instruments/resultsimport.py
@@ -438,6 +438,7 @@ class AnalysisResultsImporter(Logger):
         importedinsts = {}
         rawacodes = self._parser.getAnalysisKeywords()
         exclude = self.getKeywordsToBeExcluded()
+        updated_analyses = []
         for acode in rawacodes:
             if acode in exclude or not acode:
                 continue
@@ -574,6 +575,7 @@ class AnalysisResultsImporter(Logger):
                         values['DateTime'] = capturedate
                     processed = self._process_analysis(objid, analysis, values)
                     if processed:
+                        updated_analyses.append(analysis)
                         ancount += 1
                         if inst:
                             # Calibration Test (import to Instrument)
@@ -601,6 +603,11 @@ class AnalysisResultsImporter(Logger):
                                 "Attachment cannot be linked to analysis as "
                                 "it is not assigned to a worksheet (%s)" %
                                 analysis)
+
+        # recalculate analyses with calculations after all results are set
+        for analysis in updated_analyses:
+            sample_id = analysis.getRequestID()
+            self.calculateTotalResults(sample_id, analysis)
 
         for arid, acodes in six.iteritems(importedars):
             acodesmsg = "Analysis %s" % ', '.join(acodes)

--- a/src/senaite/core/exportimport/instruments/resultsimport.py
+++ b/src/senaite/core/exportimport/instruments/resultsimport.py
@@ -976,20 +976,22 @@ class AnalysisResultsImporter(Logger):
 
         # Set result if present.
         res = values.get(defresultkey, '')
-        if res or res == 0 or self._override[1]:
+        calc = analysis.getCalculation()
 
-            # handle non-floating values in result options
-            result_options = analysis.getResultOptions()
-            if result_options:
-                result_values = map(
-                    lambda r: r.get("ResultValue"), result_options)
-                if "{:.0f}".format(res) in result_values:
-                    res = int(res)
-
-            analysis.setResult(res)
-            if capturedate:
-                analysis.setResultCaptureDate(capturedate)
-            resultsaved = True
+        # don't set results on calculated analyses
+        if not calc:
+            if api.is_floatable(res) or self._override[1]:
+                # handle non-floating values in result options
+                result_options = analysis.getResultOptions()
+                if result_options:
+                    result_values = map(
+                        lambda r: r.get("ResultValue"), result_options)
+                    if "{:.0f}".format(res) in result_values:
+                        res = int(res)
+                analysis.setResult(res)
+                if capturedate:
+                    analysis.setResultCaptureDate(capturedate)
+                resultsaved = True
 
         if resultsaved is False:
             self.log(

--- a/src/senaite/core/exportimport/instruments/resultsimport.py
+++ b/src/senaite/core/exportimport/instruments/resultsimport.py
@@ -968,10 +968,11 @@ class AnalysisResultsImporter(Logger):
                 resultsaved = True
             else:
                 interimsout.append(interim)
+
         # write interims
         if len(interimsout) > 0:
             analysis.setInterimFields(interimsout)
-            analysis.calculateResult(override=self._override[1])
+            resultsaved = analysis.calculateResult(override=self._override[0])
 
         # Set result if present.
         res = values.get(defresultkey, '')

--- a/src/senaite/core/exportimport/instruments/resultsimport.py
+++ b/src/senaite/core/exportimport/instruments/resultsimport.py
@@ -879,6 +879,7 @@ class AnalysisResultsImporter(Logger):
             success = obj.calculateResult(override=self._override[0])
             if success:
                 self.save_submit_analysis(obj)
+                obj.reindexObject(idxs=["Result"])
                 self.log(
                     "${request_id}: calculated result for "
                     "'${analysis_keyword}': '${analysis_result}'",
@@ -984,15 +985,18 @@ class AnalysisResultsImporter(Logger):
 
         if resultsaved is False:
             self.log(
-                "${request_id} result for '${analysis_keyword}': '${result}'",
+                "${request_id} result for '${analysis_keyword}' not set",
                 mapping={"request_id": objid,
-                         "analysis_keyword": acode,
-                         "result": ""})
+                         "analysis_keyword": acode})
 
         if resultsaved:
             self.save_submit_analysis(analysis)
-            self.calculateTotalResults(objid, analysis)
             fields_to_reindex.append('Result')
+            self.log(
+                "${request_id} result for '${analysis_keyword}': '${result}'",
+                mapping={"request_id": objid,
+                         "analysis_keyword": acode,
+                         "result": res})
 
         if (resultsaved) \
            and values.get('Remarks', '') \


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes inconsistencies in the instrument results import.

## Current behavior before PR

- results were overwritten although the option "Don't override results" was set
- analysis results were not recalculated, if they were dependent on another calculated analysis

## Desired behavior after PR is merged

- override option properly checked
- analysis results are recalculated, if they are dependent on another calculated analysis

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
