### PR TITLE
Enable check for 'return' outside function (F706)

### DIFF
--- a/src/bika/lims/adapters/widgetvisibility.py
+++ b/src/bika/lims/adapters/widgetvisibility.py
@@ -156,7 +156,7 @@ class SamplingFieldsVisibility(SenaiteATWidgetVisibility):
         # If object has been already created, get SWF statues from it.
         swf_enabled = False
         if hasattr(self.context, 'getSamplingWorkflowEnabled') and \
-                self.context.getSamplingWorkflowEnabled() is not '':
+                self.context.getSamplingWorkflowEnabled() != '':
             swf_enabled = self.context.getSamplingWorkflowEnabled()
         else:
             swf_enabled = self.context.bika_setup.getSamplingWorkflowEnabled()

--- a/src/senaite/core/exportimport/instruments/resultsimport.py
+++ b/src/senaite/core/exportimport/instruments/resultsimport.py
@@ -443,8 +443,8 @@ class AnalysisResultsImporter(Logger):
         for acode in rawacodes:
             if acode in exclude or not acode:
                 continue
-            service = self.bsc(getKeyword=acode)
-            if not service:
+            analysis_service = self.bsc(getKeyword=acode)
+            if not analysis_service:
                 self.warn('Service keyword ${analysis_keyword} not found',
                           mapping={"analysis_keyword": acode})
             else:

--- a/src/senaite/core/tests/test_duplicate-analysis.py
+++ b/src/senaite/core/tests/test_duplicate-analysis.py
@@ -82,8 +82,7 @@ class TestAddDuplicateAnalysis(DataTestCase):
         # Add analyses into the worksheet
         self.request['context_uid'] = ws.UID()
         for analysis in ar.getAnalyses():
-            an = analysis.getObject()
-            ws.addAnalysis(an)
+            ws.addAnalysis(analysis.getObject())
         self.assertEquals(len(ws.getAnalyses()), 3)
 
         # Add a duplicate for slot 1 (there's only one slot)
@@ -137,8 +136,7 @@ class TestAddDuplicateAnalysis(DataTestCase):
         wf.doActionFor(ar, 'receive')
         # Add analyses into the worksheet
         for analysis in ar.getAnalyses():
-            an = analysis.getObject()
-            ws.addAnalysis(an)
+            ws.addAnalysis(analysis.getObject())
         ans = ws.getAnalyses()
         reg = [an for an in ans if an.portal_type == 'Analysis']
         regkeys = [an.getKeyword() for an in reg]

--- a/travis_ci_flake8.cfg
+++ b/travis_ci_flake8.cfg
@@ -71,8 +71,6 @@ extend-ignore =
     E502,
     # E722: do not use bare 'except'
     E722,
-    # F812: list comprehension redefines 'service' from line 446
-    F812,
     # F821: undefined name 'Report'
     F821,
     # F841: local variable 'icon' is assigned to but never used

--- a/travis_ci_flake8.cfg
+++ b/travis_ci_flake8.cfg
@@ -73,8 +73,6 @@ extend-ignore =
     E722,
     # F632: use ==/!= to compare constant literals (str, bytes, int, float, tuple)
     F632,
-    # F706: 'return' outside function
-    F706,
     # F812: list comprehension redefines 'service' from line 446
     F812,
     # F821: undefined name 'Report'
@@ -97,7 +95,6 @@ extend-ignore =
     W605,
 per-file-ignores =
     # ignore unused imports (F401) in meta packages
-    src/bika/lims/skins/bika/guard_handler.py:F401
     src/bika/lims/browser/worksheet/views/__init__.py:F401
     src/bika/lims/browser/analyses/__init__.py:F401
     src/bika/lims/browser/client/__init__.py:F401
@@ -110,3 +107,6 @@ per-file-ignores =
     src/senaite/core/behaviors/__init__.py:F401
     # ignore "import *" (F403, F405) in Archetypes models
     src/bika/lims/content/*.py:F403,F405
+    # Zope scripts are only function bodies (see https://zope.readthedocs.io/en/latest/zopebook/BasicScripting.html)
+    src/bika/lims/skins/bika/guard_handler.py:F401,F706
+    src/senaite/core/skins/senaite_scripts/*.py:F706

--- a/travis_ci_flake8.cfg
+++ b/travis_ci_flake8.cfg
@@ -71,8 +71,6 @@ extend-ignore =
     E502,
     # E722: do not use bare 'except'
     E722,
-    # F632: use ==/!= to compare constant literals (str, bytes, int, float, tuple)
-    F632,
     # F812: list comprehension redefines 'service' from line 446
     F812,
     # F821: undefined name 'Report'


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Enables flake8 check for 'return' outside function (F706) and ignores Zope scripts.
