### PR TITLE
Fix LabManager and LabClerk cannot add preservations (#2026 port)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #2042 Fix LabManager and LabClerk cannot add preservations (#2026 port)
 - #1986 Fixed error with sampler mail (#1941 port)
 - #1985 Disallow client users to create sample partitions (#1965 port)
 - #1984 Fix default roles for client field in samples (#1968 port)

--- a/bika/lims/profiles/default/rolemap.xml
+++ b/bika/lims/profiles/default/rolemap.xml
@@ -268,6 +268,12 @@
       <role name="Manager"/>
       <role name="Owner"/>
     </permission>
+    <permission name="senaite.core: Add Preservation" acquire="False">
+      <role name="LabClerk"/>
+      <role name="LabManager"/>
+      <role name="Manager"/>
+      <role name="Owner"/>
+    </permission>
     <permission name="senaite.core: Add Pricelist" acquire="False">
       <role name="LabClerk"/>
       <role name="LabManager"/>

--- a/bika/lims/upgrade/v01_03_006.py
+++ b/bika/lims/upgrade/v01_03_006.py
@@ -42,6 +42,7 @@ def upgrade(tool):
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
     # -------- ADD YOUR STUFF BELOW --------
+    setup.runImportStepFromProfile(profile, "rolemap")
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #2026 to 1.3.x

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
