### PR TITLE
Resolve issue with conditions in Reference analyses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1946 Fix conditions issue in Reference Analyses display view
 - #1944 Add handler for "content_status_modify"-like requests
 - #1943 Support UIDs from interim fields as input values for calculations
 - #1942 Fix tab styling in email log popup

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -36,6 +36,7 @@ from bika.lims.config import UDL
 from bika.lims.interfaces import IAnalysisRequest
 from bika.lims.interfaces import IFieldIcons
 from bika.lims.interfaces import IRoutineAnalysis
+from bika.lims.interfaces import IReferenceAnalysis
 from bika.lims.permissions import EditFieldResults
 from bika.lims.permissions import EditResults
 from bika.lims.permissions import FieldEditAnalysisHidden
@@ -377,6 +378,10 @@ class AnalysesView(ListingView):
         """
         # Check if permission is granted for the given analysis
         obj = self.get_object(analysis_brain)
+
+        if IReferenceAnalysis.providedBy(obj):
+            return False
+
         if not self.has_permission(FieldEditAnalysisConditions, obj):
             return False
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

After #1935 (Allow to edit analysis (pre) conditions) PR was released there is a problem raised with display of Reference Analyses ananalyses/view.py, because Reference Analisys entity has no getConditions() method.

## Current behavior before PR

<img width="1671" alt="image" src="https://user-images.githubusercontent.com/14867014/158126979-8b69f3af-dd85-45db-a536-23c50c453e11.png">


Senaite raises error in QCAnalysesView(AnalysesView) when it tries to call:

```python
def folderitem(self, obj, item, index):
    item = super(QCAnalysesView, self).folderitem(obj, item, index)
```

which finally calls is_analysis_conditions_edition_allowed() method where in turn getConditions() method called for ReferenceAnalysis object, but no such method exist for this type of content.

Traceback:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.app.listing.view, line 224, in call
  Module senaite.app.listing.ajax, line 111, in handle_subpath
  Module senaite.core.decorators, line 22, in decorator
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 436, in ajax_folderitems
  Module senaite.app.listing.decorators, line 88, in wrapper
  Module senaite.app.listing.ajax, line 317, in get_folderitems
  Module bika.lims.browser.analyses.view, line 711, in folderitems
  Module senaite.app.listing.view, line 938, in folderitems
  Module bika.lims.browser.analyses.qc, line 96, in folderitem
  Module bika.lims.browser.analyses.view, line 641, in folderitem
  Module plone.memoize.view, line 59, in memogetter
  Module bika.lims.browser.analyses.view, line 384, in is_analysis_conditions_edition_allowed
AttributeError: 'RequestContainer' object has no attribute 'getConditions'
```

## Desired behavior after PR is merged

no exception raised.

@xispa may be it's reasonble to add conditions property to reference analyses? but im not sure about your initial intentions of conditions feature.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
