### PR TITLE
Provide the request record to object info adapters in the sample add form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1916 Provide the request record to object info adapters in the sample add form
 - #1913 Ported PR #1865 for dexterity contents
 - #1915 Support list queries in dx reference widget
 - #1914 Provide context, widget and fieldname for callable base queries in AT reference widgets

--- a/src/bika/lims/adapters/addsample.py
+++ b/src/bika/lims/adapters/addsample.py
@@ -50,3 +50,9 @@ class AddSampleObjectInfoAdapter(object):
         See IAddSampleObjectInfo for further details
         """
         raise NotImplementedError("get_object_info not implemented")
+
+    def get_object_info_with_record(self, record):
+        """Same as get_object_record, but contains the current request record
+        """
+        # default to the base object info
+        return self.get_object_info()

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1357,18 +1357,19 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         # can be multivalued
         uids = self.get_uids_from_record(record, key)
         objects = map(self.get_object_by_uid, uids)
-        objects = map(lambda obj: self.get_object_info(obj, key), objects)
+        objects = map(lambda obj: self.get_object_info(
+            obj, key, record=record), objects)
         return filter(None, objects)
 
-    def object_info_cache_key(method, self, obj, key):
+    def object_info_cache_key(method, self, obj, key, **kw):
         if obj is None or not key:
             raise DontCache
         field_name = key.replace("_uid", "").lower()
         obj_key = api.get_cache_key(obj)
-        return "-".join([field_name, obj_key])
+        return "-".join([field_name, obj_key] + kw.keys())
 
     @cache(object_info_cache_key)
-    def get_object_info(self, obj, key):
+    def get_object_info(self, obj, key, record=None):
         """Returns the object info metadata for the passed in object and key
         :param obj: the object from which extract the info from
         :param key: The key of the field from the record (e.g. Client_uid)
@@ -1385,7 +1386,10 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         # Check if there is any adapter to handle objects for this field
         for name, adapter in getAdapters((obj, ), IAddSampleObjectInfo):
             logger.info("adapter for '{}': {}".format(field_name, name))
-            ad_info = adapter.get_object_info()
+            if record is not None:
+                ad_info = adapter.get_object_info_with_record(record)
+            else:
+                ad_info = adapter.get_object_info(record)
             self.update_object_info(info, ad_info)
 
         return info

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1389,7 +1389,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             if record is not None:
                 ad_info = adapter.get_object_info_with_record(record)
             else:
-                ad_info = adapter.get_object_info(record)
+                ad_info = adapter.get_object_info()
             self.update_object_info(info, ad_info)
 
         return info


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR provides the current request record to object info adapter in the sample add form.

A request record contains all of the already set fields of the form and allows the adapters to change the `field_values` and `filter_queries` depending on the values of the record.

## Current behavior before PR

It is not possible to filter a reference field depending on the values of the current record.

## Desired behavior after PR is merged

Values of the current request record can be used to set the filter queries for reference fields.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
