### PR TITLE
Fix error when invalidating samples with copies of analyses (1.3.x)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 - #1851 Added readonly_transactions decorator (#1732 port)
+- #1866 Fix error when invalidating samples with retests
 
 1.3.5 (2021-07-23)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 ------------------
 
 - #1851 Added readonly_transactions decorator (#1732 port)
-- #1866 Fix error when invalidating samples with retests
+- #1866 Fix error when invalidating samples with copies of analyses
 
 1.3.5 (2021-07-23)
 ------------------

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -307,7 +307,7 @@ def create_retest(ar):
             # Exclude intermediate analyses
             continue
 
-        nan = _createObjectByType("Analysis", retest, an.getKeyword())
+        nan = _createObjectByType("Analysis", retest, api.get_id(an))
 
         # Make a copy
         ignore_fieldnames = ['DataAnalysisPublished']

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -303,11 +303,20 @@ def create_retest(ar):
         # skip retests
         if an.isRetest():
             continue
-        if (api.get_workflow_status_of(an) in intermediate_states):
+
+        if api.get_workflow_status_of(an) in intermediate_states:
             # Exclude intermediate analyses
             continue
 
-        nan = _createObjectByType("Analysis", retest, api.get_id(an))
+        # Original sample might have multiple copies of same analysis
+        keyword = an.getKeyword()
+        analyses = retest.getAnalyses(full_objects=True)
+        analyses = filter(lambda ret: ret.getKeyword() == keyword, analyses)
+        if analyses:
+            keyword = '{}-{}'.format(keyword, len(analyses))
+
+        # Create the analysis retest
+        nan = _createObjectByType("Analysis", retest, keyword)
 
         # Make a copy
         ignore_fieldnames = ['DataAnalysisPublished']


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Requests makes the invalidation transition aware of samples with copies of same analysis, so no error arises when creating the sample retest on invalidation.

## Current behavior before PR

A traceback arises when invalidating a Sample with more than one copy of same analysis:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.workflow, line 143, in __call__
  Module bika.lims.browser.workflow.analysisrequest, line 156, in __call__
  Module bika.lims.browser.workflow, line 173, in do_action
  Module bika.lims.workflow, line 123, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 241, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 552, in _invokeWithNotification
  Module Products.DCWorkflow.DCWorkflow, line 282, in doActionFor
  Module Products.DCWorkflow.DCWorkflow, line 421, in _changeStateOf
  Module Products.DCWorkflow.DCWorkflow, line 531, in _executeTransition
  Module zope.event, line 31, in notify
  Module zope.component.event, line 24, in dispatch
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module zope.component.event, line 32, in objectEventNotify
  Module zope.component._api, line 136, in subscribers
  Module zope.component.registry, line 321, in subscribers
  Module zope.interface.adapter, line 585, in subscribers
  Module bika.lims.workflow, line 186, in AfterTransitionEventHandler
  Module bika.lims.workflow, line 161, in call_workflow_event
  Module bika.lims.workflow.analysisrequest.events, line 86, in after_invalidate
  Module bika.lims.utils.analysisrequest, line 311, in create_retest
  Module Products.CMFPlone.utils, line 340, in _createObjectByType
  Module Products.CMFCore.TypesTool, line 552, in _constructInstance
  Module OFS.ObjectManager, line 325, in _setObject
  Module Products.CMFCore.PortalFolder, line 310, in _checkId
  Module OFS.ObjectManager, line 116, in checkValidId
```

## Desired behavior after PR is merged

No traceback arises

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
