### PR TITLE
Include sample ID in form ID for lab, field and qc analyses listings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2082 Include sample ID in form ID for lab, field and qc analyses listings
 - #2074 Allow to disable global Auditlogging
 - #2072 Refactor report filename generation to own method
 - #2071 Move sample reports to report catalog, add batch ID and email sent flag to listing

--- a/src/bika/lims/browser/analysisrequest/tables.py
+++ b/src/bika/lims/browser/analysisrequest/tables.py
@@ -35,7 +35,7 @@ class LabAnalysesTable(AnalysesView):
             "getAncestorsUIDs": [api.get_uid(context)]
         })
 
-        self.form_id = "lab_analyses"
+        self.form_id = "{}_lab_analyses".format(api.get_id(context))
         self.allow_edit = True
         self.show_workflow_action_buttons = True
         self.show_select_column = True
@@ -54,7 +54,7 @@ class FieldAnalysesTable(AnalysesView):
             "getAncestorsUIDs": [api.get_uid(context)]
         })
 
-        self.form_id = "field_analyses"
+        self.form_id = "{}_field_analyses".format(api.get_id(context))
         self.allow_edit = True
         self.show_workflow_action_buttons = True
         self.show_select_column = True
@@ -68,7 +68,7 @@ class QCAnalysesTable(QCAnalysesView):
     def __init__(self, context, request):
         super(QCAnalysesTable, self).__init__(context, request)
 
-        self.form_id = "qc_analyses"
+        self.form_id = "{}_qc_analyses".api.get_id(context)
         self.allow_edit = False
         self.show_select_column = False
         self.show_workflow_action_buttons = False

--- a/src/bika/lims/browser/analysisrequest/tables.py
+++ b/src/bika/lims/browser/analysisrequest/tables.py
@@ -35,7 +35,7 @@ class LabAnalysesTable(AnalysesView):
             "getAncestorsUIDs": [api.get_uid(context)]
         })
 
-        self.form_id = "{}_lab_analyses".format(api.get_id(context))
+        self.form_id = "%s_lab_analyses" % api.get_id(context)
         self.allow_edit = True
         self.show_workflow_action_buttons = True
         self.show_select_column = True
@@ -54,7 +54,7 @@ class FieldAnalysesTable(AnalysesView):
             "getAncestorsUIDs": [api.get_uid(context)]
         })
 
-        self.form_id = "{}_field_analyses".format(api.get_id(context))
+        self.form_id = "%s_field_analyses" % api.get_id(context)
         self.allow_edit = True
         self.show_workflow_action_buttons = True
         self.show_select_column = True
@@ -68,7 +68,7 @@ class QCAnalysesTable(QCAnalysesView):
     def __init__(self, context, request):
         super(QCAnalysesTable, self).__init__(context, request)
 
-        self.form_id = "{}_qc_analyses".api.get_id(context)
+        self.form_id = "%s_qc_analyses" % api.get_id(context)
         self.allow_edit = False
         self.show_select_column = False
         self.show_workflow_action_buttons = False


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the listing table `form_id` for the lab, field and qc analyses tables to include the ID of the sample as well.

This is needed to render multiple analyses tables from different samples on one page.
 
## Current behavior before PR

The `form_id` of the analyses listing tables is always the same per sample

## Desired behavior after PR is merged

The `form_id` of the analyses listing tables contains the ID of each sample

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
