### PR TITLE
Fix Email address is not displayed in clients listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2030 Fix Email address is not displayed in clients listing
 - #2025 Display full name of analyst and submitter in analyses listing
 - #2025 Fix analyst unchanged in analyses listing after worksheet reassignment
 - #2028 Fix Definition is not displayed in Reference Samples listing

--- a/src/bika/lims/browser/clientfolder.py
+++ b/src/bika/lims/browser/clientfolder.py
@@ -175,7 +175,8 @@ class ClientFolderContentsView(BikaListingView):
         item["replace"]["title"] = get_link(link_url, item["title"])
         item["replace"]["getClientID"] = get_link(link_url, item["getClientID"])
         # render an email link
-        item["replace"]["EmailAddress"] = get_email_link(item["EmailAddress"])
+        email = obj.getEmailAddress()
+        item["replace"]["EmailAddress"] = get_email_link(email)
         # translate True/FALSE values
         item["replace"]["BulkDiscount"] = obj.getBulkDiscount() and _("Yes") or _("No")
         item["replace"]["MemberDiscountApplies"] = obj.getMemberDiscountApplies() and _("Yes") or _("No")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes email address visibile in clients listing

## Current behavior before PR

The email address is not displayed in clients listing although column is present

## Desired behavior after PR is merged

The email address is displayed in clients listing

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
