### PR TITLE
Fix wrong context in reference widget lookups

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1917 Fix wrong context in reference widget lookups
 - #1916 Provide the request record to object info adapters in the sample add form
 - #1913 Ported PR #1865 for dexterity contents
 - #1915 Support list queries in dx reference widget

--- a/src/senaite/core/browser/widgets/referencewidget.py
+++ b/src/senaite/core/browser/widgets/referencewidget.py
@@ -100,8 +100,14 @@ class ReferenceWidget(StringWidget):
         colModel = self.colModel
         if "UID" not in [x["columnName"] for x in colModel]:
             colModel.append({"columnName": "UID", "hidden": True})
+
+        # ensure we have an absolute url for the current context
+        url = api.get_url(context)
+        search_path = self.url.split(url)[-1]
+        search_url = "/".join([url, search_path])
+
         options = {
-            "url": self.url,
+            "url": search_url,
             "colModel": colModel,
             "showOn": self.showOn,
             "width": self.popup_width,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the AT referencewidget lookup URL to be absolute.

## Current behavior before PR

Reference widget context for sample lookups is the client object.

## Desired behavior after PR is merged

Reference widget context for sample lookups is the sample object.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
