### PR TITLE
Add a more descriptive message for "Reject" action inside a Worksheet

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2110 Add a more descriptive message for "Reject" action inside a Worksheet
 - #2104 Fix result formatting when result is below LDL or above UDL
 - #2103 Convert LDL/UDL fields to string
 - #2101 Add help text for numeric result

--- a/src/bika/lims/browser/worksheet/views/analyses.py
+++ b/src/bika/lims/browser/worksheet/views/analyses.py
@@ -142,6 +142,12 @@ class AnalysesView(BaseView):
                 "contentFilter": {},
                 "custom_transitions": [],
                 "columns": self.columns.keys(),
+                "confirm_messages": {
+                    "reject": _(
+                        "This operation can not be undone. Are you sure "
+                        "you want to reject the selected analyses?"
+                    )
+                }
             },
         ]
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Please merge https://github.com/senaite/senaite.app.listing/pull/82 first**

This Pull Request adds a more descriptive message for the "Reject" action of analyses inside a Worksheet. Reason is that when "Reject" action is clicked, all selected analyses are rejected and there is no way to restore them afterwards.

## Current behavior before PR

No descriptive message is displayed when "Reject" button is clicked

## Desired behavior after PR is merged

A descriptive message is displayed when "Reject" button is clicked

![Captura de 2022-08-10 16-42-05](https://user-images.githubusercontent.com/832627/183935519-596b9d63-170e-4e5a-a26e-edb2b7d6945c.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
