### PR TITLE
Move sample reports to report catalog, add batch ID and email sent flag to listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2071 Include batch in report listing and move ARReports to report catalog
 - #2066 Fix samples w/o active analyses are displayed under "unassigned" filter
 - #2065 Fix "Create Worksheet" modal visible for samples w/o unassigned analyses
 - #2063 Allow to customize email publication template in setup

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
-- #2071 Include batch in report listing and move ARReports to report catalog
+- #2071 Move sample reports to report catalog and add batch ID and email sent flag in listing columns
 - #2066 Fix samples w/o active analyses are displayed under "unassigned" filter
 - #2065 Fix "Create Worksheet" modal visible for samples w/o unassigned analyses
 - #2063 Allow to customize email publication template in setup

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
-- #2071 Move sample reports to report catalog and add batch ID and email sent flag in listing columns
+- #2071 Move sample reports to report catalog, add batch ID and email sent flag to listing
 - #2066 Fix samples w/o active analyses are displayed under "unassigned" filter
 - #2065 Fix "Create Worksheet" modal visible for samples w/o unassigned analyses
 - #2063 Allow to customize email publication template in setup

--- a/src/bika/lims/browser/publish/reports_listing.py
+++ b/src/bika/lims/browser/publish/reports_listing.py
@@ -119,6 +119,8 @@ class ReportsListingView(BikaListingView):
                 "title": _("Published Date")},),
             ("PublishedBy", {
                 "title": _("Published By")},),
+            ("Sent", {
+                "title": _("Email sent")},),
             ("Recipients", {
                 "title": _("Recipients")},),
         ))
@@ -202,6 +204,10 @@ class ReportsListingView(BikaListingView):
         fmt_date = self.localize_date(obj.created())
         item["Date"] = fmt_date
         item["PublishedBy"] = self.user_fullname(obj.Creator())
+
+        item["Sent"] = _("No")
+        if obj.getSendLog():
+            item["Sent"] = _("Yes")
 
         # N.B. There is a bug in the current publication machinery, so that
         # only the primary contact get stored in the Attachment as recipient.

--- a/src/bika/lims/browser/publish/reports_listing.py
+++ b/src/bika/lims/browser/publish/reports_listing.py
@@ -27,6 +27,7 @@ from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.utils import get_link
 from bika.lims.utils import to_utf8
 from Products.CMFPlone.utils import safe_unicode
+from senaite.core.catalog import REPORT_CATALOG
 from ZODB.POSException import POSKeyError
 
 
@@ -37,7 +38,7 @@ class ReportsListingView(BikaListingView):
     def __init__(self, context, request):
         super(ReportsListingView, self).__init__(context, request)
 
