### PR TITLE
Remove `zopyx.txng3.ext` requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,6 @@ setup(
         "Products.ATContentTypes",
         "Products.CMFEditions",
         "Products.DataGridField",
-        "Products.TextIndexNG3",
         "Products.contentmigration",
         # tinycss2 >= 1.0.0 does not support Python 2.x anymore
         "tinycss2<1.0.0",


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request addresses the traceback that arises when trying to install the product with buildout because of https://github.com/senaite/senaite.core/pull/2011 :

## Current behavior before PR

```
[...]
Getting distribution for 'zopyx.txng3.ext'.
[...]
Got zopyx.txng3.ext 4.0.0.
Version and requirements information containing zopyx.txng3.ext:
  Requirement of Products.TextIndexNG3: zopyx.txng3.ext
  Requirement of zopyx.txng3.ext: setuptools
  Requirement of zopyx.txng3.core: zopyx.txng3.ext<3.4.99999
While:
  Updating instance.
Error: There is a version conflict.
We already have: zopyx.txng3.ext 4.0.0
but zopyx.txng3.core 3.6.2 requires 'zopyx.txng3.ext<3.4.99999'.
```

## Desired behavior after PR is merged

`zopyx.txng3.ext`  is no longer a requirement

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
