### PR TITLE
Fix traceback when retracting an analysis with a detection limit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,6 @@ Changelog
 ------------------
 
 - #2204 Fix traceback when retracting an analysis with a detection limit
-- #2203 Fix empty date sampled in samples listing when sampling workflow is enabled
 - #2202 Fix detection limit set manually is not displayed on result save
 - #2203 Fix empty date sampled in samples listing when sampling workflow is enabled 
 - #2197 Use portal as relative path for sticker icons

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
-- #2203 Fix empty date sampled in samples listing when sampling workflow is enabled 
+- #2204 Fix traceback when retracting an analysis with a detection limit
+- #2203 Fix empty date sampled in samples listing when sampling workflow is enabled
 - #2197 Use portal as relative path for sticker icons
 - #2196 Order sample analyses by sortable title on get per default
 - #2193 Fix analyst cannot import results from instruments

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -353,14 +353,12 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         """
         if self.isLowerDetectionLimit():
             result = self.getResult()
-            try:
-                # in this case, the result itself is the LDL.
-                return float(result)
-            except (TypeError, ValueError):
-                logger.warn("The result for the analysis %s is a lower "
-                            "detection limit, but not floatable: '%s'. "
-                            "Returnig AS's default LDL." %
-                            (self.id, result))
+            if api.is_floatable(result):
+                return result
+
+            logger.warn("The result for the analysis %s is a lower detection "
+                        "limit, but not floatable: '%s'. Returning AS's "
+                        "default LDL." % (self.id, result))
         return AbstractBaseAnalysis.getLowerDetectionLimit(self)
 
     # Method getUpperDetectionLimit overrides method of class BaseAnalysis
@@ -373,14 +371,12 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         """
         if self.isUpperDetectionLimit():
             result = self.getResult()
-            try:
-                # in this case, the result itself is the LDL.
-                return float(result)
-            except (TypeError, ValueError):
-                logger.warn("The result for the analysis %s is a lower "
-                            "detection limit, but not floatable: '%s'. "
-                            "Returnig AS's default LDL." %
-                            (self.id, result))
+            if api.is_floatable(result):
+                return result
+
+            logger.warn("The result for the analysis %s is an upper detection "
+                        "limit, but not floatable: '%s'. Returning AS's "
+                        "default UDL." % (self.id, result))
         return AbstractBaseAnalysis.getUpperDetectionLimit(self)
 
     @security.public
@@ -487,13 +483,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             # Result prefixed with LDL/UDL
             oper = val[0]
             # Strip off LDL/UDL from the result
-            val = val.replace(oper, "", 1)
-            # Check if the value is indeterminate / non-floatable
-            try:
-                val = float(val)
-            except (ValueError, TypeError):
-                val = value
-
+            val = val.replace(oper, "", 1).strip()
             # We dismiss the operand and the selector visibility unless the user
             # is allowed to manually set the detection limit or the DL selector
             # is visible.

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2403</version>
+  <version>2405</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/tests/doctests/WorkflowAnalysisRetract.rst
+++ b/src/senaite/core/tests/doctests/WorkflowAnalysisRetract.rst
@@ -329,3 +329,79 @@ But the retest does not provide `IRetracted`:
     >>> retest = analysis.getRetest()
     >>> IRetracted.providedBy(retest)
     False
