### PR TITLE
Explicitly set client on sample creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2240 Explicitly set client on sample creation
 - #2237 Fix default value of interim choices and allow empty selection
 - #2234 Add interpretation template columns for assigned sampletypes and result text
 - #2234 Change base class for interpretation templates from Item -> Container

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -71,6 +71,11 @@ def create_analysisrequest(client, request, values, analyses=None,
     # Don't pollute the dict param passed in
     values = dict(values.items())
 
+    # Explicitly set client instead of relying on the passed in vales.
+    # This might happen if this function is called programmatically outside of
+    # the sample add form.
+    values["Client"] = client
+
     # Resolve the Service uids of analyses to be added in the Sample. Values
     # passed-in might contain Profiles and also values that are not uids. Also,
     # additional analyses can be passed-in through either values or services

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -640,14 +640,13 @@ def ensure_sample_client_fields_are_set(portal):
             transaction.savepoint()
 
         obj = api.get_object(obj)
-        field = obj.getField("Client")
-        value = field.get(obj)
+        client_uid = obj.getRawClient()
 
-        if not value:
+        if not client_uid:
             client = obj.getClient()
             logger.info("Set empty client field of sample %s -> %s" % (
                 api.get_path(obj), api.get_path(client)))
-            field.set(obj, client)
+            obj.setClient(client)
 
         # Flush the object from memory
         obj._p_deactivate()

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -161,4 +161,12 @@
       handler="senaite.core.upgrade.v02_04_000.migrate_interim_values_to_string"
       profile="senaite.core:default"/>
 
+  <genericsetup:upgradeStep
+      title="SENAITE CORE 2.4.0: Ensure sample client fields are set"
+      description="Iterate through all samples and check if the `Client` schema field is set"
+      source="2416"
+      destination="2417"
+      handler="senaite.core.upgrade.v02_04_000.ensure_sample_client_fields_are_set"
+      profile="senaite.core:default"/>
+
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR ensures that the `Client` schema field is set properly when creating new samples with `create_analysisrequest`.

## Current behavior before PR

If the function `create_analysisrequest` is called programmatically outside the sample add form, the `Client` value was expected to be passed in with the `values`, instead of using it from the first parameter:

```python
def create_analysisrequest(client, request, values, analyses=None,
                           results_ranges=None, prices=None):

```

As a result, these samples couldn't be copied:

<img width="1225" alt="AR-Add" src="https://user-images.githubusercontent.com/713193/214836304-3df1685f-4ab6-459f-b766-4e8ebf50d007.png">



## Desired behavior after PR is merged

The client field is explicitly set to the client parameter.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
