### PR TITLE
Allow to set default result for analyses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1857 Allow to set default result for analyses
 - #1856 Fix referenceanalysis popup in Worksheets
 - #1855 Fix analyses results not set after auto import
 - #1853 Fix sample progress update after instrument results import

--- a/src/bika/lims/browser/fields/aranalysesfield.py
+++ b/src/bika/lims/browser/fields/aranalysesfield.py
@@ -229,6 +229,9 @@ class ARAnalysesField(ObjectField):
         prices = kwargs.get("prices") or {}
         price = prices.get(service_uid) or service.getPrice()
 
+        # Get the default result for the service
+        default_result = service.getDefaultResult()
+
         # Gets the analysis or creates the analysis for this service
         # Note this returns a list, because is possible to have multiple
         # partitions with same analysis
@@ -257,6 +260,10 @@ class ARAnalysesField(ObjectField):
             # Set the internal use status
             parent_sample = analysis.getRequest()
             analysis.setInternalUse(parent_sample.getInternalUse())
+
+            # Set the default result to the analysis
+            if not analysis.getResult():
+                analysis.setResult(default_result)
 
             # Set the result range to the analysis
             analysis_rr = specs.get(service_uid) or analysis.getResultsRange()

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -457,6 +457,11 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         # Always update ResultCapture date when this field is modified
         self.setResultCaptureDate(DateTime())
 
+        # Convert to list ff the analysis has result options set with multi
+        if self.getResultOptions() and "multi" in self.getResultOptionsType():
+            if not isinstance(value, (list, tuple)):
+                value = filter(None, [value])
+
         # Handle list results
         if isinstance(value, (list, tuple)):
             value = json.dumps(value)

--- a/src/bika/lims/content/analysisservice.py
+++ b/src/bika/lims/content/analysisservice.py
@@ -37,12 +37,14 @@ from bika.lims.content.abstractbaseanalysis import schema
 from bika.lims.interfaces import IAnalysisService
 from bika.lims.interfaces import IDeactivable
 from Products.Archetypes.atapi import PicklistWidget
+from Products.Archetypes.Field import StringField
 from Products.Archetypes.public import BooleanField
 from Products.Archetypes.public import BooleanWidget
 from Products.Archetypes.public import DisplayList
 from Products.Archetypes.public import Schema
 from Products.Archetypes.public import SelectionWidget
 from Products.Archetypes.public import registerType
+from Products.Archetypes.Widget import StringWidget
 from Products.CMFCore.utils import getToolByName
 from senaite.core.p3compat import cmp
 from zope.interface import implements
@@ -186,6 +188,19 @@ PartitionSetup = PartitionSetupField(
     )
 )
 
+# Allow/disallow the capture of text as the result of the analysis
+DefaultResult = StringField(
+    "DefaultResult",
+    schemata="Analysis",
+    validators=('service_defaultresult_validator',),
+    widget=StringWidget(
+        label=_("Default result"),
+        description=_(
+            "Default result to display on result entry"
+        )
+    )
+)
+
 
 schema = schema.copy() + Schema((
     Methods,
@@ -197,12 +212,15 @@ schema = schema.copy() + Schema((
     Preservation,
     Container,
     PartitionSetup,
+    DefaultResult,
 ))
 
 # Move default method field after available methods field
 schema.moveField("Method", after="Methods")
 # Move default instrument field after available instruments field
 schema.moveField("Instrument", after="Instruments")
+# Move default result field after String result
+schema.moveField("DefaultResult", after="StringResult")
 
 
 class AnalysisService(AbstractBaseAnalysis):

--- a/src/bika/lims/content/analysisservice.py
+++ b/src/bika/lims/content/analysisservice.py
@@ -199,6 +199,7 @@ DefaultResult = StringField(
         description=_(
             "Default result to display on result entry"
         )
+    )
 )
 
 Conditions = RecordsField(

--- a/src/bika/lims/content/analysisservice.py
+++ b/src/bika/lims/content/analysisservice.py
@@ -199,6 +199,7 @@ DefaultResult = StringField(
         description=_(
             "Default result to display on result entry"
         )
+)
 
 Conditions = RecordsField(
     "Conditions",

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -1518,4 +1518,3 @@ class ServiceConditionsValidator(object):
 
 
 validation.register(ServiceConditionsValidator())
->>>>>>> 2.x

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -1409,3 +1409,38 @@ class ImportValidator(object):
 
 
 validation.register(ImportValidator())
+
+
+class DefaultResultValidator(object):
+    """Validate AnalysisService's DefaultResult field value
+    """
+    implements(IValidator)
+    name = "service_defaultresult_validator"
+
+    def __call__(self, value, **kwargs):
+        instance = kwargs['instance']
+        request = kwargs.get('REQUEST', {})
+        field_name = kwargs['field'].getName()
+        translate = getToolByName(instance, 'translation_service').translate
+
+        default_result = request.get(field_name, None)
+        if default_result:
+            # Default result must be one of the available result options
+            options = request.get("ResultOptions", None)
+            if options:
+                values = map(lambda ro: ro.get("ResultValue"), options)
+                if default_result not in values:
+                    msg = _("Default result must be one of the following "
+                            "result options: {}").format(", ".join(values))
+                    return to_utf8(translate(msg))
+
+            elif not request.get("StringResult"):
+                # Default result must be numeric
+                if not api.is_floatable(default_result):
+                    msg = _("Default result is not numeric")
+                    return to_utf8(translate(msg))
+
+        return True
+
+
+validation.register(DefaultResultValidator())


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request allows lab manager to set default result for analysis. A new field "Default Result" has been added to `AnalysisService`. As soon as the analysis is added to the Sample, the default result is set to the analysis.

![Captura de 2021-10-15 18-54-58](https://user-images.githubusercontent.com/832627/137524722-16b019bf-3380-469a-aba9-5c9da168fd0d.png)

## Current behavior before PR

Not possible to define the default result for an analysis

## Desired behavior after PR is merged

Is possible to define the default result for an analysis

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
