### PR TITLE
Fix stale combobox items displayed when search query changed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1918 Fix stale combobox items displayed when search query changed
 - #1917 Fix wrong context in reference widget lookups
 - #1916 Provide the request record to object info adapters in the sample add form
 - #1913 Ported PR #1865 for dexterity contents

--- a/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
@@ -510,8 +510,7 @@
         return;
       }
       options = JSON.parse(field.attr("combogrid_options"));
-      url = this.get_base_url();
-      url += "/" + options.url;
+      url = options.url;
       url += "?_authenticator=" + (this.get_authenticator());
       url += "&catalog_name=" + catalog_name;
       url += "&colModel=" + (JSON.stringify(options.colModel));
@@ -532,7 +531,8 @@
       options.url = url;
       options.force_all = "false";
       field.combogrid(options);
-      return field.attr("search_query", "{}");
+      field.attr("search_query", "{}");
+      return field.trigger("blur");
     };
 
     AnalysisRequestAdd.prototype.set_reference_field = function(field, uid, title) {

--- a/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -491,9 +491,11 @@ class window.AnalysisRequestAdd
     # get the combogrid options
     options = JSON.parse field.attr "combogrid_options"
 
+    # we have absolute URLs now
+    # https://github.com/senaite/senaite.core/pull/1917
+    url = options.url
+
     # prepare the new query url
-    url = @get_base_url()
-    url += "/#{options.url}"
     url += "?_authenticator=#{@get_authenticator()}"
     url += "&catalog_name=#{catalog_name}"
     url += "&colModel=#{JSON.stringify options.colModel}"
@@ -519,9 +521,11 @@ class window.AnalysisRequestAdd
     options.url = url
     options.force_all = "false"
 
-
     field.combogrid options
     field.attr "search_query", "{}"
+
+    # close on any open searchbox to force reload on the next focus
+    field.trigger("blur")
 
 
   set_reference_field: (field, uid, title) =>

--- a/src/senaite/core/browser/widgets/referencewidget.py
+++ b/src/senaite/core/browser/widgets/referencewidget.py
@@ -96,18 +96,25 @@ class ReferenceWidget(StringWidget):
             uid = None
         return uid, {}
 
+    def get_search_url(self, context):
+        """Prepare an absolute search url for the combobox
+        """
+        # ensure we have an absolute url for the current context
+        url = api.get_url(context)
+        # normalize portal factory urls
+        url = url.split("portal_factory")[0]
+        # ensure the search path does not contain already the url
+        search_path = self.url.split(url)[-1]
+        # return the absolute search url
+        return "/".join([url, search_path])
+
     def get_combogrid_options(self, context, fieldName):
         colModel = self.colModel
         if "UID" not in [x["columnName"] for x in colModel]:
             colModel.append({"columnName": "UID", "hidden": True})
 
-        # ensure we have an absolute url for the current context
-        url = api.get_url(context)
-        search_path = self.url.split(url)[-1]
-        search_url = "/".join([url, search_path])
-
         options = {
-            "url": search_url,
+            "url": self.get_search_url(context),
             "colModel": colModel,
             "showOn": self.showOn,
             "width": self.popup_width,

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/referencewidget.js
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/referencewidget.js
@@ -133,9 +133,6 @@ function referencewidget_lookups(elements) {
       }
     };
 
-    if (window.location.href.search("portal_factory") > -1) {
-      options.url = window.location.href.split("/portal_factory")[0] + "/" + options.url;
-    }
     options.url = options.url + "?_authenticator=" + $("input[name='_authenticator']").val();
     options.url = options.url + "&catalog_name=" + $(element).attr("catalog_name");
     options.url = options.url + "&base_query=" + $(element).attr("base_query");


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue that stale combobox items are displayed after the search query changed, e.g. after the selection of another field that filters the current open one (due to request/response delay).

## Current behavior before PR

Stale items are displayed in open comboboxes, event though the search query was changed.

## Desired behavior after PR is merged

Combo box closes and a new search is initiated when the field get the focus again

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
