### PR TITLE
Add help text for numeric result

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2101 Added help text for numeric result
 - #2097 Fix Attribute Error in Multi- Sample Add form when current user is linked to a client contact
 - #2095 Fix rounded uncertainty value is stored in the database
 - #2094 Skip Auditlog catalog if disabled for DX types catalog multiplexer

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
-- #2101 Added help text for numeric result
+- #2101 Add help text for numeric result
 - #2097 Fix Attribute Error in Multi- Sample Add form when current user is linked to a client contact
 - #2095 Fix rounded uncertainty value is stored in the database
 - #2094 Skip Auditlog catalog if disabled for DX types catalog multiplexer

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -881,6 +881,9 @@ class AnalysesView(ListingView):
 
             else:
                 item["result_type"] = "numeric"
+                item["help"]["result"] = _(
+                    "Enter the result either in decimal or scientific "
+                    "notation, e.g. 0.00005 or 1e-5, 10000 or 1e5")
 
         if not result:
             return

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -706,6 +706,10 @@ class AnalysesView(ListingView):
                 if field not in item:
                     item[field] = ""
 
+            # Graceful handling of new item key introduced in
+            # https://github.com/senaite/senaite.app.listing/pull/81
+            item["help"] = item.get("help", {})
+
         # XXX order the list of interim columns
         interim_keys = self.interim_columns.keys()
         interim_keys.reverse()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**☝️NOTE:** This PR requires https://github.com/senaite/senaite.app.listing/pull/81

This PR adds a help text for numeric fields on item level.

## Current behavior before PR

Only the field title (Result) was displayed on hover on a numeric result field

## Desired behavior after PR is merged

Better help text is displayed for numeric results

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
