### PR TITLE
Fix conditions are not set when adding analyses manually via manage analyses view 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1997 Fix conditions not set when adding analyses via "Manage Analyses" view
 - #1995 Dynamic assingment of "Owner" role for Client Contacts
 - #1994 Support for dynamic assignment of Local Roles for context and principal
 - #1992 Fix Generic Setup XML export/import adapters for Dexterity fields

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -381,7 +381,7 @@ class AnalysesView(ListingView):
             return False
 
         # Omit analysis does not have conditions set
-        if not obj.getConditions():
+        if not obj.getConditions(empties=True):
             return False
 
         return True

--- a/src/bika/lims/browser/fields/aranalysesfield.py
+++ b/src/bika/lims/browser/fields/aranalysesfield.py
@@ -228,9 +228,20 @@ class ARAnalysesField(ObjectField):
         def is_missing(condition):
             return condition.get("title") not in existing_titles
 
-        # Set only those conditions that are missing
+        # Add only those conditions that are missing
         missing = filter(is_missing, default_conditions)
-        return existing + missing
+
+        # Sort them to match with same order as in service
+        titles = [condition.get("title") for condition in default_conditions]
+
+        def index(condition):
+            cond_title = condition.get("title")
+            if cond_title in titles:
+                return titles.index(cond_title)
+            return len(titles)
+
+        conditions = existing + missing
+        return sorted(conditions, key=lambda con: index(con))
 
     def add_analysis(self, instance, service, **kwargs):
         service_uid = api.get_uid(service)

--- a/src/bika/lims/browser/fields/aranalysesfield.py
+++ b/src/bika/lims/browser/fields/aranalysesfield.py
@@ -214,6 +214,24 @@ class ARAnalysesField(ObjectField):
         value["uid"] = uid
         return value
 
+    def resolve_conditions(self, analysis):
+        """Returns the conditions to be applied to this analysis by merging
+        those already set at sample level with defaults
+        """
+        service = analysis.getAnalysisService()
+        default_conditions = service.getConditions()
+
+        # Extract the conditions set for this analysis already
+        existing = analysis.getConditions()
+        existing_titles = [cond.get("title") for cond in existing]
+
+        def is_missing(condition):
+            return condition.get("title") not in existing_titles
+
+        # Set only those conditions that are missing
+        missing = filter(is_missing, default_conditions)
+        return existing + missing
+
     def add_analysis(self, instance, service, **kwargs):
         service_uid = api.get_uid(service)
 
@@ -269,6 +287,11 @@ class ARAnalysesField(ObjectField):
             # Set the result range to the analysis
             analysis_rr = specs.get(service_uid) or analysis.getResultsRange()
             analysis.setResultsRange(analysis_rr)
+
+            # Set default (pre)conditions
+            conditions = self.resolve_conditions(analysis)
+            analysis.setConditions(conditions)
+
             analysis.reindexObject()
 
     def generate_analysis_id(self, instance, service):

--- a/src/senaite/core/browser/modals/analysis.py
+++ b/src/senaite/core/browser/modals/analysis.py
@@ -69,7 +69,10 @@ class SetAnalysisConditionsView(BrowserView):
         return api.get_title(analysis)
 
     def get_conditions(self):
-        conditions = self.get_analysis().getConditions()
+        """Returns the conditions to display in the form, those with empty or
+        non-set value included
+        """
+        conditions = self.get_analysis().getConditions(empties=True)
         conditions = copy.deepcopy(conditions)
         for condition in conditions:
             choices = condition.get("choices", "")

--- a/src/senaite/core/browser/modals/templates/set_analysis_conditions.pt
+++ b/src/senaite/core/browser/modals/templates/set_analysis_conditions.pt
@@ -32,7 +32,9 @@
                 <col style="width:20%"/>
               </colgroup>
               <tal:condition repeat="condition python:view.get_conditions()">
-                <tr tal:define="required python:condition.get('required') == 'on';">
+                <tr tal:define="required python:condition.get('required') == 'on';
+                                is_checkbox python:condition.get('type') == 'checkbox';
+                                required python:required and not is_checkbox;">
                   <td>
                     <label class="formQuestion">
                       <span tal:content="structure condition/title"/>
@@ -61,10 +63,16 @@
                            tal:attributes="value condition/required"/>
 
                     <select tal:condition="options"
+                            tal:define="value condition/value|nothing"
                             name="conditions.value:records">
-                      <option tal:condition="required"/>
-                      <option tal:repeat="option options"
-                              tal:content="option"/>
+                      <option tal:condition="not:required"/>
+                      <tal:option repeat="option options">
+                        <option tal:content="option"
+                                tal:condition="python:option == value"
+                                selected="selected"/>
+                        <option tal:content="option"
+                                tal:condition="python:option != value" />
+                      </tal:option>
                     </select>
 
                     <tal:non_select condition="not:options">
@@ -77,7 +85,6 @@
                       <input tal:attributes="type condition/type;
                                              value condition/value"
                              tal:condition="not:required"
-                             required="required"
                              name="conditions.value:records"/>
                     </tal:non_select>
 

--- a/src/senaite/core/browser/modals/templates/set_analysis_conditions.pt
+++ b/src/senaite/core/browser/modals/templates/set_analysis_conditions.pt
@@ -14,13 +14,10 @@
            tal:define="conditions python:view.get_conditions()"
            tal:condition="nocall:conditions">
         <div class="col-sm-12">
-          <h3>
+          <h3 class="mb-4">
             <i class="fas fa-list"/>
             <span i18n:translate="" tal:content="python:view.get_analysis_name()"/>
           </h3>
-          <h4>
-            <span i18n:translate="">Set analysis conditions</span>
-          </h4>
           <form name="set-analysis-conditions-form"
                 class="form"
                 method="POST"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that when an analysis is added via "Manage analyses" view, the conditions for the selected analysis are also added, so their values can later be set as usual from the analyses listing.

## Current behavior before PR

Analyses added manually via "Manage analyses" come without (pre)conditions

## Desired behavior after PR is merged

Analyses added manually via "Manage analyses" come with (pre)conditions

![Captura de 2022-05-20 17-28-12](https://user-images.githubusercontent.com/832627/169561475-49bebd97-50cc-405c-8dab-8754f99eeb74.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
