### PR TITLE
Fix printed time does not get updated on re-Print

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2043 Fix printed time does not get updated on re-Print
 - #2033 Fix blurry Barcode and QRCode in stickers
 - #2032 Fix add-on stickers not displayed in sample type admitted stickers
 - #2031 Make the "Other reasons" text area from rejection view wider

--- a/src/bika/lims/browser/workflow/analysisrequest.py
+++ b/src/bika/lims/browser/workflow/analysisrequest.py
@@ -278,14 +278,14 @@ class WorkflowActionPrintSampleAdapter(WorkflowActionGenericAdapter):
         """
         if api.get_workflow_status_of(sample) != "published":
             return False
-        reports = sample.objectValues("ARReport")
-        reports = sorted(reports, key=lambda report: report.getDatePublished())
+
+        reports = sample.objectIds("ARReport")
         if not reports:
             return False
-        last_report = reports[-1]
-        if not last_report.getDatePrinted():
-            last_report.setDatePrinted(DateTime())
-            sample.reindexObject(idxs=["getPrinted"])
+
+        last_report = sample.get(reports[-1])
+        last_report.setDatePrinted(DateTime())
+        sample.reindexObject(idxs=["getPrinted"])
         return True
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that when the button "Print" is pressed for some samples in samples listing, the printed date for all them are updated, even if they where flagged as printed before.

## Current behavior before PR

The printed date of samples that were printed previously does not get updated when "Print" button is pressed

## Desired behavior after PR is merged

The printed date of samples that were printed previously does get updated when "Print" button is pressed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
