### PR TITLE
Fix AttributeError in grade step 2416

### DIFF
--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -616,11 +616,10 @@ def migrate_interim_values_to_string(tool):
         # Migrate float values of interim fields
         try:
             obj = api.get_object(brain)
+            interims = obj.getInterimFields()
         except AttributeError:
             uncatalog_brain(brain)
             continue
-
-        interims = obj.getInterimFields()
 
         for interim in interims:
             value = interim.get("value")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the following `AttributeError` when the upgrade step `2416` is run:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.GenericSetup.tool, line 1135, in manage_doUpgrades
  Module Products.GenericSetup.upgrade, line 185, in doStep
  Module senaite.core.upgrade.v02_04_000, line 623, in migrate_interim_values_to_string
AttributeError: 'NoneType' object has no attribute 'getInterimFields'
```

## Current behavior before PR

Stale Analyses brain let the upgrade step fail

## Desired behavior after PR is merged

Stale Analyses brain are removed and the upgrade procedure continues

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
