### PR TITLE
Always redirect multi-results to samples view

### DIFF
--- a/src/senaite/core/adapters/sample.py
+++ b/src/senaite/core/adapters/sample.py
@@ -27,6 +27,7 @@ class WorkflowActionMultiResultsAdapter(RequestContextAware):
     def __call__(self, action, uids):
         """Redirects the user to the multi results form
         """
-        url = "{}/multi_results?uids={}".format(
-            api.get_url(self.context), ",".join(uids))
+        portal_url = api.get_url(api.get_portal())
+        url = "{}/samples/multi_results?uids={}".format(
+            portal_url, ",".join(uids))
         return self.redirect(redirect_url=url)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This is a complementary change for https://github.com/senaite/senaite.core/pull/2114

Background:
PR https://github.com/senaite/senaite.core/pull/2137 updates the workflow menu when an analysis is transitioned via Ajax (see https://github.com/senaite/senaite.app.listing/pull/87).
When the multi results action was executed from inside a client, the WF menu of the client is present in this view and causes a JS error.

## Current behavior before PR

Multi results action uses current page URL as base URL

## Desired behavior after PR is merged

Multi results action uses samples listing as base URL

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
