### PR TITLE
Fixed typo in sample view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1912 Fixed typo in sample view
 - #1909 Allow to navigate and select with arrow keys in dexterity reference widget
 - #1908 Added searchable text querystring converter to catalog API
 - #1907 Fix datetime field/widget shows current date and time if empty

--- a/src/bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt
+++ b/src/bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt
@@ -19,7 +19,7 @@
         <!-- Title -->
         <span class="documentFirstHeading" tal:content="context/id"></span>
         <!-- Hazardous icon -->
-        <i class="hazardous-icon" title="Hazdardous" i18n:attributes="title"
+        <i class="hazardous-icon" title="Hazardous" i18n:attributes="title"
            tal:condition="python:view.is_hazardous()">
           <svg tal:replace="structure senaite_theme/icon_data/hazardous" />
         </i>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a typo in the sample view

## Current behavior before PR

Hazdardous is used

## Desired behavior after PR is merged

Hazardous is used

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
