### PR TITLE
Fix catalog logging counter duplicates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2048 Fix catalog logging counter duplicates
 - #2047 Make resultsinterpretation.pt to retrieve departments from viewlet
 - #2045 Fix instrument types instruments view
 - #2044 Skip Invoice for content exports


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the progress counting when doing a catalog rebuild.

## Current behavior before PR

Double numbers appear in the log:
```
2022-07-11 17:20:11,453 INFO    [senaite.core:150][waitress-0] Progress: 22400 objects have been cataloged for senaite_catalog_sample.
2022-07-11 17:20:21,936 INFO    [senaite.core:150][waitress-0] Progress: 22500 objects have been cataloged for senaite_catalog_sample.
2022-07-11 17:20:22,415 INFO    [senaite.core:150][waitress-0] Progress: 22500 objects have been cataloged for senaite_catalog_sample.
2022-07-11 17:20:22,469 INFO    [senaite.core:150][waitress-0] Progress: 22500 objects have been cataloged for senaite_catalog_sample.
2022-07-11 17:20:32,913 INFO    [senaite.core:150][waitress-0] Progress: 22600 objects have been cataloged for senaite_catalog_sample.
2022-07-11 17:20:33,394 INFO    [senaite.core:150][waitress-0] Progress: 22600 objects have been cataloged for senaite_catalog_sample.
2022-07-11 17:20:44,849 INFO    [senaite.core:150][waitress-0] Progress: 22700 objects have been cataloged for senaite_catalog_sample.
2022-07-11 17:20:45,319 INFO    [senaite.core:150][waitress-0] Progress: 22700 objects have been cataloged for senaite_catalog_sample.
2022-07-11 17:20:55,290 INFO    [senaite.core:150][waitress-0] Progress: 22800 objects have been cataloged for senaite_catalog_sample.
2022-07-11 17:20:55,720 INFO    [senaite.core:150][waitress-0] Progress: 22800 objects have been cataloged for senaite_catalog_sample.
2022-07-11 17:21:06,103 INFO    [senaite.core:150][waitress-0] Progress: 22900 objects have been cataloged for senaite_catalog_sample.
2022-07-11 17:21:06,591 INFO    [senaite.core:150][waitress-0] Progress: 22900 objects have been cataloged for senaite_catalog_sample.
2022-07-11 17:21:17,469 INFO    [senaite.core:150][waitress-0] Progress: 23000 objects have been cataloged for senaite_catalog_sample.
2022-07-11 17:21:18,031 INFO    [senaite.core:150][waitress-0] Progress: 23000 objects have been cataloged for senaite_catalog_sample.
2022-07-11 17:21:18,087 INFO    [senaite.core:150][waitress-0] Progress: 23000 objects have been cataloged for senaite_catalog_sample.
2022-07-11 17:21:28,491 INFO    [senaite.core:150][waitress-0] Progress: 23100 objects have been cataloged for senaite_catalog_sample.
```

## Desired behavior after PR is merged

```
2022-07-11 21:23:20,368 INFO    [senaite.core:120][waitress-0] Progress: 7000 objects have been cataloged for senaite_catalog_sample.
2022-07-11 21:23:28,667 INFO    [senaite.core:120][waitress-0] Progress: 7100 objects have been cataloged for senaite_catalog_sample.
2022-07-11 21:23:36,328 INFO    [senaite.core:120][waitress-0] Progress: 7200 objects have been cataloged for senaite_catalog_sample.
2022-07-11 21:23:43,697 INFO    [senaite.core:120][waitress-0] Progress: 7300 objects have been cataloged for senaite_catalog_sample.
2022-07-11 21:23:51,576 INFO    [senaite.core:120][waitress-0] Progress: 7400 objects have been cataloged for senaite_catalog_sample.
2022-07-11 21:23:59,471 INFO    [senaite.core:120][waitress-0] Progress: 7500 objects have been cataloged for senaite_catalog_sample.
2022-07-11 21:24:07,504 INFO    [senaite.core:120][waitress-0] Progress: 7600 objects have been cataloged for senaite_catalog_sample.
2022-07-11 21:24:15,997 INFO    [senaite.core:120][waitress-0] Progress: 7700 objects have been cataloged for senaite_catalog_sample.
```

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
