### PR TITLE
Fix empty field in sample add form when using edit accessor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1905 Fix empty field in sample add form when using edit accessor
+
 
 2.1.0 (2022-01-05)
 ------------------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,8 +1,8 @@
 [buildout]
 index = https://pypi.org/simple/
-extends = https://dist.plone.org/release/5.2.5/versions.cfg
+extends = https://dist.plone.org/release/5.2.6/versions.cfg
 find-links =
-    https://dist.plone.org/release/5.2.5/
+    https://dist.plone.org/release/5.2.6/
     https://dist.plone.org/thirdparty/
 
 parts =

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -224,6 +224,7 @@ class AnalysisRequestAddView(BrowserView):
         # XXX: This is a hack to make the widget available in the template
         schema._fields[new_fieldname] = new_field
         new_field.getAccessor = getAccessor
+        new_field.getEditAccessor = getAccessor
 
         # set the default value
         form = dict()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an empty field issue in the sample add form when the widget template uses the `getEditAccessor` to retrieve the current value

## Current behavior before PR

Field keeps empty when the value is obtained with the `getEditAccessor` method in the widget

## Desired behavior after PR is merged

Field is filled with the copied value when the `getEditAccessor` is used in the widget

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
