### PR TITLE
Fix Email address is not displayed in clients listing (#2030 port)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #2055 Fix Email address is not displayed in clients listing (#2030 port)
 - #2042 Fix LabManager and LabClerk cannot add preservations (#2026 port)
 - #2041 Fix indexing of DX temp objects resulting in orphan entries (#1913 port)
 - #2040 Fix analysis hidden status erases on results submit (#1998 port)

--- a/bika/lims/browser/clientfolder.py
+++ b/bika/lims/browser/clientfolder.py
@@ -177,7 +177,8 @@ class ClientFolderContentsView(BikaListingView):
         item["replace"]["title"] = get_link(link_url, item["title"])
         item["replace"]["getClientID"] = get_link(link_url, item["getClientID"])
         # render an email link
-        item["replace"]["EmailAddress"] = get_email_link(item["EmailAddress"])
+        email = obj.getEmailAddress()
+        item["replace"]["EmailAddress"] = get_email_link(email)
         # translate True/FALSE values
         item["replace"]["BulkDiscount"] = obj.getBulkDiscount() and _("Yes") or _("No")
         item["replace"]["MemberDiscountApplies"] = obj.getMemberDiscountApplies() and _("Yes") or _("No")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #2030 to 1.3.x

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
