### PR TITLE
Add setting to CC responsible persons in publication emails 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2226 #Add setting to CC responsible persons in publication emails
 - #2224 Fix wrong precision for exponential formatted uncertainties
 - #2219 Make `UIDReferenceField` to not keep back-references by default
 - #2209 Migrate AnalysisRequest's ReferenceField fields to UIDReferenceField

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
-- #2226 #Add setting to CC responsible persons in publication emails
+- #2226 Add setting to CC responsible persons in publication emails
 - #2224 Fix wrong precision for exponential formatted uncertainties
 - #2219 Make `UIDReferenceField` to not keep back-references by default
 - #2209 Migrate AnalysisRequest's ReferenceField fields to UIDReferenceField

--- a/src/bika/lims/browser/publish/emailview.py
+++ b/src/bika/lims/browser/publish/emailview.py
@@ -219,10 +219,22 @@ class EmailView(BrowserView):
         return api.get_portal()
 
     @property
+    def setup(self):
+        """Get the setup object
+        """
+        return api.get_setup()
+
+    @property
     def laboratory(self):
         """Laboratory object from the LIMS setup
         """
         return api.get_setup().laboratory
+
+    @property
+    def always_cc_responsibles(self):
+        """Setting if responsibles should be always CC'ed
+        """
+        return self.setup.getAlwaysCCResponsiblesInReportEmail()
 
     @property
     @view.memoize

--- a/src/bika/lims/browser/publish/templates/email.pt
+++ b/src/bika/lims/browser/publish/templates/email.pt
@@ -89,8 +89,14 @@
                                 valid_cls python:valid and 'valid' or 'invalid';"
                     tal:attributes="class string:recipient ${valid_cls}">
 
-                <input type="hidden"
+                <input tal:condition="python:view.always_cc_responsibles"
+                       type="hidden"
                        tal:condition="email"
+                       tal:attributes="value string:${address};"
+                       name="responsibles:list"/>
+
+                <input type="checkbox"
+                       tal:condition="python:email and not view.always_cc_responsibles"
                        tal:attributes="value string:${address};"
                        name="responsibles:list"/>
 

--- a/src/bika/lims/browser/publish/templates/email.pt
+++ b/src/bika/lims/browser/publish/templates/email.pt
@@ -89,9 +89,8 @@
                                 valid_cls python:valid and 'valid' or 'invalid';"
                     tal:attributes="class string:recipient ${valid_cls}">
 
-                <input tal:condition="python:view.always_cc_responsibles"
+                <input tal:condition="python:email and view.always_cc_responsibles"
                        type="hidden"
-                       tal:condition="email"
                        tal:attributes="value string:${address};"
                        name="responsibles:list"/>
 

--- a/src/bika/lims/content/bikasetup.py
+++ b/src/bika/lims/content/bikasetup.py
@@ -651,6 +651,21 @@ schema = BikaFolderSchema.copy() + Schema((
             rows=15,
         ),
     ),
+    # NOTE: This is a Proxy Field which delegates to the SENAITE Registry!
+    BooleanField(
+        "AlwaysCCResponsiblesInReportEmail",
+        schemata="Notifications",
+        default=True,
+        widget=BooleanWidget(
+            label=_(
+                "label_bikasetup_always_cc_responsibles_in_report_emails",
+                default="Always send publication email to responsibles"),
+            description=_(
+                "description_bikasetup_always_cc_responsibles_in_report_emails",
+                default="When selected, the responsible persons of all "
+                "involved lab departments will receive publication emails."),
+        ),
+    ),
     BooleanField(
         'NotifyOnSampleRejection',
         schemata="Notifications",
@@ -1057,6 +1072,22 @@ class BikaSetup(folder.ATFolder):
         # setup is `None` during initial site content structure installation
         if setup:
             setup.setEmailBodySamplePublication(value)
+
+    def getAlwaysCCResponsiblesInReportEmail(self):
+        """Get the value from the senaite setup
+        """
+        setup = api.get_senaite_setup()
+        # setup is `None` during initial site content structure installation
+        if setup:
+            return setup.getAlwaysCCResponsiblesInReportEmail()
+
+    def setAlwaysCCResponsiblesInReportEmail(self, value):
+        """Set the value in the senaite setup
+        """
+        setup = api.get_senaite_setup()
+        # setup is `None` during initial site content structure installation
+        if setup:
+            setup.setAlwaysCCResponsiblesInReportEmail(value)
 
     def getEnableGlobalAuditlog(self):
         """Get the value from the senaite setup

--- a/src/senaite/core/content/senaitesetup.py
+++ b/src/senaite/core/content/senaitesetup.py
@@ -52,6 +52,18 @@ class ISetupSchema(model.Schema):
         required=False,
     )
 
+    always_cc_responsibles_in_report_emails = schema.Bool(
+        title=_(
+            "title_senaitesetup_always_cc_responsibles_in_report_emails",
+            default=u"Always send publication email to responsibles"),
+        description=_(
+            "description_senaitesetup_always_cc_responsibles_in_report_emails",
+            default="When selected, the responsible persons of all involved "
+            "lab departments will receive publication emails."
+        ),
+        default=True,
+    )
+
     enable_global_auditlog = schema.Bool(
         title=_(u"Enable global Auditlog"),
         description=_(
@@ -131,6 +143,7 @@ class ISetupSchema(model.Schema):
         label=_(u"Notifications"),
         fields=[
             "email_body_sample_publication",
+            "always_cc_responsibles_in_report_emails",
         ]
     )
 
@@ -169,6 +182,20 @@ class Setup(Container):
         """Set email body text for publication emails
         """
         mutator = self.mutator("email_body_sample_publication")
+        return mutator(self, value)
+
+    @security.protected(permissions.View)
+    def getAlwaysCCResponsiblesInReportEmail(self):
+        """Returns if responsibles should always receive publication emails
+        """
+        accessor = self.accessor("always_cc_responsibles_in_report_emails")
+        return accessor(self)
+
+    @security.protected(permissions.View)
+    def setAlwaysCCResponsiblesInReportEmail(self, value):
+        """Set if responsibles should always receive publication emails
+        """
+        mutator = self.mutator("always_cc_responsibles_in_report_emails")
         return mutator(self, value)
 
     @security.protected(permissions.View)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds a new setup option to configure if responsible persons from lab departments should always receive publication emails or not.

## Current behavior before PR

Responsible persons do always receive publication emails

## Desired behavior after PR is merged

It is possible to send publication reports to responsible persons optionally

<img width="800"  src="https://user-images.githubusercontent.com/713193/211528814-075ebda8-1d94-44cc-af6f-bbdad713b522.png">

<img width="796" src="https://user-images.githubusercontent.com/713193/211529362-a7605d32-99ce-48ff-851f-ddb9dd23b563.png">


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
