### PR TITLE
Fix missing client error in sample add form inside batches

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1967 Fix missing client error in sample add form inside batches
 - #1962 Allow to create worksheet from samples
 - #1966 Fix to set analysis results in batchbooks
 - #1965 Disallow client users to create sample partitions

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -299,8 +299,16 @@ class AnalysisRequestAddView(BrowserView):
     def get_field_value(self, field, context):
         """Get the stored value of the field
         """
+        value = None
         name = field.getName()
-        value = context.getField(name).get(context)
+        field = context.getField(name)
+        # get the field value by the accessor to handle computed fields that do
+        # not store a value
+        accessor = getattr(field, "getAccessor", None)
+        if callable(accessor):
+            value = accessor(context)()
+        else:
+            value = context.getField(name).get(context)
         logger.info("get_field_value: context={} field={} value={}".format(
             context, name, value))
         return value


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the missing client value in sample add form inside batches.

## Current behavior before PR

Not possible to copy existing samples inside batches,
because the client information was missing

## Desired behavior after PR is merged

Possible to create samples in batches

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
