### PR TITLE
Use isinstance for comparing types (E721)

### DIFF
--- a/src/senaite/core/browser/fields/record.py
+++ b/src/senaite/core/browser/fields/record.py
@@ -18,6 +18,7 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import six
 from types import ClassType
 from types import DictType
 from types import FileType
@@ -246,7 +247,7 @@ class RecordField(ObjectField):
         ObjectField.set(self, instance, value, **kwargs)
 
     def _to_dict(self, value):
-        if type(value) != type({}) and hasattr(value, 'keys'):
+        if not isinstance(value, dict) and hasattr(value, 'keys'):
             new_value = {}
             new_value.update(value)
             return new_value
@@ -255,8 +256,8 @@ class RecordField(ObjectField):
     def _decode_strings(self, value, instance, **kwargs):
         new_value = value
         for k, v in value.items():
-            if type(v) is type(''):
-                nv =  decode(v, instance, **kwargs)
+            if isinstance(v, six.string_types):
+                nv = decode(v, instance, **kwargs)
                 try:
                     new_value[k] = nv
                 except AttributeError: # Records don't provide __setitem__
@@ -282,7 +283,7 @@ class RecordField(ObjectField):
     def _encode_strings(self, value, instance, **kwargs):
         new_value = value
         for k, v in value.items():
-            if type(v) is type(u''):
+            if isinstance(v, six.text_type):
                 nv = encode(v, instance, **kwargs)
                 try:
                     new_value[k] = nv

--- a/travis_ci_flake8.cfg
+++ b/travis_ci_flake8.cfg
@@ -89,8 +89,6 @@ ignore =
     E712,
     # E713: test for membership should be 'not in'
     E713,
-    # E721: do not compare types, use 'isinstance()'
-    E721,
     # E722: do not use bare 'except'
     E722,
     # F401: 'bika.lims.interfaces.ISubmitted' imported but unused


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Enables check for using `isinstance` when comparing types (E721) and fixes existing violations.