### PR TITLE
Remove stale catalog brains in upgrade steps

### DIFF
--- a/src/senaite/core/upgrade/utils.py
+++ b/src/senaite/core/upgrade/utils.py
@@ -368,3 +368,20 @@ def delete_object(obj):
     uncatalog_object(obj)
     parent = aq_parent(obj)
     parent._delObject(obj.getId(), suppress_events=True)
+
+
+def uncatalog_brain(brain):
+    """Uncatalog a stale catalog entry
+    """
+    if not api.is_brain(brain):
+        return False
+
+    catalog = brain.aq_parent
+    uid = brain.UID
+    path = brain.getPath()
+    logger.warn(80*"*")
+    logger.warn("Removing stale catalog entry for catalog %s: %s -> %s"
+                % (catalog.getId(), uid, path))
+    logger.warn(80*"*")
+    catalog.uncatalog_object(path)
+    return True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes stale catalog brains if no object can be retrieved.

## Current behavior before PR

Upgrade steps may fail if stale catalog entries exist, e.g. in UID catalog

## Desired behavior after PR is merged

Upgrade steps remove stale catalog entries, e.g. from UID catalog

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
