### PR TITLE
Fix sample actions without translation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2190 Fix sample actions without translation
 - #2185 Fix analysis profiles not recognised on AR template creation
 - #2186 Fix sticker template for sample type is not selected by default
 - #2183 Fix instrument supplier does not load on test data import

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2402</version>
+  <version>2403</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
+++ b/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
@@ -1353,7 +1353,7 @@
 
   <transition transition_id="receive" title="Receive" new_state="sample_received"
               trigger="USER" before_script="" after_script="" i18n:attributes="title">
-    <action url="" category="workflow" icon="">Receive sample</action>
+    <action url="" category="workflow" icon="">Receive</action>
     <guard>
       <guard-permission>senaite.core: Transition: Receive Sample</guard-permission>
       <guard-expression>python:here.guard_handler("receive")</guard-expression>
@@ -1478,7 +1478,7 @@
   </transition>
 
   <transition transition_id="submit" title="Submit" new_state="to_be_verified" trigger="USER" before_script="" after_script="" i18n:attributes="title">
-    <action url="" category="workflow" icon="">Submit for verification</action>
+    <action url="" category="workflow" icon="">Submit</action>
     <guard>
       <guard-expression>python:here.guard_handler("submit")</guard-expression>
     </guard>

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -109,3 +109,22 @@ def mark_retracted_and_rejected_analyses(tool):
             alsoProvides(obj, IRejected)
 
     logger.info("Set IRetracted/IRejected interface to analyses [DONE]")
+
+
+def fix_sample_actions_not_translated(tool):
+    """Changes the name of the action item displayed in the actions list from
+    sample (actbox) for the transitions 'submit' and 'receive'
+
+    :param tool: portal_setup tool
+    """
+    logger.info("Fix sample actions without translation ...")
+    actions = ["submit", "receive"]
+    wf_tool = api.get_tool("portal_workflow")
+    workflow = wf_tool.getWorkflowById("senaite_sample_workflow")
+    for action in actions:
+        transition = workflow.transitions.get(action)
+
+        # update action with title
+        transition.actbox_name = transition.title
+
+    logger.info("Fix sample actions without translation [DONE]")

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -23,4 +23,14 @@
       handler="senaite.core.upgrade.v02_04_000.mark_retracted_and_rejected_analyses"
       profile="senaite.core:default"/>
 
+  <!-- Fix sample actions without translation
+       https://github.com/senaite/senaite.core/pull/2190 -->
+  <genericsetup:upgradeStep
+      title="SENAITE CORE 2.4.0: Fix sample actions without translation"
+      description="FFix sample actions without translation"
+      source="2402"
+      destination="2403"
+      handler="senaite.core.upgrade.v02_04_000.fix_sample_actions_not_translated"
+      profile="senaite.core:default"/>
+
 </configure>

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -27,7 +27,7 @@
        https://github.com/senaite/senaite.core/pull/2190 -->
   <genericsetup:upgradeStep
       title="SENAITE CORE 2.4.0: Fix sample actions without translation"
-      description="FFix sample actions without translation"
+      description="Fix sample actions without translation"
       source="2402"
       destination="2403"
       handler="senaite.core.upgrade.v02_04_000.fix_sample_actions_not_translated"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the name displayed under the actions box in sample view for transitions "receive" and "submit" are translated and match with the titles of the transitions, that are displayed in listings.

## Current behavior before PR

Action texts are not properly translated for transitions "receive" and "submit":

![Captura de 2022-11-18 13-03-08](https://user-images.githubusercontent.com/832627/202701057-02902cbe-f982-4d4e-921a-415f038f93e4.png)

## Desired behavior after PR is merged

Action texts are properly translated and match with the titles of the transition counterparts

![Captura de 2022-11-18 13-03-18](https://user-images.githubusercontent.com/832627/202701078-29805b40-82ff-4aaa-b81d-a68e63278eee.png)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
