### PR TITLE
Support for `%(context_uid)s` wildcard in calculation formulas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1874 Support for `%(context_uid)s` wildcard in calculations
 - #1871 Allow calculations to rely on results of tests in subsamples (partitiones)
 - #1864 Added UID reference field/widget for Dexterity Contents
 - #1867 Fix error when invalidating samples with copies of analyses

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -513,7 +513,9 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         if not calc:
             return False
 
-        mapping = {}
+        # Include the current context UID in the mapping, so it can be passed
+        # as a param in built-in functions, like 'get_result(%(context_uid)s)'
+        mapping = {"context_uid": '"{}"'.format(self.UID())}
 
         # Interims' priority order (from low to high):
         # Calculation < Analysis


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

With this Pull Request, the wildcard `%(context_uid)s` in calculation formulas is automatically replaced by the Unique identifier (UID) of the analysis from which the calculation has been triggered. This is specially useful for custom built-in functions where
the context is required for returning a result 

## Current behavior before PR

Cannot pass the UID of the analysis that triggered a calculation through a built-in function

## Desired behavior after PR is merged

Can pass the UID of the analysis that triggered a calculation through a built-in function

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
