### PR TITLE
Add ".pdf" extension to filenames for productivity reports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2243 Add ".pdf" extension to filenames for productivity reports
 - #2239 Allow to create multiple samples for each sample record in add form
 - #2241 Little improvement of getRaw function from legacy uidreference field
 - #2238 Split the add sample's `ajax_form` function to make patching easier

--- a/src/bika/lims/browser/reports/__init__.py
+++ b/src/bika/lims/browser/reports/__init__.py
@@ -32,12 +32,9 @@ from bika.lims.interfaces import IProductivityReport
 from bika.lims.utils import createPdf
 from bika.lims.utils import getUsers
 from bika.lims.utils import logged_in_client
-from bika.lims.utils import to_unicode as _u
-from bika.lims.utils import to_utf8 as _c
 from DateTime import DateTime
 from plone.app.layout.globals.interfaces import IViewView
 from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.utils import _createObjectByType
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from senaite.core.catalog import REPORT_CATALOG
 from zope.component import getAdapters

--- a/src/bika/lims/browser/reports/__init__.py
+++ b/src/bika/lims/browser/reports/__init__.py
@@ -20,7 +20,9 @@
 
 import importlib
 import os
+from datetime import datetime
 
+from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser import BrowserView
 from bika.lims.browser.bika_listing import BikaListingView
@@ -288,30 +290,27 @@ class SubmitForm(BrowserView):
         framed_output = self.frame_template()
 
         # this is the good part
-        result = createPdf(framed_output)
+        pdf = createPdf(framed_output)
 
         # remove temporary files
         for f in self.request['to_remove']:
             os.remove(f)
 
-        if result:
-            # Create new report object
-            reportid = self.context.generateUniqueId('Report')
-            report = _createObjectByType("Report", self.context, reportid)
-            report.edit(Client=clientuid)
-            report.processForm()
+        if not pdf:
+            return
 
-            # write pdf to report object
-            report.edit(title=output['report_title'], ReportFile=result)
-            report.reindexObject()
+        # Create new report object
+        title = output["report_title"]
+        data = {"title": title, "Client": clientuid, "ReportFile": pdf}
+        api.create(self.context, "Report", **data)
 
-            fn = "%s - %s" % (self.date.strftime(self.date_format_short),
-                              _u(output['report_title']))
+        now = datetime.now().strftime("%Y%m%d")
+        fn = "{}-{}.pdf".format(now, title)
 
-            setheader = self.request.RESPONSE.setHeader
-            setheader('Content-Type', 'application/pdf')
-            setheader("Content-Disposition",
-                      "attachment;filename=\"%s\"" % _c(fn))
-            self.request.RESPONSE.write(result)
-
-        return
+        setheader = self.request.response.setHeader
+        setheader("Content-Type", "application/pdf")
+        setheader("Content-Disposition", "attachment; filename=\"%s\"" % fn)
+        setheader("Content-Length", len(pdf))
+        setheader("Cache-Control", "no-store")
+        setheader("Pragma", "no-cache")
+        self.request.response.write(pdf)

--- a/src/bika/lims/browser/reports/__init__.py
+++ b/src/bika/lims/browser/reports/__init__.py
@@ -301,7 +301,7 @@ class SubmitForm(BrowserView):
         data = {"title": title, "Client": clientuid, "ReportFile": pdf}
         api.create(self.context, "Report", **data)
 
-        now = datetime.now().strftime("%Y%m%d")
+        now = datetime.now().strftime("%y%m%d%H%M%S")
         fn = "{}-{}.pdf".format(now, title)
 
         setheader = self.request.response.setHeader


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds the ".pdf" suffix to the filenames for productivity reports

## Current behavior before PR

Filenames of productivity reports without ".pdf" extension

## Desired behavior after PR is merged

Filenames of productivity reports with ".pdf" extension

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
