### PR TITLE
Fix ProfileKey is not shown in Profiles table (#1987 port)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #2050 Fix ProfileKey is not shown in Profiles table
 - #2042 Fix LabManager and LabClerk cannot add preservations (#2026 port)
 - #2041 Fix indexing of DX temp objects resulting in orphan entries (#1913 port)
 - #2040 Fix analysis hidden status erases on results submit (#1998 port)

--- a/bika/lims/controlpanel/bika_analysisprofiles.py
+++ b/bika/lims/controlpanel/bika_analysisprofiles.py
@@ -127,6 +127,7 @@ class AnalysisProfilesView(BikaListingView):
 
         item["replace"]["Title"] = get_link(url, value=title)
         item["Description"] = description
+        item["ProfileKey"] = obj.getProfileKey()
 
         return item
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #1987 to 1.3.x

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
