### PR TITLE
Fix error when invalidating sample with copies of analyses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1867 Fix error when invalidating samples with copies of analyses
 - #1861 Fix export interface lookup when name contains uppercase letters
 - #1858 Show "copy to new" transition to Clients in samples listing
 - #1858 Cannot override behavior of Methods folder when using `before_render`

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -303,11 +303,20 @@ def create_retest(ar):
         # skip retests
         if an.isRetest():
             continue
-        if (api.get_workflow_status_of(an) in intermediate_states):
+
+        if api.get_workflow_status_of(an) in intermediate_states:
             # Exclude intermediate analyses
             continue
 
-        nan = _createObjectByType("Analysis", retest, an.getKeyword())
+        # Original sample might have multiple copies of same analysis
+        keyword = an.getKeyword()
+        analyses = retest.getAnalyses(full_objects=True)
+        analyses = filter(lambda ret: ret.getKeyword() == keyword, analyses)
+        if analyses:
+            keyword = '{}-{}'.format(keyword, len(analyses))
+
+        # Create the analysis retest
+        nan = _createObjectByType("Analysis", retest, keyword)
 
         # Make a copy
         ignore_fieldnames = ['DataAnalysisPublished']

--- a/src/senaite/core/tests/doctests/WorkflowAnalysisRequestInvalidate.rst
+++ b/src/senaite/core/tests/doctests/WorkflowAnalysisRequestInvalidate.rst
@@ -14,6 +14,7 @@ Needed Imports:
     >>> from AccessControl.PermissionRole import rolesForPermissionOn
     >>> from bika.lims import api
     >>> from bika.lims.interfaces import IAnalysisRequestRetest
+    >>> from bika.lims.utils.analysis import create_analysis
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
     >>> from bika.lims.workflow import isTransitionAllowed
@@ -132,6 +133,60 @@ From the retest, I can go back to the invalidated Analysis Request:
 
     >>> retest.getInvalidated()
     <AnalysisRequest at /plone/clients/client-1/W-0001>
+
+
+Invalidate a sample with multiple copies of same analysis
+.........................................................
+
+Create and receive an Analysis Request:
+
+    >>> ar = new_ar([Cu, Fe, Au])
+    >>> ar
+    <AnalysisRequest at /plone/clients/client-1/W-0002>
+
+    >>> success = do_action_for(ar, "receive")
+    >>> api.get_workflow_status_of(ar)
+    'sample_received'
+
+Add another copy of existing analyses:
+
+    >>> analyses = ar.getAnalyses(full_objects=True)
+    >>> for analysis in analyses:
+    ...     new_id = "{}-1".format(analysis.getKeyword())
+    ...     duplicate = create_analysis(ar, analysis, id=new_id)
+
+    >>> analyses = ar.getAnalyses(full_objects=True)
+    >>> sorted(map(api.get_id, analyses))
+    ['Au', 'Au-1', 'Cu', 'Cu-1', 'Fe', 'Fe-1']
+
+Submit and verify analyses:
+
+    >>> setup.setSelfVerificationEnabled(True)
+    >>> for analysis in ar.getAnalyses(full_objects=True):
+    ...     analysis.setResult(12)
+    ...     submitted = do_action_for(analysis, "submit")
+    ...     verified = do_action_for(analysis, "verify")
+    >>> setup.setSelfVerificationEnabled(False)
+
+Invalidate the sample:
+
+    >>> success = do_action_for(ar, "invalidate")
+    >>> api.get_workflow_status_of(ar)
+    'invalid'
+
+    >>> retest = ar.getRetest()
+    >>> retest
+    <AnalysisRequest at /plone/clients/client-1/W-0002-R01>
+
+And the retest provides `IAnalysisRequestRetest` interface:
+
+    >>> IAnalysisRequestRetest.providedBy(retest)
+    True
+
+From the retest, I can go back to the invalidated Analysis Request:
+
+    >>> retest.getInvalidated()
+    <AnalysisRequest at /plone/clients/client-1/W-0002>
 
 
 Check permissions for Invalidate transition


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Requests makes the invalidation transition aware of samples with copies of same analysis, so no error arises when creating the sample retest on invalidation.

This Pull Request ports #1866 to 2.x

## Current behavior before PR

A traceback arises when invalidating a Sample with more than one copy of same analysis

## Desired behavior after PR is merged

No traceback arises and the retest of the sample is created succesfully

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
