### PR TITLE
Fix sticker template for sample type is not selected by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2186 Fix sticker template for sample type is not selected by default
 - #2180 Rely on analysis permission when displaying results
 - #2179 Fix Traceback when removing a Worksheet
 - #2178 AT Queryselect Widget

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1724,10 +1724,8 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                         len(uids),  # ar_count
                         sample_uids)  # sample_uids
         elif "register" in auto_print and sample_uids:
-            redirect_to = "{}/sticker?autoprint=1&template={}&items={}".format(
-                self.context.absolute_url(),
-                setup.getAutoStickerTemplate(),
-                sample_uids)
+            redirect_to = "{}/sticker?autoprint=1&items={}".format(
+                self.context.absolute_url(), sample_uids)
         elif immediate_results_entry and sample_uids:
             redirect_to = "{}/multi_results?uids={}".format(
                 self.context.absolute_url(),

--- a/src/bika/lims/browser/stickers.py
+++ b/src/bika/lims/browser/stickers.py
@@ -345,4 +345,4 @@ class Sticker(BrowserView):
         setup = api.get_setup()
         if size == "small":
             return setup.getSmallStickerTemplate()
-        return setup.getSmallStickerTemplate()
+        return setup.getLargeStickerTemplate()

--- a/src/bika/lims/browser/stickers.py
+++ b/src/bika/lims/browser/stickers.py
@@ -27,10 +27,13 @@ from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
 from bika.lims.browser import BrowserView
+from bika.lims.interfaces import IAnalysisRequest
 from bika.lims.interfaces import IGetStickerTemplates
+from bika.lims.interfaces import ISampleType
 from bika.lims.utils import createPdf
 from bika.lims.utils import to_int
 from bika.lims.vocabularies import getStickerTemplates
+from plone.memoize.view import memoize
 from plone.resource.utils import queryResourceDirectory
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -129,15 +132,16 @@ class Sticker(BrowserView):
         """Returns a list of SuperModel items
         """
         uids = self.get_uids()
-        if not uids:
-            return [SuperModel(self.context)]
         items = map(lambda uid: SuperModel(uid), uids)
         return self._resolve_number_of_copies(items)
 
     def get_uids(self):
         """Parse the UIDs from the request `items` parameter
         """
-        return filter(None, self.request.get("items", "").split(","))
+        uids = filter(None, self.request.get("items", "").split(","))
+        if not uids:
+            return api.get_uid(self.context)
+        return uids
 
     def getAvailableTemplates(self):
         """Returns an array with the templates of stickers available.
@@ -170,45 +174,15 @@ class Sticker(BrowserView):
             templates.append(out)
         return templates
 
-    def getSelectedTemplate(self, default="Code_39_40x20mm.pt"):
-        """Returns the id of the sticker template selected.
-
-        If no specific template found in the request (parameter template),
-        returns the default template set in Setup > Stickers.
-
-        If the template doesn't exist, uses the default template.
-
-        If no template selected but size param, get the sticker template set as
-        default in Bika Setup for the size set.
+    def getSelectedTemplate(self):
+        """Returns the id of the sticker template selected in the request. If
+        no template has been selected, returns default's depending on the
+        selected items and setup settings
         """
-        # Default sticker
-        bs_template = self.context.bika_setup.getAutoStickerTemplate()
-        size = self.request.get("size", "")
-
-        if self.filter_by_type:
-            templates = getStickerTemplates(filter_by_type=self.filter_by_type)
-            # Get the first sticker
-            bs_template = templates[0].get("id", "") if templates else ""
-        elif size == "small":
-            bs_template = self.context.bika_setup.getSmallStickerTemplate()
-        elif size == "large":
-            bs_template = self.context.bika_setup.getLargeStickerTemplate()
-        rq_template = self.request.get("template", bs_template)
-        # Check if the template exists. If not, fallback to default's
-        # 'prefix' is also the resource folder's name
-        prefix = ""
-        templates_dir = ""
-        if rq_template.find(":") >= 0:
-            prefix, rq_template = rq_template.split(":")
-            templates_dir = self._getStickersTemplatesDirectory(prefix)
-        else:
-            this_dir = os.path.dirname(os.path.abspath(__file__))
-            templates_dir = os.path.join(this_dir, "templates/stickers/")
-            if self.filter_by_type:
-                templates_dir = templates_dir + "/" + self.filter_by_type
-        if not os.path.isfile(os.path.join(templates_dir, rq_template)):
-            rq_template = default
-        return "%s:%s" % (prefix, rq_template) if prefix else rq_template
+        template_id = self.request.get("template")
+        if not template_id:
+            template_id = self.get_default_template()
+        return template_id
 
     def getSelectedTemplateCSS(self):
         """Looks for the CSS file from the selected template and return its
@@ -332,3 +306,43 @@ class Sticker(BrowserView):
         default_num = setup.getDefaultNumberOfCopies()
         request_num = self.request.form.get("copies_count")
         return to_int(request_num, default_num)
+
+    def get_default_template_for(self, obj, size):
+        """Returns the id of the sticker template to be rendered for the given
+        object and size
+        """
+        obj = api.get_object(obj)
+        if ISampleType.providedBy(obj):
+            if size == "small":
+                return obj.getDefaultSmallSticker()
+            return obj.getDefaultLargeSticker()
+
+        elif IAnalysisRequest.providedBy(obj):
+            sample_type = obj.getSampleType()
+            return self.get_default_template_for(sample_type, size)
+
+        return None
+
+    @memoize
+    def get_default_template(self):
+        """Returns the default sticker template to use for the given context
+        and selected items
+        """
+        if self.filter_by_type:
+            templates = getStickerTemplates(filter_by_type=self.filter_by_type)
+            template_id = templates[0].get("id", "") if templates else ""
+            if template_id:
+                return template_id
+
+        # pick the default template from the first item
+        size = self.request.get("size", "")
+        for uid in self.get_uids():
+            template = self.get_default_template_for(uid, size)
+            if template:
+                return template
+
+        # rely on the default setup template
+        setup = api.get_setup()
+        if size == "small":
+            return setup.getSmallStickerTemplate()
+        return setup.getSmallStickerTemplate()

--- a/src/bika/lims/browser/stickers.py
+++ b/src/bika/lims/browser/stickers.py
@@ -140,7 +140,7 @@ class Sticker(BrowserView):
         """
         uids = filter(None, self.request.get("items", "").split(","))
         if not uids:
-            return api.get_uid(self.context)
+            return [api.get_uid(self.context)]
         return uids
 
     def getAvailableTemplates(self):

--- a/src/bika/lims/browser/workflow/analysisrequest.py
+++ b/src/bika/lims/browser/workflow/analysisrequest.py
@@ -55,8 +55,7 @@ class WorkflowActionPrintStickersAdapter(RequestContextAware):
     implements(IWorkflowActionUIDsAdapter)
 
     def __call__(self, action, uids):
-        url = "{}/sticker?template={}&items={}".format(self.back_url,
-            self.context.bika_setup.getAutoStickerTemplate(), ",".join(uids))
+        url = "{}/sticker?items={}".format(self.back_url, ",".join(uids))
         return self.redirect(redirect_url=url)
 
 
@@ -126,9 +125,7 @@ class WorkflowActionReceiveAdapter(WorkflowActionGenericAdapter):
         if self.is_auto_print_stickers_enabled():
             # Redirect to the auto-print stickers view
             uids = ",".join(map(api.get_uid, transitioned))
-            sticker_template = self.context.bika_setup.getAutoStickerTemplate()
-            url = "{}/sticker?autoprint=1&template={}&items={}".format(
-                self.back_url, sticker_template, uids)
+            url = "{}/sticker?autoprint=1&items={}".format(self.back_url, uids)
             return self.redirect(redirect_url=url)
 
         # Redirect the user to success page


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that the sticker template set by default for the sample type the sample belongs to is selected by default, as well as the rendered barcode.

If only one template is admitted for the sample type and the current context is a Sample, the system renders the default template from setup, but since the selection list is populated with only one option, the user cannot render the expected barcode.

## Current behavior before PR

System always renders the template set as default in setup at first render and user is forced to manually choose the selected template. If only one sticker is allowed for the current sample type and it does not match with the default, user cannot manually choose the expected barcode.

## Desired behavior after PR is merged

The default template assigned to the sample type the sample belongs to is rendered from the very beginning

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
