### PR TITLE
Fix auto-print of barcode labels when auto-receive is enabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2189 Fix auto-print of barcode labels when auto-receive is enabled
 - #2185 Fix analysis profiles not recognised on AR template creation
 - #2186 Fix sticker template for sample type is not selected by default
 - #2183 Fix instrument supplier does not load on test data import

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1698,12 +1698,21 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
         return self.handle_redirect(ARs.values(), message)
 
+    def is_automatic_label_printing_enabled(self):
+        """Returns whether the automatic printing of barcode labels is active
+        """
+        setup = api.get_setup()
+        auto_print = setup.getAutoPrintStickers()
+        auto_receive = setup.getAutoreceiveSamples()
+        action = "receive" if auto_receive else "register"
+        return action in auto_print
+
     def handle_redirect(self, uids, message):
         """Handle redirect after sample creation or cancel
         """
         # Automatic label printing
         setup = api.get_setup()
-        auto_print = setup.getAutoPrintStickers()
+        auto_print = self.is_automatic_label_printing_enabled()
         immediate_results_entry = setup.getImmediateResultsEntry()
         redirect_to = self.context.absolute_url()
 
@@ -1723,7 +1732,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                         ",".join(uids),  # copy_from
                         len(uids),  # ar_count
                         sample_uids)  # sample_uids
-        elif "register" in auto_print and sample_uids:
+        elif auto_print and sample_uids:
             redirect_to = "{}/sticker?autoprint=1&items={}".format(
                 self.context.absolute_url(), sample_uids)
         elif immediate_results_entry and sample_uids:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the system to automatically display the barcode labels after sample creation when the setting "Automatic sticker printing" in setup is set to "receive" and the setting "Auto-receive samples" is enabled

## Current behavior before PR

System does not auto-print barcode labels when "Automatic sticker printing" is set to "receive" and "Auto-receive samples" is selected

## Desired behavior after PR is merged

System does auto-print barcode labels when "Automatic sticker printing" is set to "receive" and "Auto-receive samples" is selected

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
