### PR TITLE
Fire notifications when UID references are created/destroyed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2061 Fire notifications when UID references are created/destroyed
 - #2058 Filter 'Interpretation templates' in sample view by template and type
 - #2048 Fix catalog logging counter duplicates
 - #2047 Make resultsinterpretation.pt to retrieve departments from viewlet

--- a/src/senaite/core/events/uidreference.py
+++ b/src/senaite/core/events/uidreference.py
@@ -18,6 +18,12 @@ class IUIDReferenceDestroyedEvent(IObjectEvent):
 class UIDReferenceCreated(object):
 
     def __init__(self, field, source, target):
+        """Reference Created Event
+
+        :param field: The field on the source object
+        :param source: The context object holding the UID reference field
+        :param target: The context object being referenced
+        """
         self.field = field
         self.source = source
         self.target = target
@@ -31,6 +37,12 @@ class UIDReferenceCreated(object):
 class UIDReferenceDestroyed(object):
 
     def __init__(self, field, source, target):
+        """Reference Destroyed Event
+
+        :param field: The field on the source object
+        :param source: The context object holding the UID reference field
+        :param target: The context object being referenced
+        """
         self.field = field
         self.source = source
         self.target = target

--- a/src/senaite/core/events/uidreference.py
+++ b/src/senaite/core/events/uidreference.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+from zope.interface import implementer
+from zope.interface.interfaces import IObjectEvent
+
+
+class IUIDReferenceCreatedEvent(IObjectEvent):
+    """An event fired after a reference between two objects was cretated
+    """
+
+
+class IUIDReferenceDestroyedEvent(IObjectEvent):
+    """An event fired after a reference between two objects was destroyed
+    """
+
+
+@implementer(IUIDReferenceCreatedEvent)
+class UIDReferenceCreated(object):
+
+    def __init__(self, field, source, target):
+        self.field = field
+        self.source = source
+        self.target = target
+
+        # See IObjectEvent
+        # -> Allow to define an event subscriber for a custom type
+        self.object = source
+
+
+@implementer(IUIDReferenceDestroyedEvent)
+class UIDReferenceDestroyed(object):
+
+    def __init__(self, field, source, target):
+        self.field = field
+        self.source = source
+        self.target = target
+
+        # See IObjectEvent
+        # -> Allow to define an event subscriber for a custom type
+        self.object = source

--- a/src/senaite/core/schema/configure.zcml
+++ b/src/senaite/core/schema/configure.zcml
@@ -3,6 +3,9 @@
     i18n_domain="senaite.core">
 
   <!-- Event subscribers -->
-  <subscriber handler=".uidreferencefield.on_object_created" />
+  <subscriber
+      for="senaite.core.interfaces.IHaveUIDReferences
+           zope.lifecycleevent.interfaces.IObjectCreatedEvent"
+      handler=".uidreferencefield.on_object_created" />
 
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds 2 notification events for UIDReference fields:

- IUIDReferenceCreatedEvent
- IUIDReferenceDestroyedEvent

Code that would like to e.g. reindex the target object when a reference is created/destroyed, might register event handlers like this:

```xml
<configure>
  <subscriber
      for="senaite.core.interfaces.IHaveUIDReferences
           senaite.core.events.uidreference.IUIDReferenceCreatedEvent"
      handler=".handlers.on_reference_created" />

  <subscriber
      for="senaite.core.interfaces.IHaveUIDReferences
           senaite.core.events.uidreference.IUIDReferenceDestroyedEvent"
      handler=".handlers.on_reference_destroyed" />
</configure>
```

The code implementation looks like this:

```python
def on_reference_created(object, event):
    """Reindex the referenced (target) object if needed
    """
    event.target.reindexObject()


def on_reference_destroyed(object, event):
    """Reindex the referenced (target) object if needed
    """
    event.target.reindexObject()
```

**☝️ NOTE**
Currently these events are only fired for the new DX based UID reference field

## Current behavior before PR

No events fired when a reference between two objects is created/destroyed

## Desired behavior after PR is merged

Events fired when a reference between two objects is created/destroyed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
