### PR TITLE
Fix field error indication in sample header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2169 Fix field error indication in sample header
 - #2166 Fix partitions not displaying complete list of Interpretation Templates
 - #2165 Add DX phone field and widget
 - #2164 Added `IRetracted` and `IRejected` marker interfaces for analyses

--- a/src/senaite/core/browser/viewlets/sampleheader.py
+++ b/src/senaite/core/browser/viewlets/sampleheader.py
@@ -35,10 +35,15 @@ class SampleHeaderViewlet(ViewletBase):
         request = self.request
         submitted = request.form.get("sampleheader_form_submitted", False)
         save = request.form.get("sampleheader_form_save", False)
+        errors = {}
         if submitted and save:
-            self.handle_form_submit(request=self.request)
-            self.request.response.redirect(self.context.absolute_url())
-        return self.template()
+            errors = self.handle_form_submit(request=self.request)
+            # NOTE: we only redirect if no validation errors occured,
+            #       because otherwise the fields are not error-indicated!
+            if not errors:
+                # redirect needed to show status message
+                self.request.response.redirect(self.context.absolute_url())
+        return self.template(errors=errors)
 
     def handle_form_submit(self, request=None):
         """Handle form submission
@@ -63,9 +68,7 @@ class SampleHeaderViewlet(ViewletBase):
                 errors.update({name: error})
 
         if errors:
-            request["errors"] = errors
-            message = _("Please correct the indicated errors")
-            self.add_status_message(message, level="error")
+            return errors
         else:
             # we want to set the fields with the data manager
             dm = IDataManager(self.context)

--- a/src/senaite/core/browser/viewlets/templates/sampleheader.pt
+++ b/src/senaite/core/browser/viewlets/templates/sampleheader.pt
@@ -1,7 +1,7 @@
 <div id="senaite-sampleheader"
      tal:define="senaite_view python:context.restrictedTraverse('@@senaite_view');
                  test nocall:senaite_view/test;
-                 errors python:request.get('errors', {});
+                 errors python:options.get('errors', {});
                  config python:view.get_configuration();
                  prominent_columns python:config.get('prominent_columns');
                  standard_columns python:config.get('standard_columns');

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/field.pt
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/field.pt
@@ -81,6 +81,7 @@
                   portal python:context.portal_url.getPortalObject();
                   visCondition python:field.widget.testCondition(context.aq_inner.getParentNode(), portal, context);
                   error_id python:errors.get(fieldName)">
+
       <tal:condition
         condition="python:visState == 'visible' and visCondition">
         <div class="field"

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/field.pt
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/field.pt
@@ -81,7 +81,6 @@
                   portal python:context.portal_url.getPortalObject();
                   visCondition python:field.widget.testCondition(context.aq_inner.getParentNode(), portal, context);
                   error_id python:errors.get(fieldName)">
-
       <tal:condition
         condition="python:visState == 'visible' and visCondition">
         <div class="field"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fix the missing field error indicators when submitting fields in the sample header viewlet.

<img width="809" alt="" src="https://user-images.githubusercontent.com/713193/197334601-dc7dcc93-59be-44e1-a026-534ae6401b62.png">

## Current behavior before PR

No fields errors are indicated

## Desired behavior after PR is merged

Field errors are indicated in sample header viewlet

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
