### PR TITLE
Fix partitions not displaying complete list of Interpretation Templates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2166 Fix partitions not displaying complete list of Interpretation Templates
 - #2165 Add DX phone field and widget
 - #2164 Added `IRetracted` and `IRejected` marker interfaces for analyses
 - #2162 Allow to create samples without analyses

--- a/src/senaite/core/browser/viewlets/resultsinterpretation.py
+++ b/src/senaite/core/browser/viewlets/resultsinterpretation.py
@@ -82,15 +82,14 @@ class ResultsInterpretationViewlet(ViewletBase):
             """
             obj = api.get_object(obj)
             sample_types = obj.getRawSampleTypes() or [sample_type_uid]
-            if sample_type_uid not in sample_types:
-                return False
+            if sample_type_uid in sample_types:
+                return True
 
             analysis_templates = obj.getRawAnalysisTemplates()
-            if analysis_templates:
-                if template_uid not in analysis_templates:
-                    return False
+            if template_uid in analysis_templates:
+                return True
 
-            return True
+            return False
 
         def get_data_info(item):
             return {


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that interpretation templates that meet with any of the criteria below are rendered for selection in the picklist:

- The sample type is supported by the interpretation template
- The analysis template is supported by the interpretation template

![193172588-96b83ff3-112b-46eb-9ffe-89c1bc54f176](https://user-images.githubusercontent.com/832627/196391410-adef54ed-dfe8-46d4-90b8-683d788759e5.png)

## Current behavior before PR

Interpretation templates supported by the sample type, but for the analysis template are not rendered for selection

Note the criteria **or** stated in https://github.com/senaite/senaite.core/pull/2058 was not met: *This Pull Request makes comments available in "Result Interpretation" section to be sample type **or** analysis template specific*



## Desired behavior after PR is merged

Interpretation templates supported by the sample type, but for the analysis template are rendered for selection

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
