### PR TITLE
Multivalue support for interim fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1988 Multivalue support for interim fields
 - #1987 Fix: ProfileKey shown in Profiles table
 - #1981 Support for interim fields with empty values
 - #1979 Multiselect/Multichoice support for interim fields

--- a/src/bika/lims/browser/fields/interimfieldsfield.py
+++ b/src/bika/lims/browser/fields/interimfieldsfield.py
@@ -102,6 +102,7 @@ class InterimFieldsField(RecordsField):
                 ('select', _('Selection list')),
                 ('multiselect', _('Multiple selection')),
                 ('multichoice', _('Multiple choices')),
+                ('multivalue', _('Multiple values')),
             )),
         },
     })

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -448,11 +448,11 @@ class InterimFieldsValidator:
     def validate_choices(self, interim):
         """Checks whether the choices are valid for the given interim
         """
+        result_type = interim.get("result_type", "")
         choices = interim.get("choices")
         if not choices:
-            # No choices set, result type should remain empty
-            result_type = interim.get("result_type")
-            if not result_type:
+            # No choices set, result type should remain empty or multivalue
+            if result_type in ["", "multivalue"]:
                 return
             return _t(_("Control type is not supported for empty choices"))
 
@@ -480,6 +480,11 @@ class InterimFieldsValidator:
         if len(keys) < 2:
             return _t(_("At least, two options for choices field are required"))
 
+        # Multivalue is not supported with choices
+        if result_type in ["multivalue"]:
+            return _t(_(
+                "Multiple values control type is not supported for choices"
+            ))
 
 validation.register(InterimFieldsValidator())
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds the possibility to render multivalue controls for interim fields

**Please merge https://github.com/senaite/senaite.app.listing/pull/74 first**

Service's view edition of Results options (note "Multiple values" in the last record):

![Captura de 2022-04-27 12-57-58](https://user-images.githubusercontent.com/832627/165503734-29a5fa24-5337-4293-80a8-3f27cd0bbfac.png)

Results entry for an analysis with interims of different control types:

![Captura de 2022-04-27 12-54-29](https://user-images.githubusercontent.com/832627/165503833-5c837b9e-5674-4cb3-9f1d-a3db859a756a.png)

View of an analysis with interims of different control types:

![Captura de 2022-04-27 12-54-46](https://user-images.githubusercontent.com/832627/165503877-2cda799b-daa7-469c-ae8d-a0e570be5425.png)


## Current behavior before PR

Is not possible to render a multivalued control for interim fields

## Desired behavior after PR is merged

Is possible to render a multivalued control for interim fields

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
