### PR TITLE
Enable flake8 for new violations in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,5 @@ install:
 before_script:
   - bin/pip install flake8
 script:
-  - flake8 --config travis_ci_flake8.cfg src/
+  - bin/flake8 --config travis_ci_flake8.cfg src/
   - bin/test -s senaite.core.tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ before_install:
 install:
   - bin/buildout -N -t 3
 script:
+  - flake8 --config travis_ci_flake8.cfg src/
   - bin/test -s senaite.core.tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ before_install:
   - bin/buildout -N -t 3 annotate
 install:
   - bin/buildout -N -t 3
+before_script:
+  - bin/pip install flake8
 script:
   - flake8 --config travis_ci_flake8.cfg src/
   - bin/test -s senaite.core.tests

--- a/travis_ci_flake8.cfg
+++ b/travis_ci_flake8.cfg
@@ -1,0 +1,135 @@
+[flake8]
+# temporarily disable violations for existing code until they are cleaned up
+ignore =
+    # E101: indentation contains mixed spaces and tabs
+    E101,
+    # E111: indentation is not a multiple of 4
+    E111,
+    # E114: indentation is not a multiple of 4 (comment)
+    E114,
+    # E115: expected an indented block (comment)
+    E115,
+    # E116: unexpected indentation (comment)
+    E116,
+    # E117: over-indented
+    E117,
+    # E121: continuation line under-indented for hanging indent
+    E121,
+    # E122: continuation line missing indentation or outdented
+    E122,
+    # E123: closing bracket does not match indentation of opening bracket's line
+    E123,
+    # E124: closing bracket does not match visual indentation
+    E124,
+    # E125: continuation line with same indent as next logical line
+    E125,
+    # E126: continuation line over-indented for hanging indent
+    E126,
+    # E127: continuation line over-indented for visual indent
+    E127,
+    # E128: continuation line under-indented for visual indent
+    E128,
+    # E129: visually indented line with same indent as next logical line
+    E129,
+    # E131: continuation line unaligned for hanging indent
+    E131,
+    # E201: whitespace after '('
+    E201,
+    # E202: whitespace before ')'
+    E202,
+    # E203: whitespace before ','
+    E203,
+    # E221: multiple spaces before operator
+    E221,
+    # E222: multiple spaces after operator
+    E222,
+    # E225: missing whitespace around operator
+    E225,
+    # E226: missing whitespace around arithmetic operator
+    E226,
+    # E228: missing whitespace around modulo operator
+    E228,
+    # E231: missing whitespace after ','
+    E231,
+    # E241: multiple spaces after ':'
+    E241,
+    # E251: unexpected spaces around keyword / parameter equals
+    E251,
+    # E261: at least two spaces before inline comment
+    E261,
+    # E262: inline comment should start with '# '
+    E262,
+    # E265: block comment should start with '# '
+    E265,
+    # E266: too many leading '#' for block comment
+    E266,
+    # E271: multiple spaces after keyword
+    E271,
+    # E301: expected 1 blank line, found 0
+    E301,
+    # E302: expected 2 blank lines, found 1
+    E302,
+    # E303: too many blank lines (2)
+    E303,
+    # E305: expected 2 blank lines after class or function definition, found 1
+    E305,
+    # E306: expected 1 blank line before a nested definition, found 0
+    E306,
+    # E401: multiple imports on one line
+    E401,
+    # E501: line too long (80 > 79 characters)
+    E501,
+    # E502: the backslash is redundant between brackets
+    E502,
+    # E701: multiple statements on one line (colon)
+    E701,
+    # E703: statement ends with a semicolon
+    E703,
+    # E712: comparison to False should be 'if cond is False:' or 'if not cond:'
+    E712,
+    # E713: test for membership should be 'not in'
+    E713,
+    # E721: do not compare types, use 'isinstance()'
+    E721,
+    # E722: do not use bare 'except'
+    E722,
+    # F401: 'bika.lims.interfaces.ISubmitted' imported but unused
+    F401,
+    # F403: 'from bika.lims.permissions import *' used; unable to detect undefined names
+    F403,
+    # F405: 'AddAnalysisProfile' may be undefined, or defined from star imports: bika.lims.permissions
+    F405,
+    # F523: '...'.format(...) has unused arguments at position(s): 0
+    F523,
+    # F524: '...'.format(...) is missing argument(s) for placeholder(s): 3
+    F524,
+    # F632: use ==/!= to compare constant literals (str, bytes, int, float, tuple)
+    F632,
+    # F706: 'return' outside function
+    F706,
+    # F811: redefinition of unused 'StringIO' from line 27
+    F811,
+    # F812: list comprehension redefines 'service' from line 446
+    F812,
+    # F821: undefined name 'Report'
+    F821,
+    # F841: local variable 'icon' is assigned to but never used
+    F841,
+    # F901: 'raise NotImplemented' should be 'raise NotImplementedError'
+    F901,
+    # W191: indentation contains tabs
+    W191,
+    # W291: trailing whitespace
+    W291,
+    # W293: blank line contains whitespace
+    W293,
+    # W391: blank line at end of file
+    W391,
+    # W503: line break before binary operator
+    W503,
+    # W504: line break after binary operator
+    W504,
+    # W601: .has_key() is deprecated, use 'in'
+    W601,
+    # W605: invalid escape sequence '\d'
+    W605,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Enables flake8 in Travis CI but ignores all existing violations so we don't have to clean them up all at once.
We can then remove the ignored rules one by one from the config file to make flake8 stricter on new code.

## Current behavior before PR

No automated checks for code style in pull requests.

## Desired behavior after PR is merged

Travis CI complains about new violations.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
