### PR TITLE
Fix migration step for backreferences cleanup

### DIFF
--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -435,5 +435,6 @@ def purge_backreferences_to(obj):
         relationship = "{}{}".format(portal_type, field.getName())
         references = filter(None, references)
         for reference in references:
-            back_storage = get_storage(reference)
+            refob = api.get_object(reference)
+            back_storage = get_storage(refob)
             back_storage.pop(relationship, None)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Complementary PR for https://github.com/senaite/senaite.core/pull/2219

## Current behavior before PR

Traceback happens during Migration:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 666, in __call__
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 399, in upgrade_product
  Module Products.GenericSetup.tool, line 1202, in upgradeProfile
  Module Products.GenericSetup.upgrade, line 185, in doStep
  Module senaite.core.upgrade.v02_04_000, line 406, in purge_backreferences
  Module senaite.core.upgrade.v02_04_000, line 438, in purge_backreferences_to
  Module bika.lims.browser.fields.uidreferencefield, line 253, in get_storage
TypeError: ('Could not adapt', u'e5797d321bfc4887bd715cb07c96de44', <InterfaceClass zope.annotation.interfaces.IAnnotations>)
```

NOTE:
This is because `SampleContainer` objects are already DX types:

```
(Pdb++) reference
u'e5797d321bfc4887bd715cb07c96de44'
(Pdb++) references
[u'e5797d321bfc4887bd715cb07c96de44']
(Pdb++) references
[u'e5797d321bfc4887bd715cb07c96de44']
(Pdb++) field
<Field SampleContainers(uidreference:rw)>
(Pdb++) obj
<Method at /senaite/methods/method-42>
(Pdb++) api.get_object(reference)
<SampleContainer at /senaite/bika_setup/sample_containers/samplecontainer-5>
(Pdb++) api.get_object(reference).meta_type
'Dexterity Container'
```

## Desired behavior after PR is merged

Migration step handles DX type references

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
