### PR TITLE
Fix LDL/UDL cut-off and exponential float conversion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2089 Fix LDL/UDL cut-off and exponential float conversion
 - #2074 Allow to disable global Auditlogging
 - #2072 Refactor report filename generation to own method
 - #2071 Move sample reports to report catalog, add batch ID and email sent flag to listing

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -581,8 +581,8 @@ class AbstractAnalysis(AbstractBaseAnalysis):
                     adl = dependency.isAboveUpperDetectionLimit()
                     mapping[key] = result
                     mapping['%s.%s' % (key, 'RESULT')] = result
-                    mapping['%s.%s' % (key, 'LDL')] = ldl
-                    mapping['%s.%s' % (key, 'UDL')] = udl
+                    mapping['%s.%s' % (key, 'LDL')] = api.to_float(ldl, 0.0)
+                    mapping['%s.%s' % (key, 'UDL')] = api.to_float(udl, 0.0)
                     mapping['%s.%s' % (key, 'BELOWLDL')] = int(bdl)
                     mapping['%s.%s' % (key, 'ABOVEUDL')] = int(adl)
                 except (TypeError, ValueError):

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -388,7 +388,8 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             return True
 
         if api.is_floatable(result):
-            return api.to_float(result) < self.getLowerDetectionLimit()
+            ldl = self.getLowerDetectionLimit()
+            return api.to_float(result) < api.to_float(ldl, 0.0)
 
         return False
 
@@ -405,7 +406,8 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             return True
 
         if api.is_floatable(result):
