### PR TITLE
Avoid parse errors for ZCTextIndex

### DIFF
--- a/src/senaite/core/tests/doctests/API_catalog.rst
+++ b/src/senaite/core/tests/doctests/API_catalog.rst
@@ -183,12 +183,47 @@ Searching for two words:
     >>> capi.to_searchable_text_qs("Fresh Funky")
     u'Fresh* AND Funky*'
 
-Tricky query strings (with and/or/not in words or in between):
+Tricky query strings (with and/or in words or in between):
 
-    >>> capi.to_searchable_text_qs("Fresh and Funky or Sand but not Bor")
-    u'Fresh* AND Funky* OR Sand* AND but* NOT Bor*'
+    >>> capi.to_searchable_text_qs("Fresh and Funky Oranges from Andorra")
+    u'Fresh* AND Funky* AND Oranges* AND from* AND Andorra*'
 
-A questionmark allows to search for all strings that start with what is before:
+All wildcards are removed and replaced with `*` to avoid parse errors:
 
     >>> capi.to_searchable_text_qs("Ca? OR Mg?")
-    u'Ca? OR Mg?'
+    u'Ca* OR Mg*'
+
+Search with special characters:
+
+    >>> capi.to_searchable_text_qs("'H2O-0001'")
+    u'H2O* AND 0001*'
+
+    >>> capi.to_searchable_text_qs("\'H2O-0001\'")
+    u'H2O* AND 0001*'
+
+    >>> capi.to_searchable_text_qs("(H2O-0001)*")
+    u'H2O* AND 0001*'
+
+    >>> capi.to_searchable_text_qs("****([H2O-0001])****")
+    u'H2O* AND 0001*'
+
+    >>> capi.to_searchable_text_qs("********************")
+    u''
+
+    >>> capi.to_searchable_text_qs("????????????????????")
+    u''
+
+    >>> capi.to_searchable_text_qs("?H2O?")
+    u'H2O*'
+
+    >>> capi.to_searchable_text_qs("*H2O*")
+    u'H2O*'
+
+    >>> capi.to_searchable_text_qs("And the question is: AND OR maybe NOT AND")
+    u'the* AND question* AND is* AND OR maybe* AND NOT*'
+
+    >>> capi.to_searchable_text_qs("AND OR")
+    u''
+
+    >>> capi.to_searchable_text_qs("H2O NOT 11")
+    u'H2O* AND NOT* AND 11*'


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes https://github.com/senaite/senaite.core/pull/1908 to avoid parser errors in ZCTextIndex when using complex queries:

```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module senaite.app.listing.view, line 216, in __call__
  Module senaite.app.listing.ajax, line 109, in handle_subpath
  Module senaite.core.decorators, line 20, in decorator
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 432, in ajax_folderitems
  Module senaite.app.listing.decorators, line 88, in wrapper
  Module senaite.app.listing.ajax, line 313, in get_folderitems
  Module senaite.app.listing.view, line 901, in folderitems
  Module senaite.app.listing.view, line 715, in _fetch_brains
  Module senaite.app.listing.view, line 781, in search
  Module senaite.app.listing.view, line 708, in text_index_search
  Module Products.CMFPlone.CatalogTool, line 463, in searchResults
  Module Products.ZCatalog.ZCatalog, line 625, in searchResults
  Module Products.ZCatalog.Catalog, line 1091, in searchResults
  Module Products.ZCatalog.Catalog, line 634, in search
  Module Products.ZCatalog.Catalog, line 564, in _search_index
  Module Products.ZCTextIndex.ZCTextIndex, line 209, in query_index
  Module Products.ZCTextIndex.QueryParser, line 153, in parseQuery
  Module Products.ZCTextIndex.QueryParser, line 193, in _parseOrExpr
  Module Products.ZCTextIndex.QueryParser, line 211, in _parseAndExpr
  Module Products.ZCTextIndex.QueryParser, line 233, in _parseNotExpr
  Module Products.ZCTextIndex.QueryParser, line 241, in _parseTerm
  Module Products.ZCTextIndex.QueryParser, line 260, in _parseAtom
  Module Products.ZCTextIndex.QueryParser, line 188, in _get
  Module Products.ZCTextIndex.QueryParser, line 174, in _require
ParseError: Token <Token:ATOM> required, u'OR' found
```

## Current behavior before PR

Tracebacks occur e.g. when using `NOT` alone instead of `AND NOT`, multiple wildcards in a row like `??????????` or `******`, operators at the beginning or end of the search term `AND H2O OR` and many other combinations

## Desired behavior after PR is merged

Reduce search filter functionality to `AND` or `OR` searches and make all search terms wildcard searches.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
