### PR TITLE
Ensure valid timezone in DX datetime field setter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1930 Ensure valid timezone in DX datetime field setter
 - #1927 Fix Analysis attachment is copied on retest
 - #1928 Added `on_change` hook for methods in analyses listings
 - #1925 Fix sample transition in listings

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -157,7 +157,7 @@ def get_timezone(dt, default="UTC"):
     elif is_d(dt):
         tz = default
 
-    if dt is not None:
+    if tz:
         # convert DateTime `GMT` to `Etc/GMT` timezones
         # NOTE: `GMT+1` get `Etc/GMT-1`!
         if tz.startswith("GMT+0"):
@@ -165,11 +165,10 @@ def get_timezone(dt, default="UTC"):
         elif tz.startswith("GMT+"):
             tz = tz.replace("GMT+", "Etc/GMT-")
         elif tz.startswith("GMT-"):
-            tz = tz.replace("GMT+", "Etc/GMT-")
+            tz = tz.replace("GMT-", "Etc/GMT+")
         elif tz.startswith("GMT"):
             tz = tz.replace("GMT", "Etc/GMT")
-
-    if tz is None:
+    else:
         tz = default
 
     return tz

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -126,7 +126,12 @@ def to_dt(dt):
     :returns: datetime object
     """
     if is_DT(dt):
-        return dt.asdatetime()
+        # get a valid pytz timezone
+        tz = get_timezone(dt)
+        dt = dt.asdatetime()
+        if is_valid_timezone(tz):
+            dt = to_zone(dt, tz)
+        return dt
     elif is_str(dt):
         DT = to_DT(dt)
         return to_dt(DT)
@@ -136,6 +141,38 @@ def to_dt(dt):
         return datetime(dt.year, dt.month, dt.day)
     else:
         return None
+
+
+def get_timezone(dt, default="UTC"):
+    """Get a valid pytz timezone of the datetime object
+
+    :param dt: date object
+    :returns: timezone as string, e.g. Etc/GMT or CET
+    """
+    tz = None
+    if is_dt(dt):
+        tz = dt.tzname()
+    elif is_DT(dt):
+        tz = dt.timezone()
+    elif is_d(dt):
+        tz = default
+
+    if dt is not None:
+        # convert DateTime `GMT` to `Etc/GMT` timezones
+        # NOTE: `GMT+1` get `Etc/GMT-1`!
+        if tz.startswith("GMT+0"):
+            tz = tz.replace("GMT+0", "Etc/GMT")
+        elif tz.startswith("GMT+"):
+            tz = tz.replace("GMT+", "Etc/GMT-")
+        elif tz.startswith("GMT-"):
+            tz = tz.replace("GMT+", "Etc/GMT-")
+        elif tz.startswith("GMT"):
+            tz = tz.replace("GMT", "Etc/GMT")
+
+    if tz is None:
+        tz = default
+
+    return tz
 
 
 def is_valid_timezone(timezone):

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -143,7 +143,7 @@ def to_dt(dt):
         return None
 
 
-def get_timezone(dt, default="UTC"):
+def get_timezone(dt, default="Etc/GMT"):
     """Get a valid pytz timezone of the datetime object
 
     :param dt: date object
@@ -187,12 +187,11 @@ def is_valid_timezone(timezone):
         return False
 
 
-def get_os_timezone():
+def get_os_timezone(default="Etc/GMT"):
     """Return the default timezone of the system
 
-    :returns: OS timezone or UTC
+    :returns: OS timezone or default timezone
     """
-    fallback = "UTC"
     timezone = None
     if "TZ" in os.environ.keys():
         # Timezone from OS env var
@@ -203,13 +202,12 @@ def get_os_timezone():
         if zones and len(zones) > 0:
             timezone = zones[0]
         else:
-            # Default fallback = UTC
             logger.warn(
                 "Operating system\'s timezone cannot be found. "
-                "Falling back to UTC.")
-            timezone = fallback
+                "Falling back to %s." % default)
+            timezone = default
     if not is_valid_timezone(timezone):
-        return fallback
+        return default
     return timezone
 
 

