### PR TITLE
Allow to create multiple samples for each sample record in add form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2238 Split the add sample's `ajax_form` function to make patching easier
 - #2234 Add interpretation template columns for assigned sampletypes and result text
 - #2234 Change base class for interpretation templates from Item -> Container
 - #2231 Cannot set conditions with a '<' char when others are from type "file"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2239 Allow to create multiple samples for each sample record in add form
 - #2238 Split the add sample's `ajax_form` function to make patching easier
 - #2234 Add interpretation template columns for assigned sampletypes and result text
 - #2234 Change base class for interpretation templates from Item -> Container

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1754,15 +1754,19 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             # Pop the attachments
             attachments = record.pop("attachments", [])
 
-            # Create the Analysis Request
-            sample = crar(client, self.request, record)
+            # Create as many samples as required
+            num_samples = record.get("NumSamples", 1)
+            num_samples = api.to_int(num_samples, default=1)
+            num_samples = num_samples if num_samples > 0 else 1
+            for idx in range(num_samples):
+                sample = crar(client, self.request, record)
 
-            # Create the attachments
-            for attachment_record in attachments:
-                self.create_attachment(sample, attachment_record)
+                # Create the attachments
+                for attachment_record in attachments:
+                    self.create_attachment(sample, attachment_record)
 
-            # Add the sample
-            samples.append(sample)
+                # Add the sample
+                samples.append(sample)
 
         return samples
 

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1585,6 +1585,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
         # Get AR required fields (including extended fields)
         fields = self.get_ar_fields()
+        required_keys = [field.getName() for field in fields if field.required]
 
         # extract records from request
         records = self.get_records()
@@ -1613,8 +1614,6 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             attachments = [self.to_attachment_record(f) for f in uploads]
 
             # Required fields and their values
-            required_keys = [field.getName() for field in fields
-                             if field.required]
             required_values = [record.get(key) for key in required_keys]
             required_fields = dict(zip(required_keys, required_values))
 

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1655,9 +1655,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                     fielderrors["Contact"] = msg
 
             # Check if the number of samples per record is permitted
