### PR TITLE
Fix TypeError when accessing the DX setup folder

### DIFF
--- a/src/bika/lims/content/bikasetup.py
+++ b/src/bika/lims/content/bikasetup.py
@@ -1191,6 +1191,8 @@ class BikaSetup(folder.ATFolder):
         setup = api.get_senaite_setup()
         # setup is `None` during initial site content structure installation
         if setup:
+            # we get a string value here!
+            value = api.to_float(value, default=10.0)
             setup.setMaxNumberOfSamplesAdd(value)
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an error that was introduced with https://github.com/senaite/senaite.core/pull/2239 when accessing the new setup object:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module plone.z3cform.layout, line 63, in __call__
  Module plone.z3cform.layout, line 47, in update
  Module plone.dexterity.browser.edit, line 55, in update
  Module plone.z3cform.fieldsets.extensible, line 65, in update
  Module plone.z3cform.patch, line 30, in GroupForm_update
  Module z3c.form.group, line 141, in update
  Module z3c.form.group, line 52, in update
  Module z3c.form.group, line 48, in updateWidgets
  Module z3c.form.field, line 277, in update
  Module z3c.form.browser.text, line 36, in update
  Module z3c.form.browser.widget, line 171, in update
  Module Products.CMFPlone.patches.z3c_form, line 47, in _wrapped
  Module z3c.form.widget, line 132, in update
  Module z3c.form.converter, line 116, in toWidgetValue
  Module zope.i18n.format, line 484, in format
TypeError: a float is required
```


## Current behavior before PR

The field in the new DX setup expects a float value, but got a string from the custom setter located in the old setup:

https://github.com/senaite/senaite.core/blob/2.x/src/bika/lims/content/bikasetup.py#L1188


## Desired behavior after PR is merged

Value is correctly converted to a float before setting it to the new DX setup

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
