### PR TITLE
Fix default roles for client field in samples (#1968 port)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #1984 Fix default roles for client field in samples (#1968 port)
 - #1954 Allow custom id formatting regardless of portal type (#1953 port)
 - #1939 Fix retracted and rejected analyses cannot be added to a Sample
 - #1906 Fix traceback in auditlog view when context is a Dexterity type

--- a/bika/lims/profiles/default/rolemap.xml
+++ b/bika/lims/profiles/default/rolemap.xml
@@ -493,6 +493,7 @@
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
+      <role name="Client"/>
     </permission>
     <permission name="senaite.core: Field: Edit Client Order Number" acquire="False">
       <role name="LabClerk"/>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #1968 to 1.3.x

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
