### PR TITLE
Split the add sample's `ajax_form` function to make patching easier

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2238 Split the add sample's `ajax_form` function to make patching easier
 - #2234 Add interpretation template columns for assigned sampletypes and result text
 - #2234 Change base class for interpretation templates from Item -> Container
 - #2231 Cannot set conditions with a '<' char when others are from type "file"

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1585,6 +1585,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
         # Get AR required fields (including extended fields)
         fields = self.get_ar_fields()
+        required_keys = [field.getName() for field in fields if field.required]
 
         # extract records from request
         records = self.get_records()
@@ -1613,8 +1614,6 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             attachments = [self.to_attachment_record(f) for f in uploads]
 
             # Required fields and their values
-            required_keys = [field.getName() for field in fields
-                             if field.required]
             required_values = [record.get(key) for key in required_keys]
             required_fields = dict(zip(required_keys, required_values))
 

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1597,7 +1597,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         valid_records = []
 
         # Validate required fields
-        for n, record in enumerate(records):
+        for num, record in enumerate(records):
 
             # Process UID fields first and set their values to the linked field
             uid_fields = filter(lambda f: f.endswith("_uid"), record)
@@ -1678,7 +1678,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
             # If there are required fields missing, flag an error
             for field in missing:
-                fieldname = "{}-{}".format(field, n)
+                fieldname = "{}-{}".format(field, num)
                 msg = _("Field '{}' is required").format(safe_unicode(field))
                 fielderrors[fieldname] = msg
 

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1749,7 +1749,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         """Creates samples for the given records
         """
         samples = []
-        for num, record in enumerate(records):
+        for record in records:
             client_uid = record.get("Client")
             client = self.get_object_by_uid(client_uid)
             if not client:

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -429,7 +429,8 @@ class AnalysisRequestAddView(BrowserView):
         elif client == api.get_current_client():
             # Current user is a Client contact. Use current contact
             current_user = api.get_current_user()
-            return api.get_user_contact(current_user, contact_types=["Contact"])
+            return api.get_user_contact(current_user,
+                                        contact_types=["Contact"])
 
         return None
 
@@ -1053,7 +1054,9 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             "DateSampled": {"value": self.to_iso_date(obj.getDateSampled())},
             "SamplingDate": {"value": self.to_iso_date(obj.getSamplingDate())},
             "SampleType": self.to_field_value(sample_type),
-            "EnvironmentalConditions": {"value": obj.getEnvironmentalConditions()},
+            "EnvironmentalConditions": {
+                "value": obj.getEnvironmentalConditions(),
+            },
             "ClientSampleID": {"value": obj.getClientSampleID()},
             "ClientReference": {"value": obj.getClientReference()},
             "ClientOrderNumber": {"value": obj.getClientOrderNumber()},
@@ -1285,7 +1288,8 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             obj = self.get_object_by_uid(uid)
             if not obj:
                 continue
-            obj_info = self.get_object_info(obj, field_name, record=extra_fields)
+            obj_info = self.get_object_info(
+                obj, field_name, record=extra_fields)
             if not obj_info or "uid" not in obj_info:
                 continue
             metadata[key] = {obj_info["uid"]: obj_info}

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -36,7 +36,6 @@ from bika.lims.interfaces import IAddSampleObjectInfo
 from bika.lims.interfaces import IAddSampleRecordsValidator
 from bika.lims.interfaces import IGetDefaultFieldValueARAddHook
 from bika.lims.utils.analysisrequest import create_analysisrequest as crar
-from bika.lims.workflow import ActionHandlerPool
 from BTrees.OOBTree import OOBTree
 from DateTime import DateTime
 from plone import protect


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request splits the function `ajaxAnalysisRequestAddView.ajax_form` into two functions to make the patching easier. It also removes the `ActionHandlerPool`-thing dependency

## Current behavior before PR

On single long function

## Desired behavior after PR is merged

Two less complex functions

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
