### PR TITLE
Little improvement of getRaw function from legacy uidreference field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2241 Little improvement of getRaw function from legacy uidreference field
 - #2240 Explicitly set client on sample creation
 - #2237 Fix default value of interim choices and allow empty selection
 - #2234 Add interpretation template columns for assigned sampletypes and result text


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds a little improvement to make the `getRaw` function from legacy uidreference field a bit more efficient

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
