### PR TITLE
Added data-name to field attributes

### DIFF
--- a/src/senaite/core/z3cform/widgets/phone.py
+++ b/src/senaite/core/z3cform/widgets/phone.py
@@ -39,7 +39,10 @@ class PhoneWidget(text.TextWidget):
 
         :returns: dictionary of HTML attributes
         """
-        attrs = {}
+        attrs = {
+            "data-name": self.name,
+        }
+
         initial_country = self.initial_country
         if initial_country is None:
             initial_country = self.get_default_country()

--- a/src/senaite/core/z3cform/widgets/phone.py
+++ b/src/senaite/core/z3cform/widgets/phone.py
@@ -39,10 +39,7 @@ class PhoneWidget(text.TextWidget):
 
         :returns: dictionary of HTML attributes
         """
-        attrs = {
-            "name": self.name,
-        }
-
+        attrs = {}
         initial_country = self.initial_country
         if initial_country is None:
             initial_country = self.get_default_country()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is a fixture for https://github.com/senaite/senaite.core/pull/2165 that caused the following traceback:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module plone.z3cform.layout, line 63, in __call__
  Module plone.z3cform.layout, line 47, in update
  Module plone.dexterity.browser.add, line 138, in update
  Module plone.z3cform.fieldsets.extensible, line 65, in update
  Module plone.z3cform.patch, line 30, in GroupForm_update
  Module z3c.form.group, line 141, in update
  Module z3c.form.group, line 52, in update
  Module z3c.form.group, line 48, in updateWidgets
  Module z3c.form.field, line 277, in update
  Module z3c.form.browser.multi, line 63, in update
  Module z3c.form.browser.widget, line 171, in update
  Module z3c.form.widget, line 496, in update
  Module Products.CMFPlone.patches.z3c_form, line 47, in _wrapped
  Module z3c.form.widget, line 92, in update
  Module z3c.form.widget, line 491, in value
  Module collective.z3cform.datagridfield.datagridfield, line 177, in updateWidgets
  Module collective.z3cform.datagridfield.datagridfield, line 149, in getWidget
  Module z3c.form.browser.widget, line 171, in update
  Module z3c.form.object, line 216, in update
  Module Products.CMFPlone.patches.z3c_form, line 47, in _wrapped
  Module z3c.form.widget, line 88, in update
  Module z3c.form.object, line 285, in extract
  Module z3c.form.group, line 98, in extractData
  Module z3c.form.form, line 148, in extractData
  Module z3c.form.field, line 303, in extract
  Module z3c.form.converter, line 56, in toFieldValue
  Module zope.schema._field, line 193, in fromUnicode
  Module zope.schema._compat, line 38, in make_binary
AttributeError: 'list' object has no attribute 'encode'
```

The reason for this was, that both, the display input field and the hidden input field had the same `name` attribute and were converted to a list from ZPublisher.

## Current behavior before PR

Traceback occured when a phone field was submitted

## Desired behavior after PR is merged

No traceback occures when the phone field is submitted

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
