### PR TITLE
Fix to set analysis results in batchbooks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1966 Fix to set analysis results in batchbooks
 - #1964 Fix add samples URL in batch context for Clients
 - #1963 Hide custom set-remarks transition when global remarks are disabled in setup
 - #1961 Added `geo` api  that relies on `pycountry` for retrieval of countries

--- a/src/bika/lims/browser/batch/batchbook.py
+++ b/src/bika/lims/browser/batch/batchbook.py
@@ -31,7 +31,6 @@ from bika.lims.permissions import AddAnalysisRequest
 from bika.lims.permissions import FieldEditAnalysisResult
 from bika.lims.permissions import ManageAnalysisRequests
 from Products.CMFCore.permissions import ModifyPortalContent
-from Products.CMFPlone import PloneMessageFactory
 from zope.interface import implementer
 from bika.lims.utils import t
 
@@ -48,6 +47,7 @@ class BatchBookView(BikaListingView):
         self.Description = context.Description()
 
         self.show_select_column = True
+        self.show_search = False
         self.pagesize = 999999
         self.form_id = "batchbook"
         self.show_categories = True

--- a/src/bika/lims/browser/batch/batchbook.py
+++ b/src/bika/lims/browser/batch/batchbook.py
@@ -19,19 +19,21 @@
 # Some rights reserved, see README and LICENSE.
 
 import re
+from collections import OrderedDict
 from operator import itemgetter
 
-from AccessControl import getSecurityManager
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
+from bika.lims.api.security import check_permission
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.interfaces import IBatchBookView
 from bika.lims.permissions import AddAnalysisRequest
-from bika.lims.permissions import EditResults
+from bika.lims.permissions import FieldEditAnalysisResult
 from bika.lims.permissions import ManageAnalysisRequests
 from Products.CMFCore.permissions import ModifyPortalContent
 from Products.CMFPlone import PloneMessageFactory
 from zope.interface import implementer
+from bika.lims.utils import t
 
 
 @implementer(IBatchBookView)
@@ -39,104 +41,102 @@ class BatchBookView(BikaListingView):
 
     def __init__(self, context, request):
         super(BatchBookView, self).__init__(context, request)
-        self.icon = self.portal_url + \
-            "/++resource++bika.lims.images/batchbook_big.png"
+
         self.context_actions = {}
         self.contentFilter = {"sort_on": "created"}
         self.title = context.Title()
         self.Description = context.Description()
-        self.show_select_all_checkbox = True
 
-        self.show_column_toggles = True
-        self.show_select_row = False
         self.show_select_column = True
         self.pagesize = 999999
-        self.form_id = "list"
-        self.page_start_index = 0
+        self.form_id = "batchbook"
         self.show_categories = True
         self.expand_all_categories = True
+        self.show_column_toggles = False
 
-        request.set('disable_plone.rightcolumn', 1)
+        self.icon = "{}{}".format(
+            self.portal_url, "/senaite_theme/icon/batchbook")
 
-        self.columns = {
-            'AnalysisRequest': {
-                'title': _('Sample'),
-                'index': 'id',
-                'sortable': True,
-            },
-
-            'SampleType': {
-                'title': _('Sample Type'),
-                'sortable': True,
-            },
-            'SamplePoint': {
-                'title': _('Sample Point'),
-                'sortable': True,
-            },
-            'ClientOrderNumber': {
-                'title': _('Client Order Number'),
-                'sortable': True,
-            },
-            'created': {
-                'title': PloneMessageFactory('Date Created'),
-                'index': 'created',
-                'toggle': False,
-            },
-            'state_title': {
-                'title': _('State'),
-                'index': 'review_state'
-            },
-        }
+        self.columns = OrderedDict((
+            ("AnalysisRequest", {
+                "title": _("Sample"),
+                "index": "id",
+                "sortable": True,
+            }),
+            ("SampleType", {
+                "title": _("Sample Type"),
+                "sortable": True,
+            }),
+            ("SamplePoint", {
+                "title": _("Sample Point"),
+                "sortable": True,
+            }),
+            ("ClientOrderNumber", {
+                "title": _("Client Order Number"),
+                "sortable": True,
+            }),
+            ("created", {
+                "title": PloneMessageFactory("Date Created"),
+                "index": "created",
+                "toggle": False,
+            }),
+            ("state_title", {
+                "title": _("State"),
+                "index": "review_state"
+            }),
+        ))
 
         self.review_states = [
-            {'id': 'default',
-             'title': _('All'),
-             'contentFilter': {},
-             'columns': ['AnalysisRequest',
-                         'ClientOrderNumber',
-                         'SampleType',
-                         'SamplePoint',
-                         'created',
-                         'state_title'],
-             },
+            {
+                "id": "default",
+                "title": _("All"),
+                "contentFilter": {},
+                "columns": self.columns.keys()
+            },
         ]
 
