### PR TITLE
Fix missing catalog mappings after migration

### DIFF
--- a/src/bika/lims/setuphandlers.py
+++ b/src/bika/lims/setuphandlers.py
@@ -106,7 +106,6 @@ def setup_handler(context):
     hide_navbar_items(portal)
     reindex_content_structure(portal)
     setup_groups(portal)
-    setup_catalog_mappings(portal)
     add_dexterity_portal_items(portal)
     add_dexterity_setup_items(portal)
     # XXX P5: Fix HTML filtering

--- a/src/senaite/core/upgrade/v02_00_001.py
+++ b/src/senaite/core/upgrade/v02_00_001.py
@@ -28,6 +28,7 @@ from senaite.core.api.catalog import get_index
 from senaite.core.api.catalog import get_indexes
 from senaite.core.config import PROJECTNAME as product
 from senaite.core.setuphandlers import setup_auditlog_catalog_mappings
+from senaite.core.setuphandlers import setup_catalog_mappings
 from senaite.core.setuphandlers import setup_core_catalogs
 from senaite.core.upgrade import upgradestep
 from senaite.core.upgrade.utils import UpgradeUtils
@@ -92,7 +93,8 @@ def migrate_catalogs(portal):
     logger.info("Migrate catalogs to Senaite...")
     # 1. Install new core catalogs
     setup_core_catalogs(portal)
-    # 2. Setup auditog catalog
+    # 2. Setup catalog mappings
+    setup_catalog_mappings(portal)
     setup_auditlog_catalog_mappings(portal)
 
     # 3. Migrate old -> new indexes


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes missing catalog mappings in `archetype_tool` after the migration step for 2.0.1 was run

## Current behavior before PR

E.g. `AnalysisService` type was not mapped to `senaite_catalog_setup`

## Desired behavior after PR is merged

Catalog mappings named in `senaite.core.setuphandlers.CATALOG_MAPPINGS` are set correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
