### PR TITLE
Fix error in sample view when ccemails is None (#1674 port)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 1.3.6 (unreleased)
 ------------------
-
+- #2034 Fix error in sample view when ccemails is None (#1674 port)
 - #1986 Fixed error with sampler mail (#1941 port)
 - #1985 Disallow client users to create sample partitions (#1965 port)
 - #1984 Fix default roles for client field in samples (#1968 port)

--- a/bika/lims/browser/analysisrequest/__init__.py
+++ b/bika/lims/browser/analysisrequest/__init__.py
@@ -143,6 +143,8 @@ class mailto_link_from_ccemails(object):
 
     def __call__(self, field):
         ccemails = field.get(self.context)
+        if not ccemails:
+            return ""
         addresses = ccemails.split(",")
         ret = []
         for address in addresses:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports https://github.com/senaite/senaite.core/pull/1674 to 1.3.x


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
