### PR TITLE
Added date and time field/widget for Dexterity contents

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -21,18 +21,15 @@ filter:
 
 build:
   environment:
-    python: 2.7.9
+    python: 2.7.18
 
   dependencies:
     before:
-      - pip install -v pip==19.3.1
-      - pip install -v setuptools==44.1.1
-      - pip install -v zc.buildout==2.13.3
       - pip install virtualenv
       - pip install -r requirements.txt
-      - /home/scrutinizer/.pyenv/versions/2.7.9/bin/buildout -v
-      - mv -v /home/scrutinizer/build/develop-eggs/* /home/scrutinizer/.pyenv/versions/2.7.9/lib/python2.7/site-packages/
-      - mv -v /home/scrutinizer/build/eggs/*.egg /home/scrutinizer/.pyenv/versions/2.7.9/lib/python2.7/site-packages/
+      - /home/scrutinizer/.pyenv/versions/2.7.18/bin/buildout -v
+      - mv -v /home/scrutinizer/build/develop-eggs/* /home/scrutinizer/.pyenv/versions/2.7.18/lib/python2.7/site-packages/
+      - mv -v /home/scrutinizer/build/eggs/*.egg /home/scrutinizer/.pyenv/versions/2.7.18/lib/python2.7/site-packages/
 
   nodes:
     analysis:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- #1903 Added date and time field/widget for Dexterity contents
 - #1900 Fix snapshot listing fails on orphan catalog entries
 - #1897 Support date and number fields copy in sample add form
 - #1896 Custom date and time widget

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -1,12 +1,22 @@
 # -*- coding: utf-8 -*-
 
 import os
+from datetime import date
 from datetime import datetime
 from time import tzname
 
 import pytz
 from bika.lims import logger
 from DateTime import DateTime
+
+
+def is_d(dt):
+    """Check if the date is a Python `date` object
+
+    :param dt: date to check
+    :returns: True when the date is a Python `date`
+    """
+    return isinstance(dt, date)
 
 
 def is_dt(dt):
@@ -62,29 +72,34 @@ def is_timezone_aware(dt):
     return not is_timezone_naive(dt)
 
 
-def dt_to_DT(dt):
-    """Convert datetime to DateTime
+def to_DT(dt):
+    """Convert to DateTime
 
-    :param dt: datetime object
+    :param dt: DateTime/datetime/date
     :returns: DateTime object
     """
     if is_DT(dt):
         return dt
     elif is_dt(dt):
-        return DateTime(dt)
+        return DateTime(dt.isoformat())
+    elif is_d(dt):
+        dt = datetime(dt.year, dt.month, dt.day)
+        return DateTime(dt.isoformat())
     raise TypeError("Expected datetime, got '%r'" % type(dt))
 
 
-def DT_to_dt(dt):
-    """Convert DateTime to datetime
+def to_dt(dt):
+    """Convert to datetime
 
-    :param dt: DateTime object
+    :param dt: DateTime/datetime/date
     :returns: datetime object
     """
     if is_DT(dt):
         return dt.asdatetime()
     elif is_dt(dt):
         return dt
+    elif is_d(dt):
+        return datetime(dt.year, dt.month, dt.day)
     raise TypeError("Expected DateTime, got '%r'" % type(dt))
 
 
@@ -142,4 +157,5 @@ def to_zone(dt, timezone):
             return dt.astimezone(zone)
         return zone.localize(dt)
     if is_DT(dt):
+        # NOTE: This shifts the time according to the TZ offset
         return dt.toZone(timezone)

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+
+import os
+from datetime import datetime
+from time import tzname
+
+import pytz
+from bika.lims import logger
+from DateTime import DateTime
+
+
+def is_dt(dt):
+    """Check if the date is a Python `datetime` object
+
+    :param dt: date to check
+    :returns: True when the date is a Python `datetime`
+    """
+    return isinstance(dt, datetime)
+
+
+def is_DT(dt):
+    """Check if the date is a Zope `DateTime` object
+
+    :param dt: object to check
+    :returns: True when the object is a Zope `DateTime`
+    """
+    return isinstance(dt, DateTime)
+
+
+def is_date(dt):
+    """Check if the date is a datetime or DateTime object
+
+    :param dt: date to check
+    :returns: True when the object is either a datetime or DateTime
+    """
+    if is_dt(dt):
+        return True
+    if is_DT(dt):
+        return True
+    return False
+
+
+def is_timezone_naive(dt):
+    """Check if the date is timezone naive
+
+    :param dt: date to check
+    :returns: True when the date has no timezone
+    """
+    if is_DT(dt):
+        return dt.timezoneNaive()
+    elif is_dt(dt):
+        return dt.tzinfo is None
+    raise TypeError("Expected a date, got '%r'" % type(dt))
+
+
+def is_timezone_aware(dt):
+    """Check if the date is timezone aware
+
+    :param dt: date to check
+    :returns: True when the date has a timezone
+    """
+    return not is_timezone_naive(dt)
+
+
+def dt_to_DT(dt):
+    """Convert datetime to DateTime
+
+    :param dt: datetime object
+    :returns: DateTime object
+    """
+    if is_DT(dt):
+        return dt
+    elif is_dt(dt):
+        return DateTime(dt)
+    raise TypeError("Expected datetime, got '%r'" % type(dt))
+
+
+def DT_to_dt(dt):
+    """Convert DateTime to datetime
+
+    :param dt: DateTime object
+    :returns: datetime object
+    """
+    if is_DT(dt):
+        return dt.asdatetime()
+    elif is_dt(dt):
+        return dt
+    raise TypeError("Expected DateTime, got '%r'" % type(dt))
+
+
+def is_valid_timezone(timezone):
+    """Checks if the timezone is a valid pytz/Olson name
+
+    :param timezone: pytz/Olson timezone name
+    :returns: True when the timezone is a valid zone
+    """
+    try:
+        pytz.timezone(timezone)
+        return True
+    except pytz.UnknownTimeZoneError:
+        return False
+
+
+def get_os_timezone():
+    """Return the default timezone of the system
+
+    :returns: OS timezone or UTC
+    """
+    fallback = "UTC"
+    timezone = None
+    if "TZ" in os.environ.keys():
+        # Timezone from OS env var
+        timezone = os.environ["TZ"]
+    if not timezone:
+        # Timezone from python time
+        zones = tzname
+        if zones and len(zones) > 0:
+            timezone = zones[0]
+        else:
+            # Default fallback = UTC
+            logger.warn(
+                "Operating system\'s timezone cannot be found. "
+                "Falling back to UTC.")
+            timezone = fallback
+    if not is_valid_timezone(timezone):
+        return fallback
+    return timezone
+
+
+def to_zone(dt, timezone):
+    """Convert date to timezone
+
+    Adds the timezone for timezone naive datetimes
+
+    :param dt: date object
+    :param timezone: timezone
+    :returns: date converted to timezone
+    """
+    if is_dt(dt):
+        zone = pytz.timezone(timezone)
+        if is_timezone_aware(dt):
+            return dt.astimezone(zone)
+        return zone.localize(dt)
+    if is_DT(dt):
+        return dt.toZone(timezone)

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -184,3 +184,13 @@ def from_timestamp(timestamp):
     """
 
     return datetime.utcfromtimestamp(timestamp)
+
+
+def to_iso_format(dt):
+    """Convert to ISO format
+    """
+    if is_dt(dt):
+        return dt.isoformat()
+    elif is_DT(dt):
+        return dt.ISO()
+    return None

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import time
 from datetime import date
 from datetime import datetime
 from time import tzname
@@ -159,3 +160,17 @@ def to_zone(dt, timezone):
     if is_DT(dt):
         # NOTE: This shifts the time according to the TZ offset
         return dt.toZone(timezone)
+
+
+def to_timestamp(dt):
+    """Generate a Portable Operating System Interface (POSIX) timestamp
+
+    :param dt: date object
+    :returns: timestamp in seconds
+    """
+    timestamp = 0
+    if is_DT(dt):
+        timestamp = dt.timeTime()
+    elif is_dt(dt):
+        timestamp = time.mktime(dt.timetuple())
+    return timestamp

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -4,7 +4,6 @@ import os
 import time
 from datetime import date
 from datetime import datetime
-from time import tzname
 
 import pytz
 from bika.lims import logger
@@ -133,7 +132,7 @@ def get_os_timezone():
         timezone = os.environ["TZ"]
     if not timezone:
         # Timezone from python time
-        zones = tzname
+        zones = time.tzname
         if zones and len(zones) > 0:
             timezone = zones[0]
         else:

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -17,7 +17,7 @@ def is_d(dt):
     :param dt: date to check
     :returns: True when the date is a Python `date`
     """
-    return isinstance(dt, date)
+    return type(dt) is date
 
 
 def is_dt(dt):
@@ -26,7 +26,7 @@ def is_dt(dt):
     :param dt: date to check
     :returns: True when the date is a Python `datetime`
     """
-    return isinstance(dt, datetime)
+    return type(dt) is datetime
 
 
 def is_DT(dt):
@@ -35,7 +35,7 @@ def is_DT(dt):
     :param dt: object to check
     :returns: True when the object is a Zope `DateTime`
     """
-    return isinstance(dt, DateTime)
+    return type(dt) is DateTime
 
 
 def is_date(dt):
@@ -44,6 +44,8 @@ def is_date(dt):
     :param dt: date to check
     :returns: True when the object is either a datetime or DateTime
     """
+    if is_d(dt):
+        return True
     if is_dt(dt):
         return True
     if is_DT(dt):
@@ -57,7 +59,9 @@ def is_timezone_naive(dt):
     :param dt: date to check
     :returns: True when the date has no timezone
     """
-    if is_DT(dt):
+    if is_d(dt):
+        return True
+    elif is_DT(dt):
         return dt.timezoneNaive()
     elif is_dt(dt):
         return dt.tzinfo is None

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -174,3 +174,13 @@ def to_timestamp(dt):
     elif is_dt(dt):
         timestamp = time.mktime(dt.timetuple())
     return timestamp
+
+
+def from_timestamp(timestamp):
+    """Generate a datetime object from a POSIX timestamp
+
+    :param timestamp: POSIX timestamp
+    :returns: datetime object
+    """
+
+    return datetime.utcfromtimestamp(timestamp)

--- a/src/senaite/core/schema/__init__.py
+++ b/src/senaite/core/schema/__init__.py
@@ -2,7 +2,7 @@
 
 from zope.interface import classImplementsFirst
 
-from .datetime import DatetimeField
+from .datetimefield import DatetimeField
 from .fields import IntField
 from .interfaces import IDatetimeField
 from .interfaces import IIntField

--- a/src/senaite/core/schema/__init__.py
+++ b/src/senaite/core/schema/__init__.py
@@ -2,10 +2,13 @@
 
 from zope.interface import classImplementsFirst
 
+from .datetime import DatetimeField
 from .fields import IntField
+from .interfaces import IDatetimeField
 from .interfaces import IIntField
 from .uidreferencefield import IUIDReferenceField
 from .uidreferencefield import UIDReferenceField
 
 classImplementsFirst(IntField, IIntField)
 classImplementsFirst(UIDReferenceField, IUIDReferenceField)
+classImplementsFirst(DatetimeField, IDatetimeField)

--- a/src/senaite/core/schema/datetime.py
+++ b/src/senaite/core/schema/datetime.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+from senaite.core.schema.fields import BaseField
+from senaite.core.schema.interfaces import IDatetimeField
+from zope.interface import implementer
+from zope.schema import Datetime
+
+
+@implementer(IDatetimeField)
+class DatetimeField(Datetime, BaseField):
+    """A field that handles date and time
+    """
+    def _validate(self, value):
+        """Validator when called from form submission
+        """
+        super(DatetimeField, self)._validate(value)

--- a/src/senaite/core/schema/datetime.txt
+++ b/src/senaite/core/schema/datetime.txt
@@ -1,0 +1,70 @@
+Datetime field
+==============
+
+The datetime field stores Python datetime values.
+
+
+Running this test from the buildout directory:
+
+    bin/test test_schema_fields -t datetime
+
+
+Hints
+
+- z3c.form.converter.txt (Date Data Converter)
+
+
+Test preparation
+----------------
+
+    >>> import sys
+    >>> from bika.lims import api
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_NAME
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+
+Helper functions:
+
+    >>> def commit():
+    ...    import transaction; transaction.commit()
+     
+
+Grant required privileges:
+
+    >>> setRoles(portal, TEST_USER_ID, ["Manager",])
+    >>> commit()
+
+
+Using the field
+---------------
+
+The field can be used much like any other field:
+
+    >>> from zope.interface import Interface, implementer
+    >>> from senaite.core.schema import DatetimeField
+
+    >>> class IContent(Interface):
+    ...     date = DatetimeField(title=u"Date")
+
+    >>> field = IContent['date']
+    >>> field
+    <senaite.core.schema.datetime.DatetimeField object at ...>
+
+    >>> from persistent import Persistent
+    >>> @implementer(IContent)
+    ... class Content(Persistent):
+    ...     def __init__(self, date=None):
+    ...         self.date = date
+
+
+    >>> from datetime import datetime
+    >>> date = datetime.strptime("2030-12-24", "%Y-%m-%d")
+    >>> content = Content()
+
+
+Set a value through the field:
+
+    >>> field.set(date, content)
+    >>> field.get(content)
+    datetime.datetime(2030, 12, 24, 0, 0)

--- a/src/senaite/core/schema/datetimefield.py
+++ b/src/senaite/core/schema/datetimefield.py
@@ -2,6 +2,8 @@
 
 from datetime import datetime
 
+import pytz
+from plone.app.event.base import default_timezone as current_timezone
 from senaite.core.schema.fields import BaseField
 from senaite.core.schema.interfaces import IDatetimeField
 from zope.interface import implementer
@@ -21,6 +23,22 @@ class DatetimeField(Datetime, BaseField):
         :type value: datetime
         """
         super(DatetimeField, self).set(object, value)
+
+    def get(self, object):
+        """Get the current date
+
+        :param object: the instance of the field
+        :returns: datetime or None
+        """
+        value = super(DatetimeField, self).get(object)
+        if not isinstance(value, datetime):
+            return None
+        # append current timezone if timezone naive
+        if value.tzinfo is None:
+            tz = current_timezone()
+            tzinfo = pytz.timezone(tz)
+            value = tzinfo.localize(value)
+        return value
 
     def _validate(self, value):
         """Validator when called from form submission

--- a/src/senaite/core/schema/datetimefield.py
+++ b/src/senaite/core/schema/datetimefield.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from datetime import datetime
+
 from senaite.core.schema.fields import BaseField
 from senaite.core.schema.interfaces import IDatetimeField
 from zope.interface import implementer
@@ -10,6 +12,18 @@ from zope.schema import Datetime
 class DatetimeField(Datetime, BaseField):
     """A field that handles date and time
     """
+
+    def set(self, object, value):
+        """Set UID reference
+
+        :param object: the instance of the field
+        :param value: datetime value
+        :type value: datetime
+        """
+        if not isinstance(value, datetime):
+            raise TypeError("Expected datetime, got %r" % type(value))
+        super(DatetimeField, self).set(object, value)
+
     def _validate(self, value):
         """Validator when called from form submission
         """

--- a/src/senaite/core/schema/datetimefield.py
+++ b/src/senaite/core/schema/datetimefield.py
@@ -20,8 +20,6 @@ class DatetimeField(Datetime, BaseField):
         :param value: datetime value
         :type value: datetime
         """
-        if not isinstance(value, datetime):
-            raise TypeError("Expected datetime, got %r" % type(value))
         super(DatetimeField, self).set(object, value)
 
     def _validate(self, value):

--- a/src/senaite/core/schema/datetimefield.txt
+++ b/src/senaite/core/schema/datetimefield.txt
@@ -69,11 +69,3 @@ Set a value through the field:
     >>> field.set(content, date)
     >>> field.get(content)
     datetime.datetime(2030, 12, 24, 0, 0)
-
-Setting a wrong type raises an error:
-
-    >>> field.set(content, datestring)
-    Traceback (most recent call last):
-    ...
-    TypeError: Expected datetime, got <type 'str'>
-

--- a/src/senaite/core/schema/datetimefield.txt
+++ b/src/senaite/core/schema/datetimefield.txt
@@ -6,7 +6,7 @@ The datetime field stores Python datetime values.
 
 Running this test from the buildout directory:
 
-    bin/test test_schema_fields -t datetime
+    bin/test test_schema_fields -t datetimefield
 
 
 Hints
@@ -49,7 +49,7 @@ The field can be used much like any other field:
 
     >>> field = IContent['date']
     >>> field
-    <senaite.core.schema.datetime.DatetimeField object at ...>
+    <senaite.core.schema.datetimefield.DatetimeField object at ...>
 
     >>> from persistent import Persistent
     >>> @implementer(IContent)
@@ -59,12 +59,21 @@ The field can be used much like any other field:
 
 
     >>> from datetime import datetime
-    >>> date = datetime.strptime("2030-12-24", "%Y-%m-%d")
+    >>> datestring = "2030-12-24"
+    >>> date = datetime.strptime(datestring, "%Y-%m-%d")
     >>> content = Content()
 
 
 Set a value through the field:
 
-    >>> field.set(date, content)
+    >>> field.set(content, date)
     >>> field.get(content)
     datetime.datetime(2030, 12, 24, 0, 0)
+
+Setting a wrong type raises an error:
+
+    >>> field.set(content, datestring)
+    Traceback (most recent call last):
+    ...
+    TypeError: Expected datetime, got <type 'str'>
+

--- a/src/senaite/core/schema/datetimefield.txt
+++ b/src/senaite/core/schema/datetimefield.txt
@@ -35,6 +35,11 @@ Grant required privileges:
     >>> setRoles(portal, TEST_USER_ID, ["Manager",])
     >>> commit()
 
+Test fixture:
+
+    >>> import os
+    >>> os.environ["TZ"] = "CET"
+
 
 Using the field
 ---------------
@@ -68,4 +73,4 @@ Set a value through the field:
 
     >>> field.set(content, date)
     >>> field.get(content)
-    datetime.datetime(2030, 12, 24, 0, 0)
+    datetime.datetime(2030, 12, 24, 0, 0, tzinfo=<DstTzInfo 'CET' CET+1:00:00 STD>)

--- a/src/senaite/core/schema/fields.py
+++ b/src/senaite/core/schema/fields.py
@@ -41,11 +41,15 @@ class BaseField(Field):
 
     def get(self, object):
         """Custom field getter
+
+        see zope.schem._bootstrapfields.Field
         """
         return super(BaseField, self).get(object)
 
     def query(self, object, default=None):
         """Custom field query
+
+        see zope.schem._bootstrapfields.Field
         """
         return super(BaseField, self).query(object, default=default)
 
@@ -54,6 +58,8 @@ class BaseField(Field):
 
         This place would theoretically allow to set custom "change" events or
         check permissions to write the field.
+
+        see zope.schem._bootstrapfields.Field
         """
         super(BaseField, self).set(object, value)
 

--- a/src/senaite/core/schema/interfaces.py
+++ b/src/senaite/core/schema/interfaces.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from collective.z3cform.datagridfield.interfaces import IRow
+from zope.schema.interfaces import IDatetime
 from zope.schema.interfaces import IField
 from zope.schema.interfaces import IInt
 from zope.schema.interfaces import IList
@@ -28,4 +29,9 @@ class IDataGridRow(IRow):
 
 class IUIDReferenceField(IList):
     """Senaite UID reference field
+    """
+
+
+class IDatetimeField(IDatetime):
+    """Senaite Datetime field
     """

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -212,3 +212,18 @@ Convert `DateTime` objects to a timezone:
 
     >>> dtime.to_zone(DT_utc, "CET")
     DateTime('1970/01/01 02:00:00 GMT+1')
+
+
+Make a POSIX timestamp
+......................
+
+
+    >>> DATE = "1970-01-01 01:00"
+    >>> DT = DateTime(DATE)
+    >>> dt = datetime.strptime(DATE, DATEFORMAT)
+
+    >>> dtime.to_timestamp(dt)
+    3600.0
+
+    >>> dtime.to_timestamp(DT)
+    3600.0

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -1,0 +1,162 @@
+SENAITE datetime API
+--------------------
+
+The datetime API provides fuctions to handle Python `datetime` and Zope's `DateTime` objects.
+
+Running this test from the buildout directory::
+
+    bin/test test_textual_doctests -t API_datetime
+
+
+Test Setup
+..........
+
+Imports:
+
+    >>> from senaite.core.api import dtime
+
+
+Setup the test user
+...................
+
+We need certain permissions to create and access objects used in this test,
+so here we will assume the role of Lab Manager.
+
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import setRoles
+    >>> setRoles(portal, TEST_USER_ID, ['Manager',])
+
+
+Check if an object is a Python `datetime`
+.........................................
+
+    >>> from datetime import datetime
+
+    >>> dtime.is_dt(datetime.now())
+    True
+
+    >>> dtime.is_dt("2021-12-24")
+    False
+
+
+Check if an object is a ZOPE `DateTime`
+.......................................
+
+    >>> from DateTime import DateTime
+
+    >>> dtime.is_DT(DateTime())
+    True
+
+    >>> dtime.is_DT("2021-12-24")
+    False
+
+
+Check if an object represents a date
+....................................
+
+    >>> dtime.is_date(datetime.now())
+    True
+
+    >>> dtime.is_date(DateTime())
+    True
+
+    >>> dtime.is_date("2021-12-24")
+    False
+
+    >>> dtime.is_date(object())
+    False
+
+
+Check if a datetime object is TZ naive
+......................................
+
+    >>> dtime.is_timezone_naive(datetime.now())
+    True
+
+    >>> dtime.is_timezone_naive(DateTime())
+    False
+
+
+Check if a datetime object is TZ aware
+......................................
+
+    >>> dtime.is_timezone_aware(datetime.now())
+    False
+
+    >>> dtime.is_timezone_aware(DateTime())
+    True
+
+
+Convert datetime to DateTime
+............................
+
+    >>> dt = dtime.dt_to_DT(datetime.now())
+    >>> isinstance(dt, DateTime)
+    True
+
+
+Convert DateTime to datetime
+............................
+
+    >>> dt = dtime.DT_to_dt(DateTime())
+    >>> isinstance(dt, datetime)
+    True
+
+
+Check if timezone is valid
+..........................
+
+    >>> dtime.is_valid_timezone("Europe/Berlin")
+    True
+
+    >>> dtime.is_valid_timezone("UTC")
+    True
+
+    >>> dtime.is_valid_timezone("CET")
+    True
+
+    >>> dtime.is_valid_timezone("CEST")
+    False
+
+
+Get the default timezone from the system
+........................................
+
+    >>> import os
+    >>> import time
+
+    >>> os.environ["TZ"] = "Europe/Berlin"
+    >>> dtime.get_os_timezone()
+    'Europe/Berlin'
+
+    >>> os.environ["TZ"] = ""
+    >>> time.tzname = ("CET", "CEST")
+    >>> dtime.get_os_timezone()
+    'CET'
+
+
+Convert date to timezone
+........................
+
+    >>> DATE = "1970-01-01 01:00"
+    >>> FORMAT = "%Y-%m-%d %H:%M"
+
+Convert `datetime` objects to a timezone:
+
+    >>> dt = datetime.strptime(DATE, FORMAT)
+    >>> dt_utc = dtime.to_zone(dt, "UTC")
+    >>> dt_utc
+    datetime.datetime(1970, 1, 1, 1, 0, tzinfo=<UTC>)
+
+    >>> dtime.to_zone(dt_utc, "CET")
+    datetime.datetime(1970, 1, 1, 2, 0, tzinfo=<DstTzInfo 'CET' CET+1:00:00 STD>)
+
+Convert `DateTime` objects to a timezone:
+
+    >>> DT = DateTime(DATE)
+    >>> DT_utc = dtime.to_zone(DT, "UTC")
+    >>> DT_utc
+    DateTime('1970/01/01 01:00:00 UTC')
+
+    >>> dtime.to_zone(DT_utc, "CET")
+    DateTime('1970/01/01 02:00:00 GMT+1')

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -213,7 +213,7 @@ Get the default timezone from the system
     'Europe/Berlin'
 
     >>> os.environ["TZ"] = ""
-    >>> time.tzname = ("CET", "CEST")
+    >>> dtime.time.tzname = ("CET", "CEST")
     >>> dtime.get_os_timezone()
     'CET'
 

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -19,6 +19,11 @@ Define some variables:
 
     >>> DATEFORMAT = "%Y-%m-%d %H:%M"
 
+Test fixture:
+
+    >>> import os
+    >>> os.environ["TZ"] = "CET"
+
 
 Setup the test user
 ...................

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -227,3 +227,6 @@ Make a POSIX timestamp
 
     >>> dtime.to_timestamp(DT)
     3600.0
+
+    >>> dtime.from_timestamp(dtime.to_timestamp(dt)) == dt
+    True

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -15,6 +15,10 @@ Imports:
 
     >>> from senaite.core.api import dtime
 
+Define some variables:
+
+    >>> DATEFORMAT = "%Y-%m-%d %H:%M"
+
 
 Setup the test user
 ...................
@@ -87,20 +91,69 @@ Check if a datetime object is TZ aware
     True
 
 
-Convert datetime to DateTime
-............................
+Convert to DateTime
+...................
 
-    >>> dt = dtime.dt_to_DT(datetime.now())
-    >>> isinstance(dt, DateTime)
-    True
+    >>> DATE = "2021-12-24 12:00"
+
+Timezone naive datetimes are converterd to `GMT+0`:
+
+    >>> dt = datetime.strptime(DATE, DATEFORMAT)
+    >>> dt
+    datetime.datetime(2021, 12, 24, 12, 0)
+
+    >>> dtime.to_DT(dt)
+    DateTime('2021/12/24 12:00:00 GMT+0')
+
+    >>> DATE = "2021-08-01 12:00"
+
+    >>> dt = datetime.strptime(DATE, DATEFORMAT)
+    >>> dt
+    datetime.datetime(2021, 8, 1, 12, 0)
+
+    >>> dtime.to_DT(dt)
+    DateTime('2021/08/01 12:00:00 GMT+0')
+
+Timezone aware datetimes are converterd to `GMT+<tzoffset>`
+
+    >>> local_dt = dtime.to_zone(dt, "CET")
+    >>> local_dt
+    datetime.datetime(2021, 8, 1, 12, 0, tzinfo=<DstTzInfo 'CET' CEST+2:00:00 DST>)
+
+    >>> dtime.to_DT(local_dt)
+    DateTime('2021/08/01 12:00:00 GMT+2')
 
 
-Convert DateTime to datetime
-............................
+Convert to datetime
+...................
 
-    >>> dt = dtime.DT_to_dt(DateTime())
+    >>> dt = dtime.to_dt(DateTime())
     >>> isinstance(dt, datetime)
     True
+
+Timezone naive `DateTime` is converted w/o timezone:
+
+    >>> dt = DateTime(DATE)
+    >>> dt
+    DateTime('2021/08/01 12:00:00 GMT+0')
+
+    >>> dtime.is_timezone_naive(dt)
+    True
+
+    >>> dtime.to_dt(dt)
+    datetime.datetime(2021, 8, 1, 12, 0)
+
+Timezone aware `DateTime` is converted with timezone.
+
+    >>> dt = dtime.to_zone(dt, "CET")
+    >>> dtime.is_timezone_naive(dt)
+    False
+
+    >>> dt
+    DateTime('2021/08/01 13:00:00 GMT+1')
+
+    >>> dtime.to_dt(dt)
+    datetime.datetime(2021, 8, 1, 13, 0, tzinfo=<StaticTzInfo 'GMT+1'>)
 
 
 Check if timezone is valid
@@ -139,11 +192,10 @@ Convert date to timezone
 ........................
 
     >>> DATE = "1970-01-01 01:00"
-    >>> FORMAT = "%Y-%m-%d %H:%M"
 
 Convert `datetime` objects to a timezone:
 
-    >>> dt = datetime.strptime(DATE, FORMAT)
+    >>> dt = datetime.strptime(DATE, DATEFORMAT)
     >>> dt_utc = dtime.to_zone(dt, "UTC")
     >>> dt_utc
     datetime.datetime(1970, 1, 1, 1, 0, tzinfo=<UTC>)

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -43,6 +43,18 @@ Check if an object is a Python `datetime`
     False
 
 
+Check if an object is a Python `date`
+.....................................
+
+    >>> from datetime import date
+
+    >>> dtime.is_d(date.today())
+    True
+
+    >>> dtime.is_d("2022-01-01")
+    False
+
+
 Check if an object is a ZOPE `DateTime`
 .......................................
 
@@ -57,6 +69,9 @@ Check if an object is a ZOPE `DateTime`
 
 Check if an object represents a date
 ....................................
+
+    >>> dtime.is_date(date.today())
+    True
 
     >>> dtime.is_date(datetime.now())
     True
@@ -74,6 +89,9 @@ Check if an object represents a date
 Check if a datetime object is TZ naive
 ......................................
 
+    >>> dtime.is_timezone_naive(date.today())
+    True
+
     >>> dtime.is_timezone_naive(datetime.now())
     True
 
@@ -83,6 +101,9 @@ Check if a datetime object is TZ naive
 
 Check if a datetime object is TZ aware
 ......................................
+
+    >>> dtime.is_timezone_aware(date.today())
+    False
 
     >>> dtime.is_timezone_aware(datetime.now())
     False
@@ -113,6 +134,10 @@ Timezone naive datetimes are converterd to `GMT+0`:
 
     >>> dtime.to_DT(dt)
     DateTime('2021/08/01 12:00:00 GMT+0')
+
+    >>> dtime.to_DT(date.fromtimestamp(0))
+    DateTime('1970/01/01 00:00:00 GMT+0')
+
 
 Timezone aware datetimes are converterd to `GMT+<tzoffset>`
 
@@ -246,5 +271,3 @@ Convert to ISO format
 
     >>> dtime.to_iso_format(dtime.to_DT(dt_local))
     '2021-08-01T12:00:00+02:00'
-
-

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -230,3 +230,21 @@ Make a POSIX timestamp
 
     >>> dtime.from_timestamp(dtime.to_timestamp(dt)) == dt
     True
+
+
+Convert to ISO format
+.....................
+
+    >>> DATE = "2021-08-01 12:00"
+    >>> dt = datetime.strptime(DATE, DATEFORMAT)
+    >>> dt_local = dtime.to_zone(dt, "CET")
+    >>> dt_local
+    datetime.datetime(2021, 8, 1, 12, 0, tzinfo=<DstTzInfo 'CET' CEST+2:00:00 DST>)
+
+    >>> dtime.to_iso_format(dt_local)
+    '2021-08-01T12:00:00+02:00'
+
+    >>> dtime.to_iso_format(dtime.to_DT(dt_local))
+    '2021-08-01T12:00:00+02:00'
+
+

--- a/src/senaite/core/z3cform/interfaces.py
+++ b/src/senaite/core/z3cform/interfaces.py
@@ -23,3 +23,8 @@ class IDataGridWidget(IDataGridField):
 class IDataGridRowWidget(IObjectWidget):
     """Datagrid row widget (table rows)
     """
+
+
+class IDatetimeWidget(IObjectWidget):
+    """Date and time widget
+    """

--- a/src/senaite/core/z3cform/static/datetimewidget.js
+++ b/src/senaite/core/z3cform/static/datetimewidget.js
@@ -1,0 +1,85 @@
+document.addEventListener("DOMContentLoaded", () => {
+
+  class DateTimeWidget {
+
+    constructor() {
+      let datefields = document.querySelectorAll("input[type='date']");
+      let timefields = document.querySelectorAll("input[type='time']");
+
+      // bind event handlers
+      this.update_date = this.update_date.bind(this);
+      this.on_change = this.on_change.bind(this);
+
+      // bind datefields
+      datefields.forEach((el, idx) => {
+        el.addEventListener("change", this.on_change);
+      });
+
+      // bind timefields
+      timefields.forEach((el, idx) => {
+        el.addEventListener("change", this.on_change);
+      });
+    }
+
+    /**
+     * set an input field value (if the field exists)
+     * @param {object} field input field
+     * @param {string} value the value the should get set on the field
+     */
+    set_field(field, value) {
+      if (!field) return;
+      field.value = value;
+    }
+
+    /**
+      * generate a full date w/o TZ from the date and time inputs
+      * @param {object} date the date input field
+      * @param {object} time the time input field
+      * @param {object} hidden hidden field that contains the full date for from submission
+    */
+    update_date(date, time, input) {
+      // console.debug("DateTimeWidget::update_date");
+      let ds = date ? date.value : "";
+      let ts = time ? time.value : "";
+
+      // set the values of the fields
+      this.set_field(date, ds);
+      this.set_field(time, ts);
+
+      if (ds && ts) {
+        // set date and time
+        this.set_field(input, `${ds} ${ts}`);
+      } else if (ds) {
+        // set date only
+        this.set_field(input, `${ds}`);
+      } else {
+        this.set_field(input, "");
+      }
+    }
+
+    /**
+     * event handler for `change` event
+     *
+     * collect the date/time and hidden input of the field
+     * and set the full date for form submission.
+     *
+     * Fires when the date/time changes
+     * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date
+     */
+    on_change(event) {
+      // console.debug("DateTimeWidget::on_change");
+      let el = event.currentTarget;
+      let target = el.getAttribute("target");
+
+      // for simplicity, we just fetch all the required elements here
+      let date = el.parentElement.querySelector("input[type='date']");
+      let time = el.parentElement.querySelector("input[type='time']");
+      let input = document.querySelector(`input[name='${target}']`);
+
+      // always write the full date to the hidden field
+      this.update_date(date, time, input);
+    }
+  }
+
+  new DateTimeWidget();
+});