-    @property
-    def copy_to_new_allowed(self):
-        mtool = api.get_tool('portal_membership')
-        if mtool.checkPermission(ManageAnalysisRequests, self.context) \
-                or mtool.checkPermission(ModifyPortalContent, self.context) \
-                or mtool.checkPermission(AddAnalysisRequest, self.portal):
+    def is_copy_to_new_allowed(self):
+        if check_permission(ManageAnalysisRequests, self.context) \
+                or check_permission(ModifyPortalContent, self.context) \
+                or check_permission(AddAnalysisRequest, self.portal):
             return True
         return False
 
-    def __call__(self):
-        # Allow "Modify portal content" to see edit widgets
-        mtool = api.get_tool('portal_membership')
-        self.allow_edit = mtool.checkPermission("Modify portal content", self.context)
-        # Allow certain users to duplicate ARs (Copy to new).
-        if self.copy_to_new_allowed:
+    def can_edit_analysis_result(self, analysis):
+        """Checks if the current user can edit the analysis result
+        """
+        return check_permission(FieldEditAnalysisResult, analysis)
+
+    def update(self):
+        """Update hook
+        """
+        super(BatchBookView, self).update()
+        # XXX: Why is this for clients?
+        if self.is_copy_to_new_allowed():
             review_states = []
             for review_state in self.review_states:
