### PR TITLE
Fix allow sample partitions in submitted states

### DIFF
--- a/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
+++ b/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
@@ -599,6 +599,7 @@
     <exit-transition transition_id="reject" />
     <exit-transition transition_id="rollback_to_receive" />
     <exit-transition transition_id="detach" />
+    <exit-transition transition_id="create_partitions" />
     <exit-transition transition_id="dispatch" />
     <!-- /TRANSITIONS -->
 
@@ -622,7 +623,7 @@
     <permission-map name="senaite.core: Transition: Retract" acquired="True"/>
     <permission-map name="senaite.core: Transition: Sample Sample" acquired="False"/>
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
-    <permission-map name="senaite.core: Transition: Create Partitions" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Create Partitions" acquired="True"/>
 
     <permission-map name="senaite.core: Add Analysis" acquired="False">
       <!-- LabClerk role has this permission  granted by default in rolemap -->
@@ -787,6 +788,7 @@
     <exit-transition transition_id="invalidate" />
     <exit-transition transition_id="rollback_to_receive" />
     <exit-transition transition_id="detach" />
+    <exit-transition transition_id="create_partitions" />
     <exit-transition transition_id="dispatch" />
     <!-- /TRANSITIONS -->
 
@@ -810,7 +812,7 @@
     <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
     <permission-map name="senaite.core: Transition: Sample Sample" acquired="False"/>
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
-    <permission-map name="senaite.core: Transition: Create Partitions" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Create Partitions" acquired="True"/>
 
     <!-- Hide the 'Manage Analyses' tab -->
     <permission-map name="senaite.core: Add Analysis" acquired="False"/>
@@ -889,6 +891,7 @@
     <!-- TRANSITIONS -->
     <exit-transition transition_id="republish"/>
     <exit-transition transition_id="invalidate"/>
+    <exit-transition transition_id="create_partitions" />
     <exit-transition transition_id="dispatch" />
     <!-- /TRANSITIONS -->
 
@@ -908,7 +911,7 @@
     <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
     <permission-map name="senaite.core: Transition: Sample Sample" acquired="False"/>
     <permission-map name="senaite.core: Transition: Schedule Sampling" acquired="False"/>
-    <permission-map name="senaite.core: Transition: Create Partitions" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Create Partitions" acquired="True"/>
     <!-- Hide the 'Manage Analyses' tab -->
     <permission-map name="senaite.core: Add Analysis" acquired="False"/>
     <!-- Hide the 'Manage Results' tab -->

--- a/src/senaite/core/tests/doctests/WorkflowAnalysisRequestCreatePartitions.rst
+++ b/src/senaite/core/tests/doctests/WorkflowAnalysisRequestCreatePartitions.rst
@@ -91,13 +91,13 @@ Submit all analyses:
     ...     analysis.setResult(12)
     ...     success = do_action_for(analysis, "submit")
 
-Partitions cannot be created when the status is `to_be_verified`:
+Partitions can be created when the status is `to_be_verified`:
 
     >>> api.get_workflow_status_of(ar)
     'to_be_verified'
 
     >>> isTransitionAllowed(ar, "create_partitions")
-    False
+    True
 
 Verify all analyses:
 
@@ -106,22 +106,22 @@ Verify all analyses:
     ...     success = do_action_for(analysis, "verify")
     >>> setup.setSelfVerificationEnabled(False)
 
-Partitions cannot be created when the status is `verified`:
+Partitions can be created when the status is `verified`:
 
     >>> api.get_workflow_status_of(ar)
     'verified'
 
     >>> isTransitionAllowed(ar, "create_partitions")
-    False
+    True
 
-Partitions cannot be created when the status is `published`:
+Partitions can be created when the status is `published`:
 
     >>> success = do_action_for(ar, "publish")
     >>> api.get_workflow_status_of(ar)
     'published'
 
     >>> isTransitionAllowed(ar, "create_partitions")
-    False
+    True
 
 Partitions cannot be created when the status is `invalid`:
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the regression in #2024 for #1839:

- https://github.com/senaite/senaite.core/pull/1839
- https://github.com/senaite/senaite.core/pull/2024

## Current behavior before PR

Create partitions not possible in submitted states

## Desired behavior after PR is merged

Create partitions possible in submitted states


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
