### PR TITLE
Allow string results for calculation dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #2002 Allow string results for calculation dependencies
 - #2001 Fix Traceback when rendering UIDReferenceWidget with limited privileges
 - #1999 Allow multi-choice/multiselect interim fields in calculations
 - #1998 Fix analisys hidden status erases when submit through worksheet 

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -582,8 +582,8 @@ class AbstractAnalysis(AbstractBaseAnalysis):
                 except (TypeError, ValueError):
                     return False
 
-            # replace immediately the dependency placeholder with the actual result
-            formula = formula.replace("[" + keyword +  "]", result)
+                # replace immediately the dependency placeholder with the actual result
+                formula = formula.replace("[" + keyword +  "]", result)
 
         # Calculate
         try:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR allows string results of calculation dependencies

Example Formula:

`get_control_result([control_sample_id], "H2O")`

The `control_sample_id` is an analysis service that allows to enter the ID of another sample, e.g. `22-4711-ABC`. The service is configured with "String Result".


## Current behavior before PR

Result calculation returned immediately when the result of the calculation dependency was not floatable

## Desired behavior after PR is merged

Result calculation checks if the dependency contains a string results and replaces the formula correctly with the actual result value

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
