### PR TITLE
Added readonly_transactions decorator (#1732 port)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #1851 Added readonly_transactions decorator (#1732 port)
 
 1.3.5 (2021-07-23)
 ------------------

--- a/bika/lims/decorators.py
+++ b/bika/lims/decorators.py
@@ -23,6 +23,7 @@ import json
 import os
 import threading
 import time
+import transaction
 from functools import wraps
 
 from bika.lims import api
@@ -157,3 +158,17 @@ def synchronized(max_connections=2, verbose=0):
 
         return wrapper
     return inner
+
+
+def readonly_transaction(func):
+    """Decorator to doom the current transaction
+    https://transaction.readthedocs.io/en/latest/doom.html#dooming-transactions
+    """
+    @wraps(func)
+    def decorator(self, *args, **kwargs):
+        logger.info("*** READONLY TRANSACTION: '{}.{}' ***".
+                    format(self.__class__.__name__, self.__name__))
+        tx = transaction.get()
+        tx.doom()
+        return func(self, *args, **kwargs)
+    return decorator


### PR DESCRIPTION
## Description of the issue/feature this PR addresses


This Pull Requests ports #1732 to 1.3.x

## Current behavior before PR

No `readonly_transactions` decorator available

## Desired behavior after PR is merged

`readonly_transactions` decorator available

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
