### PR TITLE
Hide the "User and Groups" control panel from "Site Setup"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #2005 Hide the "User and Groups" control panel from "Site Setup"
 - #2001 Fix Traceback when rendering UIDReferenceWidget with limited privileges
 - #1999 Allow multi-choice/multiselect interim fields in calculations
 - #1998 Fix analisys hidden status erases when submit through worksheet 

--- a/src/senaite/core/profiles/default/controlpanel.xml
+++ b/src/senaite/core/profiles/default/controlpanel.xml
@@ -167,11 +167,11 @@
     <permission>Plone Site Setup: Types</permission>
   </configlet>
 
-  <!-- Users and Groups -->
+  <!-- Users and Groups (hidden) -->
   <configlet title="Users and Groups" action_id="UsersGroups"
              appId="UsersGroups" category="plone-users" condition_expr=""
              icon_expr="string:$portal_url/group.png"
-             url_expr="string:${portal_url}/@@usergroup-userprefs" visible="True">
+             url_expr="string:${portal_url}/@@usergroup-userprefs" visible="False">
     <permission>Plone Site Setup: Users and Groups</permission>
   </configlet>
 

--- a/src/senaite/core/upgrade/v02_02_000.py
+++ b/src/senaite/core/upgrade/v02_02_000.py
@@ -63,6 +63,7 @@ def upgrade(tool):
     setup.runImportStepFromProfile(profile, "rolemap")
     setup.runImportStepFromProfile(profile, "workflow")
     setup.runImportStepFromProfile(profile, "typeinfo")
+    setup.runImportStepFromProfile(profile, "controlpanel")
 
     # Setup the permission for the edition of analysis conditions
     setup_edit_analysis_conditions(portal)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request hides the "User and groups" control panel link from "Site Setup" to reduce confusion and prevent manual assignment of groups/roles. In SENAITE, users and the assingment of roles must be done through "Laboratory Contacts" or from "Client Contacts".

## Current behavior before PR

User can manually create users and assign roles and groups via "User and groups" from Site Setup

## Desired behavior after PR is merged

Creation of users and assignment of groups is mainly done through SENAITE

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
