### PR TITLE
Fix instrument types instruments view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2045 Fix instrument types instruments view
 - #2044 Skip Invoice for content exports
 - #2043 Fix printed time does not get updated on re-Print
 - #2033 Fix blurry Barcode and QRCode in stickers

--- a/src/bika/lims/browser/instrumenttype.py
+++ b/src/bika/lims/browser/instrumenttype.py
@@ -18,19 +18,27 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from bika.lims.controlpanel.bika_instruments import InstrumentsView
+from bika.lims import api
 from bika.lims import bikaMessageFactory as _
+from bika.lims.controlpanel.bika_instruments import InstrumentsView
+
 
 class InstrumentTypeInstrumentsView(InstrumentsView):
+    """Display instruments assigned to this instrument type
+    """
 
     def __init__(self, context, request):
         super(InstrumentTypeInstrumentsView, self).__init__(context, request)
         url = self.portal.absolute_url()
         url += "/bika_setup/bika_instruments/"
-        self.context_actions = {_('Add'):
-                                {'url': url+'createObject?type_name=Instrument',
-                                 'icon': '++resource++bika.lims.images/add.png'}}
+
+        self.context_actions = {
+            _("Add"): {
+                "url": url+"createObject?type_name=Instrument",
+                "icon": "++resource++bika.lims.images/add.png",
+            }}
 
     def isItemAllowed(self, obj):
+        obj = api.get_object(obj)
         itype = obj.getInstrumentType() if obj else None
         return itype.UID() == self.context.UID() if itype else False


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the following traceback:

```
2022-07-05 20:02:14 ERROR Zope.SiteErrorLog 1657044134.370.635157666595 http://localhost:8080/senaite/bika_setup/bika_instrumenttypes/instrumenttype-3/instruments/folderitems
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module senaite.app.listing.view, line 224, in __call__
  Module senaite.app.listing.ajax, line 111, in handle_subpath
  Module senaite.core.decorators, line 22, in decorator
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 436, in ajax_folderitems
  Module senaite.app.listing.decorators, line 88, in wrapper
  Module senaite.app.listing.ajax, line 317, in get_folderitems
  Module senaite.app.listing.view, line 912, in folderitems
  Module senaite.app.listing.view, line 723, in _fetch_brains
  Module senaite.app.listing.view, line 797, in search
  Module senaite.app.listing.view, line 797, in <lambda>
  Module bika.lims.browser.instrumenttype, line 35, in isItemAllowed
AttributeError: 'RequestContainer' object has no attribute 'getInstrumentType'
```

## Current behavior before PR

Accessing the "instruments" view from inside an instrument type raised an error

## Desired behavior after PR is merged

Accessing the "instruments" view from inside an instrument shows all assigned instruments of this instrument type

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
