### PR TITLE
Fix snapshot listing fails on orphan catalog entries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1900 Fix snapshot listing fails on orphan catalog entries
 - #1897 Support date and number fields copy in sample add form
 - #1896 Custom date and time widget
 - #1895 Disable native form validation in header table

--- a/src/bika/lims/api/snapshot.py
+++ b/src/bika/lims/api/snapshot.py
@@ -118,8 +118,6 @@ def get_version(obj):
     :returns: Current version of the object or -1
     """
     count = get_snapshot_count(obj)
-    if count == 0:
-        return -1
     return count - 1
 
 
@@ -441,6 +439,8 @@ def _get_title_or_id_from_uid(uid):
     try:
         obj = api.get_object_by_uid(uid)
     except api.APIError:
+        obj = None
+    if not obj:
         return "<Deleted {}>".format(uid)
     title_or_id = api.get_title(obj) or api.get_id(obj)
     return title_or_id


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR includes a minor change in the snapshot API

## Current behavior before PR

Listing fails on orphan catalog entries

## Desired behavior after PR is merged

Orphan catalog entries are displayed as "Deleted"

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
