### PR TITLE
Use native date input fields in reports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1923 Use native date input fields in reports
 - #1918 Fix stale combobox items displayed when search query changed
 - #1917 Fix wrong context in reference widget lookups
 - #1916 Provide the request record to object info adapters in the sample add form

--- a/src/bika/lims/browser/reports/selection_macros/select_daterange.pt
+++ b/src/bika/lims/browser/reports/selection_macros/select_daterange.pt
@@ -5,35 +5,23 @@
   <table id="date">
     <tr>
       <td>
-        <span i18n:translate="">From</span>
+        <span i18n:translate="label_date_from">From</span>
       </td>
       <td>
-        <tal:date tal:define="input_id string:${view/field_id}_fromdate;
-                              input_name input_id">
-          <input class='datepicker_2months'
-                 size="10"
-                 type='text'
-                 readonly="readonly"
-                 tal:attributes="value python:'';
-                                 name input_name;"/>
+        <tal:date tal:define="input_name string:${view/field_id}_fromdate;">
+          <input type="date" tal:attributes="name input_name;"/>
         </tal:date>
       </td>
     </tr>
 
     <tr>
       <td>
-        <span i18n:translate="">to</span>
+        <span i18n:translate="label_date_to">to</span>
       </td>
       <td>
-        <tal:date tal:define="input_id string:${view/field_id}_todate;
-                              input_name input_id">
-          <input class='datepicker_2months'
-                 size="10"
-                 type='text'
-                 readonly="readonly"
-                 tal:attributes="
-                        value python:'';
-                        name input_name;"/>
+        <tal:date tal:define="input_name string:${view/field_id}_todate;">
+          <input type="date"
+                 tal:attributes="name input_name;"/>
         </tal:date>
       </td>
     </tr>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1922

This was a side effect from https://github.com/senaite/senaite.core/pull/1892

## Current behavior before PR

No date widgets displayed for reports

## Desired behavior after PR is merged

Native HTML date widget is displayed

<img width="975" alt="Reports — SENAITE LIMS 2022-01-25 10-28-42" src="https://user-images.githubusercontent.com/713193/150949689-7c4fd28e-5585-4fbc-8677-369c059b0345.png">


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
