### PR TITLE
Fix Definition is not displayed in Reference Samples listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2027 Fix Manufacturer is not displayed in Reference Samples listing
 - #2024 Cannot create partitions from samples in received status
 - #2023 Render hyperlinks for reference widget targets in view/edit mode
 - #2022 Replace Worksheet's Analysis ReferenceField by UIDReferenceField

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2028 Fix Definition is not displayed in Reference Samples listing
 - #2027 Fix Manufacturer is not displayed in Reference Samples listing
 - #2024 Cannot create partitions from samples in received status
 - #2023 Render hyperlinks for reference widget targets in view/edit mode

--- a/src/bika/lims/browser/referencesample.py
+++ b/src/bika/lims/browser/referencesample.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 import collections
+from bika.lims.utils import get_link_for
 from datetime import datetime
 
 from bika.lims import api
@@ -404,9 +405,7 @@ class ReferenceSamplesView(BikaListingView):
                 "replace_url": "aq_parent.absolute_url"}),
             ("Manufacturer", {
                 "title": _("Manufacturer"),
-                "toggle": True,
-                "attr": "getManufacturer.Title",
-                "replace_url": "getManufacturer.absolute_url"}),
+                "toggle": True}),
             ("Definition", {
                 "title": _("Reference Definition"),
                 "toggle": True,
@@ -506,6 +505,9 @@ class ReferenceSamplesView(BikaListingView):
         item["DateReceived"] = self.ulocalized_time(obj.getDateReceived())
         item["DateOpened"] = self.ulocalized_time(obj.getDateOpened())
         item["ExpiryDate"] = self.ulocalized_time(obj.getExpiryDate())
+
+        manufacturer = obj.getManufacturer()
+        item["replace"]["Manufacturer"] = get_link_for(manufacturer)
 
         # Icons
         after_icons = ''

--- a/src/bika/lims/browser/referencesample.py
+++ b/src/bika/lims/browser/referencesample.py
@@ -400,17 +400,13 @@ class ReferenceSamplesView(BikaListingView):
                 "toggle": True}),
             ("Supplier", {
                 "title": _("Supplier"),
-                "toggle": True,
-                "attr": "aq_parent.Title",
-                "replace_url": "aq_parent.absolute_url"}),
+                "toggle": True}),
             ("Manufacturer", {
                 "title": _("Manufacturer"),
                 "toggle": True}),
             ("Definition", {
                 "title": _("Reference Definition"),
-                "toggle": True,
-                "attr": "getReferenceDefinition.Title",
-                "replace_url": "getReferenceDefinition.absolute_url"}),
+                "toggle": True}),
             ("DateSampled", {
                 "title": _("Date Sampled"),
                 "index": "getDateSampled",
@@ -508,6 +504,12 @@ class ReferenceSamplesView(BikaListingView):
 
         manufacturer = obj.getManufacturer()
         item["replace"]["Manufacturer"] = get_link_for(manufacturer)
+
+        supplier = api.get_parent(obj)
+        item["replace"]["Supplier"] = get_link_for(supplier)
+
+        ref_definition = obj.getReferenceDefinition()
+        item["replace"]["Definition"] = get_link_for(ref_definition)
 
         # Icons
         after_icons = ''


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Merge https://github.com/senaite/senaite.core/pull/2027 first**

This Pull Request ensures the Reference Definition is correctly displayed in Reference Samples listing

## Current behavior before PR

Reference Definition is not displayed in Reference Samples listing

## Desired behavior after PR is merged

Reference Definition is displayed in Reference Samples listing

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
