### PR TITLE
Fixed error with sampler mail

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 2.2.0 (unreleased)
 ------------------
-
+- #1941 Fixed error with sampler mail
 - #1938 Converted sample interpretation and remarks widgets into viewlets
 - #1937 Position the user to the analysis listing after an action is triggered
 - #1935 Allow to edit analysis (pre) conditions

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -2182,7 +2182,7 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
         """
         Returns the email of this analysis request's sampler.
         """
-        return user_email(self, self.Creator())
+        return user_email(self, self.getSampler())
 
     def getPriorityText(self):
         """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixed error with sampler mail

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR

The getSamplerEmail() function for analysis request returns the email of the creator 

## Desired behavior after PR is merged

The getSamplerEmail() function for analysis request returns the email of the sampler
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
