### PR TITLE
Fix Traceback for SENAITE Setup during installation

### DIFF
--- a/src/bika/lims/content/bikasetup.py
+++ b/src/bika/lims/content/bikasetup.py
@@ -989,13 +989,17 @@ class BikaSetup(folder.ATFolder):
         """Get the value from the senaite setup
         """
         setup = api.get_senaite_setup()
-        return setup.getEmailBodySamplePublication()
+        # setup is `None` during initial site content structure installation
+        if setup:
+            return setup.getEmailBodySamplePublication()
 
     def setEmailBodySamplePublication(self, value):
         """Set the value in the senaite setup
         """
         setup = api.get_senaite_setup()
-        setup.setEmailBodySamplePublication(value)
+        # setup is `None` during initial site content structure installation
+        if setup:
+            setup.setEmailBodySamplePublication(value)
 
 
 registerType(BikaSetup, PROJECTNAME)

--- a/src/senaite/core/setuphandlers.py
+++ b/src/senaite/core/setuphandlers.py
@@ -172,9 +172,6 @@ def install(context):
     logger.info("SENAITE CORE install handler [BEGIN]")
     portal = context.getSite()
 
-    # Used in bika_setup, therefore it has to be added here
-    add_senaite_setup(portal)
-
     # Run required import steps
     _run_import_step(portal, "skins")
     _run_import_step(portal, "browserlayer")
@@ -200,6 +197,7 @@ def install(context):
     setup_catalog_mappings(portal)
     setup_auditlog_catalog_mappings(portal)
     setup_content_structure(portal)
+    add_senaite_setup(portal)
     add_dexterity_portal_items(portal)
     add_dexterity_setup_items(portal)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a Traceback that occurs during initial site installation which was introduced in #2063

## Current behavior before PR

Traceback happens during initial site installation, because the site structure has not been yet setup and because the old setup is created before the new setup container.

## Desired behavior after PR is merged

initial site installation works w/o Tracebacks

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
