### PR TITLE
Fix IndexError in Unit formatter (#1975 + #1980 port)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #1982 Fix IndexError in Unit formatter (#1975 + #1980 port)
 - #1954 Allow custom id formatting regardless of portal type (#1953 port)
 - #1939 Fix retracted and rejected analyses cannot be added to a Sample
 - #1906 Fix traceback in auditlog view when context is a Dexterity type

--- a/bika/lims/content/abstractbaseanalysis.py
+++ b/bika/lims/content/abstractbaseanalysis.py
@@ -772,6 +772,13 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
         return _c(self.title)
 
     @security.public
+    def getUnit(self):
+        """Returns the Unit
+        """
+        unit = self.Schema().getField("Unit").get(self) or ""
+        return unit.strip()
+
+    @security.public
     def getDefaultVAT(self):
         """Return default VAT from bika_setup
         """

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -549,7 +549,7 @@ def format_supsub(text):
     subsup = []
     clauses = []
     insubsup = True
-    for c in str(text):
+    for c in str(text).strip():
         if c == '(':
             if insubsup is False:
                 out.append(c)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #1975 and #1980 to 1.3.x

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
