### PR TITLE
Fix traceback when accessing registry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2158 Fix traceback when accessing registry
 - #2154 Cleanup the internal logic used for the creation of analysis objects
 - #2156 Fix groups for selection in login details view are hardcoded
 

--- a/src/senaite/core/browser/bootstrap/bootstrap.py
+++ b/src/senaite/core/browser/bootstrap/bootstrap.py
@@ -156,9 +156,19 @@ class BootstrapView(BrowserView):
             "data-portal-url": portal_url,
             "data-i18ncatalogurl": portal_url + "/plonejsi18n",
             "data-auto-logoff": setup.getAutoLogOff(),
-            "data-portal-type": api.get_portal_type(self.context),
+            "data-portal-type": self.get_portal_type(),
         }
         return data
+
+    def get_portal_type(self):
+        """Returns either the portal type or the name of the current object
+        """
+        try:
+            return api.get_portal_type(self.context)
+        except api.APIError:
+            return self.context.__name__
+        except AttributeError:
+            return ""
 
     def get_viewport_values(self, view=None):
         """Determine the value of the viewport meta-tag


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a traceback that occurs either when the portal registry is accessed or when e.g. a static text portlet is added.

Traceback:
```
2022-10-07 11:32:47 ERROR Zope.SiteErrorLog 1665135167.130.6936807085 http://localhost:8080/senaite/portal_registry/@@configuration_registry
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module plone.app.registry.browser.records, line 208, in __call__
  Module z3c.form.form, line 239, in __call__
  Module z3c.form.form, line 163, in render
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 215, in render
  Module chameleon.template, line 192, in render
  Module c3c7e9bdd310792d9676d88bfc1dc46b, line 1527, in render
  Module 255f600648823759a7a455775bd95385, line 382, in render_master
  Module 5caecfa22a4d1fe5b829052c80588504, line 1065, in render_master
  Module zope.tales.pythonexpr, line 73, in __call__
   - __traceback_info__: (bootstrapview.get_data_settings())
  Module <string>, line 1, in <module>
  Module senaite.core.browser.bootstrap.bootstrap, line 153, in get_data_settings
  Module bika.lims.api, line 472, in get_portal_type
  Module bika.lims.api, line 347, in fail
APIError: <plone.app.registry.registry.Registry object at 0x10c845bd0 oid 0x10eb in <Connection at 10c6cd550>> is not supported.
```

## Current behavior before PR

Traceback occurs

## Desired behavior after PR is merged

No tracback occurs

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
