### PR TITLE
Cannot override behavior of Methods folder when using `before_render`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1858 Cannot override behavior of Methods folder when using `before_render`
 - #1856 Fix referenceanalysis popup in Worksheets
 - #1855 Fix analyses results not set after auto import
 - #1853 Fix sample progress update after instrument results import

--- a/src/bika/lims/browser/methodfolder.py
+++ b/src/bika/lims/browser/methodfolder.py
@@ -94,10 +94,12 @@ class MethodFolderContentsView(BikaListingView):
             },
         ]
 
-    def before_render(self):
+    def update(self):
         """Before template render hook
         """
-        # Render the Add button if the user has the AddClient permission
+        super(MethodFolderContentsView, self).update()
+
+        # Render the Add button if the user has the AddMethod permission
         if check_permission(AddMethod, self.context):
             self.context_actions[_("Add")] = {
                 "url": "createObject?type_name=Method",


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`senaite.core`'s MethodFolder is used as the "root" listing view for methods listings. Nevertheless, it overrides the function `before_render`. As a result, some of the changes made in subscriber adapters from another add-ons are omitted. For instance, trying to modify `context_actions` via subscriber adapters won't have any effect because after the call, the value is overriden in MethodFolder.

This Pull Request, moves the logic for `before_render` from the base class "MethodFolder" to the function `update`.

## Current behavior before PR

Cannot override some behavior (e.g., `context_actions`) of MethodFolder listing by using subscriber adapters.

## Desired behavior after PR is merged

Can override behavior MethodFolder listing by using subscriber adapters.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
