### PR TITLE
Lookup for dependent analysis in partitions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1871 Allow calculations to rely on results of tests in subsamples (partitiones)
 - #1864 Added UID reference field/widget for Dexterity Contents
 - #1867 Fix error when invalidating samples with copies of analyses
 - #1865 Fix indexing of temporary objects resulting in orphan entries in catalog

--- a/src/bika/lims/content/abstractroutineanalysis.py
+++ b/src/bika/lims/content/abstractroutineanalysis.py
@@ -320,8 +320,13 @@ class AbstractRoutineAnalysis(AbstractAnalysis, ClientAwareMixin):
             query = dict(UID=services, getKeyword=self.getKeyword())
             services = api.search(query, "bika_setup_catalog")
             return len(services) > 0
-
-        siblings = self.getSiblings(with_retests=with_retests)
+        
+        request = self.getRequest()                                                                                                                    
+        if request.isPartition():                                                                                                                      
+            siblings = request.getParentAnalysisRequest().getAnalyses(full_objects=True)                                                               
+        else:                                                                                                                                          
+            siblings = self.getSiblings(with_retests=with_retests)                                                                                     
+                                                                                                                                                                                                                                              
         dependents = filter(lambda sib: is_dependent(sib), siblings)
         if not recursive:
             return dependents

--- a/src/senaite/core/tests/doctests/ARAnalysesFieldWithPartitions.rst
+++ b/src/senaite/core/tests/doctests/ARAnalysesFieldWithPartitions.rst
@@ -67,6 +67,11 @@ Create some basic objects for the test:
     >>> Fe = api.create(setup.bika_analysisservices, "AnalysisService", title="Iron", Keyword="Fe", Price="10", Category=category.UID())
     >>> Au = api.create(setup.bika_analysisservices, "AnalysisService", title="Gold", Keyword="Au", Price="20", Category=category.UID())
     >>> Mg = api.create(setup.bika_analysisservices, "AnalysisService", title="Magnesium", Keyword="Mg", Price="20", Category=category.UID())
+    >>> Ca = api.create(setup.bika_analysisservices, "AnalysisService", title="Calcium", Keyword="Ca", Price="20", Category=category.UID())
+    >>> THCaCO3 = api.create(setup.bika_analysisservices, "AnalysisService", title="Calcium", Keyword="THCaCO3", Price="20", Category=category.UID())
+    >>> calc = api.create(setup.bika_calculations, "Calculation", title="Total Hardness")
+    >>> calc.setFormula("[Ca] + [Mg]")
+    >>> THCaCO3.setCalculation(calc)
 
 
 Creation of a Sample with a Partition
@@ -330,3 +335,32 @@ partition, nothing will happen:
     [<Analysis at /plone/clients/client-1/W-0001/Mg>]
     >>> partition.objectValues("Analysis")
     [<Analysis at /plone/clients/client-1/W-0001-P01/Cu>, <Analysis at /plone/clients/client-1/W-0001-P01/Fe>, <Analysis at /plone/clients/client-1/W-0001-P01/Au>]
+
+
+Test calculation when dependant service assigned to a partition subsample:
+..........................................................................
+
+Create a Sample and receive:
+
+    >>> sample2 = new_sample([Ca, Mg, THCaCO3])
+
+Create a Partition containing of the Sample, containing the analysis `Ca`:
+
+    >>> ca = get_analysis_from(sample2, Ca)
+    >>> partition2 = create_partition(sample, request, [ca])
+
+Set result values to analysis (Ca, Mg)
+
+    >>> analyses = sample2.getAnalyses(full_objects=True)
+    >>> ca_analysis = filter(lambda an: an.getKeyword()=="Ca", analyses)[0]
+    >>> mg_analysis = filter(lambda an: an.getKeyword()=="Mg", analyses)[0]
+    >>> ca_analysis.setResult(10)
+    >>> mg_analysis.setResult(10)
+
+Calculate dependant result and make sure it's correct:
+    >>> th_analysis = filter(lambda an: an.getKeyword()=="THCaCO3", analyses)[0]
+    >>> th_analysis.calculateResult()
+    True
+    >>> th_analysis.getResult()
+    '20.0'
+


### PR DESCRIPTION
Let calculations work in case dependent analysis assigned to the subsample (partition)

## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1870

## Current behavior before PR
If calculation relies on the analysis assigned to subsample (partition) - it's not being calculated.

## Desired behavior after PR is merged
That makes sense for complex calculations to have access to the results of tests in subsamples.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
