### PR TITLE
Purge ComputedField fields from AnalysisRequest related with Profiles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2213 Purge ComputedField fields from AnalysisRequest related with Profiles
 - #2212 Improve performance of legacy AT `UIDReferenceField`'s getter
 - #2211 Remove `Profile` field (stale) from AnalysisRequest
 - #2207 Support for file upload on analysis (pre) conditions

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -1180,12 +1180,6 @@ schema = BikaSchema.copy() + Schema((
         widget=ComputedWidget(visible=False),
     ),
     ComputedField(
-        'ProfilesURL',
-        expression="[p.absolute_url_path() for p in here.getProfiles()] " \
-                   "if here.getProfiles() else []",
-        widget=ComputedWidget(visible=False),
-    ),
-    ComputedField(
         'ProfilesTitle',
         expression="[p.Title() for p in here.getProfiles()] " \
                    "if here.getProfiles() else []",

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -1180,12 +1180,6 @@ schema = BikaSchema.copy() + Schema((
         widget=ComputedWidget(visible=False),
     ),
     ComputedField(
-        'ProfilesTitleStr',
-        expression="', '.join([p.Title() for p in here.getProfiles()]) " \
-                   "if here.getProfiles() else ''",
-        widget=ComputedWidget(visible=False),
-    ),
-    ComputedField(
         'TemplateUID',
         expression="here.getTemplate().UID() if here.getTemplate() else ''",
         widget=ComputedWidget(visible=False),
@@ -1487,6 +1481,10 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
         if IBatch.providedBy(self.aq_parent):
             return self.aq_parent.getClient()
         return None
+
+    def getProfilesTitleStr(self):
+        profiles = [profile.Title() for profile in self.getProfiles()]
+        return ", ".join(profiles)
 
     def getAnalysisService(self):
         proxies = self.getAnalyses(full_objects=False)

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -1483,6 +1483,9 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
         return None
 
     def getProfilesTitleStr(self):
+        """Returns a comma-separated string withg the titles of the profiles
+        assigned to this Sample. Used to populate a metadata field
+        """
         profiles = [profile.Title() for profile in self.getProfiles()]
         return ", ".join(profiles)
 

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -1180,12 +1180,6 @@ schema = BikaSchema.copy() + Schema((
         widget=ComputedWidget(visible=False),
     ),
     ComputedField(
-        'ProfilesTitle',
-        expression="[p.Title() for p in here.getProfiles()] " \
-                   "if here.getProfiles() else []",
-        widget=ComputedWidget(visible=False),
-    ),
-    ComputedField(
         'ProfilesTitleStr',
         expression="', '.join([p.Title() for p in here.getProfiles()]) " \
                    "if here.getProfiles() else ''",
@@ -1493,9 +1487,6 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
         if IBatch.providedBy(self.aq_parent):
             return self.aq_parent.getClient()
         return None
-
-    def getProfilesTitle(self):
-        return [profile.Title() for profile in self.getProfiles()]
 
     def getAnalysisService(self):
         proxies = self.getAnalyses(full_objects=False)

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -1099,15 +1099,6 @@ schema = BikaSchema.copy() + Schema((
     ),
 
     ComputedField(
-        'ProfilesUID',
-        expression="[p.UID() for p in here.getProfiles()] " \
-                   "if here.getProfiles() else []",
-        widget=ComputedWidget(
-            visible=False,
-        ),
-    ),
-
-    ComputedField(
         'Invoiced',
         expression='here.getInvoice() and True or False',
         default=False,

--- a/src/senaite/core/browser/samples/view.py
+++ b/src/senaite/core/browser/samples/view.py
@@ -201,8 +201,7 @@ class SamplesView(ListingView):
                 "toggle": False}),
             ("getProfilesTitle", {
                 "title": _("Profile"),
-                "sortable": True,
-                "index": "getProfilesTitle",
+                "sortable": False,
                 "toggle": False}),
             ("getAnalysesNum", {
                 "title": _("Number of Analyses"),

--- a/src/senaite/core/catalog/sample_catalog.py
+++ b/src/senaite/core/catalog/sample_catalog.py
@@ -74,7 +74,6 @@ COLUMNS = BASE_COLUMNS + [
     "getPrioritySortkey",
     "getProfilesTitle",
     "getProfilesTitleStr",
-    "getProfilesURL",
     "getProgress",
     "getProvince",
     "getRawParentAnalysisRequest",

--- a/src/senaite/core/catalog/sample_catalog.py
+++ b/src/senaite/core/catalog/sample_catalog.py
@@ -72,7 +72,6 @@ COLUMNS = BASE_COLUMNS + [
     "getPhysicalPath",
     "getPrinted",
     "getPrioritySortkey",
-    "getProfilesTitle",
     "getProfilesTitleStr",
     "getProgress",
     "getProvince",

--- a/src/senaite/core/catalog/sample_catalog.py
+++ b/src/senaite/core/catalog/sample_catalog.py
@@ -74,7 +74,6 @@ COLUMNS = BASE_COLUMNS + [
     "getPrioritySortkey",
     "getProfilesTitle",
     "getProfilesTitleStr",
-    "getProfilesUID",
     "getProfilesURL",
     "getProgress",
     "getProvince",

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2405</version>
+  <version>2406</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -200,6 +200,7 @@ def purge_computed_fields_profile(self):
     ]
     columns_to_remove = [
         ("getProfilesUID", SAMPLE_CATALOG),
+        ("getProfilesURL", SAMPLE_CATALOG),
     ]
 
     # Purge the catalogs

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -201,6 +201,7 @@ def purge_computed_fields_profile(self):
     columns_to_remove = [
         ("getProfilesUID", SAMPLE_CATALOG),
         ("getProfilesURL", SAMPLE_CATALOG),
+        ("getProfilesTitle", SAMPLE_CATALOG),
     ]
 
     # Purge the catalogs

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -54,7 +54,7 @@
       profile="senaite.core:default"/>
 
   <!-- Purge ComputedField from AnalysisRequest related with Profiles
-       https://github.com/senaite/senaite.core/pull/2212 -->
+       https://github.com/senaite/senaite.core/pull/2213 -->
   <genericsetup:upgradeStep
       title="SENAITE CORE 2.4.0: Purge ComputedField from AnalysisRequest related with Profiles"
       description="Purge ComputedField from AnalysisRequest related with Profiles"

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -53,4 +53,14 @@
       handler="senaite.core.upgrade.v02_04_000.fix_traceback_retract_dl"
       profile="senaite.core:default"/>
 
+  <!-- Purge ComputedField from AnalysisRequest related with Profiles
+       https://github.com/senaite/senaite.core/pull/2212 -->
+  <genericsetup:upgradeStep
+      title="SENAITE CORE 2.4.0: Purge ComputedField from AnalysisRequest related with Profiles"
+      description="Purge ComputedField from AnalysisRequest related with Profiles"
+      source="2405"
+      destination="2406"
+      handler="senaite.core.upgrade.v02_04_000.purge_computed_fields_profile"
+      profile="senaite.core:default"/>
+
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request purges unnecessary fields from type `ComputedField` defined for `AnalysisRequest` content type that are related with `Profiles`. This involves the removal of metadata column as well.

## Current behavior before PR

Unnecessary fields from type `ComputedField`, that are related with `Profiles` are defined for `AnalysisRequest` type

## Desired behavior after PR is merged

Unnecessary fields from type `ComputedField`, that are related with `Profiles` are not defined for `AnalysisRequest` type

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
