### PR TITLE
Allow to create samples without analyses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2162 Allow to create samples without analyses
 - #2160 Allow indexed attributes for ZCTextIndex in catalog API
 - #2158 Fix traceback when accessing registry
 - #2154 Cleanup the internal logic used for the creation of analysis objects

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -132,6 +132,13 @@ class AnalysisRequestAddView(BrowserView):
             logger.warn("!! No object found for UID #{} !!")
         return obj
 
+    @viewcache.memoize
+    def analyses_required(self):
+        """Check if analyses are required
+        """
+        setup = api.get_setup()
+        return setup.getSampleAnalysesRequired()
+
     def get_currency(self):
         """Returns the configured currency
         """
@@ -1569,6 +1576,10 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             # columns pass the required check below.
             if record.get("Client", False):
                 required_fields.pop('Client', None)
+
+            # Check if analyses are required for sample registration
+            if not self.analyses_required():
+                required_fields.pop("Analyses", None)
 
             # Contacts get pre-filled out if only one contact exists.
             # We won't force those columns with only the Contact filled out to

--- a/src/bika/lims/content/bikasetup.py
+++ b/src/bika/lims/content/bikasetup.py
@@ -325,6 +325,17 @@ schema = BikaFolderSchema.copy() + Schema((
         ),
     ),
     BooleanField(
+        "SampleAnalysesRequired",
+        schemata="Analyses",
+        default=True,
+        widget=BooleanWidget(
+            label=_("label_bikasetup_sampleanalysesrequired",
+                    default="Require sample analyses"),
+            description=_("description_bikasetup_sampleanalysesrequired",
+                          "Analyses are required for sample registration")
+        ),
+    ),
+    BooleanField(
         'EnableARSpecs',
         schemata="Analyses",
         default=False,
@@ -1097,6 +1108,23 @@ class BikaSetup(folder.ATFolder):
         # setup is `None` during initial site content structure installation
         if setup:
             setup.setCategorizeSampleAnalyses(value)
+
+    def getSampleAnalysesRequired(self):
+        """Get the value from the senaite setup
+        """
+        setup = api.get_senaite_setup()
+        # setup is `None` during initial site content structure installation
+        if setup:
+            return setup.getSampleAnalysesRequired()
+        return False
+
+    def setSampleAnalysesRequired(self, value):
+        """Set the value in the senaite setup
+        """
+        setup = api.get_senaite_setup()
+        # setup is `None` during initial site content structure installation
+        if setup:
+            setup.setSampleAnalysesRequired(value)
 
 
 registerType(BikaSetup, PROJECTNAME)

--- a/src/senaite/core/content/senaitesetup.py
+++ b/src/senaite/core/content/senaitesetup.py
@@ -103,6 +103,16 @@ class ISetupSchema(model.Schema):
         default=False,
     )
 
+    sample_analyses_required = schema.Bool(
+        title=_("title_senaitesetup_sampleanalysesrequired",
+                default=u"Require sample analyses"),
+        description=_(
+            "description_senaitesetup_sampleanalysesrequired",
+            default=u"Analyses are required for sample registration"
+        ),
+        default=True,
+    )
+
     ###
     # Fieldsets
     ###
@@ -112,6 +122,7 @@ class ISetupSchema(model.Schema):
         fields=[
             "immediate_results_entry",
             "categorize_sample_analyses",
+            "sample_analyses_required",
         ]
     )
 
@@ -232,4 +243,18 @@ class Setup(Container):
         """Enable/Disable grouping of analyses by category for samples
         """
         mutator = self.mutator("categorize_sample_analyses")
+        return mutator(self, value)
+
+    @security.protected(permissions.View)
+    def getSampleAnalysesRequired(self):
+        """Returns if analyses are required in sample add form
+        """
+        accessor = self.accessor("sample_analyses_required")
+        return accessor(self)
+
+    @security.protected(permissions.ModifyPortalContent)
+    def setSampleAnalysesRequired(self, value):
+        """Allow/Disallow to create samples without analyses
+        """
+        mutator = self.mutator("sample_analyses_required")
         return mutator(self, value)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds a new setup option to allow/disallow sample creation without analyses:

<img width="1056" src="https://user-images.githubusercontent.com/713193/195689194-4a1e41e4-ea80-4d89-a4fc-c87c6628189a.png">

## Current behavior before PR

Analyses are required to register a sample

## Desired behavior after PR is merged

Analyses can be configured to be optional for sample registration

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
