### PR TITLE
Fix datetime field/widget shows current date and time if empty

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1907 Fix datetime field/widget shows current date and time if empty
 - #1905 Fix empty field in sample add form when using edit accessor
 
 

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -9,6 +9,7 @@ import six
 
 import pytz
 from bika.lims import logger
+from bika.lims.api import APIError
 from DateTime import DateTime
 from DateTime.DateTime import DateError
 from DateTime.DateTime import SyntaxError
@@ -84,7 +85,7 @@ def is_timezone_naive(dt):
     elif is_str(dt):
         DT = to_DT(dt)
         return is_timezone_naive(DT)
-    raise TypeError("Expected a date, got '%r'" % type(dt))
+    raise APIError("Expected a date type, got '%r'" % type(dt))
 
 
 def is_timezone_aware(dt):

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -5,9 +5,23 @@ import time
 from datetime import date
 from datetime import datetime
 
+import six
+
 import pytz
 from bika.lims import logger
 from DateTime import DateTime
+from DateTime.DateTime import DateError
+from DateTime.DateTime import SyntaxError
+from DateTime.DateTime import TimeError
+
+
+def is_str(obj):
+    """Check if the given object is a string
+
+    :param obj: arbitrary object
+    :returns: True when the object is a string
+    """
+    return isinstance(obj, six.string_types)
 
 
 def is_d(dt):
@@ -43,6 +57,9 @@ def is_date(dt):
     :param dt: date to check
     :returns: True when the object is either a datetime or DateTime
     """
+    if is_str(dt):
+        DT = to_DT(dt)
+        return is_date(DT)
     if is_d(dt):
         return True
     if is_dt(dt):
@@ -64,6 +81,9 @@ def is_timezone_naive(dt):
         return dt.timezoneNaive()
     elif is_dt(dt):
         return dt.tzinfo is None
+    elif is_str(dt):
+        DT = to_DT(dt)
+        return is_timezone_naive(DT)
     raise TypeError("Expected a date, got '%r'" % type(dt))
 
 
@@ -84,12 +104,18 @@ def to_DT(dt):
     """
     if is_DT(dt):
         return dt
+    elif is_str(dt):
+        try:
+            return DateTime(dt)
+        except (DateError, TimeError, SyntaxError, IndexError):
+            return None
     elif is_dt(dt):
         return DateTime(dt.isoformat())
     elif is_d(dt):
         dt = datetime(dt.year, dt.month, dt.day)
         return DateTime(dt.isoformat())
-    raise TypeError("Expected datetime, got '%r'" % type(dt))
+    else:
+        return None
 
 
 def to_dt(dt):
@@ -100,11 +126,15 @@ def to_dt(dt):
     """
     if is_DT(dt):
         return dt.asdatetime()
+    elif is_str(dt):
+        DT = to_DT(dt)
+        return to_dt(DT)
     elif is_dt(dt):
         return dt
     elif is_d(dt):
         return datetime(dt.year, dt.month, dt.day)
-    raise TypeError("Expected DateTime, got '%r'" % type(dt))
+    else:
+        return None
 
 
 def is_valid_timezone(timezone):
@@ -155,14 +185,16 @@ def to_zone(dt, timezone):
     :param timezone: timezone
     :returns: date converted to timezone
     """
-    if is_dt(dt):
+    if is_dt(dt) or is_d(dt):
+        dt = to_dt(dt)
         zone = pytz.timezone(timezone)
         if is_timezone_aware(dt):
             return dt.astimezone(zone)
         return zone.localize(dt)
-    if is_DT(dt):
+    elif is_DT(dt):
         # NOTE: This shifts the time according to the TZ offset
         return dt.toZone(timezone)
+    raise TypeError("Expected a date, got '%r'" % type(dt))
 
 
 def to_timestamp(dt):
@@ -176,6 +208,9 @@ def to_timestamp(dt):
         timestamp = dt.timeTime()
     elif is_dt(dt):
         timestamp = time.mktime(dt.timetuple())
+    elif is_str(dt):
+        DT = to_DT(dt)
+        return to_timestamp(DT)
     return timestamp
 
 
@@ -185,7 +220,6 @@ def from_timestamp(timestamp):
     :param timestamp: POSIX timestamp
     :returns: datetime object
     """
-
     return datetime.utcfromtimestamp(timestamp)
 
 
@@ -196,4 +230,7 @@ def to_iso_format(dt):
         return dt.isoformat()
     elif is_DT(dt):
         return dt.ISO()
+    elif is_str(dt):
+        DT = to_DT(dt)
+        return to_iso_format(DT)
     return None

--- a/src/senaite/core/schema/datetimefield.py
+++ b/src/senaite/core/schema/datetimefield.py
@@ -32,8 +32,8 @@ class DatetimeField(Datetime, BaseField):
         :param value: datetime value
         :type value: datetime
         """
