### PR TITLE
Fix `AttributeError` when running upgrade 240x with stale brains

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2247 Fix `AttributeError` when running upgrade 240x with stale brains
 - #2246 Update ReactJS to version 18.2.0
 - #2245 Add missing translation for "Show more" (from app.listing)
 - #2243 Add ".pdf" extension to filenames for productivity reports

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -169,8 +169,9 @@ def fix_traceback_retract_dl(tool):
             # reduce memory size of the transaction
             transaction.savepoint()
 
-        obj = api.get_object(brain)
-        if not obj:
+        try:
+            obj = api.get_object(brain)
+        except AttributeError:
             uncatalog_brain(brain)
             continue
 
@@ -405,8 +406,9 @@ def rename_retestof_relationship(tool):
             transaction.savepoint()
 
         # find out if the current analysis is a retest
-        obj = api.get_object(brain)
-        if not obj:
+        try:
+            obj = api.get_object(brain)
+        except AttributeError:
             uncatalog_brain(brain)
             continue
 
@@ -461,10 +463,12 @@ def purge_backreferences(tool):
             transaction.savepoint()
 
         # Purge back-references to current object
-        obj = api.get_object(brain)
-        if not obj:
+        try:
+            obj = api.get_object(brain)
+        except AttributeError:
             uncatalog_brain(brain)
             continue
+
         purge_backreferences_to(obj)
 
         # Flush the object from memory
@@ -582,10 +586,12 @@ def purge_backreferences_analysisrequest(tool):
             transaction.savepoint()
 
         # Purge back-references to current object
-        obj = api.get_object(brain)
-        if not obj:
+        try:
+            obj = api.get_object(brain)
+        except AttributeError:
             uncatalog_brain(brain)
             continue
+
         purge_backreferences_to(obj)
 
         # Flush the object from memory
@@ -608,10 +614,12 @@ def migrate_interim_values_to_string(tool):
             logger.info("Processed objects: {}/{}".format(num, total))
 
         # Migrate float values of interim fields
-        obj = api.get_object(brain)
-        if not obj:
+        try:
+            obj = api.get_object(brain)
+        except AttributeError:
             uncatalog_brain(brain)
             continue
+
         interims = obj.getInterimFields()
 
         for interim in interims:
@@ -656,8 +664,9 @@ def ensure_sample_client_fields_are_set(portal):
             # reduce memory size of the transaction
             transaction.savepoint()
 
-        obj = api.get_object(brain)
-        if not obj:
+        try:
+            obj = api.get_object(brain)
+        except AttributeError:
             uncatalog_brain(brain)
             continue
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes an `AttributeError` that arises when running some upgrade steps 240x when orphan brains are found on searches against catalogs

## Current behavior before PR

`AttributeError` when running an upgrade step 240x

## Desired behavior after PR is merged

No `AttributeError` when running an upgrade step 240x

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
