### PR TITLE
Fix Manufacturer is not displayed in Reference Samples listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2027 Fix Manufacturer is not displayed in Reference Samples listing
 - #2024 Cannot create partitions from samples in received status
 - #2023 Render hyperlinks for reference widget targets in view/edit mode
 - #2022 Replace Worksheet's Analysis ReferenceField by UIDReferenceField

--- a/src/bika/lims/browser/referencesample.py
+++ b/src/bika/lims/browser/referencesample.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 import collections
+from bika.lims.utils import get_link_for
 from datetime import datetime
 
 from bika.lims import api
@@ -404,9 +405,7 @@ class ReferenceSamplesView(BikaListingView):
                 "replace_url": "aq_parent.absolute_url"}),
             ("Manufacturer", {
                 "title": _("Manufacturer"),
-                "toggle": True,
-                "attr": "getManufacturer.Title",
-                "replace_url": "getManufacturer.absolute_url"}),
+                "toggle": True}),
             ("Definition", {
                 "title": _("Reference Definition"),
                 "toggle": True,
@@ -506,6 +505,9 @@ class ReferenceSamplesView(BikaListingView):
         item["DateReceived"] = self.ulocalized_time(obj.getDateReceived())
         item["DateOpened"] = self.ulocalized_time(obj.getDateOpened())
         item["ExpiryDate"] = self.ulocalized_time(obj.getExpiryDate())
+
+        manufacturer = obj.getManufacturer()
+        item["replace"]["Manufacturer"] = get_link_for(manufacturer)
 
         # Icons
         after_icons = ''


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the Manufacturer is correctly displayed in Reference Samples listing

## Current behavior before PR

Manufacturer is not displayed in Reference Samples listing

![Captura de 2022-06-30 00-41-12](https://user-images.githubusercontent.com/832627/176558467-f24ce88a-9e24-4cbb-b542-62263a5341f3.png)


## Desired behavior after PR is merged

Manufacturer is displayed in Reference Samples listing

![Captura de 2022-06-30 00-44-30](https://user-images.githubusercontent.com/832627/176558480-281704ce-0907-4ef1-82f9-be3dea5bf8e6.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
