### PR TITLE
Fix retracted and rejected analyses cannot be added to a Sample

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #1939 Fix retracted and rejected analyses cannot be added to a Sample
 - #1906 Fix traceback in auditlog view when context is a Dexterity type
 - #1885 Allow to re-add cancelled/rejected/retracted analyses (#1777 port)
 - #1885 Fix APIError when a retest analysis source is removed (#1777 port)

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -34,6 +34,8 @@ from plone.memoize import view
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.i18n.locales import locales
 
+DETACHED_STATES = ["cancelled", "rejected", "retracted"]
+
 
 class AnalysisRequestAnalysesView(BikaListingView):
     """AR Manage Analyses View
@@ -218,14 +220,17 @@ class AnalysisRequestAnalysesView(BikaListingView):
 
         if uid in self.analyses:
             analysis = self.analyses[uid]
-            # Might differ from the service keyword
-            keyword = analysis.getKeyword()
-            # Mark the row as disabled if the analysis has been submitted
-            item["disabled"] = ISubmitted.providedBy(analysis)
-            # get the hidden status of the analysis
-            hidden = analysis.getHidden()
-            # get the price of the analysis
-            price = analysis.getPrice()
+            review_state = api.get_review_status(analysis)
+            if review_state not in DETACHED_STATES:
+                # Might differ from the service keyword
+                keyword = analysis.getKeyword()
+                # Mark the row as disabled if the analysis has been submitted
+                item["disabled"] = ISubmitted.providedBy(analysis)
+                # get the hidden status of the analysis
+                hidden = analysis.getHidden()
+                # get the price of the analysis
+                price = analysis.getPrice()
+                item["selected"] = True
 
         # get the specification of this object
         rr = self.get_results_range()
@@ -236,7 +241,6 @@ class AnalysisRequestAnalysesView(BikaListingView):
         item["Price"] = price
         item["before"]["Price"] = self.get_currency_symbol()
         item["allow_edit"] = self.get_editable_columns(obj)
-        item["selected"] = uid in self.selected
         item["min"] = str(spec.get("min", ""))
         item["max"] = str(spec.get("max", ""))
         item["warn_min"] = str(spec.get("warn_min", ""))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes possible to re-add an analysis that was previously retracted or rejected (checkbox was disabled) via "Manage analyses" view. These changes were missing in https://github.com/senaite/senaite.core/pull/1885

## Current behavior before PR

Is not possible to re-add an analysis that was previously retracted or rejected to a sample via "Manage analyses" view

## Desired behavior after PR is merged

Is possible to re-add an analysis that was previously retracted or rejected to a sample via "Manage analyses" view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
