### PR TITLE
Position the user to the analysis listing from which an action is triggered

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1937 Position the user to the analysis listing after an action is triggered
 - #1935 Allow to edit analysis (pre) conditions
 - #1936 Do not display capture date when no result or default result
 - #1933 Added SENAITE maintenance scripts

--- a/src/bika/lims/browser/workflow/analysis.py
+++ b/src/bika/lims/browser/workflow/analysis.py
@@ -38,6 +38,15 @@ class WorkflowActionSubmitAdapter(WorkflowActionGenericAdapter):
     """Adapter in charge of submission of analyses
     """
 
+    def __init__(self, context, request):
+        super(WorkflowActionSubmitAdapter, self).__init__(context, request)
+
+        form_id = self.request.get("form_id")
+        if form_id:
+            # Inject the form id as the anchor to make the browser to position
+            # down to the listing from which the action has been triggered
+            self.back_url = "{}#{}".format(self.back_url, form_id)
+
     def __call__(self, action, objects):
         # Store invalid instruments-ref.analyses
         invalid_instrument_refs = defaultdict(set)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Requirement: https://github.com/senaite/senaite.app.listing/pull/69**

This Pull Request makes the browser to position the user to the analysis listing after an action ("submit", "retract", etc.) from such listing is triggered.

## Current behavior before PR

Have to constantly scroll from top to bottom as you add and submit results

## Desired behavior after PR is merged

Reduce key strokes as you add and submit results

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
