### PR TITLE
Fix UnicodeDecodeError in report email form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2251 Fix UnicodeDecodeError in report email form
 - #2247 Fix `AttributeError` when running upgrade 240x with stale brains
 - #2246 Update ReactJS to version 18.2.0
 - #2245 Add missing translation for "Show more" (from app.listing)

--- a/src/bika/lims/browser/publish/emailview.py
+++ b/src/bika/lims/browser/publish/emailview.py
@@ -300,7 +300,7 @@ class EmailView(BrowserView):
         subject = self.request.get("subject", None)
         if subject is not None:
             return subject
-        subject = self.context.translate(_("Analysis Results for {}"))
+        subject = self.context.translate(_(u"Analysis Results for {}"))
         return subject.format(self.client_name)
 
     @property
@@ -379,13 +379,15 @@ class EmailView(BrowserView):
     def lab_address(self):
         """Returns the laboratory print address
         """
-        return "<br/>".join(self.laboratory.getPrintAddress())
+        lab_address = self.laboratory.getPrintAddress()
+        return u"<br/>".join(map(api.safe_unicode, lab_address))
 
     @property
     def lab_name(self):
         """Returns the laboratory name
         """
-        return self.laboratory.getName()
+        lab_name = self.laboratory.getName()
+        return api.safe_unicode(lab_name)
 
     @property
     def exit_url(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the following Traceback if the lab name, address or the client name contains uniode characters:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module bika.lims.browser.publish.emailview, line 97, in __call__
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 215, in render
  Module chameleon.template, line 192, in render
  Module 744d7350108d6559e9bff22e5ce859da, line 1924, in render
  Module 2b8c982ad0c9a5179689105a88585c31, line 1449, in render_master
  Module 2b8c982ad0c9a5179689105a88585c31, line 407, in render_content
  Module 744d7350108d6559e9bff22e5ce859da, line 1137, in __fill_content_core
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 217, in _eval
  Module zope.tales.expressions, line 153, in _eval
  Module Products.PageTemplates.Expressions, line 134, in trustedBoboAwareZopeTraverse
  Module zope.traversing.adapters, line 156, in traversePathElement
   - __traceback_info__: (<Products.Five.browser.metaconfigure.EmailView object at 0x11c102390>, 'email_body')
  Module zope.traversing.adapters, line 47, in traverse
   - __traceback_info__: (<Products.Five.browser.metaconfigure.EmailView object at 0x11c102390>, 'email_body', [])
  Module bika.lims.browser.publish.emailview, line 319, in email_body
  Module bika.lims.browser.publish.emailview, line 385, in lab_address
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 0: ordinal not in range(128)
```

## Current behavior before PR

Traceback occurs in email form if e.g. the laboratory contains unicode characters

## Desired behavior after PR is merged

No Traceback occurs in email form if e.g. the laboratory contains unicode characters


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
