### PR TITLE
Performance: prioritize raw getter for AllowedMethods field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2150 Performance: prioritize raw getter for AllowedMethods field
 - #2147 Remove stale function workflow.getReviewHistory
 - #2146 Fix "No object found for UID: <laboratory_uid>" in report preview
 - #2145 Crop page navigation for DX reference widget

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -1516,11 +1516,11 @@ class AnalysesView(ListingView):
         """
         # Always return true if the analysis has a method assigned
         obj = self.get_object(analysis)
-        method = obj.getMethod()
+        method = obj.getRawMethod()
         if method:
             return True
 
-        methods = obj.getAllowedMethods()
+        methods = obj.getRawAllowedMethods()
         return len(methods) > 0
 
     def is_instrument_required(self, analysis):

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -739,7 +739,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         :rtype: bool
         """
         uid = api.get_uid(method)
-        return uid in map(api.get_uid, self.getAllowedMethods())
+        return uid in self.getRawAllowedMethods()
 
     @security.public
     def getAllowedMethods(self):
@@ -755,6 +755,15 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             return []
         # get the available methods of the service
         return service.getMethods()
+
+    @security.public
+    def getRawAllowedMethods(self):
+        """Returns the UIDs of the allowed methods for this analysis
+        """
+        service = self.getAnalysisService()
+        if not service:
+            return []
+        return service.getRawMethods()
 
     @security.public
     def getAllowedInstruments(self):

--- a/src/bika/lims/content/analysisservice.py
+++ b/src/bika/lims/content/analysisservice.py
@@ -315,17 +315,14 @@ class AnalysisService(AbstractBaseAnalysis):
 
         :returns: List of method objects
         """
-        field = self.getField("Methods")
-        methods = field.get(self)
-        return methods
+        return self.getField("Methods").get(self)
 
     def getRawMethods(self):
         """Returns the assigned method UIDs
 
         :returns: List of method UIDs
         """
-        methods = self.getMethods()
-        return map(api.get_uid, methods)
+        return self.getField("Methods").getRaw(self)
 
     def getMethod(self):
         """Get the default method


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the system to rely on `getRawAllowedMethods` instead of `getAllowedMethods` when there is no need to wake up objects, but only interested in UIDs or if there are methods allowed for the given analysis.

## Current behavior before PR

System wakes up Method objects unnecessarily

## Desired behavior after PR is merged

System does not wake up Method objects unnecessarily

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
