### PR TITLE
Make `UIDReferenceField` to not keep back-references by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
-- #2219 Allow to not keep backreferences through `UIDReferenceField`
+- #2219 Make `UIDReferenceField` to not keep back-references by default
 - #2209 Migrate AnalysisRequest's ReferenceField fields to UIDReferenceField
 - #2218 Improve performance of legacy AT `UIDReferenceField`'s setter
 - #2214 Remove `DefaultContainerType` field (stale) from AnalysisRequest

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2219 Allow to not keep backreferences through `UIDReferenceField`
 - #2209 Migrate AnalysisRequest's ReferenceField fields to UIDReferenceField
 - #2218 Improve performance of legacy AT `UIDReferenceField`'s setter
 - #2214 Remove `DefaultContainerType` field (stale) from AnalysisRequest

--- a/src/bika/lims/browser/fields/uidreferencefield.py
+++ b/src/bika/lims/browser/fields/uidreferencefield.py
@@ -55,6 +55,13 @@ class UIDReferenceField(StringField):
 
     security = ClassSecurityInfo()
 
+    @property
+    def keep_backreferences(self):
+        """Returns whether this field must keep back references. Returns True
+        if the value for property relationship is None
+        """
+        return self.relationship is not None
+
     def get_relationship_key(self, context):
         """Return the configured relationship key or generate a new one
         """
@@ -231,7 +238,8 @@ class UIDReferenceField(StringField):
         uids = filter(api.is_uid, uids)
 
         # Back-reference current object to referenced objects
-        self._set_backreferences(context, uids, **kwargs)
+        if self.keep_backreferences:
+            self._set_backreferences(context, uids, **kwargs)
 
         # Store the referenced objects as uids
         if not self.multiValued:

