### PR TITLE
Improve the creation process of AT content types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 2.3.0 (unreleased)
 ------------------
 
+- #2151 Improve the creation process of AT content types
+- #2151 Added a naive edit function in the API
 - #2150 Performance: prioritize raw getter for AllowedMethods field
 - #2148 Performance: prioritize raw getter for AllowedInstruments field
 - #2147 Remove stale function workflow.getReviewHistory

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -165,8 +165,7 @@ def create(container, portal_type, *args, **kwargs):
             obj._renameAfterCreation(check_auto_id=True)
         # we are no longer under creation
         obj.unmarkCreationFlag()
-        # reindex and notify
-        obj.reindexObject()
+        # notify that the object was created
         notify(ObjectInitializedEvent(obj))
     else:
         # newstyle factory

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -191,6 +191,8 @@ def create(container, portal_type, *args, **kwargs):
 def edit(obj, **kwargs):
     """Updates the values of object fields with the new values passed-in
     """
+    # Prevent circular dependencies
+    from security import check_permission
     fields = get_fields(obj)
     temporary = is_temporary(obj)
     for name, value in kwargs.items():
@@ -206,8 +208,6 @@ def edit(obj, **kwargs):
         # check field writable permission
         permission = getattr(field, "write_permission", ModifyPortalContent)
         if not temporary and permission:
-            # Prevent circular dependencies
-            from security import check_permission
             if not check_permission(permission, obj):
                 raise Unauthorized("Field '{}' is not writeable".format(name))
 

--- a/src/bika/lims/subscribers/configure.zcml
+++ b/src/bika/lims/subscribers/configure.zcml
@@ -110,7 +110,7 @@
     handler="bika.lims.subscribers.analysisrequest.AfterTransitionEventHandler"
   />
 
-  <!-- Batch modified event
+  <!-- Batch initialized and modified events
   This subscriber moves a Batch to its corresponding client folder when the
   the batch is being created in batches folder and a client is set. This only
   happens when the Batch is created by lab personnel, cause batches created by
@@ -118,6 +118,10 @@
   Therefore, this behaviour allows client contacts to access to batches that
   were created by lab personnel and were assigned to their client.
   -->
+  <subscriber
+    for="bika.lims.interfaces.IBatch
+         Products.Archetypes.interfaces.IObjectInitializedEvent"
+    handler="bika.lims.subscribers.batch.ObjectInitializedEventHandler" />
   <subscriber
     for="bika.lims.interfaces.IBatch
          zope.lifecycleevent.interfaces.IObjectModifiedEvent"

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -104,6 +104,44 @@ It also works for DX content types::
     >>> senaite_setup.getSiteLogoCSS()
     'my-test-logo'
 
+The field need to be writeable::
+
+    >>> field = client.getField("BankName")
+    >>> field.readonly = True
+    >>> api.edit(client, BankName="Lydian Lion Coins Bank")
+    Traceback (most recent call last):
+    [...]
+    ValueError: Field 'BankName' is readonly
+
+    >>> client.getBankName()
+    'BTC Bank'
+
+    >>> field.readonly = False
+    >>> api.edit(client, BankName="Lydian Lion Coins Bank")
+    >>> client.getBankName()
+    'Lydian Lion Coins Bank'
+
+And user need to have enough permissions to change the value as well::
+
+    >>> field.write_permission = "Delete objects"
+    >>> api.edit(client, BankName="Electrum Coins")
+    Traceback (most recent call last):
+    [...]
+    Unauthorized: Field 'BankName' is not writeable
+
+    >>> client.getBankName()
+    'Lydian Lion Coins Bank'
+
+Unless we manually force to bypass the permissions check::
+
+    >>> api.edit(client, check_permissions=False, BankName="Electrum Coins")
+    >>> client.getBankName()
+    'Electrum Coins'
+
+Restore permission::
+
+    >>> field.write_permission = "Modify Portal Content"
+
 
 Getting a Tool
 ..............

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -84,6 +84,27 @@ Here we create a new `Client` in the `plone/clients` folder::
      'Test Client'
 
 
+Editing Content
+...............
+
+This function helps to edit a given content.
+
+Here we update the `Client` we created earlier, an AT::
+
+    >>> api.edit(client, AccountNumber="12343567890", BankName="BTC Bank")
+    >>> client.getAccountNumber()
+    '12343567890'
+
+    >>> client.getBankName()
+    'BTC Bank'
+
+It also works for DX content types::
+
+    >>> api.edit(senaite_setup, site_logo_css="my-test-logo")
+    >>> senaite_setup.getSiteLogoCSS()
+    'my-test-logo'
+
+
 Getting a Tool
 ..............
 

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -80,8 +80,19 @@ Here we create a new `Client` in the `plone/clients` folder::
     >>> client
     <Client at /plone/clients/client-1>
 
-     >>> client.Title()
-     'Test Client'
+    >>> client.Title()
+    'Test Client'
+
+Created objects are properly indexed::
+
+    >>> services = self.portal.bika_setup.bika_analysisservices
+    >>> service = api.create(services, "AnalysisService",
+    ...                      title="Dummy service", Keyword="DUM")
+    >>> uid = api.get_uid(service)
+    >>> catalog = api.get_tool("senaite_catalog_setup")
+    >>> brains = catalog(portal_type="AnalysisService", UID=uid)
+    >>> brains[0].getKeyword
+    'DUM'
 
 
 Editing Content

--- a/src/senaite/core/tests/doctests/BatchClientAssignment.rst
+++ b/src/senaite/core/tests/doctests/BatchClientAssignment.rst
@@ -54,7 +54,6 @@ Client's folder:
 If the client is assigned on creation, same behavior as before:
 
     >>> batch = api.create(portal.batches, "Batch", Client=client)
-    >>> modified(batch)
     >>> len(batches.objectValues("Batch"))
     0
     >>> len(client.objectValues("Batch"))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request improves the creation process of AT content types via core's API. The creation of an AT content type is now consistent with events when values are set by default on creation. Before this change, system was creating an empty AT first that was triggering initialization event via `processForm`, although it was edited afterwards. As a result, two reindex processes were taking place, but with only one `ObjectInitializedEvent` (before the object was edited). With this PR, only one reindex takes place and the `ObjectInitializedEvent` is triggered after all values are set.

## Current behavior before PR

- `ObjectInitializedEvent` is triggered before initial values are set in the newly created object, after `processForm()`
- Object is reindexed twice: one after `processForm()` and another after initial values are set

## Desired behavior after PR is merged

- `ObjectInitializedEvent` is triggered after initial values are set in the newly created object
- Object is reindexed once, after initial values are set

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
