### PR TITLE
Fix rounded uncertainty value is stored in the database

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2095 Fix rounded uncertainty value is stored in the database
 - #2094 Skip Auditlog catalog if disabled for DX types catalog multiplexer
 - #2090 Add support for dates before 1900
 - #2089 Fix LDL/UDL cut-off and exponential float conversion


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue that the rounded uncertainty value get inserted into the database.

## Steps to reproduce

1. Create an Analysis Service with the option `Allow manual uncertainty value input` checked and leave the field `Precision as number of decimals` empty.
2. Create a Sample with that Analysis and enter the Result `0.013` and the Uncertainty to `0.026`
3. Press Save

<img width="1840" alt="220212-07 — SENAITE LIMS 2022-08-03 11 AM-57-02" src="https://user-images.githubusercontent.com/713193/182580780-2f94ff52-fe1a-4092-aec1-1c46235f0a09.png">

Note that the Uncertainty value changed to `0.03`.

4. Submit the sample

The DB value of the uncertainty is now set to `0.03`:
```
>>> obj.getResult()
'0.013'
>>> obj.getUncertainty()
0.03 
```


## Current behavior before PR

Rounded Uncertainty get stored in the database after submit

## Desired behavior after PR is merged

The unformatted/rounded value is stored in the database after submit

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
