### PR TITLE
Hide method and instrument columns in analysis listing when not required

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1951 Hide method and instrument columns in analysis listing when not required
 - #1947 Fix worksheet attachments viewlet
 - #1946 Fix conditions issue in Reference Analyses display view
 - #1944 Add handler for "content_status_modify"-like requests

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -43,12 +43,12 @@ sources = sources
 auto-checkout = *
 
 [sources]
-senaite.app.listing = git git://github.com/senaite/senaite.app.listing.git pushurl=git@github.com:senaite/senaite.app.listing.git branch=2.x
-senaite.app.spotlight = git git://github.com/senaite/senaite.app.spotlight.git pushurl=git@github.com:senaite/senaite.app.spotlight.git branch=2.x
-senaite.app.supermodel = git git://github.com/senaite/senaite.app.supermodel.git pushurl=git@github.com:senaite/senaite.app.supermodel.git branch=2.x
-senaite.impress = git git://github.com/senaite/senaite.impress.git pushurl=git@github.com:senaite/senaite.impress.git branch=2.x
-senaite.jsonapi = git git://github.com/senaite/senaite.jsonapi.git pushurl=git@github.com:senaite/senaite.jsonapi.git branch=2.x
-senaite.lims = git git://github.com/senaite/senaite.lims.git pushurl=git@github.com:senaite/senaite.lims.git branch=2.x
+senaite.app.listing = git https://github.com/senaite/senaite.app.listing.git pushurl=git@github.com:senaite/senaite.app.listing.git branch=2.x
+senaite.app.spotlight = git https://github.com/senaite/senaite.app.spotlight.git pushurl=git@github.com:senaite/senaite.app.spotlight.git branch=2.x
+senaite.app.supermodel = git https://github.com/senaite/senaite.app.supermodel.git pushurl=git@github.com:senaite/senaite.app.supermodel.git branch=2.x
+senaite.impress = git https://github.com/senaite/senaite.impress.git pushurl=git@github.com:senaite/senaite.impress.git branch=2.x
+senaite.jsonapi = git https://github.com/senaite/senaite.jsonapi.git pushurl=git@github.com:senaite/senaite.jsonapi.git branch=2.x
+senaite.lims = git https://github.com/senaite/senaite.lims.git pushurl=git@github.com:senaite/senaite.lims.git branch=2.x
 
 [instance]
 recipe = plone.recipe.zope2instance

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -437,8 +437,6 @@ class AnalysesView(ListingView):
         """
         obj = self.get_object(analysis_brain)
         methods = obj.getAllowedMethods()
-        if not methods:
-            return [{"ResultValue": "", "ResultText": _("None")}]
         vocab = []
         for method in methods:
             vocab.append({

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -987,17 +987,17 @@ class AnalysesView(ListingView):
         """
         obj = self.get_object(analysis_brain)
         is_editable = self.is_analysis_edition_allowed(analysis_brain)
-        method = obj.getMethod()
-        method_title = method and api.get_title(method) or ""
-        item["Method"] = method_title or _("Manual")
         if is_editable:
             method_vocabulary = self.get_methods_vocabulary(analysis_brain)
             item["Method"] = obj.getRawMethod()
             item["choices"]["Method"] = method_vocabulary
             item["allow_edit"].append("Method")
-        elif method_title:
-            item["replace"]["Method"] = get_link(
-                api.get_url(method), method_title, tabindex="-1")
+        else:
+            item["Method"] = _("Manual")
+            method = obj.getMethod()
+            if method:
+                item["Method"] = api.get_title(method)
+                item["replace"]["Method"] = get_link_for(method, tabindex="-1")
 
     def _on_method_change(self, uid=None, value=None, item=None, **kw):
         """Update instrument and calculation when the method changes
@@ -1041,12 +1041,10 @@ class AnalysesView(ListingView):
 
         elif instrument:
             # Edition not allowed
-            instrument_title = instrument and instrument.Title() or ""
-            instrument_link = get_link(instrument.absolute_url(),
-                                       instrument_title, tabindex="-1")
-            item["Instrument"] = instrument_title
+            item["Instrument"] = api.get_title(instrument)
+            instrument_link = get_link_for(instrument, tabindex="-1")
             item["replace"]["Instrument"] = instrument_link
-            return
+
         else:
             item["Instrument"] = _("Manual")
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

User can define the methods and instruments that can be "used" for a given analysis service. In such case, methods and instruments are populated for selection later in listings for the analyst to choose the desired values.

This Pull Request makes the columns "Method" and "Instrument" to only be rendered in analyses listing when at least one of the analyses requires the introduction of either method or analysis. The columns are also rendered when at least one of the analyses has a value assigned for any of the two fields.

## Current behavior before PR

Columns "Method" and "Instrument" are always displayed in analyses listing, regardless of their suitability

## Desired behavior after PR is merged

Columns "Method" and "Instrument" are only displayed in analyses listing when at least one of the analyses listed requires them to be displayed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
