### PR TITLE
Fix sample progress update after instrument results import

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1853 Fix sample progress update after instrument results import
 - #1852 Fix `{client}` is wrongly stated as a variable on ID generation
 - #1850 Add valid password for portal_setup tarball import new user creation
 - #1845 Added edit form adapter for lab contacts

--- a/src/senaite/core/exportimport/instruments/resultsimport.py
+++ b/src/senaite/core/exportimport/instruments/resultsimport.py
@@ -609,6 +609,11 @@ class AnalysisResultsImporter(Logger):
             sample_id = analysis.getRequestID()
             self.calculateTotalResults(sample_id, analysis)
 
+        # reindex sample to update progress (and other indexes/metadata)
+        samples = set(map(api.get_parent, updated_analyses))
+        for sample in samples:
+            sample.reindexObject()
+
         for arid, acodes in six.iteritems(importedars):
             acodesmsg = "Analysis %s" % ', '.join(acodes)
             self.log(


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the stale sample progress bar (and probably other stale sample indexes/metadata) after instrument import
 
## Current behavior before PR

Progress bar not updated in samples listing

## Desired behavior after PR is merged

Progress bar updated in samples listing

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
