### PR TITLE
Indexing 'getClientID' attribute on the portal_catalog

### DIFF
--- a/bika/lims/setuphandlers.py
+++ b/bika/lims/setuphandlers.py
@@ -192,6 +192,7 @@ INDEXES = (
 
     ("portal_catalog", "Analyst", "", "FieldIndex"),
     ("portal_catalog", "sample_uid", "", "KeywordIndex"),
+    ("portal_catalog", "getClientID", "", "FieldIndex"),
 )
 
 COLUMNS = (


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1948

## Current behavior before PR
Searches by `getClientID` on the `Client` portal not possible within the `portal_catalog`

## Desired behavior after PR is merged
Searches by `getClientID` on the `Client` portal now possible within the `portal_catalog`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html