### PR TITLE
Improve default body text for email publication to allow translations

### DIFF
--- a/src/bika/lims/browser/publish/emailview.py
+++ b/src/bika/lims/browser/publish/emailview.py
@@ -498,7 +498,7 @@ class EmailView(BrowserView):
         """
 
         # allow to add translation for initial template
-        template = self.context.translate(template)
+        template = self.context.translate(_(template))
         recipients = self.email_recipients_and_responsibles
         if template_context is None:
             template_context = {

--- a/src/bika/lims/browser/publish/emailview.py
+++ b/src/bika/lims/browser/publish/emailview.py
@@ -303,6 +303,8 @@ class EmailView(BrowserView):
         body = setup.getEmailBodySamplePublication()
         template_context = {
             "client_name": self.client_name,
+            "lab_name": self.lab_name,
+            "lab_address": self.lab_address,
         }
         rendered_body = self.render_email_template(
             body, template_context=template_context)
@@ -360,6 +362,18 @@ class EmailView(BrowserView):
         """Returns the client name
         """
         return safe_unicode(self.context.Title())
+
+    @property
+    def lab_address(self):
+        """Returns the laboratory print address
+        """
+        return "<br/>".join(self.laboratory.getPrintAddress())
+
+    @property
+    def lab_name(self):
+        """Returns the laboratory name
+        """
+        return "<br/>".join(self.laboratory.getPrintAddress())
 
     @property
     def exit_url(self):

--- a/src/bika/lims/browser/publish/emailview.py
+++ b/src/bika/lims/browser/publish/emailview.py
@@ -373,7 +373,7 @@ class EmailView(BrowserView):
     def lab_name(self):
         """Returns the laboratory name
         """
-        return "<br/>".join(self.laboratory.getPrintAddress())
+        return self.laboratory.getName()
 
     @property
     def exit_url(self):

--- a/src/bika/lims/content/bikasetup.py
+++ b/src/bika/lims/content/bikasetup.py
@@ -625,10 +625,15 @@ schema = BikaFolderSchema.copy() + Schema((
         # Needed to fetch the default value from the registry
         edit_accessor="getEmailBodySamplePublication",
         widget=RichWidget(
-            label=_("Email body for Sample publication notifications"),
+            label=_(
+                "label_bikasetup_email_body_sample_publication",
+                "Email body for Sample publication notifications"),
             description=_(
-                "The default text that is used for the publication email. "
-                " sending publication reports."),
+                "description_bikasetup_email_body_sample_publication",
+                default="Set the email body text to be used by default when "
+                "sending out result reports to the selected recipients. "
+                "You can use reserved keywords: "
+                "$client_name, $recipients, $lab_name, $lab_address"),
             default_mime_type="text/x-html",
             output_mime_type="text/x-html",
             allow_file_upload=False,

--- a/src/senaite/core/browser/setup/templates/email_body_sample_publication.pt
+++ b/src/senaite/core/browser/setup/templates/email_body_sample_publication.pt
@@ -21,7 +21,7 @@
     With best regards
   </p>
 
-  <p>$lab_address</p>
+  <p>$lab_name</p>
 
   <p i18n:translate="">
     *** This is an automatically generated email, please do not reply to this message. ***

--- a/src/senaite/core/browser/setup/templates/email_body_sample_publication.pt
+++ b/src/senaite/core/browser/setup/templates/email_body_sample_publication.pt
@@ -15,12 +15,13 @@
     This report was sent to the following contacts:
   </p>
 
-  $recipients
+  <p>$recipients</p>
 
   <p i18n:translate="">
     With best regards
   </p>
-  <tal:laboratory tal:replace="python:laboratory.getName() or 'SENAITE LIMS'"/>
+
+  <p>$lab_address</p>
 
   <p i18n:translate="">
     *** This is an automatically generated email, please do not reply to this message. ***

--- a/src/senaite/core/content/senaitesetup.py
+++ b/src/senaite/core/content/senaitesetup.py
@@ -40,9 +40,14 @@ class ISetupSchema(model.Schema):
 
     directives.widget("email_body_sample_publication", RichTextFieldWidget)
     email_body_sample_publication = RichTextField(
-        title=_(u"Publication Email Text"),
+        title=_("title_senaitesetup_publication_email_text",
+                default=u"Publication Email Text"),
         description=_(
-            "The default text that is used for the publication email."),
+            "description_senaitesetup_publication_email_text",
+            default=u"Set the email body text to be used by default "
+            "when sending out result reports to the selected recipients. "
+            "You can use reserved keywords: "
+            "$client_name, $recipients, $lab_name, $lab_address"),
         defaultFactory=default_email_body_sample_publication,
         required=False,
     )


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This is a complementary PR for https://github.com/senaite/senaite.core/pull/2063

## Current behavior before PR

Default body text for email publication was no longer translated once it was saved 

## Desired behavior after PR is merged

Default body text for email publication is translated even when saved

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
