### PR TITLE
Provide context, widget and fieldname for callable base queries in AT reference widgets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1914 Provide context, widget and fieldname for callable base queries in AT reference widgets
 - #1912 Fixed typo in sample view
 - #1909 Allow to navigate and select with arrow keys in dexterity reference widget
 - #1908 Added searchable text querystring converter to catalog API

--- a/src/senaite/core/browser/widgets/referencewidget.py
+++ b/src/senaite/core/browser/widgets/referencewidget.py
@@ -120,7 +120,10 @@ class ReferenceWidget(StringWidget):
     def get_base_query(self, context, fieldName):
         base_query = self.base_query
         if callable(base_query):
-            base_query = base_query()
+            try:
+                base_query = base_query(context, self, fieldName)
+            except TypeError:
+                base_query = base_query()
         if base_query and isinstance(base_query, six.string_types):
             base_query = json.loads(base_query)
 

--- a/src/senaite/core/browser/widgets/referencewidget.py
+++ b/src/senaite/core/browser/widgets/referencewidget.py
@@ -139,7 +139,7 @@ class ReferenceWidget(StringWidget):
             if allowed_types \
             else self.portal_types
 
-        return json.dumps(self.base_query)
+        return json.dumps(base_query)
 
     def initial_uid_field_value(self, value):
         if type(value) in (list, tuple):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the AT reference widget `base_query` handling, so that it is called with the current context, widget and fieldname.

## Current behavior before PR

Base query callables called without arguments

## Desired behavior after PR is merged

Base query callables called with context, widget and fieldname

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
