### PR TITLE
Fix wrong precision for exponential formatted uncertainties

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2224 Fix wrong precision for exponential formatted uncertainties
 - #2219 Make `UIDReferenceField` to not keep back-references by default
 - #2209 Migrate AnalysisRequest's ReferenceField fields to UIDReferenceField
 - #2218 Improve performance of legacy AT `UIDReferenceField`'s setter

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -1192,9 +1192,8 @@ class AnalysesView(ListingView):
             item["allow_edit"].append("Uncertainty")
             return
 
-        result = obj.getResult()
         formatted = format_uncertainty(
-            obj, result, decimalmark=self.dmk, sciformat=int(self.scinot))
+            obj, decimalmark=self.dmk, sciformat=int(self.scinot))
         if formatted:
             item["replace"]["Uncertainty"] = formatted
             item["before"]["Uncertainty"] = "± "

--- a/src/bika/lims/browser/worksheet/views/printview.py
+++ b/src/bika/lims/browser/worksheet/views/printview.py
@@ -453,7 +453,8 @@ class PrintView(BrowserView):
         elif specs.get('max', None):
             fs = '< %s' % specs['max']
         andict['formatted_specs'] = formatDecimalMark(fs, decimalmark)
-        andict['formatted_uncertainty'] = format_uncertainty(analysis, analysis.getResult(), decimalmark=decimalmark, sciformat=int(scinot))
+        andict['formatted_uncertainty'] = format_uncertainty(
+            analysis, decimalmark=decimalmark, sciformat=int(scinot))
 
         # Out of range?
         andict['outofrange'] = is_out_of_range(analysis)[0]

--- a/src/bika/lims/utils/analysis.py
+++ b/src/bika/lims/utils/analysis.py
@@ -278,7 +278,8 @@ def format_uncertainty(analysis, result, decimalmark='.', sciformat=1):
     formatted = _format_decimal_or_sci(
         uncertainty, precision, threshold, sciformat)
 
-    # strip off trailing zeros and the orphane dot
+    # strip off trailing zeros and the orphane dot,
+    # e.g.: 1.000000 -> 1
     if "." in formatted:
         formatted = formatted.rstrip("0").rstrip(".")
 

--- a/src/bika/lims/utils/analysis.py
+++ b/src/bika/lims/utils/analysis.py
@@ -246,6 +246,10 @@ def format_uncertainty(analysis, decimalmark=".", sciformat=1):
     if not uncertainty:
         return ""
 
+    # always convert exponential notation to decimal
+    if "e" in uncertainty.lower():
+        uncertainty = api.float_to_string(float(uncertainty))
+
     precision = -1
     # always get full precision of the uncertainty if user entered manually
     # => avoids rounding and cut-off

--- a/src/bika/lims/utils/analysis.py
+++ b/src/bika/lims/utils/analysis.py
@@ -183,10 +183,8 @@ def _format_decimal_or_sci(result, precision, threshold, sciformat):
     return formatted
 
 
-def format_uncertainty(analysis, decimalmark='.', sciformat=1):
-    """
-    Returns the formatted uncertainty according to the analysis, result
-    and decimal mark specified following these rules:
+def format_uncertainty(analysis, decimalmark=".", sciformat=1):
+    """Return formatted uncertainty value
 
     If the "Calculate precision from uncertainties" is enabled in
     the Analysis service, and

--- a/src/bika/lims/utils/analysis.py
+++ b/src/bika/lims/utils/analysis.py
@@ -221,9 +221,6 @@ def format_uncertainty(analysis, result, decimalmark='.', sciformat=1):
     the uncertainty neither the result. The fixed length precision is
     used instead.
 
-    For further details, visit
-    https://jira.bikalabs.com/browse/LIMS-1334
-
     If the result is not floatable or no uncertainty defined, returns
     an empty string.
 

--- a/src/bika/lims/utils/analysis.py
+++ b/src/bika/lims/utils/analysis.py
@@ -183,7 +183,7 @@ def _format_decimal_or_sci(result, precision, threshold, sciformat):
     return formatted
 
 
-def format_uncertainty(analysis, result, decimalmark='.', sciformat=1):
+def format_uncertainty(analysis, decimalmark='.', sciformat=1):
     """
     Returns the formatted uncertainty according to the analysis, result
     and decimal mark specified following these rules:
@@ -229,8 +229,6 @@ def format_uncertainty(analysis, result, decimalmark='.', sciformat=1):
 
     :param analysis: the analysis from which the uncertainty, precision
                      and other additional info have to be retrieved
-    :param result: result of the analysis. Used to retrieve and/or
-                   calculate the precision and/or uncertainty
     :param decimalmark: decimal mark to use. By default '.'
     :param sciformat: 1. The sci notation has to be formatted as aE^+b
                   2. The sci notation has to be formatted as ax10^b
@@ -241,22 +239,11 @@ def format_uncertainty(analysis, result, decimalmark='.', sciformat=1):
     :returns: the formatted uncertainty
     """
     try:
