### PR TITLE
Allow to disable global Auditlogging (#2074 #2094 ports)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #2106 Skip Auditlog catalog if disabled for DX types multiplexer (#2094 port)
+- #2106 Allow to disable global Auditlogging (#2074 port)
 - #2060 Added `api.is_temporary` function for both DX and AT types (#2018 port)
 - #2060 Performance: Avoid to catalog temporary objects (#2015 port)
 - #2059 Fix Definition not displayed in Reference Samples listing (#2028 port)

--- a/bika/lims/browser/viewlets/auditlog.py
+++ b/bika/lims/browser/viewlets/auditlog.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+from bika.lims import api
+from plone.app.layout.viewlets import ViewletBase
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
+
+class AuditlogDisabledViewlet(ViewletBase):
+    """Viewlet that is displayed when the Auditlog is disabled
+    """
+    template = ViewPageTemplateFile("templates/auditlog_disabled.pt")
+
+    def __init__(self, context, request, view, manager=None):
+        super(AuditlogDisabledViewlet, self).__init__(
+            context, request, view, manager=manager)
+        self.context = context
+        self.request = request
+        self.view = view
+
+    @property
+    def setup(self):
+        return api.get_setup()
+
+    def get_setup_url(self):
+        """Return the absolute URL of the setup
+        """
+        return api.get_url(self.setup)
+
+    def is_enabled(self):
+        """Returns whether the global auditlog is disabled
+        """
+        return self.setup.getEnableGlobalAuditlog()
+
+    def is_disabled(self):
+        """Returns whether the global auditlog is disabled
+        """
+        return not self.is_enabled()
+
+    def index(self):
+        if self.is_enabled():
+            return ""
+        return self.template()

--- a/bika/lims/browser/viewlets/configure.zcml
+++ b/bika/lims/browser/viewlets/configure.zcml
@@ -314,4 +314,14 @@
     layer="bika.lims.interfaces.IBikaLIMS"
   />
 
+  <!-- Auditlog viewlet -->
+  <browser:viewlet
+      for="bika.lims.interfaces.IAuditLog"
+      name="auditlog_disabled"
+      class=".auditlog.AuditlogDisabledViewlet"
+      manager="plone.app.layout.viewlets.interfaces.IAboveContent"
+      template="templates/auditlog_disabled.pt"
+      permission="zope2.View"
+      layer="bika.lims.interfaces.IBikaLIMS" />
+
 </configure>

--- a/bika/lims/browser/viewlets/templates/auditlog_disabled.pt
+++ b/bika/lims/browser/viewlets/templates/auditlog_disabled.pt
@@ -1,0 +1,22 @@
+<div tal:omit-tag=""
+     tal:condition="python:view.is_disabled()"
+     i18n:domain="senaite.core">
+
+  <div id="portal-alert">
+    <div class="portlet-alert-item alert alert-warning alert-dismissible">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <p class="title">
+        <strong i18n:translate="">
+          Global Audit Log is disabled
+        </strong>
+      </p>
+      <p class="description" i18n:translate="">
+        You can enable the global Audit Log again in the
+        <a href="#" tal:attributes="href python:view.get_setup_url()">Setup</a>
+      </p>
+    </div>
+  </div>
+
+</div>

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -209,6 +209,20 @@ schema = BikaFolderSchema.copy() + Schema((
         )
     ),
     BooleanField(
+        "EnableGlobalAuditlog",
+        schemata="Security",
+        default=False,
+        widget=BooleanWidget(
+            label=_("Enable global Audit Log"),
+            description=_(
+                "The global Auditlog shows all modifications of the system. "
+                "When enabled, all entities will be indexed in a separate "
+                "catalog. This will increase the time when objects are "
+                "created or modified."
+            )
+        )
+    ),
+    BooleanField(
         'ShowPrices',
         schemata="Accounting",
         default=True,

--- a/bika/lims/monkey/catalog.py
+++ b/bika/lims/monkey/catalog.py
@@ -1,9 +1,19 @@
 # -*- coding: utf-8 -*-
 
-from bika.lims import api
 from plone.indexer.interfaces import IIndexableObject
 from Products.ZCatalog.ZCatalog import ZCatalog
 from zope.component import queryMultiAdapter
+
+from bika.lims import api
+from bika.lims.catalog import CATALOG_AUDITLOG
+
+
+def is_auditlog_enabled():
+    setup = api.get_setup()
+    # might happen during installation
+    if not setup:
+        return False
+    return setup.getEnableGlobalAuditlog()
 
 
 def catalog_object(self, object, uid=None, idxs=None,
@@ -12,6 +22,11 @@ def catalog_object(self, object, uid=None, idxs=None,
     # Never catalog temporary objects
     if api.is_temporary(object):
         return
+
+    # skip indexing auditlog catalog if disabled
+    if self.id == CATALOG_AUDITLOG:
+        if not is_auditlog_enabled():
+            return
 
     if idxs is None:
         idxs = []


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #2074 and #2094 to 1.3.x

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
