### PR TITLE
Fix Traceback when using reaodnly_transaction decorator for objects with no __name__

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2143 Fix Traceback when using readonly decorator for objects w/o __name__
 - #2140 Allow to enable/disable analysis categories for samples
 - #2137 Dynamic Workflow Menu
 - #2139 Fix LabClerk cannot create partitions from received samples

--- a/src/senaite/core/decorators/__init__.py
+++ b/src/senaite/core/decorators/__init__.py
@@ -16,7 +16,7 @@ def readonly_transaction(func):
     @wraps(func)
     def decorator(self, *args, **kwargs):
         logger.info("*** READONLY TRANSACTION: '{}.{}' ***".
-                    format(self.__class__.__name__, self.__name__))
+                    format(self.__class__.__name__, func.__name__))
         tx = transaction.get()
         tx.doom()
         return func(self, *args, **kwargs)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures no Traceback arises when using the `readonly_transaction` for objects (e.g. adapters that directly inherit from `object`) that do not have the attr `__name__`

## Current behavior before PR

```
Traceback (most recent call last):
  File "/home/senaite/buildout-cache/eggs/plone.jsonapi.core-0.7.0-py2.7.egg/plone/jsonapi/core/browser/decorators.py", line 23, in decorator
    return f(*args, **kwargs)
  File "/home/senaite/buildout-cache/eggs/plone.jsonapi.core-0.7.0-py2.7.egg/plone/jsonapi/core/browser/api.py", line 57, in to_json
    return self.dispatch()
  File "/home/senaite/buildout-cache/eggs/plone.jsonapi.core-0.7.0-py2.7.egg/plone/jsonapi/core/browser/api.py", line 51, in dispatch
    return router(self.context, self.request, path)
  File "/home/senaite/buildout-cache/eggs/plone.jsonapi.core-0.7.0-py2.7.egg/plone/jsonapi/core/browser/router.py", line 150, in __call__
    return self.view_functions[endpoint](context, request, **values)
  File "/home/senaite/zinstance/src/senaite.jsonapi/src/senaite/jsonapi/v1/routes/push.py", line 58, in push
    success = consumer.process()
  File "/home/senaite/zinstance/src/senaite.core/src/senaite/core/decorators/__init__.py", line 19, in decorator
    format(self.__class__.__name__, self.__name__))
AttributeError: 'PushConsumer' object has no attribute '__name__'
```

## Desired behavior after PR is merged

No traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
