### PR TITLE
Render unit after result and interim fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2134 Render unit after result and interim fields
 - #2129 Fix Traceback when invalidating a Sample with Remarks
 - #2128 Fix referenceresults widget view mode
 - #2127 Fix instrument expiry date display in listing view

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -862,6 +862,11 @@ class AnalysesView(ListingView):
         item["CaptureDate"] = capture_date_str
         item["result_captured"] = capture_date_str
 
+        # Add the unit after the result
+        unit = item.get("Unit")
+        if unit:
+            item["after"]["Result"] = self.render_unit(unit)
+
         # Get the analysis object
         obj = self.get_object(analysis_brain)
 

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -768,6 +768,12 @@ class AnalysesView(ListingView):
 
         return items
 
+    def render_unit(self, unit, css_class="unit small text-secondary"):
+        """Render HTML element for unit
+        """
+        return "<span class='{css_class}'>{unit}</span>".format(
+            unit=unit, css_class=css_class)
+
     def _folder_item_category(self, analysis_brain, item):
         """Sets the category to the item passed in
 

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -962,10 +962,17 @@ class AnalysesView(ListingView):
                 continue
 
             interim_value = interim_field.get("value", "")
+            interim_unit = interim_field.get("unit", "")
             interim_formatted = formatDecimalMark(interim_value, self.dmk)
             interim_field["formatted_value"] = interim_formatted
             item[interim_keyword] = interim_field
             item["class"][interim_keyword] = "interim"
+
+            # render the unit after the interim field
+            if interim_unit:
+                formatted_interim_unit = format_supsub(interim_unit)
+                item["after"][interim_keyword] = self.render_unit(
+                    formatted_interim_unit)
 
             # Note: As soon as we have a separate content type for field
             #       analysis, we can solely rely on the field permission


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR explicitly adds the formatted unit after the result and interim fields.

## Current behavior before PR

Unit was added by `senaite.app.listing`

## Desired behavior after PR is merged

Unit is added in Analyses View

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
