### PR TITLE
Ensure `get_tool` returns a tool when a name is set as the default param

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1901 Ensure `get_tool` returns a tool when a name is set as the default param
 - #1900 Fix snapshot listing fails on orphan catalog entries
 - #1897 Support date and number fields copy in sample add form
 - #1896 Custom date and time widget

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -191,6 +191,8 @@ def get_tool(name, context=None, default=_marker):
         return ploneapi.portal.get_tool(name)
     except InvalidParameterError:
         if default is not _marker:
+            if isinstance(default, six.string_types):
+                return get_tool(default)
             return default
         fail("No tool named '%s' found." % name)
 

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -99,6 +99,21 @@ This error can also be used for custom methods with the `fail` function::
     [...]
     APIError: This failed badly
 
+When default param is specified, the system returns the tool if the parameter
+is a string:
+
+    >>> api.get_tool("NotExistingTool", default="senaite_catalog_setup")
+    <SetupCatalog at /plone/senaite_catalog_setup>
+
+but returns the default value otherwise:
+
+    >>> api.get_tool("NotExistingTool", default=None) is None
+    True
+
+    >>> catalog_setup = api.get_tool("senaite_catalog_setup")
+    >>> api.get_tool("NotExistingTool", default=catalog_setup)
+    <SetupCatalog at /plone/senaite_catalog_setup>
+
 
 Getting an Object
 .................


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the `api.get_tool` consistent, so if a tool name is passed-in with the parameter `default`, the system returns the corresponding tool. This was causing the following traceback when trying to install a fresh instance after updating `senaite.app.supermodel` with https://github.com/senaite/senaite.app.supermodel/pull/11 :

```
2021-12-23 15:02:39,400 ERROR   [txn.140194282682112:556][waitress-2] Failed to abort resource manager: <Products.CMFCore.indexing.QueueTM object at 0x7f8188296db8>
Traceback (most recent call last):
  File "/home/senaite/buildout-cache/eggs/transaction-3.0.1-py2.7.egg/transaction/_transaction.py", line 551, in abort
    rm.abort(self)
  File "/home/senaite/buildout-cache/eggs/Products.CMFCore-2.5.4-py2.7.egg/Products/CMFCore/indexing.py", line 328, in tpc_abort
    self.queue.abort()
  File "/home/senaite/buildout-cache/eggs/Products.CMFCore-2.5.4-py2.7.egg/Products/CMFCore/indexing.py", line 244, in abort
    for name, util in sm.getUtilitiesFor(IIndexQueueProcessor):
  File "/home/senaite/buildout-cache/eggs/zope.interface-5.4.0-py2.7-linux-x86_64.egg/zope/interface/registry.py", line 296, in getUtilitiesFor
    for name, utility in self.utilities.lookupAll((), interface):
AttributeError: 'PersistentAdapterRegistry' object has no attribute 'lookupAll'
2021-12-23 15:02:39,401 ERROR   [txn.140194282682112:556][waitress-2] Failed to abort resource manager: <Products.CMFCore.indexing.QueueTM object at 0x7f8188296668>
Traceback (most recent call last):
  File "/home/senaite/buildout-cache/eggs/transaction-3.0.1-py2.7.egg/transaction/_transaction.py", line 551, in abort
    rm.abort(self)
  File "/home/senaite/buildout-cache/eggs/Products.CMFCore-2.5.4-py2.7.egg/Products/CMFCore/indexing.py", line 328, in tpc_abort
    self.queue.abort()
  File "/home/senaite/buildout-cache/eggs/Products.CMFCore-2.5.4-py2.7.egg/Products/CMFCore/indexing.py", line 244, in abort
    for name, util in sm.getUtilitiesFor(IIndexQueueProcessor):
  File "/home/senaite/buildout-cache/eggs/zope.interface-5.4.0-py2.7-linux-x86_64.egg/zope/interface/registry.py", line 296, in getUtilitiesFor
    for name, utility in self.utilities.lookupAll((), interface):
AttributeError: 'PersistentAdapterRegistry' object has no attribute 'lookupAll'
2021-12-23 15:02:39,401 ERROR   [waitress:358][waitress-2] Exception while serving /@@senaite-addsite
Traceback (most recent call last):
  File "/home/senaite/buildout-cache/eggs/waitress-1.4.4-py2.7.egg/waitress/channel.py", line 350, in service
    task.service()
  File "/home/senaite/buildout-cache/eggs/waitress-1.4.4-py2.7.egg/waitress/task.py", line 171, in service
    self.execute()
  File "/home/senaite/buildout-cache/eggs/waitress-1.4.4-py2.7.egg/waitress/task.py", line 441, in execute
    app_iter = self.channel.server.application(environ, start_response)
  File "/home/senaite/buildout-cache/eggs/Paste-3.5.0-py2.7.egg/paste/translogger.py", line 69, in __call__
    return self.application(environ, replacement_start_response)
  File "/home/senaite/buildout-cache/eggs/Zope-4.6.3-py2.7.egg/ZPublisher/httpexceptions.py", line 30, in __call__
    return self.application(environ, start_response)
  File "/home/senaite/buildout-cache/eggs/Zope-4.6.3-py2.7.egg/ZPublisher/WSGIPublisher.py", line 376, in publish_module
    environ['REMOTE_USER'] = user.getUserName()
  File "/home/senaite/Python-2.7/lib/python2.7/contextlib.py", line 35, in __exit__
    self.gen.throw(type, value, traceback)
  File "/home/senaite/buildout-cache/eggs/Zope-4.6.3-py2.7.egg/ZPublisher/WSGIPublisher.py", line 215, in transaction_pubevents
    tm.abort()
  File "/home/senaite/buildout-cache/eggs/transaction-3.0.1-py2.7.egg/transaction/_manager.py", line 260, in abort
    return self.manager.abort()
  File "/home/senaite/buildout-cache/eggs/transaction-3.0.1-py2.7.egg/transaction/_manager.py", line 139, in abort
    return self.get().abort()
  File "/home/senaite/buildout-cache/eggs/transaction-3.0.1-py2.7.egg/transaction/_transaction.py", line 570, in abort
    reraise(t, v, tb)
  File "/home/senaite/buildout-cache/eggs/transaction-3.0.1-py2.7.egg/transaction/_transaction.py", line 551, in abort
    rm.abort(self)
  File "/home/senaite/buildout-cache/eggs/Products.CMFCore-2.5.4-py2.7.egg/Products/CMFCore/indexing.py", line 328, in tpc_abort
    self.queue.abort()
  File "/home/senaite/buildout-cache/eggs/Products.CMFCore-2.5.4-py2.7.egg/Products/CMFCore/indexing.py", line 244, in abort
    for name, util in sm.getUtilitiesFor(IIndexQueueProcessor):
  File "/home/senaite/buildout-cache/eggs/zope.interface-5.4.0-py2.7-linux-x86_64.egg/zope/interface/registry.py", line 296, in getUtilitiesFor
    for name, utility in self.utilities.lookupAll((), interface):
AttributeError: 'PersistentAdapterRegistry' object has no attribute 'lookupAll'
```

## Current behavior before PR

- Cannot install a fresh instance of SENAITE LIMS with latest version of `senaite.app.supermodel`
- `api.get_tool` function is consistent

## Desired behavior after PR is merged

- Can install a fresh instance of SENAITE LIMS with latest version of `senaite.app.supermodel`
- `api.get_tool` function is consistent

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
