### PR TITLE
Do not keep DX UID reference field back-references per default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2256 Do not keep DX UID reference field back-references per default
 - #2254 Fix attachments to be ignored are included in email results view
 - #2253 Allow to flush referencefields in sample header
 - #2251 Fix UnicodeDecodeError in report email form

--- a/src/senaite/core/schema/uidreferencefield.py
+++ b/src/senaite/core/schema/uidreferencefield.py
@@ -105,6 +105,7 @@ class UIDReferenceField(List, BaseField):
     def __init__(self, allowed_types=None, multi_valued=True, **kw):
         if allowed_types is None:
             allowed_types = ()
+        self.relationship = kw.get("relationship")
         self.allowed_types = allowed_types
         self.multi_valued = multi_valued
         super(UIDReferenceField, self).__init__(**kw)

--- a/src/senaite/core/schema/uidreferencefield.py
+++ b/src/senaite/core/schema/uidreferencefield.py
@@ -53,19 +53,17 @@ def on_object_created(object, event):
         value = field.get(object)
         # handle single valued reference fields
         if api.is_object(value):
-            logger.info(
-                "Adding back reference from %s -> %s" % (
-                    value, object))
             if field.link_backref(value, object):
-                notify_reference_created(field, object, value)
+                logger.info(
+                    "Added back reference from %s -> %s" % (value, object))
+            notify_reference_created(field, object, value)
         # handle multi valued reference fields
         elif isinstance(value, list):
             for ref in value:
-                logger.info(
-                    "Adding back reference from %s -> %s" % (
-                        ref, object))
                 if field.link_backref(ref, object):
-                    notify_reference_created(field, object, ref)
+                    logger.info(
+                        "Added back reference from %s -> %s" % (ref, object))
+                notify_reference_created(field, object, ref)
 
 
 def get_backrefs(context, relationship, as_objects=False):
@@ -147,8 +145,21 @@ class UIDReferenceField(List, BaseField):
 
         :returns: storage key to lookup back references
         """
-        portal_type = api.get_portal_type(context)
-        return "%s.%s" % (portal_type, self.__name__)
+        relationship = getattr(self, "relationship", None)
+        if not relationship:
+            portal_type = api.get_portal_type(context)
+            relationship = "%s.%s" % (portal_type, self.__name__)
+        return relationship
+
+    @property
+    def keep_backreferences(self):
+        """Returns whether this field must keep back references. Returns False
+        if the value for property relationship is None or empty
+        """
+        relationship = getattr(self, "relationship", None)
+        if relationship and isinstance(relationship, six.string_types):
+            return True
+        return False
 
     def get_uid(self, value):
         """Value -> UID
@@ -227,8 +238,8 @@ class UIDReferenceField(List, BaseField):
 
         # unlink backreferences of removed UIDs
         for removed_obj in removed_objs:
-            if self.unlink_backref(removed_obj, object):
-                notify_reference_destroyed(self, object, removed_obj)
+            self.unlink_backref(removed_obj, object)
+            notify_reference_destroyed(self, object, removed_obj)
 
         super(UIDReferenceField, self).set(object, uids)
 
@@ -239,6 +250,9 @@ class UIDReferenceField(List, BaseField):
         :param target: the object where the backref points to (our object)
         :returns: True when the backref was removed, False otherwise
         """
+        # only unlink backreference if a `relationship` key is explicitly set
+        if not self.keep_backreferences:
+            return False
 
         # Target might be a behavior instead of the object itself
         target = self._get_content_object(target)
@@ -272,6 +286,9 @@ class UIDReferenceField(List, BaseField):
         :param target: the object where the backref points to (our object)
         :returns: True when the backref was written
         """
+        # only link backreference if a `relationship` key is explicitly set
+        if not self.keep_backreferences:
+            return False
 
         # Target might be a behavior instead of the object itself
         target = self._get_content_object(target)

--- a/src/senaite/core/schema/uidreferencefield.txt
+++ b/src/senaite/core/schema/uidreferencefield.txt
@@ -63,6 +63,7 @@ The field can be used for dexterity types:
 
     >>> class IContentSchema(Interface):
     ...     contact = UIDReferenceField(title=u"Contact",
+    ...                                 relationship="Content.contact",
     ...                                 allowed_types=("Contact", ),
     ...                                 multi_valued=True)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is analog to https://github.com/senaite/senaite.core/pull/2219 and removes the functionality to automatically keep backreferences on the target objects.

## Current behavior before PR

Back references are kept on all target objects per default

## Desired behavior after PR is merged

Back references are only kept if the `relationship` key was defined on the field

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
