### PR TITLE
Fix missing references because of old relationships with wrong names

### DIFF
--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2411</version>
+  <version>2412</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -113,14 +113,14 @@
       handler="senaite.core.upgrade.v02_04_000.purge_setup_backreferences"
       profile="senaite.core:default"/>
 
-  <!-- Fix Laboratory Contacts without departments
+  <!-- Fix missing references due to wrong relationship names
        https://github.com/senaite/senaite.core/pull/2230 -->
   <genericsetup:upgradeStep
-      title="SENAITE CORE 2.4.0: Fix Laboratory Contacts without departments"
-      description="Fix Laboratory Contacts without departments"
+      title="SENAITE CORE 2.4.0: Fix missing references"
+      description="Fix missing references due to wrong relationship names"
       source="2411"
       destination="2412"
-      handler="senaite.core.upgrade.v02_04_000.fix_labcontacts_without_departments"
+      handler="senaite.core.upgrade.v02_04_000.fix_missing_references"
       profile="senaite.core:default"/>
 
 </configure>

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -113,4 +113,14 @@
       handler="senaite.core.upgrade.v02_04_000.purge_setup_backreferences"
       profile="senaite.core:default"/>
 
+  <!-- Fix Laboratory Contacts without departments
+       https://github.com/senaite/senaite.core/pull/2230 -->
+  <genericsetup:upgradeStep
+      title="SENAITE CORE 2.4.0: Fix Laboratory Contacts without departments"
+      description="Fix Laboratory Contacts without departments"
+      source="2411"
+      destination="2412"
+      handler="senaite.core.upgrade.v02_04_000.fix_labcontacts_without_departments"
+      profile="senaite.core:default"/>
+
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes references that have not been migrated with https://github.com/senaite/senaite.core/pull/2229 because their old relationship names did not adhere to the convention `<portal_type><field_name>`.

## Current behavior before PR

Some old references are still missing although upgrade step for https://github.com/senaite/senaite.core/pull/2221 and https://github.com/senaite/senaite.core/pull/2229 was run

## Desired behavior after PR is merged

No old references are missing after the upgrade step 2412

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
