### PR TITLE
Replace dynamic code execution with dynamic import in reports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2078 Replace dynamic code execution with dynamic import in reports
 - #2074 Allow to disable global Auditlogging
 - #2072 Refactor report filename generation to own method
 - #2071 Move sample reports to report catalog, add batch ID and email sent flag to listing

--- a/src/bika/lims/browser/reports/__init__.py
+++ b/src/bika/lims/browser/reports/__init__.py
@@ -257,11 +257,11 @@ class SubmitForm(BrowserView):
         else:
             module = "bika.lims.browser.reports.%s" % report_id
         try:
-            exec ("from %s import Report" % module)
+            Report = getattr(__import__(module), "Report")
             # required during error redirect: the report must have a copy of
             # additional_reports, because it is used as a surrogate view.
             Report.additional_reports = self.additional_reports
-        except ImportError:
+        except (ImportError, AttributeError):
             message = "Report %s.Report not found (shouldn't happen)" % module
             self.logger.error(message)
             self.context.plone_utils.addPortalMessage(message, 'error')

--- a/src/bika/lims/browser/reports/__init__.py
+++ b/src/bika/lims/browser/reports/__init__.py
@@ -18,6 +18,7 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import importlib
 import os
 
 from bika.lims import bikaMessageFactory as _
@@ -257,7 +258,7 @@ class SubmitForm(BrowserView):
         else:
             module = "bika.lims.browser.reports.%s" % report_id
         try:
-            Report = getattr(__import__(module), "Report")
+            Report = getattr(importlib.import_module(module), "Report")
             # required during error redirect: the report must have a copy of
             # additional_reports, because it is used as a surrogate view.
             Report.additional_reports = self.additional_reports

--- a/src/senaite/core/content/senaitesetup.py
+++ b/src/senaite/core/content/senaitesetup.py
@@ -172,3 +172,4 @@ class Setup(Container):
         """
         mutator = self.mutator("site_logo_css")
         return mutator(self, value)
+    


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Import report class using `importlib` instead of `exec`.

## Current behavior before PR

Code to be executed is concatenated at run time and contains a potentially unsanitized request parameter.
Also global symbol `Report` is only known at runtime which confuses static code analysis.

## Desired behavior after PR is merged

Make sure we only dynamically import a module and don't execute any other (potentially dangerous) code.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
