### PR TITLE
Fix indexing of temporary objects resulting in orphan entries in catalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1865 Fix indexing of temporary objects resulting in orphan entries in catalog
 - #1861 Fix export interface lookup when name contains uppercase letters
 - #1858 Show "copy to new" transition to Clients in samples listing
 - #1858 Cannot override behavior of Methods folder when using `before_render`

--- a/src/senaite/core/configure.zcml
+++ b/src/senaite/core/configure.zcml
@@ -16,6 +16,7 @@
   <include package=".datamanagers" />
   <include package=".exportimport" />
   <include package=".locales" />
+  <include package=".patches" />
   <include package=".schema" />
   <include package=".upgrade" />
   <include package=".z3cform" />

--- a/src/senaite/core/patches/__init__.py
+++ b/src/senaite/core/patches/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from Acquisition import aq_base
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from Products.Archetypes import utils
+
+
+def isFactoryContained(obj):
+    """Are we inside the portal_factory?
+    """
+    if obj.isTemporary():
+        return True
+    parent = aq_parent(aq_inner(obj))
+    if parent is None:
+        # We don't have enough context to know where we are
+        return False
+    meta_type = getattr(aq_base(parent), "meta_type", "")
+    return meta_type == "TempFolder"
+
+
+# https://pypi.org/project/collective.monkeypatcher/#patching-module-level-functions 
+utils.isFactoryContained = isFactoryContained

--- a/src/senaite/core/patches/archetypes.py
+++ b/src/senaite/core/patches/archetypes.py
@@ -5,7 +5,6 @@ import re
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from bika.lims import api
-from Products.Archetypes.utils import isFactoryContained
 from Products.Archetypes.utils import shasattr
 from senaite.core import logger
 
@@ -29,20 +28,3 @@ def isTemporary(self):
     return tmp
 
 
-def indexObject(self):
-    if isFactoryContained(self):
-        return
-    parent = aq_parent(aq_inner(self))
-    # Fix indexing of temporary objects resulting in orphan entries in catalog
-    # https://github.com/senaite/senaite.core/pull/1865
-    if is_tmp_id(self.id) or is_tmp_id(parent.id):
-        logger.debug("Object %s is temporary!" % api.get_path(self))
-        return
-    catalogs = self.getCatalogs()
-    url = api.get_path(self)
-    for c in catalogs:
-        if c.id == "portal_catalog":
-            # use catalog tool queuing system
-            c.indexObject(self)
-            continue
-        c.catalog_object(self, url)

--- a/src/senaite/core/patches/archetypes.py
+++ b/src/senaite/core/patches/archetypes.py
@@ -17,7 +17,9 @@ def is_tmp_id(id):
 
 def isTemporary(self):
     parent = aq_parent(aq_inner(self))
-    # temporary IDs from `tmpID()` look like UIDs
+
+    # Fix indexing of temporary objects resulting in orphan entries in catalog
+    # https://github.com/senaite/senaite.core/pull/1865
     if is_tmp_id(self.id) or is_tmp_id(parent.id):
         logger.debug("Object %s is temporary!" % api.get_path(self))
         return True

--- a/src/senaite/core/patches/archetypes.py
+++ b/src/senaite/core/patches/archetypes.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+import re
+
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from bika.lims import api
+from Products.Archetypes.utils import shasattr
+from senaite.core import logger
+
+TMP_RX = re.compile("[a-z0-9]{32}$")
+
+
+def is_tmp_id(id):
+    return TMP_RX.match(id)
+
+
+def isTemporary(self):
+    parent = aq_parent(aq_inner(self))
+    # temporary IDs from `tmpID()` look like UIDs
+    if is_tmp_id(parent.id) or is_tmp_id(self.id):
+        logger.debug("Object %s is temporary!" % api.get_path(self))
+        return True
+    # Checks to see if we are created as temporary object by
+    # portal factory.
+    tmp = shasattr(parent, "meta_type") and parent.meta_type == "TempFolder"
+    return tmp

