### PR TITLE
Fix referenceresults widget view mode

### DIFF
--- a/src/bika/lims/browser/widgets/referenceresultswidget.py
+++ b/src/bika/lims/browser/widgets/referenceresultswidget.py
@@ -272,6 +272,12 @@ class ReferenceResultsWidget(TypesWidget):
         # Call listing hooks
         table.update()
         table.before_render()
+
+        if allow_edit is False:
+            # This is a hack to notify read-only mode to the view
+            table.allow_edit = allow_edit
+            return table.contents_table_view()
+
         return table.ajax_contents_table()
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/2080

## Current behavior before PR

Reference definition widget is always in edit mode

## Desired behavior after PR is merged

Reference definition widget renders in view mode when not edited

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
