### PR TITLE
Cannot create partitions from samples in received status

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2024 Cannot create partitions from samples in received status
 - #2023 Render hyperlinks for reference widget targets in view/edit mode
 - #2022 Replace Worksheet's Analysis ReferenceField by UIDReferenceField
 - #2021 Reduced logging when creating samples

--- a/src/bika/lims/permissions.py
+++ b/src/bika/lims/permissions.py
@@ -113,6 +113,7 @@ TransitionSampleSample = "senaite.core: Transition: Sample Sample"
 TransitionScheduleSampling = "senaite.core: Transition: Schedule Sampling"
 TransitionDispatchSample = "senaite.core: Transition: Dispatch Sample"
 TransitionRestoreSample = "senaite.core: Transition: Restore Sample"
+TransitionCreatePartitions = "senaite.core: Transition: Create Partitions"
 
 
 # Type-specific permissions

--- a/src/bika/lims/permissions.zcml
+++ b/src/bika/lims/permissions.zcml
@@ -85,6 +85,7 @@
   <permission id="senaite.core.permissions.TransitionScheduleSampling" title="senaite.core: Transition: Schedule Sampling"/>
   <permission id="senaite.core.permissions.TransitionDispatchSample" title="senaite.core: Transition: Dispatch Sample"/>
   <permission id="senaite.core.permissions.TransitionRestoreSample" title="senaite.core: Transition: Restore Sample"/>
+  <permission id="senaite.core.permissions.TransitionCreatePartitions" title="senaite.core: Transition: Create Partitions"/>
 
   # Object-specific permissions
   # ---------------------------

--- a/src/bika/lims/profiles/default/rolemap.xml
+++ b/src/bika/lims/profiles/default/rolemap.xml
@@ -487,6 +487,11 @@
       <role name="LabManager"/>
       <role name="Manager"/>
     </permission>
+    <permission name="senaite.core: Transition: Create Partitions" acquire="False">
+      <role name="LabManager"/>
+      <role name="Manager"/>
+      <role name="LabClerk"/>
+    </permission>
 
     <!-- Type-specific permissions -->
     <permission name="senaite.core: Sample: Add Attachment" acquire="False">

--- a/src/bika/lims/workflow/analysisrequest/guards.py
+++ b/src/bika/lims/workflow/analysisrequest/guards.py
@@ -19,10 +19,8 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims import api
-from bika.lims.api.security import check_permission
 from bika.lims.interfaces import IInternalUse
 from bika.lims.interfaces import IVerified
-from bika.lims.permissions import TransitionReceiveSample
 from bika.lims.workflow import isTransitionAllowed
 
 # States to be omitted in regular transitions
