### PR TITLE
Enable checks for "not in" order (E713) and semicolon at line end (E703)

### DIFF
--- a/src/bika/lims/browser/widgets/partitionsetupwidget.py
+++ b/src/bika/lims/browser/widgets/partitionsetupwidget.py
@@ -50,10 +50,10 @@ class PartitionSetupWidget(RecordsWidget):
         newvalue = []
         for v in value:
             v = dict(v)
-            if v.get('separate', '') == 'on' and not 'preservation' in v:
-                container_uid = v.get('container', [''])[0];
+            if v.get('separate', '') == 'on' and 'preservation' not in v:
+                container_uid = v.get('container', [''])[0]
                 if container_uid:
-                    container = bsc(UID=container_uid)[0].getObject();
+                    container = bsc(UID=container_uid)[0].getObject()
                     if container.getPrePreserved():
                         pres = container.getPreservation()
                         if pres:

--- a/src/senaite/core/browser/fields/record.py
+++ b/src/senaite/core/browser/fields/record.py
@@ -19,7 +19,6 @@
 # Some rights reserved, see README and LICENSE.
 
 import six
-from types import ClassType
 from types import DictType
 from types import ListType
 from types import StringType

--- a/src/senaite/core/browser/fields/record.py
+++ b/src/senaite/core/browser/fields/record.py
@@ -328,7 +328,7 @@ class RecordField(ObjectField):
                 log('WARNING: Unknow validation %s. Disabling!' % current_validators)
                 validators = ()
 
-            if not subfield in self.required_subfields:
+            if subfield not in self.required_subfields:
                 if validators == ():
                     validators = ValidationChain(chainname)
                 if len(validators):

--- a/src/senaite/core/exportimport/instruments/biodrop/ulite/__init__.py
+++ b/src/senaite/core/exportimport/instruments/biodrop/ulite/__init__.py
@@ -54,7 +54,7 @@ class BioDropCSVParser(InstrumentCSVResultsFileParser):
             for d in (row_values, self.file_header):
                 raw_result.update(d)
             raw_result['DefaultResult'] = 'Concentration'
-            raw_result = {self.analysiskey: raw_result};
+            raw_result = {self.analysiskey: raw_result}
 
             sample_id = row_values['Sample Name']
             self._addRawResult(sample_id, raw_result)

--- a/src/senaite/core/exportimport/instruments/foss/fiastar/fiastar.py
+++ b/src/senaite/core/exportimport/instruments/foss/fiastar/fiastar.py
@@ -69,7 +69,7 @@ class Export(BrowserView):
             a_uid = layout[x]['analysis_uid']
             p_uid = uc(UID=a_uid)[0].getObject().aq_parent.UID()
             layout[x]['parent_uid'] = p_uid
-            if not p_uid in parent_to_slot.keys():
+            if p_uid not in parent_to_slot.keys():
                 parent_to_slot[p_uid] = int(layout[x]['position'])
 
         # write rows, one per PARENT

--- a/src/senaite/core/exportimport/instruments/lifetechnologies/qubit/__init__.py
+++ b/src/senaite/core/exportimport/instruments/lifetechnologies/qubit/__init__.py
@@ -54,7 +54,7 @@ class QuBitCSVParser(InstrumentCSVResultsFileParser):
             # 2010/11/02,10:33 AM
             dtstr = '%s %s' % (_values['Date'], _values['Time'])
             dtobj = datetime.strptime(dtstr, '%Y/%m/%d %H:%M %p')
-            values[self.analysiskey]['DateTime'] = dtobj.strftime("%Y%m%d %H:%M:%S");
+            values[self.analysiskey]['DateTime'] = dtobj.strftime("%Y%m%d %H:%M:%S")
         except:
             pass
 

--- a/src/senaite/core/exportimport/instruments/panalytical/omnia/__init__.py
+++ b/src/senaite/core/exportimport/instruments/panalytical/omnia/__init__.py
@@ -495,7 +495,7 @@ class AxiosXrfCSVParser(InstrumentCSVResultsFileParser):
         rawres = self.getRawResults().get(rid, [])
         raw = rawres[0] if len(rawres) > 0 else {}
         raw[aname] = rawdict
-        if not 'DateTime' in raw:
+        if 'DateTime' not in raw:
             try:
                 raw['DateTime'] = {'DateTime':self.csvDate2BikaDate(self._header['Date']),
                                    'DefaultValue':'DateTime'}

--- a/src/senaite/core/tests/test_calculations.py
+++ b/src/senaite/core/tests/test_calculations.py
@@ -398,7 +398,7 @@ class TestCalculations(DataTestCase):
             for k,v in f['interims'].items():
                 interims.append({'keyword': k, 'title':k, 'value': v,
                                  'hidden': False, 'type': 'int',
-                                 'unit': ''});
+                                 'unit': ''})
             self.calculation.setInterimFields(interims)
             self.assertEqual(self.calculation.getInterimFields(), interims)
 

