### PR TITLE
Fix tab styling in email log popup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Changelog
 
 2.2.0 (unreleased)
 ------------------
+
+- #1942 Fix tab styling in email log popup
 - #1941 Fixed error with sampler mail
 - #1938 Converted sample interpretation and remarks widgets into viewlets
 - #1937 Position the user to the analysis listing after an action is triggered

--- a/src/bika/lims/browser/templates/analysisreport_info.pt
+++ b/src/bika/lims/browser/templates/analysisreport_info.pt
@@ -102,12 +102,13 @@
               <li role="presentation"
                   tal:define="num repeat/record/number;
                               send_date record/email_send_date"
-                  tal:attributes="class python:num==1 and 'active' or ''">
+                  class="nav-item">
                 <a href="#"
                    role="tab"
                    data-toggle="tab"
                    tal:content="python:view.ulocalized_time(send_date, 1)"
-                   tal:attributes="href string:#tab-${num};">
+                   tal:attributes="href string:#tab-${num};
+                                   class python:num==1 and 'active nav-link' or 'nav-link'">
                 </a>
               </li>
             </tal:record>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the CSS style for the email log tabs in the results report popup.

<img width="1081" alt="OPS-0012 — SENAITE LIMS 2022-02-22 2 PM-42-01" src="https://user-images.githubusercontent.com/713193/155144584-c7c174e4-d0f3-46f5-8671-be144def0f75.png">


## Current behavior before PR

No tabs for sent emails displayed.

## Desired behavior after PR is merged

Tabs for sent email displayed correctly.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
