### PR TITLE
Use the current timestamp instead of the client name for report archive download

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1886 Use the current timestamp instead of the client name for report archive download
 - #1883 Fix possible XSS in remarks field
 - #1882 Fix catalog query in analysis category modified handler
 - #1878 Fix two dimension results parser for Analyses containing a dash in the name

--- a/src/bika/lims/browser/workflow/client.py
+++ b/src/bika/lims/browser/workflow/client.py
@@ -27,6 +27,7 @@ from bika.lims import api
 from bika.lims.browser.workflow import RequestContextAware
 from bika.lims.interfaces import IWorkflowActionUIDsAdapter
 from bika.lims.workflow import doActionFor
+from DateTime import DateTime
 from ZODB.POSException import POSKeyError
 from zope.interface import implements
 
@@ -60,7 +61,8 @@ class WorkflowActionDownloadReportsAdapter(RequestContextAware):
             return self.download(pdf.data, filename, type="application/pdf")
 
         with self.create_archive(pdfs) as archive:
-            archive_name = "Reports-{}.zip".format(self.context.getName())
+            timestamp = DateTime().strftime("%Y%m%d_%H%M%S")
+            archive_name = "Reports-{}.zip".format(timestamp)
             data = archive.file.read()
             return self.download(data, archive_name, type="application/zip")
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR makes the download workflow action compatible with other contexts

## Current behavior before PR

The client name is used to generate the archive name, e.g. `Reports-Happy Hills-zip`

## Desired behavior after PR is merged

The current time stamp is used to generate the archive name, e.g. `Reports-20211125_203611.zip`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
