### PR TITLE
Fix TypeError in Analyses Listing View

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2010 Fix TypeError in Analyses Listing View
+
 
 
 2.2.0 (2022-06-11)

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -914,7 +914,7 @@ class AnalysesView(ListingView):
             val = json.loads(value)
             if isinstance(val, (list, tuple, set)):
                 value = val
-        except ValueError:
+        except (ValueError, TypeError):
             pass
         if not isinstance(value, (list, tuple, set)):
             value = [value]


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a `TypeError` in analyses listings, where Interims with choices were set.

## Current behavior before PR

```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module senaite.app.listing.view, line 224, in __call__
  Module senaite.app.listing.ajax, line 111, in handle_subpath
  Module senaite.core.decorators, line 22, in decorator
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 436, in ajax_folderitems
  Module senaite.app.listing.decorators, line 88, in wrapper
  Module senaite.app.listing.ajax, line 317, in get_folderitems
  Module bika.lims.browser.analyses.view, line 711, in folderitems
  Module senaite.app.listing.view, line 938, in folderitems
  Module bika.lims.browser.analyses.view, line 664, in folderitem
  Module bika.lims.browser.analyses.view, line 981, in _folder_item_calculation
  Module bika.lims.browser.analyses.view, line 914, in to_list
  Module json, line 339, in loads
  Module json.decoder, line 364, in decode
TypeError: expected string or buffer
```

## Desired behavior after PR is merged

No more traceback occurs

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
