### PR TITLE
Fix IndexError in Unit formatter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1975 Fix IndexError in Unit formatter
 - #1973 Fix AjaxEditForm does not work for default edit form of Dexterity types
 - #1970 Better error messages in sample add form
 - #1960 AddressField and AddressWidget with React component for DX types

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -749,6 +749,13 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
         return _c(self.title)
 
     @security.public
+    def getUnit(self):
+        """Returns the Unit
+        """
+        unit = self.Schema().getField("Unit").get(self)
+        return unit.strip()
+
+    @security.public
     def getDefaultVAT(self):
         """Return default VAT from bika_setup
         """

--- a/src/bika/lims/utils/__init__.py
+++ b/src/bika/lims/utils/__init__.py
@@ -515,7 +515,7 @@ def format_supsub(text):
     subsup = []
     clauses = []
     insubsup = True
-    for c in str(text):
+    for c in str(text).strip():
         if c == '(':
             if insubsup is False:
                 out.append(c)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an `IndexError` that happens when the unit of an analysis service is empty, but contains spaces.

Traceback:
```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish                                                                                                                             
  Module ZPublisher.mapply, line 85, in mapply                                                                                                                                        
  Module ZServer.ZPublisher.Publish, line 44, in call_object                                                                                                                          
  Module senaite.app.listing.view, line 224, in __call__                                                                                                                              
  Module senaite.app.listing.ajax, line 111, in handle_subpath                                                                                                                        
  Module senaite.core.decorators, line 22, in decorator                                                                                                                               
  Module senaite.app.listing.decorators, line 63, in wrapper                                                                                                                          
  Module senaite.app.listing.decorators, line 50, in wrapper                                                                                                                          
  Module senaite.app.listing.decorators, line 100, in wrapper                                                                                                                         
  Module senaite.app.listing.ajax, line 436, in ajax_folderitems                                                                                                                      
  Module senaite.app.listing.decorators, line 88, in wrapper                                                                                                                          
  Module senaite.app.listing.ajax, line 317, in get_folderitems                                                                                                                       
  Module bika.lims.controlpanel.bika_analysisservices, line 427, in folderitems                                                                                                       
  Module senaite.app.listing.view, line 938, in folderitems                                                                                                                           
  Module bika.lims.controlpanel.bika_analysisservices, line 396, in folderitem                                                                                                        
  Module bika.lims.utils, line 546, in format_supsub                                                                                                                                  
IndexError: pop from empty list    
```

## Current behavior before PR

Traceback occurs in analysis services listing

## Desired behavior after PR is merged

No traceback happens for analysis services listing when a service contains spaces in the unit

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
