### PR TITLE
Fix missing keyword in analysis profile view (#2009 port)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #2051 Fix missing keyword in analysis profile view (#2009 port)
 - #2042 Fix LabManager and LabClerk cannot add preservations (#2026 port)
 - #2041 Fix indexing of DX temp objects resulting in orphan entries (#1913 port)
 - #2040 Fix analysis hidden status erases on results submit (#1998 port)

--- a/bika/lims/browser/widgets/analysisprofileanalyseswidget.py
+++ b/bika/lims/browser/widgets/analysisprofileanalyseswidget.py
@@ -224,6 +224,7 @@ class AnalysisProfileAnalysesView(BikaListingView):
         item["selected"] = False
         item["Hidden"] = hidden
         item["selected"] = uid in self.configuration
+        item["Keyword"] = obj.getKeyword()
 
         # Add methods
         methods = obj.getMethods()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #2009 to 1.3.x

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
