### PR TITLE
Fix Multi Results Action is displayed for Clients, but raises a Permission Error

### DIFF
--- a/src/senaite/core/profiles/default/rolemap.xml
+++ b/src/senaite/core/profiles/default/rolemap.xml
@@ -17,7 +17,6 @@
       <role name="LabClerk"/>
       <role name="LabManager"/>
       <role name="Manager"/>
-      <role name="Owner"/>
       <role name="Sampler"/>
       <role name="Verifier"/>
     </permission>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the `Owner` role for the permission `senaite.core: Transition: Multi Results` to avoid a permission error when performed by a client contact.

Traceback:

2022-09-26 14:02:44 DEBUG ImplPython Unauthorized: Your user account does not have the required permission.  Access to 'multi_results' of (Samples at /senaite/samples) denied. Your user account, rbartl, exists at /senaite/acl_users. Access requires senaite_core__Transition__Multi_Results_Permission, granted to the following roles: ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Owner', 'Sampler', 'Verifier']. Your roles in this context are ['Authenticated', 'Client', 'Member'].

## Current behavior before PR

Multi Results action is displayed for Client Contacts because of the `Owner` role

## Desired behavior after PR is merged

Multi Results action is no longer displayed for Client Contacts

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
