### PR TITLE
Fix metadata version to 2417

### DIFF
--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2416</version>
+  <version>2417</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the metadata version to `2417

## Current behavior before PR

 metadata version to `2416` was used

## Desired behavior after PR is merged

 metadata version to `2417` is used

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
