### PR TITLE
Fix groups for selection in login details view are hardcoded

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2156 Fix groups for selection in login details view are hardcoded
 
 
 2.3.0 (2022-10-03)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,8 +1,8 @@
 [buildout]
 index = https://pypi.org/simple/
-extends = https://dist.plone.org/release/5.2.7/versions.cfg
+extends = https://dist.plone.org/release/5.2.9/versions.cfg
 find-links =
-    https://dist.plone.org/release/5.2.7/
+    https://dist.plone.org/release/5.2.9/
     https://dist.plone.org/thirdparty/
 
 parts =

--- a/src/bika/lims/browser/contact.py
+++ b/src/bika/lims/browser/contact.py
@@ -35,6 +35,7 @@ from plone.protect import CheckAuthenticator
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from senaite.core.config.groups import HIDDEN_GROUPS
 from senaite.core.p3compat import cmp
 
 
@@ -75,6 +76,18 @@ class ContactLoginDetailsView(BrowserView):
         # view logic to make sure we get all users from all plugins (e.g. LDAP)
         users_view = UsersOverviewControlPanel(self.context, self.request)
         return users_view.doSearch("")
+
+    def get_laboratory_groups(self):
+        """Return the groups available for laboratory users
+        """
+        gtool = api.get_tool("portal_groups")
+        groups = gtool.listGroupIds()
+
+        # exclude hidden groups (Administrators, etc.)
+        groups = filter(lambda group: group not in HIDDEN_GROUPS, groups)
+
+        # sort them
+        return sorted(groups)
 
     def get_user_properties(self):
         """Return the properties of the User

--- a/src/bika/lims/browser/contact.py
+++ b/src/bika/lims/browser/contact.py
@@ -29,10 +29,11 @@ from bika.lims.api import security
 from bika.lims.browser import BrowserView
 from bika.lims.content.contact import Contact
 from bika.lims.content.labcontact import LabContact
-from Products.CMFPlone.controlpanel.browser.usergroups_usersoverview import UsersOverviewControlPanel
 from plone.memoize import view
 from plone.protect import CheckAuthenticator
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.controlpanel.browser.usergroups_usersoverview import \
+    UsersOverviewControlPanel
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from senaite.core.config.groups import HIDDEN_GROUPS

--- a/src/bika/lims/browser/templates/login_details.pt
+++ b/src/bika/lims/browser/templates/login_details.pt
@@ -279,15 +279,12 @@
                 <label i18n:translate="label_add_to_groups">Add to the following groups:</label>
                 <span class="fieldRequired" i18n:translate="">(Required)</span>
                 <br/>
-                <select class="form-control form-control-sm" name="groups" size="10" multiple="1">
-                  <option value='LabManagers'>LabManagers</option>
-                  <option value='LabClerks'>LabClerks</option>
-                  <option value='Analysts'>Analysts</option>
-                  <option value='Verifiers'>Verifiers</option>
-                  <option value='Samplers'>Samplers</option>
-                  <option value='Preservers'>Preservers</option>
-                  <option value='Publishers'>Publishers</option>
-                  <option value='Reviewers'>Reviewers</option>
+                <select class="form-control form-control-sm" name="groups"
+                        size="10" multiple="1"
+                        tal:define="groups python:view.get_laboratory_groups()">
+                  <option tal:repeat="group groups"
+                          tal:attributes="value group"
+                          tal:content="group"/>
                 </select>
               </div>
 

--- a/src/senaite/core/config/groups.py
+++ b/src/senaite/core/config/groups.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+HIDDEN_GROUPS = [
+    "Administrators",
+    "AuthenticatedUsers",
+    "Site Administrators",
+    "Clients",
+]


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the list for selection of user groups in login details view to display the groups retrieved from the system instead of being hard-coded in the template.

![Captura de 2022-10-06 18-46-26](https://user-images.githubusercontent.com/832627/194372464-0041aee0-5317-46e8-83ab-9d2ce6b34c1a.png)


## Current behavior before PR

Groups for selection in login_details view are hard-coded in the .pt template

## Desired behavior after PR is merged

Groups for selection in login_details view are retrieved from the system

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
