### PR TITLE
Fix Traceback when rendering UIDReferenceWidget without View permissions for referenced objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #2001 Fix Traceback when rendering UIDReferenceWidget with limited privileges
 - #1998 Fix analisys hidden status erases when submit through worksheet 
 - #1997 Fix conditions not set when adding analyses via "Manage Analyses" view
 - #1995 Dynamic assingment of "Owner" role for Client Contacts

--- a/src/senaite/core/z3cform/widgets/uidreference.py
+++ b/src/senaite/core/z3cform/widgets/uidreference.py
@@ -6,6 +6,7 @@ import string
 import six
 
 from bika.lims import api
+from bika.lims import logger
 from Products.CMFPlone.utils import base_hasattr
 from senaite.app.supermodel import SuperModel
 from senaite.core.interfaces import ISenaiteFormLayer
@@ -209,7 +210,13 @@ class UIDReferenceWidget(TextLinesWidget):
         """Returns a rendered HTML element for the reference
         """
         template = string.Template(self.get_display_template())
-        obj_info = self.get_obj_info(uid)
+        try:
+            obj_info = self.get_obj_info(uid)
+        except ValueError as e:
+            # Current user might not have privileges to view this object
+            logger.error(e.message)
+            return ""
+
         return template.safe_substitute(obj_info)
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes the Tracbeack that arises when the `UIDReferenceWidget` control is rendered by a user that does not have the "View" permission granted for referenced elements.

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module plone.autoform.view, line 42, in __call__
  Module plone.autoform.view, line 33, in render
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module fc497b3cfaaf4ac10981517c24a777f8, line 517, in render
  Module 127780d726c00d373f3c3c3c25627f5f, line 1449, in render_master
  Module 127780d726c00d373f3c3c3c25627f5f, line 407, in render_content
  Module fc497b3cfaaf4ac10981517c24a777f8, line 502, in __fill_content_core
  Module fc497b3cfaaf4ac10981517c24a777f8, line 279, in render_content_core
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module zope.browserpage.simpleviewclass, line 41, in __call__
  Module zope.browserpage.viewpagetemplatefile, line 81, in __call__
  Module zope.browserpage.viewpagetemplatefile, line 49, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module 4e1632ffb8f0abed199df1565bcb01d7, line 586, in render
  Module 4e1632ffb8f0abed199df1565bcb01d7, line 456, in render_widget_wrapper
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module z3c.form.widget, line 154, in render
  Module zope.browserpage.viewpagetemplatefile, line 49, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 215, in render
  Module chameleon.template, line 192, in render
  Module 6b5016155236d13f9db16e1deb48f04c, line 152, in render
  Module zope.tales.pythonexpr, line 73, in __call__
   - __traceback_info__: (view.render_reference(uid))
  Module <string>, line 1, in <module>
  Module senaite.core.z3cform.widgets.uidreference, line 212, in render_reference
  Module senaite.core.z3cform.widgets.uidreference, line 203, in get_obj_info
  Module senaite.app.supermodel.model, line 413, in to_dict
  Module senaite.app.supermodel.model, line 163, in iteritems
  Module senaite.app.supermodel.model, line 155, in __iter__
  Module senaite.app.supermodel.model, line 159, in keys
  Module senaite.app.supermodel.model, line 283, in instance
  Module senaite.app.supermodel.model, line 292, in brain
  Module senaite.app.supermodel.model, line 343, in get_brain_by_uid
ValueError: No results found for UID '5b7cda312e8847d58f3762e177228863'
```

## Desired behavior after PR is merged

The `UIDReferenceWidget` is rendered correctly, without displaying the referenced elements

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
