### PR TITLE
Disable native form validation in header table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1895 Disable native form validation in header table
 - #1893 Removed unused field PasswordLifeTime
 - #1892 Drop jQuery Datepicker for HTML5 native date fields
 - #1886 Use the current timestamp instead of the client name for report archive download

--- a/src/bika/lims/browser/templates/header_table.pt
+++ b/src/bika/lims/browser/templates/header_table.pt
@@ -20,7 +20,16 @@
                 sublists python:dummy[1];
                 errors python:request.get('errors',{})"
     tal:condition="sublists">
-    <form method="post" name="header_form">
+    <tal:comment condition="python:False">
+      <!--
+        Note: the `novalidate` attribute is needed to avoid browser validation
+        when e.g. the "expected sampling date" has passed and another value
+        wants to be changed.
+
+        https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Constraint_validation
+      -->
+    </tal:comment>
+    <form novalidate method="post" name="header_form">
       <input type="hidden" name="header_table_submitted" value="1" />
 
       <table class="header_table table table-condensed table-bordered table-sm">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR supersedes https://github.com/senaite/senaite.core/pull/1894

## Current behavior before PR

Native form validation disallowed form submission if e.g. the "expected sampling date" has been passed.

## Desired behavior after PR is merged

No native form validation in sample header table

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
