### PR TITLE
Fix instrument expiry date display in listing view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2127 Fix instrument expiry date display in listing view
 - #2123 Add Sample Form: Save and Copy Action
 - #2119 Fix linked client contact user can not see existing samples
 - #2118 Customized Quickinstaller Configlet

--- a/src/bika/lims/controlpanel/bika_instruments.py
+++ b/src/bika/lims/controlpanel/bika_instruments.py
@@ -163,9 +163,8 @@ class InstrumentsView(BikaListingView):
         if expiry_date is None:
             item["ExpiryDate"] = _("No date set")
         else:
-
-            item["ExpiryDate"] = expiry_date.asdatetime().strftime(
-                self.date_format_short)
+            item["ExpiryDate"] = self.ulocalized_time(
+                expiry_date, long_format=0)
 
         if obj.isOutOfDate():
             item["WeeksToExpire"] = _("Out of date")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the instrument expiry date display in the instruments listing

## Current behavior before PR

Instrument expiry date shows always `00:00`

## Desired behavior after PR is merged

Instrument expiry date shows the localized date until when the instrument is valid

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
