### PR TITLE
Unit selection

### DIFF
--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -103,10 +103,48 @@ Unit = StringField(
     'Unit',
     schemata="Description",
     widget=StringWidget(
-        label=_("Unit"),
+        label=_("Default Unit"),
         description=_(
             "The measurement units for this analysis service' results, e.g. "
             "mg/l, ppm, dB, mV, etc."),
+    )
+)
+
+
+UnitChoices = RecordsField(
+    "UnitChoices",
+    schemata="Description",
+    type="UnitChoices",
+    subfields=(
+        "unitchoice",
+    ),
+    required_subfields=(
+        "unitchoice",
+    ),
+    subfield_labels={
+        "unitchoice": _("Units"),
+    },
+    subfield_descriptions={
+        "unitchoice": _("Please provide a list of units"),
+    },
+    subfield_types={
+        "unitchoice": "string",
+    },
+    subfield_sizes={
+        "unitchoice": 20,
+    },
+    subfield_validators={
+        "unitchoice": "service_unitchoices_validator",
+    },
+    subfield_maxlength={
+        "unitchoice": 50,
+        "description": 200,
+    },
+    widget=RecordsWidget(
+        label=_("Multiple Unit Selection"),
+        description=_(
+            "Provide a list of units that are suitable for the analysis."
+        ),
     )
 )
 
@@ -680,6 +718,8 @@ Remarks = TextField(
     schemata='Description'
 )
 
+
+
 schema = BikaSchema.copy() + Schema((
     ShortTitle,
     SortKey,
@@ -687,6 +727,7 @@ schema = BikaSchema.copy() + Schema((
     ProtocolID,
     ScientificName,
     Unit,
+    UnitChoices,
     Precision,
     ExponentialFormatPrecision,
     LowerDetectionLimit,
@@ -752,6 +793,14 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
         """
         unit = self.Schema().getField("Unit").get(self) or ""
         return unit.strip()
+
+    @security.public
+    def getUnitChoices(self):
+        '''Returns the UnitChoices
+
+        :returns: List of UnitChoices objects
+        '''
+        return self.Schema().getField("UnitChoices").get(self) or ""
 
     @security.public
     def getDefaultVAT(self):

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -1507,3 +1507,44 @@ class ServiceConditionsValidator(object):
 
 
 validation.register(ServiceConditionsValidator())
+
+class ServiceUnitChoicesValidator(object):
+    """Validate AnalysisService UnitChoices field
+    """
+    implements(IValidator)
+    name = "service_unitchoices_validator"
+
+    def __call__(self, field_value, **kwargs):
+        instance = kwargs["instance"]
+        request = kwargs.get("REQUEST", {})
+        translate = getToolByName(instance, "translation_service").translate
+        field_name = kwargs["field"].getName()
+
+        # This value in request prevents running once per subfield value.
+        # self.name returns the name of the validator. This allows other
+        # subfield validators to be called if defined (eg. in other add-ons)
+        key = "{}-{}-{}".format(self.name, instance.getId(), field_name)
+        if instance.REQUEST.get(key, False):
+            return True
+
+        # Walk through all records set for this records field
+        field_name_value = "{}_value".format(field_name)
+        records = request.get(field_name_value, [])
+        for record in records:
+            # Validate the record
+            msg = self.validate_record(record)
+            if msg:
+                return to_utf8(translate(msg))
+
+        instance.REQUEST[key] = True
+        return True
+
+    def validate_record(self, record):
+        unit_choice = record.get("unitchoice")
+        # Check that the unit choice is a string
+        if not unit_choice:
+                    return _("Validation failed: '{}' is not a string").format(
+                        unit_choice)
+
+
+validation.register(ServiceUnitChoicesValidator())

--- a/src/senaite/core/catalog/analysis_catalog.py
+++ b/src/senaite/core/catalog/analysis_catalog.py
@@ -66,6 +66,7 @@ COLUMNS = BASE_COLUMNS + [
     "getServiceUID",
     "getSubmittedBy",
     "getUnit",
+    "getUnitChoices",
     "getVerificators",
     "isSelfVerificationEnabled",
 ]


### PR DESCRIPTION
+ A list of units can be defined for an analysis service
+ The user can select the units when submitting data.

## Description of the issue/feature this PR addresses
Feature allows for a list of units to be defined. The user can then select the desired unit when submitting data 

## Current behavior before PR
Must define a single unit

## Desired behavior after PR is merged
The user can choose from a list of units
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