--- a/src/senaite/core/schema/datetimefield.py
+++ b/src/senaite/core/schema/datetimefield.py
@@ -35,7 +35,7 @@ class DatetimeField(Datetime, BaseField):
         # ensure we have a `datetime` object
         dt = dtime.to_dt(value)
         # ensure we have always a date with a valid timezone
-        if dtime.is_timezone_naive(dt):
+        if dt and dtime.is_timezone_naive(dt):
             # append default OS timezone
             tz = dtime.get_os_timezone()
             dt = dtime.to_zone(dt, tz)

--- a/src/senaite/core/schema/datetimefield.py
+++ b/src/senaite/core/schema/datetimefield.py
@@ -26,7 +26,6 @@ class DatetimeField(Datetime, BaseField):
     def set(self, object, value):
         """Set datetime value
 
-
         NOTE: we need to ensure timzone aware datetime values,
               so that also API calls work
 

--- a/src/senaite/core/schema/datetimefield.py
+++ b/src/senaite/core/schema/datetimefield.py
@@ -6,6 +6,8 @@ from senaite.core.schema.interfaces import IDatetimeField
 from zope.interface import implementer
 from zope.schema import Datetime
 
+DATE_FORMAT = "%Y-%m-%d"
+
 
 def localize(dt, fallback="UTC"):
     if dtime.is_timezone_naive(dt):
@@ -32,8 +34,18 @@ class DatetimeField(Datetime, BaseField):
         :param value: datetime value
         :type value: datetime
         """
-        if dtime.is_date(value):
-            value = localize(dtime.to_dt(value))
+        if dtime.is_DT(value):
+            # convert to a date string w/o zone info
+            # see doctest for further information
+            value = value.strftime(DATE_FORMAT)
+
+        # convert to localized datetime object
+        value = dtime.to_dt(value)
+        if value:
+            value = localize(value)
+        else:
+            value = None
+
         super(DatetimeField, self).set(object, value)
 
     def get(self, object):

--- a/src/senaite/core/schema/datetimefield.py
+++ b/src/senaite/core/schema/datetimefield.py
@@ -33,11 +33,6 @@ class DatetimeField(Datetime, BaseField):
         :param value: datetime value
         :type value: datetime
         """
-        if dtime.is_DT(value):
-            # convert to a date string w/o zone info
-            # see doctest for further information
-            value = value.strftime(DATE_FORMAT)
-
         # convert to localized datetime object
         value = dtime.to_dt(value)
         if value:

--- a/src/senaite/core/schema/datetimefield.py
+++ b/src/senaite/core/schema/datetimefield.py
@@ -6,17 +6,6 @@ from senaite.core.schema.interfaces import IDatetimeField
 from zope.interface import implementer
 from zope.schema import Datetime
 
-DATE_FORMAT = "%Y-%m-%d"
-
-
-def localize(dt, fallback="UTC"):
-    if dtime.is_timezone_naive(dt):
-        zone = dtime.get_os_timezone()
-        if not zone:
-            zone = fallback
-        dt = dtime.to_zone(dt, zone)
-    return dt
-
 
 @implementer(IDatetimeField)
 class DatetimeField(Datetime, BaseField):
@@ -33,13 +22,7 @@ class DatetimeField(Datetime, BaseField):
         :param value: datetime value
         :type value: datetime
         """
-        # convert to localized datetime object
         value = dtime.to_dt(value)
-        if value:
-            value = localize(value)
-        else:
-            value = None
-
         super(DatetimeField, self).set(object, value)
 
     def get(self, object):
@@ -49,13 +32,14 @@ class DatetimeField(Datetime, BaseField):
         :returns: datetime or None
         """
         value = super(DatetimeField, self).get(object)
-        # bail out if value is not a known date object
-        if not dtime.is_date(value):
-            return None
         # ensure we have a `datetime` object
-        value = dtime.to_dt(value)
-        # always return localized datetime objects
-        return localize(value)
+        dt = dtime.to_dt(value)
+        # ensure we have always a date with a valid timezone
+        if dtime.is_timezone_naive(dt):
+            # append default OS timezone
+            tz = dtime.get_os_timezone()
+            dt = dtime.to_zone(dt, tz)
+        return dt
 
     def _validate(self, value):
         """Validator when called from form submission

