### PR TITLE
Fix UnicodeDecodeError when a required condition is empty in add form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2173 Fix UnicodeDecodeError when a required condition is empty in add form
 - #2172 Fix SuperModel import error introduced in PR #2154
 - #2169 Fix field error indication in sample header
 - #2166 Fix partitions not displaying complete list of Interpretation Templates

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1617,7 +1617,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             # If there are required fields missing, flag an error
             for field in missing:
                 fieldname = "{}-{}".format(field, n)
-                msg = _("Field '{}' is required".format(field))
+                msg = _("Field '{}' is required").format(safe_unicode(field))
                 fielderrors[fieldname] = msg
 
             # Process valid record


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes an `UnicodeDecodeError` that arises on Sample add form when a required pre-condition with a title that contains special characters is not filled.

![Captura de 2022-10-27 15-38-39](https://user-images.githubusercontent.com/832627/198301418-70fe3c39-df13-445d-b0d0-279ede14a187.png)


## Current behavior before PR

![Captura de 2022-10-27 15-42-55](https://user-images.githubusercontent.com/832627/198301088-4de5b944-b33c-403a-9670-c177caf4ab7c.png)

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module bika.lims.browser.analysisrequest.add2, line 72, in decorator
  Module bika.lims.browser.analysisrequest.add2, line 717, in __call__
  Module bika.lims.browser.analysisrequest.add2, line 1620, in ajax_submit
  Module zope.i18nmessageid.message, line 112, in __call__
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 8: ordinal not in range(128)
```

## Desired behavior after PR is merged

![Captura de 2022-10-27 15-42-25](https://user-images.githubusercontent.com/832627/198301046-0951fa3e-4803-4874-9989-c119fb622c1b.png)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
