### PR TITLE
Add ProfileKey to AnalysisProfiles table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1987 Fix: ProfileKey shown in Profiles table
 - #1981 Support for interim fields with empty values
 - #1979 Multiselect/Multichoice support for interim fields
 - #1980 Fix: Absent value for Unit field causes error

--- a/src/bika/lims/controlpanel/bika_analysisprofiles.py
+++ b/src/bika/lims/controlpanel/bika_analysisprofiles.py
@@ -122,6 +122,7 @@ class AnalysisProfilesView(BikaListingView):
 
         item["replace"]["Title"] = get_link(url, value=title)
         item["Description"] = description
+        item["ProfileKey"] = obj.ProfileKey
 
         return item
 

--- a/src/bika/lims/controlpanel/bika_analysisprofiles.py
+++ b/src/bika/lims/controlpanel/bika_analysisprofiles.py
@@ -122,7 +122,7 @@ class AnalysisProfilesView(BikaListingView):
 
         item["replace"]["Title"] = get_link(url, value=title)
         item["Description"] = description
-        item["ProfileKey"] = obj.ProfileKey
+        item["ProfileKey"] = obj.getProfileKey()
 
         return item
 


### PR DESCRIPTION
microfix

## Description of the issue/feature this PR addresses


ProfileKey does not appear in the Profiles table
Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR

No profile key 
<img width="1427" alt="image" src="https://user-images.githubusercontent.com/14867014/165232162-0cca1bcf-6be8-441d-87dc-9b63fef9d5a3.png">


## Desired behavior after PR is merged
ProfileKey shown
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
