### PR TITLE
Fix two dimension results parser for Analyses containing a dash in the name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1878 Fix two dimension results parser for Analyses containing a dash in the name
 - #1876 Hide contents listing for dexterity containers
 - #1872 Upgrade/migrate catalogs and remove dependency to TextindexNG3
 - #1862 Fix failing instrument import for some QC analyes

--- a/src/senaite/core/exportimport/instruments/generic/two_dimension.py
+++ b/src/senaite/core/exportimport/instruments/generic/two_dimension.py
@@ -219,7 +219,8 @@ class TwoDimensionCSVParser(InstrumentCSVResultsFileParser):
             result = self.get_result(column_name, result, line)
             quantitation[quantitation['DefaultResult']] = result
 
-            kw = re.sub(r"\W", "", self._keywords[i])
+            # remove all non alphanumeric words, except `-+.`
+            kw = re.sub(r"[^a-zA-Z0-9_\-\+\.]", "", self._keywords[i])
             if not is_keyword(kw):
                 new_kw = find_kw(quantitation['AR'], kw)
                 if new_kw:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue with the two dimensional results importer with analysis keywords containing a dash.

## Current behavior before PR

Analysis keywords containing a minus are parsed without the minus

## Desired behavior after PR is merged

Analysis keywords containing a minus are parsed correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
