### PR TITLE
Show "copy to new" transition to Clients in samples listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1858 Show "copy to new" transition to Clients in samples listing
 - #1856 Fix referenceanalysis popup in Worksheets
 - #1855 Fix analyses results not set after auto import
 - #1853 Fix sample progress update after instrument results import


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request enables the "Copy to new" transition in samples listing to client users

## Current behavior before PR

The "Copy to new" transition in samples listing is not displayed to client users

## Desired behavior after PR is merged

The "Copy to new" transition in samples listing is displayed to client users

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
