### PR TITLE
Show only active dynamic analysisspecs in reference widget (#1684 port)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #2036 Show only active dynamic analysisspecs in reference widget (#1684 port)
 - #1986 Fixed error with sampler mail (#1941 port)
 - #1985 Disallow client users to create sample partitions (#1965 port)
 - #1984 Fix default roles for client field in samples (#1968 port)

--- a/bika/lims/content/analysisspec.py
+++ b/bika/lims/content/analysisspec.py
@@ -67,6 +67,7 @@ schema = Schema((
             showOn=True,
             catalog_name=SETUP_CATALOG,
             base_query=dict(
+                is_active=True,
                 sort_on="sortable_title",
                 sort_order="ascending"
             ),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #1684 to 1.3.x

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
