### PR TITLE
Fix analyst cannot import results from instruments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2193 Fix analyst cannot import results from instruments
 - #2190 Fix sample actions without translation
 - #2189 Fix auto-print of barcode labels when auto-receive is enabled
 - #2188 Fix archive path for Generic Setup file imports

--- a/src/senaite/core/browser/form/configure.zcml
+++ b/src/senaite/core/browser/form/configure.zcml
@@ -9,7 +9,7 @@
   <browser:page
       name="ajax_form"
       for="*"
-      permission="cmf.ModifyPortalContent"
+      permission="zope2.View"
       class=".ajax.FormView"
       allowed_attributes="initialized modified submit"
       layer="senaite.core.interfaces.ISenaiteCore"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures analyst can import results from instruments. The "modified" endpoint from the ajax form used in the instrument results import view was not loaded because of not enough privileges

## Current behavior before PR

The form for the import of results from instruments when an instrument is selected is not rendered

![Captura de 2022-11-24 09-21-39](https://user-images.githubusercontent.com/832627/203730271-efb1ed84-fcaa-4bad-903f-be519bc05c29.png)

## Desired behavior after PR is merged

The form for the import of results from instruments when an instrument is selected is rendered

![Captura de 2022-11-24 09-22-18](https://user-images.githubusercontent.com/832627/203730238-c6a97f59-124a-4a30-b2a0-c1fa1cb411df.png)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
