### PR TITLE
Replace ParentAnalysisRequest ReferenceField by UIDReferenceField

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2067 Replace ParentAnalysisRequest ReferenceField by UIDReferenceField
 - #2066 Fix samples w/o active analyses are displayed under "unassigned" filter
 - #2065 Fix "Create Worksheet" modal visible for samples w/o unassigned analyses
 - #2063 Allow to customize email publication template in setup

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -1243,7 +1243,7 @@ schema = BikaSchema.copy() + Schema((
         widget=ComputedWidget(visible=False),
     ),
 
-    ReferenceField(
+    UIDReferenceField(
         'ParentAnalysisRequest',
         allowed_types=('AnalysisRequest',),
         relationship='AnalysisRequestParentAnalysisRequest',

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -2271,10 +2271,7 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
         This method is used as metadata
         """
         rel_id = "AnalysisRequestParentAnalysisRequest"
-        uids = get_backreferences(self, relationship=rel_id)
-        if not uids:
-            return []
-        return uids
+        return get_backreferences(self, relationship=rel_id)
 
     def isPartition(self):
         """Returns true if this Analysis Request is a partition

--- a/src/senaite/core/catalog/indexer/sample.py
+++ b/src/senaite/core/catalog/indexer/sample.py
@@ -42,8 +42,8 @@ def assigned_state(instance):
     # ARAnalysesField getter returns all the analyses from the sample, those
     # from partitions included. Since we do not rely on the getter, we need to
     # manually extract the analyses from the partitions
-    # Pity is, that for the retrieval of partitions we need to rely on
-    # getBackReferences, that is a query against reference_catalog
+    # Pity is, that for the retrieval of partitions we need to rely on a
+    # query against uid_catalog (get_backreferences)
     for partition in instance.getDescendants():
         # Note we call this same index, but for the partition
         partition_status = assigned_state(partition)()

--- a/src/senaite/core/upgrade/v02_03_000.py
+++ b/src/senaite/core/upgrade/v02_03_000.py
@@ -93,18 +93,23 @@ def fix_samples_primary(portal):
         if num and num % 10 == 0:
             logger.info("Processed samples: {}/{}".format(num, total))
 
-        # Extract the primary from this sample
+        # Extract the parent(s) from this sample
         sample = api.get_object(sample)
-        primary = sample.getRefs(relationship=ref_id)
-        if not primary:
+        parents = sample.getRefs(relationship=ref_id)
+        if not parents:
             # Processed already
             continue
 
-        # Re-assign the primary sample
-        sample.setPrimaryAnalysisRequest(primary)
+        # Re-assign the parent sample(s)
+        sample.setParentAnalysisRequest(parents)
 
         # Remove this relationship from reference catalog
         ref_tool.deleteReferences(sample, relationship=ref_id)
+
+        # Reindex both the partition and parent(s)
+        sample.reindexObject()
+        for primary_sample in parents:
+            primary_sample.reindexObject()
 
     logger.info("Fix AnalysisRequests PrimaryAnalysisRequest [DONE]")
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request replaces the type of the field "ParentAnalysisRequest", from "ReferenceField" to "UIDReferenceField". This makes the system faster and more reliable, since system no need to rely on `reference_catalog` for the retrieval of reference objects, but on `uid_catalog` only.

## Current behavior before PR

The field "ParentAnalysisRequest" from "AnalysisRequest" is from "ReferenceField" type

## Desired behavior after PR is merged

The field "ParentAnalysisRequest" from "AnalysisRequest" is from "UIDReferenceField" type

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
