### PR TITLE
Do not display capture date when no result or default result

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1936 Do not display capture date when no result or default result
 - #1933 Added SENAITE maintenance scripts
 - #1932 Fix cannot attach documents to individual analyses in Worksheet context
 - #1930 Ensure valid timezone in DX datetime field setter

--- a/src/bika/lims/browser/fields/aranalysesfield.py
+++ b/src/bika/lims/browser/fields/aranalysesfield.py
@@ -262,8 +262,9 @@ class ARAnalysesField(ObjectField):
             analysis.setInternalUse(parent_sample.getInternalUse())
 
             # Set the default result to the analysis
-            if not analysis.getResult():
+            if not analysis.getResult() and default_result:
                 analysis.setResult(default_result)
+                analysis.setResultCaptureDate(None)
 
             # Set the result range to the analysis
             analysis_rr = specs.get(service_uid) or analysis.getResultsRange()

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -452,8 +452,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         account the Detection Limits.
         :param value: is expected to be a string.
         """
-        # Always update ResultCapture date when this field is modified
-        self.setResultCaptureDate(DateTime())
+        prev_result = self.getField("Result").get(self) or ""
 
         # Convert to list ff the analysis has result options set with multi
         if self.getResultOptions() and "multi" in self.getResultOptionsType():
@@ -497,6 +496,12 @@ class AbstractAnalysis(AbstractBaseAnalysis):
                         val = self.getLowerDetectionLimit()
                     else:
                         val = self.getUpperDetectionLimit()
+
+        # Update ResultCapture date if necessary
+        if not val:
+            self.setResultCaptureDate(None)
+        elif prev_result != val:
+            self.setResultCaptureDate(DateTime())
 
         # Set the result field
         self.getField("Result").set(self, val)

--- a/src/bika/lims/workflow/analysis/events.py
+++ b/src/bika/lims/workflow/analysis/events.py
@@ -18,19 +18,16 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from zope.interface import alsoProvides
-
 from bika.lims import api
-from bika.lims import logger
 from bika.lims.interfaces import IDuplicateAnalysis
 from bika.lims.interfaces import ISubmitted
 from bika.lims.interfaces import IVerified
 from bika.lims.interfaces.analysis import IRequestAnalysis
-from bika.lims.utils import changeWorkflowState
-from bika.lims.utils.analysis import create_analysis
 from bika.lims.utils.analysis import create_retest
 from bika.lims.workflow import doActionFor
 from bika.lims.workflow import push_reindex_to_actions_pool
+from DateTime import DateTime
+from zope.interface import alsoProvides
 
 
 def after_assign(analysis):
@@ -130,6 +127,11 @@ def after_submit(analysis):
     This function is called automatically by
     bika.lims.workfow.AfterTransitionEventHandler
     """
+    # Ensure there is a Result Capture Date even if the result was set
+    # automatically on creation because of a "DefaultResult"
+    if not analysis.getResultCaptureDate():
+        analysis.setResultCaptureDate(DateTime())
+
     # Mark this analysis as ISubmitted
     alsoProvides(analysis, ISubmitted)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the system to not story a result capture date for analyses unless a non-empty result has been set or the analysis submitted.

## Current behavior before PR

System displays a date for Capture Date even when no result has been set for a given analysis

## Desired behavior after PR is merged

Capture date is only displayed when a result is set for a given analysis or the analysis has been submitted

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
