### PR TITLE
Skip AutoImportLog on  content export

### DIFF
--- a/src/senaite/core/exportimport/genericsetup/structure.py
+++ b/src/senaite/core/exportimport/genericsetup/structure.py
@@ -54,10 +54,11 @@ SKIP_EXPORT_TYPES = [
     "ARReport",
     "AnalysisRequest",
     "Attachment",
+    "AutoImportLog",
     "Batch",
+    "Invoice",
     "ReferenceSample",
     "Worksheet",
-    "Invoice",
 ]
 
 ID_MAP = {}


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Skip `AutoImportLog` on Generic Setup content export

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
