### PR TITLE
Support for dynamic assignment of Local Roles for context and principal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1994 Support for dynamic assignment of Local Roles for context and principal
 - #1990 Fix items not filtered by Worksheet Template's method in Add analyses
 - #1991 Update default worksheet layout 
 - #1887 Fix instruments not filtered by method in Worksheet Template edit view

--- a/src/senaite/core/adapters/configure.zcml
+++ b/src/senaite/core/adapters/configure.zcml
@@ -23,4 +23,7 @@
     provides="bika.lims.interfaces.IWorkflowActionAdapter"
     permission="zope.Public" />
 
+  <!-- Dynamic calculation of local roles for a given context and principal -->
+  <adapter factory=".localroles.DynamicLocalRoleAdapter" />
+
 </configure>

--- a/src/senaite/core/adapters/localroles.py
+++ b/src/senaite/core/adapters/localroles.py
@@ -22,9 +22,9 @@ import six
 from bika.lims import api
 from bika.lims import logger
 from borg.localrole.default_adapter import DefaultLocalRoleAdapter
+from collections import defaultdict
 from senaite.core.interfaces import IDynamicLocalRoles
 from zope.component import getAdapters
-from collections import defaultdict
 
 
 class DynamicLocalRoleAdapter(DefaultLocalRoleAdapter):
@@ -53,18 +53,18 @@ class DynamicLocalRoleAdapter(DefaultLocalRoleAdapter):
             return roles.get(principal_id)
 
         # Look for adapters
-        roles = []
+        roles = set()
         path = api.get_path(context)
         adapters = getAdapters((context,), IDynamicLocalRoles)
         for name, adapter in adapters:
             local_roles = adapter.getRoles(principal_id)
             logger.info(u"{}::{}::{}: {}".format(name, path, principal_id,
                                                  repr(local_roles)))
-            roles.extend(local_roles)
+            roles.update(local_roles)
 
         # Store in cache
         self._roles_in_context[context_uid].update({
-            principal_id: list(set(roles))
+            principal_id: list(roles)
         })
         return self._roles_in_context[context_uid][principal_id]
 

--- a/src/senaite/core/adapters/localroles.py
+++ b/src/senaite/core/adapters/localroles.py
@@ -24,6 +24,7 @@ from bika.lims import logger
 from borg.localrole.default_adapter import DefaultLocalRoleAdapter
 from senaite.core.interfaces import IDynamicLocalRoles
 from zope.component import getAdapters
+from collections import defaultdict
 
 
 class DynamicLocalRoleAdapter(DefaultLocalRoleAdapter):
@@ -32,7 +33,7 @@ class DynamicLocalRoleAdapter(DefaultLocalRoleAdapter):
     current traverse path
     """
 
-    _roles_in_context = {}
+    _roles_in_context = defaultdict(dict)
 
     def getRolesInContext(self, context, principal_id):
         """Returns the dynamically calculated 'local' roles for the given
@@ -62,7 +63,7 @@ class DynamicLocalRoleAdapter(DefaultLocalRoleAdapter):
             roles.extend(local_roles)
 
         # Store in cache
