### PR TITLE
Analysis attachment is copied on retest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1927 Fix Analysis attachment is copied on retest
 - #1925 Fix sample transition in listings
 - #1924 Fix Login screen shows message error while rendering plone.htmlhead.socialtags
 - #1923 Use native date input fields in reports

--- a/src/bika/lims/utils/analysis.py
+++ b/src/bika/lims/utils/analysis.py
@@ -58,7 +58,7 @@ def copy_analysis_field_values(source, analysis, **kwargs):
     IGNORE_FIELDNAMES = [
         'UID', 'id', 'allowDiscussion', 'subject', 'location', 'contributors',
         'creators', 'effectiveDate', 'expirationDate', 'language', 'rights',
-        'creation_date', 'modification_date', 'Hidden']
+        'creation_date', 'modification_date', 'Hidden', 'Attachment']
     for field in src_schema.fields():
         fieldname = field.getName()
         if fieldname in IGNORE_FIELDNAMES and fieldname not in kwargs:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When a retest is created, the system generates a copy of the original analysis. User will then be able to input results for this new analysis as a retest. The attachment in analyses is quite often considered as the "result" itself and there is no option of overriding. This Pull Request prevents the attachment to be copied when a retest is created.

## Current behavior before PR

Attachment is copied from original analysis to the retest

## Desired behavior after PR is merged

Attachment is not copied from original analysis to the retest

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
