### PR TITLE
Fix APIError when a retest analysis source is removed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #1885 Allow to re-add cancelled/rejected/retracted analyses (#1777 port)
+- #1885 Fix APIError when a retest analysis source is removed (#1777 port)
 - #1868 Fix indexing of temporary objects resulting in orphan entries in catalog
 - #1866 Fix error when invalidating samples with copies of analyses
 - #1851 Added readonly_transactions decorator (#1732 port)

--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -1181,4 +1181,8 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             return None
         if len(back_refs) > 1:
             logger.warn("Analysis {} with multiple retests".format(self.id))
-        return api.get_object_by_uid(back_refs[0])
+        retest_uid = back_refs[0]
+        retest = api.get_object_by_uid(retest_uid, default=None)
+        if retest is None:
+            logger.error("Retest with UID {} not found".format(retest_uid))
+        return retest


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #1777 to v1.3.x

## Current behavior before PR

- Retest analysis still had a reference to the original analysis
- APIError occurred when analyses were selected afterwards
- It was not possible to re-add an analysis that was previously retracted or rejected (checkbox was disabled)

## Desired behavior after PR is merged

- Retest reference is unlinked when the original analysis is removed
- Missing retest UID fails gracefully
- It is possible to re-add an analysis that was previously retracted or rejected (checkbox was disabled)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
