### PR TITLE
Fix cannot set string result with greater than ">" or less than "<" symbols

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2250 Fix cannot set string result with greater or less than symbols
 - #2247 Fix `AttributeError` when running upgrade 240x with stale brains
 - #2246 Update ReactJS to version 18.2.0
 - #2245 Add missing translation for "Show more" (from app.listing)

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -473,8 +473,11 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         # Ensure result integrity regards to None, empty and 0 values
         val = str("" if not value and value != 0 else value).strip()
 
+        # Check if an string result is expected
+        string_result = self.getStringResult()
+
         # UDL/LDL directly entered in the results field
-        if val and val[0] in [LDL, UDL]:
+        if not string_result and val[:1] in [LDL, UDL]:
             # Strip off the detection limit operand from the result
             operand = val[0]
             val = val.replace(operand, "", 1).strip()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the system accepts the symbols "<" and ">" in results entry when the analysis is configured to accept the result as an string

## Current behavior before PR

Symbol "<" and ">" are not accepted in results entry for analyses that admit string as a result

## Desired behavior after PR is merged

Symbol "<" and ">" are accepted in results entry for analyses that admit string as a result

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
