### PR TITLE
Fix Generic Setup XML export/import adapters for Dexterity fields 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1992 Fix Generic Setup XML export/import adapters for Dexterity fields
 - #1990 Fix items not filtered by Worksheet Template's method in Add analyses
 - #1991 Update default worksheet layout 
 - #1887 Fix instruments not filtered by method in Worksheet Template edit view

--- a/src/senaite/core/exportimport/genericsetup/adapters.py
+++ b/src/senaite/core/exportimport/genericsetup/adapters.py
@@ -52,6 +52,7 @@ from zope.schema.interfaces import IDatetime
 from zope.schema.interfaces import IField as ISchemaField
 from zope.schema.interfaces import IText
 from zope.schema.interfaces import ITextLine
+from zope.schema.interfaces import ITuple
 
 from .config import SITE_ID
 from .interfaces import IFieldNode
@@ -347,22 +348,39 @@ class ATRichTextFieldNodeAdapter(ATFieldNodeAdapter):
             return value
 
 
+class DXTupleFieldNodeAdapter(DXFieldNodeAdapter):
+    """Node im- and exporter for DX Tuple fields.
+    """
+    implements(IFieldNode)
+    adapts(IDexterityContent, ITuple, ISetupEnviron)
+
+    def set_field_value(self, value, **kw):
+        """Set the field value
+        """
+        if not value:
+            value = tuple
+        if isinstance(value, list):
+            value = tuple(value)
+        dm = getMultiAdapter((self.context, self.field), IDataManager)
+        dm.set(value, **kw)
+
+
 class DXTextLineFieldNodeAdapter(DXFieldNodeAdapter):
-    """Node im- and exporter for AT RichText fields.
+    """Node im- and exporter for DX TextLine fields.
     """
     implements(IFieldNode)
     adapts(IDexterityContent, ITextLine, ISetupEnviron)
 
 
 class DXTextFieldNodeAdapter(DXFieldNodeAdapter):
-    """Node im- and exporter for AT RichText fields.
+    """Node im- and exporter for DX Text fields.
     """
     implements(IFieldNode)
     adapts(IDexterityContent, IText, ISetupEnviron)
 
 
 class DXRichTextFieldNodeAdapter(ATRichTextFieldNodeAdapter):
-    """Node im- and exporter for AT RichText fields.
+    """Node im- and exporter for DX RichText fields.
     """
     implements(IFieldNode)
     adapts(IDexterityContent, IRichText, ISetupEnviron)

--- a/src/senaite/core/exportimport/genericsetup/adapters.py
+++ b/src/senaite/core/exportimport/genericsetup/adapters.py
@@ -406,11 +406,24 @@ class DXTextFieldNodeAdapter(DXFieldNodeAdapter):
     adapts(IDexterityContent, IText, ISetupEnviron)
 
 
-class DXRichTextFieldNodeAdapter(ATRichTextFieldNodeAdapter):
+class DXRichTextFieldNodeAdapter(DXFieldNodeAdapter):
     """Node im- and exporter for DX RichText fields.
     """
     implements(IFieldNode)
     adapts(IDexterityContent, IRichText, ISetupEnviron)
+
+    def get_field_value(self):
+        """Get the field value
+        """
+        value = self.field.get(self.context)
+        if not value:
+            return ""
+        try:
+            return value.raw
+        except AttributeError as e:
+            logger.info("Imported value has no Attribute 'raw' {}"
+                        .format(str(e)))
+            return value
 
 
 class DXReferenceFieldNodeAdapter(ATReferenceFieldNodeAdapter):

--- a/src/senaite/core/exportimport/genericsetup/adapters.py
+++ b/src/senaite/core/exportimport/genericsetup/adapters.py
@@ -282,7 +282,7 @@ class ATReferenceFieldNodeAdapter(ATFieldNodeAdapter):
     adapts(IBaseObject, IReferenceField, ISetupEnviron)
 
     def get_json_value(self):
-        """Returns the date as ISO string
+        """Convert referenced objects to UIDs
         """
         value = self.field.get(self.context)
         if api.is_object(value):
