### PR TITLE
Allow custom id formatting regardless of portal type (Port #1953)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #1954 Allow custom id formatting regardless of portal type (#1953 port)
 - #1939 Fix retracted and rejected analyses cannot be added to a Sample
 - #1906 Fix traceback in auditlog view when context is a Dexterity type
 - #1885 Allow to re-add cancelled/rejected/retracted analyses (#1777 port)

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -589,6 +589,17 @@ class IIdServerVariables(Interface):
         """
 
 
+class IIdServerTypeID(Interface):
+    """Marker interface for type id resolution for ID Server
+    """
+
+    def get_type_id(self, **kw):
+        """Returns the type id for the context passed in the constructor, that
+        is used for custom ID formatting, regardless of the real portal type of
+        the context. Return None if no type id can be resolved by this adapter
+        """
+
+
 class IReferenceWidgetVocabulary(Interface):
     """Return values for reference widgets in AR contexts
     """

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -43,12 +43,12 @@ auto-checkout = *
 develop = .
 
 [sources]
-senaite.core.listing = git git://github.com/senaite/senaite.core.listing.git pushurl=git@github.com:senaite/senaite.core.listing.git branch=1.x
-senaite.core.spotlight = git git://github.com/senaite/senaite.core.spotlight.git pushurl=git@github.com:senaite/senaite.core.spotlight.git branch=1.x
-senaite.core.supermodel = git git://github.com/senaite/senaite.core.supermodel.git pushurl=git@github.com:senaite/senaite.core.supermodel.git branch=1.x
-senaite.impress = git git://github.com/senaite/senaite.impress.git pushurl=git@github.com:senaite/senaite.impress.git branch=1.x
-senaite.jsonapi = git git://github.com/senaite/senaite.jsonapi.git pushurl=git@github.com:senaite/senaite.jsonapi.git branch=1.x
-senaite.lims = git git://github.com/senaite/senaite.lims.git pushurl=git@github.com:senaite/senaite.lims.git branch=1.x
+senaite.core.listing = git https://github.com/senaite/senaite.core.listing.git pushurl=git@github.com:senaite/senaite.core.listing.git branch=1.x
+senaite.core.spotlight = git https://github.com/senaite/senaite.core.spotlight.git pushurl=git@github.com:senaite/senaite.core.spotlight.git branch=1.x
+senaite.core.supermodel = git https://github.com/senaite/senaite.core.supermodel.git pushurl=git@github.com:senaite/senaite.core.supermodel.git branch=1.x
+senaite.impress = git https://github.com/senaite/senaite.impress.git pushurl=git@github.com:senaite/senaite.impress.git branch=1.x
+senaite.jsonapi = git https://github.com/senaite/senaite.jsonapi.git pushurl=git@github.com:senaite/senaite.jsonapi.git branch=1.x
+senaite.lims = git https://github.com/senaite/senaite.lims.git pushurl=git@github.com:senaite/senaite.lims.git branch=1.x
 
 [instance]
 recipe = plone.recipe.zope2instance


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #1953 to 1.3.x series

## Current behavior before PR

Is not possible to apply custom id formatting regardless of portal_type

## Desired behavior after PR is merged

Is possible to apply custom id formatting regardless of portal_type

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
