### PR TITLE
Enable checks for multiple imports on same line (E401) and "import *" (F403, F405)

### DIFF
--- a/src/bika/lims/browser/client/views/analysisprofiles.py
+++ b/src/bika/lims/browser/client/views/analysisprofiles.py
@@ -20,7 +20,7 @@
 
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.bika_listing import BikaListingView
-from bika.lims.permissions import *
+from bika.lims.permissions import AddAnalysisProfile
 from Products.CMFCore.utils import getToolByName
 
 

--- a/src/bika/lims/browser/client/views/artemplates.py
+++ b/src/bika/lims/browser/client/views/artemplates.py
@@ -20,7 +20,7 @@
 
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.bika_listing import BikaListingView
-from bika.lims.permissions import *
+from bika.lims.permissions import AddARTemplate
 from Products.CMFCore.utils import getToolByName
 
 

--- a/src/bika/lims/jsonapi/__init__.py
+++ b/src/bika/lims/jsonapi/__init__.py
@@ -29,13 +29,13 @@ from bika.lims import logger
 import json
 import Missing
 import six
-import sys, traceback
+import sys
+import traceback
 
 
 def handle_errors(f):
     """ simple JSON error handler
     """
-    import traceback
     from plone.jsonapi.core.helpers import error
 
     def decorator(*args, **kwargs):

--- a/src/senaite/core/browser/fields/record.py
+++ b/src/senaite/core/browser/fields/record.py
@@ -19,7 +19,6 @@
 # Some rights reserved, see README and LICENSE.
 
 import six
-from types import ClassType
 from types import DictType
 from types import ListType
 from types import StringType

--- a/travis_ci_flake8.cfg
+++ b/travis_ci_flake8.cfg
@@ -75,8 +75,6 @@ extend-ignore =
     E713,
     # E722: do not use bare 'except'
     E722,
-    # F403: 'from bika.lims.permissions import *' used; unable to detect undefined names
-    F403,
     # F405: 'AddAnalysisProfile' may be undefined, or defined from star imports: bika.lims.permissions
     F405,
     # F632: use ==/!= to compare constant literals (str, bytes, int, float, tuple)
@@ -104,6 +102,7 @@ extend-ignore =
     # W605: invalid escape sequence '\d'
     W605,
 per-file-ignores =
+    # ignore unused imports (F401) in meta packages
     src/bika/lims/skins/bika/guard_handler.py:F401,
     src/bika/lims/browser/worksheet/views/__init__.py:F401,
     src/bika/lims/browser/analyses/__init__.py:F401,
@@ -115,3 +114,5 @@ per-file-ignores =
     src/bika/lims/interfaces/__init__.py:F401,
     src/senaite/core/exportimport/instruments/__init__.py:F401,
     src/senaite/core/behaviors/__init__.py:F401,
+    # ignore "import *" (F403) in Archetypes models
+    src/bika/lims/content/*.py:F403,

--- a/travis_ci_flake8.cfg
+++ b/travis_ci_flake8.cfg
@@ -65,8 +65,6 @@ extend-ignore =
     E305,
     # E306: expected 1 blank line before a nested definition, found 0
     E306,
-    # E401: multiple imports on one line
-    E401,
     # E501: line too long (80 > 79 characters)
     E501,
     # E502: the backslash is redundant between brackets

--- a/travis_ci_flake8.cfg
+++ b/travis_ci_flake8.cfg
@@ -101,16 +101,16 @@ extend-ignore =
     W605,
 per-file-ignores =
     # ignore unused imports (F401) in meta packages
-    src/bika/lims/skins/bika/guard_handler.py:F401,
-    src/bika/lims/browser/worksheet/views/__init__.py:F401,
-    src/bika/lims/browser/analyses/__init__.py:F401,
-    src/bika/lims/browser/client/__init__.py:F401,
-    src/bika/lims/browser/widgets/__init__.py:F401,
-    src/bika/lims/browser/analysisrequest/analysisrequests.py:F401,
-    src/bika/lims/browser/analysisrequest/__init__.py:F401,
-    src/bika/lims/subscribers/__init__.py:F401,
-    src/bika/lims/interfaces/__init__.py:F401,
-    src/senaite/core/exportimport/instruments/__init__.py:F401,
-    src/senaite/core/behaviors/__init__.py:F401,
+    src/bika/lims/skins/bika/guard_handler.py:F401
+    src/bika/lims/browser/worksheet/views/__init__.py:F401
+    src/bika/lims/browser/analyses/__init__.py:F401
+    src/bika/lims/browser/client/__init__.py:F401
+    src/bika/lims/browser/widgets/__init__.py:F401
+    src/bika/lims/browser/analysisrequest/analysisrequests.py:F401
+    src/bika/lims/browser/analysisrequest/__init__.py:F401
+    src/bika/lims/subscribers/__init__.py:F401
+    src/bika/lims/interfaces/__init__.py:F401
+    src/senaite/core/exportimport/instruments/__init__.py:F401
+    src/senaite/core/behaviors/__init__.py:F401
     # ignore "import *" (F403, F405) in Archetypes models
-    src/bika/lims/content/*.py:F403,F405,
+    src/bika/lims/content/*.py:F403,F405

--- a/travis_ci_flake8.cfg
+++ b/travis_ci_flake8.cfg
@@ -75,8 +75,6 @@ extend-ignore =
     E713,
     # E722: do not use bare 'except'
     E722,
-    # F405: 'AddAnalysisProfile' may be undefined, or defined from star imports: bika.lims.permissions
-    F405,
     # F632: use ==/!= to compare constant literals (str, bytes, int, float, tuple)
     F632,
     # F706: 'return' outside function
@@ -114,5 +112,5 @@ per-file-ignores =
     src/bika/lims/interfaces/__init__.py:F401,
     src/senaite/core/exportimport/instruments/__init__.py:F401,
     src/senaite/core/behaviors/__init__.py:F401,
-    # ignore "import *" (F403) in Archetypes models
-    src/bika/lims/content/*.py:F403,
+    # ignore "import *" (F403, F405) in Archetypes models
+    src/bika/lims/content/*.py:F403,F405,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Enables the following flake8 checks on Travis CI:

- multiple imports on same line (E401)
- 'from module import *' used; unable to detect undefined names (F403)
- Name may be undefined, or defined from star imports: module (F405)

Existing violations are ignored in Archetypes models and otherwise cleaned up.