### PR TITLE
Fix indexing of DX temp objects resulting in orphan entries (#1913 port)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #2041 Fix indexing of DX temp objects resulting in orphan entries (#1913 port)
 - #1986 Fixed error with sampler mail (#1941 port)
 - #1985 Disallow client users to create sample partitions (#1965 port)
 - #1984 Fix default roles for client field in samples (#1968 port)
@@ -14,7 +15,7 @@ Changelog
 - #1906 Fix traceback in auditlog view when context is a Dexterity type
 - #1885 Allow to re-add cancelled/rejected/retracted analyses (#1777 port)
 - #1885 Fix APIError when a retest analysis source is removed (#1777 port)
-- #1868 Fix indexing of temporary objects resulting in orphan entries in catalog
+- #1868 Fix indexing of temp objects resulting in orphan entries (#1865 port)
 - #1866 Fix error when invalidating samples with copies of analyses
 - #1851 Added readonly_transactions decorator (#1732 port)
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ Changelog
 - #1906 Fix traceback in auditlog view when context is a Dexterity type
 - #1885 Allow to re-add cancelled/rejected/retracted analyses (#1777 port)
 - #1885 Fix APIError when a retest analysis source is removed (#1777 port)
-- #1868 Fix indexing of temp objects resulting in orphan entries (#1865 port)
+- #1868 Fix indexing of AT temp objects resulting in orphan entries (#1865 port)
 - #1866 Fix error when invalidating samples with copies of analyses
 - #1851 Added readonly_transactions decorator (#1732 port)
 

--- a/bika/lims/monkey/configure.zcml
+++ b/bika/lims/monkey/configure.zcml
@@ -68,4 +68,13 @@
       replacement=".archetypes.isTemporary"
   />
 
+  <!-- Port #1868 for dexterity contents to avoid duplicate catalog entries when using `api.create` -->
+  <monkey:patch
+      description="Patch `DexterityContent.isTemporary` to avoid duplicate indexing in *portal catalog* during object creation"
+      class="plone.dexterity.content.DexterityContent"
+      original="isTemporary"
+      ignoreOriginal="True"
+      replacement=".dexterity.isTemporary"
+  />
+
 </configure>

--- a/bika/lims/monkey/dexterity.py
+++ b/bika/lims/monkey/dexterity.py
@@ -6,7 +6,6 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from bika.lims import api
 from bika.lims import logger
-from Products.Archetypes.utils import shasattr
 
 TMP_RX = re.compile("[a-z0-9]{32}$")
 
@@ -18,13 +17,7 @@ def is_tmp_id(id):
 def isTemporary(self):
     parent = aq_parent(aq_inner(self))
     # Fix indexing of temporary objects resulting in orphan entries in catalog
-    # https://github.com/senaite/senaite.core/pull/1865
     if is_tmp_id(self.id) or is_tmp_id(parent.id):
-        logger.debug("AT object %s is temporary!" % api.get_path(self))
+        logger.debug("DX object %s is temporary!" % api.get_path(self))
         return True
-    # Checks to see if we are created as temporary object by
-    # portal factory.
-    tmp = shasattr(parent, "meta_type") and parent.meta_type == "TempFolder"
-    return tmp
-
-
+    return False


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #1913 to 1.3.x

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
