### PR TITLE
Make the "Other reasons" text area from rejection view wider

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2031 Make the "Other reasons" text area from rejection view wider
 - #2025 Display full name of analyst and submitter in analyses listing
 - #2025 Fix analyst unchanged in analyses listing after worksheet reassignment
 - #2028 Fix Definition is not displayed in Reference Samples listing

--- a/src/bika/lims/browser/analysisrequest/templates/reject_samples.pt
+++ b/src/bika/lims/browser/analysisrequest/templates/reject_samples.pt
@@ -88,11 +88,11 @@
 
                       <!-- Other rejection reasons -->
                       <div class="col-sm-12">
-                        <div class="form-group field">
+                        <div class="form-group">
                           <label tal:condition="reasons" i18n:translate="">Other reasons</label>
                           <label tal:condition="python: not reasons" i18n:translate="">Rejection reasons</label>
-                          <textarea cols="5"
-                            tal:attributes="name string:samples.other_reasons:records"></textarea>
+                          <textarea rows="5" class="form-control"
+                            tal:attributes="name string:samples.other_reasons:records"/>
                         </div>
                       </div>
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the textarea for "Other reasons" field from Sample rejection view wider

## Current behavior before PR

![Captura de 2022-06-30 13-54-42](https://user-images.githubusercontent.com/832627/176671761-07df3cb2-f0e7-4675-bc09-0e98651c5ff1.png)


## Desired behavior after PR is merged

![Captura de 2022-06-30 13-55-35](https://user-images.githubusercontent.com/832627/176671779-249f1312-af56-43be-afd2-9300aef71479.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
