### PR TITLE
Fix duplicates and QC analyses are not added in worksheet

### DIFF
--- a/src/bika/lims/content/worksheet.py
+++ b/src/bika/lims/content/worksheet.py
@@ -416,6 +416,12 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         self.setAnalyses(self.getAnalyses() + [ref_analysis, ])
         self.addToLayout(ref_analysis, slot)
 
+        # TODO This shuldn't be necessary, but `getWorksheetUID` relies on
+        #      backreference, while it should be the other way round.
+        #      `getAnalyst` is affected as well, because in turn, it relies
+        #      on `getWorksheet` to get the assigned analyst.
+        ref_analysis.reindexObject(idxs=["getWorksheetUID", "getAnalyst"])
+
         # Reindex
         self.reindexObject(idxs=["getAnalysesUIDs"])
         return ref_analysis
@@ -531,6 +537,12 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         # Add the duplicate into the worksheet
         self.addToLayout(duplicate, destination_slot)
         self.setAnalyses(self.getAnalyses() + [duplicate, ])
+
+        # TODO This shuldn't be necessary, but `getWorksheetUID` relies on
+        #      backreference, while it should be the other way round.
+        #      `getAnalyst` is affected as well, because in turn, it relies
+        #      on `getWorksheet` to get the assigned analyst.
+        duplicate.reindexObject(idxs=["getWorksheetUID", "getAnalyst"])
 
         # Reindex
         self.reindexObject(idxs=["getAnalysesUIDs"])

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2.4.0</version>
+  <version>2401</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/configure.zcml
+++ b/src/senaite/core/upgrade/configure.zcml
@@ -11,6 +11,9 @@
       handler="senaite.core.upgrade.v02_04_000.upgrade"
       profile="senaite.core:default"/>
 
+  <!-- Include all upgrade steps for 2.4.0 -->
+  <include file="v02_04_000.zcml" />
+
   <!-- 2.2.0 to 2.3.0 -->
   <genericsetup:upgradeStep
       title="Upgrade to SENAITE.CORE 2.3.0"

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -18,10 +18,12 @@
 # Copyright 2018-2022 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from bika.lims import api
 from senaite.core import logger
 from senaite.core.config import PROJECTNAME as product
 from senaite.core.upgrade import upgradestep
 from senaite.core.upgrade.utils import UpgradeUtils
+from senaite.core.catalog import ANALYSIS_CATALOG
 
 version = "2.4.0"  # Remember version number in metadata.xml and setup.py
 profile = "profile-{0}:default".format(product)
@@ -41,6 +43,30 @@ def upgrade(tool):
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
     # -------- ADD YOUR STUFF BELOW --------
+    reindex_qc_analyses(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
+
+
+def reindex_qc_analyses(portal):
+    """Reindex the QC analyses to ensure they are displayed again in worksheets
+    """
+    logger.info("Reindexing QC Analyses ...")
+    query = {
+        "portal_type": ["DuplicateAnalysis", "ReferenceAnalysis"],
+        "review_state": "assigned",
+    }
+    brains = api.search(query, ANALYSIS_CATALOG)
+    total = len(brains)
+    for num, brain in enumerate(brains):
+        if num and num % 100 == 0:
+            logger.info("Reindexed {0}/{1} QC analyses".format(num, total))
+
+        obj = api.get_object(brain)
+        obj.reindexObject(idxs=["getWorksheetUID", "getAnalyst"])
+
+        # Flush the object from memory
+        obj._p_deactivate()
+
+    logger.info("Reindexing QC Analyses [DONE]")

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -43,14 +43,15 @@ def upgrade(tool):
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
     # -------- ADD YOUR STUFF BELOW --------
-    reindex_qc_analyses(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
 
 
-def reindex_qc_analyses(portal):
+def reindex_qc_analyses(tool):
     """Reindex the QC analyses to ensure they are displayed again in worksheets
+
+    :param tool: portal_setup tool
     """
     logger.info("Reindexing QC Analyses ...")
     query = {

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -1,0 +1,16 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    i18n_domain="senaite.core">
+
+  <!-- Reindex QC Analyses
+       https://github.com/senaite/senaite.core/pull/2157 -->
+  <genericsetup:upgradeStep
+      title="SENAITE CORE 2.4.0: Reindex QC Analyses"
+      description="Reindex the QC analyses to ensure they are displayed again in worksheets"
+      source="2.4.0"
+      destination="2401"
+      handler="senaite.core.upgrade.v02_04_000.reindex_qc_analyses"
+      profile="senaite.core:default"/>
+
+</configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the duplicates and reference analyses are properly reindexed when added into a worksheet. This is a temporary patch until the logic behind `getWorksheetUID` is refactored to not rely on backreferences, but the other way round.

## Current behavior before PR

Duplicates and reference analyses are not displayed in worksheet when added

## Desired behavior after PR is merged

Duplicates and reference analyses are displayed in worksheet when added

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
