### PR TITLE
Fix read endpoint from internal api does not return uid for uidreference

### DIFF
--- a/src/bika/lims/jsonapi/__init__.py
+++ b/src/bika/lims/jsonapi/__init__.py
@@ -113,7 +113,7 @@ def load_field_values(instance, include_fields):
             if field_type == "blob" or field_type == 'file':
                 continue
             # I put the UID of all references here in *_uid.
-            if field_type == 'reference':
+            if field_type in ['reference', 'uidreference']:
                 if type(val) in (list, tuple):
                     ret[fieldname + "_uid"] = [v.UID() for v in val]
                     val = [to_utf8(v.Title()) for v in val]


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a bug that introduced with https://github.com/senaite/senaite.core/pull/2221 . By default, the `read` endpoint from the internal (legacy) jsonapi was always including the uid of fields from reference type in the response. Since `ReferenceField` have been migrated to `UIDReferenceField`, this behavior has been lost and therefore legacy compatibility with other add-ons that make use of this feature.

## Current behavior before PR

The JSON response for `read` endpoint does not include the `UID` from referenced objects through `UIDReferenceField` fields

## Desired behavior after PR is merged

The JSON response for `read` endpoint does include the `UID` from referenced objects through `UIDReferenceField` fields

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
