### PR TITLE
Result Value to not be fixed to integer

### DIFF
--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -89,7 +89,7 @@ Thanks.
 
 _marker = object()
 
-UID_RX = re.compile("[a-z0-9]{32}$")
+UID_RX = re.compile("[a-zA-Z0-9\\-]{32,36}$")
 
 
 class APIError(Exception):
@@ -1236,7 +1236,7 @@ def is_uid(uid, validate=False):
         return False
     if uid == '0':
         return True
-    if len(uid) != 32:
+    if not (len(uid) >= 32 and len(uid) <= 36):
         return False
     if not UID_RX.match(uid):
         return False

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -547,9 +547,9 @@ ResultOptions = RecordsField(
                      'ResultText': _('Display Value'), },
     subfield_validators={'ResultValue': 'result_options_value_validator',
                          'ResultText': 'result_options_text_validator'},
-    subfield_sizes={'ResultValue': 5,
+    subfield_sizes={'ResultValue': 20,
                     'ResultText': 25,},
-    subfield_maxlength={'ResultValue': 5,
+    subfield_maxlength={'ResultValue': 40,
                         'ResultText': 255,},
     widget=RecordsWidget(
         label=_("Predefined results"),

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -642,7 +642,8 @@ class ResultOptionsValueValidator(object):
     def __call__(self, value, *args, **kwargs):
         # Result Value must be floatable
         if not api.is_floatable(value):
-            return _t(_("Result Value must be a number"))
+            if not api.is_uid(value):
+                return _t(_("Result Value must be a number or valid UID"))
 
         # Get all records
         instance = kwargs['instance']
@@ -651,10 +652,12 @@ class ResultOptionsValueValidator(object):
         records = request.form.get(field_name)
 
         # Result values must be unique
-        value = api.to_float(value)
         values = map(lambda ro: ro.get("ResultValue"), records)
-        values = filter(api.is_floatable, values)
-        values = map(api.to_float, values)
+        if api.is_floatable(value):
+            value = api.to_float(value)
+            values = filter(api.is_floatable, values)
+            values = map(api.to_float, values)
+
         duplicates = filter(lambda val: val == value, values)
         if len(duplicates) > 1:
             return _t(_("Result Value must be unique"))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1956

## Current behavior before PR
Results Options widget does not accept non-numeric values for it's options.

## Desired behavior after PR is merged
Results Options fields should accept non-numeric values(at-least valid uids) for it's options just like the the Interim Results fields do.

---
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
