### PR TITLE
Added `IRetracted` and `IRejected` marker interfaces for analyses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2164 Added `IRetracted` and `IRejected` marker interfaces for analyses
 - #2162 Allow to create samples without analyses
 - #2160 Allow indexed attributes for ZCTextIndex in catalog API
 - #2158 Fix traceback when accessing registry

--- a/docs/doctests.rst
+++ b/docs/doctests.rst
@@ -66,7 +66,7 @@ Doctests
 .. include:: ../src/senaite/core/tests/doctests/WorkflowDuplicateAnalysisSubmit.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowDuplicateAnalysisVerify.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowReferenceAnalysisBlankAssign.rst
-.. include:: ../src/senaite/core/tests/doctests/WorkflowReferenceAnalysisBLankRetract.rst
+.. include:: ../src/senaite/core/tests/doctests/WorkflowReferenceAnalysisBlankRetract.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowReferenceAnalysisBlankMultiVerify.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowReferenceAnalysisBlankSubmit.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowReferenceAnalysisBlankVerify.rst

--- a/docs/doctests.rst
+++ b/docs/doctests.rst
@@ -66,14 +66,15 @@ Doctests
 .. include:: ../src/senaite/core/tests/doctests/WorkflowDuplicateAnalysisSubmit.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowDuplicateAnalysisVerify.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowReferenceAnalysisBlankAssign.rst
+.. include:: ../src/senaite/core/tests/doctests/WorkflowReferenceAnalysisBLankRetract.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowReferenceAnalysisBlankMultiVerify.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowReferenceAnalysisBlankSubmit.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowReferenceAnalysisBlankVerify.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowReferenceAnalysisControlAssign.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowReferenceAnalysisControlMultiVerify.rst
+.. include:: ../src/senaite/core/tests/doctests/WorkflowReferenceAnalysisControlRetract.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowReferenceAnalysisControlSubmit.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowReferenceAnalysisControlVerify.rst
-.. include:: ../src/senaite/core/tests/doctests/WorkflowReferenceAnalysisRetract.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowWorksheetAutotransitions.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowWorksheetRemove.rst
 .. include:: ../src/senaite/core/tests/doctests/WorkflowWorksheetRetract.rst

--- a/src/bika/lims/interfaces/__init__.py
+++ b/src/bika/lims/interfaces/__init__.py
@@ -951,6 +951,16 @@ class IReceived(Interface):
     """
 
 
+class IRejected(Interface):
+    """Marker interface for rejected objects
+    """
+
+
+class IRetracted(Interface):
+    """Marker interface for retracted objects
+    """
+
+
 class IInternalUse(Interface):
     """Marker interface for objects only lab personnel must have access
     """

--- a/src/bika/lims/workflow/analysis/events.py
+++ b/src/bika/lims/workflow/analysis/events.py
@@ -20,6 +20,8 @@
 
 from bika.lims import api
 from bika.lims.interfaces import IDuplicateAnalysis
+from bika.lims.interfaces import IRejected
+from bika.lims.interfaces import IRetracted
 from bika.lims.interfaces import ISubmitted
 from bika.lims.interfaces import IVerified
 from bika.lims.interfaces.analysis import IRequestAnalysis
@@ -154,9 +156,11 @@ def after_retract(analysis):
     """Function triggered after a 'retract' transition for the analysis passed
     in is performed. The analysis transitions to "retracted" state and a new
     copy of the analysis is created. The copy initial state is "unassigned",
-    unless the the retracted analysis was assigned to a worksheet. In such case,
-    the copy is transitioned to 'assigned' state too
+    unless the the retracted analysis was assigned to a worksheet. In such
+    case, the copy is transitioned to 'assigned' state too
     """
+    # Mark this analysis as IRetracted
+    alsoProvides(analysis, IRetracted)
 
     # Retract our dependents (analyses that depend on this analysis)
     cascade_to_dependents(analysis, "retract")
@@ -176,6 +180,9 @@ def after_retract(analysis):
 def after_reject(analysis):
     """Function triggered after the "reject" transition for the analysis passed
     in is performed."""
+    # Mark this analysis with IRejected
+    alsoProvides(analysis, IRejected)
+
     # Remove from the worksheet
     remove_analysis_from_worksheet(analysis)
 

--- a/src/bika/lims/workflow/duplicateanalysis/events.py
+++ b/src/bika/lims/workflow/duplicateanalysis/events.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 import transaction
+
 from bika.lims import api
 from bika.lims import logger
 from bika.lims.interfaces import IRetracted

--- a/src/bika/lims/workflow/duplicateanalysis/events.py
+++ b/src/bika/lims/workflow/duplicateanalysis/events.py
@@ -19,13 +19,14 @@
 # Some rights reserved, see README and LICENSE.
 
 import transaction
-
 from bika.lims import api
 from bika.lims import logger
+from bika.lims.interfaces import IRetracted
 from bika.lims.utils.analysis import create_retest
 from bika.lims.utils.analysis import generate_analysis_id
 from bika.lims.workflow import doActionFor
 from bika.lims.workflow.analysis import events as analysis_events
+from zope.interface import alsoProvides
 
 
 def after_submit(duplicate_analysis):
@@ -59,6 +60,9 @@ def after_retract(duplicate_analysis):
     in is performed. The duplicate transitions to "retracted" state and a new
     copy of the duplicate is created.
     """
