### PR TITLE
Purge remaining back-references from AnalysisRequest type

### DIFF
--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -177,7 +177,6 @@ schema = BikaSchema.copy() + Schema((
         'CCContact',
         multiValued=1,
         allowed_types=('Contact',),
-        relationship='AnalysisRequestCCContact',
         mode="rw",
         read_permission=View,
         write_permission=FieldEditContact,
@@ -294,7 +293,6 @@ schema = BikaSchema.copy() + Schema((
     UIDReferenceField(
         'Batch',
         allowed_types=('Batch',),
-        relationship='AnalysisRequestBatch',
         mode="rw",
         read_permission=View,
         write_permission=FieldEditBatch,
@@ -332,7 +330,6 @@ schema = BikaSchema.copy() + Schema((
         'SubGroup',
         required=False,
         allowed_types=('SubGroup',),
-        relationship='AnalysisRequestSubGroup',
         mode="rw",
         read_permission=View,
         write_permission=FieldEditBatch,
@@ -363,7 +360,6 @@ schema = BikaSchema.copy() + Schema((
     UIDReferenceField(
         'Template',
         allowed_types=('ARTemplate',),
-        relationship='AnalysisRequestARTemplate',
         mode="rw",
         read_permission=View,
         write_permission=FieldEditTemplate,
@@ -391,7 +387,6 @@ schema = BikaSchema.copy() + Schema((
         'Profiles',
         multiValued=1,
         allowed_types=('AnalysisProfile',),
-        relationship='AnalysisRequestAnalysisProfiles',
         mode="rw",
         read_permission=View,
         write_permission=FieldEditProfiles,
@@ -626,7 +621,6 @@ schema = BikaSchema.copy() + Schema((
         required=0,
         primary_bound=True,  # field changes propagate to partitions
         allowed_types='AnalysisSpec',
-        relationship='AnalysisRequestAnalysisSpec',
         mode="rw",
         read_permission=View,
         write_permission=FieldEditSpecification,
@@ -677,7 +671,6 @@ schema = BikaSchema.copy() + Schema((
         'PublicationSpecification',
         required=0,
         allowed_types='AnalysisSpec',
-        relationship='AnalysisRequestPublicationSpec',
         mode="rw",
         read_permission=View,
         write_permission=FieldEditPublicationSpecifications,
@@ -968,7 +961,6 @@ schema = BikaSchema.copy() + Schema((
     UIDReferenceField(
         'Invoice',
         allowed_types=('Invoice',),
-        relationship='AnalysisRequestInvoice',
         mode="rw",
         read_permission=View,
         write_permission=ModifyPortalContent,
@@ -1179,7 +1171,6 @@ schema = BikaSchema.copy() + Schema((
     UIDReferenceField(
         "DetachedFrom",
         allowed_types=("AnalysisRequest",),
-        relationship="AnalysisRequestDetachedFrom",
         mode="rw",
         read_permission=View,
         write_permission=ModifyPortalContent,

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2413</version>
+  <version>2415</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -307,6 +307,10 @@ def get_relationship_key(obj, field):
     # (<portal_type><field_name>, old_relationship_name)
     relationships = dict([
         ("AutoImportLogInstrument", "InstrumentImportLogs"),
+        ("AnalysisRequestProfiles", "AnalysisRequestAnalysisProfiles"),
+        ("AnalysisRequestSpecification", "AnalysisRequestAnalysisSpec"),
+        ("AnalysisRequestPublicationSpecification", "AnalysisRequestPublicationSpec"),
+        ("AnalysisRequestTemplate", "AnalysisRequestARTemplate"),
         ("ContactCCContact", "ContactContact"),
         ("DepartmentManager", "DepartmentLabContact"),
         ("InstrumentCalibrationWorker", "LabContactInstrumentCalibration"),

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -422,7 +422,6 @@ def purge_backreferences(tool):
     logger.info("Purge no longer required back-references ...")
     portal_types = [
         "Analysis",
-        "AnalysisRequest",
         "AnalysisService",
         "AnalysisSpec",
         "ARReport",
@@ -449,7 +448,7 @@ def purge_backreferences(tool):
             # reduce memory size of the transaction
             transaction.savepoint()
 
-        # Migrate the reference fields for current sample
+        # Purge back-references to current object
         obj = api.get_object(obj)
         purge_backreferences_to(obj)
 
@@ -550,3 +549,28 @@ def migrate_interpretationtemplate_item_to_container(tool):
 
     transaction.commit()
     logger.info("Migrate interpretationtemplates to be folderish [DONE]")
+
+
+def purge_backreferences_analysisrequest(tool):
+    """Purges back-references that are no longer required from AnalysisRequest
+    """
+    logger.info("Purge stale back-references from samples ...")
+    uc = api.get_tool("uid_catalog")
+    brains = uc(portal_type="AnalysisRequest")
+    total = len(brains)
+    for num, obj in enumerate(brains):
+        if num and num % 100 == 0:
+            logger.info("Processed objects: {}/{}".format(num, total))
+
+        if num and num % 1000 == 0:
+            # reduce memory size of the transaction
+            transaction.savepoint()
+
+        # Purge back-references to current object
+        obj = api.get_object(obj)
+        purge_backreferences_to(obj)
+
+        # Flush the object from memory
+        obj._p_deactivate()
+
+    logger.info("Purge stale back-references from samples [DONE]")

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -150,7 +150,7 @@
       description="Purge remaining back-references from AnalysisRequest types"
       source="2414"
       destination="2415"
-      handler="senaite.core.upgrade.v02_04_000.purge_backreferences"
+      handler="senaite.core.upgrade.v02_04_000.purge_backreferences_analysisrequest"
       profile="senaite.core:default"/>
 
 </configure>

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -143,4 +143,14 @@
       handler="senaite.core.upgrade.v02_04_000.migrate_interpretationtemplate_item_to_container"
       profile="senaite.core:default"/>
 
+  <!-- Purge remaining back-references from AnalysisRequest type
+       https://github.com/senaite/senaite.core/pull/2236 -->
+  <genericsetup:upgradeStep
+      title="SENAITE CORE 2.4.0: Purge remaining back-references from AnalysisRequest type"
+      description="Purge remaining back-references from AnalysisRequest types"
+      source="2414"
+      destination="2415"
+      handler="senaite.core.upgrade.v02_04_000.purge_backreferences"
+      profile="senaite.core:default"/>
+
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request purges remaining back-references to AnalysisRequest objects that are no longer required.

The following relationships have been kept, cause they are the only ones being used:

- `AnalysisRequestPrimaryAnalysisRequest`
- `AnalysisRequestAttachment`
- `AnalysisRequestParentAnalysisRequest`
- `AnalysisRequestRetracted`

## Current behavior before PR

Stale backreferences to AnalysisRequest objects

## Desired behavior after PR is merged

No stale backreferences to AnalysisRequest objects

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
