### PR TITLE
Fix AttributeError in Manufacturer's Instruments view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2029 Fix AttributeError in Manufacturer's Instruments view
 - #2025 Display full name of analyst and submitter in analyses listing
 - #2025 Fix analyst unchanged in analyses listing after worksheet reassignment
 - #2028 Fix Definition is not displayed in Reference Samples listing

--- a/src/bika/lims/browser/manufacturer.py
+++ b/src/bika/lims/browser/manufacturer.py
@@ -18,13 +18,13 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from bika.lims import api
 from bika.lims.controlpanel.bika_instruments import InstrumentsView
+
 
 class ManufacturerInstrumentsView(InstrumentsView):
 
-    def __init__(self, context, request):
-        super(ManufacturerInstrumentsView, self).__init__(context, request)
-
     def isItemAllowed(self, obj):
-        manuf = obj.getManufacturer() if obj else None
-        return manuf.UID() == self.context.UID() if manuf else False
+        obj = api.get_object(obj)
+        uid = obj.getRawManufacturer()
+        return uid == api.get_uid(self.context)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a traceback that arises when visiting the Manufacturer's Instruments listing view


## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.app.listing.view, line 224, in __call__
  Module senaite.app.listing.ajax, line 111, in handle_subpath
  Module senaite.core.decorators, line 22, in decorator
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 436, in ajax_folderitems
  Module senaite.app.listing.decorators, line 88, in wrapper
  Module senaite.app.listing.ajax, line 317, in get_folderitems
  Module senaite.app.listing.view, line 919, in folderitems
  Module bika.lims.browser.manufacturer, line 29, in isItemAllowed
AttributeError: 'RequestContainer' object has no attribute 'getManufacturer'
```

## Desired behavior after PR is merged

No traceback arises at manufacturer's instruments view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
