### PR TITLE
Fix LabClerk cannot create partitions from received samples

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2139 Fix LabClerk cannot create partitions from received samples
 - #2130 Catalog mapping for Samples and Analyses
 - #2131 Allow to edit the analysis service sort keys in the services listing
 - #2133 Filter Contact and CCContact by Client on first click

--- a/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
+++ b/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
@@ -518,6 +518,7 @@
     <!-- PLONE PERMISSIONS -->
     <permission-map name="Delete objects" acquired="False">
       <!-- Allow the removal of analyses and attachments -->
+      <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
     </permission-map>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request complements #2024 by giving the "Delete objects" permission to LabClerk for samples in `sample_received` status, so users from this role can create partitions from samples in such status as well.

No need to do an update role mappings of existing samples because the upgrade step 2.3.0 already does in [`fix_cannot_create_partitions`](https://github.com/senaite/senaite.core/blob/2.x/src/senaite/core/upgrade/v02_03_000.py#L182`)

## Current behavior before PR

Traceback arises when trying to create partitions from received samples with a LabClerk user.

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module bika.lims.browser.partition_magic, line 98, in __call__
  Module bika.lims.utils.analysisrequest, line 422, in create_partition
  Module bika.lims.utils.analysisrequest, line 87, in create_analysisrequest
  Module Products.Archetypes.ClassGen, line 77, in generatedMutator
  Module bika.lims.browser.fields.aranalysesfield, line 143, in set
  Module bika.lims.browser.fields.aranalysesfield, line 143, in <lambda>
  Module bika.lims.browser.fields.aranalysesfield, line 267, in add_analysis
  Module bika.lims.browser.fields.aranalysesfield, line 375, in resolve_analyses
  Module OFS.CopySupport, line 326, in manage_pasteObjects
  Module OFS.CopySupport, line 211, in _pasteObjects
  Module Products.CMFCore.PortalFolder, line 391, in _verifyObjectPaste
Unauthorized: Delete not allowed.
```

## Desired behavior after PR is merged

Partitions are created without errors

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
