### PR TITLE
Remove stale function workflow.getReviewHistory

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2147 Remove stale function workflow.getReviewHistory
 - #2145 Crop page navigation for DX reference widget
 - #2143 Fix Traceback when using readonly decorator for objects w/o __name__
 - #2140 Allow to enable/disable analysis categories for samples

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -30,7 +30,6 @@ from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import deprecated
 from bika.lims import logger
-from bika.lims import workflow as wf
 from bika.lims.browser.fields import HistoryAwareReferenceField
 from bika.lims.browser.fields import InterimFieldsField
 from bika.lims.browser.fields import ResultRangeField

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -214,7 +214,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         """
         verifiers = list()
         actions = ["verify", "multi_verify"]
-        for event in wf.getReviewHistory(self):
+        for event in api.get_review_history(self):
             if event['action'] in actions:
                 verifiers.append(event['actor'])
         sorted(verifiers, reverse=True)

--- a/src/bika/lims/workflow/__init__.py
+++ b/src/bika/lims/workflow/__init__.py
@@ -249,20 +249,6 @@ def getAllowedTransitions(instance):
     return [trans['id'] for trans in transitions]
 
 
-def get_review_history_statuses(instance, reverse=False):
-    """Returns a list with the statuses of the instance from the review_history
-    """
-    review_history = getReviewHistory(instance, reverse=reverse)
-    return map(lambda event: event["review_state"], review_history)
-
-
-def getReviewHistory(instance, reverse=True):
-    """Returns the review history for the instance
-    :returns: the list of historic events as dicts
-    """
-    return api.get_review_history(instance, rev=reverse)
-
-
 def getCurrentState(obj, stateflowid='review_state'):
     """ The current state of the object for the state flow id specified
         Return empty if there's no workflow state for the object and flow id
@@ -285,7 +271,7 @@ def getTransitionActor(obj, action_id):
     :return: the username of the user that performed the transition passed-in
     :type: string
     """
-    review_history = getReviewHistory(obj)
+    review_history = api.get_review_history(obj)
     for event in review_history:
         if event.get('action') == action_id:
             return event.get('actor')
@@ -297,7 +283,7 @@ def getTransitionDate(obj, action_id, return_as_datetime=False):
     Returns date of action for object. Sometimes we need this date in Datetime
     format and that's why added return_as_datetime param.
     """
-    review_history = getReviewHistory(obj)
+    review_history = api.get_review_history(obj)
     for event in review_history:
         if event.get('action') == action_id:
             evtime = event.get('time')

--- a/src/senaite/core/tests/doctests/AnalysisTurnaroundTime.rst
+++ b/src/senaite/core/tests/doctests/AnalysisTurnaroundTime.rst
@@ -22,7 +22,6 @@ Needed Imports:
     >>> from bika.lims.workflow import doActionFor
     >>> from bika.lims.workflow import getCurrentState
     >>> from bika.lims.workflow import getAllowedTransitions
-    >>> from bika.lims.workflow import getReviewHistory
     >>> from DateTime import DateTime
     >>> from datetime import timedelta
     >>> from plone.app.testing import TEST_USER_ID

--- a/src/senaite/core/tests/doctests/WorkflowAnalysisMultiVerify.rst
+++ b/src/senaite/core/tests/doctests/WorkflowAnalysisMultiVerify.rst
@@ -15,7 +15,6 @@ Needed Imports:
     >>> from bika.lims import api
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
-    >>> from bika.lims.workflow import getReviewHistory
     >>> from bika.lims.workflow import isTransitionAllowed
     >>> from DateTime import DateTime
     >>> from plone.app.testing import setRoles
@@ -216,7 +215,7 @@ The status of the analysis and others is still `to_be_verified`:
 
 And my user id is recorded as such:
 
-    >>> action = getReviewHistory(analysis)[0]
+    >>> action = api.get_review_history(analysis)[0]
     >>> action['actor'] == TEST_USER_ID
     True
 

--- a/src/senaite/core/tests/doctests/WorkflowDuplicateAnalysisMultiVerify.rst
+++ b/src/senaite/core/tests/doctests/WorkflowDuplicateAnalysisMultiVerify.rst
@@ -15,7 +15,6 @@ Needed Imports:
     >>> from bika.lims import api
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
-    >>> from bika.lims.workflow import getReviewHistory
     >>> from bika.lims.workflow import isTransitionAllowed
     >>> from DateTime import DateTime
     >>> from plone.app.testing import setRoles
@@ -234,7 +233,7 @@ The status remains to `to_be_verified`:
 
 And my user id is recorded as such:
 
-    >>> action = getReviewHistory(duplicate)[0]
+    >>> action = api.get_review_history(duplicate)[0]
     >>> action['actor'] == TEST_USER_ID
     True
 

--- a/src/senaite/core/tests/doctests/WorkflowReferenceAnalysisBlankMultiVerify.rst
+++ b/src/senaite/core/tests/doctests/WorkflowReferenceAnalysisBlankMultiVerify.rst
@@ -15,7 +15,6 @@ Needed Imports:
     >>> from bika.lims import api
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
-    >>> from bika.lims.workflow import getReviewHistory
     >>> from bika.lims.workflow import isTransitionAllowed
     >>> from DateTime import DateTime
     >>> from plone.app.testing import setRoles
@@ -245,7 +244,7 @@ The status remains to `to_be_verified`:
 
 And my user id is recorded as such:
 
-    >>> action = getReviewHistory(blank)[0]
+    >>> action = api.get_review_history(blank)[0]
     >>> action['actor'] == TEST_USER_ID
     True
 

--- a/src/senaite/core/tests/doctests/WorkflowReferenceAnalysisControlMultiVerify.rst
+++ b/src/senaite/core/tests/doctests/WorkflowReferenceAnalysisControlMultiVerify.rst
@@ -15,7 +15,6 @@ Needed Imports:
     >>> from bika.lims import api
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
-    >>> from bika.lims.workflow import getReviewHistory
     >>> from bika.lims.workflow import isTransitionAllowed
     >>> from DateTime import DateTime
     >>> from plone.app.testing import setRoles
@@ -245,7 +244,7 @@ The status remains to `to_be_verified`:
 
 And my user id is recorded as such:
 
-    >>> action = getReviewHistory(control)[0]
+    >>> action = api.get_review_history(control)[0]
     >>> action['actor'] == TEST_USER_ID
     True
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request removes the stale function `getReviewHistory` in favour of `api.get_review_history`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
