### PR TITLE
Fix detection limit set manually is not displayed on result save

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2202 Fix DL selector is not displayed on result save
 - #2197 Use portal as relative path for sticker icons
 - #2196 Order sample analyses by sortable title on get per default
 - #2193 Fix analyst cannot import results from instruments

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
-- #2202 Fix DL selector is not displayed on result save
+- #2202 Fix detection limit set manually is not displayed on result save
 - #2197 Use portal as relative path for sticker icons
 - #2196 Order sample analyses by sortable title on get per default
 - #2193 Fix analyst cannot import results from instruments

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -892,6 +892,14 @@ class AnalysesView(ListingView):
             if self.is_result_edition_allowed(analysis_brain):
                 item["allow_edit"].append("Result")
 
+            # Display the DL operand (< or >) in the results entry field if
+            # the manual entry of DL is set, but DL selector is hidden
+            allow_manual = obj.getAllowManualDetectionLimit()
+            selector = obj.getDetectionLimitSelector()
+            if allow_manual and not selector:
+                operand = obj.getDetectionLimitOperand()
+                item["Result"] = "{} {}".format(operand, result).strip()
+
             # Prepare result options
             choices = obj.getResultOptions()
             if choices:

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -475,34 +475,19 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         # Ensure result integrity regards to None, empty and 0 values
         val = str("" if not value and value != 0 else value).strip()
 
-        # UDL/LDL directly entered in the results field
+        # Store the detection limit (UDL/LDL) operand if necessary
+        dl_selector = self.getDetectionLimitSelector()
         if val and val[0] in [LDL, UDL]:
-            # Result prefixed with LDL/UDL
-            oper = val[0]
-            # Strip off LDL/UDL from the result
-            val = val.replace(oper, "", 1)
-            # Check if the value is indeterminate / non-floatable
-            try:
-                val = float(val)
-            except (ValueError, TypeError):
-                val = value
-
-            # Dismiss the operand and the selector visibility unless the user
-            # is allowed to manually set the detection limit or the DL selector
-            # is visible.
-            allow_manual = self.getAllowManualDetectionLimit()
-            selector = self.getDetectionLimitSelector()
-            if allow_manual or selector:
-
-                # Set the detection limit operand
-                self.setDetectionLimitOperand(oper)
-
-                if not allow_manual:
-                    # Override value by default DL
-                    if oper == LDL:
-                        val = self.getLowerDetectionLimit()
-                    else:
-                        val = self.getUpperDetectionLimit()
+            # Result prefixed with DL operand
+            self.setDetectionLimitOperand(val[0])
+            # Strip off the detection limit operand from the result
+            val = val.replace(val[0], "", 1)
+        elif not dl_selector:
+            # User cannot choose the detection limit from a selection list,
+            # but might be allowed to manually enter the dl with the result.
+            # If so, reset the detection limit operand, cause the previous
+            # entered result might be an DL, but current doesn't
+            self.setDetectionLimitOperand("")
 
         # Update ResultCapture date if necessary
         if not val:

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -481,7 +481,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             # Result prefixed with DL operand
             self.setDetectionLimitOperand(val[0])
             # Strip off the detection limit operand from the result
-            val = val.replace(val[0], "", 1)
+            val = val.replace(val[0], "", 1).strip()
         elif not dl_selector:
             # User cannot choose the detection limit from a selection list,
             # but might be allowed to manually enter the dl with the result.

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -476,7 +476,6 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         val = str("" if not value and value != 0 else value).strip()
 
         # Store the detection limit (UDL/LDL) operand if necessary
-        dl_selector = self.getDetectionLimitSelector()
         if val and val[0] in [LDL, UDL]:
             # Strip off the detection limit operand from the result
             wo_dl = val.replace(val[0], "", 1).strip()
@@ -484,7 +483,8 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             if api.is_floatable(wo_dl):
                 self.setDetectionLimitOperand(val[0])
                 val = api.to_float(wo_dl)
-        elif not dl_selector:
+
+        elif not self.getDetectionLimitSelector():
             # User cannot choose the detection limit from a selection list,
             # but might be allowed to manually enter the dl with the result.
             # If so, reset the detection limit operand, cause the previous

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -329,13 +329,6 @@ class AbstractAnalysis(AbstractBaseAnalysis):
 
         else:
             value = ""
-            # Restore the DetectionLimitSelector, cause maybe its visibility
-            # was changed because allow manual detection limit was enabled and
-            # the user set a result with "<" or ">"
-            if manual_dl:
-                service = self.getAnalysisService()
-                selector = service.getDetectionLimitSelector()
-                self.setDetectionLimitSelector(selector)
 
         # Set the result
         self.getField("Result").set(self, result)
@@ -494,14 +487,12 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             except (ValueError, TypeError):
                 val = value
 
-            # We dismiss the operand and the selector visibility unless the user
+            # Dismiss the operand and the selector visibility unless the user
             # is allowed to manually set the detection limit or the DL selector
             # is visible.
             allow_manual = self.getAllowManualDetectionLimit()
             selector = self.getDetectionLimitSelector()
             if allow_manual or selector:
-                # Ensure visibility of the detection limit selector
-                self.setDetectionLimitSelector(True)
 
                 # Set the detection limit operand
                 self.setDetectionLimitOperand(oper)

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -478,10 +478,12 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         # Store the detection limit (UDL/LDL) operand if necessary
         dl_selector = self.getDetectionLimitSelector()
         if val and val[0] in [LDL, UDL]:
-            # Result prefixed with DL operand
-            self.setDetectionLimitOperand(val[0])
             # Strip off the detection limit operand from the result
-            val = val.replace(val[0], "", 1).strip()
+            wo_dl = val.replace(val[0], "", 1).strip()
+            # We won't consider this a DL unless float-able
+            if api.is_floatable(wo_dl):
+                self.setDetectionLimitOperand(val[0])
+                val = api.to_float(wo_dl)
         elif not dl_selector:
             # User cannot choose the detection limit from a selection list,
             # but might be allowed to manually enter the dl with the result.


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Background info: when the "Allow Manual Detection Limit Input" option is enabled, but "Display a Detection Limit selector" is not enabled, the user can type "<" or ">" in results input text box to indicate the value is a detection limit instead of a discrete result.

This Pull Request ensures the detection limit set manually on results introduction is properly displayed after the "Save" action is clicked. 

## Current behavior before PR

When the user enters a detection limit (value starting with either '<' or '>') and clicks the "Save" button, the detection limit operand is no longer displayed. If the whole page is refreshed, the detection limit selector is displayed though, even if the setting "Display a Detection Limit selector" for the given analysis was set to False.

## Desired behavior after PR is merged

When the user enters a detection limit (value starting with either '<' or '>') and clicks the "Save" button, the detection limit operand is displayed in the results text area. If the whole page is refreshed, the detection limit selector is not displayed.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
