### PR TITLE
Dynamic assingment of "Owner" role for Client Contacts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1995 Dynamic assingment of "Owner" role for Client Contacts
 - #1994 Support for dynamic assignment of Local Roles for context and principal
 - #1992 Fix Generic Setup XML export/import adapters for Dexterity fields
 - #1993 Avoid line wrapping in login form for small screens

--- a/src/bika/lims/content/contact.py
+++ b/src/bika/lims/content/contact.py
@@ -244,10 +244,9 @@ class Contact(Person):
         # N.B. Local owner role and client group applies only to client
         #      contacts, but not lab contacts.
         if IClient.providedBy(self.aq_parent):
-            # Grant local Owner role
-            self._addLocalOwnerRole(username)
             # Add user to "Clients" group
             self._addUserToGroup(username, group="Clients")
+            self._recursive_reindex_object_security(self.aq_parent)
 
         return True
 
@@ -282,10 +281,9 @@ class Contact(Person):
         # N.B. Local owner role and client group applies only to client
         #      contacts, but not lab contacts.
         if IClient.providedBy(self.aq_parent):
-            # Revoke local Owner role
-            self._delLocalOwnerRole(username)
             # Remove user from "Clients" group
             self._delUserFromGroup(username, group="Clients")
+            self._recursive_reindex_object_security(self.aq_parent)
 
         return True
 
@@ -304,26 +302,6 @@ class Contact(Person):
         portal_groups = api.portal.get_tool("portal_groups")
         group = portal_groups.getGroupById(group)
         group.removeMember(username)
-
-    @security.private
-    def _addLocalOwnerRole(self, username):
-        """Add local owner role from parent object
-        """
-        parent = self.getParent()
-        if parent.portal_type == "Client":
-            parent.manage_setLocalRoles(username, ["Owner", ])
-            # reindex object security
-            self._recursive_reindex_object_security(parent)
-
-    @security.private
-    def _delLocalOwnerRole(self, username):
-        """Remove local owner role from parent object
-        """
-        parent = self.getParent()
-        if parent.portal_type == "Client":
-            parent.manage_delLocalRoles([username])
-            # reindex object security
-            self._recursive_reindex_object_security(parent)
 
     def _recursive_reindex_object_security(self, obj):
         """Reindex object security after user linking

--- a/src/senaite/core/adapters/configure.zcml
+++ b/src/senaite/core/adapters/configure.zcml
@@ -26,4 +26,12 @@
   <!-- Dynamic calculation of local roles for a given context and principal -->
   <adapter factory=".localroles.DynamicLocalRoleAdapter" />
 
+  <!-- Dynamic assignment of local roles for objects that belong to the same
+  Client as the contact the current user is linked to -->
+  <adapter
+      for="*"
+      provides="senaite.core.interfaces.IDynamicLocalRoles"
+      factory=".localroles.ClientAwareLocalRoles"
+      name="senaite.core.adapter.localroles.clientaware" />
+
 </configure>

--- a/src/senaite/core/adapters/localroles.py
+++ b/src/senaite/core/adapters/localroles.py
@@ -60,8 +60,9 @@ class DynamicLocalRoleAdapter(DefaultLocalRoleAdapter):
         adapters = getAdapters((context,), IDynamicLocalRoles)
         for name, adapter in adapters:
             local_roles = adapter.getRoles(principal_id)
-            logger.info(u"{}::{}::{}: {}".format(name, path, principal_id,
-                                                 repr(local_roles)))
+            if local_roles:
+                logger.info(u"{}::{}::{}: {}".format(name, path, principal_id,
+                                                     repr(local_roles)))
             roles.update(local_roles)
 
         # Store in cache

--- a/src/senaite/core/adapters/localroles.py
+++ b/src/senaite/core/adapters/localroles.py
@@ -98,8 +98,6 @@ class ClientAwareLocalRoles(object):
     linked to a ClientContact for objects that belong to same client
     """
 
-    _user_client = {}
-
     def __init__(self, context):
         self.context = context
 

--- a/src/senaite/core/upgrade/v02_02_000.py
+++ b/src/senaite/core/upgrade/v02_02_000.py
@@ -20,6 +20,7 @@
 
 from bika.lims import api
 from bika.lims.interfaces.analysis import IRequestAnalysis
+from collections import defaultdict
 from senaite.core import logger
 from senaite.core.catalog import ANALYSIS_CATALOG
 from senaite.core.catalog import WORKSHEET_CATALOG
@@ -28,10 +29,10 @@ from senaite.core.interfaces import IContentMigrator
 from senaite.core.setuphandlers import _run_import_step
 from senaite.core.setuphandlers import add_dexterity_setup_items
 from senaite.core.upgrade import upgradestep
-from senaite.core.upgrade.utils import UpgradeUtils
 from senaite.core.upgrade.utils import copy_snapshots
 from senaite.core.upgrade.utils import delete_object
 from senaite.core.upgrade.utils import uncatalog_object
+from senaite.core.upgrade.utils import UpgradeUtils
 from zope.component import getMultiAdapter
 
 version = "2.2.0"  # Remember version number in metadata.xml and setup.py
@@ -77,6 +78,9 @@ def upgrade(tool):
 
     # Migrate worksheet layouts
     migrate_worksheet_layouts(portal)
+
+    # Remove explicit owner role for contacts
+    remove_contacts_ownership(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
@@ -223,3 +227,56 @@ def migrate_worksheet_layouts(portal):
         setup.setWorksheetLayout(default_layout)
 
     logger.info("Migrating worksheet layouts [DONE]")
+
+
+def remove_contacts_ownership(portal):
+    logger.info("Removing Contacts explicit ownership ...")
+
+    def remove_owner_role(obj, usernames):
+        reindex = False
+        obj_roles = obj.get_local_roles()
+        for user, roles in obj_roles:
+            if user not in usernames:
+                continue
+            if "Owner" not in roles:
+                continue
+
+            # Need to update the local roles for this object
+            local_roles = filter(lambda r: r != "Owner", roles)
+            if local_roles:
+                obj.manage_setLocalRoles(user, local_roles)
+            else:
+                obj.manage_delLocalRoles([user])
+            reindex = True
+
+        # Iterate through children for ownership removal
+        for child in obj.objectValues():
+            remove_owner_role(child, usernames)
+
+        # Only reindex if local roles have changed
+        if reindex:
+            obj.reindexObjectSecurity()
+
+    # Extract contacts and group them by client
+    client_contacts = defaultdict(list)
+    query = {"portal_type": "Contact"}
+    for brain in api.search(query):
+        contact = api.get_object(brain)
+        username = contact.getUsername()
+        if not username:
+            continue
+
+        client = api.get_parent(contact)
+        client_uid = api.get_uid(client)
+        client_contacts[client_uid].append(username)
+
+    # Remove the owner role for all contacts at once for each client
+    client_uids = client_contacts.keys()
+    total = len(client_uids)
+    for num, client_uid in enumerate(client_uids):
+        logger.info("Removing 'Owner' roles: {0}/{1}".format(num+1, total))
+        usernames = client_contacts.get(client_uid)
+        client = api.get_object(client_uid)
+        remove_owner_role(client, usernames)
+
+    logger.info("Removing Contacts explicit ownership [DONE]")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request removes the explicit assigment of "Owner" role to users that are linked to a Client Contact, but computes the local role dynamically.

## Current behavior before PR

"Owner" local role is manually assigned to client contacts

## Desired behavior after PR is merged

"Owner" local role is dynamically computed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
