### PR TITLE
Render hyperlinks for reference widget targets in view/edit mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2023 Render hyperlinks for reference widget targets in view/edit mode
 - #2021 Reduced logging when creating samples
 - #2017 Added `api.is_temporary` function for both DX and AT types
 - #2019 Performance: Avoid profile analyses assignment for temporary samples

--- a/src/bika/lims/browser/header_table.py
+++ b/src/bika/lims/browser/header_table.py
@@ -18,7 +18,6 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from AccessControl.Permissions import view
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
@@ -131,12 +130,6 @@ class HeaderTableView(BrowserView):
         return check_permission(ModifyPortalContent, self.context)
 
     @cache(field_type_cache_key, get_cache=store_on_portal)
-    def is_reference_field(self, field):
-        """Check if the field is a reference field
-        """
-        return field.getType().find("Reference") > -1
-
-    @cache(field_type_cache_key, get_cache=store_on_portal)
     def is_boolean_field(self, field):
         """Check if the field is a boolean
         """
@@ -158,53 +151,6 @@ class HeaderTableView(BrowserView):
             "fieldName": fieldname,
             "mode": "structure",
             "html": t(_("Yes")) if value else t(_("No"))
-        }
-
-    def get_reference_field_data(self, field):
-        """Get reference field view data for the template
-        """
-        targets = None
-        fieldname = field.getName()
-
-        accessor = getattr(self.context, "get%s" % fieldname, None)
-        if accessor and callable(accessor):
-            targets = accessor()
-        else:
-            targets = field.get(self.context)
-
-        if targets:
-            if not isinstance(targets, list):
-                targets = [targets, ]
-
-            if all([check_permission(view, target) for target in targets]):
-                elements = [
-                    "<div id='{id}' class='field reference'>"
-                    "  <a class='link' uid='{uid}' href='{url}'>"
-                    "    {title}"
-                    "  </a>"
-                    "</div>"
-                    .format(id=target.getId(),
-                            uid=target.UID(),
-                            url=target.absolute_url(),
-                            title=target.Title())
-                    for target in targets]
-
-                return {
-                    "fieldName": fieldname,
-                    "mode": "structure",
-                    "html": "".join(elements),
-                }
-            else:
-                return {
-                    "fieldName": fieldname,
-                    "mode": "structure",
-                    "html": ", ".join([ta.Title() for ta in targets]),
-                }
-
-        return {
-            "fieldName": fieldname,
-            "mode": "structure",
-            "html": ""
         }
 
     def get_date_field_data(self, field):
@@ -262,8 +208,6 @@ class HeaderTableView(BrowserView):
 
         if self.is_boolean_field(field):
             data = self.get_boolean_field_data(field)
-        elif self.is_reference_field(field):
-            data = self.get_reference_field_data(field)
         elif self.is_date_field(field):
             data = self.get_date_field_data(field)
 

--- a/src/bika/lims/browser/invoice.py
+++ b/src/bika/lims/browser/invoice.py
@@ -21,7 +21,25 @@
 from bika.lims import api
 from bika.lims.browser import BrowserView
 from bika.lims.interfaces import IInvoiceView
+from bika.lims.utils import get_link_for
 from zope.interface import implements
+
+
+class RenderHeaderTableInvoiceField(object):
+    """Render invoice link in header table view
+
+    NOTE: Reference fields generate an overlay to show the referenced content.
+          This is not possible for invoices, because the base_view returns a
+          PDF to download.
+    """
+    def __init__(self, context):
+        self.context = context
+
+    def __call__(self, field):
+        invoice = field.get(self.context)
+        if not invoice:
+            return ""
+        return get_link_for(invoice, target="_blank")
 
 
 class InvoiceView(BrowserView):

--- a/src/bika/lims/browser/invoice.zcml
+++ b/src/bika/lims/browser/invoice.zcml
@@ -12,4 +12,11 @@
       layer="bika.lims.interfaces.IBikaLIMS"
       />
 
