### PR TITLE
Extend default ignores of flake8

### DIFF
--- a/src/senaite/core/exportimport/instruments/__init__.py
+++ b/src/senaite/core/exportimport/instruments/__init__.py
@@ -54,7 +54,7 @@ from rigaku.supermini import wxrf
 from myself import myinstrument
 from nuclisens import easyq
 from genexpert import genexpert
-from varian.vistapro import icp
+from varian.vistapro import icp as icp_2
 from cobasintegra.model_400_plus import model_400_plus
 from facscalibur.calibur import model_e9750
 

--- a/travis_ci_flake8.cfg
+++ b/travis_ci_flake8.cfg
@@ -89,8 +89,6 @@ extend-ignore =
     F632,
     # F706: 'return' outside function
     F706,
-    # F811: redefinition of unused 'StringIO' from line 27
-    F811,
     # F812: list comprehension redefines 'service' from line 446
     F812,
     # F821: undefined name 'Report'

--- a/travis_ci_flake8.cfg
+++ b/travis_ci_flake8.cfg
@@ -1,6 +1,6 @@
 [flake8]
 # temporarily disable violations for existing code until they are cleaned up
-ignore =
+extend-ignore =
     # E101: indentation contains mixed spaces and tabs
     E101,
     # E111: indentation is not a multiple of 4
@@ -13,18 +13,12 @@ ignore =
     E116,
     # E117: over-indented
     E117,
-    # E121: continuation line under-indented for hanging indent
-    E121,
     # E122: continuation line missing indentation or outdented
     E122,
-    # E123: closing bracket does not match indentation of opening bracket's line
-    E123,
     # E124: closing bracket does not match visual indentation
     E124,
     # E125: continuation line with same indent as next logical line
     E125,
-    # E126: continuation line over-indented for hanging indent
-    E126,
     # E127: continuation line over-indented for visual indent
     E127,
     # E128: continuation line under-indented for visual indent
@@ -45,14 +39,10 @@ ignore =
     E222,
     # E225: missing whitespace around operator
     E225,
-    # E226: missing whitespace around arithmetic operator
-    E226,
     # E228: missing whitespace around modulo operator
     E228,
     # E231: missing whitespace after ','
     E231,
-    # E241: multiple spaces after ':'
-    E241,
     # E251: unexpected spaces around keyword / parameter equals
     E251,
     # E261: at least two spaces before inline comment
@@ -117,10 +107,6 @@ ignore =
     W293,
     # W391: blank line at end of file
     W391,
-    # W503: line break before binary operator
-    W503,
-    # W504: line break after binary operator
-    W504,
     # W601: .has_key() is deprecated, use 'in'
     W601,
     # W605: invalid escape sequence '\d'


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This changes the flake8 configuration for Travis CI which was introduced in https://github.com/senaite/senaite.core/pull/2077.

## Current behavior before PR

Ignores are overwritten with custom config.

## Desired behavior after PR is merged

Default ignores are extended with custom config. See https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-ignore for the list of default ignores.