--- a/src/bika/lims/browser/fields/uidreferencefield.py
+++ b/src/bika/lims/browser/fields/uidreferencefield.py
@@ -39,9 +39,8 @@ class ReferenceException(Exception):
 
 class UIDReferenceField(StringField):
     """A field that stores References as UID values.  This acts as a drop-in
-    replacement for Archetypes' ReferenceField.  A relationship is required
-    but if one is not provided, it will be composed from a concatenation
-    of `portal_type` + `fieldname`.
+    replacement for Archetypes' ReferenceField. If no relationship is provided,
+    the field won't keep backreferences in referenced objects
     """
     _properties = Field._properties.copy()
     _properties.update({
@@ -60,7 +59,11 @@ class UIDReferenceField(StringField):
         """Returns whether this field must keep back references. Returns True
         if the value for property relationship is None
         """
-        return self.relationship is not None
+        if not isinstance(self.relationship, six.string_types):
+            return False
+        if not self.relationship:
+            return False
+        return True
 
     def get_relationship_key(self, context):
         """Return the configured relationship key or generate a new one

--- a/src/bika/lims/browser/fields/uidreferencefield.py
+++ b/src/bika/lims/browser/fields/uidreferencefield.py
@@ -56,14 +56,13 @@ class UIDReferenceField(StringField):
 
     @property
     def keep_backreferences(self):
-        """Returns whether this field must keep back references. Returns True
+        """Returns whether this field must keep back references. Returns False
         if the value for property relationship is None or empty
         """
-        if not isinstance(self.relationship, six.string_types):
-            return False
-        if not self.relationship.strip():
-            return False
-        return True
+        relationship = getattr(self, "relationship", None)
+        if relationship and isinstance(relationship, six.string_types):
+            return True
+        return False
 
     def get_relationship_key(self, context):
         """Return the configured relationship key or generate a new one

--- a/src/bika/lims/browser/fields/uidreferencefield.py
+++ b/src/bika/lims/browser/fields/uidreferencefield.py
@@ -57,11 +57,11 @@ class UIDReferenceField(StringField):
     @property
     def keep_backreferences(self):
         """Returns whether this field must keep back references. Returns True
-        if the value for property relationship is None
+        if the value for property relationship is None or empty
         """
         if not isinstance(self.relationship, six.string_types):
             return False
-        if not self.relationship:
+        if not self.relationship.strip():
             return False
         return True
 

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -66,7 +66,8 @@ AnalysisService = UIDReferenceField(
 Attachment = UIDReferenceField(
     'Attachment',
     multiValued=1,
-    allowed_types=('Attachment',)
+    allowed_types=('Attachment',),
+    relationship='AnalysisAttachment'
 )
 
 # The final result of the analysis is stored here.  The field contains a
@@ -88,7 +89,8 @@ ResultCaptureDate = DateTimeField(
 
 # Returns the retracted analysis this analysis is a retest of
 RetestOf = UIDReferenceField(
-    'RetestOf'
+    'RetestOf',
+    relationship="AnalysisRetestOf",
 )
 
 # If the result is outside of the detection limits of the method or instrument,
@@ -1127,7 +1129,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
     def getRawRetest(self):
         """Returns the UID of the retest that comes from this analysis, if any
         """
-        relationship = "{}RetestOf".format(self.portal_type)
+        relationship = self.getField("RetestOf").relationship
         uids = get_backreferences(self, relationship)
         if not uids:
             return None

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -230,12 +230,6 @@ schema = BikaSchema.copy() + Schema((
         'Client',
         required=1,
         allowed_types=('Client',),
-        # Do not back-reference. This field is only used for the rendering of
-        # the reference widget in Add Form. An AnalysisRequest is always
-        # created inside a Client object. Therefore, there is no need to keep
-        # back references. Since the Client object is not updated, this should
-        # also reduce the chance of transaction conflicts as well
-        relationship=None,
         mode="rw",
         read_permission=View,
         write_permission=FieldEditClient,

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -230,7 +230,12 @@ schema = BikaSchema.copy() + Schema((
         'Client',
         required=1,
         allowed_types=('Client',),
-        relationship='AnalysisRequestClient',
+        # Do not back-reference. This field is only used for the rendering of
+        # the reference widget in Add Form. An AnalysisRequest is always
+        # created inside a Client object. Therefore, there is no need to keep
+        # back references. Since the Client object is not updated, this should
+        # also reduce the chance of transaction conflicts as well
+        relationship=None,
         mode="rw",
         read_permission=View,
         write_permission=FieldEditClient,

--- a/src/bika/lims/content/analysisservice.py
+++ b/src/bika/lims/content/analysisservice.py
@@ -98,6 +98,7 @@ Calculation = UIDReferenceField(
     "Calculation",
     schemata="Method",
     required=0,
+    relationship="AnalysisServiceCalculation",
     vocabulary="_default_calculation_vocabulary",
     allowed_types=("Calculation", ),
     accessor="getRawCalculation",

--- a/src/bika/lims/content/calculation.py
+++ b/src/bika/lims/content/calculation.py
@@ -71,6 +71,7 @@ schema = BikaSchema.copy() + Schema((
         'DependentServices',
         required=1,
         multiValued=1,
+        relationship="CalculationDependentServices",
         allowed_types=('AnalysisService',),
         widget=ReferenceWidget(
             checkbox_bound=0,

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2409</version>
+  <version>2410</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2408</version>
+  <version>2409</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -23,6 +23,7 @@ import transaction
 from bika.lims import api
 from bika.lims import LDL
 from bika.lims import UDL
+from bika.lims.browser.fields.uidreferencefield import get_storage
 from bika.lims.interfaces import IRejected
 from bika.lims.interfaces import IRetracted
 from Products.Archetypes.config import REFERENCE_CATALOG
@@ -351,7 +352,13 @@ def rename_retestof_relationship(tool):
         field = obj.getField("RetestOf")
         retest_of = field.get(obj)
         if retest_of:
-            # re-link referenced object
+            # remove the back-reference with the old relationship name
+            portal_type = api.get_portal_type(obj)
+            old_relationship_key = "{}RetestOf".format(portal_type)
+            back_storage = get_storage(retest_of)
+            back_storage.pop(old_relationship_key, None)
+
+            # re-link referenced object with the new relationship name
             field.link_reference(retest_of, obj)
 
         # Flush the object from memory

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -340,7 +340,8 @@ def rename_retestof_relationship(tool):
     total = len(brains)
     for num, brain in enumerate(brains):
         if num and num % 100 == 0:
-            logger.info("Rename RetestOf relationship {0}".format(num, total))
+            logger.info("Rename RetestOf relationship {}/{}"
+                        .format(num, total))
 
         if num and num % 1000 == 0:
             transaction.savepoint()

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -357,4 +357,3 @@ def rename_retestof_relationship(tool):
         obj._p_deactivate()
 
     logger.info("Rename RetestOf relationship [DONE]")
-

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -415,7 +415,8 @@ def purge_backreferences_to(obj):
     """Removes back-references that are no longer needed that point to the
     given object
     """
-    for field in api.get_fields(obj):
+    fields = api.get_fields(obj)
+    for field_name, field in fields.items():
         if not isinstance(field, UIDReferenceField):
             continue
 

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -416,6 +416,8 @@ def purge_backreferences_to(obj):
     given object
     """
     fields = api.get_fields(obj)
+    portal_type = api.get_portal_type(obj)
+
     for field_name, field in fields.items():
         if not isinstance(field, UIDReferenceField):
             continue
@@ -430,7 +432,6 @@ def purge_backreferences_to(obj):
             references = [references]
 
         # Remove the back-references from these referenced objects to current
-        portal_type = api.get_portal_type(obj)
         relationship = "{}{}".format(portal_type, field.getName())
         references = filter(None, references)
         for reference in references:

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -87,10 +87,20 @@
        https://github.com/senaite/senaite.core/pull/2219 -->
   <genericsetup:upgradeStep
       title="SENAITE CORE 2.4.0: Rename RetestOf relationship"
-      description="Rename RetestOf relationship"
+      description="Rename ?RetestOf relationship to AnalysisRetestOf"
       source="2408"
       destination="2409"
       handler="senaite.core.upgrade.v02_04_000.rename_retestof_relationship"
+      profile="senaite.core:default"/>
+
+  <!-- Purge back-references that are no longer required
+       https://github.com/senaite/senaite.core/pull/2219 -->
+  <genericsetup:upgradeStep
+      title="SENAITE CORE 2.4.0: Purge back-references that are no longer required"
+      description="Purge back-references from UIDReferenceField that are no longer required"
+      source="2409"
+      destination="2410"
+      handler="senaite.core.upgrade.v02_04_000.purge_backreferences"
       profile="senaite.core:default"/>
 
 </configure>

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -87,7 +87,7 @@
        https://github.com/senaite/senaite.core/pull/2219 -->
   <genericsetup:upgradeStep
       title="SENAITE CORE 2.4.0: Rename RetestOf relationship"
-      description="Rename ?RetestOf relationship to AnalysisRetestOf"
+      description="Rename RetestOf relationship to AnalysisRetestOf"
       source="2408"
       destination="2409"
       handler="senaite.core.upgrade.v02_04_000.rename_retestof_relationship"

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -83,4 +83,14 @@
       handler="senaite.core.upgrade.v02_04_000.migrate_analysisrequest_referencefields"
       profile="senaite.core:default"/>
 
+  <!-- Rename RetestOf relationship
+       https://github.com/senaite/senaite.core/pull/2220 -->
+  <genericsetup:upgradeStep
+      title="SENAITE CORE 2.4.0: Rename RetestOf relationship"
+      description="Rename RetestOf relationship"
+      source="2408"
+      destination="2409"
+      handler="senaite.core.upgrade.v02_04_000.rename_retestof_relationship"
+      profile="senaite.core:default"/>
+
 </configure>

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -84,7 +84,7 @@
       profile="senaite.core:default"/>
 
   <!-- Rename RetestOf relationship
-       https://github.com/senaite/senaite.core/pull/2220 -->
+       https://github.com/senaite/senaite.core/pull/2219 -->
   <genericsetup:upgradeStep
       title="SENAITE CORE 2.4.0: Rename RetestOf relationship"
       description="Rename RetestOf relationship"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request allows the possibility to tell to an `UIDReferenceField` to not keep back-references. If the parameter `relationship` is empty or None, system assumes that no back-refernces should be kept.

## Current behavior before PR

Annotations from Client object are updated with the full list of sample UIDs each time a new sample is added

## Desired behavior after PR is merged

Annotations from Client object are not updated with the full list of sample UIDs when samples are added

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
