### PR TITLE
Rely on analysis permission when displaying results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2180 Rely on analysis permission when displaying results
 - #2178 AT Queryselect Widget
 - #2177 Dexterity Queryselect Widget
 - #2173 Fix UnicodeDecodeError when a required condition is empty in add form

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -861,9 +861,7 @@ class AnalysesView(ListingView):
 
         item["Result"] = ""
 
-        # TODO: The permission `ViewResults` is managed on the sample.
-        #       -> Change to a proper field permission!
-        if not self.has_permission(ViewResults, self.context):
+        if not self.has_permission(ViewResults, analysis_brain):
             # If user has no permissions, don"t display the result but an icon
             img = get_image("to_follow.png", width="16px", height="16px")
             item["before"]["Result"] = img

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -42,6 +42,7 @@ from bika.lims.content.abstractbaseanalysis import AbstractBaseAnalysis
 from bika.lims.content.abstractbaseanalysis import schema
 from bika.lims.interfaces import IDuplicateAnalysis
 from bika.lims.permissions import FieldEditAnalysisResult
+from bika.lims.permissions import ViewResults
 from bika.lims.utils import formatDecimalMark
 from bika.lims.utils.analysis import format_numeric_result
 from bika.lims.utils.analysis import get_significant_digits
@@ -73,7 +74,7 @@ Attachment = UIDReferenceField(
 # a non-numeric result is needed, ResultOptions can be used.
 Result = StringField(
     'Result',
-    read_permission=View,
+    read_permission=ViewResults,
     write_permission=FieldEditAnalysisResult,
 )
 

--- a/src/bika/lims/profiles/default/rolemap.xml
+++ b/src/bika/lims/profiles/default/rolemap.xml
@@ -839,30 +839,6 @@
       <role name="Sampler"/>
       <role name="SamplingCoordinator"/>
       <role name="Verifier"/>
-      <!-- @xispa conflicts
-      Usage in workflows:
-        - ar_workflow.xml: as regular permission
-        - analysis_workflow.xml: as regular permission
-        - referenceanalysis_workflow.xml: as regular permission
-        - duplicateanalysis_workflow.xml: as regular permission
-        - rejectanalysis_workflow.xml: as regualr permission
-
-      Usage in views:
-        - worksheet: View, ManageResults
-        - analysisrequest: Published Results
-
-      Usage in code:
-        - Analyses listing: folder_item (Result + Uncertainty + Attachments)
-
-      Additional notes:
-        - Does not make sense to have different permissions for WS Manage
-          Results and AR Manage Results
-        - Don't think View Results permission should be used in AR's
-          Published results view. A permission "View Results Reports" would fit
-          better imo.
-        - Consider to stick to field-specific permissions ("Field: View ?") in
-          analyses listing
-      -->
     </permission>
 
     <!-- View/Action permissions -->

--- a/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
+++ b/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
@@ -39,7 +39,6 @@
   <permission>senaite.core: Edit Field Results</permission>
   <permission>senaite.core: Edit Results</permission>
   <permission>senaite.core: Manage Invoices</permission>
-  <permission>senaite.core: View Results</permission>
   <permission>Access contents information</permission>
   <permission>Add portal content</permission>
   <permission>Modify portal content</permission>
@@ -133,7 +132,6 @@
     <permission-map name="senaite.core: Edit Field Results" acquired="True"/>
     <permission-map name="senaite.core: Edit Results" acquired="True"/>
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
-    <permission-map name="senaite.core: View Results" acquired="True"/>
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
@@ -232,7 +230,6 @@
     <permission-map name="senaite.core: Edit Field Results" acquired="True"/>
     <permission-map name="senaite.core: Edit Results" acquired="False"/>
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
-    <permission-map name="senaite.core: View Results" acquired="True"/>
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
@@ -344,7 +341,6 @@
     <permission-map name="senaite.core: Edit Field Results" acquired="True"/>
     <permission-map name="senaite.core: Edit Results" acquired="False"/>
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
-    <permission-map name="senaite.core: View Results" acquired="True"/>
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
@@ -447,7 +443,6 @@
     <permission-map name="senaite.core: Edit Field Results" acquired="True"/>
     <permission-map name="senaite.core: Edit Results" acquired="False"/>
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
-    <permission-map name="senaite.core: View Results" acquired="True"/>
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
@@ -543,7 +538,6 @@
     <permission-map name="senaite.core: Edit Field Results" acquired="True"/>
     <permission-map name="senaite.core: Edit Results" acquired="True"/>
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
-    <permission-map name="senaite.core: View Results" acquired="True"/>
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
@@ -639,7 +633,6 @@
     <permission-map name="senaite.core: Edit Field Results" acquired="False"/>
     <permission-map name="senaite.core: Edit Results" acquired="False"/>
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
-    <permission-map name="senaite.core: View Results" acquired="True"/>
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Add portal content" acquired="True">
       <!-- Publisher role must be able to add ARReports -->
@@ -735,7 +728,6 @@
     <permission-map name="senaite.core: Edit Field Results" acquired="True"/>
     <permission-map name="senaite.core: Edit Results" acquired="True"/>
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
-    <permission-map name="senaite.core: View Results" acquired="True"/>
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
@@ -828,7 +820,6 @@
     <permission-map name="senaite.core: Edit Field Results" acquired="False"/>
     <permission-map name="senaite.core: Edit Results" acquired="False"/>
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
-    <permission-map name="senaite.core: View Results" acquired="True"/>
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Add portal content" acquired="True">
       <!-- Publisher role must be able to add ARReports -->
@@ -927,7 +918,6 @@
     <permission-map name="senaite.core: Edit Field Results" acquired="False"/>
     <permission-map name="senaite.core: Edit Results" acquired="False"/>
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
-    <permission-map name="senaite.core: View Results" acquired="True"/>
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
@@ -1014,7 +1004,6 @@
     <permission-map name="senaite.core: Edit Field Results" acquired="False"/>
     <permission-map name="senaite.core: Edit Results" acquired="False"/>
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
-    <permission-map name="senaite.core: View Results" acquired="True"/>
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
@@ -1094,7 +1083,6 @@
     <permission-map name="senaite.core: Edit Field Results" acquired="False"/>
     <permission-map name="senaite.core: Edit Results" acquired="False"/>
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
-    <permission-map name="senaite.core: View Results" acquired="True"/>
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
@@ -1179,7 +1167,6 @@
     <permission-map name="senaite.core: Edit Field Results" acquired="False"/>
     <permission-map name="senaite.core: Edit Results" acquired="False"/>
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
-    <permission-map name="senaite.core: View Results" acquired="True"/>
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="Modify portal content" acquired="True"/>
     <permission-map name="View" acquired="True"/>
@@ -1259,7 +1246,6 @@
     <permission-map name="senaite.core: Edit Field Results" acquired="False"/>
     <permission-map name="senaite.core: Edit Results" acquired="False"/>
     <permission-map name="senaite.core: Manage Invoices" acquired="True"/>
-    <permission-map name="senaite.core: View Results" acquired="True"/>
     <permission-map name="Access contents information" acquired="True"/>
     <permission-map name="View" acquired="True"/>
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the system to rely on the `ViewResults` permission at Analysis level for the rendering of the result in listings. System was relying on such permission, but from sample level instead.

## Current behavior before PR

System relies on `ViewResults` permission from Sample for the visualization of an analysis result

## Desired behavior after PR is merged

System relies on `ViewResults` permission from Analysis for the visualization of an analysis result

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
