### PR TITLE
Support HTML titles and descriptions for Service conditions

### DIFF
--- a/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -239,14 +239,14 @@
           <tr data-subfield="{{title}}">
             <td class="service-conditions-label">
               <label class="formQuestion">
-                <span class="">{{title}}</span>
+                <span class="">{{{title}}}</span>
                 {{#if required}}
                 <span class="fieldRequired"
                       i18n:attributes="title title_required;"
                       title="Required">&nbsp;</span>
                 {{/if}}
                 <span class="formHelp discreet help-block small"
-                      id="ServiceConditions-{{arnum}}_help">{{description}}</span>
+                      id="ServiceConditions-{{arnum}}_help">{{{description}}}</span>
               </label>
             </td>
             <td class="service-conditions-value">

--- a/src/bika/lims/content/analysisservice.py
+++ b/src/bika/lims/content/analysisservice.py
@@ -249,8 +249,8 @@ Conditions = RecordsField(
         "title": "service_conditions_validator",
     },
     subfield_maxlength={
-        "title": 20,
-        "description": 100,
+        "title": 50,
+        "description": 200,
     },
     subfield_vocabularies={
         "type": DisplayList((


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes possible to display html formatted Title and Description for Analysis Service conditions in Sample Add form:

![Captura de 2021-11-03 16-37-42](https://user-images.githubusercontent.com/832627/140092814-96b17673-b3ae-4068-88ca-f921beabe0c7.png)

![Captura de 2021-11-03 17-04-39](https://user-images.githubusercontent.com/832627/140097636-d3235ca9-50df-420c-ad46-d6cc1fe7541f.png)


## Current behavior before PR

Is not possible to display superindexes/subindexes in titles of service conditions

## Desired behavior after PR is merged

Is possible to display superindexes/subindexes in titles of service conditions

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