@@ -330,3 +330,15 @@ class DXRichTextFieldNodeAdapter(ATRichTextFieldNodeAdapter):
     """
     implements(IFieldNode)
     adapts(IDexterityContent, IRichText, ISetupEnviron)
+
+
+class DXReferenceFieldNodeAdapter(ATReferenceFieldNodeAdapter):
+    """Import/Export DX UID Reference Fields
+    """
+    adapts(IDexterityContent, IUIDReferenceFieldDX, ISetupEnviron)
+
+
+class DXDataGridFieldNodeAdapter(ATRecordFieldNodeAdapter):
+    """Import/Export if DataGrid Fields
+    """
+    adapts(IDexterityContent, IDataGridField, ISetupEnviron)

--- a/src/senaite/core/exportimport/genericsetup/adapters.py
+++ b/src/senaite/core/exportimport/genericsetup/adapters.py
@@ -41,6 +41,7 @@ from Products.Archetypes.interfaces import ITextField
 from Products.CMFPlone.utils import safe_unicode
 from Products.GenericSetup.interfaces import ISetupEnviron
 from Products.GenericSetup.utils import NodeAdapterBase
+from senaite.core.api import dtime
 from senaite.core.schema.interfaces import IDataGridField
 from senaite.core.schema.interfaces import \
     IUIDReferenceField as IUIDReferenceFieldDX
@@ -289,13 +290,14 @@ class DXDateTimeFieldNodeAdapter(ATFieldNodeAdapter):
         value = self.field.get(self.context)
         if not isinstance(value, datetime):
             return ""
-        return value.isoformat()
+        return dtime.to_iso_format(value)
 
     def parse_json_value(self, value):
         if not value:
             return None
-        dt = api.to_date(value)
-        return dt.asdatetime()
+        # Avoid `UnknownTimeZoneError` by using the date API for conversion
+        # also see https://github.com/senaite/senaite.patient/pull/29
+        return dtime.to_dt(value)
 
 
 class ATReferenceFieldNodeAdapter(ATFieldNodeAdapter):

--- a/src/senaite/core/exportimport/genericsetup/adapters.py
+++ b/src/senaite/core/exportimport/genericsetup/adapters.py
@@ -19,10 +19,10 @@
 # Some rights reserved, see README and LICENSE.
 
 import json
-import six
-
 from datetime import datetime
 from mimetypes import guess_type
+
+import six
 
 from bika.lims import api
 from bika.lims import logger
@@ -41,6 +41,9 @@ from Products.Archetypes.interfaces import ITextField
 from Products.CMFPlone.utils import safe_unicode
 from Products.GenericSetup.interfaces import ISetupEnviron
 from Products.GenericSetup.utils import NodeAdapterBase
+from senaite.core.schema.interfaces import IDataGridField
+from senaite.core.schema.interfaces import \
+    IUIDReferenceField as IUIDReferenceFieldDX
 from zope.component import adapts
 from zope.interface import implements
 from zope.schema.interfaces import IDatetime

--- a/src/senaite/core/exportimport/genericsetup/configure.zcml
+++ b/src/senaite/core/exportimport/genericsetup/configure.zcml
@@ -33,6 +33,8 @@
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXFieldNodeAdapter"/>
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXNamedFileFieldNodeAdapter"/>
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXDateTimeFieldNodeAdapter"/>
+  <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXTextLineFieldNodeAdapter"/>
+  <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXTextFieldNodeAdapter"/>
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXRichTextFieldNodeAdapter"/>
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXReferenceFieldNodeAdapter"/>
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXDataGridFieldNodeAdapter"/>

--- a/src/senaite/core/exportimport/genericsetup/configure.zcml
+++ b/src/senaite/core/exportimport/genericsetup/configure.zcml
@@ -30,14 +30,15 @@
   <!-- DX Field Adapters
        Know how to Import/Export field values
   -->
+  <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXDataGridFieldNodeAdapter"/>
+  <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXDateTimeFieldNodeAdapter"/>
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXFieldNodeAdapter"/>
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXNamedFileFieldNodeAdapter"/>
-  <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXDateTimeFieldNodeAdapter"/>
-  <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXTextLineFieldNodeAdapter"/>
-  <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXTextFieldNodeAdapter"/>
-  <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXRichTextFieldNodeAdapter"/>
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXReferenceFieldNodeAdapter"/>
-  <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXDataGridFieldNodeAdapter"/>
+  <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXRichTextFieldNodeAdapter"/>
+  <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXTextFieldNodeAdapter"/>
+  <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXTextLineFieldNodeAdapter"/>
+  <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXTupleFieldNodeAdapter"/>
 
   <class class="senaite.core.browser.fields.record.RecordField">
     <implements interface=".interfaces.IRecordField" />

--- a/src/senaite/core/exportimport/genericsetup/configure.zcml
+++ b/src/senaite/core/exportimport/genericsetup/configure.zcml
@@ -34,6 +34,8 @@
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXNamedFileFieldNodeAdapter"/>
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXDateTimeFieldNodeAdapter"/>
   <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXRichTextFieldNodeAdapter"/>
+  <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXReferenceFieldNodeAdapter"/>
+  <adapter provides=".interfaces.IFieldNode" factory=".adapters.DXDataGridFieldNodeAdapter"/>
 
   <class class="senaite.core.browser.fields.record.RecordField">
     <implements interface=".interfaces.IRecordField" />

--- a/src/senaite/core/exportimport/genericsetup/structure.py
+++ b/src/senaite/core/exportimport/genericsetup/structure.py
@@ -479,6 +479,7 @@ def create_or_get(parent, id, uid, portal_type):
         notify(ObjectCreatedEvent(obj))
         parent._setObject(tmp_id, obj)
         obj = parent._getOb(api.get_id(obj))
+        obj.reindexObject()
 
     return obj
 

--- a/src/senaite/core/exportimport/genericsetup/structure.py
+++ b/src/senaite/core/exportimport/genericsetup/structure.py
@@ -479,7 +479,6 @@ def create_or_get(parent, id, uid, portal_type):
         notify(ObjectCreatedEvent(obj))
         parent._setObject(tmp_id, obj)
         obj = parent._getOb(api.get_id(obj))
-        obj.reindexObject()
 
     return obj
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR introduces dexterity field adapters for the GS content export/import step

## Current behavior before PR

Fields were not correctly exported and fails during import

## Desired behavior after PR is merged

Dexterity fields are exported and imported correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
