### PR TITLE
Better error messages in sample add form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1970 Better error messages in sample add form
 - #1960 AddressField and AddressWidget with React component for DX types
 - #1968 Fix default roles for client field in samples
 - #1962 Allow to create worksheet from samples

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1647,9 +1647,9 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                     self.request,
                     record,
                 )
-            except (KeyError, RuntimeError) as e:
+            except Exception as e:
                 actions.resume()
-                errors["message"] = e.message
+                errors["message"] = str(e)
                 return {"errors": errors}
             # We keep the title to check if AR is newly created
             # and UID to print stickers

--- a/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
@@ -1377,7 +1377,7 @@
         if (data['errors']) {
           msg = data.errors.message;
           if (msg !== "") {
-            msg = msg + "<br/>";
+            msg = _t("Sorry, an error occured 🙈<p class='code'>" + msg + "</p>");
           }
           for (fieldname in data.errors.fielderrors) {
             field = $("#" + fieldname);

--- a/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -1379,7 +1379,7 @@ class window.AnalysisRequestAdd
       if data['errors']
         msg = data.errors.message
         if msg isnt ""
-          msg = "#{msg}<br/>"
+          msg = _t("Sorry, an error occured 🙈<p class='code'>#{msg}</p>")
 
         for fieldname of data.errors.fielderrors
           field = $("##{fieldname}")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR improves the error messages displayed on Sample Add Form

## Current behavior before PR

Often the only error message was just `error`

## Desired behavior after PR is merged

All errors are catched and the  traceback text is displayed in the message

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
