### PR TITLE
Performance: Avoid profile analyses assignment for temporary samples

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2019 Performance: Avoid profile analyses assignment for temporary samples
 - #2015 Performance: Avoid to catalog temporary objects
 - #2013 Fix ValueError in uidreferencefield when context is not a IBehavior
 - #2012 Remove stale supply order code

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -1497,17 +1497,22 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
         # return immediately if nothing changed
         if current_profiles == uids:
             return
-        # get the profiles
-        profiles = map(api.get_object_by_uid, uids)
-        # get the current set of analyses/services
-        analyses = self.getAnalyses(full_objects=True)
-        services = map(lambda an: an.getAnalysisService(), analyses)
-        # determine all the services to add
-        services_to_add = set(services)
-        for profile in profiles:
-            services_to_add.update(profile.getService())
-        # set all analyses
-        self.setAnalyses(list(services_to_add))
+
+        # Don't add analyses from profiles during sample creation.
+        # In this case the required analyses are added afterwards explicitly.
+        if not self.isTemporary():
+            # get the profiles
+            profiles = map(api.get_object_by_uid, uids)
+            # get the current set of analyses/services
+            analyses = self.getAnalyses(full_objects=True)
+            services = map(lambda an: an.getAnalysisService(), analyses)
+            # determine all the services to add
+            services_to_add = set(services)
+            for profile in profiles:
+                services_to_add.update(profile.getService())
+            # set all analyses
+            self.setAnalyses(list(services_to_add))
+
         # set the profiles value
         self.getField("Profiles").set(self, value)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the sample profile setter to skip analysis creation for temporary samples

## Current behavior before PR

analyses from profiles were added for temporary sample objects during creation

## Desired behavior after PR is merged

analyses from profiles are not added for temporary samples

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
