### PR TITLE
Fix add samples URL in batch context for Clients

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1964 Fix add samples URL in batch context for Clients
 - #1961 Added `geo` api  that relies on `pycountry` for retrieval of countries
 - #1911 Converted Container to Dexterity Contents
 - #1931 Removed archetypes.schemaextender from senaite.core

--- a/src/senaite/core/browser/viewlets/add_samples.py
+++ b/src/senaite/core/browser/viewlets/add_samples.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from bika.lims import api
+from bika.lims.interfaces import IBatch
 from bika.lims.permissions import AddAnalysisRequest
 from plone.app.layout.viewlets import ViewletBase
 from plone.memoize.instance import memoize
@@ -37,6 +38,8 @@ class AddSamplesViewlet(ViewletBase):
     def get_samples_container(self):
         """Returns the container object where new samples will be added
         """
+        if IBatch.providedBy(self.context):
+            return self.context
         return api.get_current_client() or self.context
 
     @property


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the generated URL of the add-samples action in batches for Clients.

## Current behavior before PR

Adding samples in batch context used the client URL, so that new samples were not properly assigned to the batch.

## Desired behavior after PR is merged

Adding samples in batch context use the batch context when adding new samples

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
