### PR TITLE
Skip Invoice for content exports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2044 Skip Invoice for content exports
 - #2043 Fix printed time does not get updated on re-Print
 - #2033 Fix blurry Barcode and QRCode in stickers
 - #2032 Fix add-on stickers not displayed in sample type admitted stickers

--- a/src/senaite/core/exportimport/genericsetup/structure.py
+++ b/src/senaite/core/exportimport/genericsetup/structure.py
@@ -57,6 +57,7 @@ SKIP_EXPORT_TYPES = [
     "Batch",
     "ReferenceSample",
     "Worksheet",
+    "Invoice",
 ]
 
 ID_MAP = {}


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR skips the type `Invoice` for content exports

## Current behavior before PR

Invoices exported

## Desired behavior after PR is merged

Traceback `ReferenceException: Invalid Target UID` occurred, because it links to a (non-exported) sample

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