--- a/src/senaite/core/z3cform/widgets/configure.zcml
+++ b/src/senaite/core/z3cform/widgets/configure.zcml
@@ -3,8 +3,9 @@
     xmlns:z3c="http://namespaces.zope.org/z3c"
     i18n_domain="senaite.core">
 
-  <include file="number.zcml" />
   <include file="datagrid.zcml" />
+  <include file="datetimewidget.zcml" />
+  <include file="number.zcml" />
   <include file="uidreference.zcml" />
 
 </configure>

--- a/src/senaite/core/z3cform/widgets/datetimewidget.py
+++ b/src/senaite/core/z3cform/widgets/datetimewidget.py
@@ -73,7 +73,7 @@ class DatetimeDataConverter(BaseDataConverter):
         :returns: Datetime in format `Y-m-d H:M`
         :rtype: string
         """
-        if value is self.field.missing_value:
+        if value is None:
             return u""
         if getattr(self.widget, "show_time", None) is False:
             return DATE_ONLY.format(value=value)
@@ -88,7 +88,7 @@ class DatetimeDataConverter(BaseDataConverter):
         :returns: `datetime.datetime` object.
         :rtype: datetime
         """
-        default = self.field.missing_value
+        default = getattr(self.field, "missing_value", None)
         timezone = self.widget.default_timezone or dtime.get_os_timezone()
         return to_datetime(value, timezone=timezone, default=default)
 
