### PR TITLE
Fix unit overlapping with additional icons

### DIFF
--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -768,9 +768,11 @@ class AnalysesView(ListingView):
 
         return items
 
-    def render_unit(self, unit, css_class="unit small text-secondary"):
+    def render_unit(self, unit, css_class=None):
         """Render HTML element for unit
         """
+        if css_class is None:
+            css_class = "unit d-inline-block py-2 small text-secondary"
         return "<span class='{css_class}'>{unit}</span>".format(
             unit=unit, css_class=css_class)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a display issue when the Unit was shown together with additional icons.

Related PRs:

- https://github.com/senaite/senaite.core/pull/2134
- https://github.com/senaite/senaite.app.listing/pull/86

## Current behavior before PR

<img width="102" alt="" src="https://user-images.githubusercontent.com/713193/191258431-a96c4a61-8b5f-404a-ac7c-b83bfe9e0ccc.png">

## Desired behavior after PR is merged

<img width="150" alt="" src="https://user-images.githubusercontent.com/713193/191258298-b1b79854-b48e-42fb-a4c6-ab97a6860f1e.png">


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
