### PR TITLE
Remove `Profile` field (stale) from AnalysisRequest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2211 Remove `Profile` field (stale) from AnalysisRequest
 - #2208 Remove `default_method` from AnalysisRequest's Contact field
 - #2204 Fix traceback when retracting an analysis with a detection limit
 - #2202 Fix detection limit set manually is not displayed on result save

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -396,29 +396,6 @@ schema = BikaSchema.copy() + Schema((
         ),
     ),
 
-    # TODO Remove Profile field (in singular)
-    ReferenceField(
-        'Profile',
-        allowed_types=('AnalysisProfile',),
-        referenceClass=HoldingReference,
-        relationship='AnalysisRequestAnalysisProfile',
-        mode="rw",
-        read_permission=View,
-        write_permission=ModifyPortalContent,
-        widget=ReferenceWidget(
-            label=_("Analysis Profile"),
-            description=_("Analysis profiles apply a certain set of analyses"),
-            size=20,
-            render_own_label=True,
-            visible=False,
-            catalog_name='senaite_catalog_setup',
-            base_query={"is_active": True,
-                        "sort_on": "sortable_title",
-                        "sort_order": "ascending"},
-            showOn=False,
-        ),
-    ),
-
     ReferenceField(
         'Profiles',
         multiValued=1,

--- a/src/senaite/core/exportimport/setupdata/__init__.py
+++ b/src/senaite/core/exportimport/setupdata/__init__.py
@@ -2280,13 +2280,13 @@ class Analysis_Requests(WorksheetImporter):
                              getFullname=row['CCContact_Fullname'])[0].getObject()
                 obj.setCCContact(contact)
             if row['AnalysisProfile_title']:
-                profile = pc(portal_type="AnalysisProfile",
-                             title=row['AnalysisProfile_title'].getObject())
-                obj.setProfile(profile)
+                profiles = pc(portal_type="AnalysisProfile",
+                              title=row['AnalysisProfile_title'])[0].getObject()
+                obj.setProfiles([profiles])
             if row['ARTemplate_title']:
                 template = pc(portal_type="ARTemplate",
                              title=row['ARTemplate_title'])[0].getObject()
-                obj.setProfile(template)
+                obj.setTemplate(template)
 
             obj.unmarkCreationFlag()
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request removes the `Profile` field from AnalysisRequest content type, that is no longer used since a long time ago, when `Profiles` field was introduced on 2015 with https://github.com/senaite/senaite.core/commit/b94567b5b31247fb5b77d86efe8728ef0d861a18#diff-1976c3f970f4f2ac289764a3f0d23f1e3170875a64db404ce7d3ef5e1a263d74R49

## Current behavior before PR

Stale `Profile` field in `AnalysisRequest` content type

## Desired behavior after PR is merged

No stale `Profile` field in `AnalysisRequest` content type

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
