### PR TITLE
Fix indexed attributes not set when adding a new index with catalog API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1920 Fix indexed attributes not set when adding a new index with catalog API
 - #1918 Fix stale combobox items displayed when search query changed
 - #1917 Fix wrong context in reference widget lookups
 - #1916 Provide the request record to object info adapters in the sample add form

--- a/src/senaite/core/api/catalog.py
+++ b/src/senaite/core/api/catalog.py
@@ -75,8 +75,8 @@ def add_index(catalog, index, index_type, indexed_attrs=None):
         return add_zc_text_index(catalog, index)
     catalog.addIndex(index, index_type)
     # set indexed attribute
-    if indexed_attrs and hasattr(index, "indexed_attrs"):
-        index_obj = get_index(index)
+    index_obj = get_index(catalog, index)
+    if indexed_attrs and hasattr(index_obj, "indexed_attrs"):
         if not isinstance(indexed_attrs, list):
             indexed_attrs = [indexed_attrs]
         index_obj.indexed_attrs = indexed_attrs


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the catalog API `add_index` function when indexed attributes need to be set.

## Current behavior before PR

Indexed attributes not set

## Desired behavior after PR is merged

Indexed attributes are set correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
