### PR TITLE
Support UIDs from interim fields as input values for calculations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1943 Support UIDs from interim fields as input values for calculations
 - #1942 Fix tab styling in email log popup
 - #1941 Fixed error with sampler mail
 - #1938 Converted sample interpretation and remarks widgets into viewlets

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -528,17 +528,24 @@ class AbstractAnalysis(AbstractBaseAnalysis):
 
         # Add interims to mapping
         for i in interims:
-            if 'keyword' not in i:
+
+            interim_keyword = i.get("keyword")
+            if not interim_keyword:
                 continue
+
             # skip unset values
-            if i['value'] == '':
+            interim_value = i.get("value", "")
+            if interim_value == "":
                 continue
-            try:
-                ivalue = float(i['value'])
-                mapping[i['keyword']] = ivalue
-            except (TypeError, ValueError):
-                # Interim not float, abort
+
+            # Only floatable and UIDs are supported
+            if api.is_floatable(interim_value):
+                interim_value = float(interim_value)
+
+            elif not api.is_uid(interim_value):
                 return False
+
+            mapping[interim_keyword] = interim_value
 
         # Add dependencies results to mapping
         dependencies = self.getDependencies()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Calculations have been enhanced a lot since their initial conception. At current time is possible to setup calculations programmatically that can receive different types of information. The use of current analysis UID as an input parameter is something that was already introduced with #1874 

This Pull Request makes possible the use of UIDs from interim field values as input variables for calculations. Thus, calculation can be triggered for analysis with interims that have choices, with UIDs as values and object names as titles, like the analysis *Breakpoints table* from `senaite.ast`:

        # Convert these breakpoints to interim choices and update interim
        breakpoints = get_breakpoints_tables_for(microorganism, uid)
        choices = to_interim_choices(breakpoints, empty_value=_("N/S"))
        interim_field.update({"choices": choices})

See https://github.com/senaite/senaite.ast/blob/501bc770acbf4feff53f6620f4cf6d3850fad3b2/src/senaite/ast/utils.py#L203-L205

## Current behavior before PR

Calculation for analyses with interim fields with non-floatable values are aborted

## Desired behavior after PR is merged

Calculation for analysis with interim fields with floatable or UID-like values are not aborted

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
