### PR TITLE
Convert LDL/UDL fields to string

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2103 Convert LDL/UDL fields to string
 - #2097 Fix Attribute Error in Multi- Sample Add form when current user is linked to a client contact
+- #2096 Convert uncertainty field to string
 - #2095 Fix rounded uncertainty value is stored in the database
 - #2094 Skip Auditlog catalog if disabled for DX types catalog multiplexer
 - #2090 Add support for dates before 1900

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -136,16 +136,13 @@ ExponentialFormatPrecision = IntegerField(
     )
 )
 
-# TODO: Use a plain string field when converting to DX!
-#
 # If the value is below this limit, it means that the measurement lacks
 # accuracy and this will be shown in manage_results and also on the final
 # report.
-LowerDetectionLimit = FixedPointField(
+LowerDetectionLimit = StringField(
     "LowerDetectionLimit",
     schemata="Analysis",
     default="0.0",
-    precision=1000,  # avoid precision cut-off done by the field
     widget=DecimalWidget(
         label=_("Lower Detection Limit (LDL)"),
         description=_(
@@ -156,16 +153,13 @@ LowerDetectionLimit = FixedPointField(
     )
 )
 
-# TODO: Use a plain string field when converting to DX!
-#
 # If the value is above this limit, it means that the measurement lacks
 # accuracy and this will be shown in manage_results and also on the final
 # report.
-UpperDetectionLimit = FixedPointField(
+UpperDetectionLimit = StringField(
     "UpperDetectionLimit",
     schemata="Analysis",
     default="1000000000.0",
-    precision=1000,  # avoid precision cut-off done by the field
     widget=DecimalWidget(
         label=_("Upper Detection Limit (UDL)"),
         description=_(
@@ -848,32 +842,6 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
             items.append((o.UID(), o.Title()))
         items.sort(lambda x, y: cmp(x[1], y[1]))
         return DisplayList(list(items))
-
-    @security.public
-    def getLowerDetectionLimit(self):
-        """Get the lower detection limit without trailing zeros
-        """
-        field = self.getField("LowerDetectionLimit")
-        value = field.get(self)
-        # NOTE: This is a workaround to avoid the cut-off done by the field
-        #       if the value is lower than the precision
-        #       => we should use a string instead
-        # remove trailing zeros and possible trailing dot
-        value = value.rstrip("0").rstrip(".")
-        return value
-
-    @security.public
-    def getUpperDetectionLimit(self):
-        """Get the upper detection limit without trailing zeros
-        """
-        field = self.getField("UpperDetectionLimit")
-        value = field.get(self)
-        # NOTE: This is a workaround to avoid the cut-off done by the field
-        #       if the value is lower than the precision
-        #       => we should use a string instead
-        # remove trailing zeros and possible trailing dot
-        value = value.rstrip("0").rstrip(".")
-        return value
 
     @security.public
     def isSelfVerificationEnabled(self):

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -849,6 +849,9 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
         """
         field = self.getField("LowerDetectionLimit")
         value = field.get(self)
+        # cut off trailing zeros
+        if "." in value:
+            value = value.rstrip("0").rstrip(".")
         return value
 
     @security.public
@@ -857,6 +860,9 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
         """
         field = self.getField("UpperDetectionLimit")
         value = field.get(self)
+        # cut off trailing zeros
+        if "." in value:
+            value = value.rstrip("0").rstrip(".")
         return value
 
     @security.public

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -844,6 +844,22 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
         return DisplayList(list(items))
 
     @security.public
+    def getLowerDetectionLimit(self):
+        """Get the lower detection limit
+        """
+        field = self.getField("LowerDetectionLimit")
+        value = field.get(self)
+        return value
+
+    @security.public
+    def getUpperDetectionLimit(self):
+        """Get the upper detection limit
+        """
+        field = self.getField("UpperDetectionLimit")
+        value = field.get(self)
+        return value
+
+    @security.public
     def isSelfVerificationEnabled(self):
         """Returns if the user that submitted a result for this analysis must
         also be able to verify the result

--- a/src/senaite/core/upgrade/v02_03_000.py
+++ b/src/senaite/core/upgrade/v02_03_000.py
@@ -370,7 +370,7 @@ def migrate_ldl_field_to_string(obj):
     if isinstance(value, tuple):
         migrated_value = fixed_point_value_to_string(value, 7)
         logger.info("Migrating LDL field of %s: %s -> %s" % (
-            api.get_pat(obj), value, migrated_value))
+            api.get_path(obj), value, migrated_value))
         value = migrated_value
 
     # set the new value

--- a/src/senaite/core/upgrade/v02_03_000.py
+++ b/src/senaite/core/upgrade/v02_03_000.py
@@ -343,62 +343,63 @@ def migrate_analyses_fields(portal):
     logger.info("Migrate Analyses Fields [DONE]")
 
 
-def migrate_udl_field_to_string(analysis):
+def migrate_udl_field_to_string(obj):
     """Migrate the UDL field to string
     """
-    field = analysis.getField("UpperDetectionLimit")
-    value = field.get(analysis)
+    field = obj.getField("UpperDetectionLimit")
+    value = field.get(obj)
 
     # Leave any other value type unchanged
     if isinstance(value, tuple):
-        migrated_value = fixed_point_value_to_string(value, precision=7)
+        migrated_value = fixed_point_value_to_string(value, 7)
         logger.info("Migrating UDL field of %s: %s -> %s" % (
-            api.get_path(analysis), value, migrated_value))
+            api.get_path(obj), value, migrated_value))
         value = migrated_value
 
     # set the new value
-    field.set(analysis, value)
+    field.set(obj, value)
 
 
-def migrate_ldl_field_to_string(analysis):
+def migrate_ldl_field_to_string(obj):
     """Migrate the LDL field to string
     """
-    field = analysis.getField("LowerDetectionLimit")
-    value = field.get(analysis)
+    field = obj.getField("LowerDetectionLimit")
+    value = field.get(obj)
 
     # Leave any other value type unchanged
     if isinstance(value, tuple):
-        migrated_value = fixed_point_value_to_string(value, precision=7)
+        migrated_value = fixed_point_value_to_string(value, 7)
         logger.info("Migrating LDL field of %s: %s -> %s" % (
-            api.get_pat(analysis), value, migrated_value))
+            api.get_pat(obj), value, migrated_value))
         value = migrated_value
 
     # set the new value
-    field.set(analysis, value)
+    field.set(obj, value)
 
 
-def migrate_uncertainty_field_to_string(analysis):
+def migrate_uncertainty_field_to_string(obj):
     """Migrate the uncertainty field to string
     """
-    field = analysis.getField("Uncertainty")
-    value = field.get(analysis)
+    field = obj.getField("Uncertainty")
+    value = field.get(obj)
 
     # Leave any other value type unchanged
     if isinstance(value, tuple):
-        migrated_value = fixed_point_value_to_string(value, precision=10)
+        migrated_value = fixed_point_value_to_string(value, 10)
         logger.info("Migrating Uncertainty field of %s: %s -> %s" % (
-            api.get_pat(analysis), value, migrated_value))
+            api.get_pat(obj), value, migrated_value))
         value = migrated_value
 
     # set the new value
-    field.set(analysis, value)
+    field.set(obj, value)
 
 
-def fixed_point_value_to_string(value, precision=10):
+def fixed_point_value_to_string(value, precision):
     """Code taken and modified from FixedPointField get method
 
     IMPORTANT: The precision has to be the same as it was initially
                defined in the field when the value was set!
+               Otherwise, values > 0, e.g. 0.0005 are converted wrong!
     """
     template = "%%s%%d.%%0%dd" % precision
     front, fra = value


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR migrates the LDL/UDL fields of Analyses, Reference Analyses and Analysis Services from FixedPoint to String as suggested in https://github.com/senaite/senaite.core/pull/2089.

**☝️ Important**
The change of the precision introduced in https://github.com/senaite/senaite.core/pull/2089 is malicious and returns wrong values for those that were stored with the initial precision of `7`!

## Current behavior before PR

FixedPoint fields used to store LDL/UDL values

## Desired behavior after PR is merged

String fields used to store LDL/UDL values

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
