### PR TITLE
Fix: Absent value for Unit field causes error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1980 Fix: Absent value for Unit field causes error
 - #1978 Unify field sizes in sample view
 - #1975 Fix IndexError in Unit formatter
 - #1973 Fix AjaxEditForm does not work for default edit form of Dexterity types

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -752,7 +752,7 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
     def getUnit(self):
         """Returns the Unit
         """
-        unit = self.Schema().getField("Unit").get(self)
+        unit = self.Schema().getField("Unit").get(self) or ""
         return unit.strip()
 
     @security.public


### PR DESCRIPTION
minifix error when Unit field is absent

## Description of the issue/feature this PR addresses

With PR #1975  excpetion raises when Unit value is absent

## Current behavior before PR

```
2022-04-25T10:19:50 ERROR Zope.SiteErrorLog 1650878390.730.179975823545 http://localhost/senaite20/bika_setup/bika_analysisservices/folder_view/folderitems
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module senaite.app.listing.view, line 224, in __call__
  Module senaite.app.listing.ajax, line 111, in handle_subpath
  Module senaite.core.decorators, line 22, in decorator
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 436, in ajax_folderitems
  Module senaite.app.listing.decorators, line 88, in wrapper
  Module senaite.app.listing.ajax, line 317, in get_folderitems
  Module bika.lims.controlpanel.bika_analysisservices, line 425, in folderitems
  Module senaite.app.listing.view, line 938, in folderitems
  Module bika.lims.controlpanel.bika_analysisservices, line 395, in folderitem
  Module bika.lims.content.abstractbaseanalysis, line 756, in getUnit
AttributeError: 'NoneType' object has no attribute 'strip'
```
## Desired behavior after PR is merged

if Unit value is None returns empty string yo the strip() method.
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
