### PR TITLE
Fix UnicodeEncode error when viewing report objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2257 Fix UnicodeDecode Error when viewing report objects
 - #2254 Fix attachments to be ignored are included in email results view
 - #2253 Allow to flush referencefields in sample header
 - #2251 Fix UnicodeDecodeError in report email form

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
-- #2257 Fix UnicodeDecode Error when viewing report objects
+- #2257 Fix UnicodeEncode error when viewing report objects
 - #2254 Fix attachments to be ignored are included in email results view
 - #2253 Allow to flush referencefields in sample header
 - #2251 Fix UnicodeDecodeError in report email form

--- a/src/senaite/core/browser/fields/records.py
+++ b/src/senaite/core/browser/fields/records.py
@@ -18,8 +18,11 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import six
+
 from AccessControl import ClassSecurityInfo
 from App.class_init import InitializeClass
+from bika.lims import api
 from Products.Archetypes.Registry import registerField
 from Products.Archetypes.Registry import registerPropertyType
 from Products.PythonScripts.standard import html_quote
@@ -96,8 +99,12 @@ class RecordsField(RecordField):
         raw = self.getRaw(instance)[idx].get(subfield, '')
         if type(raw) in (type(()), type([])):
             raw = joinWith.join(raw)
+        if isinstance(raw, six.string_types):
+            raw = api.to_utf8(raw)
+        else:
+            raw = str(raw)
         # Prevent XSS attacks by quoting all user input
-        raw = html_quote(str(raw))
+        raw = html_quote(raw)
         # this is now very specific
         if subfield == 'email':
             return self.hideEmail(raw, instance)
@@ -125,7 +132,7 @@ class RecordsField(RecordField):
 
     # convert the records to persistent dictionaries
     def _to_dict(self, value):
-        if type(value) != list or type(value) !=tuple:
+        if type(value) != list or type(value) != tuple:
             if type(value) == dict:
                 value = [value]
             elif type(value) == str:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a traceback that occurs when viewing the ARReport objects directly:

```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module Shared.DC.Scripts.Bindings, line 335, in __call__
  Module Shared.DC.Scripts.Bindings, line 372, in _bindAndExec
  Module Products.CMFCore.FSPageTemplate, line 257, in _exec
  Module Products.CMFCore.FSPageTemplate, line 198, in pt_render
  Module Products.PageTemplates.PageTemplate, line 85, in pt_render
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 215, in render
  Module chameleon.template, line 192, in render
  Module 0ee958e7c8e421efabeb077c73e80256, line 953, in render
  Module cb7b4317c42f160249cbbbb5918f6041, line 1449, in render_master
  Module cb7b4317c42f160249cbbbb5918f6041, line 407, in render_content
  Module 0ee958e7c8e421efabeb077c73e80256, line 938, in __fill_content_core
  Module 0ee958e7c8e421efabeb077c73e80256, line 205, in render_content_core
  Module a875a278d7255347c0aa0f32076b7eea, line 252, in render_body
  Module 8c0104da372508639ed7fe1d9478e4d2, line 1779, in render_view
  Module 8c0104da372508639ed7fe1d9478e4d2, line 1101, in render_base_view
  Module 1aee5eacabe24a01b8395c36774fede0, line 1591, in render_data
  Module 741e8183706b00b26802ac1f5a26d075, line 2749, in render_view
  Module 741e8183706b00b26802ac1f5a26d075, line 2546, in render_records_field_view
  Module Products.PageTemplates.ZRPythonExpr, line 49, in __call__
   - __traceback_info__: [field.getViewFor(here,idx,key,innerJoin) for key in field.getSubfields()]
  Module PythonExpr, line 1, in <module>
  Module senaite.core.browser.fields.records, line 100, in getViewFor
UnicodeEncodeError: 'ascii' codec can't encode character u'\xf6' in position 37: ordinal not in range(128)
```

## Current behavior before PR

Traceback occurs when viewing an ARReports directly that contain unicode characters metadata

## Desired behavior after PR is merged

No traceback occurs when viewing ARReports directly that contain unicode characters

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
