### PR TITLE
Disallow client users to create sample partitions (#1965 port)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #1985 Disallow client users to create sample partitions (#1965 port)
 - #1954 Allow custom id formatting regardless of portal type (#1953 port)
 - #1939 Fix retracted and rejected analyses cannot be added to a Sample
 - #1906 Fix traceback in auditlog view when context is a Dexterity type

--- a/bika/lims/workflow/analysisrequest/guards.py
+++ b/bika/lims/workflow/analysisrequest/guards.py
@@ -19,7 +19,10 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims import api
-from bika.lims.interfaces import IVerified, IInternalUse
+from bika.lims.api.security import check_permission
+from bika.lims.interfaces import IInternalUse
+from bika.lims.interfaces import IVerified
+from bika.lims.permissions import TransitionReceiveSample
 from bika.lims.workflow import isTransitionAllowed
 
 # States to be omitted in regular transitions
@@ -53,6 +56,12 @@ def guard_create_partitions(analysis_request):
     """
     if analysis_request.isPartition():
         # Do not allow the creation of partitions from partitions
+        return False
+
+    # Clients have the AddAnalysisRequest permission, but should not be allowed
+    # to create partitions. Therefore, we check here if the current user has
+    # the permission to receive a sample as well.
+    if not check_permission(TransitionReceiveSample, analysis_request):
         return False
 
     # Allow only the creation of partitions if all analyses from the Analysis


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #1965 to 1.3.x

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
