### PR TITLE
Fix worksheet template title is not updated after template assignment

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 2.4.0 (unreleased)
 ------------------
-- #2228 Fix worksheet template title reindex
+- #2228 Fix worksheet template title is not updated after template assignment
 - #2226 Add setting to CC responsible persons in publication emails
 - #2224 Fix wrong precision for exponential formatted uncertainties
 - #2219 Make `UIDReferenceField` to not keep back-references by default

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 2.4.0 (unreleased)
 ------------------
-
+- #2228 Fix worksheet template title reindex
 - #2226 Add setting to CC responsible persons in publication emails
 - #2224 Fix wrong precision for exponential formatted uncertainties
 - #2219 Make `UIDReferenceField` to not keep back-references by default

--- a/src/bika/lims/content/worksheet.py
+++ b/src/bika/lims/content/worksheet.py
@@ -1076,9 +1076,10 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
             only be applied to those analyses for which the instrument
             is allowed, the same happens with methods.
         """
-        # Store the Worksheet Template field
+        # Store the Worksheet Template field and reindex it
         self.getField('WorksheetTemplate').set(self, wst)
-
+        self.reindexObject(idxs=["getWorksheetTemplateTitle"])
+        
         if not wst:
             return
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

WorksheetsList template title field does not updates properly for empty worksheets or if analyst being reassigned

## Current behavior before PR

When user choose to create worksheet with template, but do not assign any analyses on the add form, empty worksheet instance shown in the list with no template title.

Same happens when user calls "Apply Template" manually.

## Desired behavior after PR is merged

getWorksheetTemplateTitle - reindexes for any applyWorksheetTemplate() call.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
