### PR TITLE
Always call object info adapters with a record

### DIFF
--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1221,7 +1221,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                     if len(uids) == 1:
                         extra_fields[field_name] = uids[0]
 
-        # Populate metadata with object info from extra fields
+        # Populate metadata with object info from extra fields (hidden fields)
         for field_name, uid in extra_fields.items():
             key = "{}_metadata".format(field_name.lower())
             if metadata.get(key):
@@ -1230,7 +1230,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             obj = self.get_object_by_uid(uid)
             if not obj:
                 continue
-            obj_info = self.get_object_info(obj, field_name)
+            obj_info = self.get_object_info(obj, field_name, record=extra_fields)
             if not obj_info or "uid" not in obj_info:
                 continue
             metadata[key] = {obj_info["uid"]: obj_info}
@@ -1380,16 +1380,17 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         func_name = "get_{}_info".format(field_name.lower())
         func = getattr(self, func_name, None)
 
+        # always ensure we have a record
+        if record is None:
+            record = {}
+
         # Get the info for each object
         info = callable(func) and func(obj) or self.get_base_info(obj)
 
         # Check if there is any adapter to handle objects for this field
         for name, adapter in getAdapters((obj, ), IAddSampleObjectInfo):
             logger.info("adapter for '{}': {}".format(field_name, name))
-            if record is not None:
-                ad_info = adapter.get_object_info_with_record(record)
-            else:
-                ad_info = adapter.get_object_info()
+            ad_info = adapter.get_object_info_with_record(record)
             self.update_object_info(info, ad_info)
 
         return info


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR improves https://github.com/senaite/senaite.core/pull/1916

## Current behavior before PR

`get_object_info` was called without a record when handling extra fields

## Desired behavior after PR is merged

`get_object_info` is called always with record

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