+
+
+Retract an analysis with a result that is a Detection Limit
+...........................................................
+
+Allow the user to manually enter the detection limit as the result:
+
+    >>> Cu.setAllowManualDetectionLimit(True)
+
+Create the sample:
+
+    >>> sample = new_ar([Cu])
+    >>> cu = sample.getAnalyses(full_objects=True)[0]
+    >>> cu.setResult("< 10")
+    >>> success = do_action_for(cu, "submit")
+    >>> cu.getResult()
+    '10'
+
+    >>> cu.getFormattedResult(html=False)
+    '< 10'
+
+    >>> cu.isLowerDetectionLimit()
+    True
+
+    >>> cu.getDetectionLimitOperand()
+    '<'
+
+The Detection Limit is not kept on the retest:
+
+    >>> success = do_action_for(analysis, "retract")
+    >>> retest = analysis.getRetest()
+    >>> retest.getResult()
+    ''
+
+    >>> retest.getFormattedResult(html=False)
+    ''
+
+    >>> retest.isLowerDetectionLimit()
+    False
+
+    >>> retest.getDetectionLimitOperand()
+    ''
+
+Do the same with Upper Detection Limit (UDL):
+
+    >>> sample = new_ar([Cu])
+    >>> cu = sample.getAnalyses(full_objects=True)[0]
+    >>> cu.setResult("> 10")
+    >>> success = do_action_for(cu, "submit")
+    >>> cu.getResult()
+    '10'
+
+    >>> cu.getFormattedResult(html=False)
+    '> 10'
+
+    >>> cu.isUpperDetectionLimit()
+    True
+
+    >>> cu.getDetectionLimitOperand()
+    '>'
+
+The Detection Limit is not kept on the retest:
+
+    >>> success = do_action_for(analysis, "retract")
+    >>> retest = analysis.getRetest()
+    >>> retest.getResult()
+    ''
+
+    >>> retest.getFormattedResult(html=False)
+    ''
+
+    >>> retest.isUpperDetectionLimit()
+    False
+
+    >>> retest.getDetectionLimitOperand()
+    ''

--- a/src/senaite/core/tests/test_calculations.py
+++ b/src/senaite/core/tests/test_calculations.py
@@ -354,7 +354,7 @@ class TestCalculations(DataTestCase):
                         or an.isUpperDetectionLimit():
                         operator = an.getDetectionLimitOperand()
                         strres = f['analyses'][key].replace(operator, '')
-                        self.assertEqual(an.getResult(), float(strres))
+                        self.assertEqual(an.getResult(), strres)
                     else:
                         self.assertEqual(an.getResult(), f['analyses'][key])
                 elif key == self.calcservice.getKeyword():

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -43,4 +43,14 @@
       handler="senaite.core.upgrade.v02_04_000.import_typeinfo"
       profile="senaite.core:default"/>
 
+  <!-- Fix traceback when retracting an analysis with a detection limit
+       https://github.com/senaite/senaite.core/pull/2204 -->
+  <genericsetup:upgradeStep
+      title="SENAITE CORE 2.4.0: Fix traceback when retracting DL"
+      description="Fix traceback when retracting an analysis with a detection limit"
+      source="2404"
+      destination="2405"
+      handler="senaite.core.upgrade.v02_04_000.fix_traceback_retract_dl"
+      profile="senaite.core:default"/>
+
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures an analysis with a detection limit set (either manually or through the detection limit selector) can be retracted without traceback. 

The traceback is a collateral effect of https://github.com/senaite/senaite.core/pull/2103, system was failing because a string type instead of a float/int was expected here:
- https://github.com/senaite/senaite.core/pull/2103/files#diff-4b1e4865f41cae407b6d57d7a4f4d54ec094b2b47f16ff0be7257d94c7f5c3ecR853
- https://github.com/senaite/senaite.core/pull/2103/files#diff-4b1e4865f41cae407b6d57d7a4f4d54ec094b2b47f16ff0be7257d94c7f5c3ecR864

Therefore, this Pull Request ensures that the result and detection limit are always stored and returned as strings.


## Current behavior before PR

```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module bika.lims.browser.workflow, line 154, in __call__
  Module bika.lims.browser.workflow, line 165, in __call__
  Module bika.lims.browser.workflow, line 184, in do_action
  Module bika.lims.workflow, line 123, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 252, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 537, in _invokeWithNotification
AttributeError: 'exceptions.TypeError' object has no attribute 'with_traceback'
```

## Desired behavior after PR is merged

The analysis with a detection limit set is retracted without error

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
