### PR TITLE
Fix insufficient privileges for instrument QC viewlet

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2115 Fix insufficient privileges for instrument QC viewlet
 - #2111 Replace header table with customizable sample header viewlet
 - #2110 Add a more descriptive message for "Reject" action inside a Worksheet
 - #2104 Fix result formatting when result is below LDL or above UDL

--- a/src/bika/lims/browser/viewlets/configure.zcml
+++ b/src/bika/lims/browser/viewlets/configure.zcml
@@ -9,7 +9,7 @@
       class="bika.lims.browser.viewlets.InstrumentQCFailuresViewlet"
       manager="plone.app.layout.viewlets.interfaces.IAboveContent"
       template="templates/instrument_qc_failures_viewlet.pt"
-      permission="senaite.core.permissions.ManageBika"
+      permission="zope2.View"
       layer="bika.lims.interfaces.IBikaLIMS"
       />
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the viewlet base permission to `zope2.View` to avoid insufficient privileges for views rendered on the portal root.

NOTE: The viewlet class already ensures that users with insufficient privileges won't get anything displayed from the viewlet

## Current behavior before PR

Insufficient privileges error raised for views located at the portal root

## Desired behavior after PR is merged

Views located on the portal root, e.g. the `multi_results` from #2114, will get rendered correctly.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
