### PR TITLE
Support for file upload on analysis (pre) conditions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2207 Support for file upload on analysis (pre) conditions
 - #2204 Fix traceback when retracting an analysis with a detection limit
 - #2202 Fix detection limit set manually is not displayed on result save
 - #2203 Fix empty date sampled in samples listing when sampling workflow is enabled 

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -1146,12 +1146,12 @@ class AnalysesView(ListingView):
         attachments_names = []
         attachments_html = []
         analysis = self.get_object(obj)
-        for at in analysis.getAttachment():
-            at_file = at.getAttachmentFile()
-            url = "{}/at_download/AttachmentFile".format(api.get_url(at))
-            link = get_link(url, at_file.filename, tabindex="-1")
+        for attachment in analysis.getRawAttachment():
+            attachment = self.get_object(attachment)
+            link = self.get_attachment_link(attachment)
             attachments_html.append(link)
-            attachments_names.append(at_file.filename)
+            filename = attachment.getFilename()
+            attachments_names.append(filename)
 
         if attachments_html:
             item["replace"]["Attachments"] = "<br/>".join(attachments_html)
@@ -1160,6 +1160,14 @@ class AnalysesView(ListingView):
         elif analysis.getAttachmentRequired():
             img = get_image("warning.png", title=_("Attachment required"))
             item["replace"]["Attachments"] = img
+
+    def get_attachment_link(self, attachment):
+        """Returns a well-formed link for the attachment passed in
+        """
+        filename = attachment.getFilename()
+        att_url = api.get_url(attachment)
+        url = "{}/at_download/AttachmentFile".format(att_url)
+        return get_link(url, filename, tabindex="-1")
 
     def _folder_item_uncertainty(self, analysis_brain, item):
         """Fills the analysis' uncertainty to the item passed in.
@@ -1508,12 +1516,21 @@ class AnalysesView(ListingView):
             return
 
         conditions = analysis.getConditions()
-        if conditions:
-            conditions = map(lambda it: ": ".join([it["title"], it["value"]]),
-                             conditions)
-            conditions = "<br/>".join(conditions)
-            service = item["replace"].get("Service") or item["Service"]
-            item["replace"]["Service"] = "{}<br/>{}".format(service, conditions)
+        if not conditions:
+            return
+
+        def to_str(condition):
+            title = condition.get("title")
+            value = condition.get("value", "")
+            if condition.get("type") == "file" and api.is_uid(value):
+                att = self.get_object(value)
+                value = self.get_attachment_link(att)
+            return ": ".join([title, str(value)])
+
+        # Display the conditions properly formatted
+        conditions = "<br/>".join([to_str(cond) for cond in conditions])
+        service = item["replace"].get("Service") or item["Service"]
+        item["replace"]["Service"] = "<br/>".join([service, conditions])
 
     def is_method_required(self, analysis):
         """Returns whether the render of the selection list with methods is

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -35,7 +35,6 @@ from bika.lims.interfaces import IAddSampleFieldsFlush
 from bika.lims.interfaces import IAddSampleObjectInfo
 from bika.lims.interfaces import IAddSampleRecordsValidator
 from bika.lims.interfaces import IGetDefaultFieldValueARAddHook
-from bika.lims.utils import tmpID
 from bika.lims.utils.analysisrequest import create_analysisrequest as crar
 from bika.lims.workflow import ActionHandlerPool
 from BTrees.OOBTree import OOBTree
@@ -45,7 +44,6 @@ from plone.memoize import view as viewcache
 from plone.memoize.volatile import DontCache
 from plone.memoize.volatile import cache
 from plone.protect.interfaces import IDisableCSRFProtection
-from Products.CMFPlone.utils import _createObjectByType
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1084,7 +1084,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             "title": obj and api.get_title(obj) or ""
         }
 
-    def to_attachment_record(self, fileupload, **kwargs):
+    def to_attachment_record(self, fileupload):
         """Returns a dict-like structure with suitable information for the
         proper creation of Attachment objects
         """

--- a/src/bika/lims/content/analysisservice.py
+++ b/src/bika/lims/content/analysisservice.py
@@ -259,6 +259,7 @@ Conditions = RecordsField(
             ('number', _('Number')),
             ('checkbox', _('Checkbox')),
             ('select', _('Select')),
+            ('file', _('File upload')),
         )),
     },
     widget=RecordsWidget(

--- a/src/bika/lims/content/attachment.py
+++ b/src/bika/lims/content/attachment.py
@@ -235,5 +235,12 @@ class Attachment(BaseFolder, ClientAwareMixin):
         """
         return DateTime()
 
+    @security.public
+    def getFilename(self):
+        """Returns the filename of the underlying File object
+        """
+        att_file = self.getAttachmentFile()
+        return att_file.filename
+
 
 registerType(Attachment, PROJECTNAME)

--- a/src/senaite/core/browser/modals/templates/set_analysis_conditions.pt
+++ b/src/senaite/core/browser/modals/templates/set_analysis_conditions.pt
@@ -58,6 +58,8 @@
                            tal:attributes="value condition/type"/>
                     <input type="hidden" name="conditions.required:records"
                            tal:attributes="value condition/required"/>
+                    <input type="hidden" name="conditions.attachment:records"
+                           tal:attributes="value condition/attachment/uid|nothing"/>
 
                     <select tal:condition="options"
                             tal:define="value condition/value|nothing"
@@ -84,6 +86,13 @@
                              tal:condition="not:required"
                              name="conditions.value:records"/>
                     </tal:non_select>
+
+                    <div tal:define="attachment condition/attachment|nothing"
+                         tal:condition="attachment" class="mt-2">
+
+                      <a tal:content="attachment/filename"
+                         tal:attributes="href attachment/download_url"/>
+                    </div>
 
                   </td>
                 </tr>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request introduces a new type "File upload" to analysis conditions that makes the upload of files possible.

New "File upload" type in Service conditions (under "Advanced" tab):

![Captura de 2022-12-23 17-54-56](https://user-images.githubusercontent.com/832627/209374771-6da292de-4a71-4be9-bf8d-e940d60fee82.png)

Direct upload of files for conditions in Sample add form:

![Captura de 2022-12-23 18-00-36](https://user-images.githubusercontent.com/832627/209374852-912394a2-46a8-442c-982c-b2a43306b83e.png)

Direct link to conditions files in analysis listing

![Captura de 2022-12-23 18-00-58](https://user-images.githubusercontent.com/832627/209375005-4edda868-40dc-4f83-aeca-19affb7dcaeb.png)

Visualization of files in conditions preview:

![Captura de 2022-12-23 18-01-09](https://user-images.githubusercontent.com/832627/209375084-0668f384-cce1-4e53-97c7-debdf7aaffce.png)



## Current behavior before PR

Is not possible to define analysis conditions with file upload

## Desired behavior after PR is merged

Is possible to define analysis conditions with file upload

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