-        if dtime.is_dt(value):
-            value = localize(value)
+        if dtime.is_date(value):
+            value = localize(dtime.to_dt(value))
         super(DatetimeField, self).set(object, value)
 
     def get(self, object):
@@ -43,8 +43,12 @@ class DatetimeField(Datetime, BaseField):
         :returns: datetime or None
         """
         value = super(DatetimeField, self).get(object)
-        if not dtime.is_dt(value):
+        # bail out if value is not a known date object
+        if not dtime.is_date(value):
             return None
+        # ensure we have a `datetime` object
+        value = dtime.to_dt(value)
+        # always return localized datetime objects
         return localize(value)
 
     def _validate(self, value):

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -85,6 +85,15 @@ Check if an object represents a date
     True
 
     >>> dtime.is_date("2021-12-24")
+    True
+
+    >>> dtime.is_date("2021-12-24T12:00:00")
+    True
+
+    >>> dtime.is_date("2021-12-24T12:00:00+01:00")
+    True
+
+    >>> dtime.is_date("Hello World")
     False
 
     >>> dtime.is_date(object())
@@ -103,6 +112,15 @@ Check if a datetime object is TZ naive
     >>> dtime.is_timezone_naive(DateTime())
     False
 
+    >>> dtime.is_timezone_naive("2021-12-24")
+    True
+
+    >>> dtime.is_timezone_naive("2021-12-24T12:00:00")
+    True
+
+    >>> dtime.is_timezone_naive("2021-12-24T12:00:00+01:00")
+    False
+
 
 Check if a datetime object is TZ aware
 ......................................
@@ -116,6 +134,15 @@ Check if a datetime object is TZ aware
     >>> dtime.is_timezone_aware(DateTime())
     True
 
+    >>> dtime.is_timezone_aware("2021-12-24")
+    False
+
+    >>> dtime.is_timezone_aware("2021-12-24T12:00:00")
+    False
+
+    >>> dtime.is_timezone_aware("2021-12-24T12:00:00+01:00")
+    True
+
 
 Convert to DateTime
 ...................
@@ -127,6 +154,9 @@ Timezone naive datetimes are converterd to `GMT+0`:
     >>> dt = datetime.strptime(DATE, DATEFORMAT)
     >>> dt
     datetime.datetime(2021, 12, 24, 12, 0)
+
+    >>> dtime.to_DT(DATE)
+    DateTime('2021/12/24 12:00:00 GMT+0')
 
     >>> dtime.to_DT(dt)
     DateTime('2021/12/24 12:00:00 GMT+0')
@@ -233,6 +263,13 @@ Convert `datetime` objects to a timezone:
     >>> dtime.to_zone(dt_utc, "CET")
     datetime.datetime(1970, 1, 1, 2, 0, tzinfo=<DstTzInfo 'CET' CET+1:00:00 STD>)
 
+Convert `date` objects to a timezone (converts to `datetime`):
+
+    >>> d = date.fromordinal(dt.toordinal())
+    >>> d_utc = dtime.to_zone(d, "UTC")
+    >>> d_utc
+    datetime.datetime(1970, 1, 1, 0, 0, tzinfo=<UTC>)
+
 Convert `DateTime` objects to a timezone:
 
     >>> DT = DateTime(DATE)
@@ -252,6 +289,9 @@ Make a POSIX timestamp
     >>> DT = DateTime(DATE)
     >>> dt = datetime.strptime(DATE, DATEFORMAT)
 
+    >>> dtime.to_timestamp(DATE)
+    3600.0
+
     >>> dtime.to_timestamp(dt)
     3600.0
 
@@ -270,6 +310,9 @@ Convert to ISO format
     >>> dt_local = dtime.to_zone(dt, "CET")
     >>> dt_local
     datetime.datetime(2021, 8, 1, 12, 0, tzinfo=<DstTzInfo 'CET' CEST+2:00:00 DST>)
+
+    >>> dtime.to_iso_format(DATE)
+    '2021-08-01T12:00:00'
 
     >>> dtime.to_iso_format(dt_local)
     '2021-08-01T12:00:00+02:00'

--- a/src/senaite/core/z3cform/widgets/datetimewidget.py
+++ b/src/senaite/core/z3cform/widgets/datetimewidget.py
@@ -167,6 +167,8 @@ class DatetimeWidget(HTMLInputWidget, Widget):
         if dm:
             # extract the object from the database
             value = dm.query()
+        if not dtime.is_date(value):
+            return None
         return self.to_localized_time(value)
 
     def to_datetime(self, value):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue with the value conversion of the new DX datetime field/widget when a non `datetime` object was stored in the DB, e.g. `datetime.date`, or simply no value was stored.

## Current behavior before PR

Current date was displayed in view mode
No value was displayed in edit mode

## Desired behavior after PR is merged

Correct date and time is displayed in view and edit mode

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
