### PR TITLE
Fix traceback when creating multiple samples with attachments

### DIFF
--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1740,8 +1740,8 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             ARs[ar.Title()] = ar.UID()
 
             # Create the attachments
-            attachments = filter(None, attachments.get(n, []))
-            for attachment_record in attachments:
+            ar_attachments = filter(None, attachments.get(n, []))
+            for attachment_record in ar_attachments:
                 self.create_attachment(ar, attachment_record)
 
         actions.resume()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a bug introduced with #2207 . `attachments` variable was being overwritten each time the system was trying to create a sample in `ajax_submit`

## Current behavior before PR

Cannot create multiple-samples with attachments in a single submit

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module bika.lims.browser.analysisrequest.add2, line 70, in decorator
  Module bika.lims.browser.analysisrequest.add2, line 715, in __call__
  Module bika.lims.browser.analysisrequest.add2, line 1743, in ajax_submit
AttributeError: 'list' object has no attribute 'get'
```

## Desired behavior after PR is merged

Can create multiple samples with attachments in a single submit

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
