### PR TITLE
Fix issues with new UID reference field for dexterity types

### DIFF
--- a/src/senaite/core/schema/uidreferencefield.py
+++ b/src/senaite/core/schema/uidreferencefield.py
@@ -6,6 +6,7 @@ from Acquisition import aq_base
 from bika.lims import api
 from persistent.dict import PersistentDict
 from persistent.list import PersistentList
+from plone.behavior.interfaces import IBehavior
 from plone.uuid.interfaces import ATTRIBUTE_NAME
 from senaite.core import logger
 from senaite.core.interfaces import IHaveUIDReferences
@@ -221,7 +222,7 @@ class UIDReferenceField(List, BaseField):
         """
 
         # Target might be a behavior instead of the object itself
-        if not api.is_object(target):
+        if IBehavior.providedBy(target):
             target = target.context
 
         # This should be actually not possible
@@ -255,7 +256,7 @@ class UIDReferenceField(List, BaseField):
         """
 
         # Target might be a behavior instead of the object itself
-        if not api.is_object(target):
+        if IBehavior.providedBy(target):
             target = target.context
 
         # Object is initializing and don't have an UID!

--- a/src/senaite/core/schema/uidreferencefield.py
+++ b/src/senaite/core/schema/uidreferencefield.py
@@ -220,6 +220,10 @@ class UIDReferenceField(List, BaseField):
         :returns: True when the backref was removed, False otherwise
         """
 
+        # Target might be a behavior instead of the object itself
+        if not api.is_object(target):
+            target = target.context
+
         # This should be actually not possible
         if self.is_initializing(target):
             raise ValueError("Objects in initialization state "
@@ -249,6 +253,10 @@ class UIDReferenceField(List, BaseField):
         :param target: the object where the backref points to (our object)
         :returns: True when the backref was written
         """
+
+        # Target might be a behavior instead of the object itself
+        if not api.is_object(target):
+            target = target.context
 
         # Object is initializing and don't have an UID!
         # -> Postpone to set back references in event handler

--- a/src/senaite/core/z3cform/widgets/uidreference.py
+++ b/src/senaite/core/z3cform/widgets/uidreference.py
@@ -92,7 +92,9 @@ class UIDReferenceWidget(TextLinesWidget):
         # we are in ++add++ form and have no context!
         # Create a temporary object to be able to access class methods
         form = self.get_form()
-        portal_type = form.portal_type
+        portal_type = getattr(form, "portal_type", None)
+        if not portal_type:
+            portal_type = api.get_portal_type(self.context)
         portal_types = api.get_tool("portal_types")
         fti = portal_types[portal_type]
         factory = getUtility(IFactory, fti.factory)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes two tracebacks that arise when using the new `UIDReferenceField` for dexterity types:

- When saving the object once a value is selected for a non-multivalued reference field
- When saving the object once a value is removed for a non-multivalued reference field

## Current behavior before PR

- When saving the object once a value is selected for a non-multivalued reference field:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module plone.autoform.view, line 42, in __call__
  Module plone.autoform.view, line 33, in render
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module 346cb68a0f0844429cacfbe2e98d87b8, line 419, in render
  Module cda2dbd14c33e8ec246aff05da1e55bc, line 1449, in render_master
  Module cda2dbd14c33e8ec246aff05da1e55bc, line 407, in render_content
  Module 346cb68a0f0844429cacfbe2e98d87b8, line 404, in __fill_content_core
  Module 346cb68a0f0844429cacfbe2e98d87b8, line 150, in render_content_core
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module zope.browserpage.simpleviewclass, line 41, in __call__
  Module zope.browserpage.viewpagetemplatefile, line 81, in __call__
  Module zope.browserpage.viewpagetemplatefile, line 49, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module 0d3a9da64b3443b8ffaff79385eb319f, line 586, in render
  Module 0d3a9da64b3443b8ffaff79385eb319f, line 456, in render_widget_wrapper
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module z3c.form.widget, line 154, in render
  Module zope.browserpage.viewpagetemplatefile, line 49, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 215, in render
  Module chameleon.template, line 192, in render
  Module ae5ff69a75b8cded49f12b36f1427872, line 152, in render
  Module zope.tales.pythonexpr, line 73, in __call__
   - __traceback_info__: (view.render_reference(uid))
  Module <string>, line 1, in <module>
  Module senaite.core.z3cform.widgets.uidreference, line 198, in render_reference
  Module senaite.core.z3cform.widgets.uidreference, line 143, in get_display_template
  Module senaite.core.z3cform.widgets.uidreference, line 111, in attr
  Module senaite.core.z3cform.widgets.uidreference, line 95, in get_context
AttributeError: 'SimpleViewClass from /home/jordi/Desenvolupament/p' object has no attribute 'portal_type'
```

- When saving the object once a value is removed for a non-multivalued reference field:

```
2021-11-10 10:33:14,222 ERROR   [Zope.SiteErrorLog:252][waitress-0] 1636536794.220.25843379875 http://localhost:9090/senaite/bika_setup/astpanels/astpanel-2/@@edit
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module plone.z3cform.layout, line 63, in __call__
  Module plone.z3cform.layout, line 47, in update
  Module plone.dexterity.browser.edit, line 58, in update
  Module plone.z3cform.fieldsets.extensible, line 65, in update
  Module plone.z3cform.patch, line 30, in GroupForm_update
  Module z3c.form.group, line 145, in update
  Module plone.app.z3cform.csrf, line 22, in execute
  Module z3c.form.action, line 98, in execute
  Module z3c.form.button, line 315, in __call__
  Module z3c.form.button, line 170, in __call__
  Module plone.dexterity.browser.edit, line 30, in handleApply
  Module z3c.form.group, line 114, in applyChanges
  Module z3c.form.form, line 51, in applyChanges
  Module senaite.core.z3cform.datamanager, line 36, in set
  Module senaite.core.schema.uidreferencefield, line 211, in set
  Module senaite.core.schema.uidreferencefield, line 225, in unlink_backref
```

## Desired behavior after PR is merged

No traceback arises and the relationship between the object and referenced object is successfully established

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