--- a/src/senaite/core/patches/archetypes.py
+++ b/src/senaite/core/patches/archetypes.py
@@ -18,7 +18,7 @@ def is_tmp_id(id):
 def isTemporary(self):
     parent = aq_parent(aq_inner(self))
     # temporary IDs from `tmpID()` look like UIDs
-    if is_tmp_id(parent.id) or is_tmp_id(self.id):
+    if is_tmp_id(self.id) or is_tmp_id(parent.id):
         logger.debug("Object %s is temporary!" % api.get_path(self))
         return True
     # Checks to see if we are created as temporary object by

--- a/src/senaite/core/patches/archetypes.py
+++ b/src/senaite/core/patches/archetypes.py
@@ -5,6 +5,7 @@ import re
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from bika.lims import api
+from Products.Archetypes.utils import isFactoryContained
 from Products.Archetypes.utils import shasattr
 from senaite.core import logger
 
@@ -17,7 +18,6 @@ def is_tmp_id(id):
 
 def isTemporary(self):
     parent = aq_parent(aq_inner(self))
-
     # Fix indexing of temporary objects resulting in orphan entries in catalog
     # https://github.com/senaite/senaite.core/pull/1865
     if is_tmp_id(self.id) or is_tmp_id(parent.id):
@@ -27,3 +27,22 @@ def isTemporary(self):
     # portal factory.
     tmp = shasattr(parent, "meta_type") and parent.meta_type == "TempFolder"
     return tmp
+
+
+def indexObject(self):
+    if isFactoryContained(self):
+        return
+    parent = aq_parent(aq_inner(self))
+    # Fix indexing of temporary objects resulting in orphan entries in catalog
+    # https://github.com/senaite/senaite.core/pull/1865
+    if is_tmp_id(self.id) or is_tmp_id(parent.id):
+        logger.debug("Object %s is temporary!" % api.get_path(self))
+        return
+    catalogs = self.getCatalogs()
+    url = api.get_path(self)
+    for c in catalogs:
+        if c.id == "portal_catalog":
+            # use catalog tool queuing system
+            c.indexObject(self)
+            continue
+        c.catalog_object(self, url)

--- a/src/senaite/core/patches/configure.zcml
+++ b/src/senaite/core/patches/configure.zcml
@@ -3,18 +3,14 @@
     xmlns:monkey="http://namespaces.plone.org/monkey"
     i18n_domain="senaite.core">
 
+  <!-- https://github.com/senaite/senaite.core/pull/1865
+       Please also note the patch of `isFactoryContained` in ´__init__´
+  -->
   <monkey:patch
       description="Patch `BaseObject.isTemporary` to avoid duplicate indexing in *portal catalog* during object creation"
       class="Products.Archetypes.BaseObject.BaseObject"
       original="isTemporary"
       replacement=".archetypes.isTemporary"
-      />
-
-  <monkey:patch
-      description="Patch `CatalogMultiplex.indexObject` to avoid duplicate indexing during object creation in *other catalogs*"
-      class="Products.Archetypes.CatalogMultiplex.CatalogMultiplex"
-      original="indexObject"
-      replacement=".archetypes.indexObject"
       />
 
 </configure>

--- a/src/senaite/core/patches/configure.zcml
+++ b/src/senaite/core/patches/configure.zcml
@@ -4,10 +4,17 @@
     i18n_domain="senaite.core">
 
   <monkey:patch
-      description="Pach BasObject.isTemporary to avoid duplicate indexing during object creation"
+      description="Patch `BaseObject.isTemporary` to avoid duplicate indexing in *portal catalog* during object creation"
       class="Products.Archetypes.BaseObject.BaseObject"
       original="isTemporary"
       replacement=".archetypes.isTemporary"
+      />
+
+  <monkey:patch
+      description="Patch `CatalogMultiplex.indexObject` to avoid duplicate indexing during object creation in *other catalogs*"
+      class="Products.Archetypes.CatalogMultiplex.CatalogMultiplex"
+      original="indexObject"
+      replacement=".archetypes.indexObject"
       />
 
 </configure>

