### PR TITLE
Allow to disable global Auditlogging

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2074 Allow to disable global Auditlogging
 - #2072 Refactor report filename generation to own method
 - #2071 Move sample reports to report catalog, add batch ID and email sent flag to listing
 - #2070 Fix typo/duplicate translation key in colophon

--- a/src/bika/lims/content/bikasetup.py
+++ b/src/bika/lims/content/bikasetup.py
@@ -200,6 +200,21 @@ schema = BikaFolderSchema.copy() + Schema((
                           "this option will be checked and readonly.")
         )
     ),
+    # NOTE: This is a Proxy Field which delegates to the SENAITE Registry!
+    BooleanField(
+        "EnableGlobalAuditlog",
+        schemata="Security",
+        default=False,
+        widget=BooleanWidget(
+            label=_("Enable global Auditlog"),
+            description=_(
+                "The global Auditlog shows all modifications of the system. "
+                "When enabled, all entities will be indexed in a separate "
+                "catalog. This will increase the time when objects are "
+                "created or modified."
+            )
+        )
+    ),
     BooleanField(
         'ShowPrices',
         schemata="Accounting",
@@ -1000,6 +1015,23 @@ class BikaSetup(folder.ATFolder):
         # setup is `None` during initial site content structure installation
         if setup:
             setup.setEmailBodySamplePublication(value)
+
+    def getEnableGlobalAuditlog(self):
+        """Get the value from the senaite setup
+        """
+        setup = api.get_senaite_setup()
+        # setup is `None` during initial site content structure installation
+        if setup:
+            return setup.getEnableGlobalAuditlog()
+        return False
+
+    def setEnableGlobalAuditlog(self, value):
+        """Set the value in the senaite setup
+        """
+        setup = api.get_senaite_setup()
+        # setup is `None` during initial site content structure installation
+        if setup:
+            setup.setEnableGlobalAuditlog(value)
 
 
 registerType(BikaSetup, PROJECTNAME)

--- a/src/bika/lims/content/bikasetup.py
+++ b/src/bika/lims/content/bikasetup.py
@@ -206,7 +206,7 @@ schema = BikaFolderSchema.copy() + Schema((
         schemata="Security",
         default=False,
         widget=BooleanWidget(
-            label=_("Enable global Auditlog"),
+            label=_("Enable global Audit Log"),
             description=_(
                 "The global Auditlog shows all modifications of the system. "
                 "When enabled, all entities will be indexed in a separate "

--- a/src/senaite/core/browser/controlpanel/setupview.py
+++ b/src/senaite/core/browser/controlpanel/setupview.py
@@ -81,6 +81,10 @@ class SetupView(BrowserView):
         # filter out items
         items = filter(lambda item: not item.exclude_from_nav, items)
 
+        if self.setup.getEnableGlobalAuditlog() is False:
+            # remove the Auditlog tail
+            items = filter(lambda item: api.get_id(item) != "auditlog", items)
+
         # sort by (translated) title
         def cmp_by_translated_title(brain1, brain2):
             title1 = t(api.get_title(brain1))

--- a/src/senaite/core/browser/controlpanel/setupview.py
+++ b/src/senaite/core/browser/controlpanel/setupview.py
@@ -81,10 +81,6 @@ class SetupView(BrowserView):
         # filter out items
         items = filter(lambda item: not item.exclude_from_nav, items)
 
-        if self.setup.getEnableGlobalAuditlog() is False:
-            # remove the Auditlog tail
-            items = filter(lambda item: api.get_id(item) != "auditlog", items)
-
         # sort by (translated) title
         def cmp_by_translated_title(brain1, brain2):
             title1 = t(api.get_title(brain1))

--- a/src/senaite/core/browser/viewlets/auditlog.py
+++ b/src/senaite/core/browser/viewlets/auditlog.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+from bika.lims import api
+from plone.app.layout.viewlets import ViewletBase
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
+
+class AuditlogDisabledViewlet(ViewletBase):
+    """Viewlet that is displayed when the Auditlog is disabled
+    """
+    template = ViewPageTemplateFile("templates/auditlog_disabled.pt")
+
+    def __init__(self, context, request, view, manager=None):
+        super(AuditlogDisabledViewlet, self).__init__(
+            context, request, view, manager=manager)
+        self.context = context
+        self.request = request
+        self.view = view
+
+    @property
+    def setup(self):
+        return api.get_setup()
+
+    def get_setup_url(self):
+        """Return the absolute URL of the setup
+        """
+        return api.get_url(self.setup)
+
+    def is_enabled(self):
+        """Returns whether the global auditlog is disabled
+        """
+        return self.setup.getEnableGlobalAuditlog()
+
+    def is_disabled(self):
+        """Returns whether the global auditlog is disabled
+        """
+        return not self.is_enabled()
+
+    def index(self):
+        if self.is_enabled():
+            return ""
+        return self.template()

--- a/src/senaite/core/browser/viewlets/configure.zcml
+++ b/src/senaite/core/browser/viewlets/configure.zcml
@@ -328,4 +328,14 @@
       permission="zope2.View"
       layer="senaite.core.interfaces.ISenaiteCore" />
 
+  <!-- Auditlog viewlet -->
+  <browser:viewlet
+      for="bika.lims.interfaces.IAuditLog"
+      name="auditlog_disabled"
+      class=".auditlog.AuditlogDisabledViewlet"
+      manager="plone.app.layout.viewlets.interfaces.IAboveContent"
+      template="templates/auditlog_disabled.pt"
+      permission="zope2.View"
+      layer="senaite.core.interfaces.ISenaiteCore" />
+
 </configure>

--- a/src/senaite/core/browser/viewlets/templates/auditlog_disabled.pt
+++ b/src/senaite/core/browser/viewlets/templates/auditlog_disabled.pt
@@ -1,0 +1,22 @@
+<div tal:omit-tag=""
+     tal:condition="python:view.is_disabled()"
+     i18n:domain="senaite.core">
+
+  <div id="portal-alert">
+    <div class="portlet-alert-item alert alert-warning alert-dismissible">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <p class="title">
+        <strong i18n:translate="">
+          Global Audit Log is disabled
+        </strong>
+      </p>
+      <p class="description" i18n:translate="">
+        You can enable the global Audit Log again in the
+        <a href="#" tal:attributes="href python:view.get_setup_url()">Setup</a>
+      </p>
+    </div>
+  </div>
+
+</div>

--- a/src/senaite/core/patches/catalog.py
+++ b/src/senaite/core/patches/catalog.py
@@ -3,7 +3,15 @@
 from bika.lims import api
 from plone.indexer.interfaces import IIndexableObject
 from Products.ZCatalog.ZCatalog import ZCatalog
+from senaite.core.catalog import AUDITLOG_CATALOG
 from zope.component import queryMultiAdapter
+
+
+def is_auditlog_enabled():
+    setup = api.get_senaite_setup()
+    if not setup:
+        return False
+    return setup.getEnableGlobalAuditlog()
 
 
 def catalog_object(self, object, uid=None, idxs=None,
@@ -12,6 +20,11 @@ def catalog_object(self, object, uid=None, idxs=None,
     # Never catalog temporary objects
     if api.is_temporary(object):
         return
+
+    # skip indexing auditlog catalog if disabled
+    if self.id == AUDITLOG_CATALOG:
+        if not is_auditlog_enabled():
+            return
 
     if idxs is None:
         idxs = []


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds a setup option to enable/disable global Auditlogging.
When disabled, a status notification is displayed in the auditlog setup view.

Per default, global auditlogging is disabled.
This means, that for existing sites the global auditlogging must be explicitly enabled again if wanted. However, it will initially keep the auditlog catalog untouched to retain eventual existing catalog entries.

**☝️Note**:
When the global auditlog is disabled, the auditlog catalog is cleared.

<img width="1448" alt="Setup — SENAITE LIMS 2022-07-27 9 PM-14-47" src="https://user-images.githubusercontent.com/713193/181353736-6f0769d8-59da-4df2-b93e-884190fda1fb.png">

<img width="1418" alt="Audit Log — SENAITE LIMS 2022-07-28 1 PM-37-31" src="https://user-images.githubusercontent.com/713193/181496187-89e07e00-3eab-4828-8674-2934a75dc175.png">


## Current behavior before PR

Global auditlogging is disabled per default and decreases the performance when creating new samples or any other object in SENAITE

## Desired behavior after PR is merged

Global auditlogging is disabled per default and increases the performance when creating new samples or any other object in SENAITE

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
