### PR TITLE
Fix analyst unchanged in analyses listing after worksheet reassignment

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2025 Display full name of analyst and submitter in analyses listing
+- #2025 Fix analyst unchanged in analyses listing after worksheet reassignment
 - #2024 Cannot create partitions from samples in received status
 - #2023 Render hyperlinks for reference widget targets in view/edit mode
 - #2022 Replace Worksheet's Analysis ReferenceField by UIDReferenceField

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -517,16 +517,6 @@ class AnalysesView(ListingView):
 
         return vocab
 
-    @viewcache.memoize
-    def get_analysts(self):
-        analysts = getUsers(self.context, ['Manager', 'LabManager', 'Analyst'])
-        analysts = analysts.sortedByKey()
-        results = list()
-        for analyst_id, analyst_name in analysts.items():
-            results.append({'ResultValue': analyst_id,
-                            'ResultText': analyst_name})
-        return results
-
     def load_analysis_categories(self):
         # Getting analysis categories
         bsc = api.get_tool('senaite_catalog_setup')
@@ -1088,25 +1078,21 @@ class AnalysesView(ListingView):
             item["Instrument"] = _("Manual")
 
     def _folder_item_analyst(self, obj, item):
-        is_editable = self.is_analysis_edition_allowed(obj)
-        if not is_editable:
-            item['Analyst'] = obj.getAnalystName
-            return
-
-        # Analyst is editable
-        item['Analyst'] = obj.getAnalyst or api.get_current_user().id
-        item['choices']['Analyst'] = self.get_analysts()
+        obj = self.get_object(obj)
+        analyst = obj.getAnalyst()
+        item["Analyst"] = self.get_user_name(analyst)
 
     def _folder_item_submitted_by(self, obj, item):
-        submitted_by = obj.getSubmittedBy
-        if submitted_by:
-            user = self.get_user_by_id(submitted_by)
-            user_name = user and user.getProperty("fullname") or submitted_by
-            item['SubmittedBy'] = user_name
+        obj = self.get_object(obj)
+        submitted_by = obj.getSubmittedBy()
+        item["SubmittedBy"] = self.get_user_name(submitted_by)
 
     @viewcache.memoize
-    def get_user_by_id(self, user_id):
-        return api.get_user(user_id)
+    def get_user_name(self, user_id):
+        if not user_id:
+            return ""
+        user = api.get_user_properties(user_id)
+        return user and user.get("fullname") or user_id
 
     def _folder_item_attachments(self, obj, item):
         if not self.has_permission(ViewResults, obj):

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -1000,8 +1000,8 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         analyst = self.getAnalyst()
         if not analyst:
             return ""
-        user = api.get_user(analyst.strip())
-        return user and user.getProperty("fullname") or analyst
+        user = api.get_user_properties(analyst.strip())
+        return user and user.get("fullname") or analyst
 
     @security.public
     def getSubmittedBy(self):

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -994,16 +994,6 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         return worksheet.getAnalyst() or ""
 
     @security.public
-    def getAnalystName(self):
-        """Returns the name of the currently assigned analyst
-        """
-        analyst = self.getAnalyst()
-        if not analyst:
-            return ""
-        user = api.get_user_properties(analyst.strip())
-        return user and user.get("fullname") or analyst
-
-    @security.public
     def getSubmittedBy(self):
         """
         Returns the identifier of the user who submitted the result if the

--- a/src/senaite/core/catalog/analysis_catalog.py
+++ b/src/senaite/core/catalog/analysis_catalog.py
@@ -37,7 +37,6 @@ INDEXES = BASE_INDEXES + [
 COLUMNS = BASE_COLUMNS + [
     # attribute name
     "getAnalysisPortalType",
-    "getAnalyst",
     "getCategoryTitle",
     "getClientOrderNumber",
     "getClientTitle",

--- a/src/senaite/core/catalog/analysis_catalog.py
+++ b/src/senaite/core/catalog/analysis_catalog.py
@@ -38,7 +38,6 @@ COLUMNS = BASE_COLUMNS + [
     # attribute name
     "getAnalysisPortalType",
     "getAnalyst",
-    "getAnalystName",
     "getCategoryTitle",
     "getClientOrderNumber",
     "getClientTitle",

--- a/src/senaite/core/upgrade/v02_03_000.py
+++ b/src/senaite/core/upgrade/v02_03_000.py
@@ -34,6 +34,7 @@ profile = "profile-{0}:default".format(product)
 
 METADATA_TO_REMOVE = [
     # No longer used, see https://github.com/senaite/senaite.core/pull/2025/
+    (ANALYSIS_CATALOG, "getAnalyst"),
     (ANALYSIS_CATALOG, "getAnalystName"),
 ]
 
@@ -61,6 +62,7 @@ def upgrade(tool):
     setup.runImportStepFromProfile(profile, "rolemap")
     setup.runImportStepFromProfile(profile, "workflow")
 
+    remove_stale_metadata(portal)
     fix_worksheets_analyses(portal)
     fix_cannot_create_partitions(portal)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the analyst in analysis listing gets updated after the worksheet the analysis is assigned to is reassigned to another analyst. Besides, displays the fullname of the analyst and user who submitted the result

## Current behavior before PR

Analyst displayed in analysis listing does not change after the worksheet is reassigned to another analyst

## Desired behavior after PR is merged

Analyst displayed in analysis listing does get updated after the worksheet is reassigned to another analyst

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
