### PR TITLE
Better error messages in sample add form (#1970 port)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #1983 Better error messages in sample add form (#1970 port)
 - #1954 Allow custom id formatting regardless of portal type (#1953 port)
 - #1939 Fix retracted and rejected analyses cannot be added to a Sample
 - #1906 Fix traceback in auditlog view when context is a Dexterity type

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1706,9 +1706,9 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                     record,
                     results_ranges=specifications
                 )
-            except (KeyError, RuntimeError) as e:
+            except Exception as e:
                 actions.resume()
-                errors["message"] = e.message
+                errors["message"] = str(e)
                 return {"errors": errors}
             # We keep the title to check if AR is newly created
             # and UID to print stickers

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -1337,7 +1337,7 @@
         if (data['errors']) {
           msg = data.errors.message;
           if (msg !== "") {
-            msg = _t("Sorry, an error occured 🙈<p class='code'>" + msg + "</p>");
+            msg = _("Sorry, an error occured 🙈<p class='code'>" + msg + "</p>");
           }
           for (fieldname in data.errors.fielderrors) {
             field = $("#" + fieldname);

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -1337,7 +1337,7 @@
         if (data['errors']) {
           msg = data.errors.message;
           if (msg !== "") {
-            msg = msg + "<br/>";
+            msg = _t("Sorry, an error occured 🙈<p class='code'>" + msg + "</p>");
           }
           for (fieldname in data.errors.fielderrors) {
             field = $("#" + fieldname);

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -1364,7 +1364,7 @@ class window.AnalysisRequestAdd
       if data['errors']
         msg = data.errors.message
         if msg isnt ""
-          msg = "#{msg}<br/>"
+          msg = _("Sorry, an error occured 🙈<p class='code'>#{msg}</p>")
 
         for fieldname of data.errors.fielderrors
           field = $("##{fieldname}")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #1970 to v1.3.x

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
