### PR TITLE
Fix overflow of selected values for queryselect/uidreference widgets

### DIFF
--- a/src/senaite/core/z3cform/widgets/queryselect/display.pt
+++ b/src/senaite/core/z3cform/widgets/queryselect/display.pt
@@ -2,9 +2,9 @@
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
 
-  <ul class="list-unstyled list-group list-group-horizontal">
-    <li tal:repeat="value view/get_value">
-      <div class="p-1 mb-1 mr-1 bg-light border rounded d-inline-block">
+  <ul class="list-unstyled d-table-row">
+    <li tal:repeat="value view/get_value" class="d-inline-block">
+      <div class="p-1 mb-1 mr-1 bg-light border rounded">
         <span tal:replace="python:value"/>
       </div>
     </li>

--- a/src/senaite/core/z3cform/widgets/uidreference/display.pt
+++ b/src/senaite/core/z3cform/widgets/uidreference/display.pt
@@ -2,10 +2,10 @@
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
 
-  <ul class="list-unstyled list-group list-group-horizontal">
+  <ul class="list-unstyled d-table-row">
     <!-- list all referenced items -->
-    <li tal:repeat="uid view/get_value">
-      <div class="p-1 mb-1 mr-1 bg-light border rounded d-inline-block">
+    <li tal:repeat="uid view/get_value" class="d-inline-block">
+      <div class="p-1 mb-1 mr-1 bg-light border rounded">
         <span tal:replace="structure python:view.render_reference(uid)"/>
       </div>
     </li>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR belongs to https://github.com/senaite/senaite.core/pull/2178

## Current behavior before PR

UIDReference/Queryselect display widgets overflow when listing the selected values

<img width="742" src="https://user-images.githubusercontent.com/713193/201032836-def47277-9377-4bbf-99e2-ca15afeb4d26.png">

## Desired behavior after PR is merged

Selected values do not overflow

<img width="675" src="https://user-images.githubusercontent.com/713193/201032704-8c6473e4-0e2b-42d7-9591-780ceaacfa6c.png">


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
