### PR TITLE
Fix date sampled is empty in listings when sampling workflow is enabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
-2203
-- #2203 Added missing parameter date to date_to_string on sample listing
+- #2203 Fix empty date sampled in samples listing when sampling workflow is enabled 
 - #2197 Use portal as relative path for sticker icons
 - #2196 Order sample analyses by sortable title on get per default
 - #2193 Fix analyst cannot import results from instruments

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+2203
+- #2203 Added missing parameter date to date_to_string on sample listing
 - #2197 Use portal as relative path for sticker icons
 - #2196 Order sample analyses by sortable title on get per default
 - #2193 Fix analyst cannot import results from instruments

--- a/src/senaite/core/browser/samples/view.py
+++ b/src/senaite/core/browser/samples/view.py
@@ -762,7 +762,7 @@ class SamplesView(ListingView):
         """
         if not isinstance(date, DateTime):
             return ""
-        return dtime.date_to_string("%Y-%m-%d %H:%M")
+        return dtime.date_to_string(date, fmt="%Y-%m-%d %H:%M")
 
     def getDefaultAddCount(self):
         return self.context.bika_setup.getDefaultNumberOfARsToAdd()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR
With Sampling enabled, Date Sampled can be capture on Sample Views, but they are empty on Sample lists
![image](https://user-images.githubusercontent.com/10023210/208412189-ecfebef0-1502-47bc-b132-274cd43c6c50.png)

## Desired behavior after PR is merged
With Sampling enabled Date Sampling values must be shown on the Sample listing 
![image](https://user-images.githubusercontent.com/10023210/208412470-34b0287e-2655-4f09-a978-82bc7f70b1f7.png)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
