### PR TITLE
Fix archetype tool catalog mappings

### DIFF
--- a/src/senaite/core/upgrade/v02_00_001.py
+++ b/src/senaite/core/upgrade/v02_00_001.py
@@ -72,6 +72,7 @@ def upgrade(tool):
     # https://github.com/senaite/senaite.core/pull/1872
     migrate_catalogs(portal)
 
+    # https://github.com/senaite/senaite.core/pull/1898
     fix_catalog_mappings(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))

--- a/src/senaite/core/upgrade/v02_00_001.py
+++ b/src/senaite/core/upgrade/v02_00_001.py
@@ -72,6 +72,8 @@ def upgrade(tool):
     # https://github.com/senaite/senaite.core/pull/1872
     migrate_catalogs(portal)
 
+    fix_catalog_mappings(portal)
+
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
 
@@ -157,3 +159,21 @@ def migrate_catalogs(portal):
         portal.manage_delObjects([src_cat_id])
 
     logger.info("Migrate catalogs to Senaite [DONE]")
+
+
+def fix_catalog_mappings(portal):
+    """Removes invalid catalog mappings
+    """
+    logger.info("Fix Archetype Tool catalog mappings ...")
+
+    # Remove invalid mappings in archetype tool
+    at = api.get_tool("archetype_tool")
+    catalog_map = getattr(at, "catalog_map", {})
+    to_remove = dict(MIGRATE_CATALOGS).keys()
+    for portal_type, catalogs in catalog_map.items():
+        new_catalogs = filter(lambda cid: cid not in to_remove, catalogs)
+        at.setCatalogsByType(portal_type, new_catalogs)
+        logger.info("Updated catalog mapping for '%s' to %r" % (
+            portal_type, new_catalogs))
+
+    logger.info("Fix Archetype Tool catalog mappings [DONE]")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is an addition for https://github.com/senaite/senaite.core/pull/1872 and fixes the catalog mappings of the `archetype_tool`.

## Current behavior before PR

Invalid catalogs mapped for some types, e.g. `auditlog_catalog`.
This resulted in a log line like `"No tool 'auditlog_catalog'"`

## Desired behavior after PR is merged

Invalid catalogs removed from archetype tool

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