+    # Mark this duplicate as IRetracted
+    alsoProvides(duplicate_analysis, IRetracted)
+
     # Rename the analysis to make way for it's successor
     parent = api.get_parent(duplicate_analysis)
     keyword = duplicate_analysis.getKeyword()

--- a/src/bika/lims/workflow/referenceanalysis/events.py
+++ b/src/bika/lims/workflow/referenceanalysis/events.py
@@ -21,7 +21,9 @@
 from bika.lims import api
 from bika.lims import logger
 from bika.lims import workflow as wf
+from bika.lims.interfaces import IRetracted
 from bika.lims.workflow.analysis import events as analysis_events
+from zope.interface import alsoProvides
 
 
 def after_submit(reference_analysis):
@@ -53,6 +55,9 @@ def after_retract(reference_analysis):
     analysis passed in is performed. The reference analysis transitions to
     "retracted" state and a new copy of the reference analysis is created
     """
+    # Mark this reference analysis with IRetracted
+    alsoProvides(reference_analysis, IRetracted)
+
     reference = reference_analysis.getSample()
     service = reference_analysis.getAnalysisService()
     worksheet = reference_analysis.getWorksheet()
@@ -61,7 +66,8 @@ def after_retract(reference_analysis):
         # This a reference analysis in a worksheet
         slot = worksheet.get_slot_position_for(reference_analysis)
         refgid = reference_analysis.getReferenceAnalysesGroupID()
-        ref = worksheet.add_reference_analysis(reference, service, slot, refgid)
+        ref = worksheet.add_reference_analysis(reference, service, slot,
+                                               refgid)
         if not ref:
             logger.warn("Cannot add a retest for reference analysis {} into {}"
                         .format(reference_analysis.getId(), worksheet.getId()))

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2401</version>
+  <version>2402</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
+++ b/src/senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
@@ -95,42 +95,6 @@
 
   </state>
 
-  <!-- State: rejected
-       The analysis has been rejected and cannot be used anymore -->
-  <state state_id="rejected" title="Rejected" i18n:attributes="title">
-
-    <!-- TRANSITIONS -->
-    <exit-transition transition_id="" />
-    <!-- /TRANSITIONS -->
-
-    <!-- Only allow modification of fields explicitly granted
-         N.B. Permissions are *only* checked in process_form and *not* if we set the
-         field directly via the generated mutator -->
-    <permission-map name="Modify portal content" acquired="False">
-    </permission-map>
-
-    <permission-map name="senaite.core: Edit Results" acquired="False">
-    </permission-map>
-
-    <permission-map name="senaite.core: View Results" acquired="False">
-      <permission-role>Analyst</permission-role>
-      <permission-role>LabClerk</permission-role>
-      <permission-role>LabManager</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>RegulatoryInspector</permission-role>
-    </permission-map>
-
-    <!-- FIELD PERMISSIONS (rejected) -->
-    <permission-map name="senaite.core: Field: Edit Analysis Result" acquired="False">
-    </permission-map>
-    <permission-map name="senaite.core: Field: Edit Analysis Remarks" acquired="False">
-    </permission-map>
-    <permission-map name="senaite.core: Field: Edit Analysis Hidden" acquired="False">
-    </permission-map>
-    <!-- /FIELD PERMISSIONS -->
-
-  </state>
-
   <!-- State: to_be_verified
   Results have been submitted and awaiting for review -->
   <state state_id="to_be_verified" title="To be verified" i18n:attributes="title">
@@ -139,7 +103,6 @@
     <exit-transition transition_id="multi_verify" />
     <exit-transition transition_id="verify" />
     <exit-transition transition_id="retract" />
-    <exit-transition transition_id="reject" />
     <exit-transition transition_id="unassign" />
     <!-- /TRANSITIONS -->
 

--- a/src/senaite/core/tests/doctests/WorkflowAnalysisMultiVerify.rst
+++ b/src/senaite/core/tests/doctests/WorkflowAnalysisMultiVerify.rst
@@ -13,6 +13,7 @@ Needed Imports:
 
     >>> from AccessControl.PermissionRole import rolesForPermissionOn
     >>> from bika.lims import api
+    >>> from bika.lims.interfaces import IVerified
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
     >>> from bika.lims.workflow import isTransitionAllowed
@@ -385,3 +386,29 @@ And to ensure consistency amongst tests, we disable self-verification:
     >>> bikasetup.setSelfVerificationEnabled(False)
     >>> bikasetup.getSelfVerificationEnabled()
     False
+
+
+IVerified interface is provided by fully verified analyses
+..........................................................
+
+Analyses that have not been fully verified do not provide `IVerified`:
+
+    >>> bikasetup.setSelfVerificationEnabled(True)
+    >>> bikasetup.setNumberOfRequiredVerifications(2)
+    >>> bikasetup.setTypeOfmultiVerification("self_multi_enabled")
+    >>> sample = new_ar([Cu])
+    >>> submit_analyses(sample)
+    >>> analysis = sample.getAnalyses(full_objects=True)[0]
+    >>> IVerified.providedBy(analysis)
+    False
+
+    >>> success = do_action_for(analysis, "multi_verify")
+    >>> IVerified.providedBy(analysis)
+    False
+
+    >>> success = do_action_for(analysis, "verify")
+    >>> IVerified.providedBy(analysis)
+    True
+
+    >>> bikasetup.setSelfVerificationEnabled(False)
+    >>> bikasetup.setNumberOfRequiredVerifications(1)

--- a/src/senaite/core/tests/doctests/WorkflowAnalysisReject.rst
+++ b/src/senaite/core/tests/doctests/WorkflowAnalysisReject.rst
@@ -1,4 +1,4 @@
-from bika.lims.interfaces import IRejectedAnalysis retract guard and event
+Analysis retract guard and event
 --------------------------------
 
 Running this test from the buildout directory:

--- a/src/senaite/core/tests/doctests/WorkflowAnalysisReject.rst
+++ b/src/senaite/core/tests/doctests/WorkflowAnalysisReject.rst
@@ -1,4 +1,4 @@
-Analysis retract guard and event
+from bika.lims.interfaces import IRejectedAnalysis retract guard and event
 --------------------------------
 
 Running this test from the buildout directory:
@@ -13,6 +13,7 @@ Needed Imports:
 
     >>> from AccessControl.PermissionRole import rolesForPermissionOn
     >>> from bika.lims import api
+    >>> from bika.lims.interfaces import IRejected
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
     >>> from bika.lims.workflow import getAllowedTransitions
@@ -593,3 +594,18 @@ And no transition can be done from this state:
 
     >>> getAllowedTransitions(analysis)
     []
+
+
+IRejected interface is provided by rejected analyses
+....................................................
+
+When rejected, routine analyses are marked with the `IRejected` interface:
+
+    >>> ar = new_ar([Cu])
+    >>> analysis = ar.getAnalyses(full_objects=True)[0]
+    >>> IRejected.providedBy(analysis)
+    False
+
+    >>> success = do_action_for(analysis, "reject")
+    >>> IRejected.providedBy(analysis)
+    True

--- a/src/senaite/core/tests/doctests/WorkflowAnalysisRetract.rst
+++ b/src/senaite/core/tests/doctests/WorkflowAnalysisRetract.rst
@@ -13,6 +13,7 @@ Needed Imports:
 
     >>> from AccessControl.PermissionRole import rolesForPermissionOn
     >>> from bika.lims import api
+    >>> from bika.lims.interfaces import IRetracted
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
     >>> from bika.lims.workflow import isTransitionAllowed
@@ -306,3 +307,25 @@ And the current state of the Analysis Request is `sample_received` now:
 
     >>> api.get_workflow_status_of(ar)
     'sample_received'
+
+
+IRetracted interface is provided by retracted analyses
+......................................................
+
+When retracted, routine analyses are marked with the `IRetracted` interface:
+
+    >>> sample = new_ar([Cu])
+    >>> submit_analyses(sample)
+    >>> analysis = sample.getAnalyses(full_objects=True)[0]
+    >>> IRetracted.providedBy(analysis)
+    False
+
+    >>> success = do_action_for(analysis, "retract")
+    >>> IRetracted.providedBy(analysis)
+    True
+
+But the retest does not provide `IRetracted`:
+
+    >>> retest = analysis.getRetest()
+    >>> IRetracted.providedBy(retest)
+    False

--- a/src/senaite/core/tests/doctests/WorkflowAnalysisVerify.rst
+++ b/src/senaite/core/tests/doctests/WorkflowAnalysisVerify.rst
@@ -13,6 +13,7 @@ Needed Imports:
 
     >>> from AccessControl.PermissionRole import rolesForPermissionOn
     >>> from bika.lims import api
+    >>> from bika.lims.interfaces import IVerified
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
     >>> from bika.lims.workflow import isTransitionAllowed
@@ -414,3 +415,22 @@ And to ensure consistency amongst tests, we disable self-verification:
     >>> bikasetup.setSelfVerificationEnabled(False)
     >>> bikasetup.getSelfVerificationEnabled()
     False
+
+
+IVerified interface is provided by verified analyses
+....................................................
+
+When verified, routine analyses are marked with the `IVerified` interface:
+
+    >>> bikasetup.setSelfVerificationEnabled(True)
+    >>> sample = new_ar([Cu])
+    >>> submit_analyses(sample)
+    >>> analysis = ar.getAnalyses(full_objects=True)[0]
+    >>> IVerified.providedBy(analysis)
+    False
+
+    >>> success = do_action_for(analysis, "verify")
+    >>> IVerified.providedBy(analysis)
+    True
+
+    >>> bikasetup.setSelfVerificationEnabled(False)

--- a/src/senaite/core/tests/doctests/WorkflowDuplicateAnalysisMultiVerify.rst
+++ b/src/senaite/core/tests/doctests/WorkflowDuplicateAnalysisMultiVerify.rst
@@ -13,6 +13,7 @@ Needed Imports:
 
     >>> from AccessControl.PermissionRole import rolesForPermissionOn
     >>> from bika.lims import api
+    >>> from bika.lims.interfaces import IVerified
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
     >>> from bika.lims.workflow import isTransitionAllowed
@@ -421,3 +422,30 @@ And to ensure consistency amongst tests, we disable self-verification:
     >>> bikasetup.setSelfVerificationEnabled(False)
     >>> bikasetup.getSelfVerificationEnabled()
     False
+
+
+IVerified interface is provided by fully verified duplicates
+............................................................
+
+Duplicates that have not been fully verified do not provide `IVerified`:
+
+    >>> bikasetup.setSelfVerificationEnabled(True)
+    >>> bikasetup.setNumberOfRequiredVerifications(2)
+    >>> bikasetup.setTypeOfmultiVerification("self_multi_enabled")
+    >>> sample = new_ar([Cu])
+    >>> worksheet = to_new_worksheet_with_duplicate(sample)
+    >>> duplicate = worksheet.getDuplicateAnalyses()[0]
+    >>> duplicate.setResult(12)
+    >>> success = do_action_for(duplicate, "submit")
+    >>> IVerified.providedBy(duplicate)
+    False
+
+    >>> success = do_action_for(duplicate, "multi_verify")
+    >>> IVerified.providedBy(duplicate)
+    False
+
+    >>> success = do_action_for(duplicate, "verify")
+    >>> IVerified.providedBy(duplicate)
+    True
+
+    >>> bikasetup.setSelfVerificationEnabled(False)

--- a/src/senaite/core/tests/doctests/WorkflowDuplicateAnalysisRetract.rst
+++ b/src/senaite/core/tests/doctests/WorkflowDuplicateAnalysisRetract.rst
@@ -13,6 +13,7 @@ Needed Imports:
 
     >>> from AccessControl.PermissionRole import rolesForPermissionOn
     >>> from bika.lims import api
+    >>> from bika.lims.interfaces import IRetracted
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
     >>> from bika.lims.workflow import isTransitionAllowed
@@ -328,3 +329,27 @@ And the current state of the Analysis Request is `sample_received` now:
 
     >>> api.get_workflow_status_of(ar)
     'sample_received'
+
+
+IRetracted interface is provided by retracted duplicates
+........................................................
+
+When retracted, duplicate analyses are marked with the `IRetracted` interface:
+
+    >>> sample = new_ar([Cu])
+    >>> worksheet = to_new_worksheet_with_duplicate(sample)
+    >>> duplicate = worksheet.getDuplicateAnalyses()[0]
+    >>> duplicate.setResult(12)
+    >>> success = do_action_for(duplicate, "submit")
+    >>> IRetracted.providedBy(duplicate)
+    False
+
+    >>> success = do_action_for(duplicate, "retract")
+    >>> IRetracted.providedBy(duplicate)
+    True
+
+But the retest does not provide `IRetracted`:
+
+    >>> retest = duplicate.getRetest()
+    >>> IRetracted.providedBy(retest)
+    False

--- a/src/senaite/core/tests/doctests/WorkflowDuplicateAnalysisVerify.rst
+++ b/src/senaite/core/tests/doctests/WorkflowDuplicateAnalysisVerify.rst
@@ -13,6 +13,7 @@ Needed Imports:
 
     >>> from AccessControl.PermissionRole import rolesForPermissionOn
     >>> from bika.lims import api
+    >>> from bika.lims.interfaces import IVerified
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
     >>> from bika.lims.workflow import isTransitionAllowed
@@ -225,3 +226,24 @@ And to ensure consistency amongst tests, we disable self-verification:
     >>> bikasetup.setSelfVerificationEnabled(False)
     >>> bikasetup.getSelfVerificationEnabled()
     False
+
+
+IVerified interface is provided by duplicate analysis that are verified
+.......................................................................
+
+When verified, duplicate analyses are marked with the `IVerified` interface:
+
+    >>> bikasetup.setSelfVerificationEnabled(True)
+    >>> sample = new_ar([Cu])
+    >>> worksheet = to_new_worksheet_with_duplicate(sample)
+    >>> duplicate = worksheet.getDuplicateAnalyses()[0]
+    >>> duplicate.setResult(12)
+    >>> success = do_action_for(duplicate, "submit")
+    >>> IVerified.providedBy(duplicate)
+    False
+
+    >>> success = do_action_for(duplicate, "verify")
+    >>> IVerified.providedBy(duplicate)
+    True
+
+    >>> bikasetup.setSelfVerificationEnabled(False)

--- a/src/senaite/core/tests/doctests/WorkflowReferenceAnalysisBlankMultiVerify.rst
+++ b/src/senaite/core/tests/doctests/WorkflowReferenceAnalysisBlankMultiVerify.rst
@@ -13,6 +13,7 @@ Needed Imports:
 
     >>> from AccessControl.PermissionRole import rolesForPermissionOn
     >>> from bika.lims import api
+    >>> from bika.lims.interfaces import IVerified
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
     >>> from bika.lims.workflow import isTransitionAllowed
@@ -426,3 +427,30 @@ And to ensure consistency amongst tests, we disable self-verification:
     >>> bikasetup.setSelfVerificationEnabled(False)
     >>> bikasetup.getSelfVerificationEnabled()
     False
+
+
+IVerified interface is provided by fully verified blanks
+........................................................
+
+Blanks do not provide `IVerified` unless fully verified:
+
+    >>> bikasetup.setSelfVerificationEnabled(True)
+    >>> bikasetup.setNumberOfRequiredVerifications(2)
+    >>> bikasetup.setTypeOfmultiVerification("self_multi_enabled")
+    >>> sample = new_ar([Cu])
+    >>> worksheet = to_new_worksheet_with_reference(sample, blank_sample)
+    >>> blank = worksheet.getReferenceAnalyses()[0]
+    >>> blank.setResult(0)
+    >>> success = do_action_for(blank, "submit")
+    >>> IVerified.providedBy(blank)
+    False
+
+    >>> success = do_action_for(blank, "multi_verify")
+    >>> IVerified.providedBy(blank)
+    False
+
+    >>> success = do_action_for(blank, "verify")
+    >>> IVerified.providedBy(blank)
+    True
+
+    >>> bikasetup.setSelfVerificationEnabled(False)

--- a/src/senaite/core/tests/doctests/WorkflowReferenceAnalysisBlankVerify.rst
+++ b/src/senaite/core/tests/doctests/WorkflowReferenceAnalysisBlankVerify.rst
@@ -13,6 +13,7 @@ Needed Imports:
 
     >>> from AccessControl.PermissionRole import rolesForPermissionOn
     >>> from bika.lims import api
+    >>> from bika.lims.interfaces import IVerified
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
     >>> from bika.lims.workflow import isTransitionAllowed
@@ -230,3 +231,24 @@ And to ensure consistency amongst tests, we disable self-verification:
     >>> bikasetup.setSelfVerificationEnabled(False)
     >>> bikasetup.getSelfVerificationEnabled()
     False
+
+
+IVerified interface is provided by verified blanks
+..................................................
+
+When verified, blank analyses are marked with the `IVerified` interface:
+
+    >>> bikasetup.setSelfVerificationEnabled(True)
+    >>> sample = new_ar([Cu])
+    >>> worksheet = to_new_worksheet_with_reference(sample, blank_sample)
+    >>> blank = worksheet.getReferenceAnalyses()[0]
+    >>> blank.setResult(0)
+    >>> success = do_action_for(blank, "submit")
+    >>> IVerified.providedBy(blank)
+    False
+
+    >>> success = do_action_for(blank, "verify")
+    >>> IVerified.providedBy(blank)
+    True
+
+    >>> bikasetup.setSelfVerificationEnabled(False)

--- a/src/senaite/core/tests/doctests/WorkflowReferenceAnalysisControlMultiVerify.rst
+++ b/src/senaite/core/tests/doctests/WorkflowReferenceAnalysisControlMultiVerify.rst
@@ -13,6 +13,7 @@ Needed Imports:
 
     >>> from AccessControl.PermissionRole import rolesForPermissionOn
     >>> from bika.lims import api
+    >>> from bika.lims.interfaces import IVerified
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
     >>> from bika.lims.workflow import isTransitionAllowed
@@ -426,3 +427,31 @@ And to ensure consistency amongst tests, we disable self-verification:
     >>> bikasetup.setSelfVerificationEnabled(False)
     >>> bikasetup.getSelfVerificationEnabled()
     False
+
+
+
+IVerified interface is provided by fully verified controls
+..........................................................
+
+Controls do not provide `IVerified` unless fully verified:
+
+    >>> bikasetup.setSelfVerificationEnabled(True)
+    >>> bikasetup.setNumberOfRequiredVerifications(2)
+    >>> bikasetup.setTypeOfmultiVerification("self_multi_enabled")
+    >>> sample = new_ar([Cu])
+    >>> worksheet = to_new_worksheet_with_reference(sample, control_sample)
+    >>> control = worksheet.getReferenceAnalyses()[0]
+    >>> control.setResult(12)
+    >>> success = do_action_for(control, "submit")
+    >>> IVerified.providedBy(control)
+    False
+
+    >>> success = do_action_for(control, "multi_verify")
+    >>> IVerified.providedBy(control)
+    False
+
+    >>> success = do_action_for(control, "verify")
+    >>> IVerified.providedBy(control)
+    True
+
+    >>> bikasetup.setSelfVerificationEnabled(False)

--- a/src/senaite/core/tests/doctests/WorkflowReferenceAnalysisControlMultiVerify.rst
+++ b/src/senaite/core/tests/doctests/WorkflowReferenceAnalysisControlMultiVerify.rst
@@ -429,7 +429,6 @@ And to ensure consistency amongst tests, we disable self-verification:
     False
 
 
-
 IVerified interface is provided by fully verified controls
 ..........................................................
 

--- a/src/senaite/core/tests/doctests/WorkflowReferenceAnalysisControlRetract.rst
+++ b/src/senaite/core/tests/doctests/WorkflowReferenceAnalysisControlRetract.rst
@@ -1,0 +1,289 @@
+Reference Analysis retract guard and event
+------------------------------------------
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t WorkflowReferenceAnalysisControlRetract
+
+
+Test Setup
+..........
+
+Needed Imports:
+
+    >>> from AccessControl.PermissionRole import rolesForPermissionOn
+    >>> from bika.lims import api
+    >>> from bika.lims.interfaces import IRetracted
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+    >>> from bika.lims.workflow import isTransitionAllowed
+    >>> from DateTime import DateTime
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+
+Functional Helpers:
+
+    >>> def start_server():
+    ...     from Testing.ZopeTestCase.utils import startZServer
+    ...     ip, port = startZServer()
+    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
+
+    >>> def timestamp(format="%Y-%m-%d"):
+    ...     return DateTime().strftime(format)
+
+    >>> def start_server():
+    ...     from Testing.ZopeTestCase.utils import startZServer
+    ...     ip, port = startZServer()
+    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
+
+    >>> def new_ar(services):
+    ...     values = {
+    ...         'Client': client.UID(),
+    ...         'Contact': contact.UID(),
+    ...         'DateSampled': date_now,
+    ...         'SampleType': sampletype.UID()}
+    ...     service_uids = map(api.get_uid, services)
+    ...     ar = create_analysisrequest(client, request, values, service_uids)
+    ...     transitioned = do_action_for(ar, "receive")
+    ...     return ar
+
+    >>> def to_new_worksheet_with_reference(ar, reference):
+    ...     worksheet = api.create(portal.worksheets, "Worksheet")
+    ...     service_uids = list()
+    ...     for analysis in ar.getAnalyses(full_objects=True):
+    ...         worksheet.addAnalysis(analysis)
+    ...         service_uids.append(analysis.getServiceUID())
+    ...     worksheet.addReferenceAnalyses(reference, service_uids)
+    ...     return worksheet
+
+    >>> def submit_regular_analyses(worksheet):
+    ...     for analysis in worksheet.getRegularAnalyses():
+    ...         analysis.setResult(13)
+    ...         do_action_for(analysis, "submit")
+
+    >>> def try_transition(object, transition_id, target_state_id):
+    ...      success = do_action_for(object, transition_id)[0]
+    ...      state = api.get_workflow_status_of(object)
+    ...      return success and state == target_state_id
+
+    >>> def submit_analyses(ar):
+    ...     for analysis in ar.getAnalyses(full_objects=True):
+    ...         analysis.setResult(13)
+    ...         do_action_for(analysis, "submit")
+
+    >>> def get_roles_for_permission(permission, context):
+    ...     allowed = set(rolesForPermissionOn(permission, context))
+    ...     return sorted(allowed)
+
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> bikasetup = portal.bika_setup
+    >>> date_now = DateTime().strftime("%Y-%m-%d")
+    >>> date_future = (DateTime() + 5).strftime("%Y-%m-%d")
+
+We need to create some basic objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
+    >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH", MemberDiscountApplies=True)
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(bikasetup.bika_sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> labcontact = api.create(bikasetup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(bikasetup.bika_departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = api.create(bikasetup.bika_analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> supplier = api.create(bikasetup.bika_suppliers, "Supplier", Name="Naralabs")
+    >>> Cu = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID(), Accredited=True)
+    >>> Fe = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Iron", Keyword="Fe", Price="10", Category=category.UID())
+    >>> Au = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Gold", Keyword="Au", Price="20", Category=category.UID())
+    >>> control_def = api.create(bikasetup.bika_referencedefinitions, "ReferenceDefinition", title="Control definition")
+    >>> control_refs = [{'uid': api.get_uid(Cu), 'result': '10', 'min': '0', 'max': '0'},
+    ...                 {'uid': api.get_uid(Fe), 'result': '10', 'min': '0', 'max': '0'},
+    ...                 {'uid': api.get_uid(Au), 'result': '15', 'min': '14.5', 'max': '15.5'},]
+    >>> control_def.setReferenceResults(control_refs)
+    >>> control_sample = api.create(supplier, "ReferenceSample", title="Control",
+    ...                      ReferenceDefinition=control_def,
+    ...                      Blank=False, ExpiryDate=date_future,
+    ...                      ReferenceResults=control_refs)
+
+
+Retract transition and guard basic constraints
+..............................................
+
+Create an Analysis Request and submit regular analyses:
+
+    >>> ar = new_ar([Cu])
+    >>> worksheet = to_new_worksheet_with_reference(ar, control_sample)
+    >>> submit_regular_analyses(worksheet)
+
+Get the reference and submit:
+
+    >>> reference = worksheet.getReferenceAnalyses()[0]
+    >>> reference.setResult(12)
+    >>> try_transition(reference, "submit", "to_be_verified")
+    True
+    >>> api.get_workflow_status_of(reference)
+    'to_be_verified'
+    >>> api.get_workflow_status_of(worksheet)
+    'to_be_verified'
+
+Retract the reference:
+
+    >>> try_transition(reference, "retract", "retracted")
+    True
+    >>> api.get_workflow_status_of(reference)
+    'retracted'
+
+And one new additional reference has been added in `assigned` state:
+
+    >>> references = worksheet.getReferenceAnalyses()
+    >>> sorted(map(api.get_workflow_status_of, references))
+    ['assigned', 'retracted']
+
+And the Worksheet has been transitioned to `open`:
+
+    >>> api.get_workflow_status_of(worksheet)
+    'open'
+
+While the Analysis Request is still in `to_be_verified`:
+
+    >>> api.get_workflow_status_of(ar)
+    'to_be_verified'
+
+The new analysis is a copy of retracted one:
+
+    >>> retest = filter(lambda an: api.get_workflow_status_of(an) == "assigned", references)[0]
+    >>> retest.getKeyword() == reference.getKeyword()
+    True
+    >>> retest.getReferenceAnalysesGroupID() == reference.getReferenceAnalysesGroupID()
+    True
+    >>> retest.getRetestOf() == reference
+    True
+    >>> reference.getRetest() == retest
+    True
+    >>> retest.getAnalysisService() == reference.getAnalysisService()
+    True
+
+And keeps the same results as the retracted one:
+
+    >>> retest.getResult() == reference.getResult()
+    True
+
+And is located in the same slot as well:
+
+    >>> worksheet.get_slot_position_for(reference) == worksheet.get_slot_position_for(retest)
+    True
+
+If I submit the result for the new reference:
+
+    >>> try_transition(retest, "submit", "to_be_verified")
+    True
+
+The status of both the reference and the Worksheet is "to_be_verified":
+
+    >>> api.get_workflow_status_of(retest)
+    'to_be_verified'
+    >>> api.get_workflow_status_of(worksheet)
+    'to_be_verified'
+
+And I can even retract the retest:
+
+    >>> try_transition(retest, "retract", "retracted")
+    True
+    >>> api.get_workflow_status_of(retest)
+    'retracted'
+
+And one new additional reference has been added in `assigned` state:
+
+    >>> references = worksheet.getReferenceAnalyses()
+    >>> sorted(map(api.get_workflow_status_of, references))
+    ['assigned', 'retracted', 'retracted']
+
+And the Worksheet has been transitioned to `open`:
+
+    >>> api.get_workflow_status_of(worksheet)
+    'open'
+
+Retract transition when reference analyses from same Reference Sample are added
+-------------------------------------------------------------------------------
+
+When analyses from same Reference Sample are added in a worksheet, the
+worksheet allocates different slots for them, although each of the slots keeps
+the container the analysis belongs to (in this case the same Reference Sample).
+Hence, when retracting a reference analysis, the retest must be added in the
+same position as the original, regardless of how many reference analyses from
+same reference sample exist.
+Further information: https://github.com/senaite/senaite.core/pull/1179
+
+Create an Analysis Request:
+
+    >>> ar = new_ar([Cu])
+    >>> worksheet = api.create(portal.worksheets, "Worksheet")
+    ... for analysis in ar.getAnalyses(full_objects=True):
+    ...     worksheet.addAnalysis(analysis)
+
+Add same reference sample twice:
+
+    >>> ref_1 = worksheet.addReferenceAnalyses(control_sample, [api.get_uid(Cu)])[0]
+    >>> ref_2 = worksheet.addReferenceAnalyses(control_sample, [api.get_uid(Cu)])[0]
+    >>> ref_1 != ref_2
+    True
+
+Get the reference analyses positions:
+
+    >>> ref_1_pos = worksheet.get_slot_position_for(ref_1)
+    >>> ref_1_pos
+    1
+    >>> ref_2_pos = worksheet.get_slot_position_for(ref_2)
+    >>> ref_2_pos
+    2
+
+Submit both:
+
+    >>> ref_1.setResult(12)
+    >>> ref_2.setResult(13)
+    >>> try_transition(ref_1, "submit", "to_be_verified")
+    True
+    >>> try_transition(ref_2, "submit", "to_be_verified")
+    True
+
+Retract the first reference analysis. The retest has been added in same slot:
+
+    >>> try_transition(ref_1, "retract", "retracted")
+    True
+    >>> retest_1 = ref_1.getRetest()
+    >>> worksheet.get_slot_position_for(retest_1)
+    1
+
+And the same if we retract the second reference analysis:
+
+    >>> try_transition(ref_2, "retract", "retracted")
+    True
+    >>> retest_2 = ref_2.getRetest()
+    >>> worksheet.get_slot_position_for(retest_2)
+    2
+
+IRetracted interface is provided by retracted controls
+......................................................
+
+When retracted, control analyses are marked with the `IRetracted` interface:
+
+    >>> sample = new_ar([Cu])
+    >>> worksheet = to_new_worksheet_with_reference(sample, control_sample)
+    >>> reference = worksheet.getReferenceAnalyses()[0]
+    >>> reference.setResult(12)
+    >>> success = do_action_for(reference, "submit")
+    >>> IRetracted.providedBy(reference)
+    False
+
+    >>> success = do_action_for(reference, "retract")
+    >>> IRetracted.providedBy(reference)
+    True
+
+But the retest does not provide `IRetracted`:
+
+    >>> retest = reference.getRetest()
+    >>> IRetracted.providedBy(retest)
+    False

--- a/src/senaite/core/tests/doctests/WorkflowReferenceAnalysisControlVerify.rst
+++ b/src/senaite/core/tests/doctests/WorkflowReferenceAnalysisControlVerify.rst
@@ -13,6 +13,7 @@ Needed Imports:
 
     >>> from AccessControl.PermissionRole import rolesForPermissionOn
     >>> from bika.lims import api
+    >>> from bika.lims.interfaces import IVerified
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
     >>> from bika.lims.workflow import isTransitionAllowed
@@ -230,3 +231,24 @@ And to ensure consistency amongst tests, we disable self-verification:
     >>> bikasetup.setSelfVerificationEnabled(False)
     >>> bikasetup.getSelfVerificationEnabled()
     False
+
+
+IVerified interface is provided by verified controls
+....................................................
+
+When verified, blank analyses are marked with the `IVerified` interface:
+
+    >>> bikasetup.setSelfVerificationEnabled(True)
+    >>> sample = new_ar([Cu])
+    >>> worksheet = to_new_worksheet_with_reference(sample, control_sample)
+    >>> control = worksheet.getReferenceAnalyses()[0]
+    >>> control.setResult(12)
+    >>> success = do_action_for(control, "submit")
+    >>> IVerified.providedBy(control)
+    False
+
+    >>> success = do_action_for(control, "verify")
+    >>> IVerified.providedBy(control)
+    True
+
+    >>> bikasetup.setSelfVerificationEnabled(False)

--- a/src/senaite/core/tests/doctests/WorkflowWorksheetRetract.rst
+++ b/src/senaite/core/tests/doctests/WorkflowWorksheetRetract.rst
@@ -13,6 +13,7 @@ Needed Imports:
 
     >>> from AccessControl.PermissionRole import rolesForPermissionOn
     >>> from bika.lims import api
+    >>> from bika.lims.interfaces import IRetracted
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
     >>> from bika.lims.workflow import isTransitionAllowed
@@ -137,6 +138,8 @@ The retraction of the worksheet causes all its analyses to be retracted:
     6
     >>> sorted(map(api.get_workflow_status_of, analyses))
     ['assigned', 'assigned', 'assigned', 'retracted', 'retracted', 'retracted']
+    >>> sorted(map(IRetracted.providedBy, analyses))
+    [False, False, False, True, True, True]
 
 And the Worksheet transitions to "open":
 

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -19,11 +19,14 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims import api
+from bika.lims.interfaces import IRejected
+from bika.lims.interfaces import IRetracted
 from senaite.core import logger
+from senaite.core.catalog import ANALYSIS_CATALOG
 from senaite.core.config import PROJECTNAME as product
 from senaite.core.upgrade import upgradestep
 from senaite.core.upgrade.utils import UpgradeUtils
-from senaite.core.catalog import ANALYSIS_CATALOG
+from zope.interface import alsoProvides
 
 version = "2.4.0"  # Remember version number in metadata.xml and setup.py
 profile = "profile-{0}:default".format(product)
@@ -43,6 +46,9 @@ def upgrade(tool):
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
     # -------- ADD YOUR STUFF BELOW --------
+
+    # Mark analyses with IRetracted and IRejected
+    mark_retracted_and_rejected_analyses(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
@@ -71,3 +77,37 @@ def reindex_qc_analyses(tool):
         obj._p_deactivate()
 
     logger.info("Reindexing QC Analyses [DONE]")
+
+
+def mark_retracted_and_rejected_analyses(portal):
+    """Sets the IRetracted and/or IRejected interface to analyses that were
+    either retracted or rejected
+    """
+    logger.info("Applying IRetracted/IRejected interface to analyses ...")
+    query = {
+        "portal_type": ["Analysis", "ReferenceAnalysis", "DuplicateAnalysis"],
+        "review_state": ["retracted", "rejected"],
+    }
+    brains = api.search(query, ANALYSIS_CATALOG)
+    total = len(brains)
+
+    for num, brain in enumerate(brains):
+        if num and num % 100 == 0:
+            logger.info("Apply IRetracted/IRejected {0}/{1}".format(num, total))
+
+        obj = api.get_object(brain)
+        if IRetracted.providedBy(obj):
+            obj._p_deactivate()  # noqa
+            continue
+
+        if IRejected.providedBy(obj):
+            obj._p_deactivate()  # noqa
+            continue
+
+        status = api.get_review_status(obj)
+        if status == "retracted":
+            alsoProvides(obj, IRetracted)
+        elif status == "rejected":
+            alsoProvides(obj, IRejected)
+
+    logger.info("Applying IRetracted/IRejected interface to analyses [DONE]")

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -47,9 +47,6 @@ def upgrade(tool):
 
     # -------- ADD YOUR STUFF BELOW --------
 
-    # Mark analyses with IRetracted and IRejected
-    mark_retracted_and_rejected_analyses(portal)
-
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
 

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -83,7 +83,7 @@ def mark_retracted_and_rejected_analyses(portal):
     """Sets the IRetracted and/or IRejected interface to analyses that were
     either retracted or rejected
     """
-    logger.info("Applying IRetracted/IRejected interface to analyses ...")
+    logger.info("Set IRetracted/IRejected interface to analyses ...")
     query = {
         "portal_type": ["Analysis", "ReferenceAnalysis", "DuplicateAnalysis"],
         "review_state": ["retracted", "rejected"],
@@ -93,7 +93,7 @@ def mark_retracted_and_rejected_analyses(portal):
 
     for num, brain in enumerate(brains):
         if num and num % 100 == 0:
-            logger.info("Apply IRetracted/IRejected {0}/{1}".format(num, total))
+            logger.info("Set IRetracted/IRejected {0}/{1}".format(num, total))
 
         obj = api.get_object(brain)
         if IRetracted.providedBy(obj):
@@ -110,4 +110,4 @@ def mark_retracted_and_rejected_analyses(portal):
         elif status == "rejected":
             alsoProvides(obj, IRejected)
 
-    logger.info("Applying IRetracted/IRejected interface to analyses [DONE]")
+    logger.info("Set IRetracted/IRejected interface to analyses [DONE]")

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -76,9 +76,10 @@ def reindex_qc_analyses(tool):
     logger.info("Reindexing QC Analyses [DONE]")
 
 
-def mark_retracted_and_rejected_analyses(portal):
+def mark_retracted_and_rejected_analyses(tool):
     """Sets the IRetracted and/or IRejected interface to analyses that were
     either retracted or rejected