@@ -153,15 +153,11 @@ class DatetimeWidget(HTMLInputWidget, Widget):
     def to_localized_time(self, time, long_format=None, time_only=None):
         """Convert time to localized time
         """
-        if dtime.is_dt(time):
-            # NOTE: ts.ulocalized_time converts the value into a DateTime
-            #       object, which always uses the current timezone without
-            #       daylight savings, which might result in an offset.
-            time = time.isoformat()
+        dt = self.to_datetime(time)
         ts = api.get_tool("translation_service")
         long_format = True if self.show_time else False
         return ts.ulocalized_time(
-            time, long_format, time_only, self.context, domain="senaite.core")
+            dt, long_format, time_only, self.context, domain="senaite.core")
 
     def get_display_value(self):
         """Returns the localized date value
@@ -180,7 +176,7 @@ class DatetimeWidget(HTMLInputWidget, Widget):
         :type value: string or datetime object
         :returns: datetime object
         """
-        default = self.field.missing_value
+        default = getattr(self.field, "missing_value", None)
         timezone = self.default_timezone
         return to_datetime(value, timezone=timezone, default=default)
 

--- a/src/senaite/core/z3cform/widgets/datetimewidget.py
+++ b/src/senaite/core/z3cform/widgets/datetimewidget.py
@@ -117,6 +117,8 @@ def to_datetime(value, timezone=None, default=None):
 
     ret = datetime(*map(int, value))
     if timezone:
