### PR TITLE
Fix attachments from retracted/rejected analyses are not ignored in email results view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2255 Fix attachments from retracted or rejected analyses are not ignored
 - #2253 Allow to flush referencefields in sample header
 - #2251 Fix UnicodeDecodeError in report email form
 - #2250 Fix cannot set string result with greater or less than symbols

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2254 Fix attachments to be ignored are included in email results view
 - #2253 Allow to flush referencefields in sample header
 - #2251 Fix UnicodeDecodeError in report email form
 - #2250 Fix cannot set string result with greater or less than symbols

--- a/src/bika/lims/browser/publish/emailview.py
+++ b/src/bika/lims/browser/publish/emailview.py
@@ -569,7 +569,15 @@ class EmailView(BrowserView):
         """Report data to be used in the template
         """
         sample = report.getAnalysisRequest()
-        analyses = sample.getAnalyses(full_objects=True)
+
+        # ignore attachments from cancelled, retracted and rejected analyses
+        analyses = []
+        skip = ["cancelled", "rejected", "retracted"]
+        for analysis in sample.getAnalyses(full_objects=True):
+            if api.get_review_status(analysis) in skip:
+                continue
+            analyses.append(analysis)
+
         # merge together sample + analyses attachments
         attachments = itertools.chain(
             sample.getAttachment(),

--- a/src/bika/lims/browser/publish/emailview.py
+++ b/src/bika/lims/browser/publish/emailview.py
@@ -574,7 +574,15 @@ class EmailView(BrowserView):
         attachments = itertools.chain(
             sample.getAttachment(),
             *map(lambda an: an.getAttachment(), analyses))
-        attachments_data = map(self.get_attachment_data, attachments)
+
+        attachments_data = []
+        for attachment in attachments:
+            attachment_data = self.get_attachment_data(attachment)
+            if attachment_data.get("report_option") == "i":
+                # attachment to be ignored from results report
+                continue
+            attachments_data.append(attachment_data)
+
         pdf = self.get_pdf(report)
         filesize = "{} Kb".format(self.get_filesize(pdf))
         filename = self.get_report_filename(report)

--- a/src/bika/lims/workflow/analysis/events.py
+++ b/src/bika/lims/workflow/analysis/events.py
@@ -162,6 +162,10 @@ def after_retract(analysis):
     # Mark this analysis as IRetracted
     alsoProvides(analysis, IRetracted)
 
+    # Ignore attachments of this analysis in results report
+    for attachment in analysis.getAttachment():
+        attachment.setReportOption("i")
+
     # Retract our dependents (analyses that depend on this analysis)
     cascade_to_dependents(analysis, "retract")
 
@@ -185,6 +189,10 @@ def after_reject(analysis):
 
     # Remove from the worksheet
     remove_analysis_from_worksheet(analysis)
+
+    # Ignore attachments of this analysis in results report
+    for attachment in analysis.getAttachment():
+        attachment.setReportOption("i")
 
     # Reject our dependents (analyses that depend on this analysis)
     cascade_to_dependents(analysis, "reject")

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2417</version>
+  <version>2418</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -169,4 +169,12 @@
       handler="senaite.core.upgrade.v02_04_000.ensure_sample_client_fields_are_set"
       profile="senaite.core:default"/>
 
+  <genericsetup:upgradeStep
+      title="SENAITE CORE 2.4.0: Ignore attachments from invalid analyses"
+      description="Ignore attachments from invalid analyses"
+      source="2417"
+      destination="2418"
+      handler="senaite.core.upgrade.v02_04_000.ignore_attachments_from_invalid_analyses"
+      profile="senaite.core:default"/>
+
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Merge https://github.com/senaite/senaite.core/pull/2254 first!**

This Pull Request ensures that when retracting or rejecting an analysis, the associated attachments are flagged as "Ignore in report". Note these attachments are no longer displayed in attachments viewlet (that is ok) in Sample view.

## Current behavior before PR

Attachments from rejected or retracted analyses are displayed in results report email view

## Desired behavior after PR is merged

Attachments from rejected or retracted analyses are displayed in results report email view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