--- a/src/senaite/core/patches/configure.zcml
+++ b/src/senaite/core/patches/configure.zcml
@@ -1,0 +1,13 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:monkey="http://namespaces.plone.org/monkey"
+    i18n_domain="senaite.core">
+
+  <monkey:patch
+      description="Pach BasObject.isTemporary to avoid duplicate indexing during object creation"
+      class="Products.Archetypes.BaseObject.BaseObject"
+      original="isTemporary"
+      replacement=".archetypes.isTemporary"
+      />
+
+</configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Objects are catalogued twice when using _createObjectByType and an orphan catalog entry remains.

Problem:

When using `_createObjectByType`, the object is catalogued with the temporary ID.
Example from `bika.lims.utils.analysisrequest.create_analysisrequest`:

```python
...
>>> ar = _createObjectByType("AnalysisRequest", client, tmpID())

>>> ar
<AnalysisRequest at /senaite/clients/client-785/59b6333cd94c848826aee50bea1e38e5>

>>> pc = api.get_tool("portal_catalog")

>>> path = api.get_path(ar)

>>> pc._catalog.uids[path]
155986825

>>> rid = pc._catalog.uids[path]

>>> pc._catalog.paths[rid]
'/senaite/clients/client-785/59b6333cd94c848826aee50bea1e38e5'

>>> pc._catalog.data[rid]
 ('2021-11-01T14:59:25+01:00', 'admin', '2021-11-01T14:59:25+01:00', '59b6333cd94c848826aee50bea1e38e5 01-Test', 'None', 'None', '2021-11-01T14:59:25+01:00', (), '59b6333cd94c848826aee50bea1e38e5', u'Sample', '4c51fb7ce3e84ceda778e728e368ea17', DateTime('2021/11/01 14:59:25.912069 GMT+1'), DateTime('1000/01/01 00:00:00 GMT+1'), Missing.Value, Missing.Value, DateTime('2499/12/31 00:00:00 GMT+1'), False, '59b6333cd94c848826aee50bea1e38e5', '1 KB', Missing.Value, '59b6333cd94c848826aee50bea1e38e5', True, ('admin',), '', 'AnalysisRequest', DateTime('2021/11/01 14:59:25.912308 GMT+1'), 'AnalysisRequest', 'sample_registered', Missing.Value, Missing.Value, 0, None, (), Missing.Value, Missing.Value, Missing.Value, Missing.Value, Missing.Value, Missing.Value, '', '', '01-Test', Missing.Value, Missing.Value, Missing.Value, u'')
```

After `processForm` was called, the object get the generated ID from the Senaite ID Server:

```python
>>> ar.processForm(REQUEST=request, values=values)
>>> ar
<AnalysisRequest at /senaite/clients/client-785/wmKSS-21-3812-R01>

>>> pc._catalog.uids[api.get_path(ar)]
155986826
```

NOTE:

Indexing is done in `Products.CMFCore.CatalogTool.reindexObject`, where also the `filterTemporaryItems` method is called, which checks the patched `isTemporary` method of this PR.

Therefore, this should also work for DX contents. 

```python
 def reindexObject(self, object, idxs=[], update_metadata=1, uid=None):
     # `CMFCatalogAware.reindexObject` also updates the modification date
     # of the object for the "reindex all" case.  unfortunately, some other
     # packages like `CMFEditions` check that date to see if the object was
     # modified during the request, which fails when it's only set on commit
     if not CATALOG_OPTIMIZATION_DISABLED:
         if idxs in (None, []) and \
                 hasattr(aq_base(object), 'notifyModified'):
             object.notifyModified()
         obj = filterTemporaryItems(object)
         if obj is not None:
             indexer = getQueue()
             indexer.reindex(obj, idxs, update_metadata=update_metadata)
     else:
         self._reindexObject(
             object,
             idxs=idxs,
             update_metadata=update_metadata,
             uid=uid,
         )
```

## Current behavior before PR

Orphan catalog entries exist

## Desired behavior after PR is merged

- Archetype objects created with `tmpID` are no longer indexed 
- Slightly better performance (about 0.2s).

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
