### PR TITLE
Fixed error with sampler mail (#1941 port)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #1986 Fixed error with sampler mail (#1941 port)
 - #1954 Allow custom id formatting regardless of portal type (#1953 port)
 - #1939 Fix retracted and rejected analyses cannot be added to a Sample
 - #1906 Fix traceback in auditlog view when context is a Dexterity type

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2143,7 +2143,7 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
         """
         Returns the email of this analysis request's sampler.
         """
-        return user_email(self, self.Creator())
+        return user_email(self, self.getSampler())
 
     def getPriorityText(self):
         """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #1941 to 1.3.x

## Current behavior before PR

## Desired behavior after PR is merged

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
