### PR TITLE
Fix Attribute Error in Multi- Sample Add form when current user is linked to a client contact

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2097 Fix Attribute Error in Multi- Sample Add form when current user is linked to a client contact
 - #2095 Fix rounded uncertainty value is stored in the database
 - #2094 Skip Auditlog catalog if disabled for DX types catalog multiplexer
 - #2090 Add support for dates before 1900

--- a/src/senaite/core/browser/widgets/referencewidget.py
+++ b/src/senaite/core/browser/widgets/referencewidget.py
@@ -157,7 +157,7 @@ class ReferenceWidget(StringWidget):
     def initial_uid_field_value(self, value):
         if type(value) in (list, tuple):
             ret = ",".join([v.UID() for v in value])
-        elif type(value) in [str, ]:
+        elif isinstance(value, six.string_types):
             ret = value
         else:
             ret = value.UID() if value else value

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/referencewidget.pt
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/referencewidget.pt
@@ -141,7 +141,7 @@
                                        value python:widget.initial_uid_field_value(val);"/>
 
                 <!-- Link to single valued object in edit mode -->
-                <tal:link tal:condition="python:val and not multiValued">
+                <tal:link tal:condition="python:hasattr(val, 'absolute_url') and not multiValued">
                   <a class="pl-2 d-table-cell" href="#"
                      target="blank"
                      tal:attributes="href python:val.absolute_url()">

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/referencewidget.pt
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/referencewidget.pt
@@ -91,7 +91,7 @@
                                      text_attr widget/ui_item|nothing;
                                      text python:text_attr and getattr(val, text_attr, text_default) or text_default;">
               <input type="text"
-                     class="blurrable firstToFocus referencewidget d-table-cell"
+                     class="blurrable firstToFocus referencewidget"
                      tal:condition="python:context.Schema()[fieldName].required"
                      tal:attributes="name fieldName;
                                      id fieldName;
@@ -112,7 +112,7 @@
                                      combogrid_options python:widget.get_combogrid_options(context, fieldName)" />
 
               <input type="text"
-                     class="blurrable firstToFocus referencewidget d-table-cell"
+                     class="blurrable firstToFocus referencewidget"
                      tal:condition="python:not context.Schema()[fieldName].required"
                      tal:attributes="name fieldName;
                                      id fieldName;


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the following Error in the Sample Add Form when more than `1` sample is added and the current linked to a user contact, so that the contact field is auto filled:

```
Traceback (innermost last):
    Module ZServer.ZPublisher.Publish, line 144, in publish
    Module ZPublisher.mapply, line 85, in mapply
    Module ZServer.ZPublisher.Publish, line 44, in call_object
    Module bika.lims.browser.analysisrequest.add2, line 110, in __call__
    Module Products.Five.browser.pagetemplatefile, line 126, in __call__
    Module Products.Five.browser.pagetemplatefile, line 61, in __call__
    Module zope.pagetemplate.pagetemplate, line 135, in pt_render
    Module Products.PageTemplates.engine, line 378, in __call__
    Module z3c.pt.pagetemplate, line 176, in render
    Module chameleon.zpt.template, line 302, in render
    Module chameleon.template, line 215, in render
    Module chameleon.template, line 192, in render
    Module bb968d8de38255787bf540333aab2d62, line 4448, in render
    Module da27eef20b3f6b532f22081ce455f140, line 1449, in render_master
    Module da27eef20b3f6b532f22081ce455f140, line 407, in render_content
    Module bb968d8de38255787bf540333aab2d62, line 2263, in __fill_content_core
    Module 107dc889b39b4564183aeb277ba50304, line 1173, in render_edit
    Module d88bffbebbf4e01f15a333556ab23c2e, line 702, in render_edit
    Module 107dc889b39b4564183aeb277ba50304, line 1127, in __fill_widget_body
    Module zope.tales.pythonexpr, line 73, in __call__
    - __traceback_info__: (val.absolute_url())
    Module <string>, line 1, in <module>
AttributeError: 'unicode' object has no attribute 'absolute_url'
```

## Steps to reproduce

1. Link a client contact to the current user
2. Create a new sample and select `2` in the Add field

## Current behavior before PR

Traceback is raised in the Sample add form when adding multiple samples and the current user is linked to a client contact

## Desired behavior after PR is merged

Sample Add form works w/o issues

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
