### PR TITLE
Add missing translation for "Show more" (from app.listing)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2245 Add missing translation for "Show more" (from app.listing)
 - #2239 Allow to create multiple samples for each sample record in add form
 - #2241 Little improvement of getRaw function from legacy uidreference field
 - #2238 Split the add sample's `ajax_form` function to make patching easier

--- a/src/senaite/core/locales/ca/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ca/LC_MESSAGES/senaite.core.po
@@ -1164,6 +1164,10 @@ msgstr ""
 msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
+# senaite.app.listing: Show more
+msgid "Show more"
+msgstr "Mostra'n més"
+
 #: senaite/core/browser/samples/view.py:140
 msgid "Client"
 msgstr "Client"

--- a/src/senaite/core/locales/es/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/es/LC_MESSAGES/senaite.core.po
@@ -1167,6 +1167,10 @@ msgstr "Clic para desplegar esta categoría"
 msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr "Haga clic para alternar la visibilidad o arrastre y suelte para cambiar el orden"
 
+# senaite.app.listing: Show more
+msgid "Show more"
+msgstr "Mostrar más"
+
 #: senaite/core/browser/samples/view.py:140
 msgid "Client"
 msgstr "Cliente"

--- a/src/senaite/core/locales/senaite.core-manual.pot
+++ b/src/senaite/core/locales/senaite.core-manual.pot
@@ -53,6 +53,14 @@ msgstr ""
 msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
 
+# senaite.app.listing: Show more
+msgid "Show more"
+msgstr ""
+
+# senaite.app.listing: Export
+msgid "Export"
+msgstr ""
+
 # senaite.core.browser.modals.templates.create_worksheet.pt
 msgid "Select all"
 msgstr ""


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds two strings from app.listing that are not included in locales

## Current behavior before PR

"Show more" button from listings is not translated

## Desired behavior after PR is merged

"Show more" button from listings is translated

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
