### PR TITLE
Enable remaining flake8 checks (W601, W605, F901)

### DIFF
--- a/src/bika/lims/content/worksheet.py
+++ b/src/bika/lims/content/worksheet.py
@@ -440,7 +440,7 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
             prefix = reference.id + "-D"
         bac = getToolByName(reference, 'senaite_catalog_analysis')
         ids = bac.Indexes['getReferenceAnalysesGroupID'].uniqueValues()
-        rr = re.compile("^" + prefix + "[\d+]+$")
+        rr = re.compile("^" + prefix + r"[\d+]+$")
         ids = [int(i.split(prefix)[1]) for i in ids if i and rr.match(i)]
         ids.sort()
         _id = ids[-1] if ids else 0

--- a/src/bika/lims/idserver.py
+++ b/src/bika/lims/idserver.py
@@ -328,7 +328,7 @@ def slice(string, separator="-", start=None, end=None):
     """
     # split by wildcards/keywords first
     # AR-{sampleType}-{parentId}{alpha:3a2d}
-    segments = filter(None, re.split('(\{.+?\})', string))
+    segments = filter(None, re.split(r'(\{.+?})', string))
     # ['AR-', '{sampleType}', '-', '{parentId}', '{alpha:3a2d}']
     if separator:
         # Keep track of singleton separators as empties

--- a/src/bika/lims/jsonapi/read.py
+++ b/src/bika/lims/jsonapi/read.py
@@ -38,7 +38,7 @@ import App
 
 def read(context, request):
     tag = AuthenticatorView(context, request).authenticator()
-    pattern = '<input .*name="(\w+)".*value="(\w+)"'
+    pattern = r'<input .*name="(\w+)".*value="(\w+)"'
     _authenticator = re.match(pattern, tag).groups()[1]
 
     ret = {

--- a/src/bika/lims/utils/__init__.py
+++ b/src/bika/lims/utils/__init__.py
@@ -245,7 +245,7 @@ def zero_fill(matchobj):
     return matchobj.group().zfill(8)
 
 
-num_sort_regex = re.compile('\d+')
+num_sort_regex = re.compile(r'\d+')
 
 ModuleSecurityInfo('Products.bika.utils').declarePublic('sortable_title')
 

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -787,7 +787,7 @@ validation.register(PrePreservationValidator())
 
 
 class StandardIDValidator:
-    """Matches against regular expression:
+    r"""Matches against regular expression:
        [^A-Za-z\w\d\-\_]
     """
 

--- a/src/senaite/core/browser/fields/record.py
+++ b/src/senaite/core/browser/fields/record.py
@@ -134,7 +134,7 @@ class RecordField(ObjectField):
     def isSelection(self,subfield):
         """select box needed?"""
 
-        return self.subfield_vocabularies.has_key(subfield)
+        return subfield in self.subfield_vocabularies
 
     security.declarePublic('testSubfieldCondition')
     def testSubfieldCondition(self, subfield, folder, portal, object):
@@ -349,7 +349,7 @@ class RecordField(ObjectField):
             result returned by validator
             """
             name = self.getName()
-            if errors and errors.has_key(name):
+            if errors and name in errors:
                 return True
 
             if self.required_subfields:

--- a/src/senaite/core/browser/fields/records.py
+++ b/src/senaite/core/browser/fields/records.py
@@ -144,7 +144,7 @@ class RecordsField(RecordField):
         result returned by validator
         """
         name = self.getName()
-        if errors and errors.has_key(name):
+        if errors and name in errors:
             return True
 
         validation_results = (

--- a/src/senaite/core/exportimport/instruments/panalytical/omnia/__init__.py
+++ b/src/senaite/core/exportimport/instruments/panalytical/omnia/__init__.py
@@ -203,7 +203,7 @@ class AxiosXrfCSVParser(InstrumentCSVResultsFileParser):
 
     def parse_headerline(self, line):
         #Process incoming header line
-        """
+        r"""
         29/11/2013 10:15:44
         PANalytical
         "Quantification of sample ESFERA CINZA - 1g H3BO3 -  1:0,5 - NO PPC",

--- a/src/senaite/core/exportimport/instruments/shimadzu/gcms/qp2010se.py
+++ b/src/senaite/core/exportimport/instruments/shimadzu/gcms/qp2010se.py
@@ -140,7 +140,7 @@ class GCMSQP2010SECSVParser(InstrumentCSVResultsFileParser):
             return self.parse_quantitationesultsline(line)
 
     def parse_headerline(self, line):
-        """ Parses header lines
+        r""" Parses header lines
 
             Header example:
             [Header]

--- a/travis_ci_flake8.cfg
+++ b/travis_ci_flake8.cfg
@@ -79,8 +79,6 @@ extend-ignore =
     W293,
     # W391: blank line at end of file
     W391,
-    # W605: invalid escape sequence '\d'
-    W605,
 per-file-ignores =
     # ignore unused imports (F401) in meta packages
     src/bika/lims/browser/worksheet/views/__init__.py:F401

--- a/travis_ci_flake8.cfg
+++ b/travis_ci_flake8.cfg
@@ -69,8 +69,6 @@ extend-ignore =
     E501,
     # E502: the backslash is redundant between brackets
     E502,
-    # F901: 'raise NotImplemented' should be 'raise NotImplementedError'
-    F901,
     # W191: indentation contains tabs
     W191,
     # W291: trailing whitespace

--- a/travis_ci_flake8.cfg
+++ b/travis_ci_flake8.cfg
@@ -79,8 +79,6 @@ extend-ignore =
     W293,
     # W391: blank line at end of file
     W391,
-    # W601: .has_key() is deprecated, use 'in'
-    W601,
     # W605: invalid escape sequence '\d'
     W605,
 per-file-ignores =


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Enables the following checks and fixes existing violations:

- use of deprecated `.has_key()` (W601)
- invalid escape sequences (W605)
- `NotImplementedError` instead of `NotImplemented` (F901)

All remaining checks/violations are related to whitespace and should therefore be fixed by an automated formatter (and in a separate pull request).