### PR TITLE
Add default password for tarball import when user_id is too short

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Changelog
 
 2.0.1 (unreleased)
 ------------------
-- #     Added default password for tarball imports where too short 
+- #     Fix for exception on tarball import
+- #     Added default password of '12345 'for tarball imports where too short 
 - #1845 Added edit form adapter for lab contacts
 - #1846 Fix UnicodeDecodeError on Attachment upload
 - #1847 Added Analysis Profile Edit Form Adapter

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 2.0.1 (unreleased)
 ------------------
-
+- #     Added default password for tarball imports where too short 
 - #1845 Added edit form adapter for lab contacts
 - #1846 Fix UnicodeDecodeError on Attachment upload
 - #1847 Added Analysis Profile Edit Form Adapter

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,7 @@ Changelog
 
 2.0.1 (unreleased)
 ------------------
-- #     Fix for exception on tarball import
-- #     Added default password of '12345 'for tarball imports where too short 
+- #1850 Add valid password for portal_setup tarball import new user creation
 - #1845 Added edit form adapter for lab contacts
 - #1846 Fix UnicodeDecodeError on Attachment upload
 - #1847 Added Analysis Profile Edit Form Adapter

--- a/src/senaite/core/exportimport/genericsetup/adapters.py
+++ b/src/senaite/core/exportimport/genericsetup/adapters.py
@@ -315,10 +315,10 @@ class ATRichTextFieldNodeAdapter(ATFieldNodeAdapter):
         value = self.field.get(self.context)
         if not value:
             return ""
-        #import pdb; pdb.set_trace()
         try:
             return value.raw
-        except:
+        except AttributeError as e:
+            logger.info("Imported value has no Attribute 'raw' {}".format(str(e)))
             return value
 
 

--- a/src/senaite/core/exportimport/genericsetup/adapters.py
+++ b/src/senaite/core/exportimport/genericsetup/adapters.py
@@ -315,7 +315,11 @@ class ATRichTextFieldNodeAdapter(ATFieldNodeAdapter):
         value = self.field.get(self.context)
         if not value:
             return ""
-        return value.raw
+        #import pdb; pdb.set_trace()
+        try:
+            return value.raw
+        except:
+            return value
 
 
 class DXRichTextFieldNodeAdapter(ATRichTextFieldNodeAdapter):

--- a/src/senaite/core/exportimport/genericsetup/structure.py
+++ b/src/senaite/core/exportimport/genericsetup/structure.py
@@ -137,11 +137,11 @@ class SenaiteSiteXMLAdapter(XMLAdapterBase, ObjectManagerHelpers):
                 user_id = cn.firstChild.nodeValue
                 user = api.user.get_user(user_id)
                 if not user:
-                    # add a new user with the same password as the user id or "password" if <5 chars
+                    # add new user with user_id as the password, or "12345" if user_id<5 chars
                     if len(user_id) >= 5:
                         password = user_id
                     else:
-                        password = 'password'
+                        password = '12345'
                     self._logger.info("Adding user {} with password {}".format(user_id,password))
                     user = reg_tool.addMember(user_id, password) 
 

--- a/src/senaite/core/exportimport/genericsetup/structure.py
+++ b/src/senaite/core/exportimport/genericsetup/structure.py
@@ -136,14 +136,10 @@ class SenaiteSiteXMLAdapter(XMLAdapterBase, ObjectManagerHelpers):
                     continue
                 user_id = cn.firstChild.nodeValue
                 user = api.user.get_user(user_id)
-                if not user:
-                    # add new user with user_id as the password, or "12345" if user_id<5 chars
-                    if len(user_id) >= 5:
-                        password = user_id
-                    else:
-                        password = '12345'
-                    self._logger.info("Adding user {} with password {}".format(user_id,password))
-                    user = reg_tool.addMember(user_id, password) 
+
+                if not user: # add new user with password
+                    self._logger.info("Adding user {}".format(user_id))
+                    user = reg_tool.addMember(user_id, '12345') 
 
                 # set the user properties
                 user.setProperties(properties={

--- a/src/senaite/core/exportimport/genericsetup/structure.py
+++ b/src/senaite/core/exportimport/genericsetup/structure.py
@@ -137,9 +137,13 @@ class SenaiteSiteXMLAdapter(XMLAdapterBase, ObjectManagerHelpers):
                 user_id = cn.firstChild.nodeValue
                 user = api.user.get_user(user_id)
                 if not user:
-                    self._logger.info("Adding user {}".format(user_id))
-                    # add a new user with the same password as the user id
-                    user = reg_tool.addMember(user_id, user_id)
+                    # add a new user with the same password as the user id or "password" if <5 chars
+                    if len(user_id) >= 5:
+                        password = user_id
+                    else:
+                        password = 'password'
+                    self._logger.info("Adding user {} with password {}".format(user_id,password))
+                    user = reg_tool.addMember(user_id, password) 
 
                 # set the user properties
                 user.setProperties(properties={


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The portal_setup tarball import fails on user creation for short passwords

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR
The tarball import fails on new member creation when the user_id is less
than 5 characters and is also used for the new password.

## Desired behavior after PR is merged
Import succeeds with default password as "12345" for all new site users
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
