### PR TITLE
Reduced logging when creating samples

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2021 Reduced logging when creating samples
 - #2017 Added `api.is_temporary` function for both DX and AT types
 - #2019 Performance: Avoid profile analyses assignment for temporary samples
 - #2015 Performance: Avoid to catalog temporary objects

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -106,7 +106,7 @@ class AnalysisRequestAddView(BrowserView):
         self.ShowPrices = self.setup.getShowPrices()
         self.theme = api.get_view("senaite_theme")
         self.icon = self.theme.icon_url("Sample")
-        logger.info("*** Prepared data for {} ARs ***".format(self.ar_count))
+        logger.debug("*** Prepared data for {} ARs ***".format(self.ar_count))
         return self.template()
 
     def get_view_url(self):
@@ -154,7 +154,7 @@ class AnalysisRequestAddView(BrowserView):
         """Create a temporary AR to fetch the fields from
         """
         if not self.tmp_ar:
-            logger.info("*** CREATING TEMPORARY AR ***")
+            logger.debug("*** CREATING TEMPORARY AR ***")
             self.tmp_ar = self.context.restrictedTraverse(
                 "portal_factory/AnalysisRequest/Request new analyses")
         return self.tmp_ar
@@ -162,14 +162,14 @@ class AnalysisRequestAddView(BrowserView):
     def get_ar_schema(self):
         """Return the AR schema
         """
-        logger.info("*** GET AR SCHEMA ***")
+        logger.debug("*** GET AR SCHEMA ***")
         ar = self.get_ar()
         return ar.Schema()
 
     def get_ar_fields(self):
         """Return the AR schema fields (including extendend fields)
         """
-        logger.info("*** GET AR FIELDS ***")
+        logger.debug("*** GET AR FIELDS ***")
         schema = self.get_ar_schema()
         return schema.fields()
 
@@ -230,9 +230,9 @@ class AnalysisRequestAddView(BrowserView):
         form = dict()
         form[new_fieldname] = value
         self.request.form.update(form)
-        logger.info("get_input_widget: fieldname={} arnum={} "
-                    "-> new_fieldname={} value={}".format(
-                        fieldname, arnum, new_fieldname, value))
+        logger.debug("get_input_widget: fieldname={} arnum={} "
+                     "-> new_fieldname={} value={}".format(
+                         fieldname, arnum, new_fieldname, value))
         widget = context.widget(new_fieldname, **kw)
         return widget
 
@@ -292,8 +292,8 @@ class AnalysisRequestAddView(BrowserView):
             interface=IGetDefaultFieldValueARAddHook)
         if adapter is not None:
             default = adapter(self.context)
-        logger.info("get_default_value: context={} field={} value={} arnum={}"
-                    .format(context, name, default, arnum))
+        logger.debug("get_default_value: context={} field={} value={} arnum={}"
+                     .format(context, name, default, arnum))
         return default
 
     def get_field_value(self, field, context):
@@ -301,7 +301,7 @@ class AnalysisRequestAddView(BrowserView):
         """
         name = field.getName()
         value = context.getField(name).get(context)
-        logger.info("get_field_value: context={} field={} value={}".format(
+        logger.debug("get_field_value: context={} field={} value={}".format(
             context, name, value))
         return value
 

--- a/src/bika/lims/browser/fields/historyawarereferencefield.py
+++ b/src/bika/lims/browser/fields/historyawarereferencefield.py
@@ -170,7 +170,6 @@ class HistoryAwareReferenceField(ReferenceField):
         existing_uids = self.get_backreferences_for(instance)
 
         if not value and not existing_uids:
-            logger.warning("Field and value is empty!")
             return
 
         if not self.multiValued and len(value) > 1:

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -2205,13 +2205,9 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
         return ''
 
     def get_ARAttachment(self):
-        logger.warn("_ARAttachment is a virtual field used in AR Add. "
-                    "It can not hold an own value!")
         return None
 
     def set_ARAttachment(self, value):
-        logger.warn("_ARAttachment is a virtual field used in AR Add. "
-                    "It can not hold an own value!")
         return None
 
     def get_retest(self):

--- a/src/bika/lims/decorators.py
+++ b/src/bika/lims/decorators.py
@@ -146,12 +146,12 @@ def synchronized(max_connections=2, verbose=0):
         @wraps(func)
         def wrapper(*args, **kwargs):
             try:
-                logger.info("==> {}::Acquire Semaphore ...".format(
+                logger.debug("==> {}::Acquire Semaphore ...".format(
                     func.__name__))
                 semaphore.acquire()
                 return func(*args, **kwargs)
             finally:
-                logger.info("<== {}::Release Semaphore ...".format(
+                logger.debug("<== {}::Release Semaphore ...".format(
                     func.__name__))
                 semaphore.release()
 

--- a/src/bika/lims/monkey/Widget.py
+++ b/src/bika/lims/monkey/Widget.py
@@ -74,7 +74,7 @@ def isVisible(self, instance, mode='view', default="visible", field=None):
             continue
         adapter_state = adapter(instance, mode, field, state)
         adapter_name = adapter.__class__.__name__
-        logger.info(
+        logger.debug(
             "IATWidgetVisibility: <{} for {}.{} mode:{} sort:{}> {} -> {}"
             .format(adapter_name, instance.id, field.getName(), mode,
                     adapter.sort, state, adapter_state))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the logging facility of AR Add related loggers to `debug`

## Current behavior before PR

Too many logging lines

## Desired behavior after PR is merged

Only relevant logs are displayed in `info` facility

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
