### PR TITLE
Fixed Sample Retract UnitTest

### DIFF
--- a/src/senaite/core/tests/test_AnalysisRequest_retract.py
+++ b/src/senaite/core/tests/test_AnalysisRequest_retract.py
@@ -39,7 +39,7 @@ class TestAnalysisRequestRetract(DataTestCase):
     def get_services(self):
         query = {
             "portal_type": "AnalysisService",
-            "is_active": True,
+            "getKeyword": ["Ca", "Mg", "Cu"],
         }
         return api.search(query)
 
@@ -56,8 +56,7 @@ class TestAnalysisRequestRetract(DataTestCase):
             "Contact": api.get_uid(contact),
             "DateSampled": self.timestamp(),
             "SampleType": api.get_uid(sampletype)}
-
-        services = self.get_services()[:3]
+        services = self.get_services()
         service_uids = map(api.get_uid, services)
         return crar(client, self.request, values, service_uids)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the setup for the unit test `test_AnalysisService_retract`.

## Current behavior before PR

Analyses with calculations were sometimes selected in the test, causing it to fail:

```
Error in test test_retract_an_analysis_request (senaite.core.tests.test_AnalysisRequest_retract.TestAnalysisRequestRetract)
Traceback (most recent call last):
  File "/opt/python/2.7.15/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/home/travis/build/senaite/senaite.core/src/senaite/core/tests/test_AnalysisRequest_retract.py", line 85, in test_retract_an_analysis_request
    api.do_transition_for(analysis, "retract")
  File "/home/travis/build/senaite/senaite.core/src/bika/lims/api/__init__.py", line 954, in do_transition_for
    transition, obj, str(e)))
  File "/home/travis/build/senaite/senaite.core/src/bika/lims/api/__init__.py", line 206, in fail
    raise APIError("{}".format(msg))
APIError: Failed to perform transition 'retract' on <Analysis at Ca>: Invalid transition 'retract'.
Valid transitions are:
reject
```

## Desired behavior after PR is merged

Test succeeds

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
