### PR TITLE
Removed dependency to Products.TextIndexNG3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2011 Removed dependency to Products.TextIndexNG3
+
 
 
 2.2.0 (2022-06-11)

--- a/docs/adapters/listing_searchable_text_index.rst
+++ b/docs/adapters/listing_searchable_text_index.rst
@@ -2,7 +2,7 @@ Listing Searchable Text Index
 -----------------------------
 
 The Listing Searchable Text Index (``listing_searchable_text``) is mostly used
-for wide searches in listings. It is a ``TextIndexNG3`` type index present in
+for wide searches in listings. It is a ``ZCTextIndex`` type index present in
 most catalogs. To fill this index, SENAITE concatenates the values from all
 fields registered as metadata columns for the given object and catalog. The
 value is then converted to unicode and stored. This is the default behavior, but

--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,6 @@ setup(
         "Products.DataGridField",
         "Products.TextIndexNG3",
         "Products.contentmigration",
-        # XXX: Remove after 2.1.0
-        "zopyx.txng3.ext==3.4.0",
         # tinycss2 >= 1.0.0 does not support Python 2.x anymore
         "tinycss2<1.0.0",
         # Python 2/3 compatibility library: https://six.readthedocs.io/

--- a/src/bika/lims/adapters/referencewidgetvocabulary.py
+++ b/src/bika/lims/adapters/referencewidgetvocabulary.py
@@ -212,17 +212,10 @@ class DefaultReferenceWidgetVocabulary(object):
             return []
 
         meta = index.meta_type
-        if meta == "TextIndexNG3":
-            query[index.id] = "{}*".format(search_term)
-
-        elif meta == "ZCTextIndex":
-            logger.warn("*** Field '{}' ({}). Better use TextIndexNG3"
-                        .format(meta, search_field))
+        if meta == "ZCTextIndex":
             query[index.id] = "{}*".format(search_term)
 
         elif meta in ["FieldIndex", "KeywordIndex"]:
-            logger.warn("*** Field '{}' ({}). Better use TextIndexNG3"
-                        .format(meta, search_field))
             query[index.id] = search_term
 
         else:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the dependency to [Products.TextIndexNG3](https://pypi.org/project/Products.TextIndexNG3/), because it will be not supported in Python 3

## Current behavior before PR

Dependency declared in `setup.py`

## Desired behavior after PR is merged

Dependency removed in `setup.py`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