--- a/src/senaite/core/schema/datetimefield.txt
+++ b/src/senaite/core/schema/datetimefield.txt
@@ -109,7 +109,7 @@ Thererfore, we must ensure that the field converts `DateTime` dates to a valid z
     >>> content = Content()
     >>> field.set(content, DT)
     >>> field.get(content)
-    datetime.datetime(1980, 2, 25, 0, 0, tzinfo=<DstTzInfo 'CET' CET+1:00:00 STD>)
+    datetime.datetime(1980, 2, 25, 0, 0, tzinfo=<StaticTzInfo 'Etc/GMT-1'>)
 
 NOTE:
 We assume that there is no difference between the `DateTime` timezone to the

--- a/src/senaite/core/schema/datetimefield.txt
+++ b/src/senaite/core/schema/datetimefield.txt
@@ -112,5 +112,12 @@ Thererfore, we must ensure that the field converts `DateTime` dates to a valid z
     datetime.datetime(1980, 2, 25, 0, 0, tzinfo=<StaticTzInfo 'Etc/GMT-1'>)
 
 NOTE:
-We assume that there is no difference between the `DateTime` timezone to the
-systems timezone when the field is set with a value.
+
+The Olson tz database defines Etc/GMT+N timezones which conform with the POSIX style:
+
+Those zone names beginning with "Etc/GMT" have their sign reversed from the
+standard ISO 8601 convention. In the "Etc" area, zones west of GMT have a
+positive sign and those east have a negative sign in their name (e.g
+"Etc/GMT-14" is 14 hours ahead of GMT.)
+
+https://en.wikipedia.org/wiki/Tz_database

--- a/src/senaite/core/schema/datetimefield.txt
+++ b/src/senaite/core/schema/datetimefield.txt
@@ -23,6 +23,7 @@ Test preparation
     >>> from plone.app.testing import TEST_USER_ID
     >>> from plone.app.testing import TEST_USER_NAME
     >>> from plone.app.testing import TEST_USER_PASSWORD
+    >>> from DateTime import DateTime
 
 Helper functions:
 
@@ -74,3 +75,42 @@ Set a value through the field:
     >>> field.set(content, date)
     >>> field.get(content)
     datetime.datetime(2030, 12, 24, 0, 0, tzinfo=<DstTzInfo 'CET' CET+1:00:00 STD>)
+
+
+Handling DateTime objects
+-------------------------
+
+The `DateTime` module uses timezones based on `GMT`, e.g. `GMT+1`.
+Using the `asdatetime` method to generate a `datetime` with a static zone:
+
+
+    >>> DT = DateTime("1980-02-25 GMT+1")
+    >>> DT.asdatetime()
+    datetime.datetime(1980, 2, 25, 0, 0, tzinfo=<StaticTzInfo 'GMT+1'>)
+
+When we set this value on the datetime field, we get the following traecback when
+the object is loaded from the ZODB:
+
+    Traceback (innermost last):
+      ...
+      Module ZODB.Connection, line 795, in setstate
+      Module ZODB.serialize, line 633, in setGhostState
+      Module ZODB.serialize, line 626, in getState
+      Module pytz, line 307, in _p
+      Module pytz.tzinfo, line 539, in unpickler
+      Module pytz, line 188, in timezone
+    UnknownTimeZoneError: (UnknownTimeZoneError('GMT+1',), <function _p at 0x10adda450>, ('GMT+1',))
+
+Also see here for further information:
+https://community.plone.org/t/unknowntimezoneerror-pytz-quirks
+
+Thererfore, we must ensure that the field converts `DateTime` dates to a valid zone:
+
+    >>> content = Content()
+    >>> field.set(content, DT)
+    >>> field.get(content)
+    datetime.datetime(1980, 2, 25, 0, 0, tzinfo=<DstTzInfo 'CET' CET+1:00:00 STD>)
+
+NOTE:
+We assume that there is no difference between the `DateTime` timezone to the
+systems timezone when the field is set with a value.

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -236,7 +236,7 @@ Get the timezone from `datetime.datetime` objects:
     >>> DATE = "2021-12-24 12:00"
     >>> dt = datetime.strptime(DATE, DATEFORMAT)
     >>> dtime.get_timezone(dt)
