### PR TITLE
Fix Definition not displayed in Reference Samples listing (#2028 port)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #2059 Fix Definition not displayed in Reference Samples listing (#2028 port)
+- #2059 Fix Supplier not displayed in Reference Samples listing (#2028 port)
 - #2057 Make "Other reasons" text area from rejection view wider (#2031 port)
 - #2056 Fix printed time does not get updated on re-print (#2043 port)
 - #2055 Fix Email address is not displayed in clients listing (#2030 port)

--- a/bika/lims/browser/referencesample.py
+++ b/bika/lims/browser/referencesample.py
@@ -403,17 +403,13 @@ class ReferenceSamplesView(BikaListingView):
                 "toggle": True}),
             ("Supplier", {
                 "title": _("Supplier"),
-                "toggle": True,
-                "attr": "aq_parent.Title",
-                "replace_url": "aq_parent.absolute_url"}),
+                "toggle": True}),
             ("Manufacturer", {
                 "title": _("Manufacturer"),
                 "toggle": True}),
             ("Definition", {
                 "title": _("Reference Definition"),
-                "toggle": True,
-                "attr": "getReferenceDefinition.Title",
-                "replace_url": "getReferenceDefinition.absolute_url"}),
+                "toggle": True}),
             ("DateSampled", {
                 "title": _("Date Sampled"),
                 "index": "getDateSampled",
@@ -512,6 +508,12 @@ class ReferenceSamplesView(BikaListingView):
         item["ExpiryDate"] = self.ulocalized_time(obj.getExpiryDate())
         manufacturer = obj.getManufacturer()
         item["replace"]["Manufacturer"] = get_link_for(manufacturer)
+
+        supplier = api.get_parent(obj)
+        item["replace"]["Supplier"] = get_link_for(supplier)
+
+        ref_definition = obj.getReferenceDefinition()
+        item["replace"]["Definition"] = get_link_for(ref_definition)
 
         # Icons
         after_icons = ''


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #2028 to 1.3.x

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
