### PR TITLE
Fix style of selected language in dropdown

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
-- #2076Fix style of selected language in dropdown
+- #2076 Fix style of selected language in dropdown
 - #2074 Allow to disable global Auditlogging
 - #2072 Refactor report filename generation to own method
 - #2071 Move sample reports to report catalog, add batch ID and email sent flag to listing

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2076Fix style of selected language in dropdown
 - #2074 Allow to disable global Auditlogging
 - #2072 Refactor report filename generation to own method
 - #2071 Move sample reports to report catalog, add batch ID and email sent flag to listing

--- a/src/senaite/core/browser/viewlets/templates/languageselector.pt
+++ b/src/senaite/core/browser/viewlets/templates/languageselector.pt
@@ -12,7 +12,7 @@
     </a>
 
     <!-- Available Languages -->
-    <ul class="dropdown-menu dropdown-menu-right"
+    <div class="dropdown-menu dropdown-menu-right"
         role="menu"
         aria-labelledby="portal-languageselector"
         tal:define="languages view/languages;
@@ -20,24 +20,25 @@
 
       <tal:language repeat="lang languages">
 
-        <li tal:define="code lang/code;
-                        qs request/QUERY_STRING;
-                        params python:filter(lambda x: x and not x.startswith('set_language'), qs.split('&'));
-                        lang_param string:set_language=${code};
-                        new_params python:'&'.join(params + [lang_param]);
-                        selected lang/selected;
-                        codeclass string:language-${code};
-                        current python: selected and 'currentLanguage active ' or '';"
-            tal:attributes="class string:${codeclass} nav-item">
+        <div tal:define="code lang/code;
+                         qs request/QUERY_STRING;
+                         params python:filter(lambda x: x and not x.startswith('set_language'), qs.split('&'));
+                         lang_param string:set_language=${code};
+                         new_params python:'&'.join(params + [lang_param]);
+                         selected lang/selected;
+                         codeclass string:language-${code};
+                         current python: selected and 'currentLanguage active dropdown-item' or 'dropdown-item';
+                         current_item python: selected and 'text-light' or '';"
+             tal:attributes="class string:${codeclass} ${current}">
           <a href="#"
-            tal:define="name lang/native|lang/name;"
-            tal:attributes="href string:${base_url}?${new_params};
-                            class string:${current} nav-link;
-                            title name">
+             tal:define="name lang/native|lang/name;"
+             tal:attributes="href string:${base_url}?${new_params};
+                             class string:${current_item} text-decoration-none;
+                             title name">
             <span tal:content="name"/>
           </a>
-        </li>
+        </div>
       </tal:language>
-    </ul>
+    </div>
   </nav>
 </tal:language>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the active style of the language selector dropdown
<img width="368" alt="Samples — SENAITE LIMS 2022-07-28 4 PM-47-49" src="https://user-images.githubusercontent.com/713193/181565993-1311f16f-7214-4b56-894f-8f3724b6b957.png">

## Current behavior before PR

Current language was not highlighted

## Desired behavior after PR is merged

Current language is highlighted

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
