### PR TITLE
Add a default date for batch creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 
 2.3.0 (unreleased)
 ------------------
-
+- #2132 Add a default date for batch creation 
 - #2129 Fix Traceback when invalidating a Sample with Remarks
 - #2128 Fix referenceresults widget view mode
 - #2127 Fix instrument expiry date display in listing view

--- a/src/bika/lims/content/batch.py
+++ b/src/bika/lims/content/batch.py
@@ -46,6 +46,7 @@ from Products.Archetypes.public import registerType
 from Products.CMFCore.utils import getToolByName
 from senaite.core.catalog import SAMPLE_CATALOG
 from zope.interface import implements
+from DateTime.DateTime import DateTime
 
 
 @indexer(IBatch)
@@ -98,6 +99,7 @@ schema = BikaFolderSchema.copy() + Schema((
     DateTimeField(
         'BatchDate',
         required=False,
+        default_method=DateTime,
         widget=DateTimeWidget(
             label=_('Date'),
         ),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Adding a default date (current date) when a batch is being added by a user would make adding a new batch a little quicker in most occasions.

## Current behavior before PR

When a user adds a batch on their site the batch date does not have a default.

## Desired behavior after PR is merged

When a user adds a batch on their site the batch date defaults to the current date. The user can still change that date if they would like to.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
