### PR TITLE
Fix analysis profiles not recognised on AR template creation

### DIFF
--- a/src/senaite/core/browser/static/js/bika.lims.artemplate.js
+++ b/src/senaite/core/browser/static/js/bika.lims.artemplate.js
@@ -6,6 +6,7 @@ function ARTemplateEditView() {
     var that = this;
     var samplepoint = $('#archetypes-fieldname-SamplePoint #SamplePoint');
     var sampletype = $('#archetypes-fieldname-SampleType #SampleType');
+    var analysisprofile = $('#archetypes-fieldname-AnalysisProfile #AnalysisProfile');
 
     /**
      * Entry-point method for AnalysisServiceEditView
@@ -76,7 +77,7 @@ function ARTemplateEditView() {
 
     function clickSaveButton(event){
         var selected_analyses = $('[name^="uids\\:list"]').filter(':checked');
-        if(selected_analyses.length < 1){
+        if(selected_analyses.length < 1 && !(analysisprofile.val())){
             window.bika.lims.portalMessage("No analyses have been selected");
             window.scroll(0, 0);
             return false;


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/2175

## Current behavior before PR

When creating creating a sample-template/ar-template when a Profile is selected and [Save] pressed the system responds with No analyses have been selected and it cannot be saved.

## Desired behavior after PR is merged

When an analysis profile is selected and [Save] pressed the AR template should successfully save.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html