### PR TITLE
Fix attachments to be ignored are included in email results view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2254 Fix attachments to be ignored are included in email results view
 - #2253 Allow to flush referencefields in sample header
 - #2251 Fix UnicodeDecodeError in report email form
 - #2250 Fix cannot set string result with greater or less than symbols

--- a/src/bika/lims/browser/publish/emailview.py
+++ b/src/bika/lims/browser/publish/emailview.py
@@ -574,7 +574,15 @@ class EmailView(BrowserView):
         attachments = itertools.chain(
             sample.getAttachment(),
             *map(lambda an: an.getAttachment(), analyses))
-        attachments_data = map(self.get_attachment_data, attachments)
+
+        attachments_data = []
+        for attachment in attachments:
+            attachment_data = self.get_attachment_data(attachment)
+            if attachment_data.get("report_option") == "i":
+                # attachment to be ignored from results report
+                continue
+            attachments_data.append(attachment_data)
+
         pdf = self.get_pdf(report)
         filesize = "{} Kb".format(self.get_filesize(pdf))
         filename = self.get_report_filename(report)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that attachments labeled as "Ignore in report" are not included in the email results view

## Current behavior before PR

All attachments are included in the email results report view

## Desired behavior after PR is merged

Attachments to be ignored are not included in the email results report view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
