### PR TITLE
Fix traceback in auditlog view when context is a Dexterity type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #1906 Fix traceback in auditlog view when context is a Dexterity type
 - #1885 Allow to re-add cancelled/rejected/retracted analyses (#1777 port)
 - #1885 Fix APIError when a retest analysis source is removed (#1777 port)
 - #1868 Fix indexing of temporary objects resulting in orphan entries in catalog

--- a/bika/lims/browser/auditlog.py
+++ b/bika/lims/browser/auditlog.py
@@ -128,10 +128,12 @@ class AuditLogView(BikaListingView):
     def get_widget_for(self, fieldname):
         """Lookup the widget
         """
-        field = self.context.getField(fieldname)
-        if not field:
+        fields = api.get_fields(self.context)
+        field = fields.get(fieldname)
+        if field is None:
             return None
-        return field.widget
+        # FIXME: Properly lookup widget for DX types
+        return getattr(field, "widget", None)
 
     def get_widget_label_for(self, fieldname, default=None):
         """Lookup the widget of the field and return the label


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Reuest fixes a traceback in auditlog view when current context is a Dexterity type

Ported from 33533f84d38e6a9b9f21a78ebefe5560ecafe81b

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module senaite.core.listing.view, line 214, in __call__
  Module senaite.core.listing.ajax, line 104, in handle_subpath
  Module bika.lims.decorators, line 173, in decorator
  Module senaite.core.listing.decorators, line 63, in wrapper
  Module senaite.core.listing.decorators, line 50, in wrapper
  Module senaite.core.listing.decorators, line 100, in wrapper
  Module senaite.core.listing.ajax, line 530, in ajax_folderitems
  Module senaite.core.listing.decorators, line 88, in wrapper
  Module senaite.core.listing.ajax, line 308, in get_folderitems
  Module bika.lims.browser.auditlog, line 241, in folderitems
  Module bika.lims.browser.auditlog, line 167, in render_diff
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 173, in render
  Module chameleon.zpt.template, line 306, in render
  Module chameleon.template, line 209, in render
  Module chameleon.template, line 187, in render
  Module d81f7afcb70354648250b5981353da43.py, line 193, in render
  Module bika.lims.browser.auditlog, line 139, in get_widget_label_for
  Module plone.memoize.view, line 47, in memogetter
  Module bika.lims.browser.auditlog, line 131, in get_widget_for
AttributeError: getField

 - Expression: "python:view.get_widget_label_for(field, default=field)"
 - Filename:   ... enaite.core/bika/lims/browser/templates/auditlog_diff.pt
 - Location:   (line 15: col 61)
 - Source:     ... t="python:view.get_widget_label_for(field, default=field)"/> ...
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  default: <object - at 0x7f7457260c10>
               repeat: {...} (0)
               template: <ViewPageTemplateFile - at 0x7f744205d910>
               views: <ViewMapper - at 0x7f744205d0d0>
               modules: <instance - at 0x7f7454ebb3b0>
               args: <tuple - at 0x7f7441bd0350>
               here: <ImplicitAcquisitionWrapper SH22AA001 at 0x7f744b87bc80>
               wrapped_repeat: <SafeMapping - at 0x7f7441c5b470>
               user: <ImplicitAcquisitionWrapper - at 0x7f744b843eb0>
               nothing: <NoneType - at 0x56056f7dc1a0>
               diff: {...} (3)
               container: <ImplicitAcquisitionWrapper SH22AA001 at 0x7f744b87bc80>
               request: <instance - at 0x7f74422c9c68>
               traverse_subpath: <list - at 0x7f7441db8d88>
               field: shipment_id
               context: <ImplicitAcquisitionWrapper SH22AA001 at 0x7f744b87bc80>
               view: <AuditLogView @@auditlog at 0x7f7441f5ecd0>
               translate: <function translate at 0x7f7441fb8230>
               root: <ImplicitAcquisitionWrapper Zope at 0x7f744ccce640>
               options: {...} (1)
               loop: {...} (1)
               target_language: en
```

## Desired behavior after PR is merged

No traceback. Audit log entries are displayed correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