+        if callable(timezone):
+            timezone = timezone()
         ret = dtime.to_zone(ret, timezone)
     return ret
 

--- a/src/senaite/core/z3cform/widgets/datetimewidget.py
+++ b/src/senaite/core/z3cform/widgets/datetimewidget.py
@@ -1,0 +1,209 @@
+# -*- coding: utf-8 -*-
+
+from datetime import datetime
+
+import pytz
+from bika.lims import api
+from plone.app.z3cform.converters import DatetimeWidgetConverter
+from Products.CMFPlone.utils import safe_callable
+from senaite.core.interfaces import ISenaiteFormLayer
+from senaite.core.schema.interfaces import IDatetimeField
+from senaite.core.z3cform.interfaces import IDatetimeWidget
+from z3c.form import interfaces
+from z3c.form.browser import widget
+from z3c.form.browser.widget import HTMLInputWidget
+from z3c.form.interfaces import IFieldWidget
+from z3c.form.widget import FieldWidget
+from z3c.form.widget import Widget
+from zope.component import adapter
+from zope.interface import implementer
+
+DATE_ONLY = ("{value.year:}-{value.month:02}-{value.day:02}")
+
+DATE_AND_TIME = ("{value.year:}-{value.month:02}-{value.day:02} "
+                 "{value.hour:02}:{value.minute:02}")
+
+
+@adapter(IDatetimeField, interfaces.IWidget)
+class DatetimeDataConverter(DatetimeWidgetConverter):
+    """Converts the raw field data for widget/field usage
+    """
+    def toWidgetValue(self, value):
+        """Converts from field value to widget.
+
+        called by `z3c.form.widget.update`
+
+        Bases:
+            `plone.app.z3cform.converters.DatetimeWidgetConverter`
+            `z3c.form.converter.DatetimeDataConverter`
+
+        :param value: Field value.
+        :type value: datetime
+
+        :returns: Datetime in format `Y-m-d H:M`
+        :rtype: string
+        """
+
+        if value is self.field.missing_value:
+            return u""
+        if getattr(self.widget, "show_time", None) is False:
+            return DATE_ONLY.format(value=value)
+        return DATE_AND_TIME.format(value=value)
+
+    def toFieldValue(self, value):
+        """Converts from widget value to field.
+
+        :param value: Value inserted by datetime widget.
+        :type value: string
+
+        :returns: `datetime.datetime` object.
+        :rtype: datetime
+        """
+        return super(DatetimeDataConverter, self).toFieldValue(value)
+
+
+@implementer(IDatetimeWidget)
+class DatetimeWidget(HTMLInputWidget, Widget):
+    """Senaite date and time widget
+    """
+    klass = u"senaite-datetime-widget"
+    # Olson DB/pytz timezone identifier or a callback
+    # returning such an identifier.
+    default_timezone = None
+    # enable/disable time component
+    show_time = True
+    # disable past dates in the date picker
+    datepicker_nopast = False
+    # disable future dates in the date picker
+    datepicker_nofuture = False
+
+    def __init__(self, request, *args, **kw):
+        super(DatetimeWidget, self).__init__(request)
+        self.request = request
+
+    def update(self):
+        """Computes self.value for the widget templates
+
+        see z3c.form.widget.Widget
+        """
+        super(DatetimeWidget, self).update()
+        widget.addFieldClass(self)
+
+    def to_local_date(self, value, length="short"):
+        """Converts value to localized date
+
+        Used in the display template to show a localized version of the date
+
+        :param value: date or datetime
+        :type value: string or datetime object
+        :returns: localized date string
+        """
+        dt = self.to_datetime(value)
+        if not dt:
+            return ""
+        df = "dateTime" if self.show_time else "date"
+        formatter = self.request.locale.dates.getFormatter(df, length)
+        return formatter.format(dt)
+
+    def to_datetime(self, value):
+        """convert date string to datetime object with tz
+
+        NOTE: IMO opinion the timezone won't be ever set unless the widget
+              `default_timezone` is set explicitly.
+
+        code taken from here:
+        `plone.app.z3cform.converters.DatetimeWidgetConverter`
+
+        :param value: date or datetime
+        :type value: string or datetime object
+        :returns: datetime object
+        """
+        if isinstance(value, datetime):
+            return value
+        if not value:
+            return ""
+        tmp = value.split(" ")
+        if not tmp[0]:
+            return ""
+        value = tmp[0].split("-")
+        if len(tmp) == 2 and ":" in tmp[1]:
+            value += tmp[1].split(":")
+        else:
+            value += ["00", "00"]
+
+        default_zone = self.default_timezone
+        zone = default_zone(self.context) \
+            if safe_callable(default_zone) else default_zone
+        ret = datetime(*map(int, value))
+        if zone:
+            tzinfo = pytz.timezone(zone)
+            ret = tzinfo.localize(ret)
+        return ret
+
+    def get_date(self, value):
+        """Return only the date part of the value
+
+        :returns: date string
+        """
+        dt = self.to_datetime(value)
+        if not dt:
+            return ""
+        return dt.strftime("%Y-%m-%d")
+
+    def get_time(self, value):
+        """Return only the time part of the value
+
+        :returns: time string
+        """
+        dt = self.to_datetime(value)
+        if not dt:
+            return ""
+        return dt.strftime("%H:%M")
+
+    def get_max(self):
+        """Return the max allowed date in the future
+
+        :returns: date string
+        """
+        now = datetime.now()
+        return now.strftime("%Y-%m-%d")
+
+    def get_min(self):
+        """Return the min allowed date in the past
+
+        :returns: date string
+        """
+        now = datetime.now()
+        return now.strftime("%Y-%m-%d")
+
+    def attrs(self):
+        """Return the template attributes for the date field
+
+        :returns: dictionary of HTML attributes
+        """
+        attrs = {}
+        if self.datepicker_nofuture:
+            attrs["max"] = self.get_max()
+        if self.datepicker_nopast:
+            attrs["min"] = self.get_min()
+        return attrs
+
+    @property
+    def portal(self):
+        """Return the portal object
+        """
+        return api.get_portal()
+
+    @property
+    def portal_url(self):
+        """Return the portal object URL
+        """
+        return api.get_url(self.portal)
+
+
+@adapter(IDatetimeField, ISenaiteFormLayer)
+@implementer(IFieldWidget)
+def DatetimeWidgetFactory(field, request):
+    """Widget factory for datetime field
+    """
+    return FieldWidget(field, DatetimeWidget(request))

