### PR TITLE
Improve performance of legacy AT `UIDReferenceField`'s getter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2212 Improve performance of legacy AT `UIDReferenceField`'s getter
 - #2207 Support for file upload on analysis (pre) conditions
 - #2208 Remove `default_method` from AnalysisRequest's Contact field
 - #2204 Fix traceback when retracting an analysis with a detection limit

--- a/src/bika/lims/browser/fields/uidreferencefield.py
+++ b/src/bika/lims/browser/fields/uidreferencefield.py
@@ -166,7 +166,7 @@ class UIDReferenceField(StringField):
                 return []
             return None
 
-        # Do a direct search for all brains at once instead
+        # Do a direct search for all brains at once
         uc = api.get_tool("uid_catalog")
         references = uc(UID=uids)
 

--- a/src/bika/lims/browser/fields/uidreferencefield.py
+++ b/src/bika/lims/browser/fields/uidreferencefield.py
@@ -170,16 +170,6 @@ class UIDReferenceField(StringField):
         uc = api.get_tool("uid_catalog")
         references = uc(UID=uids)
 
-        # Notify about orphan UIDs (compatibility with legacy-code)
-        # XXX This overhead is not necessary imo
-        valid_uids = dict([(api.get_uid(ref), True) for ref in references])
-        for uid in uids:
-            if valid_uids.get(uid):
-                continue
-            # Broken Reference!
-            logger.warn("Reference on {} with UID {} is broken!"
-                        .format(repr(context), uid))
-
         # Return objects by default
         full_objects = kwargs.pop("full_objects", True)
         if full_objects:

--- a/src/bika/lims/browser/fields/uidreferencefield.py
+++ b/src/bika/lims/browser/fields/uidreferencefield.py
@@ -156,7 +156,7 @@ class UIDReferenceField(StringField):
         :rtype: BaseContent | list[BaseContent]
         """
         uids = StringField.get(self, context, **kwargs)
-        if not self.multiValued:
+        if not isinstance(uids, list):
             uids = [uids]
 
         # Remove non-valid uids

--- a/src/bika/lims/browser/fields/uidreferencefield.py
+++ b/src/bika/lims/browser/fields/uidreferencefield.py
@@ -170,6 +170,9 @@ class UIDReferenceField(StringField):
         uc = api.get_tool("uid_catalog")
         references = uc(UID=uids)
 
+        # Keep the original order of items
+        references = sorted(references, key=lambda it: uids.index(it.UID))
+
         # Return objects by default
         full_objects = kwargs.pop("full_objects", True)
         if full_objects:

--- a/src/bika/lims/browser/fields/uidreferencefield.py
+++ b/src/bika/lims/browser/fields/uidreferencefield.py
@@ -171,6 +171,7 @@ class UIDReferenceField(StringField):
         references = uc(UID=uids)
 
         # Notify about orphan UIDs (compatibility with legacy-code)
+        # XXX This overhead is not necessary imo
         valid_uids = dict([(api.get_uid(ref), True) for ref in references])
         for uid in uids:
             if valid_uids.get(uid):

--- a/src/bika/lims/browser/fields/uidreferencefield.py
+++ b/src/bika/lims/browser/fields/uidreferencefield.py
@@ -159,13 +159,6 @@ class UIDReferenceField(StringField):
         if not isinstance(uids, list):
             uids = [uids]
 
-        # Remove non-valid uids
-        uids = filter(api.is_uid, uids)
-        if not uids:
-            if self.multiValued:
-                return []
-            return None
-
         # Do a direct search for all brains at once
         uc = api.get_tool("uid_catalog")
         references = uc(UID=uids)
@@ -180,7 +173,9 @@ class UIDReferenceField(StringField):
 
         if self.multiValued:
             return references
-        return references[0]
+        elif references:
+            return references[0]
+        return None
 
     @security.public
     def getRaw(self, context, aslist=False, **kwargs):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that a single search is done against the UID catalog when retrieving referenced objects through an `UIDReferenceField`. It also allows the user to use the `full_objects` parameter to retrieve the brains of the referenced objects instead of the full objects (default)

## Current behavior before PR

A single search for every referenced object

## Desired behavior after PR is merged

Single search for all referenced UIDs at once

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
