### PR TITLE
Enable checks for mismatching format arguments (F523, F524)

### DIFF
--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -276,8 +276,7 @@ def create_retest(ar):
 
     if not ar.isInvalid():
         # Analysis Request must be in 'invalid' state
-        raise ValueError("Cannot do a retest from an invalid Analysis Request"
-                         .format(repr(ar)))
+        raise ValueError("Cannot do a retest from an invalid Analysis Request")
 
     # Open the actions pool
     actions_pool = ActionHandlerPool.get_instance()

--- a/src/senaite/core/exportimport/setupdata/__init__.py
+++ b/src/senaite/core/exportimport/setupdata/__init__.py
@@ -430,9 +430,10 @@ class Lab_Contacts(WorksheetImporter):
                 username = safe_unicode(row['Username']).encode('utf-8')
                 passw = row['Password']
                 if not passw:
-                    warn = "Lab Contact: No password defined for user '{0}' in row {1}. Password established automatically to '{3}'".format(username, str(rownum), username)
-                    logger.warning(warn)
                     passw = username
+                    warn = ("Lab Contact: No password defined for user '{0}' in row {1}."
+                            " Password established automatically to '{2}'").format(username, str(rownum), passw)
+                    logger.warning(warn)
 
                 try:
                     member = portal_registration.addMember(

--- a/travis_ci_flake8.cfg
+++ b/travis_ci_flake8.cfg
@@ -99,10 +99,6 @@ ignore =
     F403,
     # F405: 'AddAnalysisProfile' may be undefined, or defined from star imports: bika.lims.permissions
     F405,
-    # F523: '...'.format(...) has unused arguments at position(s): 0
-    F523,
-    # F524: '...'.format(...) is missing argument(s) for placeholder(s): 3
-    F524,
     # F632: use ==/!= to compare constant literals (str, bytes, int, float, tuple)
     F632,
     # F706: 'return' outside function


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fixes existing mismatches of format arguments and enables corresponding flake8 checks (F523, F524).