### PR TITLE
Performance: Avoid to catalog temporary objects (#2015 + #2018 ports)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #2060 Added `api.is_temporary` function for both DX and AT types (#2018 port)
+- #2060 Performance: Avoid to catalog temporary objects (#2015 port)
 - #2057 Make "Other reasons" text area from rejection view wider (#2031 port)
 - #2056 Fix printed time does not get updated on re-print (#2043 port)
 - #2055 Fix Email address is not displayed in clients listing (#2030 port)

--- a/bika/lims/monkey/__init__.py
+++ b/bika/lims/monkey/__init__.py
@@ -20,23 +20,14 @@
 
 import add_senaite_site  # noqa
 
-from Acquisition import aq_base
-from Acquisition import aq_inner
-from Acquisition import aq_parent
+from bika.lims import api
 from Products.Archetypes import utils
 
 
 def isFactoryContained(obj):
     """Are we inside the portal_factory?
     """
-    if obj.isTemporary():
-        return True
-    parent = aq_parent(aq_inner(obj))
-    if parent is None:
-        # We don't have enough context to know where we are
-        return False
-    meta_type = getattr(aq_base(parent), "meta_type", "")
-    return meta_type == "TempFolder"
+    return api.is_temporary(obj)
 
 
 # https://pypi.org/project/collective.monkeypatcher/#patching-module-level-functions

--- a/bika/lims/monkey/archetypes.py
+++ b/bika/lims/monkey/archetypes.py
@@ -1,30 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import re
-
-from Acquisition import aq_inner
-from Acquisition import aq_parent
 from bika.lims import api
-from bika.lims import logger
-from Products.Archetypes.utils import shasattr
-
-TMP_RX = re.compile("[a-z0-9]{32}$")
-
-
-def is_tmp_id(id):
-    return TMP_RX.match(id)
 
 
 def isTemporary(self):
-    parent = aq_parent(aq_inner(self))
-    # Fix indexing of temporary objects resulting in orphan entries in catalog
-    # https://github.com/senaite/senaite.core/pull/1865
-    if is_tmp_id(self.id) or is_tmp_id(parent.id):
-        logger.debug("AT object %s is temporary!" % api.get_path(self))
-        return True
-    # Checks to see if we are created as temporary object by
-    # portal factory.
-    tmp = shasattr(parent, "meta_type") and parent.meta_type == "TempFolder"
-    return tmp
-
-
+    return api.is_temporary(self)

--- a/bika/lims/monkey/catalog.py
+++ b/bika/lims/monkey/catalog.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+from plone.indexer.interfaces import IIndexableObject
+from Products.ZCatalog.ZCatalog import ZCatalog
+from zope.component import queryMultiAdapter
+
+
+def catalog_object(self, object, uid=None, idxs=None,
+                   update_metadata=1, pghandler=None):
+
+    try:
+        # Never catalog temporary objects
+        temporary = object.isTemporary()
+        if temporary is True:
+            return
+    except AttributeError:
+        pass
+
+    if idxs is None:
+        idxs = []
+    self._increment_counter()
+
+    w = object
+    if not IIndexableObject.providedBy(object):
+        # This is the CMF 2.2 compatible approach, which should be used
+        # going forward
+        wrapper = queryMultiAdapter((object, self), IIndexableObject)
+        if wrapper is not None:
+            w = wrapper
+
+    ZCatalog.catalog_object(self, w, uid, idxs,
+                            update_metadata, pghandler=pghandler)

--- a/bika/lims/monkey/catalog.py
+++ b/bika/lims/monkey/catalog.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from bika.lims import api
 from plone.indexer.interfaces import IIndexableObject
 from Products.ZCatalog.ZCatalog import ZCatalog
 from zope.component import queryMultiAdapter
@@ -8,13 +9,9 @@ from zope.component import queryMultiAdapter
 def catalog_object(self, object, uid=None, idxs=None,
                    update_metadata=1, pghandler=None):
 
-    try:
-        # Never catalog temporary objects
-        temporary = object.isTemporary()
-        if temporary is True:
-            return
-    except AttributeError:
-        pass
+    # Never catalog temporary objects
+    if api.is_temporary(object):
+        return
 
     if idxs is None:
         idxs = []

--- a/bika/lims/monkey/configure.zcml
+++ b/bika/lims/monkey/configure.zcml
@@ -77,4 +77,11 @@
       replacement=".dexterity.isTemporary"
   />
 
+  <monkey:patch
+      description=""
+      class="Products.CMFPlone.CatalogTool.CatalogTool"
+      original="catalog_object"
+      replacement=".catalog.catalog_object"
+  />
+
 </configure>

--- a/bika/lims/monkey/dexterity.py
+++ b/bika/lims/monkey/dexterity.py
@@ -1,23 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import re
-
-from Acquisition import aq_inner
-from Acquisition import aq_parent
 from bika.lims import api
-from bika.lims import logger
-
-TMP_RX = re.compile("[a-z0-9]{32}$")
-
-
-def is_tmp_id(id):
-    return TMP_RX.match(id)
 
 
 def isTemporary(self):
-    parent = aq_parent(aq_inner(self))
-    # Fix indexing of temporary objects resulting in orphan entries in catalog
-    if is_tmp_id(self.id) or is_tmp_id(parent.id):
-        logger.debug("DX object %s is temporary!" % api.get_path(self))
-        return True
-    return False
+    return api.is_temporary(self)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #2015 and #2018 to 1.3.x

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
