### PR TITLE
Force a transaction.commit every 1000 samples on upgrade

### DIFF
--- a/bika/lims/upgrade/v01_03_006.py
+++ b/bika/lims/upgrade/v01_03_006.py
@@ -18,6 +18,8 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import transaction
+
 from bika.lims import api
 from bika.lims import logger
 from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
@@ -95,14 +97,17 @@ def fix_samples_primary(portal):
     samples = api.search(query, CATALOG_ANALYSIS_REQUEST_LISTING)
     total = len(samples)
     for num, sample in enumerate(samples):
-        if num and num % 10 == 0:
+        if num and num % 100 == 0:
             logger.info("Processed samples: {}/{}".format(num, total))
+        if num and num % 1000 == 0:
+            transaction.commit()
 
         # Extract the parent(s) from this sample
         sample = api.get_object(sample)
         parents = sample.getRefs(relationship=ref_id)
         if not parents:
             # Processed already
+            sample._p_deactivate()
             continue
 
         # Re-assign the parent sample(s)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull request prevents the system to consume too much RAM on upgrade

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