--- a/src/senaite/core/z3cform/widgets/datetimewidget.py
+++ b/src/senaite/core/z3cform/widgets/datetimewidget.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
 from datetime import datetime
+from datetime import timedelta
 
 import pytz
 from bika.lims import api
-from plone.app.z3cform.converters import DatetimeWidgetConverter
+from bika.lims import senaiteMessageFactory as _
+from plone.app.event.base import default_timezone as current_timezone
 from Products.CMFPlone.utils import safe_callable
 from senaite.core.interfaces import ISenaiteFormLayer
 from senaite.core.schema.interfaces import IDatetimeField
@@ -12,11 +14,17 @@ from senaite.core.z3cform.interfaces import IDatetimeWidget
 from z3c.form import interfaces
 from z3c.form.browser import widget
 from z3c.form.browser.widget import HTMLInputWidget
+from z3c.form.converter import BaseDataConverter
 from z3c.form.interfaces import IFieldWidget
+from z3c.form.validator import SimpleFieldValidator
 from z3c.form.widget import FieldWidget
 from z3c.form.widget import Widget
 from zope.component import adapter
+from zope.interface import Interface
 from zope.interface import implementer
+
+HOUR_FORMAT = "%H:%M"
+DATE_FORMAT = "%Y-%m-%d"
 
 DATE_ONLY = ("{value.year:}-{value.month:02}-{value.day:02}")
 
