### PR TITLE
Fix default value of interim choices and allow empty selection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2237 Fix default value of interim choices and allow empty selection
 - #2234 Add interpretation template columns for assigned sampletypes and result text
 - #2234 Change base class for interpretation templates from Item -> Container
 - #2231 Cannot set conditions with a '<' char when others are from type "file"

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -983,6 +983,7 @@ class AnalysesView(ListingView):
                 continue
 
             interim_value = interim_field.get("value", "")
+            interim_allow_empty = interim_field.get("allow_empty") == "on"
             interim_unit = interim_field.get("unit", "")
             interim_formatted = formatDecimalMark(interim_value, self.dmk)
             interim_field["formatted_value"] = interim_formatted
@@ -1023,6 +1024,11 @@ class AnalysesView(ListingView):
                 # [{"ResultValue": value, "ResultText": text},]
                 headers = ["ResultValue", "ResultText"]
                 dl = map(lambda it: dict(zip(headers, it)), choices.items())
+                # Allow empty selection by adding an empty record to the list
+                if interim_allow_empty:
+                    empty = {"ResultValue": "", "ResultText": ""}
+                    dl = [empty] + list(dl)
+
                 item.setdefault("choices", {})[interim_keyword] = dl
 
                 # Set the text as the formatted value

--- a/src/bika/lims/browser/fields/interimfieldsfield.py
+++ b/src/bika/lims/browser/fields/interimfieldsfield.py
@@ -70,7 +70,7 @@ class InterimFieldsField(RecordsField):
         },
         "subfield_types": {
             "hidden": "boolean",
-            "value": "float",
+            "value": "string",
             "choices": "string",
             "result_type": "selection",
             "allow_empty": "boolean",

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2415</version>
+  <version>2416</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -593,10 +593,10 @@ def migrate_interim_values_to_string(tool):
         if num and num % 100 == 0:
             logger.info("Processed objects: {}/{}".format(num, total))
 
-        # Purge back-references to current object
+        # Migrate float values of interim fields
         obj = api.get_object(obj)
-
         interims = obj.getInterimFields()
+
         for interim in interims:
             value = interim.get("value")
             if type(value) is float:

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -586,7 +586,7 @@ def migrate_interim_values_to_string(tool):
     logger.info("Migrate interim values to string ...")
 
     uc = api.get_tool("uid_catalog")
-    brains = uc(portal_type="Analysis")
+    brains = uc(portal_type=["Analysis", "AnalysisService"])
     total = len(brains)
     for num, obj in enumerate(brains):
         if num and num % 100 == 0:
@@ -600,14 +600,16 @@ def migrate_interim_values_to_string(tool):
             value = interim.get("value")
             if type(value) is float:
                 interim["value"] = str(value)
-                logger.info("Converted interim value of %s from %f to %s"
-                            % (interim["keyword"], value, interim["value"]))
+                logger.info(
+                    "Converted float value for interim keyword '%s' %s -> '%s'"
+                    % (interim["keyword"], value, interim["value"]))
                 obj._p_changed = True
 
         if obj._p_changed:
             # set back modified interim fields
             obj.setInterimFields(interims)
-            logger.info("Updated interims for analysis %s" % api.get_path(obj))
+            logger.info("Updated interims for [%s] %s"
+                        % (api.get_portal_type(obj), api.get_path(obj)))
 
         if num and num % 1000 == 0:
             # reduce memory size of the transaction

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -586,7 +586,8 @@ def migrate_interim_values_to_string(tool):
     logger.info("Migrate interim values to string ...")
 
     uc = api.get_tool("uid_catalog")
-    brains = uc(portal_type=["Analysis", "AnalysisService"])
+    brains = uc(portal_type=["Analysis", "AnalysisService",
+                             "ReferenceAnalysis", "DuplicateAnalysis"])
     total = len(brains)
     for num, obj in enumerate(brains):
         if num and num % 100 == 0:

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -153,4 +153,12 @@
       handler="senaite.core.upgrade.v02_04_000.purge_backreferences_analysisrequest"
       profile="senaite.core:default"/>
 
+  <genericsetup:upgradeStep
+      title="SENAITE CORE 2.4.0: Convert interim values from type float to string"
+      description="Convert interim values from type float to string"
+      source="2415"
+      destination="2416"
+      handler="senaite.core.upgrade.v02_04_000.migrate_interim_values_to_string"
+      profile="senaite.core:default"/>
+
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the type of the interim field value from `float` to `string`.

## Current behavior before PR

Currently, the interim field value is of type `float`.

Apparently, the value happens also to be the default value:

<img width="1708" src="https://user-images.githubusercontent.com/713193/214077225-88744dcd-e46a-430b-a6ce-d04c77206ceb.png">

It is therefore not possible to set a default value if the control type is a selection list,
because the value is not properly converted in the analyses view to determine the selected option.

This resulted in an empty value if the default value was chosen.

Furthermore, the option `Allow empty` was ignored for choices

## Desired behavior after PR is merged

It is possible to set default values of type string, which makes it compatible for selection lists (or any kind of choices).

A migration step has been added to ensure all existing interim values are converted to strings.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
