### PR TITLE
Fix Traceback when invalidating a Sample with Remarks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 ------------------
 
 - #2129 Fix Traceback when invalidating a Sample with Remarks
-- #2128 Fix referenceresults widget view mod
+- #2128 Fix referenceresults widget view mode
 - #2127 Fix instrument expiry date display in listing view
 - #2123 Add Sample Form: Save and Copy Action
 - #2119 Fix linked client contact user can not see existing samples

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2129 Fix Traceback when invalidating a Sample with Remarks
+- #2128 Fix referenceresults widget view mod
 - #2127 Fix instrument expiry date display in listing view
 - #2123 Add Sample Form: Save and Copy Action
 - #2119 Fix linked client contact user can not see existing samples

--- a/src/bika/lims/browser/fields/remarksfield.py
+++ b/src/bika/lims/browser/fields/remarksfield.py
@@ -179,14 +179,16 @@ class RemarksField(ObjectField):
         # Store the data
         ObjectField.set(self, instance, history)
 
-        # N.B. ensure updated catalog metadata for the snapshot
-        instance.reindexObject()
+        if not api.is_temporary(instance):
 
-        # notify object edited event
-        event.notify(ObjectEditedEvent(instance))
+            # N.B. ensure updated catalog metadata for the snapshot
+            instance.reindexObject()
 
-        # notify new remarks for e.g. later email notification etc.
-        event.notify(RemarksAddedEvent(instance, history))
+            # notify object edited event
+            event.notify(ObjectEditedEvent(instance))
+
+            # notify new remarks for e.g. later email notification etc.
+            event.notify(RemarksAddedEvent(instance, history))
 
     def to_safe_html(self, html):
         # see: Products.PortalTransforms.tests.test_xss

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -283,7 +283,7 @@ def create_retest(ar):
     actions_pool.queue_pool()
 
     # Create the Retest (Analysis Request)
-    ignore = ['Analyses', 'DatePublished', 'Invalidated', 'Sample']
+    ignore = ['Analyses', 'DatePublished', 'Invalidated', 'Sample', 'Remarks']
     retest = _createObjectByType("AnalysisRequest", ar.aq_parent, tmpID())
     copy_field_values(ar, retest, ignore_fieldnames=ignore)
 

--- a/src/senaite/core/tests/doctests/WorkflowAnalysisRequestInvalidate.rst
+++ b/src/senaite/core/tests/doctests/WorkflowAnalysisRequestInvalidate.rst
@@ -224,3 +224,48 @@ User with other roles cannot:
 Reset settings:
 
     >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
+
+
+Remarks field is not copied from invalidated to retest
+......................................................
+
+Create a Sample and receive:
+
+    >>> ar = new_ar([Cu])
+    >>> success = do_action_for(ar, "receive")
+
+Add some Remarks:
+
+    >>> ar.setRemarks("This is the first remark")
+    >>> ar.setRemarks("This is the second remark")
+    >>> ar.getRemarks()
+    [{...}]
+
+Submit results and verify them:
+
+    >>> setup.setSelfVerificationEnabled(True)
+    >>> for analysis in ar.getAnalyses(full_objects=True):
+    ...     analysis.setResult(12)
+    ...     submitted = do_action_for(analysis, "submit")
+    ...     verified = do_action_for(analysis, "verify")
+    >>> setup.setSelfVerificationEnabled(False)
+    >>> api.get_workflow_status_of(ar)
+    'verified'
+
+Invalidate the sample:
+
+    >>> success = do_action_for(ar, "invalidate")
+    >>> api.get_workflow_status_of(ar)
+    'invalid'
+
+    >>> retest = ar.getRetest()
+    >>> retest
+    <AnalysisRequest at /plone/clients/client-1/W-0004-R01>
+
+The value for Remarks field has not been copied to the retest:
+
+    >>> retest.getRemarks()
+    []
+
+    >>> ar.getRemarks()
+    [{...}]


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request allows to invalidate samples with Remarks. Reason is that system was trying to reindex the retest while still temporary when the value for Remarks field was set. Besides checking the instance is not temporary in RemarksField before trying to reindex the instance, this Pull Request prevents the Remarks field to be copied from the invalidated to the retest.

## Current behavior before PR

```
2022-09-08 04:37:44,469 INFO    [senaite.core:160][waitress-0] WF event: analysisrequest.events.after_invalidate
2022-09-08 04:37:44,700 ERROR   [senaite.core:191][waitress-0] Failed to get schema data for <AnalysisRequest at /senaite/clients/client-8/8737bd0b9e3cf7110df9447dd9949031>: No results found for UID '76f50b227fce403c80ed19099d0be7f3'
2022-09-08 04:37:44,812 ERROR   [Zope.SiteErrorLog:252][waitress-0] 1663065587.440.297702257237 http://localhost:9090/senaite/clients/client-8/CB22A005/content_status_modify
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module bika.lims.browser.workflow, line 144, in __call__
  Module bika.lims.browser.workflow.analysisrequest, line 157, in __call__
  Module bika.lims.browser.workflow, line 174, in do_action
  Module bika.lims.workflow, line 123, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 252, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 537, in _invokeWithNotification
AttributeError: 'exceptions.ValueError' object has no attribute 'with_traceback'
```

## Desired behavior after PR is merged

No traceback. Sample is invalidated and a retest (without a copy of Remarks field) is created

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html