### PR TITLE
Fix missing keyword in analysis profile view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- #2009 Fix missing keyword in analysis profile view
 - #2007 Fix `ConstraintNotSatisfied` error on language field import
 - #2008 Import demo data in tests with Generic Setup
 - #2002 Allow string results for calculation dependencies

--- a/src/bika/lims/browser/widgets/analysisprofileanalyseswidget.py
+++ b/src/bika/lims/browser/widgets/analysisprofileanalyseswidget.py
@@ -224,6 +224,7 @@ class AnalysisProfileAnalysesView(BikaListingView):
         item["selected"] = False
         item["Hidden"] = hidden
         item["selected"] = uid in self.configuration
+        item["Keyword"] = obj.getKeyword()
 
         # Add methods
         methods = obj.getMethods()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds the service keyword to the analysis profile view

## Current behavior before PR

keyword is missing

## Desired behavior after PR is merged

keyword is displayed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
