### PR TITLE
Performance: prioritize raw getter for AllowedInstruments field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2148 Performance: prioritize raw getter for AllowedInstruments field
 - #2145 Crop page navigation for DX reference widget
 - #2143 Fix Traceback when using readonly decorator for objects w/o __name__
 - #2140 Allow to enable/disable analysis categories for samples

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -1532,7 +1532,7 @@ class AnalysesView(ListingView):
         # If method selection list is required, the instrument selection too
         if self.is_method_required(analysis):
             return True
-        
+
         # Always return true if the analysis has an instrument assigned
         analysis = self.get_object(analysis)
         if analysis.getRawInstrument():

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -1538,7 +1538,7 @@ class AnalysesView(ListingView):
         if analysis.getRawInstrument():
             return True
 
-        instruments = analysis.getRawAllowedInstruments() or []
+        instruments = analysis.getRawAllowedInstruments()
         # There is no need to check for the instruments of the method assigned
         # to # the analysis (if any), because the instruments rendered in the
         # selection list are always a subset of the allowed instruments when

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -486,7 +486,7 @@ class AnalysesView(ListingView):
         # check if the analysis has a method
         if method:
             # supported instrument from the method
-            method_instruments = method.getInstruments()
+            method_instruments = method.getRawInstruments()
             # allow only method instruments that are set in service
             instruments = list(
                 set(instruments).intersection(method_instruments))

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -1534,10 +1534,10 @@ class AnalysesView(ListingView):
             return True
         
         # Always return true if the analysis has an instrument assigned
-        if self.get_instrument(analysis):
+        analysis = self.get_object(analysis)
+        if analysis.getRawInstrument():
             return True
 
-        obj = self.get_object(analysis)
         instruments = analysis.getRawAllowedInstruments() or []
         # There is no need to check for the instruments of the method assigned
         # to # the analysis (if any), because the instruments rendered in the

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -478,7 +478,7 @@ class AnalysesView(ListingView):
         """
         obj = self.get_object(analysis)
         # get the allowed interfaces from the analysis service
-        instruments = obj.getRawAllowedInstruments()
+        instruments = obj.getAllowedInstruments()
         # if no method is passed, get the assigned method of the analyis
         if method is None:
             method = obj.getMethod()
@@ -486,7 +486,7 @@ class AnalysesView(ListingView):
         # check if the analysis has a method
         if method:
             # supported instrument from the method
-            method_instruments = method.getRawInstruments()
+            method_instruments = method.getInstruments()
             # allow only method instruments that are set in service
             instruments = list(
                 set(instruments).intersection(method_instruments))

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -478,7 +478,7 @@ class AnalysesView(ListingView):
         """
         obj = self.get_object(analysis)
         # get the allowed interfaces from the analysis service
-        instruments = obj.getAllowedInstruments()
+        instruments = obj.getRawAllowedInstruments()
         # if no method is passed, get the assigned method of the analyis
         if method is None:
             method = obj.getMethod()
@@ -1538,7 +1538,7 @@ class AnalysesView(ListingView):
             return True
 
         obj = self.get_object(analysis)
-        instruments = obj.getAllowedInstruments()
+        instruments = analysis.getRawAllowedInstruments() or []
         # There is no need to check for the instruments of the method assigned
         # to # the analysis (if any), because the instruments rendered in the
         # selection list are always a subset of the allowed instruments when

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -729,7 +729,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         :rtype: bool
         """
         uid = api.get_uid(instrument)
-        return uid in map(api.get_uid, self.getAllowedInstruments())
+        return uid in self.getRawAllowedInstruments()
 
     @security.public
     def isMethodAllowed(self, method):
@@ -768,6 +768,15 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         if not service:
             return []
         return service.getInstruments()
+
+    @security.public
+    def getRawAllowedInstruments(self):
+        """Returns the UIDS of the allowed instruments from the service
+        """
+        service = self.getAnalysisService()
+        if not service:
+            return []
+        return service.getRawInstruments()
 
     @security.public
     def getExponentialFormatPrecision(self, result=None):

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -963,11 +963,7 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
 
         :returns: Instrument UID
         """
-        field = self.getField("Instrument")
-        instrument = field.getRaw(self)
-        if not instrument:
-            return None
-        return instrument
+        return self.getField("Instrument").getRaw(self)
 
     @security.public
     def getInstrumentUID(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the system to rely on `getRawAllowedInstruments` instead of `getAllowedInstruments` when there is no need to wake up objects, but only interested in UIDs or if there are instruments allowed for the given analysis.

## Current behavior before PR

System wakes up Instrument objects unnecessarily

## Desired behavior after PR is merged

System does not wake up Instrument objects unnecessarily

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