-        self.catalog = "portal_catalog"
+        self.catalog = REPORT_CATALOG
         self.contentFilter = {
             "portal_type": "ARReport",
             "path": {

--- a/src/bika/lims/browser/publish/reports_listing.py
+++ b/src/bika/lims/browser/publish/reports_listing.py
@@ -106,6 +106,8 @@ class ReportsListingView(BikaListingView):
             ("AnalysisRequest", {
                 "title": _("Primary Sample"),
                 "index": "sortable_title"},),
+            ("Batch", {
+                "title": _("Batch")},),
             ("State", {
                 "title": _("Review State")},),
             ("PDF", {
@@ -176,6 +178,15 @@ class ReportsListingView(BikaListingView):
         item["replace"]["AnalysisRequest"] = get_link(
             ar.absolute_url(), value=ar.Title()
         )
+
+        # Include Batch information of the primary Sample
+        batch_id = ar.getBatchID()
+        item["Batch"] = batch_id
+        if batch_id:
+            batch = ar.getBatch()
+            item["replace"]["Batch"] = get_link(
+                batch.absolute_url(), value=batch.Title()
+            )
 
         pdf = self.get_pdf(obj)
         filesize = self.get_filesize(pdf)

--- a/src/senaite/core/catalog/indexer/arreport.py
+++ b/src/senaite/core/catalog/indexer/arreport.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from bika.lims import api
 from bika.lims.interfaces import IARReport
 from plone.indexer import indexer
 
@@ -9,3 +10,20 @@ def sample_uid(instance):
     """Returns a list of UIDs of the contained Samples
     """
     return instance.getRawContainedAnalysisRequests()
+
+
+@indexer(IARReport)
+def arreport_searchable_text(instance):
+    sample = instance.getAnalysisRequest()
+    metadata = instance.getMetadata() or {}
+    tokens = [
+        sample.getId(),
+        sample.getBatchID(),
+        metadata.get("paperformat", ""),
+        metadata.get("orientation", ""),
+        metadata.get("template", ""),
+    ]
+    # Extend IDs of contained Samples
+    contained_samples = instance.getContainedAnalysisRequests()
+    tokens.extend(map(api.get_id, contained_samples))
+    return u" ".join(list(set(tokens)))

--- a/src/senaite/core/catalog/indexer/arreport.py
+++ b/src/senaite/core/catalog/indexer/arreport.py
@@ -16,6 +16,7 @@ def sample_uid(instance):
 def arreport_searchable_text(instance):
     sample = instance.getAnalysisRequest()
     metadata = instance.getMetadata() or {}
+
     tokens = [
         sample.getId(),
         sample.getBatchID(),
@@ -23,7 +24,17 @@ def arreport_searchable_text(instance):
         metadata.get("orientation", ""),
         metadata.get("template", ""),
     ]
+
     # Extend IDs of contained Samples
     contained_samples = instance.getContainedAnalysisRequests()
     tokens.extend(map(api.get_id, contained_samples))
+
+    # Extend email recipients
+    recipients = []
+    for log in instance.getSendLog():
+        for recipient in log.get("email_recipients", []):
+            recipients.append(recipient)
+
+    tokens.extend(recipients)
+
     return u" ".join(list(set(tokens)))

--- a/src/senaite/core/catalog/indexer/configure.zcml
+++ b/src/senaite/core/catalog/indexer/configure.zcml
@@ -20,6 +20,7 @@
 
   <!-- ARReport Indexer -->
   <adapter name="sample_uid" factory=".arreport.sample_uid"/>
+  <adapter name="arreport_searchable_text" factory=".arreport.arreport_searchable_text"/>
 
   <!-- Auditlog Indexer -->
   <adapter name="action" factory=".auditlog.action"/>

--- a/src/senaite/core/catalog/report_catalog.py
+++ b/src/senaite/core/catalog/report_catalog.py
@@ -13,6 +13,7 @@ CATALOG_TITLE = "Senaite Report Catalog"
 INDEXES = BASE_INDEXES + [
     # id, indexed attribute, type
     ("getClientUID", "", "FieldIndex"),
+    ("arreport_searchable_text", "", "ZCTextIndex"),
 ]
 
 COLUMNS = BASE_COLUMNS + [
@@ -26,6 +27,7 @@ COLUMNS = BASE_COLUMNS + [
 TYPES = [
     # portal_type name
     "Report",
+    "ARReport",
 ]
 
 

--- a/src/senaite/core/setuphandlers.py
+++ b/src/senaite/core/setuphandlers.py
@@ -128,6 +128,7 @@ COLUMNS = (
 
 CATALOG_MAPPINGS = (
     # portal_type, catalog_ids
+    ("ARReport", ["senaite_catalog_report", "portal_catalog"]),
     ("ARTemplate", ["senaite_catalog_setup", "portal_catalog"]),
     ("AnalysisCategory", ["senaite_catalog_setup", "portal_catalog"]),
     ("AnalysisProfile", ["senaite_catalog_setup", "portal_catalog"]),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds a new column "Batch" and "Email sent" to the reports list:

<img width="1918" alt="TW000004 — SENAITE LIMS 2022-07-26 5 PM-28-36" src="https://user-images.githubusercontent.com/713193/181047502-7c5192a6-137e-4806-b872-dc3faf3f6b31.png">

Furthermore, it moves `ARReport` objects to be indexed in reports catalog and use a searchable text index to filter the listing properly.

## Current behavior before PR

- No Batch ID column in reports listing
- No Email sent flag in reports listing
- Not possible to filter the listing view via the search field

## Desired behavior after PR is merged

- Batch ID column in reports listing
- Email sent flag in reports listing
- Possible to search for reports

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
