### PR TITLE
Disallow client users to create sample partitions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1965 Disallow client users to create sample partitions
 - #1961 Added `geo` api  that relies on `pycountry` for retrieval of countries
 - #1911 Converted Container to Dexterity Contents
 - #1931 Removed archetypes.schemaextender from senaite.core

--- a/src/bika/lims/workflow/analysisrequest/guards.py
+++ b/src/bika/lims/workflow/analysisrequest/guards.py
@@ -19,7 +19,10 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims import api
-from bika.lims.interfaces import IVerified, IInternalUse
+from bika.lims.api.security import check_permission
+from bika.lims.interfaces import IInternalUse
+from bika.lims.interfaces import IVerified
+from bika.lims.permissions import TransitionReceiveSample
 from bika.lims.workflow import isTransitionAllowed
 
 # States to be omitted in regular transitions
@@ -54,6 +57,13 @@ def guard_create_partitions(analysis_request):
     if analysis_request.isPartition():
         # Do not allow the creation of partitions from partitions
         return False
+
+    # Clients have the AddAnalysisRequest permission, but should not be allowed
+    # to create partitions.  Therefore, we check here if the current user has
+    # the permission to receive a sample as well.
+    if not check_permission(TransitionReceiveSample, analysis_request):
+        return False
+
     return True
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the "Create Partitions" transition if the current user is a client user.

## Current behavior before PR

Clients users are able to create partitions for received samples in their organization

## Desired behavior after PR is merged

Client users can not create partitions for received samples in their organization

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
