### PR TITLE
Documentation fix listing_searchable_text_index.rst

### DIFF
--- a/docs/adapters/listing_searchable_text_index.rst
+++ b/docs/adapters/listing_searchable_text_index.rst
@@ -38,7 +38,7 @@ The second mechanism involves the creation of an adapter that implements
 
 .. code-block:: python
 
-    @adapter(IAnalysisRequest)
+    @adapter(IAnalysisRequest, IBikaCatalogAnalysisRequestListing)
     @implementer(IListingSearchableTextProvider)
     class ListingSearchableTextProvider(object):
         """Adapter for Analysis Request Listing Searchable Text Index


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
This PR patches documentation from PR #1666
Linked issue: #1666

## Current behavior before PR
custom adapter which extends ```listing_searchable_text ``` never being called, if calling it the way described.

## Desired behavior after PR is merged

custom search starts working. :)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