-        self._roles_in_context.setdefault(context_uid, {}).update({
+        self._roles_in_context[context_uid].update({
             principal_id: list(set(roles))
         })
         return self._roles_in_context[context_uid][principal_id]

--- a/src/senaite/core/adapters/localroles.py
+++ b/src/senaite/core/adapters/localroles.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2022 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+import six
+from bika.lims import api
+from bika.lims import logger
+from borg.localrole.default_adapter import DefaultLocalRoleAdapter
+from senaite.core.interfaces import IDynamicLocalRoles
+from zope.component import getAdapters
+
+
+class DynamicLocalRoleAdapter(DefaultLocalRoleAdapter):
+    """Gives additional Member local roles based on current user and context
+    This enables giving additional permissions on items out of the user's
+    current traverse path
+    """
+
+    _roles_in_context = {}
+
+    def getRolesInContext(self, context, principal_id):
+        """Returns the dynamically calculated 'local' roles for the given
+        principal and context
+        @param context: context to calculate roles for the given principal
+        @param principal_id: User login id
+        @return List of dynamically calculated local-roles for user and context
+        """
+        if not api.is_object(context):
+            # We only apply dynamic local roles to valid objects
+            return []
+
+        # This function is called a lot within same request, do some cache
+        context_uid = api.get_uid(context)
+        roles = self._roles_in_context.get(context_uid, {})
+        if principal_id in roles:
+            return roles.get(principal_id)
+
+        # Look for adapters
+        roles = []
+        path = api.get_path(context)
+        adapters = getAdapters((context,), IDynamicLocalRoles)
+        for name, adapter in adapters:
+            local_roles = adapter.getRoles(principal_id)
+            logger.info(u"{}::{}::{}: {}".format(name, path, principal_id,
+                                                 repr(local_roles)))
+            roles.extend(local_roles)
+
+        # Store in cache
+        self._roles_in_context.setdefault(context_uid, {}).update({
+            principal_id: list(set(roles))
+        })
+        return self._roles_in_context[context_uid][principal_id]
+
+    def getRoles(self, principal_id):
+        """Returns both non-local and local roles for the given principal in
+        current context
+        @param principal_id: User login id
+        @return: list of non-local and local roles for the user and context
+        """
+        default_roles = self._rolemap.get(principal_id, [])
+        dynamic_roles = self.getRolesInContext(self.context, principal_id)
+        return list(set(default_roles + dynamic_roles))
+
+    def getAllRoles(self):
+        roles = {}
+        # Iterate through all members to extract their dynamic local role for
+        # current context
+        mtool = api.get_tool("portal_membership")
+        for principal_id in mtool.listMemberIds():
+            user_roles = self.getRoles(principal_id)
+            if user_roles:
+                roles.update({principal_id: user_roles})
+        return six.iteritems(roles)

--- a/src/senaite/core/interfaces/__init__.py
+++ b/src/senaite/core/interfaces/__init__.py
@@ -108,3 +108,8 @@ class IContentMigrator(Interface):
 class IFieldMigrator(Interface):
     """Marker interface for field migrator
     """
+
+
+class IDynamicLocalRoles(Interface):
+    """Marker interface for objects with dynamic assignment of local roles
+    """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the dynamic assignment of local roles for a given context and principal_id possible. Thus, is possible to add different local permissions on items that out of the current traverse path. See https://training.plone.org/5/workflow/dynamic-roles.html

For instance, "Patient" objects from `senaite.patient` are created inside `senaite/patients` path. By default, objects from this type are not accessible to users from client contacts because they do belong to another path, with differently governed permissions. With this Pull Request is possible to give access to existing Patients to client contacts with something like follows:

```xml
<!-- Dynamic assignment of local roles for Patient -->
<adapter
    for="senaite.patient.interfaces.IPatient"
    provides="senaite.core.interfaces.IDynamicLocalRoles"
    factory=".localroles.PatientDynamicLocalRoles"
    name="senaite.patient.adapter.localroles.patient" />
```

```python
from bika.lims import api
from senaite.core.interfaces import IDynamicLocalRoles
from zope.interface import implementer


@implementer(IDynamicLocalRoles)
class PatientDynamicLocalRoles(object):

    def __init__(self, context):
        self.context = context

    def getRoles(self, principal_id):
        # Consider only users from Client Contacts
        contact = api.get_user_contact(user, contact_types=["Contact"])
        if not contact:
            return []

        # This client contact has access to this Patient with "Physician" role
        return ["Physician"]
```


Note we could make this better and only grant access to patients assigned to a specimen that belongs to same client as the user.

## Current behavior before PR

Dynamic assignment of local roles is not possible

## Desired behavior after PR is merged

The dynamic assignment of local roles is possible

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
