### PR TITLE
Open analysis specification ranges

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1952 Open analysis specification ranges
 - #1951 Hide method and instrument columns in analysis listing when not required
 - #1947 Fix worksheet attachments viewlet
 - #1946 Fix conditions issue in Reference Analyses display view

--- a/src/bika/lims/browser/widgets/analysisspecificationwidget.py
+++ b/src/bika/lims/browser/widgets/analysisspecificationwidget.py
@@ -386,10 +386,9 @@ class AnalysisSpecificationWidget(TypesWidget):
         table.update()
         table.before_render()
 
-        # This is a hack to notify read-only mode to the view
-        table.allow_edit = allow_edit
-
         if allow_edit is False:
+            # This is a hack to notify read-only mode to the view
+            table.allow_edit = allow_edit
             return table.contents_table_view()
         return table.ajax_contents_table()
 

--- a/src/bika/lims/browser/widgets/analysisspecificationwidget.py
+++ b/src/bika/lims/browser/widgets/analysisspecificationwidget.py
@@ -314,12 +314,6 @@ class AnalysisSpecificationWidget(TypesWidget):
                 s_min = 0
                 s_max = 0
 
-            # TODO: disallow this case in the UI
-            if s_min and s_max:
-                if float(s_min) > float(s_max):
-                    logger.warn("Min({}) > Max({}) is not allowed"
-                                .format(s_min, s_max))
-                    continue
             min_operator = self._get_spec_value(
                 form, uid, "min_operator", check_floatable=False)
             max_operator = self._get_spec_value(

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -875,24 +875,31 @@ class AnalysisSpecificationsValidator:
             # Neither min nor max values have been set, dismiss
             return None
 
-        if not api.is_floatable(spec_min):
-            return "'Min' value must be numeric"
-        if not api.is_floatable(spec_max):
-            return "'Max' value must be numeric"
-        if api.to_float(spec_min) > api.to_float(spec_max):
-            return "'Max' value must be above 'Min' value"
+        # Allow to have empty min/max borders, e.g. only max being set
+        if spec_min and not api.is_floatable(spec_min):
+            return _("'Min' value must be numeric")
+        if spec_max and not api.is_floatable(spec_max):
+            return _("'Max' value must be numeric")
 
-        if warn_min:
-            if not api.is_floatable(warn_min):
-                return "'Warn Min' value must be numeric or empty"
+        # Check if min is smaller than max range
+        if spec_min and spec_max:
+            if api.to_float(spec_min) > api.to_float(spec_max):
+                return _("'Max' value must be above 'Min' value")
+
+        # Handle warn min
+        if warn_min and not api.is_floatable(warn_min):
+            return _("'Warn Min' value must be numeric or empty")
+        if warn_min and spec_min:
             if api.to_float(warn_min) > api.to_float(spec_min):
-                return "'Warn Min' value must be below 'Min' value"
+                return _("'Warn Min' value must be below 'Min' value")
 
-        if warn_max:
-            if not api.is_floatable(warn_max):
-                return "'Warn Max' value must be numeric or empty"
+        # Handle warn max
+        if warn_max and not api.is_floatable(warn_max):
+            return _("'Warn Max' value must be numeric or empty")
+        if warn_max and spec_max:
             if api.to_float(warn_max) < api.to_float(spec_max):
-                return "'Warn Max' value must be above 'Max' value"
+                return _("'Warn Max' value must be above 'Max' value")
+
         return None
 
 

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -831,14 +831,14 @@ class AnalysisSpecificationsValidator:
     name = "analysisspecs_validator"
 
     def __call__(self, value, *args, **kwargs):
-        instance = kwargs['instance']
-        request = kwargs.get('REQUEST', {})
-        fieldname = kwargs['field'].getName()
+        instance = kwargs["instance"]
+        request = kwargs.get("REQUEST", {})
+        fieldname = kwargs["field"].getName()
 
         # This value in request prevents running once per subfield value.
         # self.name returns the name of the validator. This allows other
         # subfield validators to be called if defined (eg. in other add-ons)
-        key = '{}-{}-{}'.format(self.name, instance.getId(), fieldname)
+        key = "{}-{}-{}".format(self.name, instance.getId(), fieldname)
         if instance.REQUEST.get(key, False):
             return True
 
@@ -854,7 +854,7 @@ class AnalysisSpecificationsValidator:
             title = api.get_title(service)
 
             err_msg = "{}: {}".format(title, _(err_msg))
-            translate = api.get_tool('translation_service').translate
+            translate = api.get_tool("translation_service").translate
             instance.REQUEST[key] = to_utf8(translate(safe_unicode(err_msg)))
             return instance.REQUEST[key]
 
@@ -867,7 +867,7 @@ class AnalysisSpecificationsValidator:
         """
         spec_min = get_record_value(request, uid, "min")
         spec_max = get_record_value(request, uid, "max")
-        error = get_record_value(request, uid, "error", "0")
+
         warn_min = get_record_value(request, uid, "warn_min")
         warn_max = get_record_value(request, uid, "warn_max")
 
@@ -881,8 +881,6 @@ class AnalysisSpecificationsValidator:
             return "'Max' value must be numeric"
         if api.to_float(spec_min) > api.to_float(spec_max):
             return "'Max' value must be above 'Min' value"
-        if not api.is_floatable(error) or 0.0 < api.to_float(error) > 100:
-            return "% Error must be between 0 and 100"
 
         if warn_min:
             if not api.is_floatable(warn_min):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the behavior of analysis specifications, so that open borders are allowed.

<img width="1316" alt="42  BImSchV — SENAITE LIMS 2022-03-23 3 PM-48-46" src="https://user-images.githubusercontent.com/713193/159727286-83ace521-5cc4-4d96-973a-f602dbc5c8dc.png">

<img width="1317" alt="TW-0025 — SENAITE LIMS 2022-03-23 3 PM-51-23" src="https://user-images.githubusercontent.com/713193/159727634-ec8438a2-66ed-4ef0-a376-8b363a35751d.png">


## Current behavior before PR

It is not possible to set either a minimum OR a maximum specification value, e.g. to have a maximum of "<=100"

## Desired behavior after PR is merged

Open range borders are possible

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
