### PR TITLE
Fix SuperModel import error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2172 Fix SuperModel import error introduced in PR #2154
 - #2169 Fix field error indication in sample header
 - #2166 Fix partitions not displaying complete list of Interpretation Templates
 - #2165 Add DX phone field and widget

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -27,7 +27,6 @@ from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
 from bika.lims.api import APIError
-from bika.lims.api import analysisservice as serviceapi
 from bika.lims.catalog import SETUP_CATALOG
 from bika.lims.utils import t as _t
 from bika.lims.utils import to_utf8
@@ -257,7 +256,20 @@ class ServiceKeywordValidator:
             # Nothing changed
             return
 
-        err_msg = serviceapi.check_keyword(value, instance)
+        # The validators module get imported early in __init__.py,
+        # and this line causes this (indirect) import error:
+        #
+        # from bika.lims.browser.fields.uidreferencefield import get_backreferences
+        # ImportError: cannot import name SuperModel
+        #
+        # Mental note from ramonski:
+        # Probably because *all* fields get imported in
+        # bika.lims.browser.fields.__init__.py and the ZCA is not yet fully
+        # initialized.
+        #
+        # https://github.com/senaite/senaite.docker/issues/14
+        from bika.lims.api.analysisservice import check_keyword
+        err_msg = check_keyword(value, instance)
         if err_msg:
             ts = api.get_tool("translation_service")
             return to_utf8(ts.translate(err_msg))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the following `ImportError` (also seehttps://github.com/senaite/senaite.docker/issues/14):

```
Traceback (most recent call last):
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/parts/instance/bin/interpreter", line 322, in <module>
    exec(compile(__file__f.read(), __file__, "exec"))
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/Zope-4.8.2-py2.7.egg/Zope2/Startup/serve.py", line 255, in <module>
    sys.exit(main() or 0)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/Zope-4.8.2-py2.7.egg/Zope2/Startup/serve.py", line 251, in main
    return command.run()
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/Zope-4.8.2-py2.7.egg/Zope2/Startup/serve.py", line 190, in run
    global_conf=vars)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/Zope-4.8.2-py2.7.egg/Zope2/Startup/serve.py", line 220, in loadapp
    return loadapp(app_spec, name=name, relative_to=relative_to, **kw)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/PasteDeploy-2.1.1-py2.7.egg/paste/deploy/loadwsgi.py", line 253, in loadapp
    return loadobj(APP, uri, name=name, **kw)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/PasteDeploy-2.1.1-py2.7.egg/paste/deploy/loadwsgi.py", line 278, in loadobj
    return context.create()
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/PasteDeploy-2.1.1-py2.7.egg/paste/deploy/loadwsgi.py", line 715, in create
    return self.object_type.invoke(self)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/PasteDeploy-2.1.1-py2.7.egg/paste/deploy/loadwsgi.py", line 209, in invoke
    app = context.app_context.create()
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/PasteDeploy-2.1.1-py2.7.egg/paste/deploy/loadwsgi.py", line 715, in create
    return self.object_type.invoke(self)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/PasteDeploy-2.1.1-py2.7.egg/paste/deploy/loadwsgi.py", line 152, in invoke
    return fix_call(context.object, context.global_conf, **context.local_conf)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/PasteDeploy-2.1.1-py2.7.egg/paste/deploy/util.py", line 55, in fix_call
    val = callable(*args, **kw)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/Zope-4.8.2-py2.7.egg/Zope2/Startup/run.py", line 71, in make_wsgi_app
    starter.prepare()
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/Zope-4.8.2-py2.7.egg/Zope2/Startup/starter.py", line 41, in prepare
    self.startZope()
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/Zope-4.8.2-py2.7.egg/Zope2/Startup/starter.py", line 99, in startZope
    Zope2.startup_wsgi()
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/Zope-4.8.2-py2.7.egg/Zope2/__init__.py", line 50, in startup_wsgi
    _startup()
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/Zope-4.8.2-py2.7.egg/Zope2/App/startup.py", line 143, in startup
    load_zcml()
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/Zope-4.8.2-py2.7.egg/Zope2/App/startup.py", line 58, in load_zcml
    load_site()
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/Zope-4.8.2-py2.7.egg/Zope2/App/zcml.py", line 45, in load_site
    _context = xmlconfig.file(site_zcml)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/zope.configuration-4.4.0-py2.7.egg/zope/configuration/xmlconfig.py", line 657, in file
    include(context, name, package)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/zope.configuration-4.4.0-py2.7.egg/zope/configuration/xmlconfig.py", line 557, in include
    processxmlfile(f, context)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/zope.configuration-4.4.0-py2.7.egg/zope/configuration/xmlconfig.py", line 407, in processxmlfile
    parser.parse(src)
  File "/Users/rbartl/.pyenv/versions/2.7.18/lib/python2.7/xml/sax/expatreader.py", line 111, in parse
    xmlreader.IncrementalParser.parse(self, source)
  File "/Users/rbartl/.pyenv/versions/2.7.18/lib/python2.7/xml/sax/xmlreader.py", line 123, in parse
    self.feed(buffer)
  File "/Users/rbartl/.pyenv/versions/2.7.18/lib/python2.7/xml/sax/expatreader.py", line 220, in feed
    self._parser.Parse(data, isFinal)
  File "/Users/rbartl/.pyenv/versions/2.7.18/lib/python2.7/xml/sax/expatreader.py", line 384, in end_element_ns
    self._cont_handler.endElementNS(pair, None)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/zope.configuration-4.4.0-py2.7.egg/zope/configuration/xmlconfig.py", line 393, in endElementNS
    self._handle_exception(ex, info)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/zope.configuration-4.4.0-py2.7.egg/zope/configuration/xmlconfig.py", line 391, in endElementNS
    self.context.end()
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/zope.configuration-4.4.0-py2.7.egg/zope/configuration/config.py", line 704, in end
    self.stack.pop().finish()
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/zope.configuration-4.4.0-py2.7.egg/zope/configuration/config.py", line 869, in finish
    actions = self.handler(context, **args)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/Zope-4.8.2-py2.7.egg/OFS/metaconfigure.py", line 47, in loadProducts
    xmlconfig.include(_context, zcml, package=product)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/zope.configuration-4.4.0-py2.7.egg/zope/configuration/xmlconfig.py", line 557, in include
    processxmlfile(f, context)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/zope.configuration-4.4.0-py2.7.egg/zope/configuration/xmlconfig.py", line 407, in processxmlfile
    parser.parse(src)
  File "/Users/rbartl/.pyenv/versions/2.7.18/lib/python2.7/xml/sax/expatreader.py", line 111, in parse
    xmlreader.IncrementalParser.parse(self, source)
  File "/Users/rbartl/.pyenv/versions/2.7.18/lib/python2.7/xml/sax/xmlreader.py", line 123, in parse
    self.feed(buffer)
  File "/Users/rbartl/.pyenv/versions/2.7.18/lib/python2.7/xml/sax/expatreader.py", line 220, in feed
    self._parser.Parse(data, isFinal)
  File "/Users/rbartl/.pyenv/versions/2.7.18/lib/python2.7/xml/sax/expatreader.py", line 384, in end_element_ns
    self._cont_handler.endElementNS(pair, None)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/zope.configuration-4.4.0-py2.7.egg/zope/configuration/xmlconfig.py", line 393, in endElementNS
    self._handle_exception(ex, info)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/zope.configuration-4.4.0-py2.7.egg/zope/configuration/xmlconfig.py", line 235, in _handle_exception
    reraise(exc, None, sys.exc_info()[2])
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/zope.configuration-4.4.0-py2.7.egg/zope/configuration/xmlconfig.py", line 391, in endElementNS
    self.context.end()
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/zope.configuration-4.4.0-py2.7.egg/zope/configuration/config.py", line 704, in end
    self.stack.pop().finish()
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/zope.configuration-4.4.0-py2.7.egg/zope/configuration/config.py", line 869, in finish
    actions = self.handler(context, **args)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/z3c.autoinclude-0.4.1-py2.7.egg/z3c/autoinclude/zcml.py", line 119, in includePluginsDirective
    info = PluginFinder(dotted_name).includableInfo(zcml_to_look_for)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/z3c.autoinclude-0.4.1-py2.7.egg/z3c/autoinclude/plugin.py", line 24, in includableInfo
    groups = zcml_to_include(plugin_dottedname, zcml_to_look_for)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/z3c.autoinclude-0.4.1-py2.7.egg/z3c/autoinclude/plugin.py", line 52, in zcml_to_include
    filename = resource_filename(dotted_name, zcmlgroup)
  File "/Users/rbartl/.virtualenvs/senaite.docker/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1144, in resource_filename
    return get_provider(package_or_requirement).get_resource_filename(
  File "/Users/rbartl/.virtualenvs/senaite.docker/lib/python2.7/site-packages/pkg_resources/__init__.py", line 361, in get_provider
    __import__(moduleOrReq)
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/src/senaite.app.supermodel/src/senaite/app/supermodel/__init__.py", line 32, in <module>
    from senaite.app.supermodel.model import SuperModel  # noqa
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/src/senaite.app.supermodel/src/senaite/app/supermodel/model.py", line 26, in <module>
    from bika.lims import api
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/src/senaite.core/src/bika/lims/__init__.py", line 51, in <module>
    from bika.lims.validators import *
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/src/senaite.core/src/bika/lims/validators.py", line 30, in <module>
    from bika.lims.api import analysisservice as serviceapi
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/src/senaite.core/src/bika/lims/api/analysisservice.py", line 25, in <module>
    from bika.lims.browser.fields.uidreferencefield import get_backreferences
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/src/senaite.core/src/bika/lims/browser/fields/__init__.py", line 21, in <module>
    from .addressfield import AddressField
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/src/senaite.core/src/bika/lims/browser/fields/addressfield.py", line 22, in <module>
    from senaite.core.browser.fields.record import RecordField
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/src/senaite.core/src/senaite/core/browser/fields/record.py", line 42, in <module>
    from senaite.core.browser.widgets.recordwidget import RecordWidget
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/src/senaite.core/src/senaite/core/browser/widgets/__init__.py", line 21, in <module>
    from .referencewidget import ReferenceWidget
  File "/Users/rbartl/develop/senaite/senaite.docker/latest/src/senaite.core/src/senaite/core/browser/widgets/referencewidget.py", line 34, in <module>
    from senaite.app.supermodel.model import SuperModel
zope.configuration.xmlconfig.ZopeXMLConfigurationError: File "/Users/rbartl/develop/senaite/senaite.docker/latest/eggs/cp27m/Products.CMFPlone-5.2.9-py2.7.egg/Products/CMFPlone/meta.zcml", line 38.4-42.10
    File "/Users/rbartl/develop/senaite/senaite.docker/latest/parts/instance/etc/site.zcml", line 12.2-12.39
    ImportError: cannot import name SuperModel
```

## Current behavior before PR

Indirect import of the `bika.lims.browser.fields` package causes the mentioned import error when the `bika.lims.validators` module was imported here:

https://github.com/senaite/senaite.core/blob/2.x/src/bika/lims/__init__.py#L51

## Desired behavior after PR is merged

Import is deferred in validator function

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
