### PR TITLE
Instrument Supplier does not load on data import

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
-- #2183 Use the pc catalog to get getName for Supplier and not the bsc catalog
+- #2183 Fix instrument supplier does not load on test data import
 - #2180 Rely on analysis permission when displaying results
 - #2179 Fix Traceback when removing a Worksheet
 - #2178 AT Queryselect Widget

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2183 Use the pc catalog to get getName for Supplier and not the bsc catalog
 - #2180 Rely on analysis permission when displaying results
 - #2179 Fix Traceback when removing a Worksheet
 - #2178 AT Queryselect Widget

--- a/src/senaite/core/exportimport/setupdata/__init__.py
+++ b/src/senaite/core/exportimport/setupdata/__init__.py
@@ -803,7 +803,7 @@ class Instruments(WorksheetImporter):
             )
             instrumenttype = self.get_object(bsc, 'InstrumentType', title=row.get('Type'))
             manufacturer = self.get_object(bsc, 'Manufacturer', title=row.get('Brand'))
-            supplier = self.get_object(pc, 'Supplier', getName=row.get('Supplier', ''))
+            supplier = self.get_object(bsc, 'Supplier', title=row.get('Supplier', ''))
             method = self.get_object(pc, 'Method', title=row.get('Method'))
             obj.setInstrumentType(instrumenttype)
             obj.setManufacturer(manufacturer)

--- a/src/senaite/core/exportimport/setupdata/__init__.py
+++ b/src/senaite/core/exportimport/setupdata/__init__.py
@@ -803,7 +803,7 @@ class Instruments(WorksheetImporter):
             )
             instrumenttype = self.get_object(bsc, 'InstrumentType', title=row.get('Type'))
             manufacturer = self.get_object(bsc, 'Manufacturer', title=row.get('Brand'))
-            supplier = self.get_object(bsc, 'Supplier', getName=row.get('Supplier', ''))
+            supplier = self.get_object(pc, 'Supplier', getName=row.get('Supplier', ''))
             method = self.get_object(pc, 'Method', title=row.get('Method'))
             obj.setInstrumentType(instrumenttype)
             obj.setManufacturer(manufacturer)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/2182

## Current behavior before PR
Instrument Supplier field does not  get set on import

## Desired behavior after PR is merged
Instrument Supplier field shoud be  set on import


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