@@ -24,9 +32,28 @@ DATE_AND_TIME = ("{value.year:}-{value.month:02}-{value.day:02} "
                  "{value.hour:02}:{value.minute:02}")
 
 
+@adapter(
+    Interface,           # context
+    ISenaiteFormLayer,   # request
+    interfaces.IForm,    # form
+    IDatetimeField,      # field
+    interfaces.IWidget,  # widget
+)
+class DatetimeDataValidator(SimpleFieldValidator):
+    """Datetime validator
+
+    Adapter looked up by `z3c.form.field.extract()` when storing a new value
+    """
+    def validate(self, value, force=False):
+        if isinstance(value, datetime):
+            if value.tzinfo is None:
+                return _("No timezone found for date %r" % value)
+        return super(DatetimeDataValidator, self).validate(value, force)
+
+
 @adapter(IDatetimeField, interfaces.IWidget)
-class DatetimeDataConverter(DatetimeWidgetConverter):
-    """Converts the raw field data for widget/field usage
+class DatetimeDataConverter(BaseDataConverter):
+    """Converts the value between the field and the widget
     """
     def toWidgetValue(self, value):
         """Converts from field value to widget.
@@ -43,7 +70,6 @@ class DatetimeDataConverter(DatetimeWidgetConverter):
         :returns: Datetime in format `Y-m-d H:M`
         :rtype: string
         """
-
         if value is self.field.missing_value:
             return u""
         if getattr(self.widget, "show_time", None) is False:
@@ -59,7 +85,38 @@ class DatetimeDataConverter(DatetimeWidgetConverter):
         :returns: `datetime.datetime` object.
         :rtype: datetime
         """
-        return super(DatetimeDataConverter, self).toFieldValue(value)
+        default = self.field.missing_value
+        timezone = self.widget.get_timezone()
+        return to_datetime(value, timezone=timezone, default=default)
+
+
+def to_datetime(value, timezone=None, default=None):
+    """Convert the value to a datetime object
+
+    Code originally taken from here:
+    `plone.app.z3cform.converters.DatetimeWidgetConverter.toFieldValue`
+
+    :param value: Value inserted by datetime widget.
+    :type value: string
+    """
+    if isinstance(value, datetime):
+        return value
+    if not value:
+        return default
+    tmp = value.split(" ")
+    if not tmp[0]:
+        return default
+    value = tmp[0].split("-")
+    if len(tmp) == 2 and ":" in tmp[1]:
+        value += tmp[1].split(":")
+    else:
+        value += ["00", "00"]
+
+    ret = datetime(*map(int, value))
+    if timezone:
+        tzinfo = pytz.timezone(timezone)
+        ret = tzinfo.localize(ret)
+    return ret
 
 
 @implementer(IDatetimeWidget)
@@ -89,6 +146,25 @@ class DatetimeWidget(HTMLInputWidget, Widget):
         super(DatetimeWidget, self).update()
         widget.addFieldClass(self)
 
+    def get_timezone(self):
+        """Return the current timezone
+        """
+        default_zone = self.default_timezone
+        timezone = default_zone(self.context)\
+            if safe_callable(default_zone) else default_zone
+        if not timezone:
+            # return computed timezone
+            timezone = current_timezone(context=self.context, as_tzinfo=False)
+        return timezone
+
+    def to_localized_time(self, time, long_format=None, time_only=None):
+        """Convert time to localized time
+        """
+        ts = api.get_tool("translation_service")
+        long_format = True if self.show_time else False
+        return ts.ulocalized_time(
+            time, long_format, time_only, self.context, domain="senaite.core")
+
     def to_local_date(self, value, length="short"):
         """Converts value to localized date
 
@@ -108,37 +184,13 @@ class DatetimeWidget(HTMLInputWidget, Widget):
     def to_datetime(self, value):
         """convert date string to datetime object with tz
 
