### PR TITLE
Not all objects are reindexed on catalogs setup

### DIFF
--- a/src/senaite/core/setuphandlers.py
+++ b/src/senaite/core/setuphandlers.py
@@ -221,6 +221,9 @@ def setup_core_catalogs(portal, catalog_classes=None, reindex=True):
     if catalog_classes is None:
         catalog_classes = CATALOGS
 
+    # contains tuples of (catalog, index) pairs
+    to_reindex = []
+
     for cls in catalog_classes:
         module = _resolveDottedName(cls.__module__)
 
@@ -235,9 +238,6 @@ def setup_core_catalogs(portal, catalog_classes=None, reindex=True):
             catalog = cls()
             catalog._setId(catalog_id)
             portal._setObject(catalog_id, catalog)
-
-        # contains tuples of (catalog, index) pairs
-        to_reindex = []
 
         # catalog indexes
         for idx_id, idx_attr, idx_type in catalog_indexes:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When the catalogs are setup (either in setuphandlers) or by upgrade steps, only the objects with newly added indexes or
columns from the last catalog that has been processed are reindexed. The reindexing of objects from previous catalogs does not take place

## Current behavior before PR

Only objects from last processed catalog are reindexed

## Desired behavior after PR is merged

All necessary objects are reindexed regardless the catalog

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
