### PR TITLE
UIDReferenceDataConverter check  argument type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2225 Fix UIDReferenceDataConverter argument type check
 - #2224 Fix wrong precision for exponential formatted uncertainties
 - #2219 Make `UIDReferenceField` to not keep back-references by default
 - #2209 Migrate AnalysisRequest's ReferenceField fields to UIDReferenceField

--- a/src/senaite/core/z3cform/widgets/uidreference/widget.py
+++ b/src/senaite/core/z3cform/widgets/uidreference/widget.py
@@ -52,6 +52,11 @@ class UIDReferenceDataConverter(TextLinesConverter):
     def toFieldValue(self, value):
         """Converts a unicode string to a list of UIDs
         """
+        if not value:
+            value = u""
+        if isinstance(value, (list, tuple)):
+            value = u"\n".join(value)
+
         # remove any blank lines at the end
         value = value.rstrip("\r\n")
         return super(UIDReferenceDataConverter, self).toFieldValue(value)


### PR DESCRIPTION
argument type check added. in cases non string or None argument gets in exception raises

## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/2223

