### PR TITLE
Cleanup `get*UID` functions to prevent unnecessary searches and instantiations

### DIFF
--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -1126,14 +1126,12 @@ class AbstractAnalysis(AbstractBaseAnalysis):
     def isRetest(self):
         """Returns whether this analysis is a retest or not
         """
-        return self.getRetestOf() and True or False
+        return self.getRawRetestOf() and True or False
 
     def getRetestOfUID(self):
         """Returns the UID of the retracted analysis this is a retest of
         """
-        retest_of = self.getRetestOf()
-        if retest_of:
-            return api.get_uid(retest_of)
+        return self.getRawRetestOf()
 
     def getRetest(self):
         """Returns the retest that comes from this analysis, if any

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -1126,24 +1126,35 @@ class AbstractAnalysis(AbstractBaseAnalysis):
     def isRetest(self):
         """Returns whether this analysis is a retest or not
         """
-        return self.getRawRetestOf() and True or False
+        if self.getRawRetestOf():
+            return True
+        return False
 
     def getRetestOfUID(self):
         """Returns the UID of the retracted analysis this is a retest of
         """
         return self.getRawRetestOf()
 
+    def getRawRetest(self):
+        """Returns the UID of the retest that comes from this analysis, if any
+        """
+        relationship = "{}RetestOf".format(self.portal_type)
+        uids = get_backreferences(self, relationship)
+        if not uids:
+            return None
+        if len(uids) > 1:
+            logger.warn("Analysis {} with multiple retests".format(self.id))
+        return uids[0]
+
     def getRetest(self):
         """Returns the retest that comes from this analysis, if any
         """
-        relationship = "{}RetestOf".format(self.portal_type)
-        back_refs = get_backreferences(self, relationship)
-        if not back_refs:
-            return None
-        if len(back_refs) > 1:
-            logger.warn("Analysis {} with multiple retests".format(self.id))
-        retest_uid = back_refs[0]
-        retest = api.get_object_by_uid(retest_uid, default=None)
-        if retest is None:
-            logger.error("Retest with UID {} not found".format(retest_uid))
-        return retest
+        retest_uid = self.getRawRetest()
+        return api.get_object(retest_uid, default=None)
+
+    def isRetested(self):
+        """Returns whether this analysis has been retested or not
+        """
+        if self.getRawRetest():
+            return True
+        return False

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -997,9 +997,7 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
     def getCategoryUID(self):
         """Used to populate catalog values
         """
-        category = self.getCategory()
-        if category:
-            return category.UID()
+        return self.getRawCategory()
 
     @security.public
     def getMaxTimeAllowed(self):

--- a/src/bika/lims/content/abstractroutineanalysis.py
+++ b/src/bika/lims/content/abstractroutineanalysis.py
@@ -253,9 +253,10 @@ class AbstractRoutineAnalysis(AbstractAnalysis, ClientAwareMixin):
     def getSampleTypeUID(self):
         """Used to populate catalog values.
         """
-        sample_type = self.getSampleType()
-        if sample_type:
-            return api.get_uid(sample_type)
+        sample = self.getRequest()
+        if not sample:
+            return None
+        return sample.getRawSampleType()
 
     @security.public
     def getResultsRange(self):

--- a/src/bika/lims/content/analysis.py
+++ b/src/bika/lims/content/analysis.py
@@ -64,7 +64,7 @@ class Analysis(AbstractRoutineAnalysis):
                 if api.get_workflow_status_of(sibling) in retracted_states:
                     # Exclude retracted analyses
                     continue
-                elif sibling.getRetest():
+                elif sibling.isRetested():
                     # Exclude analyses with a retest
                     continue
 

--- a/src/bika/lims/content/duplicateanalysis.py
+++ b/src/bika/lims/content/duplicateanalysis.py
@@ -118,7 +118,7 @@ class DuplicateAnalysis(AbstractRoutineAnalysis):
                     # Exclude retracted analyses
                     continue
 
-                elif analysis.getRawRetest():
+                elif analysis.isRetested():
                     # Exclude analyses with a retest
                     continue
 

--- a/src/bika/lims/content/duplicateanalysis.py
+++ b/src/bika/lims/content/duplicateanalysis.py
@@ -118,7 +118,7 @@ class DuplicateAnalysis(AbstractRoutineAnalysis):
                     # Exclude retracted analyses
                     continue
 
-                elif analysis.getRetest():
+                elif analysis.getRawRetest():
                     # Exclude analyses with a retest
                     continue
 

--- a/src/bika/lims/content/worksheet.py
+++ b/src/bika/lims/content/worksheet.py
@@ -1107,10 +1107,7 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         :returns: worksheet's UID
         :rtype: UID as string
         """
-        ws = self.getWorksheetTemplate()
-        if ws:
-            return ws.UID()
-        return ''
+        return self.getRawWorksheetTemplate()
 
     def getWorksheetTemplateTitle(self):
         """

--- a/src/bika/lims/content/worksheettemplate.py
+++ b/src/bika/lims/content/worksheettemplate.py
@@ -228,10 +228,7 @@ class WorksheetTemplate(BaseContent):
     def getMethodUID(self):
         """Return method UID
         """
-        method = self.getRestrictToMethod()
-        if method:
-            return method.UID()
-        return ""
+        return self.getRawRestrictToMethod()
 
     def _getMethodsVoc(self):
         """Return the registered methods as DisplayList


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request cleans some `get*UID` functions and makes them to rely on `getRaw*` func, so objects are searched against the db and instantiated only when necessary

## Current behavior before PR

Some `get*UID` functions make the system to search and wake up objects unnecessarily

## Desired behavior after PR is merged

Some `get*UID` functions do not make the system to search and wake up objects unnecessarily

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