@@ -56,12 +54,6 @@ def guard_create_partitions(analysis_request):
     """
     if analysis_request.isPartition():
         # Do not allow the creation of partitions from partitions
-        return False
-
-    # Clients have the AddAnalysisRequest permission, but should not be allowed
-    # to create partitions.  Therefore, we check here if the current user has
-    # the permission to receive a sample as well.
-    if not check_permission(TransitionReceiveSample, analysis_request):
         return False
 
     return True

--- a/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
+++ b/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
@@ -1387,7 +1387,7 @@
               i18n:attributes="title">
     <action url="" category="workflow" icon="">Create partitions</action>
     <guard>
-      <guard-permission>senaite.core: Transition: Create Partitions"</guard-permission>
+      <guard-permission>senaite.core: Transition: Create Partitions</guard-permission>
       <guard-expression>python:here.guard_handler("create_partitions")</guard-expression>
     </guard>
   </transition>

--- a/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
+++ b/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
@@ -32,6 +32,7 @@
   <permission>senaite.core: Transition: Schedule Sampling</permission>
   <permission>senaite.core: Transition: Dispatch Sample</permission>
   <permission>senaite.core: Transition: Restore Sample</permission>
+  <permission>senaite.core: Transition: Create Partitions</permission>
 
   <permission>senaite.core: Add Analysis</permission>
   <permission>senaite.core: Edit Field Results</permission>
@@ -90,7 +91,7 @@
   <!-- *** STATES *** -->
 
 
-  <!-- State: sample_registered (inital state) -->
+  <!-- State: sample_registered (initial state) -->
   <state state_id="sample_registered" title="Registered" i18n:attributes="title" purge="True">
     <description>Creation</description>
     <description>Sample is registered in the system</description>
@@ -124,6 +125,7 @@
     <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
     <permission-map name="senaite.core: Transition: Sample Sample" acquired="False"/>
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Create Partitions" acquired="False"/>
 
     <permission-map name="senaite.core: Add Analysis" acquired="True"/>
     <permission-map name="senaite.core: Edit Field Results" acquired="True"/>
@@ -216,6 +218,7 @@
     <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
     <permission-map name="senaite.core: Transition: Sample Sample" acquired="True"/>
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Create Partitions" acquired="False"/>
 
     <permission-map name="senaite.core: Add Analysis" acquired="False">
       <permission-role>LabClerk</permission-role>
@@ -327,6 +330,7 @@
     <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
     <permission-map name="senaite.core: Transition: Sample Sample" acquired="True"/>
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="True"/>
+    <permission-map name="senaite.core: Transition: Create Partitions" acquired="False"/>
 
     <permission-map name="senaite.core: Add Analysis" acquired="False">
       <permission-role>LabClerk</permission-role>
@@ -434,6 +438,7 @@
     <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
     <permission-map name="senaite.core: Transition: Sample Sample" acquired="False"/>
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Create Partitions" acquired="False"/>
 
     <permission-map name="senaite.core: Add Analysis" acquired="True"/>
     <permission-map name="senaite.core: Edit Field Results" acquired="True"/>
@@ -527,6 +532,7 @@
     <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
     <permission-map name="senaite.core: Transition: Sample Sample" acquired="False"/>
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Create Partitions" acquired="True"/>
 
     <permission-map name="senaite.core: Add Analysis" acquired="True"/>
     <permission-map name="senaite.core: Edit Field Results" acquired="True"/>
@@ -617,6 +623,7 @@
     <permission-map name="senaite.core: Transition: Retract" acquired="True"/>
     <permission-map name="senaite.core: Transition: Sample Sample" acquired="False"/>
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Create Partitions" acquired="False"/>
 
     <permission-map name="senaite.core: Add Analysis" acquired="False">
       <!-- LabClerk role has this permission  granted by default in rolemap -->
@@ -715,6 +722,7 @@
     <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
     <permission-map name="senaite.core: Transition: Sample Sample" acquired="False"/>
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Create Partitions" acquired="False"/>
 
     <permission-map name="senaite.core: Add Analysis" acquired="True"/>
     <permission-map name="senaite.core: Edit Field Results" acquired="True"/>
@@ -804,6 +812,7 @@
     <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
     <permission-map name="senaite.core: Transition: Sample Sample" acquired="False"/>
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Create Partitions" acquired="False"/>
 
     <!-- Hide the 'Manage Analyses' tab -->
     <permission-map name="senaite.core: Add Analysis" acquired="False"/>
@@ -902,6 +911,7 @@
     <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
     <permission-map name="senaite.core: Transition: Sample Sample" acquired="False"/>
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Create Partitions" acquired="False"/>
     <!-- Hide the 'Manage Analyses' tab -->
     <permission-map name="senaite.core: Add Analysis" acquired="False"/>
     <!-- Hide the 'Manage Results' tab -->
@@ -988,6 +998,7 @@
     <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
     <permission-map name="senaite.core: Transition: Sample Sample" acquired="False"/>
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Create Partitions" acquired="False"/>
     <!-- Hide the 'Manage Analyses' tab -->
     <permission-map name="senaite.core: Add Analysis" acquired="False"/>
     <!-- Hide the 'Manage Results' tab -->
@@ -1067,6 +1078,7 @@
     <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
     <permission-map name="senaite.core: Transition: Sample Sample" acquired="False"/>
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Create Partitions" acquired="False"/>
     <!-- Hide the 'Manage Analyses' tab -->
     <permission-map name="senaite.core: Add Analysis" acquired="False"/>
     <!-- Hide the 'Manage Results' tab -->
@@ -1151,6 +1163,7 @@
     <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
     <permission-map name="senaite.core: Transition: Sample Sample" acquired="False"/>
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Create Partitions" acquired="False"/>
     <!-- Hide the 'Manage Analyses' tab -->
     <permission-map name="senaite.core: Add Analysis" acquired="False"/>
     <!-- Hide the 'Manage Results' tab -->
@@ -1230,6 +1243,7 @@
     <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
     <permission-map name="senaite.core: Transition: Sample Sample" acquired="False"/>
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Create Partitions" acquired="False"/>
     <!-- Hide the 'Manage Analyses' tab -->
     <permission-map name="senaite.core: Add Analysis" acquired="False"/>
     <!-- Hide the 'Manage Results' tab -->
@@ -1373,7 +1387,7 @@
               i18n:attributes="title">
     <action url="" category="workflow" icon="">Create partitions</action>
     <guard>
-      <guard-permission>senaite.core: Add AnalysisRequest</guard-permission>
+      <guard-permission>senaite.core: Transition: Create Partitions"</guard-permission>
       <guard-expression>python:here.guard_handler("create_partitions")</guard-expression>
     </guard>
   </transition>

--- a/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
+++ b/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
@@ -600,7 +600,6 @@
     <exit-transition transition_id="rollback_to_receive" />
     <exit-transition transition_id="detach" />
     <exit-transition transition_id="dispatch" />
-    <exit-transition transition_id="create_partitions" />
     <!-- /TRANSITIONS -->
 
     <permission-map name="Delete objects" acquired="False">
@@ -789,7 +788,6 @@
     <exit-transition transition_id="rollback_to_receive" />
     <exit-transition transition_id="detach" />
     <exit-transition transition_id="dispatch" />
-    <exit-transition transition_id="create_partitions" />
     <!-- /TRANSITIONS -->
 
     <permission-map name="Delete objects" acquired="False">
@@ -892,7 +890,6 @@
     <exit-transition transition_id="republish"/>
     <exit-transition transition_id="invalidate"/>
     <exit-transition transition_id="dispatch" />
-    <exit-transition transition_id="create_partitions" />
     <!-- /TRANSITIONS -->
 
     <permission-map name="Delete objects" acquired="False"/>

--- a/src/senaite/core/tests/doctests/WorkflowAnalysisRequestCreatePartitions.rst
+++ b/src/senaite/core/tests/doctests/WorkflowAnalysisRequestCreatePartitions.rst
@@ -114,6 +114,34 @@ Partitions cannot be created when the status is `verified`:
     >>> isTransitionAllowed(ar, "create_partitions")
     False
 
+Partitions cannot be created when the status is `published`:
+
+    >>> success = do_action_for(ar, "publish")
+    >>> api.get_workflow_status_of(ar)
+    'published'
+
+    >>> isTransitionAllowed(ar, "create_partitions")
+    False
+
+Partitions cannot be created when the status is `invalid`:
+
+    >>> success = do_action_for(ar, "invalidate")
+    >>> api.get_workflow_status_of(ar)
+    'invalid'
+
+    >>> isTransitionAllowed(ar, "create_partitions")
+    False
+
+Partitions cannot be created when the status is `cancelled`:
+
+    >>> ar = new_ar([Cu, Fe, Au])
+    >>> success = do_action_for(ar, "cancel")
+    >>> api.get_workflow_status_of(ar)
+    'cancelled'
+
+    >>> isTransitionAllowed(ar, "create_partitions")
+    False
+
 
 Check permissions for create_partitions transition
 ..................................................

--- a/src/senaite/core/tests/doctests/WorkflowAnalysisRequestCreatePartitions.rst
+++ b/src/senaite/core/tests/doctests/WorkflowAnalysisRequestCreatePartitions.rst
@@ -1,0 +1,146 @@
+Analysis Request create_partitions guard and event
+-------------------------------------------------
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t WorkflowAnalysisRequestCreatePartitions
+
+
+Test Setup
+..........
+
+Needed Imports:
+
+    >>> from AccessControl.PermissionRole import rolesForPermissionOn
+    >>> from bika.lims import api
+    >>> from bika.lims.interfaces import IAnalysisRequestRetest
+    >>> from bika.lims.utils.analysis import create_analysis
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+    >>> from bika.lims.workflow import isTransitionAllowed
+    >>> from DateTime import DateTime
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+
+Functional Helpers:
+
+    >>> def new_ar(services):
+    ...     values = {
+    ...         'Client': client.UID(),
+    ...         'Contact': contact.UID(),
+    ...         'DateSampled': DateTime(),
+    ...         'SampleType': sampletype.UID()}
+    ...     service_uids = map(api.get_uid, services)
+    ...     ar = create_analysisrequest(client, request, values, service_uids)
+    ...     return ar
+
+    >>> def get_roles_for_permission(permission, context):
+    ...     allowed = set(rolesForPermissionOn(permission, context))
+    ...     return sorted(allowed)
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = portal.bika_setup
+
+We need to create some basic objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
+    >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH", MemberDiscountApplies=True)
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(setup.bika_sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.bika_departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = api.create(setup.bika_analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> Cu = api.create(setup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID(), Accredited=True)
+    >>> Fe = api.create(setup.bika_analysisservices, "AnalysisService", title="Iron", Keyword="Fe", Price="10", Category=category.UID())
+    >>> Au = api.create(setup.bika_analysisservices, "AnalysisService", title="Gold", Keyword="Au", Price="20", Category=category.UID())
+
+
+create_partitions transition and guard basic constraints
+........................................................
+
+Create an Analysis Request:
+
+    >>> ar = new_ar([Cu, Fe, Au])
+    >>> ar
+    <AnalysisRequest at /plone/clients/client-1/W-0001>
+
+Partitions cannot be created when the status is `sample_due`:
+
+    >>> api.get_workflow_status_of(ar)
+    'sample_due'
+
+    >>> isTransitionAllowed(ar, "create_partitions")
+    False
+
+Partitions can be created when the status is `sample_received`:
+
+    >>> success = do_action_for(ar, "receive")
+    >>> api.get_workflow_status_of(ar)
+    'sample_received'
+
+    >>> isTransitionAllowed(ar, "create_partitions")
+    True
+
+Submit all analyses:
+
+    >>> for analysis in ar.getAnalyses(full_objects=True):
+    ...     analysis.setResult(12)
+    ...     success = do_action_for(analysis, "submit")
+
+Partitions cannot be created when the status is `to_be_verified`:
+
+    >>> api.get_workflow_status_of(ar)
+    'to_be_verified'
+
+    >>> isTransitionAllowed(ar, "create_partitions")
+    False
+
+Verify all analyses:
+
+    >>> setup.setSelfVerificationEnabled(True)
+    >>> for analysis in ar.getAnalyses(full_objects=True):
+    ...     success = do_action_for(analysis, "verify")
+    >>> setup.setSelfVerificationEnabled(False)
+
+Partitions cannot be created when the status is `verified`:
+
+    >>> api.get_workflow_status_of(ar)
+    'verified'
+
+    >>> isTransitionAllowed(ar, "create_partitions")
+    False
+
+
+Check permissions for create_partitions transition
+..................................................
+
+Create an Analysis Request and receive:
+
+    >>> ar = new_ar([Cu])
+    >>> success = do_action_for(ar, "receive")
+    >>> api.get_workflow_status_of(ar)
+    'sample_received'
+
+Exactly these roles can create_partitions:
+
+    >>> get_roles_for_permission("senaite.core: Transition: Create Partitions", ar)
+    ['LabClerk', 'LabManager', 'Manager']
+
+Current user can assign because has the `LabManager` role:
+
+    >>> isTransitionAllowed(ar, "create_partitions")
+    True
+
+User with other roles cannot:
+
+    >>> setRoles(portal, TEST_USER_ID, ['Analyst', 'Authenticated', 'Client', 'Owner'])
+    >>> isTransitionAllowed(analysis, "create_partitions")
+    False
+
+Reset settings:
+
+    >>> setRoles(portal, TEST_USER_ID, ['LabManager',])


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes the impossibility to create partitions because of #1965 . Reason is that sample partitions can only be created once the (primary) sample has been received. At this status, the permission "ReceiveSample" is not granted at this point, because the sample has been received already.

## Current behavior before PR

Cannot create partitions

## Desired behavior after PR is merged

Can create partitions

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
