### PR TITLE
Added `on_change` hook for methods in analyses listings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1928 Added `on_change` hook for methods in analyses listings
 - #1925 Fix sample transition in listings
 - #1924 Fix Login screen shows message error while rendering plone.htmlhead.socialtags
 - #1923 Use native date input fields in reports

--- a/src/bika/lims/browser/worksheet/views/analyses.py
+++ b/src/bika/lims/browser/worksheet/views/analyses.py
@@ -79,6 +79,7 @@ class AnalysesView(BaseView):
             ("Method", {
                 "sortable": False,
                 "ajax": True,
+                "on_change": "_on_method_change",
                 "title": _("Method")}),
             ("Instrument", {
                 "sortable": False,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Note: This PR requires https://github.com/senaite/senaite.app.listing/pull/68 to work!

This PR allows to set an `on_change` key to a listing column with the name of an method to call when the value of an folder item changed, e.g.:

```python
...
self.columns = OrderedDict((
    ("Method", {
        "title": _("Method"),
        "sortable": False,
        "ajax": True,
        "on_change": "_on_method_change",
        "toggle": True}),
...
```

The named method is called when a value of the column/folderitem is changed, e.g. when a different method was set.

The signature of the callback method is as follows:

```python
def _on_method_change(self, uid=None, value=None, item=None, **kw):
    """Update instrument and calculation when the method changes

    :param uid: object UID
    :value: UID of the new method
    :item: old folderitem

    :returns: updated folderitem
    """
...
return item
```

## Current behavior before PR

No possibility to update dependent field when a value changed of a folderitem

## Desired behavior after PR is merged

Dependent fields can be updated with callbacks

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
