### PR TITLE
Make "Other reasons" text area from rejection view wider (#2031 port)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #2057 Make "Other reasons" text area from rejection view wider (#2031 port)
 - #2042 Fix LabManager and LabClerk cannot add preservations (#2026 port)
 - #2041 Fix indexing of DX temp objects resulting in orphan entries (#1913 port)
 - #2040 Fix analysis hidden status erases on results submit (#1998 port)

--- a/bika/lims/browser/analysisrequest/templates/reject_samples.pt
+++ b/bika/lims/browser/analysisrequest/templates/reject_samples.pt
@@ -93,10 +93,10 @@
 
                       <!-- Other rejection reasons -->
                       <div class="col-sm-12">
-                        <div class="form-group field">
+                        <div class="form-group">
                           <label tal:condition="reasons" i18n:translate="">Other reasons</label>
                           <label tal:condition="python: not reasons" i18n:translate="">Rejection reasons</label>
-                          <textarea cols="5"
+                          <textarea rows="5" class="form-control"
                             tal:attributes="name string:samples.other_reasons:records"></textarea>
                         </div>
                       </div>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #2031 to 1.3.x

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
