### PR TITLE
Fix possible XSS in remarks field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1883 Fix possible XSS in remarks field
 - #1878 Fix two dimension results parser for Analyses containing a dash in the name
 - #1876 Hide contents listing for dexterity containers
 - #1872 Upgrade/migrate catalogs and remove dependency to TextindexNG3

--- a/src/bika/lims/browser/fields/remarksfield.py
+++ b/src/bika/lims/browser/fields/remarksfield.py
@@ -171,6 +171,11 @@ class RemarksField(ObjectField):
         else:
             raise ValueError("Type not supported: {}".format(type(value)))
 
+        # filter nasty html in the complete history
+        for record in history:
+            content = record.get("content")
+            record["content"] = self.to_safe_html(content)
+
         # Store the data
         ObjectField.set(self, instance, history)
 
@@ -182,6 +187,11 @@ class RemarksField(ObjectField):
 
         # notify new remarks for e.g. later email notification etc.
         event.notify(RemarksAddedEvent(instance, history))
+
+    def to_safe_html(self, html):
+        pt = api.get_tool("portal_transforms")
+        stream = pt.convertTo("text/x-html-safe", html)
+        return stream.getData()
 
     def get(self, instance, **kwargs):
         """Returns a RemarksHistory object

--- a/src/bika/lims/browser/fields/remarksfield.py
+++ b/src/bika/lims/browser/fields/remarksfield.py
@@ -189,6 +189,7 @@ class RemarksField(ObjectField):
         event.notify(RemarksAddedEvent(instance, history))
 
     def to_safe_html(self, html):
+        # see: Products.PortalTransforms.tests.test_xss
         pt = api.get_tool("portal_transforms")
         stream = pt.convertTo("text/x-html-safe", html)
         return stream.getData()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR filters nasty tags in remarks field

## Current behavior before PR

JavaScript injection possible

## Desired behavior after PR is merged

No nasty tags possible in remarks field

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
