### PR TITLE
Fix Python version for GitHub workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,12 +11,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '2.7'
-          cache: 'pip'
+          python-version: "2.7.18"
+          cache: "pip"
       - name: cache eggs
         uses: actions/cache@v3
         with:
-          key: eggs-cache-${{ hashFiles('buildout.cfg', 'requirements.txt') }}
+          key: eggs-cache-${{ hashFiles("buildout.cfg", "requirements.txt") }}
           path: |
             eggs/
       - name: install

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,7 @@ env:
   PLONE_VERSION: "5.2"
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: linux
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,7 @@ env:
   PLONE_VERSION: "5.2"
 jobs:
   build-and-test:
-    runs-on: linux
+    runs-on: 'ubuntu-20.04'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,12 +11,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "2.7.18"
-          cache: "pip"
+          python-version: '2.7.18'
+          cache: 'pip'
       - name: cache eggs
         uses: actions/cache@v3
         with:
-          key: eggs-cache-${{ hashFiles("buildout.cfg", "requirements.txt") }}
+          key: eggs-cache-${{ hashFiles('buildout.cfg', 'requirements.txt') }}
           path: |
             eggs/
       - name: install


### PR DESCRIPTION

## Description of the issue/feature this PR addresses

This PR fixes the Python version for the GitHub build workflow:

<img width="1768" alt="senaite core 2022-11-23 3 PM-25-52" src="https://user-images.githubusercontent.com/713193/203571287-51c09def-fff4-4f0c-8f21-3148d07f542a.png">

https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
