### PR TITLE
Allow indexed attributes for ZCTextIndex in catalog API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2160 Allow indexed attributes for ZCTextIndex in catalog API
 - #2158 Fix traceback when accessing registry
 - #2154 Cleanup the internal logic used for the creation of analysis objects
 - #2156 Fix groups for selection in login details view are hardcoded

--- a/src/senaite/core/api/catalog.py
+++ b/src/senaite/core/api/catalog.py
@@ -72,7 +72,7 @@ def add_index(catalog, index, index_type, indexed_attrs=None):
     if index in indexes:
         return False
     if index_type == "ZCTextIndex":
-        return add_zc_text_index(catalog, index)
+        return add_zc_text_index(catalog, index, indexed_attrs=indexed_attrs)
     catalog.addIndex(index, index_type)
     # set indexed attribute
     index_obj = get_index(catalog, index)
@@ -112,7 +112,7 @@ def get_index(catalog, index):
     return catalog.Indexes[index]
 
 
-def add_zc_text_index(catalog, index, lex_id="Lexicon"):
+def add_zc_text_index(catalog, index, lex_id="Lexicon", indexed_attrs=None):
     """Add ZC text index to the catalog
 
     :param catalog: Catalog object
@@ -137,7 +137,7 @@ def add_zc_text_index(catalog, index, lex_id="Lexicon"):
         catalog._setObject(lex_id, lexicon)
 
     class extra(object):
-        doc_attr = index
+        doc_attr = indexed_attrs if indexed_attrs else index
         lexicon_id = lex_id
         index_type = "Okapi BM25 Rank"
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR allows to set an indexed attribute when adding a `ZCTextIndex` over the API.

<img width="1528" alt="Senaite Report Catalog 2022-10-08 10 AM-18-29" src="https://user-images.githubusercontent.com/713193/194697704-d2b21711-3ee9-45ee-a181-14c7a6172592.png">

## Current behavior before PR

Indexed attribute was always the same as the index name

## Desired behavior after PR is merged

Indexed attribute can be different from index name

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
