### PR TITLE
Allow past and future dates for expected sampling date

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1894 Allow past and future dates for expected sampling date
 - #1893 Removed unused field PasswordLifeTime
 - #1892 Drop jQuery Datepicker for HTML5 native date fields
 - #1886 Use the current timestamp instead of the client name for report archive download

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -512,7 +512,6 @@ schema = BikaSchema.copy() + Schema((
             description=_("The date when the sample will be taken"),
             size=20,
             show_time=True,
-            datepicker_nopast=1,
             render_own_label=True,
             visible={
                 'add': 'edit',


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the constraint that only future dates are allowed for the expected sampling date
and is for compatibility with the changes introduced in https://github.com/senaite/senaite.core/pull/1892

This is needed, because otherwise the sample can not be saved after the
expected sampling date have been passed.

<img width="631" alt="CL-BL-21-0185 — SENAITE LIMS 2021-12-09 10-04-43" src="https://user-images.githubusercontent.com/713193/145366330-3cb404f3-4dd2-43d3-8a6f-56e1fe4b6c24.png">

## Current behavior before PR

Sample data can not be saved after the expected sampling date have been passed
 
## Desired behavior after PR is merged

Sample data can be saved after the expected sampling date have been passed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
