### PR TITLE
Fix AjaxEditForm does not work for default edit form of Dexterity types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1973 Fix AjaxEditForm does not work for default edit form of Dexterity types
 - #1970 Better error messages in sample add form
 - #1960 AddressField and AddressWidget with React component for DX types
 - #1968 Fix default roles for client field in samples

--- a/src/senaite/core/browser/dexterity/templates/macros.pt
+++ b/src/senaite/core/browser/dexterity/templates/macros.pt
@@ -66,7 +66,7 @@
 
         <!-- Form -->
         <form data-pat-autotoc="levels: legend; section: fieldset; className: autotabs"
-              class="rowlike enableUnloadProtection" action="." method="post"
+              class="rowlike enableUnloadProtection" action="." method="post" name="edit_form"
               tal:define="groups view/groups | nothing;
                           form_name view/form_name | nothing;
                           form_class view/css_class | string:;

--- a/src/senaite/core/browser/dexterity/templates/macros.pt
+++ b/src/senaite/core/browser/dexterity/templates/macros.pt
@@ -66,7 +66,7 @@
 
         <!-- Form -->
         <form data-pat-autotoc="levels: legend; section: fieldset; className: autotabs"
-              class="rowlike enableUnloadProtection" action="." method="post" name="edit_form"
+              class="rowlike enableUnloadProtection" action="." method="post"
               tal:define="groups view/groups | nothing;
                           form_name view/form_name | nothing;
                           form_class view/css_class | string:;


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the AjaxEditForm introduced in #1719 to work properly with edit forms of Dexterity types.

AT edit form always come with the attribute `name='edit_form'`, that is used in https://github.com/senaite/senaite.core/blob/2.x/webpack/app/senaite.core.js#L43 on the initialization of the `EditForm`.

## Current behavior before PR

`AjaxEditForm` does not work for default edit form of Dexterity types

## Desired behavior after PR is merged

`AjaxEditForm` does work for default edit form of Dexterity types

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
