### PR TITLE
Added persistent field subclasss for datagrids

### DIFF
--- a/src/senaite/core/schema/registry.py
+++ b/src/senaite/core/schema/registry.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from senaite.core.schema.fields import DataGridField as BaseDataGridField
+from senaite.core.schema.fields import DataGridRow as BaseDataGridRow
+
+try:
+    from plone.registry.field import PersistentField
+except ImportError:
+    class PersistentField(object):
+        pass
+
+
+class DataGridField(PersistentField, BaseDataGridField):
+    """Use this field for registry entries
+
+    https://pypi.org/project/plone.registry/#persistent-fields
+    https://community.plone.org/t/there-is-no-persistent-field-equivalent-for-the-field-a-of-type-b
+    """
+    pass
+
+
+class DataGridRow(PersistentField, BaseDataGridRow):
+    """Use this field for registry entries
+
+    https://pypi.org/project/plone.registry/#persistent-fields
+    https://community.plone.org/t/there-is-no-persistent-field-equivalent-for-the-field-a-of-type-b
+    """
+    pass


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds persistent field subclasses for DataGrid field to be usable for registry records.

## Current behavior before PR

Traceback occurs:

TypeError: There is no persistent field equivalent for the field `...` of type `...`.

## Desired behavior after PR is merged

Datagrid field can be used for registry records.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
