### PR TITLE
Multiselect/Multichoice support for interim fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1979 Multiselect/Multichoice support for interim fields
 - #1975 Fix IndexError in Unit formatter
 - #1973 Fix AjaxEditForm does not work for default edit form of Dexterity types
 - #1970 Better error messages in sample add form

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -929,7 +929,6 @@ class AnalysesView(ListingView):
 
         # Copy to prevent to avoid persistent changes
         interim_fields = deepcopy(interim_fields)
-
         for interim_field in interim_fields:
             interim_keyword = interim_field.get('keyword', '')
             if not interim_keyword:
@@ -968,8 +967,20 @@ class AnalysesView(ListingView):
                 dl = map(lambda it: dict(zip(headers, it)), choices.items())
                 item.setdefault("choices", {})[interim_keyword] = dl
 
+                # Maybe the value is a multi-select/multi-choice?
+                try:
+                    val = json.loads(interim_value)
+                    if isinstance(val, (list, tuple, set)):
+                        interim_value = val
+                except ValueError:
+                    pass
+
+                if not isinstance(interim_value, (list, tuple, set)):
+                    interim_value = [interim_value]
+
                 # Set the text as the formatted value
-                text = choices.get(interim_value, "")
+                texts = [choices.get(v, "") for v in interim_value]
+                text = "<br/>".join(filter(None, texts))
                 interim_field["formatted_value"] = text
 
                 if not is_editable:

--- a/src/bika/lims/browser/fields/interimfieldsfield.py
+++ b/src/bika/lims/browser/fields/interimfieldsfield.py
@@ -25,6 +25,7 @@ from bika.lims import bikaMessageFactory as _
 from bika.lims.interfaces import IAnalysisService
 from bika.lims.interfaces import IRoutineAnalysis
 from bika.lims.interfaces.calculation import ICalculation
+from Products.Archetypes import DisplayList
 from Products.Archetypes.Registry import registerField
 from senaite.core.browser.fields.records import RecordsField
 
@@ -37,22 +38,39 @@ class InterimFieldsField(RecordsField):
         "minimalSize": 0,
         "maximalSize": 9999,
         "type": "InterimFields",
-        "subfields": ("keyword", "title", "value", "choices", "unit", "report", "hidden", "wide"),
+        "subfields": (
+            "keyword",
+            "title",
+            "value",
+            "choices",
+            "result_type",
+            "unit",
+            "report",
+            "hidden",
+            "wide"
+        ),
         "required_subfields": ("keyword", "title"),
         "subfield_labels": {
             "keyword": _("Keyword"),
             "title": _("Field Title"),
             "value": _("Default value"),
             "choices": _("Choices"),
+            "result_type": _("Control type"),
             "unit": _("Unit"),
             "report": _("Report"),
             "hidden": _("Hidden Field"),
             "wide": _("Apply wide"),
         },
+        "subfield_descriptions": {
+            "result_type": _(
+                "Type of control to be displayed on value entry when choices "
+                "are set")
+        },
         "subfield_types": {
             "hidden": "boolean",
             "value": "float",
             "choices": "string",
+            "result_type": "selection",
             "wide": "boolean",
             "report": "boolean",
         },
@@ -61,6 +79,7 @@ class InterimFieldsField(RecordsField):
             "title": 20,
             "value": 10,
             "choices": 50,
+            "result_type": 1,
             "unit": 10,
         },
         "subfield_maxlength": {
@@ -71,7 +90,16 @@ class InterimFieldsField(RecordsField):
             "title": "interimfieldsvalidator",
             "value": "interimfieldsvalidator",
             "unit": "interimfieldsvalidator",
-            "choices": "interimfieldsvalidator"
+            "choices": "interimfieldsvalidator",
+            "result_type": "interimfieldsvalidator",
+        },
+        "subfield_vocabularies": {
+            "result_type": DisplayList((
+                ('', ''),
+                ('select', _('Selection list')),
+                ('multiselect', _('Multiple selection')),
+                ('multichoice', _('Multiple choices')),
+            )),
         },
     })
     security = ClassSecurityInfo()

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -450,8 +450,11 @@ class InterimFieldsValidator:
         """
         choices = interim.get("choices")
         if not choices:
-            # No choices set, nothing to do
-            return
+            # No choices set, result type should remain empty
+            result_type = interim.get("result_type")
+            if not result_type:
+                return
+            return _t(_("Control type is not supported for empty choices"))
 
         # Choices are expressed like "value0:text0|value1:text1|..|valuen:textn"
         choices = choices.split("|") or []

--- a/src/senaite/core/datamanagers/analysis.py
+++ b/src/senaite/core/datamanagers/analysis.py
@@ -86,10 +86,7 @@ class RoutineAnalysisDataManager(DataManager):
             if not self.is_field_writeable(interim_field):
                 logger.error("Interim field '{}' not writeable!".format(name))
                 return []
-            for interim in interims:
-                if interim.get("keyword") == name:
-                    interim["value"] = value
-            self.context.setInterimFields(interims)
+            self.context.setInterimValue(name, value)
 
         # recalculate dependent results for result and interim fields
         if name == "Result" or name in interim_keys:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds the possibility to render multiselect/multichoice controls for interim fields

**Please merge https://github.com/senaite/senaite.app.listing/pull/72 first**

Service's view edition of Results options:

![Captura de 2022-04-25 10-12-42](https://user-images.githubusercontent.com/832627/165056970-6ebf9805-d3ce-432e-97b2-dfed7237712e.png)

Results entry for an analysis with interims of different control types:

![Captura de 2022-04-25 10-51-15](https://user-images.githubusercontent.com/832627/165057121-d44741b5-86fb-4283-8278-925df37abb10.png)


View of an analysis with interims of different control types:

![Captura de 2022-04-25 10-53-03](https://user-images.githubusercontent.com/832627/165057261-38839d43-1644-4416-92c5-366ebe9488bd.png)



## Current behavior before PR

The control rendered for interim fields with choices is always a (single) select control

## Desired behavior after PR is merged

The control rendered for interim fields with choices depends on the interim's "Control type"

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
