### PR TITLE
Refactor report filename generation to own method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2072 Refactor report filename generation to own method
 - #2066 Fix samples w/o active analyses are displayed under "unassigned" filter
 - #2065 Fix "Create Worksheet" modal visible for samples w/o unassigned analyses
 - #2063 Allow to customize email publication template in setup

--- a/src/bika/lims/browser/publish/downloadview.py
+++ b/src/bika/lims/browser/publish/downloadview.py
@@ -18,6 +18,7 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from bika.lims import api
 from Products.Five.browser import BrowserView
 
 
@@ -29,10 +30,15 @@ class DownloadView(BrowserView):
         super(DownloadView, self).__init__(context, request)
 
     def __call__(self):
-        ar = self.context.getAnalysisRequest()
-        filename = "{}.pdf".format(ar.getId())
+        filename = self.get_report_filename(self.context)
         pdf = self.context.getPdf()
         self.download(pdf.data, filename)
+
+    def get_report_filename(self, report):
+        """Generate the filename for the sample PFD
+        """
+        sample = report.getAnalysisRequest()
+        return "{}.pdf".format(api.get_id(sample))
 
     def download(self, data, filename, content_type="application/pdf"):
         """Download the PDF

--- a/src/bika/lims/browser/publish/downloadview.py
+++ b/src/bika/lims/browser/publish/downloadview.py
@@ -35,7 +35,7 @@ class DownloadView(BrowserView):
         self.download(pdf.data, filename)
 
     def get_report_filename(self, report):
-        """Generate the filename for the sample PFD
+        """Generate the filename for the sample PDF
         """
         sample = report.getAnalysisRequest()
         return "{}.pdf".format(api.get_id(sample))

--- a/src/bika/lims/browser/publish/emailview.py
+++ b/src/bika/lims/browser/publish/emailview.py
@@ -319,8 +319,7 @@ class EmailView(BrowserView):
                 logger.error("Skipping empty PDF for report {}"
                              .format(report.getId()))
                 continue
-            sample = report.getAnalysisRequest()
-            filename = "{}.pdf".format(api.get_id(sample))
+            filename = self.get_report_filename(report)
             filedata = pdf.data
             attachments.append(
                 mailapi.to_email_attachment(filedata, filename))
@@ -550,7 +549,7 @@ class EmailView(BrowserView):
         attachments_data = map(self.get_attachment_data, attachments)
         pdf = self.get_pdf(report)
         filesize = "{} Kb".format(self.get_filesize(pdf))
-        filename = "{}.pdf".format(sample.getId())
+        filename = self.get_report_filename(report)
 
         return {
             "sample": sample,
@@ -699,6 +698,12 @@ class EmailView(BrowserView):
             return float("%.2f" % (filesize / 1024))
         except (POSKeyError, TypeError, AttributeError):
             return 0.0
+
+    def get_report_filename(self, report):
+        """Generate the filename for the sample PFD
+        """
+        sample = report.getAnalysisRequest()
+        return "{}.pdf".format(api.get_id(sample))
 
     def get_pdf(self, obj):
         """Get the report PDF

--- a/src/bika/lims/browser/publish/emailview.py
+++ b/src/bika/lims/browser/publish/emailview.py
@@ -700,7 +700,7 @@ class EmailView(BrowserView):
             return 0.0
 
     def get_report_filename(self, report):
-        """Generate the filename for the sample PFD
+        """Generate the filename for the sample PDF
         """
         sample = report.getAnalysisRequest()
         return "{}.pdf".format(api.get_id(sample))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR refactors the report PDF filename generation to an explicit method

## Current behavior before PR

Report filename was generated in two places

## Desired behavior after PR is merged

Report filename is generated in explicit method

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
