### PR TITLE
Fix APIError: None is not supported (upgrade 1.3.6)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #2249 Fix APIError: None is not supported (upgrade 1.3.6)
 - #2198 Use portal as relative path for sticker icons (#2197 port)
 - #2108 Replace ParentAnalysisRequest ReferenceField by UIDReferenceField (#2069 port)
 - #2107 Replace Worksheet's Analysis ReferenceField by UIDReferenceField (#2022 port)

--- a/bika/lims/upgrade/v01_03_006.py
+++ b/bika/lims/upgrade/v01_03_006.py
@@ -142,6 +142,9 @@ def fix_worksheet_analyses(worksheet):
     """
     # Get the referenced analyses via relationship
     analyses = worksheet.getRefs(relationship="WorksheetAnalysis")
+    # Purge non-valid records
+    # Fixes APIError: None is not supported
+    analyses = filter(None, analyses)
     analyses_uids = [api.get_uid(an) for an in analyses]
 
     new_layout = []


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes an `APIError: None is not supported.` that arises when running the upgrade step 1.3.6 if there are corrupted relationships between worksheets and analyses

## Current behavior before PR

```
...
2023-02-12T18:40:56 INFO senaite.core Processed worksheets: 7970/9503
2023-02-12T18:40:59 INFO senaite.core Processed worksheets: 7980/9503
2023-02-12T18:41:02 INFO senaite.core Processed worksheets: 7990/9503
2023-02-12T18:41:05 ERROR Zope.SiteErrorLog 1676220065.520.77390633796 http://localhost:8099/senaite/portal_setup/manage_doUpgrades
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Products.GenericSetup.tool, line 1092, in manage_doUpgrades
  Module Products.GenericSetup.upgrade, line 166, in doStep
  Module bika.lims.upgrade, line 68, in wrap_func_args
  Module bika.lims.upgrade.v01_03_006, line 64, in upgrade
  Module bika.lims.upgrade.v01_03_006, line 135, in fix_worksheets_analyses
  Module bika.lims.upgrade.v01_03_006, line 145, in fix_worksheet_analyses
  Module bika.lims.api, line 431, in get_uid
  Module bika.lims.api, line 241, in get_object
  Module bika.lims.api, line 204, in fail
APIError: None is not supported.
```

## Desired behavior after PR is merged

The upgrade completes successfully

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
