### PR TITLE
Allow multi-choice/multiselect interim fields in calculations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #1999 Allow multi-choice/multiselect interim fields in calculations
 - #1997 Fix conditions not set when adding analyses via "Manage Analyses" view
 - #1995 Dynamic assingment of "Owner" role for Client Contacts
 - #1994 Support for dynamic assignment of Local Roles for context and principal

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -540,12 +540,9 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             if interim_value == "":
                 continue
 
-            # Only floatable and UIDs are supported
+            # Convert to floatable if necessary
             if api.is_floatable(interim_value):
                 interim_value = float(interim_value)
-
-            elif not api.is_uid(interim_value):
-                return False
 
             mapping[interim_keyword] = interim_value
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The introduction of [Multivalue support for interim fields #1988](https://github.com/senaite/senaite.core/pull/1988) implies that value of interim fields can also be a list (of choices) of "result option values". For instance an interim field configured as follows:

```python
{'choices': '7b63538c15824763b40c12dd435dd322:FLC|19d844c062f04e4195e260318f4efc67:CLX|f08e4c080f8241109ebcbf86d95103eb:CFZ',
  'full_title': 'Cefoxitin',
  'hidden': False,
  'keyword': 'FOX',
  'result_type': 'multichoice',
  'size': '5',
  'title': 'FOX',
  'type': 'multichoice',
  'unit': '',
  'value': '["f08e4c080f8241109ebcbf86d95103eb", "7b63538c15824763b40c12dd435dd322"]',
  'wide': False}
```

Note this is a multi-choice interim and the underlying values of displayed options are UIDs (see `choices`). In this case, the value of the interim field is a list of UIDs.

![Captura de 2022-05-25 14-12-51](https://user-images.githubusercontent.com/832627/170259253-f8501428-0370-41c3-9778-14ea31ea59c4.png)

The problem is that calculations that use analyses with multi-choice/multi-select interim fields assigned do not work because only floatable or UID values are supported. This Pull Request makes calculations to work even if the value of the interim field is neither a UID nor a floatable.

## Current behavior before PR

Calculation machinery does not support interim fields with values that are not UIDs or floatables

## Desired behavior after PR is merged

Calculation machinery does support interim fields with values that are not UIDs or floatables

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