-            return api.to_float(result) > self.getUpperDetectionLimit()
+            udl = self.getUpperDetectionLimit()
+            return api.to_float(result) > api.to_float(udl, 0.0)
 
         return False
 

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -422,7 +422,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         """
         ldl = self.getLowerDetectionLimit()
         udl = self.getUpperDetectionLimit()
-        return [api.to_float(ldl), api.to_float(udl)]
+        return [api.to_float(ldl, 0.0), api.to_float(udl, 0.0)]
 
     @security.public
     def isLowerDetectionLimit(self):

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -409,6 +409,8 @@ class AbstractAnalysis(AbstractBaseAnalysis):
 
         return False
 
+    # TODO: REMOVE:  nowhere used
+    @deprecated("This Method will be removed in version 2.5")
     @security.public
     def getDetectionLimits(self):
         """Returns a two-value array with the limits of detection (LDL and
@@ -416,7 +418,9 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         the analysis service doesn't allow manual input of detection limits,
         returns the value set by default in the Analysis Service
         """
-        return [self.getLowerDetectionLimit(), self.getUpperDetectionLimit()]
+        ldl = self.getLowerDetectionLimit()
+        udl = self.getUpperDetectionLimit()
+        return [api.to_float(ldl), api.to_float(udl)]
 
     @security.public
     def isLowerDetectionLimit(self):

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -921,6 +921,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
 
         # Below Lower Detection Limit (LDL)?
         ldl = self.getLowerDetectionLimit()
+        ldl = api.to_float(ldl, 0.0)
         if result < ldl:
             # LDL must not be formatted according to precision, etc.
             # Drop trailing zeros from decimal
@@ -930,6 +931,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
 
         # Above Upper Detection Limit (UDL)?
         udl = self.getUpperDetectionLimit()
+        udl = api.to_float(udl, 0.0)
         if result > udl:
             # UDL must not be formatted according to precision, etc.
             # Drop trailing zeros from decimal

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 from AccessControl import ClassSecurityInfo
+from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.fields import DurationField
 from bika.lims.browser.fields import UIDReferenceField
@@ -136,14 +137,16 @@ ExponentialFormatPrecision = IntegerField(
     )
 )
 
+# TODO: Use a plain string field when converting to DX!
+#
 # If the value is below this limit, it means that the measurement lacks
 # accuracy and this will be shown in manage_results and also on the final
 # report.
 LowerDetectionLimit = FixedPointField(
-    'LowerDetectionLimit',
+    "LowerDetectionLimit",
     schemata="Analysis",
-    default='0.0',
-    precision=7,
+    default="0.0",
+    precision=1000,  # avoid precision cut-off done by the field
     widget=DecimalWidget(
         label=_("Lower Detection Limit (LDL)"),
         description=_(
@@ -154,14 +157,16 @@ LowerDetectionLimit = FixedPointField(
     )
 )
 
+# TODO: Use a plain string field when converting to DX!
+#
 # If the value is above this limit, it means that the measurement lacks
 # accuracy and this will be shown in manage_results and also on the final
 # report.
 UpperDetectionLimit = FixedPointField(
-    'UpperDetectionLimit',
+    "UpperDetectionLimit",
     schemata="Analysis",
-    default='1000000000.0',
-    precision=7,
+    default="1000000000.0",
+    precision=1000,  # avoid precision cut-off done by the field
     widget=DecimalWidget(
         label=_("Upper Detection Limit (UDL)"),
         description=_(
@@ -844,6 +849,32 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
             items.append((o.UID(), o.Title()))
         items.sort(lambda x, y: cmp(x[1], y[1]))
         return DisplayList(list(items))
+
+    @security.public
+    def getLowerDetectionLimit(self):
+        """Get the lower detection limit without trailing zeros
+        """
+        field = self.getField("LowerDetectionLimit")
+        value = field.get(self)
+        # NOTE: This is a workaround to avoid the cut-off done by the field
+        #       if the value is lower than the precision
+        #       => we should use a string instead
+        # remove trailing zeros and possible trailing dot
+        value = value.rstrip("0").rstrip(".")
+        return value
+
+    @security.public
+    def getUpperDetectionLimit(self):
+        """Get the upper detection limit without trailing zeros
+        """
+        field = self.getField("UpperDetectionLimit")
+        value = field.get(self)
+        # NOTE: This is a workaround to avoid the cut-off done by the field
+        #       if the value is lower than the precision
+        #       => we should use a string instead
+        # remove trailing zeros and possible trailing dot
+        value = value.rstrip("0").rstrip(".")
+        return value
 
     @security.public
     def isSelfVerificationEnabled(self):

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -846,26 +846,6 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
         return DisplayList(list(items))
 
     @security.public
-    def getLowerDetectionLimit(self):
-        """Returns the Lower Detection Limit for this service as a floatable
-        """
-        ldl = self.getField('LowerDetectionLimit').get(self)
-        try:
-            return float(ldl)
-        except ValueError:
-            return 0
-
-    @security.public
-    def getUpperDetectionLimit(self):
-        """Returns the Upper Detection Limit for this service as a floatable
-        """
-        udl = self.getField('UpperDetectionLimit').get(self)
-        try:
-            return float(udl)
-        except ValueError:
-            return 0
-
-    @security.public
     def isSelfVerificationEnabled(self):
         """Returns if the user that submitted a result for this analysis must
         also be able to verify the result

--- a/src/senaite/core/tests/test_limitdetections.py
+++ b/src/senaite/core/tests/test_limitdetections.py
@@ -382,8 +382,8 @@ class TestLimitDetections(DataTestCase):
         for a in ans:
             an = a.getObject()
             idx = asidxs[an.id]
-            self.assertEqual(an.getLowerDetectionLimit(), float(self.lds[idx]['min']))
-            self.assertEqual(an.getUpperDetectionLimit(), float(self.lds[idx]['max']))
+            self.assertEqual(an.getLowerDetectionLimit(), self.lds[idx]['min'])
+            self.assertEqual(an.getUpperDetectionLimit(), self.lds[idx]['max'])
             self.assertEqual(an.getAllowManualDetectionLimit(), self.lds[idx]['manual'])
 
             # Empty result


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/2088

## Current behavior before PR

- LDL/UDL values lower than `0` with more than 5 digits in the fraction get converted to exponential notation by `float`, e.g. `float("0.00001"). # 1e-05`
- LDL/UDL values with more than 7 digits in the fraction get cut-off to 0

## Desired behavior after PR is merged

- LDL/UDL values have a default precision of 1000 and return string values 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
