### PR TITLE
Use <br/> to join email recipients

### DIFF
--- a/src/bika/lims/browser/publish/emailview.py
+++ b/src/bika/lims/browser/publish/emailview.py
@@ -488,7 +488,7 @@ class EmailView(BrowserView):
         recipients = self.email_recipients_and_responsibles
         if template_context is None:
             template_context = {
-                "recipients": "\n".join(recipients),
+                "recipients": "<br/>".join(recipients),
             }
 
         email_template = Template(safe_unicode(template)).safe_substitute(


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a minor styling issue that was introduced in https://github.com/senaite/senaite.core/pull/2063

## Current behavior before PR

Email recipients are concatenated with `\n` and displayed in the HTML email in one line

## Desired behavior after PR is merged

Email recipients are concatenated with `<br/>` and displayed in the HTML email with newlines

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
