### PR TITLE
Added searchable text querystring converter to catalog API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1908 Added searchable text querystring converter to catalog API
 - #1905 Fix empty field in sample add form when using edit accessor
 
 

--- a/src/senaite/core/tests/doctests/API_catalog.rst
+++ b/src/senaite/core/tests/doctests/API_catalog.rst
@@ -146,3 +146,49 @@ Check if the column was deleted:
 
     >>> COLUMN in capi.get_columns(sample_catalog)
     False
+
+
+Searchable Text Querystring
+---------------------------
+
+https://zope.readthedocs.io/en/latest/zopebook/SearchingZCatalog.html#boolean-expressions
+
+Searching for a single word:
+
+    >>> capi.to_searchable_text_qs("sample")
+    u'sample*'
+
+Without wildcard:
+
+    >>> capi.to_searchable_text_qs("sample", wildcard=False)
+    u'sample'
+
+Searching for a unicode word:
+
+    >>> capi.to_searchable_text_qs("AäOöUüZ")
+    u'A\xe4O\xf6U\xfcZ*'
+
+Searching for multiple unicode words:
+
+    >>> capi.to_searchable_text_qs("Ä Ö Ü")
+    u'\xc4* AND \xd6* AND \xdc*'
+
+Searching for a concatenated word:
+
+    >>> capi.to_searchable_text_qs("H2O-0001")
+    u'H2O* AND 0001*'
+
+Searching for two words:
+
+    >>> capi.to_searchable_text_qs("Fresh Funky")
+    u'Fresh* AND Funky*'
+
+Tricky query strings (with and/or/not in words or in between):
+
+    >>> capi.to_searchable_text_qs("Fresh and Funky or Sand but not Bor")
+    u'Fresh* AND Funky* OR Sand* AND but* NOT Bor*'
+
+A questionmark allows to search for all strings that start with what is before:
+
+    >>> capi.to_searchable_text_qs("Ca? OR Mg?")
+    u'Ca? OR Mg?'


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds a converter for searchable text querystrings to the catalog API

## Current behavior before PR

no converter for searchable text querystrings in catalog API

## Desired behavior after PR is merged

converter for searchable text querystrings in catalog API


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