+  <adapter
+      name="Invoice"
+      for="bika.lims.interfaces.IAnalysisRequest"
+      factory=".invoice.RenderHeaderTableInvoiceField"
+      provides="bika.lims.interfaces.IHeaderTableFieldRenderer"
+      />
+
 </configure>

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -1025,7 +1025,7 @@ schema = BikaSchema.copy() + Schema((
         mode="rw",
         read_permission=View,
         write_permission=ModifyPortalContent,
-        widget=ComputedWidget(
+        widget=ReferenceWidget(
             visible={
                 'edit': 'invisible',
                 'view': 'visible',

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/referencewidget.pt
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/referencewidget.pt
@@ -51,6 +51,8 @@
       <tal:edit_visible tal:condition="python: visibility_mode == 'visible'">
         <metal:use use-macro="field_macro | context/widgets/field/macros/edit">
           <metal:fill metal:fill-slot="widget_body">
+            <div class="d-table-row">
+
             <div class="multiValued-listing"
                  tal:condition="python:context.Schema()[fieldName].multiValued"
                  tal:attributes="id string:${fieldName}-listing;fieldName fieldName;"
@@ -72,11 +74,12 @@
             </div>
 
             <tal:input_field define="val python:context.Schema()[fieldName].getAccessor(context)();
+                                     multiValued python:1 if context.Schema()[fieldName].multiValued else 0;
                                      text_default val/Title|nothing;
                                      text_attr widget/ui_item|nothing;
                                      text python:text_attr and getattr(val, text_attr, text_default) or text_default;">
               <input type="text"
-                     class="blurrable firstToFocus referencewidget"
+                     class="blurrable firstToFocus referencewidget d-table-cell"
                      tal:condition="python:context.Schema()[fieldName].required"
                      tal:attributes="name fieldName;
                                      id fieldName;
@@ -93,11 +96,11 @@
                                      resetButton widget/resetButton;
                                      minLength python:widget.minLength;
                                      ui_item widget/ui_item;
-                                     multiValued python:1 if context.Schema()[fieldName].multiValued else 0;
+                                     multiValued multiValued;
                                      combogrid_options python:widget.get_combogrid_options(context, fieldName)" />
 
               <input type="text"
-                     class="blurrable firstToFocus referencewidget"
+                     class="blurrable firstToFocus referencewidget d-table-cell"
                      tal:condition="python:not context.Schema()[fieldName].required"
                      tal:attributes="name fieldName;
                                      id fieldName;
@@ -114,7 +117,7 @@
                                      resetButton widget/resetButton;
                                      minLength widget/minLength;
                                      ui_item widget/ui_item;
-                                     multiValued python:1 if context.Schema()[fieldName].multiValued else 0;
+                                     multiValued multiValued;
                                      combogrid_options python:widget.get_combogrid_options(context, fieldName)" />
 
                 <input type="hidden"
@@ -124,8 +127,19 @@
                        tal:attributes="name string:${fieldName}_uid;
                                        id string:${fieldName}_uid;
                                        value python:widget.initial_uid_field_value(val);"/>
+
+                <!-- Link to single valued object in edit mode -->
+                <tal:link tal:condition="python:val and not multiValued">
+                  <a class="pl-2 overlay_panel d-table-cell" href="#"
+                     target="blank"
+                     tal:attributes="href python:val.absolute_url()">
+                    <i class="fas fa-info-circle small text-secondary"></i>
+                  </a>
+                </tal:link>
+
               </tal:input_field>
 
+            </div>
           </metal:fill>
         </metal:use>
       </tal:edit_visible>

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/referencewidget.pt
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/referencewidget.pt
@@ -68,7 +68,11 @@
                       src string:${portal_url}/++plone++senaite.core.static/assets/icons/delete.svg;
                       fieldName fieldName;
                       uid value/UID"/>
-                  <span tal:replace="python:str(value.Title())"/>
+                  <a class="overlay_panel" href="#"
+                     target="blank"
+                     tal:content="python:str(value.Title())"
+                     tal:attributes="href python:value.absolute_url()">
+                  </a>
                 </div>
               </tal:repeat>
             </div>

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/referencewidget.pt
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/referencewidget.pt
@@ -76,7 +76,7 @@
                       src string:${portal_url}/++plone++senaite.core.static/assets/icons/delete.svg;
                       fieldName fieldName;
                       uid value/UID"/>
-                  <a class="overlay_panel" href="#"
+                  <a class="" href="#"
                      target="blank"
                      tal:content="python:str(value.Title())"
                      tal:attributes="href python:value.absolute_url()">
@@ -142,7 +142,7 @@
 
                 <!-- Link to single valued object in edit mode -->
                 <tal:link tal:condition="python:val and not multiValued">
-                  <a class="pl-2 overlay_panel d-table-cell" href="#"
+                  <a class="pl-2 d-table-cell" href="#"
                      target="blank"
                      tal:attributes="href python:val.absolute_url()">
                     <i class="fas fa-info-circle small text-secondary"></i>

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/referencewidget.pt
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/referencewidget.pt
@@ -9,33 +9,40 @@
     <!-- Reference Widget -->
     <metal:view_macro define-macro="view"
                       tal:define="kssClassesView context/@@kss_field_decorator_view;
-                                    getKssClasses nocall:kssClassesView/getKssClassesInlineEditable;">
+                                  getKssClasses nocall:kssClassesView/getKssClassesInlineEditable;">
 
-      <!-- Single Valued Field -->
+      <!-- View Mode: Single Valued Field -->
       <tal:singlevalued tal:condition="not:field/multiValued">
         <span metal:define-macro="string-field-view"
               tal:define="kss_class python:getKssClasses(fieldName,
-                                  templateId='widgets/string', macro='string-field-view');
-                                  uid context/UID|nothing"
+                          templateId='widgets/string', macro='string-field-view');
+                          uid context/UID|nothing"
               tal:attributes="class kss_class;
-                                  id string:parent-fieldname-$fieldName-$uid">
+                              id string:parent-fieldname-$fieldName-$uid">
           <span metal:define-slot="inside"
                 tal:define="value accessor;
                             text_default python: (value and hasattr(value, 'Title')) and value.Title() or '';
                             text_attr widget/ui_item|nothing;
                             text python:text_attr and getattr(value, text_attr, text_default) or text_default;"
-                tal:attributes="value text;"
-                tal:content="text">reference</span>
+                tal:attributes="value text;">
+            <a href="#"
+               tal:condition="python:value"
+               tal:attributes="href python:value.absolute_url();
+                               class python:value.portal_type.replace(' ', '_') + ' overlay_panel'"
+               tal:content="python:value.Title() or value.absolute_url(relative=1)">
+              Target Title
+            </a>
+          </span>
         </span>
       </tal:singlevalued>
 
-      <!-- Multi Valued Field -->
+      <!-- View Mode: Multi Valued Field -->
       <tal:multivalued tal:condition="field/multiValued">
-        <ul tal:define="value accessor">
+        <ul class="list-unstyled" tal:define="value accessor">
           <li tal:repeat="obj value">
             <a href="#"
                tal:attributes="href obj/absolute_url;
-                     class python:obj.portal_type.replace(' ', '_')"
+                               class python:obj.portal_type.replace(' ', '_') + ' overlay_panel'"
                tal:content="python:obj.Title() or obj.absolute_url(relative=1)">
               Target Title
             </a>
@@ -53,6 +60,7 @@
           <metal:fill metal:fill-slot="widget_body">
             <div class="d-table-row">
 
+            <!-- Edit Mode: Multi Valued Field -->
             <div class="multiValued-listing"
                  tal:condition="python:context.Schema()[fieldName].multiValued"
                  tal:attributes="id string:${fieldName}-listing;fieldName fieldName;"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR displays an info icon next to the reference widget when it is in edit mode,
or generates a hyperlink for the titles in view mode.

<img width="1140" alt="TW-0039 — SENAITE LIMS 2022-06-23 11 PM-21-23" src="https://user-images.githubusercontent.com/713193/175404719-1ed01ebf-d043-42b4-bd62-834a0de6f1b7.png">


## Current behavior before PR

It is not possible to navigate to a reference item when the field is in view or edit mode.

## Desired behavior after PR is merged

It is possible to navigate to referenced items in view/edit mode

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
