### PR TITLE
Fix Traceback when removing a Worksheet

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2179 Fix Traceback when removing a Worksheet
 - #2178 AT Queryselect Widget
 - #2177 Dexterity Queryselect Widget
 - #2173 Fix UnicodeDecodeError when a required condition is empty in add form

--- a/src/bika/lims/workflow/worksheet/events.py
+++ b/src/bika/lims/workflow/worksheet/events.py
@@ -32,4 +32,10 @@ def after_remove(worksheet):
     """Removes the worksheet from the system
     """
     container = worksheet.aq_parent
-    container.manage_delObjects([worksheet.getId()])
+
+    # bypass security checks on object removal. The removal of worksheet
+    # objects is governed by "Transition: Remove Worksheet" permission at
+    # worksheet level, along with a specific guard to ensure that only empty
+    # worksheets can be removed. Therefore, better keep the "Delete objects"
+    # permission at Worksheets folder level as false, because is less specific
+    container._delObject(worksheet.getId())

--- a/src/bika/lims/workflow/worksheet/guards.py
+++ b/src/bika/lims/workflow/worksheet/guards.py
@@ -122,6 +122,6 @@ def guard_remove(worksheet):
     """Return whether the workflow can be removed. Returns true if the worksheet
     does not contain any analysis
     """
-    if worksheet.getAnalyses():
+    if worksheet.getRawAnalyses():
         return False
     return True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures a Worksheet is properly removed when the action "remove" is triggered by a privileged user (e.g. "LabMan")

## Current behavior before PR

A traceback occurs when removing an empty worksheet

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module bika.lims.browser.workflow, line 154, in __call__
  Module bika.lims.browser.workflow, line 165, in __call__
  Module bika.lims.browser.workflow, line 184, in do_action
  Module bika.lims.workflow, line 123, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 252, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 537, in _invokeWithNotification
AttributeError: 'Unauthorized' object has no attribute 'with_traceback'
```

## Desired behavior after PR is merged

The empty worksheet is properly removed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