-                custom_transitions = review_state.get('custom_transitions', [])
+                custom_transitions = review_state.get("custom_transitions", [])
                 custom_transitions.extend(
-                    [{'id': 'copy_to_new',
-                      'title': _('Copy to new'),
-                      'url': 'workflow_action?action=copy_to_new'},
+                    [{"id": "copy_to_new",
+                      "title": _("Copy to new"),
+                      "url": "workflow_action?action=copy_to_new"},
                      ])
-                review_state['custom_transitions'] = custom_transitions
+                review_state["custom_transitions"] = custom_transitions
                 review_states.append(review_state)
             self.review_states = review_states
-        return super(BatchBookView, self).__call__()
+        self.allow_edit = check_permission(ModifyPortalContent, self.context)
+
+    def before_render(self):
+        """Before render hook
+        """
+        super(BatchBookView, self).before_render()
 
     def folderitems(self):
         """Accumulate a list of all AnalysisRequest objects contained in
         this Batch, as well as those which are inherited.
         """
-        wf = api.get_tool('portal_workflow')
-        schema = self.context.Schema()
-
         ars = self.context.getAnalysisRequests(is_active=True)
+        self.total = len(ars)
 
         self.categories = []
         analyses = {}
@@ -161,51 +161,51 @@ class BatchBookView(BikaListingView):
             arlink = "<a href='%s'>%s</a>" % (
                 ar.absolute_url(), ar.Title())
 
-            subgroup = ar.Schema()['SubGroup'].get(ar)
-            sub_title = subgroup.Title() if subgroup else 'No Subgroup'
-            sub_sort = subgroup.getSortKey() if subgroup else '1'
-            sub_class = re.sub(r"[^A-Za-z\w\d\-\_]", '', sub_title)
+            subgroup = ar.Schema()["SubGroup"].get(ar)
+            sub_title = subgroup.Title() if subgroup else t(_("No Subgroup"))
+            sub_sort = subgroup.getSortKey() if subgroup else "1"
+            sub_class = re.sub(r"[^A-Za-z\w\d\-\_]", "", sub_title)
 
             if [sub_sort, sub_title] not in self.categories:
                 self.categories.append([sub_sort, sub_title])
 
-            review_state = wf.getInfoFor(ar, 'review_state')
+            wf = api.get_tool("portal_workflow")
+            review_state = api.get_review_status(ar)
             state_title = wf.getTitleForStateOnType(
-                review_state, 'AnalysisRequest')
+                review_state, "AnalysisRequest")
 
             item = {
-                'obj': ar,
-                'id': ar.id,
-                'uid': ar.UID(),
-                'category': sub_title,
-                'title': ar.Title(),
-                'type_class': 'contenttype-AnalysisRequest',
-                'url': ar.absolute_url(),
-                'relative_url': ar.absolute_url(),
-                'view_url': ar.absolute_url(),
-                'created': self.ulocalized_time(ar.created(), long_format=1),
-                'sort_key': ar.created(),
-                'replace': {
-                    'Batch': batchlink,
-                    'AnalysisRequest': arlink,
+                "obj": ar,
+                "id": ar.id,
+                "uid": ar.UID(),
+                "category": sub_title,
+                "title": ar.Title(),
+                "type_class": "contenttype-AnalysisRequest",
+                "url": ar.absolute_url(),
+                "relative_url": ar.absolute_url(),
+                "view_url": ar.absolute_url(),
+                "created": self.ulocalized_time(ar.created(), long_format=1),
+                "sort_key": ar.created(),
+                "replace": {
+                    "Batch": batchlink,
+                    "AnalysisRequest": arlink,
                 },
-                'before': {},
-                'after': {},
-                'choices': {},
-                'class': {'Batch': 'Title'},
-                'state_class': 'state-active subgroup_{0}'.format(sub_class) if sub_class else 'state-active',
-                'allow_edit': [],
-                'Batch': '',
-                'SamplePoint': ar.getSamplePoint().Title() if ar.getSamplePoint() else '',
-                'SampleType': ar.getSampleType().Title() if ar.getSampleType() else '',
-                'ClientOrderNumber': ar.getClientOrderNumber(),
-                'AnalysisRequest': '',
-                'state_title': state_title,
+                "before": {},
+                "after": {},
+                "choices": {},
+                "class": {"Batch": "Title"},
+                "state_class": "state-active subgroup_{0}".format(sub_class) if sub_class else "state-active",
+                "allow_edit": [],
+                "Batch": "",
+                "SamplePoint": ar.getSamplePoint().Title() if ar.getSamplePoint() else "",
+                "SampleType": ar.getSampleType().Title() if ar.getSampleType() else "",
+                "ClientOrderNumber": ar.getClientOrderNumber(),
+                "AnalysisRequest": "",
+                "state_title": state_title,
             }
             items.append(item)
 
         unitstr = '<em class="discreet" style="white-space:nowrap;">%s</em>'
-        checkPermission = getSecurityManager().checkPermission
 
         # Insert columns for analyses
         for d_a in distinct:
@@ -214,37 +214,38 @@ class BatchBookView(BikaListingView):
             title = d_a.Title()
 
             self.columns[keyword] = {
-                'title':  short if short else title,
-                'sortable': True
+                "title":  short if short else title,
+                "sortable": False,
             }
-            self.review_states[0]['columns'].insert(
-                len(self.review_states[0]['columns']) - 1, keyword)
+            self.review_states[0]["columns"].insert(
+                len(self.review_states[0]["columns"]) - 1, keyword)
 
             # Insert values for analyses
             for i, item in enumerate(items):
-                for analysis in analyses[item['id']]:
+                for analysis in analyses[item["id"]]:
                     if keyword not in items[i]:
-                        items[i][keyword] = ''
+                        items[i][keyword] = ""
                     if analysis.getKeyword() != keyword:
                         continue
 
-                    edit = checkPermission(EditResults, analysis)
+                    # check if the user can edit the analysis result
+                    can_edit_result = self.can_edit_analysis_result(analysis)
+
                     calculation = analysis.getCalculation()
-                    if self.allow_edit and edit and not calculation:
-                        items[i]['allow_edit'].append(keyword)
+                    if self.allow_edit and can_edit_result and not calculation:
+                        items[i]["allow_edit"].append(keyword)
                         self.columns[keyword]["ajax"] = True
 
                     value = analysis.getResult()
                     items[i][keyword] = value
-                    items[i]['class'][keyword] = ''
+                    items[i]["class"][keyword] = ""
 
-                    if value or (edit and not calculation):
-
+                    if value or (can_edit_result and not calculation):
                         unit = unitstr % d_a.getUnit()
-                        items[i]['after'][keyword] = unit
+                        items[i]["after"][keyword] = unit
 
-                if keyword not in items[i]['class']:
-                    items[i]['class'][keyword] = 'empty'
+                if keyword not in items[i]["class"]:
+                    items[i]["class"][keyword] = "empty"
 
         self.categories.sort()
         self.categories = [x[1] for x in self.categories]

--- a/src/bika/lims/browser/batch/batchbook.py
+++ b/src/bika/lims/browser/batch/batchbook.py
@@ -60,29 +60,28 @@ class BatchBookView(BikaListingView):
         self.columns = OrderedDict((
             ("AnalysisRequest", {
                 "title": _("Sample"),
-                "index": "id",
-                "sortable": True,
+                "sortable": False,
             }),
             ("SampleType", {
                 "title": _("Sample Type"),
-                "sortable": True,
+                "sortable": False,
             }),
             ("SamplePoint", {
                 "title": _("Sample Point"),
-                "sortable": True,
+                "sortable": False,
             }),
             ("ClientOrderNumber", {
                 "title": _("Client Order Number"),
-                "sortable": True,
+                "sortable": False,
             }),
             ("created", {
-                "title": PloneMessageFactory("Date Created"),
-                "index": "created",
-                "toggle": False,
+                "title": _("Date Registered"),
+                "sortable": False,
             }),
             ("state_title", {
                 "title": _("State"),
-                "index": "review_state"
+                "index": "review_state",
+                "sortable": False,
             }),
         ))
 

--- a/src/bika/lims/interfaces/__init__.py
+++ b/src/bika/lims/interfaces/__init__.py
@@ -1155,3 +1155,8 @@ class IListingSearchableTextProvider(Interface):
     catalog index
     """
     pass
+
+
+class IBatchBookView(Interface):
+    """Marker interface for batchbook view
+    """

--- a/src/senaite/core/datamanagers/sample.py
+++ b/src/senaite/core/datamanagers/sample.py
@@ -3,6 +3,7 @@
 from AccessControl import Unauthorized
 from bika.lims import api
 from bika.lims.interfaces import IAnalysisRequest
+from bika.lims.interfaces import IBatchBookView
 from Products.Archetypes.utils import mapply
 from senaite.core import logger
 from senaite.core.datamanagers import DataManager
@@ -64,11 +65,61 @@ class SampleDataManager(DataManager):
             # Set the value on the field directly
             return field.get(self.context)
 
+    def set_analysis_result(self, name, value):
+        """Handle Batchbook Results
+
+        :param name: ID of the contained analysis
+        :param value: Result of the Analysis
+
+        :returns: True if the result was set, otherwise False
+        """
+        analysis = self.get_analysis_by_id(name)
+        if not analysis:
+            logger.error("Analysis '{}' not found".format(name))
+            return False
+
+        fields = api.get_fields(analysis)
+        field = fields.get("Result")
+        # Check the permission of the field
+        if not self.is_field_writeable(field):
+            logger.error("Field '{}' not writeable!".format(name))
+            return False
+
+        # set the analysis result with the mutator
+        analysis.setResult(value)
+        analysis.reindexObject()
+        return True
+
+    def get_analysis_by_id(self, name):
+        """Get the analysis by ID
+        """
+        return self.context.get(name)
+
+    def is_request_from_batchbook(self):
+        """Checks if the request is coming from the batchbook
+
+        If this is the case, the `name` does not refer to a field,
+        but to an analysis and the `value` is always the result.
+
+        :returns: True if the request was sent from the batchbook
+        """
+        req = api.get_request()
+        view = req.PARENTS[0]
+        return IBatchBookView.providedBy(view)
+
     def set(self, name, value):
         """Set sample field or analysis result
         """
         # set of updated objects
         updated_objects = set()
+
+        # handle batchbook results set
+        if self.is_request_from_batchbook():
+            success = self.set_analysis_result(name, value)
+            if not success:
+                raise ValueError(
+                    "Failed to set analysis result for '%s'" % name)
+            return [self.context]
 
         # get the schema field
         field = self.get_field_by_name(name)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR allows to set analysis results in batchbook.

## Current behavior before PR

Fields in batchbook were editable, but not setable

## Desired behavior after PR is merged

Analysis results can be set in batchbooks

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
