### PR TITLE
Filter 'Interpretation templates' in sample view by template and type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2058 Allow to filter 'Interpretation templates' by sample template and type
 - #2048 Fix catalog logging counter duplicates
 - #2047 Make resultsinterpretation.pt to retrieve departments from viewlet
 - #2045 Fix instrument types instruments view

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
-- #2058 Allow to filter 'Interpretation templates' by sample template and type
+- #2058 Filter 'Interpretation templates' in sample view by template and type
 - #2048 Fix catalog logging counter duplicates
 - #2047 Make resultsinterpretation.pt to retrieve departments from viewlet
 - #2045 Fix instrument types instruments view

--- a/src/senaite/core/interfaces/__init__.py
+++ b/src/senaite/core/interfaces/__init__.py
@@ -113,3 +113,8 @@ class IFieldMigrator(Interface):
 class IDynamicLocalRoles(Interface):
     """Marker interface for objects with dynamic assignment of local roles
     """
+
+
+class IInterpretationTemplate(Interface):
+    """Marker interface for interpretation template objects
+    """

--- a/src/senaite/core/profiles/default/types/InterpretationTemplate.xml
+++ b/src/senaite/core/profiles/default/types/InterpretationTemplate.xml
@@ -42,7 +42,7 @@
   <property name="add_permission">cmf.AddPortalContent</property>
 
   <!-- Python class for content items of this sort -->
-  <property name="schema">senaite.core.content.interpretationtemplate.IInterpretationTemplate</property>
+  <property name="schema">senaite.core.content.interpretationtemplate.IInterpretationTemplateSchema</property>
   <property name="klass">senaite.core.content.interpretationtemplate.InterpretationTemplate</property>
 
   <!-- Dexterity behaviours for this type -->

--- a/src/senaite/core/upgrade/v02_03_000.py
+++ b/src/senaite/core/upgrade/v02_03_000.py
@@ -167,6 +167,5 @@ def fix_interface_interpretation_template(portal):
     logger.info("Fix interface for InterpretationTemplate FTI ...")
     pt = api.get_tool("portal_types")
     fti = pt.get("InterpretationTemplate")
-    import pdb;pdb.set_trace()
     fti.schema = "senaite.core.content.interpretationtemplate.IInterpretationTemplateSchema"
     logger.info("Fix interface for InterpretationTemplate FTI ...")

--- a/src/senaite/core/upgrade/v02_03_000.py
+++ b/src/senaite/core/upgrade/v02_03_000.py
@@ -65,6 +65,7 @@ def upgrade(tool):
     remove_stale_metadata(portal)
     fix_worksheets_analyses(portal)
     fix_cannot_create_partitions(portal)
+    fix_interface_interpretation_template(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
@@ -158,3 +159,14 @@ def del_metadata(catalog_id, column):
                     .format(column, catalog_id))
         return
     catalog.delColumn(column)
+
+
+def fix_interface_interpretation_template(portal):
+    """Applies IInterpretationTempalteSchema to InterpretationTemplate FTI
+    """
+    logger.info("Fix interface for InterpretationTemplate FTI ...")
+    pt = api.get_tool("portal_types")
+    fti = pt.get("InterpretationTemplate")
+    import pdb;pdb.set_trace()
+    fti.schema = "senaite.core.content.interpretationtemplate.IInterpretationTemplateSchema"
+    logger.info("Fix interface for InterpretationTemplate FTI ...")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes comments available in "Result Interpretation" section to be sample type or analysis template specific. This reduces the number of interpretation templates available for selection and reduce errors.

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR

System lists all the available interpretation templates for selection in "Results interpretation" section from inside sample view

## Desired behavior after PR is merged

System lists the interpretation template for selection in "Results interpretation" that suits well with the sample type and analysis template

![Captura de 2022-07-14 13-47-20](https://user-images.githubusercontent.com/832627/178977871-74efb273-941e-47a7-ba2d-d83ffff56d25.png)



--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
