### PR TITLE
Added readonly transaction decorator for menu provider

### DIFF
--- a/src/senaite/core/browser/contentmenu/menu_provider.py
+++ b/src/senaite/core/browser/contentmenu/menu_provider.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from Products.Five import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from senaite.core.decorators import readonly_transaction
 from zope.component import getMultiAdapter
 from zope.interface import implementer
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
 from .interfaces import IMenuProvider
 
@@ -26,6 +27,7 @@ class MenuProviderView(BrowserView):
     def available(self):
         return self.contentmenu.available()
 
+    @readonly_transaction
     def workflow_menu(self):
         menu_id = "content_status_history"
         menu = self.contentmenu.menu()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This is a complementary PR for https://github.com/senaite/senaite.core/pull/2137 to avoid a transaction commit when the workflow menu is updated

## Current behavior before PR

Each Ajax WF menu update results in a new transaction

## Desired behavior after PR is merged

Ajax WF menu updates do not commit a new transaction

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
