### PR TITLE
Hide contents listing for dexterity containers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1876 Hide contents listing for dexterity containers
 - #1872 Upgrade/migrate catalogs and remove dependency to TextindexNG3
 - #1862 Fix failing instrument import for some QC analyes
 - #1875 Prevent max recursion depth error with copies of same analysis

--- a/src/senaite/core/browser/dexterity/configure.zcml
+++ b/src/senaite/core/browser/dexterity/configure.zcml
@@ -34,6 +34,16 @@
       layer="senaite.core.interfaces.ISenaiteCore"
       />
 
+  <!-- Default view for Dexterity Container -->
+  <browser:page
+      for="plone.dexterity.interfaces.IDexterityContainer"
+      name="view"
+      class=".views.SenaiteDefaultView"
+      template="templates/container.pt"
+      permission="zope2.View"
+      layer="senaite.core.interfaces.ISenaiteCore"
+      />
+
   <!-- Defaut edit view for Dexterity Items -->
   <browser:page
       for="plone.dexterity.interfaces.IDexterityContent"

--- a/src/senaite/core/browser/dexterity/templates/container.pt
+++ b/src/senaite/core/browser/dexterity/templates/container.pt
@@ -1,0 +1,39 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="context/@@main_template/macros/master"
+      i18n:domain="plone">
+  <body>
+
+    <metal:main fill-slot="content-core">
+      <metal:content-core define-macro="content-core">
+
+        <tal:block repeat="widget view/widgets/values|nothing">
+          <tal:block tal:condition="python:widget.__name__ not in ('IBasic.title', 'IBasic.description', 'title', 'description',)">
+            <tal:widget tal:replace="structure widget/@@ploneform-render-widget"/>
+          </tal:block>
+        </tal:block>
+
+        <fieldset tal:repeat="group view/groups|nothing"
+                  tal:attributes="id python:''.join((group.prefix, 'groups.', group.__name__)).replace('.', '-')">
+          <legend tal:content="group/label" />
+          <tal:block tal:repeat="widget group/widgets/values">
+            <tal:widget tal:replace="structure widget/@@ploneform-render-widget"/>
+          </tal:block>
+        </fieldset>
+
+        <!-- hide contents listing -->
+        <fieldset id="folder-listing" tal:condition="python:False">
+          <legend i18n:translate="" i18n:domain="plone">Contents</legend>
+          <tal:block define="view nocall:context/folder_listing; listing_macro view/macros/listing|view/index/macros/listing">
+            <metal:use_macro use-macro="listing_macro" />
+          </tal:block>
+        </fieldset>
+
+      </metal:content-core>
+    </metal:main>
+
+  </body>
+</html>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR customizes the default DX container view

## Current behavior before PR

Contents listing displayed at the bottom of the view


<img width="470" alt="In House Qualification — SENAITE LIMS 2021-11-15 22-28-48" src="https://user-images.githubusercontent.com/713193/141856318-06715d3c-6584-43a5-ba2d-8bee1fe951c3.png">

## Desired behavior after PR is merged

No contents listing displayed at the bottom of the view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
