### PR TITLE
Fix failing instrument import for some QC analyes

### DIFF
--- a/src/senaite/core/exportimport/instruments/resultsimport.py
+++ b/src/senaite/core/exportimport/instruments/resultsimport.py
@@ -537,8 +537,11 @@ class AnalysisResultsImporter(Logger):
                         # Analysis keyword doesn't exist
                         continue
 
-                    ans = [analysis for analysis in analyses
-                           if analysis.getKeyword() == acode]
+                    ans = [
+                        a for a in analyses
+                        if a.getKeyword() == acode
+                           and api.get_workflow_status_of(a)
+                           in self._allowed_analysis_states]
 
                     if len(ans) > 1:
                         self.warn("More than one analysis found for "


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

For some instrument interfaces, the QC analyses fail to import.

Linked issue: https://jira.bikalabs.com/browse/LIMS-3398

## Current behavior before PR

`resultsimport.py` ignores `self._allowed_analysis_states` and wrongly reports that multiple analyses are found.

## Desired behavior after PR is merged

When `self._allowed_analysis_states` is respected, it's possible that the warning can be avoided.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
