### PR TITLE
Add transaction savepoint in fix_traceback_retract_dl func

### DIFF
--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -18,6 +18,8 @@
 # Copyright 2018-2022 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import transaction
+
 from bika.lims import api
 from bika.lims import LDL
 from bika.lims import UDL
@@ -155,6 +157,10 @@ def fix_traceback_retract_dl(tool):
     for num, brain in enumerate(brains):
         if num and num % 100 == 0:
             logger.info("Migrated {0}/{1} LDL/UDL fields".format(num, total))
+
+        if num and num % 1000 == 0:
+            # reduce memory size of the transaction
+            transaction.savepoint()
 
         obj = api.get_object(brain)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds a transaction savepoint every 1000 iterations in the fix_traceback_retract_dl_func

## Current behavior before PR

No transaction savepoint

## Desired behavior after PR is merged

Transaction savepoint present

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
