### PR TITLE
Unify field sizes in sample view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1978 Unify field sizes in sample view
 - #1975 Fix IndexError in Unit formatter
 - #1973 Fix AjaxEditForm does not work for default edit form of Dexterity types
 - #1970 Better error messages in sample add form

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -552,6 +552,7 @@ schema = BikaSchema.copy() + Schema((
         write_permission=FieldEditContainer,
         widget=ReferenceWidget(
             label=_("Container"),
+            size=20,
             render_own_label=True,
             visible={
                 'add': 'edit',
@@ -576,6 +577,7 @@ schema = BikaSchema.copy() + Schema((
         write_permission=FieldEditPreservation,
         widget=ReferenceWidget(
             label=_("Preservation"),
+            size=20,
             render_own_label=True,
             visible={
                 'add': 'edit',
@@ -797,6 +799,7 @@ schema = BikaSchema.copy() + Schema((
         widget=StringWidget(
             label=_("Client Reference"),
             description=_("The client side reference for this request"),
+            size=20,
             render_own_label=True,
             visible={
                 'add': 'edit',


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds the `size` attribute to sample field widgets where missing.

## Current behavior before PR

Some fields used the default field size of 30

## Desired behavior after PR is merged

Fields set the field size to 20

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
