### PR TITLE
Fix LabManager and LabClerk cannot add preservations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2026 Fix LabManager and LabClerk cannot add preservations
 - #2024 Cannot create partitions from samples in received status
 - #2023 Render hyperlinks for reference widget targets in view/edit mode
 - #2022 Replace Worksheet's Analysis ReferenceField by UIDReferenceField

--- a/src/bika/lims/profiles/default/rolemap.xml
+++ b/src/bika/lims/profiles/default/rolemap.xml
@@ -293,6 +293,12 @@
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
+    <permission name="senaite.core: Add Preservation" acquire="False">
+      <role name="LabClerk"/>
+      <role name="LabManager"/>
+      <role name="Manager"/>
+      <role name="Owner"/>
+    </permission>
     <permission name="senaite.core: Add Pricelist" acquire="False">
       <role name="LabClerk"/>
       <role name="LabManager"/>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the button "[+Add]" is displayed in Preservations listing for users that belong to LabManager and/or LabClerk roles

## Current behavior before PR

The button [+Add] from Preservations listing is not displayed to LabManager or LabClerk users

## Desired behavior after PR is merged

The button [+Add] from Preservations listing is displayed to LabManager or LabClerk users

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
