### PR TITLE
Lookup workflow action redirect URL from request first

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2083 Lookup workflow action redirect URL from request first
 - #2074 Allow to disable global Auditlogging
 - #2072 Refactor report filename generation to own method
 - #2071 Move sample reports to report catalog, add batch ID and email sent flag to listing

--- a/src/bika/lims/browser/workflow/__init__.py
+++ b/src/bika/lims/browser/workflow/__init__.py
@@ -45,10 +45,20 @@ class RequestContextAware(object):
         """Redirect with a message
         """
         if redirect_url is None:
-            redirect_url = self.back_url
+            redirect_url = self.get_redirect_url()
         if message is not None:
             self.add_status_message(message, level)
         return self.request.response.redirect(redirect_url)
+
+    def get_redirect_url(self):
+        """Lookup the redirect URL
+        """
+        # Allow to set redirect_url in the request
+        redirect_url = self.request.get("redirect_url")
+        if not redirect_url:
+            # fall back to view attribute
+            return self.back_url
+        return redirect_url
 
     def add_status_message(self, message, level="info"):
         """Set a portal status message


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR allows the workflow action machinery from listing tables to lookup the redirect URL from the request variable `redirect_url`
 
## Current behavior before PR

Only `back_url` of the adapter was considered to lookup the redirect URL

## Desired behavior after PR is merged

The request might set an explicit redirect URL via the `redirect_url` variable

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
