### PR TITLE
Fix traceback when UID value is ['null']

### DIFF
--- a/src/bika/lims/browser/fields/uidreferencefield.py
+++ b/src/bika/lims/browser/fields/uidreferencefield.py
@@ -99,7 +99,7 @@ class UIDReferenceField(StringField):
         return True
 
     @security.public
-    def get_uid(self, context, value):
+    def get_uid(self, context, value, default=""):
         """Takes a brain or object (or UID), and returns a UID.
 
         :param context: context is the object who's schema contains this field.
@@ -109,11 +109,11 @@ class UIDReferenceField(StringField):
         :return: resolved UID.
         :rtype: string
         """
-        # Empty string or list with single empty string, are commonly
-        # passed to us from form submissions
-        if not value or value == ['']:
-            return ''
-        return api.get_uid(value)
+        if api.is_object(value):
+            value = api.get_uid(value)
+        elif not api.is_uid(value):
+            value = default
+        return value
 
     @security.public
     def get(self, context, **kwargs):


### PR DESCRIPTION
## Description

This PR is related to https://github.com/senaite/senaite.core/pull/2218 and fixes the following traceback when an instrument is assigned to an analysis service:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.CMFFormController.FSControllerPageTemplate, line 92, in __call__
  Module Products.CMFFormController.BaseControllerPageTemplate, line 30, in _call
  Module Products.CMFFormController.ControllerBase, line 233, in getNext
  Module Products.CMFFormController.Actions.TraverseTo, line 38, in __call__
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.CMFFormController.FSControllerPythonScript, line 104, in __call__
  Module Products.CMFFormController.Script, line 145, in __call__
  Module Products.CMFCore.FSPythonScript, line 134, in __call__
  Module Shared.DC.Scripts.Bindings, line 335, in __call__
  Module Shared.DC.Scripts.Bindings, line 372, in _bindAndExec
  Module Products.PythonScripts.PythonScript, line 349, in _exec
  Module script, line 1, in content_edit
   - <FSControllerPythonScript at /senaite/content_edit used for /senaite/bika_setup/bika_analysisservices/analysisservice-3>
   - Line 1
  Module Products.CMFCore.FSPythonScript, line 134, in __call__
  Module Shared.DC.Scripts.Bindings, line 335, in __call__
  Module Shared.DC.Scripts.Bindings, line 372, in _bindAndExec
  Module Products.PythonScripts.PythonScript, line 349, in _exec
  Module script, line 12, in content_edit_impl
   - <FSPythonScript at /senaite/content_edit_impl used for /senaite/bika_setup/bika_analysisservices/analysisservice-3>
   - Line 12
  Module Products.Archetypes.BaseObject, line 676, in processForm
  Module Products.Archetypes.BaseObject, line 666, in _processForm
   - __traceback_info__: (<AnalysisService at /senaite/bika_setup/bika_analysisservices/analysisservice-3>, <Field Instrument(uidreference:rw)>, <bound method AnalysisService.setInstrument of <AnalysisService at /senaite/bika_setup/bika_analysisservices/analysisservice-3>>)
  Module Products.Archetypes.utils, line 131, in mapply
  Module Products.Archetypes.ClassGen, line 77, in generatedMutator
  Module bika.lims.browser.fields.uidreferencefield, line 230, in set
  Module bika.lims.browser.fields.uidreferencefield, line 116, in get_uid
  Module bika.lims.api, line 575, in get_uid
  Module bika.lims.api, line 384, in get_object
  Module bika.lims.api, line 347, in fail
APIError: 'null' is not supported.
```

## Current behavior before PR

Traceback is raised when an instrument is assigned to an analysis service

## Desired behavior after PR is merged

No traceback is raised when an instrument is assigned to an analysis service

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