+    :param tool: portal_setup tool
     """
     logger.info("Set IRetracted/IRejected interface to analyses ...")
     query = {

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -13,4 +13,14 @@
       handler="senaite.core.upgrade.v02_04_000.reindex_qc_analyses"
       profile="senaite.core:default"/>
 
+  <!-- Mark analyses with IRejected or IRetracted
+       https://github.com/senaite/senaite.core/pull/2164 -->
+  <genericsetup:upgradeStep
+      title="SENAITE CORE 2.4.0: Mark analyses with IRetracted and IRejected"
+      description="Mark analyses with IRetracted and IRejected"
+      source="2401"
+      destination="2402"
+      handler="senaite.core.upgrade.v02_04_000.mark_retracted_and_rejected_analyses"
+      profile="senaite.core:default"/>
+
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds the marker interfaces `IRetracted` and `IRejected` for analyses objects (routine, duplicates and controls).

This Pull Request also removes a stale status "rejected" for reference samples (controls and blanks). The transition "reject" was missing in the workflow definition, so although it was defined as a possible transition in "to_be_verified_status" and the status "rejected" was declared, such status was never reachable. For reference analyses, "unassign" transition is used instead of "reject".

## Current behavior before PR

Retracted and rejected analyses do not provide specific interfaces

## Desired behavior after PR is merged

Retracted and rejected analyses provide specific interfaces for easy manipulation

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
