### PR TITLE
Fix analysis hidden status erases on results submit (#1998 port)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #2040 Fix analysis hidden status erases on results submit (#1998 port)
 - #1986 Fixed error with sampler mail (#1941 port)
 - #1985 Disallow client users to create sample partitions (#1965 port)
 - #1984 Fix default roles for client field in samples (#1968 port)

--- a/bika/lims/browser/workflow/analysis.py
+++ b/bika/lims/browser/workflow/analysis.py
@@ -99,8 +99,8 @@ class WorkflowActionSubmitAdapter(WorkflowActionGenericAdapter):
             analysis.setInterimFields(interims)
 
             # Save Hidden
-            hidden = self.get_form_value("Hidden", uid, "")
-            analysis.setHidden(hidden == "on")
+            hidden = self.get_form_value("Hidden", uid, default=analysis.getHidden())
+            analysis.setHidden(hidden in ("on", True))
 
             # Only set result if it differs from the actual value to preserve
             # the result capture date


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #1998 to 1.3.x

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
