### PR TITLE
Allow custom id formatting regardless of portal type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1953 Allow custom id formatting regardless of portal type
 - #1952 Open analysis specification ranges
 - #1951 Hide method and instrument columns in analysis listing when not required
 - #1947 Fix worksheet attachments viewlet

--- a/src/bika/lims/idserver.py
+++ b/src/bika/lims/idserver.py
@@ -32,7 +32,9 @@ from bika.lims.interfaces import IAnalysisRequest
 from bika.lims.interfaces import IAnalysisRequestPartition
 from bika.lims.interfaces import IAnalysisRequestRetest
 from bika.lims.interfaces import IAnalysisRequestSecondary
+from bika.lims.interfaces import IARReport
 from bika.lims.interfaces import IIdServer
+from bika.lims.interfaces import IIdServerTypeID
 from bika.lims.interfaces import IIdServerVariables
 from bika.lims.numbergenerator import INumberGenerator
 from DateTime import DateTime
@@ -85,11 +87,22 @@ def get_contained_items(obj, spec):
 
 
 def get_type_id(context, **kw):
-    """Returns the type id for the context passed in
+    """Returns the type id for the context passed in, that is used for custom
+    ID formatting, regardless of the real portal type of the context passed in.
+    Thus, the function might return different type ids for two objects from
+    same portal type (e.g AnalysisRequest). This type id is used later for
+    ID server prefixes (in lowercase)
     """
     portal_type = kw.get("portal_type", None)
     if portal_type:
         return portal_type
+
+    # Look for a get_type_id adapter
+    adapter = queryAdapter(context, IIdServerTypeID)
+    if adapter:
+        type_id = adapter.get_type_id(**kw)
+        if type_id:
+            return type_id
 
     # Override by provided marker interface
     if IAnalysisRequestPartition.providedBy(context):
@@ -217,7 +230,7 @@ def get_variables(context, **kw):
     }
 
     # Augment the variables map depending on the portal type
-    if portal_type in AR_TYPES:
+    if IAnalysisRequest.providedBy(context):
         now = DateTime()
         sampling_date = context.getSamplingDate()
         sampling_date = sampling_date and DT2dt(sampling_date) or DT2dt(now)
@@ -234,7 +247,7 @@ def get_variables(context, **kw):
         })
 
         # Partition
-        if portal_type == "AnalysisRequestPartition":
+        if IAnalysisRequestPartition.providedBy(context):
             parent_ar = context.getParentAnalysisRequest()
             parent_ar_id = api.get_id(parent_ar)
             parent_base_id = strip_suffix(parent_ar_id)
@@ -247,7 +260,7 @@ def get_variables(context, **kw):
             })
 
         # Retest
-        elif portal_type == "AnalysisRequestRetest":
+        elif IAnalysisRequestRetest.providedBy(context):
             # Note: we use "parent" instead of "invalidated" for simplicity
             parent_ar = context.getInvalidated()
             parent_ar_id = api.get_id(parent_ar)
@@ -266,7 +279,7 @@ def get_variables(context, **kw):
             })
 
         # Secondary
-        elif portal_type == "AnalysisRequestSecondary":
+        elif IAnalysisRequestSecondary.providedBy(context):
             primary_ar = context.getPrimaryAnalysisRequest()
             primary_ar_id = api.get_id(primary_ar)
             parent_base_id = strip_suffix(primary_ar_id)
@@ -278,7 +291,7 @@ def get_variables(context, **kw):
                 "secondary_count": secondary_count,
             })
 
-    elif portal_type == "ARReport":
+    elif IARReport.providedBy(context):
         variables.update({
             "clientId": context.aq_parent.getClientID(),
         })

--- a/src/bika/lims/interfaces/__init__.py
+++ b/src/bika/lims/interfaces/__init__.py
@@ -606,6 +606,17 @@ class IIdServerVariables(Interface):
         """
 
 
+class IIdServerTypeID(Interface):
+    """Marker interface for type id resolution for ID Server
+    """
+
+    def get_type_id(self, **kw):
+        """Returns the type id for the context passed in the constructor, that
+        is used for custom ID formatting, regardless of the real portal type of
+        the context. Return None if no type id can be resolved by this adapter
+        """
+
+
 class IReferenceWidgetVocabulary(Interface):
     """Return values for reference widgets in AR contexts
     """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the differential id formatting regardless of portal type possible.

For instance, to make the system to apply a different ID formatting to objects from "AnalysisRequest" portal type depending on the value from a field (e.g. Batch):

```xml

<adapter for="bika.lims.interfaces.IAnalysisRequest"
         provides="bika.lims.interfaces.IIdServerTypeID"
         factory=".idserver.IDServerTypeIDAdapter" />

```

```python
# -*- coding: utf-8 -*-

from bika.lims import api
from bika.lims.idserver import get_type_id
from bika.lims.interfaces import IAnalysisRequest
from bika.lims.interfaces import IIdServerTypeID
from bika.lims.interfaces import IIdServerVariables
from zope.interface import implementer


@implementer(IIdServerTypeID)
class IDServerTypeIDAdapter(object):
    """Marker interface for type id resolution for ID Server
    """

    def __init__(self, context):
        self.context = context

    def get_type_id(self, **kw):
        """Returns the type id for the context passed in, that is used for
        custom ID formatting, regardless of the real portal type of the context
        passed in. Return None if no type id can be resolved by this adapter
        """
        type_id = None
        if IAnalysisRequest.providedBy(self.context):
            batch = self.context.getBatch()
            if batch:
                type_id = "AnalysisRequestWithBatch"
        return type_id


```

With this approach, user can add an additional record `AnalysisRequestWithBatch` in ID Server configuration view with a custom configuration:

![Captura de 2022-03-29 12-45-59](https://user-images.githubusercontent.com/832627/160595672-2b6fc764-ac7a-4a46-aba9-7546e36dcf6f.png)

## Current behavior before PR

Is not possible to apply custom id formatting regardless of portal_type

## Desired behavior after PR is merged

Is possible to apply custom id formatting regardless of portal_type

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
