### PR TITLE
Add readonly_transaction decorator to geo_subdivisions endpoint

### DIFF
--- a/src/senaite/core/z3cform/widgets/address.py
+++ b/src/senaite/core/z3cform/widgets/address.py
@@ -22,9 +22,11 @@ import json
 import six
 from bika.lims import api
 from bika.lims import senaiteMessageFactory as _
+from bika.lims.decorators import returns_json
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 from senaite.core.api import geo
+from senaite.core.decorators import readonly_transaction
 from senaite.core.interfaces import ISenaiteFormLayer
 from senaite.core.schema.addressfield import BILLING_ADDRESS
 from senaite.core.schema.addressfield import BUSINESS_ADDRESS
@@ -277,6 +279,8 @@ class AjaxSubdivisions(BrowserView):
     """Endpoint for the retrieval of geographic subdivisions
     """
 
+    @readonly_transaction
+    @returns_json
     def __call__(self):
         """Returns a json with the list of geographic subdivisions that are
         immediately below the country or subdivision passed in with `parent`
@@ -298,7 +302,7 @@ class AjaxSubdivisions(BrowserView):
                 "type": self.context.translate(_(subdivision.type)),
             }
         items = map(to_dict, items)
-        return json.dumps(items)
+        return items
 
     def get_parent(self):
         """Returns the parent passed through the request

--- a/src/senaite/core/z3cform/widgets/address.py
+++ b/src/senaite/core/z3cform/widgets/address.py
@@ -301,8 +301,7 @@ class AjaxSubdivisions(BrowserView):
                 "code": subdivision.code,
                 "type": self.context.translate(_(subdivision.type)),
             }
-        items = map(to_dict, items)
-        return items
+        return map(to_dict, items)
 
     def get_parent(self):
         """Returns the parent passed through the request

--- a/src/senaite/core/z3cform/widgets/address.py
+++ b/src/senaite/core/z3cform/widgets/address.py
@@ -301,7 +301,7 @@ class AjaxSubdivisions(BrowserView):
                 "code": subdivision.code,
                 "type": self.context.translate(_(subdivision.type)),
             }
-        return map(to_dict, items)
+        return [to_dict(item) for item in items]
 
     def get_parent(self):
         """Returns the parent passed through the request


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds the `readonly_transaction` decorator to `geo_subdivisions` endpoint.

## Current behavior before PR

Non-dummy transaction takes place each time `geo_subdivisions` endpoint is called

## Desired behavior after PR is merged

A dummy transaction takes place each time `geo_subdivisions` endpoint is called

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
