### PR TITLE
Avoid line wrapping in login form for small screens

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1993 Avoid line wrapping in login form for small screens
 - #1990 Fix items not filtered by Worksheet Template's method in Add analyses
 - #1991 Update default worksheet layout 
 - #1887 Fix instruments not filtered by method in Worksheet Template edit view

--- a/src/senaite/core/browser/login/login.py
+++ b/src/senaite/core/browser/login/login.py
@@ -31,9 +31,9 @@ class LoginForm(BaseLoginForm):
 
     def updateWidgets(self):
         super(LoginForm, self).updateWidgets()
-        self.widgets["__ac_name"].addClass("form-control")
-        self.widgets["__ac_password"].addClass("form-control")
+        self.widgets["__ac_name"].addClass("form-control form-control-sm")
+        self.widgets["__ac_password"].addClass("form-control form-control-sm")
 
     def updateActions(self):
         super(LoginForm, self).updateActions()
-        self.actions["login"].addClass("btn btn-primary")
+        self.actions["login"].addClass("btn btn-primary btn-sm")

--- a/src/senaite/core/browser/login/templates/login.pt
+++ b/src/senaite/core/browser/login/templates/login.pt
@@ -13,7 +13,7 @@
         <div class="col-sm-4 offset-sm-4">
           <div id="login-form" class="card my-4">
 
-            <div class="portalMessage error pat-cookietrigger alert alert-danger" style="display:none">
+            <div class="portalMessage error pat-cookietrigger alert alert-danger m-1" style="display:none">
               <strong i18n:translate="">
                 Error
               </strong>
@@ -56,7 +56,7 @@
                           field description
                         </div>
 
-                        <div class="widget input-group">
+                        <div class="widget input-group flex-nowrap">
                           <div class="input-group-prepend">
                             <div class="input-group-text">
                               <i tal:attributes="class python:view.get_icon_class_for(widget)"></i>
@@ -91,7 +91,7 @@
               </form>
             </div>
 
-            <div class="card-footer"
+            <div class="card-footer small"
                  tal:define="portal_state context/@@plone_portal_state;
                         portal_url portal_state/portal_url">
               <p class="form-text text-muted">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the wrapping of the icon and input field in the login form on small screens and reduces the font sizes a little bit.

<img width="670" alt="SENAITE LIMS 2022-05-12 1 PM-35-33" src="https://user-images.githubusercontent.com/713193/168065908-9c3d1764-afe0-4a73-8e83-f90dbe536b24.png">

## Current behavior before PR

icons and input fields wrapped on small screens

## Desired behavior after PR is merged

icons and input fields not wrapped on small screens

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
