### PR TITLE
Fix archive path for Generic Setup file imports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2188 Fix archive path for Generic Setup file imports
 - #2185 Fix analysis profiles not recognised on AR template creation
 - #2186 Fix sticker template for sample type is not selected by default
 - #2183 Fix instrument supplier does not load on test data import

--- a/src/senaite/core/exportimport/genericsetup/adapters.py
+++ b/src/senaite/core/exportimport/genericsetup/adapters.py
@@ -225,8 +225,13 @@ class ATFileFieldNodeAdapter(ATFieldNodeAdapter):
         site = self.environ.getSite()
         site_path = api.get_path(site)
         obj_path = api.get_path(self.context)
-        # remove the portal path
-        rel_path = obj_path.replace(site_path, "")
+        # remove the portal path at the *beginning* of the path
+        # NOTE: avoid to replace any further paths starting with the site path,
+        #       e.g. /senaite/senaite_storage/....
+        #       >>> path = '/senaite/senaite_storage/SC0120335'
+        #       >>> path.replace("/senaite", "", 1)
+        #       '/senaite_storage/SC0120335
+        rel_path = obj_path.replace(site_path, "", 1)
 
         archive_path = [SITE_ID]
         for segment in rel_path.split("/"):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes missing/wrong files after a Generic Setup Tar-Archive content import

## Current behavior before PR

Archive path to file did not match for new created content object

## Desired behavior after PR is merged

Archive path to file is translated via the ID map to match the original path

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