-        NOTE: IMO opinion the timezone won't be ever set unless the widget
-              `default_timezone` is set explicitly.
-
-        code taken from here:
-        `plone.app.z3cform.converters.DatetimeWidgetConverter`
-
         :param value: date or datetime
         :type value: string or datetime object
         :returns: datetime object
         """
-        if isinstance(value, datetime):
-            return value
-        if not value:
-            return ""
-        tmp = value.split(" ")
-        if not tmp[0]:
-            return ""
-        value = tmp[0].split("-")
-        if len(tmp) == 2 and ":" in tmp[1]:
-            value += tmp[1].split(":")
-        else:
-            value += ["00", "00"]
-
-        default_zone = self.default_timezone
-        zone = default_zone(self.context) \
-            if safe_callable(default_zone) else default_zone
-        ret = datetime(*map(int, value))
-        if zone:
-            tzinfo = pytz.timezone(zone)
-            ret = tzinfo.localize(ret)
-        return ret
+        default = self.field.missing_value
+        timezone = self.get_timezone()
+        return to_datetime(value, timezone=timezone, default=default)
 
     def get_date(self, value):
         """Return only the date part of the value
@@ -147,8 +199,8 @@ class DatetimeWidget(HTMLInputWidget, Widget):
         """
         dt = self.to_datetime(value)
         if not dt:
-            return ""
-        return dt.strftime("%Y-%m-%d")
+            return u""
+        return dt.strftime(DATE_FORMAT)
 
     def get_time(self, value):
         """Return only the time part of the value
@@ -157,24 +209,33 @@ class DatetimeWidget(HTMLInputWidget, Widget):
         """
         dt = self.to_datetime(value)
         if not dt:
-            return ""
-        return dt.strftime("%H:%M")
+            return u""
+        return dt.strftime(HOUR_FORMAT)
+
+    def date_now(self, offset=0):
+        """Get the current date without time component
+        """
+        ts = datetime.now().strftime(DATE_FORMAT)
+        dt = datetime.strptime(ts, DATE_FORMAT)
+        if offset:
+            dt = dt + timedelta(offset)
+        return dt
 
     def get_max(self):
         """Return the max allowed date in the future
 
         :returns: date string
         """
-        now = datetime.now()
-        return now.strftime("%Y-%m-%d")
+        now = self.date_now()
+        return now.strftime(DATE_FORMAT)
 
     def get_min(self):
         """Return the min allowed date in the past
 
         :returns: date string
         """
-        now = datetime.now()
-        return now.strftime("%Y-%m-%d")
+        now = self.date_now()
+        return now.strftime(DATE_FORMAT)
 
     def attrs(self):
         """Return the template attributes for the date field

--- a/src/senaite/core/z3cform/widgets/datetimewidget.py
+++ b/src/senaite/core/z3cform/widgets/datetimewidget.py
@@ -213,32 +213,17 @@ class DatetimeWidget(HTMLInputWidget, Widget):
             dt = dt + timedelta(offset)
         return dt
 
-    def get_max(self):
-        """Return the max allowed date in the future
-
-        :returns: date string
-        """
-        now = self.date_now()
-        return now.strftime(DATE_FORMAT)
-
-    def get_min(self):
-        """Return the min allowed date in the past
-
-        :returns: date string
-        """
-        now = self.date_now()
-        return now.strftime(DATE_FORMAT)
-
     def attrs(self):
         """Return the template attributes for the date field
 
         :returns: dictionary of HTML attributes
         """
         attrs = {}
+        today = self.date_now().strftime(DATE_FORMAT)
         if self.datepicker_nofuture:
-            attrs["max"] = self.get_max()
+            attrs["max"] = today
         if self.datepicker_nopast:
-            attrs["min"] = self.get_min()
+            attrs["min"] = today
         return attrs
 
     @property

--- a/src/senaite/core/z3cform/widgets/datetimewidget.txt
+++ b/src/senaite/core/z3cform/widgets/datetimewidget.txt
@@ -102,7 +102,7 @@ Check DISPLAY_MODE:
     >>> print(widget.render())
     <html>
       <body>
-        <span class="senaite-datetime-widget">21/12/24 00:00</span>
+        <span class="senaite-datetime-widget">2021-12-24 00:00</span>
       </body>
     </html>
 

--- a/src/senaite/core/z3cform/widgets/datetimewidget.txt
+++ b/src/senaite/core/z3cform/widgets/datetimewidget.txt
@@ -1,0 +1,125 @@
+Datetime widget
+===============
+
+The datetime field widget allows to set a date and display it.
+
+
+Running this test from the buildout directory:
+
+    bin/test test_z3c_widgets -t datetimewidget
+
+Hints:
+
+`plone.app.z3cform.widget.DatetimeWidget`
+
+
+Some variables we need:
+
+    >>> DATE = "2021-12-24"
+    >>> INPUT_TPL = "datetimewidget_input.pt"
+    >>> HIDDEN_TPL = "datetimewidget_hidden.pt"
+    >>> DISPLAY_TPL = "datetimewidget_display.pt"
+
+The widget can render a input field for a date and time:
+
+    >>> from zope.interface.verify import verifyClass
+    >>> from z3c.form import interfaces
+    >>> from senaite.core.z3cform.widgets.datetimewidget import DatetimeWidget
+
+Verify widget:
+
+    >>> verifyClass(interfaces.IWidget, DatetimeWidget)
+    True
+
+The widget can render a input field only by adapting a request:
+
+    >>> from z3c.form.testing import TestRequest
+    >>> request = TestRequest()
+    >>> widget = DatetimeWidget(request)
+
+Such a field provides IWidget:
+
+    >>> interfaces.IWidget.providedBy(widget)
+    True
+
+We also need to register the template for at least the widget and request:
+
+    >>> import os.path
+    >>> import zope.interface
+    >>> from zope.publisher.interfaces.browser import IDefaultBrowserLayer
+    >>> from zope.pagetemplate.interfaces import IPageTemplate
+    >>> import senaite.core.z3cform.widgets
+    >>> import z3c.form.widget
+    >>> template = os.path.join(os.path.dirname(senaite.core.z3cform.widgets.__file__), INPUT_TPL)
+    >>> factory = z3c.form.widget.WidgetTemplateFactory(template)
+    >>> zope.component.provideAdapter(factory,
+    ...     (zope.interface.Interface, IDefaultBrowserLayer, None, None, None),
+    ...     IPageTemplate, name='input')
+
+If we render the widget we get the HTML:
+
+    >>> widget.value = DATE
+    >>> widget.mode = interfaces.INPUT_MODE
+    >>> print(widget.render().replace('\n', ''))
+    <div class="input-group flex-nowrap d-inline-flex w-auto datetimewidget">
+      <!-- date -->
+      <input type="date" class="form-control form-control-sm" name="None-date" value="2021-12-24"/>
+      <!-- time -->
+      <input type="time" class="form-control form-control-sm" name="None-time" value="00:00"/>
+    </div>
+    <!-- datetime value (outside to avoid style issues) -->
+    <input type="hidden" value="2021-12-24"/>
+    <!-- static resources -->
+    <script type="text/javascript" src="http://nohost/plone/++resource++senaite.core.z3cform.static/datetimewidget.js"></script>
+    <link rel="stylesheet" href="http://nohost/plone/++resource++senaite.core.z3cform.static/datetimewidget.css" type="text/css" media="screen"/>
+
+Render without the time component:
+
+    >>> widget.show_time = False
+    >>> print(widget.render().replace('\n', ''))
+    <div class="input-group flex-nowrap d-inline-flex w-auto datetimewidget">
+      <!-- date -->
+      <input type="date" class="form-control form-control-sm" name="None-date" value="2021-12-24"/>
+      <!-- time -->
+    </div>
+    <!-- datetime value (outside to avoid style issues) -->
+    <input type="hidden" value="2021-12-24"/>
+    <!-- static resources -->
+    <script type="text/javascript" src="http://nohost/plone/++resource++senaite.core.z3cform.static/datetimewidget.js"></script>
+    <link rel="stylesheet" href="http://nohost/plone/++resource++senaite.core.z3cform.static/datetimewidget.css" type="text/css" media="screen"/>
+
+Check DISPLAY_MODE:
+
+    >>> template = os.path.join(os.path.dirname(senaite.core.z3cform.widgets.__file__), DISPLAY_TPL)
+    >>> factory = z3c.form.widget.WidgetTemplateFactory(template)
+    >>> zope.component.provideAdapter(factory,
+    ...     (zope.interface.Interface, IDefaultBrowserLayer, None, None, None),
+    ...     IPageTemplate, name='display')
+  
+    >>> widget.show_time = True
+    >>> widget.value = DATE
+    >>> widget.mode = interfaces.DISPLAY_MODE
+    >>> print(widget.render())
+    <html>
+      <body>
+        <span class="senaite-datetime-widget">21/12/24 00:00</span>
+      </body>
+    </html>
+
+
+Check HIDDEN_MODE:
+
+    >>> template = os.path.join(os.path.dirname(senaite.core.z3cform.widgets.__file__), HIDDEN_TPL)
+    >>> factory = z3c.form.widget.WidgetTemplateFactory(template)
+    >>> zope.component.provideAdapter(factory,
+    ...     (zope.interface.Interface, IDefaultBrowserLayer, None, None, None),
+    ...     IPageTemplate, name='hidden')
+  
+    >>> widget.value = DATE
+    >>> widget.mode = interfaces.HIDDEN_MODE
+    >>> print(widget.render())
+    <html>
+      <body>
+        <input type="hidden" value="2021-12-24">
+      </body>
+    </html>

