### PR TITLE
Add interpretation template columns for assigned sampletypes and result text

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2234 Add interpretation template columns for assigned sampletypes and result text
+- #2234 Change base class for interpretation templates from Item -> Container
 - #2231 Cannot set conditions with a '<' char when others are from type "file"
 - #2221 Migrate `ReferenceField` fields from setup types to `UIDReferenceField`
 - #2228 Fix worksheet template title is not updated after template assignment

--- a/src/senaite/core/browser/controlpanel/interpretationtemplates.py
+++ b/src/senaite/core/browser/controlpanel/interpretationtemplates.py
@@ -21,9 +21,10 @@
 import collections
 
 from bika.lims import _
+from bika.lims import api
 from bika.lims.catalog import SETUP_CATALOG
 from bika.lims.utils import get_link_for
-
+from plone.app.textfield import RichTextValue
 from senaite.app.listing import ListingView
 
 
@@ -57,6 +58,12 @@ class InterpretationTemplatesView(ListingView):
             ("Description", {
                 "title": _("Description"),
                 "index": "Description"}),
+            ("SampleTypes", {
+                "title": _("Sample Types"),
+                "sortable": False}),
+            ("Text", {
+                "title": _("Text"),
+                "sortable": False}),
         ))
 
         self.review_states = [
@@ -98,5 +105,23 @@ class InterpretationTemplatesView(ListingView):
             the template
         :index: current index of the item
         """
+        obj = api.get_object(obj)
+
         item["replace"]["Title"] = get_link_for(obj)
+
+        # List all linked sampletypes
+        sampletypes = obj.getSampleTypes()
+        if sampletypes:
+            titles = map(api.get_title, sampletypes)
+            item["SampleTypes"] = ", ".join(titles)
+            item["replace"]["SampleTypes"] = ", ".join(
+                map(get_link_for, sampletypes))
+
+        text = obj.text
+        if isinstance(text, RichTextValue):
+            # convert output to plain text
+            text._outputMimeType = "text/plain"
+            text = text.output
+        item["Text"] = text
+
         return item

--- a/src/senaite/core/content/base.py
+++ b/src/senaite/core/content/base.py
@@ -16,13 +16,18 @@ class Container(BaseContainer):
     security = ClassSecurityInfo()
 
     @security.private
-    def accessor(self, fieldname):
+    def accessor(self, fieldname, raw=False):
         """Return the field accessor for the fieldname
         """
         schema = api.get_schema(self)
         if fieldname not in schema:
             return None
-        return schema[fieldname].get
+        field = schema[fieldname]
+        if raw:
+            if hasattr(field, "get_raw"):
+                return field.get_raw
+            return field.getRaw
+        return field.get
 
     @security.private
     def mutator(self, fieldname):
@@ -41,13 +46,18 @@ class Item(BaseItem):
     security = ClassSecurityInfo()
 
     @security.private
-    def accessor(self, fieldname):
+    def accessor(self, fieldname, raw=False):
         """Return the field accessor for the fieldname
         """
         schema = api.get_schema(self)
         if fieldname not in schema:
             return None
-        return schema[fieldname].get
+        field = schema[fieldname]
+        if raw:
+            if hasattr(field, "get_raw"):
+                return field.get_raw
+            return field.getRaw
+        return field.get
 
     @security.private
     def mutator(self, fieldname):

--- a/src/senaite/core/content/interpretationtemplate.py
+++ b/src/senaite/core/content/interpretationtemplate.py
@@ -19,14 +19,13 @@
 # Some rights reserved, see README and LICENSE.
 
 from AccessControl import ClassSecurityInfo
-from bika.lims import api
 from bika.lims import senaiteMessageFactory as _
 from bika.lims.catalog import SETUP_CATALOG
 from bika.lims.interfaces import IDeactivable
 from plone.autoform import directives
-from plone.dexterity.content import Item
 from plone.supermodel import model
 from Products.CMFCore import permissions
+from senaite.core.content.base import Container
 from senaite.core.interfaces import IInterpretationTemplate
 from senaite.core.schema import UIDReferenceField
 from senaite.core.z3cform.widgets.uidreference import UIDReferenceWidgetFactory
@@ -119,7 +118,7 @@ class IInterpretationTemplateSchema(model.Schema):
 
 @implementer(IInterpretationTemplate, IInterpretationTemplateSchema,
              IDeactivable)
-class InterpretationTemplate(Item):
+class InterpretationTemplate(Container):
     """Results Interpretation Template content
     """
     # Catalogs where this type will be catalogued
@@ -127,29 +126,6 @@ class InterpretationTemplate(Item):
 
     security = ClassSecurityInfo()
     exclude_from_nav = True
-
-    @security.private
-    def accessor(self, fieldname, raw=False):
-        """Return the field accessor for the fieldname
-        """
-        schema = api.get_schema(self)
-        if fieldname not in schema:
-            return None
-        field = schema[fieldname]
-        if raw:
-            if hasattr(field, "get_raw"):
-                return field.get_raw
-            return field.getRaw
-        return field.get
-
-    @security.private
-    def mutator(self, fieldname):
-        """Return the field mutator for the fieldname
-        """
-        schema = api.get_schema(self)
-        if fieldname not in schema:
-            return None
-        return schema[fieldname].set
 
     @security.protected(permissions.View)
     def getAnalysisTemplates(self):

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -19,19 +19,21 @@
 # Some rights reserved, see README and LICENSE.
 
 import transaction
-
-from bika.lims import api
 from bika.lims import LDL
 from bika.lims import UDL
+from bika.lims import api
 from bika.lims.browser.fields import UIDReferenceField
 from bika.lims.browser.fields.uidreferencefield import get_storage
 from bika.lims.interfaces import IRejected
 from bika.lims.interfaces import IRetracted
 from Products.Archetypes.config import REFERENCE_CATALOG
+from Products.BTreeFolder2.BTreeFolder2 import BTreeFolder2Base
 from senaite.core import logger
 from senaite.core.catalog import ANALYSIS_CATALOG
 from senaite.core.catalog import SAMPLE_CATALOG
+from senaite.core.catalog import SETUP_CATALOG
 from senaite.core.config import PROJECTNAME as product
+from senaite.core.content.interpretationtemplate import InterpretationTemplate
 from senaite.core.upgrade import upgradestep
 from senaite.core.upgrade.utils import UpgradeUtils
 from zope.interface import alsoProvides
@@ -519,3 +521,32 @@ def migrate_and_purge_references(tool):
         obj._p_deactivate()
 
     logger.info("Migrate and purge references [DONE]")
+
+
+def migrate_interpretationtemplate_item_to_container(tool):
+    """Make interpretationtemplates folderish
+
+    Base class changed from Item -> Container
+
+    https://community.plone.org/t/changing-dx-content-type-base-class-from-item-to-container
+    http://blog.redturtle.it/2013/02/25/migrating-dexterity-items-to-dexterity-containers
+    """
+    logger.info("Migrate interpretationtemplates to be folderish ...")
+    catalog = api.get_tool(SETUP_CATALOG)
+    query = {
+        "portal_type": "InterpretationTemplate",
+    }
+    results = catalog(query)
+
+    for brain in results:
+        obj = api.get_object(brain)
+        oid = obj.getId()
+        parent = api.get_parent(obj)
+        parent._delOb(oid)
+        obj.__class__ = InterpretationTemplate
+        parent._setOb(oid, obj)
+        BTreeFolder2Base._initBTrees(parent[oid])
+        parent[oid].reindexObject()
+
+    transaction.commit()
+    logger.info("Migrate interpretationtemplates to be folderish [DONE]")

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -134,7 +134,7 @@
       profile="senaite.core:default"/>
 
   <!-- Migrate interpretation templates from item -> container
-       https://github.com/senaite/senaite.core/pull/XXX -->
+       https://github.com/senaite/senaite.core/pull/2234 -->
   <genericsetup:upgradeStep
       title="SENAITE CORE 2.4.0: Migrate interpretation templates to be folderish"
       description="Change interpretation template base class from item -> container"

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -133,4 +133,14 @@
       handler="senaite.core.upgrade.v02_04_000.migrate_and_purge_references"
       profile="senaite.core:default"/>
 
+  <!-- Migrate interpretation templates from item -> container
+       https://github.com/senaite/senaite.core/pull/XXX -->
+  <genericsetup:upgradeStep
+      title="SENAITE CORE 2.4.0: Migrate interpretation templates to be folderish"
+      description="Change interpretation template base class from item -> container"
+      source="2413"
+      destination="2414"
+      handler="senaite.core.upgrade.v02_04_000.migrate_interpretationtemplate_item_to_container"
+      profile="senaite.core:default"/>
+
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds two columns for the interpretation template listing for the assigned sample types and the result text:

<img width="1833" alt="Interpretation Templates" src="https://user-images.githubusercontent.com/713193/213488615-81280da9-2797-4a72-abc9-db2d6bf51800.png">

Furthermore, the interpretation templates are converted to be folderish like all the other objects in SENAITE as well

## Current behavior before PR

- Only title and description columns in interpretation templates listing
- Interpretation template class inherits from `Item`

## Desired behavior after PR is merged

- Sampletypes and results text columns are displayed for interpretation templates listings
- Interpretation template class inherits from `Container`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
