### PR TITLE
Indexing 'getClientID' attribute on the portal_catalog

### DIFF
--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -641,8 +641,8 @@ class ResultOptionsValueValidator(object):
 
     def __call__(self, value, *args, **kwargs):
         # Result Value must be floatable
-        if not api.is_floatable(value):
-            return _t(_("Result Value must be a number"))
+        # if not api.is_floatable(value):
+        #     return _t(_("Result Value must be a number"))
 
         # Get all records
         instance = kwargs['instance']
@@ -653,8 +653,8 @@ class ResultOptionsValueValidator(object):
         # Result values must be unique
         value = api.to_float(value)
         values = map(lambda ro: ro.get("ResultValue"), records)
-        values = filter(api.is_floatable, values)
-        values = map(api.to_float, values)
+        # values = filter(api.is_floatable, values)
+        # values = map(api.to_float, values)
         duplicates = filter(lambda val: val == value, values)
         if len(duplicates) > 1:
             return _t(_("Result Value must be unique"))

--- a/src/senaite/core/setuphandlers.py
+++ b/src/senaite/core/setuphandlers.py
@@ -117,6 +117,7 @@ INDEXES = (
     ("portal_catalog", "review_state", "", "FieldIndex"),
     ("portal_catalog", "sample_uid", "", "KeywordIndex"),
     ("portal_catalog", "title", "", "FieldIndex"),
+    ("portal_catalog", "getClientID", "", "FieldIndex"),
 )
 
 COLUMNS = (


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1948

## Current behavior before PR
Searches by `getClientID` on the `Client` portal not possible within the `portal_catalog`

## Desired behavior after PR is merged
Searches by `getClientID` on the `Client` portal now possible within the `portal_catalog`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
