### PR TITLE
Fix worksheet attachments viewlet

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1947 Fix worksheet attachments viewlet
 - #1944 Add handler for "content_status_modify"-like requests
 - #1943 Support UIDs from interim fields as input values for calculations
 - #1942 Fix tab styling in email log popup

--- a/src/senaite/core/browser/viewlets/attachments.py
+++ b/src/senaite/core/browser/viewlets/attachments.py
@@ -22,6 +22,7 @@ from bika.lims import api
 from bika.lims import FieldEditAnalysisResult
 from bika.lims import WorksheetAddAttachment
 from bika.lims.api.security import check_permission
+from bika.lims.interfaces import IReferenceAnalysis
 from plone.app.layout.viewlets.common import ViewletBase
 from plone.memoize import view
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -112,6 +113,10 @@ class WorksheetAttachmentsViewlet(AttachmentsViewlet):
         """
         analyses = set()
         for analysis in self.context.getAnalyses():
+            # Skip Reference Analysis
+            if IReferenceAnalysis.providedBy(analysis):
+                continue
+                
             # Skip non-editable analyses
             if not check_permission(FieldEditAnalysisResult, analysis):
                 continue


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

While Viewlet gathers analyses attachments it tries to call getRequestID() method on Reference Analysis entity. Such method does not exist and it raises exception:

```
Traceback (most recent call last):
  File "/home/senaite/buildout-cache/eggs/cp27mu/plone.app.viewletmanager-3.1.2-py2.7.egg/plone/app/viewletmanager/manager.py", line 110, in render
    html.append(viewlet.render())
  File "/home/senaite/senaitelims20/src/senaite.core/src/senaite/core/browser/viewlets/attachments.py", line 65, in render
    return self.template()
  File "/home/senaite/buildout-cache/eggs/cp27mu/Zope-4.6.3-py2.7.egg/Products/Five/browser/pagetemplatefile.py", line 126, in call
    return self.__func__(__self__, *args, **kw)
  File "/home/senaite/buildout-cache/eggs/cp27mu/Zope-4.6.3-py2.7.egg/Products/Five/browser/pagetemplatefile.py", line 61, in call
    sourceAnnotations=getattr(debug_flags, 'sourceAnnotations', 0),
  File "/home/senaite/buildout-cache/eggs/cp27mu/zope.pagetemplate-4.5.0-py2.7.egg/zope/pagetemplate/pagetemplate.py", line 135, in pt_render
    strictinsert=0, sourceAnnotations=sourceAnnotations
  File "/home/senaite/buildout-cache/eggs/cp27mu/Zope-4.6.3-py2.7.egg/Products/PageTemplates/engine.py", line 378, in call
    return template.render(**kwargs)
  File "/home/senaite/buildout-cache/eggs/cp27mu/z3c.pt-3.3.0-py2.7.egg/z3c/pt/pagetemplate.py", line 176, in render
    return base_renderer(**context)
  File "/home/senaite/buildout-cache/eggs/cp27mu/Chameleon-3.9.1-py2.7.egg/chameleon/zpt/template.py", line 302, in render
    return super(PageTemplate, self).render(**_kw)
  File "/home/senaite/buildout-cache/eggs/cp27mu/Chameleon-3.9.1-py2.7.egg/chameleon/template.py", line 215, in render
    raise_with_traceback(exc, tb)
  File "/home/senaite/buildout-cache/eggs/cp27mu/Chameleon-3.9.1-py2.7.egg/chameleon/template.py", line 192, in render
    self._render(stream, econtext, rcontext)
  File "/home/senaite/senaitelims20/var/cache/b6375fef815b0f20927932b53779f2c9.py", line 214, in render
    __value = _static_140306927250896('path', u'view/get_analyses', econtext=econtext)(_static_140306927276304(econtext, __zt_tmp))
  File "/home/senaite/buildout-cache/eggs/cp27mu/zope.tales-5.1-py2.7.egg/zope/tales/expressions.py", line 250, in call
    return self._eval(econtext)
  File "/home/senaite/buildout-cache/eggs/cp27mu/Zope-4.6.3-py2.7.egg/Products/PageTemplates/Expressions.py", line 225, in _eval
    return render(ob, econtext.vars)
  File "/home/senaite/buildout-cache/eggs/cp27mu/Zope-4.6.3-py2.7.egg/Products/PageTemplates/Expressions.py", line 155, in render
    ob = ob()
  File "/home/senaite/senaitelims20/src/senaite.core/src/senaite/core/browser/viewlets/attachments.py", line 122, in get_analyses
    analyses = map(self.get_analysis_info, analyses)
  File "/home/senaite/senaitelims20/src/senaite.core/src/senaite/core/browser/viewlets/attachments.py", line 130, in get_analysis_info
    sample_id = analysis.getRequestID()
AttributeError: 'RequestContainer' object has no attribute 'getRequestID'
```
<img width="1423" alt="Screenshot 2022-03-14 at 15 11 55" src="https://user-images.githubusercontent.com/14867014/158133106-829bad69-23e5-4e82-9c31-a9fdb2c1c30a.png">

## Current behavior before PR

exception raised

## Desired behavior after PR is merged

no exception

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
