### PR TITLE
Removed add button in auditlog listing view (#1714 port)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #2037 Removed add button in auditlog listing view (#1714 port)
 - #1986 Fixed error with sampler mail (#1941 port)
 - #1985 Disallow client users to create sample partitions (#1965 port)
 - #1984 Fix default roles for client field in samples (#1968 port)

--- a/bika/lims/browser/auditlog.py
+++ b/bika/lims/browser/auditlog.py
@@ -56,6 +56,7 @@ class AuditLogView(BikaListingView):
         # the default settings
         self.catalog = "uid_catalog"
         self.contentFilter = {"UID": api.get_uid(context)}
+        self.context_actions = {}
 
         # TODO: Fix in senaite.core.listing.get_api_url
         #


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #1714 to 1.3.x

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
