### PR TITLE
Order sample analyses by sortable title on get per default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2196 Order sample analyses by sortable title on get per default
 - #2193 Fix analyst cannot import results from instruments
 - #2190 Fix sample actions without translation
 - #2189 Fix auto-print of barcode labels when auto-receive is enabled

--- a/src/bika/lims/browser/fields/aranalysesfield.py
+++ b/src/bika/lims/browser/fields/aranalysesfield.py
@@ -75,19 +75,19 @@ class ARAnalysesField(ObjectField):
         :param kwargs: Keyword arguments to inject in the search query
         :returns: A list of Analysis Objects/Catalog Brains
         """
-        # Do we need to return objects or brains
-        full_objects = kwargs.get("full_objects", False)
-
-        # Bail out parameters from kwargs that don't match with indexes
+        # Filter out parameters from kwargs that don't match with indexes
         catalog = api.get_tool(ANALYSIS_CATALOG)
         indexes = catalog.indexes()
         query = dict([(k, v) for k, v in kwargs.items() if k in indexes])
 
-        # Do the search against the catalog
         query["portal_type"] = "Analysis"
         query["getAncestorsUIDs"] = api.get_uid(instance)
+        query["sort_on"] = kwargs.get("sort_on", "sortable_title")
+        query["sort_order"] = kwargs.get("sort_order", "ascending")
+
+        # Do the search against the catalog
         brains = catalog(query)
-        if full_objects:
+        if kwargs.get("full_objects", False):
             return map(api.get_object, brains)
         return brains
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the `get` method of the sample analyses field, so that the returned analyses are always sorted on `sortable_title` per default

## Current behavior before PR

No sorting was used when analyses were retrieved from a sample via the field `get` method

## Desired behavior after PR is merged

Analyses are sorted on `sortable_title` per default when retrieved by the field `get` method

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
