### PR TITLE
Fix UnicodeDecodeError for Instrument Import Log View (#1720 port)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #2038 Fix UnicodeDecodeError for Instrument Import Log View (#1720 port)
 - #1986 Fixed error with sampler mail (#1941 port)
 - #1985 Disallow client users to create sample partitions (#1965 port)
 - #1984 Fix default roles for client field in samples (#1968 port)

--- a/bika/lims/browser/instrument.py
+++ b/bika/lims/browser/instrument.py
@@ -743,8 +743,9 @@ class InstrumentAutoImportLogsView(AutoImportLogsView):
             "sort_order": "descending",
         }
 
+        instrument = self.context.Title()
         self.title = self.context.translate(
-            _("Auto Import Logs of %s" % self.context.Title()))
+            _(u"Auto Import Logs of %s" % api.safe_unicode(instrument)))
         self.icon = "{}/{}".format(
             self.portal_url,
             "++resource++bika.lims.images/instrumentcertification_big.png"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #1720 to 1.3.x

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