-            num_samples = record.get("NumSamples", 1)
-            num_samples = api.to_int(num_samples, default=1)
-            num_samples = num_samples if num_samples > 0 else 1
+            num_samples = self.get_num_samples(record)
             if num_samples > max_samples_record:
                 msg = _(u"error_analyssirequest_numsamples_above_max",
                         u"The number of samples to create for the record "
@@ -1775,9 +1773,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             attachments = record.pop("attachments", [])
 
             # Create as many samples as required
-            num_samples = record.get("NumSamples", 1)
-            num_samples = api.to_int(num_samples, default=1)
-            num_samples = num_samples if num_samples > 0 else 1
+            num_samples = self.get_num_samples(record)
             for idx in range(num_samples):
                 sample = crar(client, self.request, record)
 
@@ -1789,6 +1785,13 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                 samples.append(sample)
 
         return samples
+
+    def get_num_samples(self, record):
+        """Return the number of samples to create for the given record
+        """
+        num_samples = record.get("NumSamples", 1)
+        num_samples = api.to_int(num_samples, default=1)
+        return num_samples if num_samples > 0 else 1
 
     def get_max_samples_per_record(self):
         """Returns the maximum number of samples that can be created for each

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1597,7 +1597,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         valid_records = []
 
         # Validate required fields
-        for n, record in enumerate(records):
+        for num, record in enumerate(records):
 
             # Process UID fields first and set their values to the linked field
             uid_fields = filter(lambda f: f.endswith("_uid"), record)
@@ -1678,7 +1678,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
             # If there are required fields missing, flag an error
             for field in missing:
-                fieldname = "{}-{}".format(field, n)
+                fieldname = "{}-{}".format(field, num)
                 msg = _("Field '{}' is required").format(safe_unicode(field))
                 fielderrors[fieldname] = msg
 

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -56,7 +56,8 @@ from zope.interface import implements
 from zope.publisher.interfaces import IPublishTraverse
 
 AR_CONFIGURATION_STORAGE = "bika.lims.browser.analysisrequest.manage.add"
-SKIP_FIELD_ON_COPY = ["Sample", "PrimaryAnalysisRequest", "Remarks"]
+SKIP_FIELD_ON_COPY = ["Sample", "PrimaryAnalysisRequest", "Remarks",
+                      "NumSamples"]
 
 
 def returns_json(func):

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1749,7 +1749,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         """Creates samples for the given records
         """
         samples = []
-        for num, record in enumerate(records):
+        for record in records:
             client_uid = record.get("Client")
             client = self.get_object_by_uid(client_uid)
             if not client:

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -429,7 +429,8 @@ class AnalysisRequestAddView(BrowserView):
         elif client == api.get_current_client():
             # Current user is a Client contact. Use current contact
             current_user = api.get_current_user()
-            return api.get_user_contact(current_user, contact_types=["Contact"])
+            return api.get_user_contact(current_user,
+                                        contact_types=["Contact"])
 
         return None
 
@@ -1053,7 +1054,9 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             "DateSampled": {"value": self.to_iso_date(obj.getDateSampled())},
             "SamplingDate": {"value": self.to_iso_date(obj.getSamplingDate())},
             "SampleType": self.to_field_value(sample_type),
-            "EnvironmentalConditions": {"value": obj.getEnvironmentalConditions()},
+            "EnvironmentalConditions": {
+                "value": obj.getEnvironmentalConditions(),
+            },
             "ClientSampleID": {"value": obj.getClientSampleID()},
             "ClientReference": {"value": obj.getClientReference()},
             "ClientOrderNumber": {"value": obj.getClientOrderNumber()},
@@ -1285,7 +1288,8 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             obj = self.get_object_by_uid(uid)
             if not obj:
                 continue
-            obj_info = self.get_object_info(obj, field_name, record=extra_fields)
+            obj_info = self.get_object_info(
+                obj, field_name, record=extra_fields)
             if not obj_info or "uid" not in obj_info:
                 continue
             metadata[key] = {obj_info["uid"]: obj_info}

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1666,7 +1666,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                         u"'Sample ${record_index}' (${num_samples}) is above "
                         u"${max_num_samples}",
                         mapping={
-                            "record_index": n+1,
+                            "record_index": num+1,
                             "num_samples": num_samples,
                             "max_num_samples": max_samples_record,
                         })
@@ -1799,6 +1799,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         num_samples = api.to_int(num_samples, default=1)
         return num_samples if num_samples > 0 else 1
 
+    @viewcache.memoize
     def get_max_samples_per_record(self):
         """Returns the maximum number of samples that can be created for each
         record/column from the sample add form

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -36,7 +36,6 @@ from bika.lims.interfaces import IAddSampleObjectInfo
 from bika.lims.interfaces import IAddSampleRecordsValidator
 from bika.lims.interfaces import IGetDefaultFieldValueARAddHook
 from bika.lims.utils.analysisrequest import create_analysisrequest as crar
-from bika.lims.workflow import ActionHandlerPool
 from BTrees.OOBTree import OOBTree
 from DateTime import DateTime
 from plone import protect

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -1286,7 +1286,6 @@ schema = BikaSchema.copy() + Schema((
                 u"description_analysisrequest_numsamples",
                 default=u"Number of samples to create with the information "
                         u"provided"),
-            maxlength=3,
             # This field is only visible in add sample form
             visible={
                 "add": "edit",

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -25,6 +25,8 @@ from decimal import Decimal
 
 from bika.lims.browser.fields.uidreferencefield import get_backreferences
 from Products.Archetypes.config import UID_CATALOG
+from Products.Archetypes.Field import IntegerField
+from Products.Archetypes.Widget import IntegerWidget
 from six.moves.urllib.parse import urljoin
 
 from AccessControl import ClassSecurityInfo
@@ -1269,7 +1271,32 @@ schema = BikaSchema.copy() + Schema((
     RecordsField(
         "ServiceConditions",
         widget=ComputedWidget(visible=False)
-    )
+    ),
+
+    # Number of samples to create on add form
+    IntegerField(
+        "NumSamples",
+        default=1,
+        widget=IntegerWidget(
+            label=_(
+                u"label_analysisrequest_numsamples",
+                default=u"Number of samples"
+            ),
+            description=_(
+                u"description_analysisrequest_numsamples",
+                default=u"Number of samples to create with the information "
+                        u"provided"),
+            maxlength=3,
+            # This field is only visible in add sample form
+            visible={
+                "add": "edit",
+                "view": "invisible",
+                "header_table": "invisible",
+                "secondary": "invisible",
+            },
+            render_own_label=True,
+        ),
+    ),
 )
 )
 

--- a/src/bika/lims/content/bikasetup.py
+++ b/src/bika/lims/content/bikasetup.py
@@ -1183,7 +1183,7 @@ class BikaSetup(folder.ATFolder):
         # setup is `None` during initial site content structure installation
         if setup:
             return setup.getMaxNumberOfSamplesAdd()
-        return False
+        return self.getField("MaxNumberOfSamplesAdd").default
 
     def setMaxNumberOfSamplesAdd(self, value):
         """Set the value in the senaite setup

--- a/src/bika/lims/content/bikasetup.py
+++ b/src/bika/lims/content/bikasetup.py
@@ -946,6 +946,25 @@ schema = BikaFolderSchema.copy() + Schema((
             description=_("Default value of the 'Sample count' when users click 'ADD' button to create new Samples"),
         )
     ),
+    IntegerField(
+        "MaxNumberOfSamplesAdd",
+        schemata="Analyses",
+        required=0,
+        default=10,
+        widget=IntegerWidget(
+            label=_(
+                u"label_senaitesetup_maxnumberofsamplesadd",
+                default=u"Maximum value for 'Number of samples' field on "
+                        u"registration"
+            ),
+            description=_(
+                u"description_senaitesetup_maxnumberofsamplesadd",
+                default=u"Maximum number of samples that can be created in "
+                        u"accordance with the value set for the field 'Number "
+                        u"of samples' on the sample registration form"
+            ),
+        )
+    ),
 ))
 
 schema['title'].validators = ()
@@ -1156,6 +1175,23 @@ class BikaSetup(folder.ATFolder):
         # setup is `None` during initial site content structure installation
         if setup:
             setup.setSampleAnalysesRequired(value)
+
+    def getMaxNumberOfSamplesAdd(self):
+        """Get the value from the senaite setup
+        """
+        setup = api.get_senaite_setup()
+        # setup is `None` during initial site content structure installation
+        if setup:
+            return setup.getMaxNumberOfSamplesAdd()
+        return False
+
+    def setMaxNumberOfSamplesAdd(self, value):
+        """Set the value in the senaite setup
+        """
+        setup = api.get_senaite_setup()
+        # setup is `None` during initial site content structure installation
+        if setup:
+            setup.setMaxNumberOfSamplesAdd(value)
 
 
 registerType(BikaSetup, PROJECTNAME)

--- a/src/senaite/core/content/senaitesetup.py
+++ b/src/senaite/core/content/senaitesetup.py
@@ -124,10 +124,31 @@ class ISetupSchema(model.Schema):
         ),
         default=True,
     )
+    max_number_of_samples_add = schema.Int(
+        title=_(
+            u"label_senaitesetup_maxnumberofsamplesadd",
+            default=u"Maximum value for 'Number of samples' field on "
+                    u"registration"
+        ),
+        description=_(
+            u"description_senaitesetup_maxnumberofsamplesadd",
+            default=u"Maximum number of samples that can be created in "
+                    u"accordance with the value set for the field 'Number of "
+                    u"samples' on the sample registration form"
+        ),
+        default=10
+    )
 
     ###
     # Fieldsets
     ###
+    model.fieldset(
+        "samples",
+        label=_("label_senaitesetup_fieldset_samples", default=u"Samples"),
+        fields=[
+            "max_number_of_samples_add",
+        ]
+    )
     model.fieldset(
         "analyses",
         label=_("label_senaitesetup_fieldset_analyses", default=u"Analyses"),
@@ -284,4 +305,22 @@ class Setup(Container):
         """Allow/Disallow to create samples without analyses
         """
         mutator = self.mutator("sample_analyses_required")
+        return mutator(self, value)
+
+    @security.protected(permissions.View)
+    def getMaxNumberOfSamplesAdd(self):
+        """Returns the maximum number of samples that can be created for each
+        column in sample add form in accordance with the value set for the
+        field 'Number of samples'
+        """
+        accessor = self.accessor("max_number_of_samples_add")
+        return accessor(self)
+
+    @security.protected(permissions.ModifyPortalContent)
+    def setMaxNumberOfSamplesAdd(self, value):
+        """Sets the maximum number of samples that can be created for each
+        column in sample add form in accordance with the value set for the
+        field 'Number of samples'
+        """
+        mutator = self.mutator("max_number_of_samples_add")
         return mutator(self, value)

--- a/src/senaite/core/content/senaitesetup.py
+++ b/src/senaite/core/content/senaitesetup.py
@@ -314,7 +314,7 @@ class Setup(Container):
         field 'Number of samples'
         """
         accessor = self.accessor("max_number_of_samples_add")
-        return accessor(self)
+        return api.to_int(accessor(self))
 
     @security.protected(permissions.ModifyPortalContent)
     def setMaxNumberOfSamplesAdd(self, value):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Accept https://github.com/senaite/senaite.core/pull/2238 first**

This Pull Request adds a new field in Sample Add form that allows to create multiple samples for each *sample* record at once:

![Captura de 2023-01-23 16-02-08](https://user-images.githubusercontent.com/832627/214573570-68872535-e2ab-4ad1-ad9f-06006cfe5b2e.png)

As well as a setting in Setup to configure the maximum number of samples that can be created per record (defaults to 10):

![Captura de 2023-01-25 14-16-18](https://user-images.githubusercontent.com/832627/214573636-bc3c4ef6-4e85-465c-8d6a-d134a151ca8d.png)

If the value set in add form exceeds the maximum, an error message is displayed:

![Captura de 2023-01-25 14-16-00](https://user-images.githubusercontent.com/832627/214573818-9d7862e3-3469-4871-907e-e1bb4ff42b4d.png)

## Current behavior before PR

Is not possible to create more than one sample per column/record in sample add form

## Desired behavior after PR is merged

Is possible to create more than one sample per column/record in sample add form

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
