### PR TITLE
Cannot set conditions with a '<' char when others are from type "file"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2231 Cannot set conditions with a '<' char when others are from type "file"
 - #2221 Migrate `ReferenceField` fields from setup types to `UIDReferenceField`
 - #2228 Fix worksheet template title is not updated after template assignment
 - #2226 Add setting to CC responsible persons in publication emails

--- a/src/senaite/core/browser/modals/analysis.py
+++ b/src/senaite/core/browser/modals/analysis.py
@@ -85,7 +85,7 @@ class SetAnalysisConditionsView(BrowserView):
                 condition["attachment"] = self.get_attachment_info(uid)
 
         # Move conditions from "file" type to the end:
-        #   Cannot set conditions containing a '<' character when files
+        #   Cannot set conditions with a '<' char when others are from file
         #   https://github.com/senaite/senaite.core/pulls/2231
         def files_last(condition1, condition2):
             type1 = condition1.get("type")

--- a/src/senaite/core/browser/modals/analysis.py
+++ b/src/senaite/core/browser/modals/analysis.py
@@ -84,7 +84,16 @@ class SetAnalysisConditionsView(BrowserView):
                 uid = condition.get("value")
                 condition["attachment"] = self.get_attachment_info(uid)
 
-        return conditions
+        # Move conditions from "file" type to the end:
+        #   Cannot set conditions containing a '<' character when files
+        #   https://github.com/senaite/senaite.core/pulls/2231
+        def files_last(condition1, condition2):
+            type1 = condition1.get("type")
+            type2 = condition2.get("type")
+            if "file" not in [type1, type2]:
+                return 0
+            return 1 if type1 == "file" else -1
+        return sorted(conditions, cmp=files_last)
 
     def get_attachment_info(self, uid):
         attachment = api.get_object_by_uid(uid, default=None)
@@ -108,8 +117,18 @@ class SetAnalysisConditionsView(BrowserView):
             message = _("Not allowed to update conditions: {}").format(title)
             return self.redirect(message=message, level="error")
 
-        # Update the conditions
+        # Sort the conditions as they were initially set
         conditions = self.request.form.get("conditions", [])
+        original = self.get_analysis().getConditions(empties=True)
+        original = [cond.get("title") for cond in original]
+
+        def original_order(condition1, condition2):
+            index1 = original.index(condition1.get("title"))
+            index2 = original.index(condition2.get("title"))
+            return (index1 > index2) - (index1 < index2)
+        conditions = sorted(conditions, cmp=original_order)
+
+        # Update the conditions
         analysis.setConditions(conditions)
         message = _("Analysis conditions updated: {}").format(title)
         return self.redirect(message=message)

--- a/src/senaite/core/browser/modals/templates/set_analysis_conditions.pt
+++ b/src/senaite/core/browser/modals/templates/set_analysis_conditions.pt
@@ -28,7 +28,7 @@
               <colgroup>
                 <col style="width:20%"/>
               </colgroup>
-              <tal:condition repeat="condition python:view.get_conditions()">
+              <tal:condition repeat="condition conditions">
                 <tr tal:define="required python:condition.get('required') == 'on';
                                 is_checkbox python:condition.get('type') == 'checkbox';
                                 required python:required and not is_checkbox;">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request overcomes an issue with mixed type records in `ZPublisher`, that prevents to store conditions when a file type control (for a "file" type condition) is present before an input text type control (for a "text" type condition) and user enters a special character (that requires tainting) for the latter. See https://github.com/zopefoundation/Zope/issues/1095 and screenshot below

## Current behavior before PR

User cannot update analysis conditions if the value set contains the '<' character and the input text is rendered after a file control

## Desired behavior after PR is merged

User can update analysis conditions regardless of the contents set for input values

## Screenshot

![Captura de 2023-01-16 11-38-58](https://user-images.githubusercontent.com/832627/212908767-a0488790-6968-4802-b4a9-f80401a95699.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
