### PR TITLE
Fix: analisys hidden status erases when submit results through worksheet

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1998 Fix analisys hidden status erases when submit through worksheet 
 - #1997 Fix conditions not set when adding analyses via "Manage Analyses" view
 - #1995 Dynamic assingment of "Owner" role for Client Contacts
 - #1994 Support for dynamic assignment of Local Roles for context and principal

--- a/src/bika/lims/browser/workflow/analysis.py
+++ b/src/bika/lims/browser/workflow/analysis.py
@@ -108,8 +108,8 @@ class WorkflowActionSubmitAdapter(WorkflowActionGenericAdapter):
             analysis.setInterimFields(interims)
 
             # Save Hidden
-            hidden = self.get_form_value("Hidden", uid, "")
-            analysis.setHidden(hidden == "on")
+            hidden = self.get_form_value("Hidden", uid, default=analysis.getHidden())
+            analysis.setHidden(hidden in ("on", True))
 
             # Only set result if it differs from the actual value to preserve
             # the result capture date


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

In case WorkflowActionSubmitAdapter called by the form which does not contain Hidden column (e.g. when submitting results from a worksheet) it erases the analysis "hidden" status.

## Desired behavior after PR is merged

Keep the proper analysis state if not changed explicitly.
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
