### PR TITLE
Replace Worksheet's Analysis ReferenceField by UIDReferenceField

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2022 Replace Worksheet's Analysis ReferenceField by UIDReferenceField
 - #2017 Added `api.is_temporary` function for both DX and AT types
 - #2019 Performance: Avoid profile analyses assignment for temporary samples
 - #2015 Performance: Avoid to catalog temporary objects

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -1054,16 +1054,16 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         """This method is used to populate catalog values
         Returns WS UID if this analysis is assigned to a worksheet, or None.
         """
-        uid = get_backreferences(self, relationship="WorksheetAnalysis")
-        if not uid:
+        uids = get_backreferences(self, relationship="WorksheetAnalysis")
+        if not uids:
             return None
 
-        if len(uid) > 1:
+        if len(uids) > 1:
             path = api.get_path(self)
             logger.error("More than one worksheet: {}".format(path))
             return None
 
-        return uid
+        return uids[0]
 
     @security.public
     def getWorksheet(self):

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -1054,22 +1054,23 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         """This method is used to populate catalog values
         Returns WS UID if this analysis is assigned to a worksheet, or None.
         """
-        worksheet = self.getWorksheet()
-        if worksheet:
-            return worksheet.UID()
+        uid = get_backreferences(self, relationship="WorksheetAnalysis")
+        if not uid:
+            return None
+
+        if len(uid) > 1:
+            path = api.get_path(self)
+            logger.error("More than one worksheet: {}".format(path))
+            return None
+
+        return uid
 
     @security.public
     def getWorksheet(self):
         """Returns the Worksheet to which this analysis belongs to, or None
         """
-        worksheet = self.getBackReferences('WorksheetAnalysis')
-        if not worksheet:
-            return None
-        if len(worksheet) > 1:
-            logger.error(
-                "Analysis %s is assigned to more than one worksheet."
-                % self.getId())
-        return worksheet[0]
+        worksheet_uid = self.getWorksheetUID()
+        return api.get_object_by_uid(worksheet_uid, None)
 
     @security.public
     def remove_duplicates(self, ws):

--- a/src/bika/lims/content/worksheet.py
+++ b/src/bika/lims/content/worksheet.py
@@ -88,7 +88,7 @@ schema = BikaSchema.copy() + Schema((
     ),
 
     # all layout info lives in Layout; Analyses is used for back references.
-    ReferenceField(
+    UIDReferenceField(
         'Analyses',
         required=1,
         multiValued=1,

--- a/src/senaite/core/upgrade/v02_03_000.py
+++ b/src/senaite/core/upgrade/v02_03_000.py
@@ -18,6 +18,8 @@
 # Copyright 2018-2022 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from bika.lims import api
+from Products.Archetypes.config import REFERENCE_CATALOG
 from senaite.core import logger
 from senaite.core.config import PROJECTNAME as product
 from senaite.core.upgrade import upgradestep
@@ -42,6 +44,55 @@ def upgrade(tool):
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
     # -------- ADD YOUR STUFF BELOW --------
+    fix_worksheets_analyses(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
+
+
+def fix_worksheets_analyses(portal):
+    logger.info("Fix Worksheets Analyses ...")
+    worksheets = portal.worksheets.objectValues()
+    total = len(worksheets)
+    for num, worksheet in enumerate(worksheets):
+        if num and num % 10 == 0:
+            logger.info("Processed worksheets: {}/{}".format(num, total))
+        fix_worksheet_analyses(worksheet)
+    logger.info("Fix Worksheets Analyses [DONE]")
+
+
+def fix_worksheet_analyses(worksheet):
+    """Purge worksheet analyses based on the layout and removes the obsolete
+    relationship from reference_catalog
+    """
+    # Get the referenced analyses via relationship
+    analyses = worksheet.getRefs(relationship="WorksheetAnalysis")
+    analyses_uids = [api.get_uid(an) for an in analyses]
+
+    new_layout = []
+    for slot in worksheet.getLayout():
+        uid = slot.get("analysis_uid")
+        if not api.is_uid(uid):
+            continue
+
+        if uid not in analyses_uids:
+            if is_orphan(uid):
+                continue
+
+        new_layout.append(slot)
+
+    # Re-assign the analyses
+    uids = [slot.get("analysis_uid") for slot in new_layout]
+    worksheet.setAnalyses(uids)
+    worksheet.setLayout(new_layout)
+
+    # Remove all records for this worksheet from reference catalog
+    tool = api.get_tool(REFERENCE_CATALOG)
+    tool.deleteReferences(worksheet, relationship="WorksheetAnalysis")
+
+
+def is_orphan(uid):
+    """Returns whether a counterpart object exists for the given UID
+    """
+    obj = api.get_object_by_uid(uid, None)
+    return obj is None


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request replaces the type of the `Analyses` field of `Worksheet` content type from `ReferenceField` to `UIDReferenceField`. This makes the system less prone to errors and more performant, cause `reference_catalog` is not used for storing this relationship anymore, but as Annotations in the Worksheet instance.

## Current behavior before PR

`Analyses` field from Worksheet is a `ReferenceField` and `reference_catalog` is used to store the relationship

## Desired behavior after PR is merged

`Analyses` field from Worksheet is a `UIDReferenceField` and `reference_catalog` is no longer used to store the relationship

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
