### PR TITLE
Fix export interface lookup when name contains uppercase letters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1861 Fix export interface lookup when name contains uppercase letters
 - #1858 Show "copy to new" transition to Clients in samples listing
 - #1858 Cannot override behavior of Methods folder when using `before_render`
 - #1857 Allow to set default result for analyses

--- a/src/bika/lims/browser/worksheet/views/export.py
+++ b/src/bika/lims/browser/worksheet/views/export.py
@@ -47,16 +47,16 @@ class ExportView(BrowserView):
         # exim refers to filename in instruments/
         if type(exim) == list:
             exim = exim[0]
-        exim = exim.lower()
-
-        # search instruments module for 'exim' module
-        if not instruments.getExim(exim):
+            
+        # search instruments classes for 'exim' class or module
+        exim = instruments.getExim(exim) if instruments.getExim(exim) else instruments.getExim(exim.lower())
+        
+        if not exim:
             self.context.plone_utils.addPortalMessage(
                 _("Instrument exporter not found"), 'error')
             self.request.RESPONSE.redirect(self.context.absolute_url())
             return
 
-        exim = instruments.getExim(exim)
         exporter = exim.Export(self.context, self.request)
         data = exporter(self.context.getAnalyses())
         pass


### PR DESCRIPTION
Export interface class or module lookup fix

## Description of the issue/feature this PR addresses

This PR fixes the problem when calling a custom instrument export interface that contains uppercase letters. 

## Current behavior before PR
Now export interface name explicitly converts to a lower case string. This string is a key for instrument interface lookup, but if interface name has uppercase letters in the class name - it can't be found. 

## Desired behavior after PR is merged

The class which implements an export interface can be camel-cased. 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