-        result = float(result)
-    except ValueError:
-        return ""
-
-    objres = None
-    try:
-        objres = float(analysis.getResult())
-    except ValueError:
+        result = float(analysis.getResult())
+    except (ValueError, TypeError):
         pass
 
-    uncertainty = None
-    if result == objres:
-        # To avoid problems with DLs
-        uncertainty = analysis.getUncertainty()
-    else:
-        uncertainty = analysis.getUncertainty(result)
+    uncertainty = analysis.getUncertainty()
 
     if not uncertainty:
         return ""

--- a/src/senaite/core/tests/doctests/Uncertainties.rst
+++ b/src/senaite/core/tests/doctests/Uncertainties.rst
@@ -339,7 +339,7 @@ Since we have neither specified a precision in the analysis service, nor did we 
 set the precision from uncertainty, we get a precision of 0:
 
     >>> au.setResult("1.4")
-    >>> format_uncertainty(au, au.getResult())
+    >>> format_uncertainty(au)
     '0'
 
 When we set the precision in the analysis, the uncertainty is formatted to this value:
@@ -347,15 +347,15 @@ When we set the precision in the analysis, the uncertainty is formatted to this 
 XXX: Why is it not rounded to 0.0002?
 
     >>> au.setPrecision(4)
-    >>> format_uncertainty(au, au.getResult())
+    >>> format_uncertainty(au)
     '0.0001'
 
     >>> au.setPrecision(5)
-    >>> format_uncertainty(au, au.getResult())
+    >>> format_uncertainty(au)
     '0.00015'
 
     >>> au.setPrecision(6)
-    >>> format_uncertainty(au, au.getResult())
+    >>> format_uncertainty(au)
     '0.00015'
 
 When the user manually entered an uncertainty and overrides an uncertainty
@@ -364,7 +364,7 @@ range, we always show all digits:
     >>> au.setPrecision(None)
     >>> au.setAllowManualUncertainty(True)
     >>> au.setUncertainty("0.00000123")
-    >>> format_uncertainty(au, au.getResult())
+    >>> format_uncertainty(au)
     '0.00000123'
 
 The uncertainty can be also defined as a percentage of the result and is then
@@ -431,7 +431,7 @@ Define it as an uncertainty as percentage of the result:
     >>> au.getUncertainty()
     '0.000001'
 
-    >>> format_uncertainty(au, au.getResult())
+    >>> format_uncertainty(au)
     '0.000001'
 
 
@@ -446,11 +446,11 @@ Define it as an uncertainty as percentage of the result:
 
 Because it exceeded the Exponential format precision, it is returned with the scientific notation:
 
-    >>> format_uncertainty(au, au.getResult())
+    >>> format_uncertainty(au)
     '1.0e-21'
 
 Change to a higher precision threshold:
 
     >>> au.setExponentialFormatPrecision(30)
-    >>> format_uncertainty(au, au.getResult())
+    >>> format_uncertainty(au)
     '0.000000000000000000001'

--- a/src/senaite/core/tests/doctests/Uncertainties.rst
+++ b/src/senaite/core/tests/doctests/Uncertainties.rst
@@ -384,6 +384,42 @@ Test the range 10-20 with an unertainty value of 5% of the result:
     '0.75'
 
 
+Test exponential format
+.......................
+
+Create a new sample:
+
+    >>> sample = new_sample([Cu, Fe, Au])
+    >>> au = get_analysis(sample, Au)
+    >>> au.setAllowManualUncertainty(True)
+    >>> au.setPrecisionFromUncertainty(False)
+
+Manually set the result and uncertainty:
+
+    >>> au.setResult("1.000123e-5")
+    >>> au.setUncertainty("0.002e-5")
+
+We expect manual uncertainties in full precision:
+
+    >>> au.getUncertainty()
+    '0.002e-5'
+
+    >>> format_uncertainty(au, sciformat=1)
+    '2e-08'
+
+    >>> format_uncertainty(au, sciformat=2)
+    '2x10^-8'
+
+    >>> format_uncertainty(au, sciformat=3)
+    '2x10<sup>-8</sup>'
+
+    >>> format_uncertainty(au, sciformat=4)
+    '2\xc2\xb710^-8'
+
+    >>> format_uncertainty(au, sciformat=5)
+    '2\xc2\xb710<sup>-8</sup>'
+
+
 Test floating point arithmetic
 ..............................
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the formatting for uncertainties if the manual value was entered in the exponential notation, e.g. `0.002e-5`.

## Current behavior before PR

The precision for `0.002e-5` was calculated as `6`.
Therefore, the uncertainty was displayed as `0`.

After save:
<img width="807" src="https://user-images.githubusercontent.com/713193/211332102-cf9f95bf-237f-42f3-a8d4-67bf987ffc58.png">

After submit:
<img width="813" src="https://user-images.githubusercontent.com/713193/211332243-5062ebb1-5239-4c3e-a288-b13031d69b91.png">


## Desired behavior after PR is merged

The precision for `0.002e-5` was calculated as `8`
The uncertainty is displayed as `0.002e-5`.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
