### PR TITLE
Allow to flush referencefields in sample header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2253 Allow to flush referencefields in sample header
 - #2251 Fix UnicodeDecodeError in report email form
 - #2250 Fix cannot set string result with greater or less than symbols
 - #2247 Fix `AttributeError` when running upgrade 240x with stale brains

--- a/src/senaite/core/browser/viewlets/templates/sampleheader.pt
+++ b/src/senaite/core/browser/viewlets/templates/sampleheader.pt
@@ -1,7 +1,7 @@
 <div id="senaite-sampleheader"
      tal:define="senaite_view python:context.restrictedTraverse('@@senaite_view');
                  test nocall:senaite_view/test;
-                 errors python:options.get('errors', {});
+                 errors python:options.get('errors', {}) or {};
                  config python:view.get_configuration();
                  prominent_columns python:config.get('prominent_columns');
                  standard_columns python:config.get('standard_columns');


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue in the sample header form with single reference fields.

## Current behavior before PR

It is not possible to removed the value, e.g. to flush the specification

## Desired behavior after PR is merged

It is possible to flush single referencefields in sampleheader

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