-    'UTC'
+    'Etc/GMT'
 
     >>> dtime.get_timezone(dtime.to_zone(dt, "Europe/Berlin"))
     'CET'
@@ -244,7 +244,7 @@ Get the timezone from `datetime.datetime` objects:
 Get the timezone from `datetime.date` objects:
 
     >>> dtime.get_timezone(dt.date)
-    'UTC'
+    'Etc/GMT'
 
 
 Check if timezone is valid

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -191,7 +191,7 @@ Convert to datetime
     >>> isinstance(dt, datetime)
     True
 
-Timezone naive `DateTime` is converted w/o timezone:
+Timezone naive `DateTime` is converted with `Etc/GMT` timezone:
 
     >>> dt = DateTime(DATE)
     >>> dt
@@ -201,7 +201,7 @@ Timezone naive `DateTime` is converted w/o timezone:
     True
 
     >>> dtime.to_dt(dt)
-    datetime.datetime(2021, 8, 1, 12, 0)
+    datetime.datetime(2021, 8, 1, 12, 0, tzinfo=<StaticTzInfo 'Etc/GMT'>)
 
 Timezone aware `DateTime` is converted with timezone.
 
@@ -213,11 +213,48 @@ Timezone aware `DateTime` is converted with timezone.
     DateTime('2021/08/01 13:00:00 GMT+1')
 
     >>> dtime.to_dt(dt)
-    datetime.datetime(2021, 8, 1, 13, 0, tzinfo=<StaticTzInfo 'GMT+1'>)
+    datetime.datetime(2021, 8, 1, 13, 0, tzinfo=<StaticTzInfo 'Etc/GMT-1'>)
+
+
+Get the timezone
+................
+
+Get the timezone from `DateTime` objects:
+
+    >>> dtime.get_timezone(DateTime("2022-02-25"))
+    'Etc/GMT'
+
+    >>> dtime.get_timezone(DateTime("2022-02-25 12:00 GMT+2"))
+    'Etc/GMT-2'
+
+    >>> dtime.get_timezone(DateTime("2022-02-25 12:00 GMT-2"))
+    'Etc/GMT+2'
+
+
+Get the timezone from `datetime.datetime` objects:
+
+    >>> DATE = "2021-12-24 12:00"
+    >>> dt = datetime.strptime(DATE, DATEFORMAT)
+    >>> dtime.get_timezone(dt)
+    'UTC'
+
+    >>> dtime.get_timezone(dtime.to_zone(dt, "Europe/Berlin"))
+    'CET'
+
+Get the timezone from `datetime.date` objects:
+
+    >>> dtime.get_timezone(dt.date)
+    'UTC'
 
 
 Check if timezone is valid
 ..........................
+
+    >>> dtime.is_valid_timezone("Etc/GMT-1")
+    True
+
+    >>> dtime.is_valid_timezone("Etc/GMT-0100")
+    False
 
     >>> dtime.is_valid_timezone("Europe/Berlin")
     True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR ensures a valid `pytz` timezone when setting a `DateTime` date to the DX datetime field.

## Current behavior before PR

Traceback occured when a `DateTime` object was set to a DX field:

```
Traceback (innermost last):
  ...
  Module ZODB.Connection, line 795, in setstate
  Module ZODB.serialize, line 633, in setGhostState
  Module ZODB.serialize, line 626, in getState
  Module pytz, line 307, in _p
  Module pytz.tzinfo, line 539, in unpickler
  Module pytz, line 188, in timezone
UnknownTimeZoneError: (UnknownTimeZoneError('GMT+1',), <function _p at 0x10adda450>, ('GMT+1',))
```

## Desired behavior after PR is merged

`DateTime` objects are converted with a valid timezone when setting the field

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
