### PR TITLE
Do not compute dynamic local permissions unless the principal is a user

### DIFF
--- a/src/senaite/core/adapters/localroles.py
+++ b/src/senaite/core/adapters/localroles.py
@@ -32,8 +32,12 @@ from zope.interface import implementer
 def _getRolesInContext_cachekey(method, self, context, principal_id):
     """Function that generates the key for volatile caching
     """
+    # We need the cachekey to change when global roles of a given user change
+    user = api.get_user(principal_id)
+    roles = user and ":".join(sorted(user.getRoles())) or ""
     return ".".join([
         principal_id,
+        roles,
         api.get_path(context),
         api.get_modification_date(context).ISO(),
     ])

--- a/src/senaite/core/adapters/localroles.py
+++ b/src/senaite/core/adapters/localroles.py
@@ -53,6 +53,10 @@ class DynamicLocalRoleAdapter(DefaultLocalRoleAdapter):
         @param principal_id: User login id
         @return List of dynamically calculated local-roles for user and context
         """
+        if not api.get_user(principal_id):
+            # principal_id can be a group name, but we consider users only
+            return []
+
         roles = set()
         path = api.get_path(context)
         adapters = getAdapters((context,), IDynamicLocalRoles)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request guarantees that the dynamic assignment of local roles only takes place for users, so groups are skipped. This also makes the system to have better performance.

## Current behavior before PR

The logic for dynamic local roles assignment is called for both users and groups

## Desired behavior after PR is merged

The logic for dynamic local roles assignment is called for users only

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
