### PR TITLE
Fix catalog query in analysis category modified handler

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1882 Fix catalog query in analysis category modified handler
 - #1878 Fix two dimension results parser for Analyses containing a dash in the name
 - #1876 Hide contents listing for dexterity containers
 - #1872 Upgrade/migrate catalogs and remove dependency to TextindexNG3

--- a/src/bika/lims/subscribers/objectmodified.py
+++ b/src/bika/lims/subscribers/objectmodified.py
@@ -61,17 +61,18 @@ def ObjectModifiedEventHandler(obj, event):
     elif obj.portal_type == 'AnalysisCategory':
         # If the analysis category's Title is modified, we must
         # re-index all services and analyses that refer to this title.
+        uid = obj.UID()
 
         # re-index all analysis services
-        query = dict(getCategoryUID=obj.UID())
+        query = dict(category_uid=uid, portal_type="AnalysisService")
         brains = api.search(query, SETUP_CATALOG)
         for brain in brains:
             obj = api.get_object(brain)
-            obj.reindexObject(idxs=['getCategoryTitle'])
+            obj.reindexObject()
 
         # re-index analyses
-        query = dict(getCategoryUID=obj.UID())
+        query = dict(getCategoryUID=uid)
         brains = api.search(query, ANALYSIS_CATALOG)
         for brain in brains:
             obj = api.get_object(brain)
-            obj.reindexObject(idxs=['getCategoryTitle'])
+            obj.reindexObject()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the object modified handler for Analysis Categories.

## Current behavior before PR

Catalog index `getCategoryUID` is used, which was renamed to `category_uid` here:
https://github.com/senaite/senaite.core/commit/e1228c1e38867d0fe6e62b4010208fc6fd63fbb9

This led to long creation time for new category objects

## Desired behavior after PR is merged

Catalog query uses index `category_uid`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