--- a/src/senaite/core/tests/test_hiddenanalyses.py
+++ b/src/senaite/core/tests/test_hiddenanalyses.py
@@ -103,7 +103,7 @@ class TestHiddenAnalyses(DataTestCase):
         self.assertFalse('hidden' in self.analysisprofile.getAnalysisServiceSettings(uid))
 
         # Modify visibility for Calcium in profile
-        uid = self.services[0].UID();
+        uid = self.services[0].UID()
         sets = [{'uid': uid}]
         self.analysisprofile.setAnalysisServicesSettings(sets)
         self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(uid))
@@ -119,7 +119,7 @@ class TestHiddenAnalyses(DataTestCase):
         self.assertTrue('hidden' in self.analysisprofile.getAnalysisServiceSettings(uid))
 
         # Modify visibility for Cooper in profile
-        uid = self.services[1].UID();
+        uid = self.services[1].UID()
         sets = [{'uid': uid}]
         self.analysisprofile.setAnalysisServicesSettings(sets)
         self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(uid))
@@ -134,7 +134,7 @@ class TestHiddenAnalyses(DataTestCase):
         self.assertTrue('hidden' in self.analysisprofile.getAnalysisServiceSettings(uid))
 
         # Modify visibility for Iron in profile
-        uid = self.services[2].UID();
+        uid = self.services[2].UID()
         sets = [{'uid': uid}]
         self.analysisprofile.setAnalysisServicesSettings(sets)
         self.assertTrue(self.analysisprofile.isAnalysisServiceHidden(uid))
@@ -154,7 +154,7 @@ class TestHiddenAnalyses(DataTestCase):
     def test_service_hidden_artemplate(self):
         # Template
         # For Calcium (unset)
-        uid = self.services[0].UID();
+        uid = self.services[0].UID()
         self.assertFalse(self.services[0].getHidden())
         self.assertFalse(self.analysisprofile.isAnalysisServiceHidden(uid))
         self.assertFalse('hidden' in self.artemplate.getAnalysisServiceSettings(uid))
@@ -172,7 +172,7 @@ class TestHiddenAnalyses(DataTestCase):
         self.assertFalse('hidden' in self.artemplate.getAnalysisServiceSettings(uid))
 
         # Modify visibility for Calcium in template
-        uid = self.services[0].UID();
+        uid = self.services[0].UID()
         sets = [{'uid': uid}]
         self.artemplate.setAnalysisServicesSettings(sets)
         self.assertFalse(self.artemplate.isAnalysisServiceHidden(uid))
@@ -188,7 +188,7 @@ class TestHiddenAnalyses(DataTestCase):
         self.assertTrue('hidden' in self.artemplate.getAnalysisServiceSettings(uid))
 
         # Modify visibility for Cooper in template
-        uid = self.services[1].UID();
+        uid = self.services[1].UID()
         sets = [{'uid': uid}]
         self.artemplate.setAnalysisServicesSettings(sets)
         self.assertFalse(self.artemplate.isAnalysisServiceHidden(uid))
@@ -203,7 +203,7 @@ class TestHiddenAnalyses(DataTestCase):
         self.assertTrue('hidden' in self.artemplate.getAnalysisServiceSettings(uid))
 
         # Modify visibility for Iron in template
-        uid = self.services[2].UID();
+        uid = self.services[2].UID()
         sets = [{'uid': uid}]
         self.artemplate.setAnalysisServicesSettings(sets)
         self.assertTrue(self.artemplate.isAnalysisServiceHidden(uid))

--- a/travis_ci_flake8.cfg
+++ b/travis_ci_flake8.cfg
@@ -71,8 +71,6 @@ extend-ignore =
     E501,
     # E502: the backslash is redundant between brackets
     E502,
-    # E703: statement ends with a semicolon
-    E703,
     # E722: do not use bare 'except'
     E722,
     # F403: 'from bika.lims.permissions import *' used; unable to detect undefined names

--- a/travis_ci_flake8.cfg
+++ b/travis_ci_flake8.cfg
@@ -73,8 +73,6 @@ extend-ignore =
     E502,
     # E703: statement ends with a semicolon
     E703,
-    # E713: test for membership should be 'not in'
-    E713,
     # E722: do not use bare 'except'
     E722,
     # F403: 'from bika.lims.permissions import *' used; unable to detect undefined names


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Enable flake8 checks for "not in" order (E713) and semicolon at line end (E703) in Travis CI and clean up existing violations.