### PR TITLE
Remove `default_method` from AnalysisRequest's Contact field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2208 Remove `default_method` from AnalysisRequest's Contact field
 - #2204 Fix traceback when retracting an analysis with a detection limit
 - #2202 Fix detection limit set manually is not displayed on result save
 - #2203 Fix empty date sampled in samples listing when sampling workflow is enabled 

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -143,7 +143,6 @@ schema = BikaSchema.copy() + Schema((
     UIDReferenceField(
         'Contact',
         required=1,
-        default_method='getContactUIDForUser',
         allowed_types=('Contact',),
         mode="rw",
         read_permission=View,
@@ -1870,20 +1869,6 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
             if contact:
                 contacts.append(contact)
         return contacts
-
-    security.declarePublic('getContactUIDForUser')
-
-    def getContactUIDForUser(self):
-        """get the UID of the contact associated with the authenticated user
-        """
-        mt = getToolByName(self, 'portal_membership')
-        user = mt.getAuthenticatedMember()
-        user_id = user.getUserName()
-        pc = getToolByName(self, 'portal_catalog')
-        r = pc(portal_type='Contact',
-               getUsername=user_id)
-        if len(r) == 1:
-            return r[0].UID
 
     security.declarePublic('current_date')
 

--- a/src/bika/lims/content/client.py
+++ b/src/bika/lims/content/client.py
@@ -190,21 +190,6 @@ class Client(Organisation):
             if contact.getUsername() == username:
                 return contact.UID()
 
-    security.declarePublic("getContactUIDForUser")
-
-    def getContactUIDForUser(self):
-        """Get the UID of the user associated with the authenticated user
-        """
-        membership_tool = api.get_tool("portal_membership")
-        member = membership_tool.getAuthenticatedMember()
-        username = member.getUserName()
-        r = self.portal_catalog(
-            portal_type="Contact",
-            getUsername=username
-        )
-        if len(r) == 1:
-            return r[0].UID
-
     def getContacts(self, only_active=True):
         """Return an array containing the contacts from this Client
         """


### PR DESCRIPTION
## Description of the issue/feature this PR addressesç

This Pull Request removes the "default_method" attribute from AnalysisRequest's Contact field that was causing a search for current contact each time the getter of the field was called if no value was set. For instance, when Add sample form was rendered, the system was doing 2 searches for Contact for each Sample.

## Current behavior before PR

No futile searches for current Contact are done when sample's add form is rendered

## Desired behavior after PR is merged

No futile searches for current Contact are done when sample's add form is rendered

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
