### PR TITLE
Fixed typo in upgrade step

### DIFF
--- a/src/senaite/core/upgrade/v02_03_000.py
+++ b/src/senaite/core/upgrade/v02_03_000.py
@@ -387,7 +387,7 @@ def migrate_uncertainty_field_to_string(obj):
     if isinstance(value, tuple):
         migrated_value = fixed_point_value_to_string(value, 10)
         logger.info("Migrating Uncertainty field of %s: %s -> %s" % (
-            api.get_pat(obj), value, migrated_value))
+            api.get_path(obj), value, migrated_value))
         value = migrated_value
 
     # set the new value


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/2121

## Current behavior before PR

Typo: `api.get_pat(...)`

## Desired behavior after PR is merged

Fixed: `api.get_path(...)`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
