### PR TITLE
Fix default roles for client field in samples

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1968 Fix default roles for client field in samples
 - #1962 Allow to create worksheet from samples
 - #1966 Fix to set analysis results in batchbooks
 - #1965 Disallow client users to create sample partitions

--- a/src/bika/lims/profiles/default/rolemap.xml
+++ b/src/bika/lims/profiles/default/rolemap.xml
@@ -512,6 +512,7 @@
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
+      <role name="Client"/>
     </permission>
     <permission name="senaite.core: Field: Edit Client Order Number" acquire="False">
       <role name="LabClerk"/>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the default roles for the Client Field in Samples

## Current behavior before PR

When a client user creates a new sample, the field `Client` remains empty

## Desired behavior after PR is merged

When a client user creates a new sample, the `Client` field can be also set by the client user

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
