### PR TITLE
Prevent max recursion depth error with copies of same analysis

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1875 Prevent max recursion depth error with copies of same analysis
 - #1874 Support for `%(context_uid)s` wildcard in calculations
 - #1871 Allow calculations to rely on results of tests in subsamples (partitiones)
 - #1864 Added UID reference field/widget for Dexterity Contents

--- a/src/bika/lims/content/abstractroutineanalysis.py
+++ b/src/bika/lims/content/abstractroutineanalysis.py
@@ -309,24 +309,31 @@ class AbstractRoutineAnalysis(AbstractAnalysis, ClientAwareMixin):
         :rtype: list of IAnalysis
         """
         def is_dependent(analysis):
+            # Never consider myself as dependent
+            if analysis.UID() == self.UID():
+                return False
+
+            # Never consider analyses from same service as dependents
+            self_service_uid = self.getRawAnalysisService()
+            if analysis.getRawAnalysisService() == self_service_uid:
+                return False
+
+            # Without calculation, no dependency relationship is possible
             calculation = analysis.getCalculation()
             if not calculation:
                 return False
 
+            # Calculation must have the service I belong to
             services = calculation.getRawDependentServices()
-            if not services:
-                return False
-
-            query = dict(UID=services, getKeyword=self.getKeyword())
-            services = api.search(query, "bika_setup_catalog")
-            return len(services) > 0
+            return self_service_uid in services
         
-        request = self.getRequest()                                                                                                                    
-        if request.isPartition():                                                                                                                      
-            siblings = request.getParentAnalysisRequest().getAnalyses(full_objects=True)                                                               
-        else:                                                                                                                                          
-            siblings = self.getSiblings(with_retests=with_retests)                                                                                     
-                                                                                                                                                                                                                                              
+        request = self.getRequest()
+        if request.isPartition():
+            parent = request.getParentAnalysisRequest()
+            siblings = parent.getAnalyses(full_objects=True)
+        else:
+            siblings = self.getSiblings(with_retests=with_retests)
+
         dependents = filter(lambda sib: is_dependent(sib), siblings)
         if not recursive:
             return dependents
@@ -356,6 +363,10 @@ class AbstractRoutineAnalysis(AbstractAnalysis, ClientAwareMixin):
         # If the calculation this analysis is bound does not have analysis
         # keywords (only interims), no need to go further
         service_uids = calc.getRawDependentServices()
+
+        # Ensure we exclude ourselves
+        service_uid = self.getRawAnalysisService()
+        service_uids = filter(lambda serv: serv != service_uid, service_uids)
         if len(service_uids) == 0:
             return []
 
@@ -372,7 +383,9 @@ class AbstractRoutineAnalysis(AbstractAnalysis, ClientAwareMixin):
                                                       recursive=True)
                     dependencies.extend(up_deps)
 
-        return dependencies
+        # Exclude analyses of same service as me to prevent max recursion depth
+        return filter(lambda dep: dep.getRawAnalysisService() != service_uid,
+                      dependencies)
 
     @security.public
     def getPrioritySortkey(self):

--- a/src/bika/lims/workflow/analysis/guards.py
+++ b/src/bika/lims/workflow/analysis/guards.py
@@ -372,7 +372,7 @@ def is_submitted_or_submittable(analysis):
     """
     if ISubmitted.providedBy(analysis):
         return True
-    if wf.isTransitionAllowed(analysis, "submit"):
+    if is_transition_allowed(analysis, "submit"):
         return True
     return False
 
@@ -382,8 +382,8 @@ def is_verified_or_verifiable(analysis):
     """
     if IVerified.providedBy(analysis):
         return True
-    if wf.isTransitionAllowed(analysis, "verify"):
+    if is_transition_allowed(analysis, "verify"):
         return True
-    if wf.isTransitionAllowed(analysis, "multi_verify"):
+    if is_transition_allowed(analysis, "multi_verify"):
         return True
     return False


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request prevents a max recursion depth error to happen when a circular dependency has been wrongly set to a calculation or when partitions of the same sample contains copies of the same analysis.

This PR also comes with a small improvement on performance

## Current behavior before PR

Max recursion depth error when a circular dependency is wrongly set in a calculation

## Desired behavior after PR is merged

No max recursion depth error

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
