### PR TITLE
Removed unused field PasswordLifeTime

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1893 Removed unused field PasswordLifeTime
 - #1892 Drop jQuery Datepicker for HTML5 native date fields
 - #1886 Use the current timestamp instead of the client name for report archive download
 - #1883 Fix possible XSS in remarks field

--- a/src/bika/lims/content/bikasetup.py
+++ b/src/bika/lims/content/bikasetup.py
@@ -152,16 +152,6 @@ STICKER_AUTO_OPTIONS = DisplayList((
 
 schema = BikaFolderSchema.copy() + Schema((
     IntegerField(
-        'PasswordLifetime',
-        schemata="Security",
-        required=1,
-        default=0,
-        widget=IntegerWidget(
-            label=_("Password lifetime"),
-            description=_("The number of days before a password expires. 0 disables password expiry"),
-        )
-    ),
-    IntegerField(
         'AutoLogOff',
         schemata="Security",
         required=1,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the schema field `PasswordLifeTime`, because there is no functionality behind.

## Current behavior before PR

Password Lifetime can be set in setup but has no further functionality

## Desired behavior after PR is merged

Password Lifetime field disabled


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
