### PR TITLE
Support date and number fields copy in sample add form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1897 Support date and number fields copy in sample add form
 - #1896 Custom date and time widget
 - #1895 Disable native form validation in header table
 - #1893 Removed unused field PasswordLifeTime

--- a/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
@@ -1163,6 +1163,25 @@
           return $(_el).val(value);
         });
       });
+      $td1.find("input[type=number]").each(function(index, el) {
+        var j, results1;
+        console.debug("-> Copy text field");
+        $el = $(el);
+        value = $el.val();
+        return $.each((function() {
+          results1 = [];
+          for (var j = 1; 1 <= ar_count ? j <= ar_count : j >= ar_count; 1 <= ar_count ? j++ : j--){ results1.push(j); }
+          return results1;
+        }).apply(this), function(arnum) {
+          var _el, _td;
+          if (!(arnum > 0)) {
+            return;
+          }
+          _td = $tr.find("td[arnum=" + arnum + "]");
+          _el = $(_td).find("input[type=number]")[index];
+          return $(_el).val(value);
+        });
+      });
       $td1.find("textarea").each(function(index, el) {
         var j, results1;
         console.debug("-> Copy textarea field");
@@ -1201,7 +1220,7 @@
           return $(_el).prop("checked", checked);
         });
       });
-      $td1.find("input[type='date'],input[type='datetime-local']").each(function(index, el) {
+      $td1.find("input[type='date']").each(function(index, el) {
         var j, results1;
         console.debug("-> Copy date field");
         $el = $(el);
@@ -1216,7 +1235,45 @@
             return;
           }
           _td = $tr.find("td[arnum=" + arnum + "]");
-          _el = $(_td).find("input[type='date'],input[type='datetime-local']")[index];
+          _el = $(_td).find("input[type='date']")[index];
+          return $(_el).val(value);
+        });
+      });
+      $td1.find("input[type='time']").each(function(index, el) {
+        var j, results1;
+        console.debug("-> Copy time field");
+        $el = $(el);
+        value = $el.val();
+        return $.each((function() {
+          results1 = [];
+          for (var j = 1; 1 <= ar_count ? j <= ar_count : j >= ar_count; 1 <= ar_count ? j++ : j--){ results1.push(j); }
+          return results1;
+        }).apply(this), function(arnum) {
+          var _el, _td;
+          if (!(arnum > 0)) {
+            return;
+          }
+          _td = $tr.find("td[arnum=" + arnum + "]");
+          _el = $(_td).find("input[type='time']")[index];
+          return $(_el).val(value);
+        });
+      });
+      $td1.find("input[type='hidden']").each(function(index, el) {
+        var j, results1;
+        console.debug("-> Copy hidden field");
+        $el = $(el);
+        value = $el.val();
+        return $.each((function() {
+          results1 = [];
+          for (var j = 1; 1 <= ar_count ? j <= ar_count : j >= ar_count; 1 <= ar_count ? j++ : j--){ results1.push(j); }
+          return results1;
+        }).apply(this), function(arnum) {
+          var _el, _td;
+          if (!(arnum > 0)) {
+            return;
+          }
+          _td = $tr.find("td[arnum=" + arnum + "]");
+          _el = $(_td).find("input[type='hidden']")[index];
           return $(_el).val(value);
         });
       });

--- a/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -1194,6 +1194,18 @@ class window.AnalysisRequestAdd
         _el = $(_td).find("input[type=text]")[index]
         $(_el).val value
 
+    # Copy <input type="number"> fields
+    $td1.find("input[type=number]").each (index, el) ->
+      console.debug "-> Copy text field"
+      $el = $(el)
+      value = $el.val()
+      $.each [1..ar_count], (arnum) ->
+        # skip the first column
+        return unless arnum > 0
+        _td = $tr.find("td[arnum=#{arnum}]")
+        _el = $(_td).find("input[type=number]")[index]
+        $(_el).val value
+
     # Copy <textarea> fields
     $td1.find("textarea").each (index, el) ->
       console.debug "-> Copy textarea field"
@@ -1219,7 +1231,7 @@ class window.AnalysisRequestAdd
         $(_el).prop "checked", checked
 
     # Copy <input type="date"> fields
-    $td1.find("input[type='date'],input[type='datetime-local']").each (index, el) ->
+    $td1.find("input[type='date']").each (index, el) ->
       console.debug "-> Copy date field"
       $el = $(el)
       value = $el.val()
@@ -1227,7 +1239,31 @@ class window.AnalysisRequestAdd
         # skip the first column
         return unless arnum > 0
         _td = $tr.find("td[arnum=#{arnum}]")
-        _el = $(_td).find("input[type='date'],input[type='datetime-local']")[index]
+        _el = $(_td).find("input[type='date']")[index]
+        $(_el).val value
+
+    # Copy <input type="time"> fields
+    $td1.find("input[type='time']").each (index, el) ->
+      console.debug "-> Copy time field"
+      $el = $(el)
+      value = $el.val()
+      $.each [1..ar_count], (arnum) ->
+        # skip the first column
+        return unless arnum > 0
+        _td = $tr.find("td[arnum=#{arnum}]")
+        _el = $(_td).find("input[type='time']")[index]
+        $(_el).val value
+
+    # Copy <input type="hidden"> fields
+    $td1.find("input[type='hidden']").each (index, el) ->
+      console.debug "-> Copy hidden field"
+      $el = $(el)
+      value = $el.val()
+      $.each [1..ar_count], (arnum) ->
+        # skip the first column
+        return unless arnum > 0
+        _td = $tr.find("td[arnum=#{arnum}]")
+        _el = $(_td).find("input[type='hidden']")[index]
         $(_el).val value
 
     # trigger form:changed event


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR enables to copy the new date and time fields from  #1896 to be copied
It also enables to copy number fields

## Current behavior before PR

date/time/hidden/number fields can not be copied in sample add form

## Desired behavior after PR is merged

date/time/hidden/number fields can be copied in sample add form

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
