### PR TITLE
Skip Auditlog catalog if disabled for DX types catalog multiplexer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2094 Skip Auditlog catalog if disabled for DX types catalog multiplexer
 - #2090 Add support for dates before 1900
 - #2089 Fix LDL/UDL cut-off and exponential float conversion
 - #2078 Replace dynamic code execution with dynamic import in reports

--- a/src/senaite/core/catalog/catalog_multiplex_processor.py
+++ b/src/senaite/core/catalog/catalog_multiplex_processor.py
@@ -22,6 +22,9 @@ class CatalogMultiplexProcessor(object):
         """Check if the global auditlogging is enabled
         """
         setup = api.get_senaite_setup()
+        # might happen during installation
+        if not setup:
+            return False
         return setup.getEnableGlobalAuditlog()
 
     def get_catalogs_for(self, obj):

--- a/src/senaite/core/catalog/catalog_multiplex_processor.py
+++ b/src/senaite/core/catalog/catalog_multiplex_processor.py
@@ -18,12 +18,23 @@ class CatalogMultiplexProcessor(object):
     """A catalog multiplex processor
     """
 
+    def is_global_auditlog_enabled(self):
+        """Check if the global auditlogging is enabled
+        """
+        setup = api.get_senaite_setup()
+        return setup.getEnableGlobalAuditlog()
+
     def get_catalogs_for(self, obj):
         catalogs = getattr(obj, "_catalogs", [])
         for rc in REQUIRED_CATALOGS:
             if rc in catalogs:
                 continue
             catalogs.append(rc)
+
+        # remove auditlog catalog if disabled
+        if not self.is_global_auditlog_enabled():
+            catalogs = filter(lambda cid: cid != AUDITLOG_CATALOG, catalogs)
+
         return map(api.get_tool, catalogs)
 
     def supports_multi_catalogs(self, obj):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is a continuation of https://github.com/senaite/senaite.core/pull/2074 and checks if the global auditlog is disabled in the DX contents catalog multiplexer.

## Current behavior before PR

DX contents were always indexed in auditlog catalog although disabled when e.g. the portal_catalog was rebuilt

## Desired behavior after PR is merged

Auditlog catalog is skipped when disabled in setup for DX contents in catalog multiplexer

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