--- a/src/senaite/core/z3cform/widgets/datetimewidget.zcml
+++ b/src/senaite/core/z3cform/widgets/datetimewidget.zcml
@@ -1,0 +1,39 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:z3c="http://namespaces.zope.org/z3c"
+    i18n_domain="z3c.form">
+
+  <!-- Datetime Widget -->
+  <adapter
+      factory=".datetimewidget.DatetimeWidgetFactory"
+      for="senaite.core.schema.interfaces.IDatetimeField
+           senaite.core.interfaces.ISenaiteFormLayer" />
+
+  <!-- Datetime data converter -->
+  <adapter factory=".datetimewidget.DatetimeDataConverter" />
+
+  <!-- Datetime input widget template -->
+  <z3c:widgetTemplate
+      mode="input"
+      widget=".datetimewidget.DatetimeWidget"
+      template="datetimewidget_input.pt"
+      layer="senaite.core.interfaces.ISenaiteFormLayer"
+      />
+
+  <!-- Datetime display widget template -->
+  <z3c:widgetTemplate
+      mode="display"
+      widget=".datetimewidget.DatetimeWidget"
+      template="datetimewidget_display.pt"
+      layer="senaite.core.interfaces.ISenaiteFormLayer"
+      />
+
+  <!-- Datetime hidden widget template -->
+  <z3c:widgetTemplate
+      mode="hidden"
+      widget=".datetimewidget.DatetimeWidget"
+      template="datetimewidget_hidden.pt"
+      layer="senaite.core.interfaces.ISenaiteFormLayer"
+      />
+
+</configure>

--- a/src/senaite/core/z3cform/widgets/datetimewidget.zcml
+++ b/src/senaite/core/z3cform/widgets/datetimewidget.zcml
@@ -12,6 +12,9 @@
   <!-- Datetime data converter -->
   <adapter factory=".datetimewidget.DatetimeDataConverter" />
 
+  <!-- Datetime data validator -->
+  <adapter factory=".datetimewidget.DatetimeDataValidator" />
+
   <!-- Datetime input widget template -->
   <z3c:widgetTemplate
       mode="input"

--- a/src/senaite/core/z3cform/widgets/datetimewidget_display.pt
+++ b/src/senaite/core/z3cform/widgets/datetimewidget_display.pt
@@ -4,11 +4,10 @@
 
 
   <span
-    tal:define="value view/value"
     tal:attributes="id view/id;
                     class view/klass;
                     style view/style;
                     title view/title;">
-    <tal:block content="python:view.to_localized_time(value)" />
+    <tal:block content="python:view.get_display_value()" />
   </span>
 </html>

--- a/src/senaite/core/z3cform/widgets/datetimewidget_display.pt
+++ b/src/senaite/core/z3cform/widgets/datetimewidget_display.pt
@@ -1,0 +1,14 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      tal:omit-tag="">
+
+
+  <span
+    tal:define="value view/value"
+    tal:attributes="id view/id;
+                    class view/klass;
+                    style view/style;
+                    title view/title;">
+    <tal:block content="python:view.to_local_date(value)" />
+  </span>
+</html>

--- a/src/senaite/core/z3cform/widgets/datetimewidget_display.pt
+++ b/src/senaite/core/z3cform/widgets/datetimewidget_display.pt
@@ -9,6 +9,6 @@
                     class view/klass;
                     style view/style;
                     title view/title;">
-    <tal:block content="python:view.to_local_date(value)" />
+    <tal:block content="python:view.to_localized_time(value)" />
   </span>
 </html>

--- a/src/senaite/core/z3cform/widgets/datetimewidget_hidden.pt
+++ b/src/senaite/core/z3cform/widgets/datetimewidget_hidden.pt
@@ -1,0 +1,13 @@
+<div xmlns="http://www.w3.org/1999/xhtml"
+     xmlns:tal="http://xml.zope.org/namespaces/tal"
+     tal:omit-tag="">
+
+  <input
+    type="hidden"
+    tal:attributes="
+          id python:view.id;
+          title python:view.title;
+          name python:view.name;
+          value python:view.value"/>
+
+</div>

--- a/src/senaite/core/z3cform/widgets/datetimewidget_input.pt
+++ b/src/senaite/core/z3cform/widgets/datetimewidget_input.pt
@@ -1,0 +1,58 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      tal:omit-tag="">
+
+  <div class="input-group flex-nowrap d-inline-flex w-auto datetimewidget"
+       tal:define="
+              name python:view.name;
+              value python:view.value;
+              disabled python:view.disabled;
+              readonly python:view.readonly;
+              tabindex python:view.tabindex;
+              klass python:view.klass"
+       tal:attributes="
+              id python:view.id;
+              style python:view.style;
+              title python:view.title;">
+
+    <!-- date -->
+    <input
+      type="date"
+      class="form-control form-control-sm"
+      tal:attributes="
+            python:view.attrs();
+            target name;
+            name string:${name}-date;
+            disabled disabled;
+            readonly readonly;
+            tabindex tabindex;
+            value python:view.get_date(value) if value else '';"/>
+
+    <!-- time -->
+    <input
+      type="time"
+      class="form-control form-control-sm"
+      tal:condition="python:view.show_time"
+      tal:attributes="
+            target name;
+            name string:${name}-time;
+            disabled disabled;
+            readonly readonly;
+            tabindex tabindex;
+            value python:view.get_time(value) if value else '';"/>
+  </div>
+
+  <!-- datetime value (outside to avoid style issues) -->
+  <input
+    type="hidden"
+    tal:attributes="
+          id python:view.id;
+          title python:view.title;
+          name python:view.name;
+          value python:view.value"/>
+
+  <!-- static resources -->
+  <script type="text/javascript" src="" tal:attributes="src string:${view/portal_url}/++resource++senaite.core.z3cform.static/datetimewidget.js"></script>
+  <link rel="stylesheet" href="" type="text/css" media="screen"  tal:attributes="href string:${view/portal_url}/++resource++senaite.core.z3cform.static/datetimewidget.css"/>
+
+</html>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR implements a native HTML 5 date and time widget for Dexterity contents.
The code is partly ported from https://github.com/senaite/senaite.core/pull/1892
 

## Current behavior before PR

No date and time field/widget for dexterity contents

## Desired behavior after PR is merged

Native date and time field/widget for dexterity contents


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
