### PR TITLE
Add Sample Form: Save and Copy Action

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2123 Add Sample Form: Save and Copy Action
 - #2119 Fix linked client contact user can not see existing samples
 - #2118 Customized Quickinstaller Configlet
 - #2117 Customized User/Groups Preferences in Site Configuration

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1514,8 +1514,15 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         records = self.get_records()
         return adapter.check_confirmation(records)
 
+    def ajax_cancel(self):
+        """Cancel and redirect to configured actions
+        """
+        message = _("Sample creation cancelled")
+        self.context.plone_utils.addPortalMessage(message, "info")
+        return self.handle_redirect([], message)
+
     def ajax_submit(self):
-        """Submit & create the ARs
+        """Create samples and redirect to configured actions
         """
         # Check if there is the need to display a confirmation pane
         confirmation = self.check_confirmation()
@@ -1677,6 +1684,11 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         # Display a portal message
         self.context.plone_utils.addPortalMessage(message, level)
 
+        return self.handle_redirect(ARs.values(), message)
+
+    def handle_redirect(self, uids, message):
+        """Handle redirect after sample creation or cancel
+        """
         # Automatic label printing
         setup = api.get_setup()
         auto_print = setup.getAutoPrintStickers()
@@ -1684,7 +1696,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         redirect_to = self.context.absolute_url()
 
         # UIDs of the new created samples
-        sample_uids = ",".join(ARs.values())
+        sample_uids = ",".join(uids)
         # UIDs of previous created samples when save&copy was selected
         prev_sample_uids = self.request.get("sample_uids")
         if prev_sample_uids:
@@ -1696,8 +1708,8 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             # previous created sample UIDs
             redirect_to = "{}/ar_add?copy_from={}&ar_count={}&sample_uids={}" \
                 .format(self.context.absolute_url(),
-                        ",".join(ARs.values()),  # copy_from
-                        len(ARs.values()),  # ar_count
+                        ",".join(uids),  # copy_from
+                        len(uids),  # ar_count
                         sample_uids)  # sample_uids
         elif "register" in auto_print and sample_uids:
             redirect_to = "{}/sticker?autoprint=1&template={}&items={}".format(

--- a/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -664,6 +664,12 @@
                i18n:attributes="value"
                value="Save and Copy"/>
 
+        <input class="btn btn-outline-secondary btn-sm"
+               type="submit"
+               name="cancel_button"
+               i18n:attributes="value"
+               value="Cancel"/>
+
         <input type="hidden" id="confirmed" name="confirmed" value="0"/>
 
         <!-- submit input field is not included in the request when submitting via JS.

--- a/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -672,10 +672,10 @@
 
         <input type="hidden" id="confirmed" name="confirmed" value="0"/>
 
-        <!-- submit input field is not included in the request when submitting via JS.
-             Therefore, we it is stored in this field from the event handler -->
+        <!-- The input[type=submit] fields are not included in the request when submitting via JS.
+             Therefore, we set the action explicitly in the ajax event handler -->
         <input type="hidden" name="submit_action" value="save"/>
-        <!-- list of previous sample UIDs from copy&save cycles -->
+        <!-- List of previous created sample UIDs from copy&save cycles -->
         <input type="hidden" name="sample_uids" value="" tal:attributes="value request/sample_uids|nothing"/>
 
       </form>

--- a/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -652,13 +652,25 @@
 
         </table>
 
-        <input class="btn btn-success btn-sm allowMultiSubmit"
+        <input class="btn btn-success btn-sm"
                type="submit"
                name="save_button"
                i18n:attributes="value"
                value="Save"/>
 
+        <input class="btn btn-outline-success btn-sm"
+               type="submit"
+               name="save_and_copy_button"
+               i18n:attributes="value"
+               value="Save and Copy"/>
+
         <input type="hidden" id="confirmed" name="confirmed" value="0"/>
+
+        <!-- submit input field is not included in the request when submitting via JS.
+             Therefore, we it is stored in this field from the event handler -->
+        <input type="hidden" name="submit_action" value="save"/>
+        <!-- list of previous sample UIDs from copy&save cycles -->
+        <input type="hidden" name="sample_uids" value="" tal:attributes="value request/sample_uids|nothing"/>
 
       </form>
       <!-- /ADD Form -->

--- a/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
@@ -91,6 +91,7 @@
       $("body").on("click", ".service-listing-header", this.on_service_listing_header_click);
       $("body").on("click", "tr.category", this.on_service_category_click);
       $("body").on("click", "[name='save_button']", this.on_form_submit);
+      $("body").on("click", "[name='save_and_copy_button']", this.on_form_submit);
       $("body").on("click", "tr[fieldname=Composite] input[type='checkbox']", this.recalculate_records);
       $("body").on("click", "tr[fieldname=InvoiceExclude] input[type='checkbox']", this.recalculate_records);
       $("body").on("click", "tr[fieldname=Analyses] input[type='checkbox'].analysisservice-cb", this.on_analysis_checkbox_click);
@@ -1326,13 +1327,17 @@
       /*
        * Ajax request started
        */
-      var button;
+      var save_and_copy_button, save_button;
       console.debug("°°° on_ajax_start °°°");
-      button = $("input[name=save_button]");
-      button.prop({
+      save_button = $("input[name=save_button]");
+      save_button.prop({
         "disabled": true
       });
-      return button[0].value = _t("Loading ...");
+      save_button[0].value = _t("Loading ...");
+      save_and_copy_button = $("input[name=save_and_copy_button]");
+      return save_and_copy_button.prop({
+        "disabled": true
+      });
     };
 
     AnalysisRequestAdd.prototype.on_ajax_end = function() {
@@ -1340,13 +1345,17 @@
       /*
        * Ajax request finished
        */
-      var button;
+      var save_and_copy_button, save_button;
       console.debug("°°° on_ajax_end °°°");
-      button = $("input[name=save_button]");
-      button.prop({
+      save_button = $("input[name=save_button]");
+      save_button.prop({
         "disabled": false
       });
-      return button[0].value = _t("Save");
+      save_button[0].value = _t("Save");
+      save_and_copy_button = $("input[name=save_and_copy_button]");
+      return save_and_copy_button.prop({
+        "disabled": false
+      });
     };
 
     AnalysisRequestAdd.prototype.on_form_submit = function(event, callback) {
@@ -1355,10 +1364,17 @@
        * Eventhandler for the form submit button.
        * Extracts and submits all form data asynchronous.
        */
-      var base_url, me, portal_url;
+      var action, action_input, base_url, btn, me, portal_url;
       console.debug("°°° on_form_submit °°°");
       event.preventDefault();
       me = this;
+      btn = event.currentTarget;
+      action = "save";
+      if (btn.name === "save_and_copy_button") {
+        action = "save_and_copy";
+      }
+      action_input = document.querySelector("input[name='submit_action']");
+      action_input.value = action;
       base_url = me.get_base_url();
       portal_url = me.get_portal_url();
       $("div.error").removeClass("error");

--- a/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
@@ -18,6 +18,7 @@
       this.set_service_conditions = bind(this.set_service_conditions, this);
       this.init_file_fields = bind(this.init_file_fields, this);
       this.on_form_submit = bind(this.on_form_submit, this);
+      this.on_cancel = bind(this.on_cancel, this);
       this.on_ajax_end = bind(this.on_ajax_end, this);
       this.on_ajax_start = bind(this.on_ajax_start, this);
       this.ajax_post_form = bind(this.ajax_post_form, this);
@@ -92,6 +93,7 @@
       $("body").on("click", "tr.category", this.on_service_category_click);
       $("body").on("click", "[name='save_button']", this.on_form_submit);
       $("body").on("click", "[name='save_and_copy_button']", this.on_form_submit);
+      $("body").on("click", "[name='cancel_button']", this.on_cancel);
       $("body").on("click", "tr[fieldname=Composite] input[type='checkbox']", this.recalculate_records);
       $("body").on("click", "tr[fieldname=InvoiceExclude] input[type='checkbox']", this.recalculate_records);
       $("body").on("click", "tr[fieldname=Analyses] input[type='checkbox'].analysisservice-cb", this.on_analysis_checkbox_click);
@@ -1355,6 +1357,20 @@
       save_and_copy_button = $("input[name=save_and_copy_button]");
       return save_and_copy_button.prop({
         "disabled": false
+      });
+    };
+
+    AnalysisRequestAdd.prototype.on_cancel = function(event, callback) {
+      var base_url;
+      console.debug("°°° on_cancel °°°");
+      event.preventDefault();
+      base_url = this.get_base_url();
+      return this.ajax_post_form("cancel").done(function(data) {
+        if (data["redirect_to"]) {
+          return window.location.replace(data["redirect_to"]);
+        } else {
+          return window.location.replace(base_url);
+        }
       });
     };
 

--- a/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -72,6 +72,8 @@ class window.AnalysisRequestAdd
     $("body").on "click", "tr.category", @on_service_category_click
     # Save button clicked
     $("body").on "click", "[name='save_button']", @on_form_submit
+    # Save and copy button clicked
+    $("body").on "click", "[name='save_and_copy_button']", @on_form_submit
     # Composite Checkbox clicked
     $("body").on "click", "tr[fieldname=Composite] input[type='checkbox']", @recalculate_records
     # InvoiceExclude Checkbox clicked
@@ -1327,11 +1329,14 @@ class window.AnalysisRequestAdd
     ###
     console.debug "°°° on_ajax_start °°°"
 
-    # deactivate the button
-    button = $("input[name=save_button]")
-    button.prop "disabled": yes
-    button[0].value = _t("Loading ...")
+    # deactivate the save button
+    save_button = $("input[name=save_button]")
+    save_button.prop "disabled": yes
+    save_button[0].value = _t("Loading ...")
 
+    # deactivate the save and copy button
+    save_and_copy_button = $("input[name=save_and_copy_button]")
+    save_and_copy_button.prop "disabled": yes
 
   on_ajax_end: =>
     ###
@@ -1339,10 +1344,14 @@ class window.AnalysisRequestAdd
     ###
     console.debug "°°° on_ajax_end °°°"
 
-    # reactivate the button
-    button = $("input[name=save_button]")
-    button.prop "disabled": no
-    button[0].value = _t("Save")
+    # reactivate the save button
+    save_button = $("input[name=save_button]")
+    save_button.prop "disabled": no
+    save_button[0].value = _t("Save")
+
+    # reactivate the save and copy button
+    save_and_copy_button = $("input[name=save_and_copy_button]")
+    save_and_copy_button.prop "disabled": no
 
 
   # Note: Context of callback bound to this object
@@ -1354,6 +1363,15 @@ class window.AnalysisRequestAdd
     console.debug "°°° on_form_submit °°°"
     event.preventDefault()
     me = this
+
+    # The clicked submit button is not part of the form data, therefore,
+    # we pass the name of the button through a hidden field
+    btn = event.currentTarget
+    action = "save"
+    if btn.name == "save_and_copy_button"
+        action = "save_and_copy"
+    action_input = document.querySelector("input[name='submit_action']")
+    action_input.value = action
 
     # get the right base url
     base_url = me.get_base_url()

--- a/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -74,6 +74,8 @@ class window.AnalysisRequestAdd
     $("body").on "click", "[name='save_button']", @on_form_submit
     # Save and copy button clicked
     $("body").on "click", "[name='save_and_copy_button']", @on_form_submit
+    # Cancel button clicked
+    $("body").on "click", "[name='cancel_button']", @on_cancel
     # Composite Checkbox clicked
     $("body").on "click", "tr[fieldname=Composite] input[type='checkbox']", @recalculate_records
     # InvoiceExclude Checkbox clicked
@@ -1338,6 +1340,7 @@ class window.AnalysisRequestAdd
     save_and_copy_button = $("input[name=save_and_copy_button]")
     save_and_copy_button.prop "disabled": yes
 
+
   on_ajax_end: =>
     ###
      * Ajax request finished
@@ -1352,6 +1355,18 @@ class window.AnalysisRequestAdd
     # reactivate the save and copy button
     save_and_copy_button = $("input[name=save_and_copy_button]")
     save_and_copy_button.prop "disabled": no
+
+
+  on_cancel: (event, callback) =>
+    console.debug "°°° on_cancel °°°"
+    event.preventDefault()
+    base_url = this.get_base_url()
+
+    @ajax_post_form("cancel").done (data) ->
+      if data["redirect_to"]
+        window.location.replace data["redirect_to"]
+      else
+        window.location.replace base_url
 
 
   # Note: Context of callback bound to this object


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR allows to create and copy new samples in one step.

This is especially useful, when large amounts of samples need to be created for the same client, which would eventually lead to timeouts or an overloaded system.

<img width="867" alt="Sample Add Form" src="https://user-images.githubusercontent.com/713193/188715652-ebd6e9c9-b7a2-4392-a8bb-55328a86cbd5.png">

## Current behavior before PR

It was not possible to save and copy new samples in one step

## Desired behavior after PR is merged

It is possible to save and copy samples in one step

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
