### PR TITLE
Performance: Avoid to catalog temporary objects

### DIFF
--- a/src/senaite/core/patches/catalog.py
+++ b/src/senaite/core/patches/catalog.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+from plone.indexer.interfaces import IIndexableObject
+from Products.ZCatalog.ZCatalog import ZCatalog
+from zope.component import queryMultiAdapter
+
+
+def catalog_object(self, object, uid=None, idxs=None,
+                   update_metadata=1, pghandler=None):
+
+    try:
+        # Never catalog temporary objects
+        temporary = object.isTemporary()
+        if temporary is True:
+            return
+    except AttributeError:
+        pass
+
+    if idxs is None:
+        idxs = []
+    self._increment_counter()
+
+    w = object
+    if not IIndexableObject.providedBy(object):
+        # This is the CMF 2.2 compatible approach, which should be used
+        # going forward
+        wrapper = queryMultiAdapter((object, self), IIndexableObject)
+        if wrapper is not None:
+            w = wrapper
+
+    ZCatalog.catalog_object(self, w, uid, idxs,
+                            update_metadata, pghandler=pghandler)

--- a/src/senaite/core/patches/configure.zcml
+++ b/src/senaite/core/patches/configure.zcml
@@ -22,4 +22,11 @@
       replacement=".dexterity.isTemporary"
       />
 
+  <monkey:patch
+      description=""
+      class="Products.CMFPlone.CatalogTool.CatalogTool"
+      original="catalog_object"
+      replacement=".catalog.catalog_object"
+      />
+
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR improves the performance when creating Samples/Analyses by patching the method `catalog_object` of `Products.CMFPlone.CatalogTool.CatalogTool`.

## Current behavior before PR

When creating new samples, the temporary objects were cataloged:

```
2022-06-21 13:10:01,583 INFO    [senaite.core:76][waitress-0] Generating catalog metadata for '/senaite/clients/client-39/e999eec5b84cf78674750ed8dd2db57e' manually
2022-06-21 13:10:02,538 INFO    [senaite.core:76][waitress-0] Generating catalog metadata for '/senaite/clients/client-39/e999eec5b84cf78674750ed8dd2db57e' manually
```

## Desired behavior after PR is merged

Temporary objects are never cataloged

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
