### PR TITLE
Reduce conflict errors on number generation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2258 Reduce conflict errors on number generation
 - #2254 Fix attachments to be ignored are included in email results view
 - #2253 Allow to flush referencefields in sample header
 - #2251 Fix UnicodeDecodeError in report email form

--- a/src/bika/lims/configure.zcml
+++ b/src/bika/lims/configure.zcml
@@ -72,9 +72,4 @@
       layer="bika.lims.interfaces.IBikaLIMS"
       />
 
-  <utility
-      provides="bika.lims.interfaces.INumberGenerator"
-      factory=".numbergenerator.NumberGenerator"
-      />
-
 </configure>

--- a/src/bika/lims/content/bikasetup.py
+++ b/src/bika/lims/content/bikasetup.py
@@ -37,7 +37,6 @@ from bika.lims.config import SCINOTATION_OPTIONS
 from bika.lims.config import WEEKDAYS
 from bika.lims.content.bikaschema import BikaFolderSchema
 from bika.lims.interfaces import IBikaSetup
-from bika.lims.numbergenerator import INumberGenerator
 from bika.lims.vocabularies import getStickerTemplates as _getStickerTemplates
 from plone.app.folder import folder
 from Products.Archetypes.atapi import BooleanField
@@ -61,6 +60,7 @@ from Products.CMFCore.utils import getToolByName
 from senaite.core.api import geo
 from senaite.core.browser.fields.records import RecordsField
 from senaite.core.interfaces import IHideActionsMenu
+from senaite.core.interfaces import INumberGenerator
 from senaite.core.p3compat import cmp
 from zope.component import getUtility
 from zope.interface import implements

--- a/src/bika/lims/idserver.py
+++ b/src/bika/lims/idserver.py
@@ -20,7 +20,10 @@
 
 import itertools
 import re
+from datetime import datetime
+
 import six
+
 import transaction
 from bika.lims import api
 from bika.lims import logger
@@ -36,14 +39,12 @@ from bika.lims.interfaces import IARReport
 from bika.lims.interfaces import IIdServer
 from bika.lims.interfaces import IIdServerTypeID
 from bika.lims.interfaces import IIdServerVariables
-from bika.lims.numbergenerator import INumberGenerator
 from DateTime import DateTime
-from datetime import datetime
 from Products.ATContentTypes.utils import DT2dt
+from senaite.core.interfaces import INumberGenerator
 from zope.component import getAdapters
 from zope.component import getUtility
 from zope.component import queryAdapter
-
 
 AR_TYPES = [
     "AnalysisRequest",

--- a/src/bika/lims/interfaces/__init__.py
+++ b/src/bika/lims/interfaces/__init__.py
@@ -873,11 +873,6 @@ class IFrontPageAdapter(Interface):
         """
 
 
-class INumberGenerator(Interface):
-    """A utility to generates unique numbers by key
-    """
-
-
 class ITopRightHTMLComponentsHook(Interface):
     """Marker interface to hook html components in bikalisting
     """

--- a/src/bika/lims/numbergenerator.py
+++ b/src/bika/lims/numbergenerator.py
@@ -19,32 +19,32 @@
 # Some rights reserved, see README and LICENSE.
 
 import thread
-import logging
+
+from bika.lims import logger
 from bika.lims.interfaces import INumberGenerator
 from BTrees.OIBTree import OIBTree
 from plone import api
 from zope.annotation.interfaces import IAnnotations
 from zope.interface import implements
 
-
-
 lock = thread.allocate_lock()
 
-logger = logging.getLogger("bika.lims.idserver")
-
-STORAGE_KEY  = "bika.lims.numbercounter"
-STORAGE_HASH = "bika.lims.numbercounter.hash"
-
+STORAGE_KEY = "bika.lims.numbercounter"
 NUMBER_STORAGE = "bika.lims.consecutive_numbers_storage"
+
+
+def get_portal():
+    return api.portal.getSite()
 
 
 def get_storage_location():
     """ get the portal with the plone.api
     """
-    location = api.portal.getSite()
+    location = get_portal()
     if location.get('bika_setup', False):
         location = location['bika_setup']
     return location
+
 
 def get_portal_annotation():
     """ annotation storage bound to the portal
@@ -63,7 +63,7 @@ class NumberGenerator(object):
         """
         annotation = get_portal_annotation()
         if annotation.get(NUMBER_STORAGE) is None:
-            annotation[NUMBER_STORAGE]  = OIBTree()
+            annotation[NUMBER_STORAGE] = OIBTree()
         return annotation[NUMBER_STORAGE]
 
     def flush(self):
@@ -97,43 +97,35 @@ class NumberGenerator(object):
     def get_number(self, key):
         """ get the next consecutive number
         """
-        storage = self.storage
-
-        logger.debug("NUMBER before => %s" % storage.get(key, '-'))
+        logger.debug("NUMBER before => %s" % self.storage.get(key, '-'))
         try:
             logger.debug("*** consecutive number lock acquire ***")
             lock.acquire()
             try:
-                counter = storage[key]
-                storage[key] = counter + 1
+                counter = self.storage[key]
+                self.storage[key] = counter + 1
             except KeyError:
-                storage[key] = 1
+                self.storage[key] = 1
         finally:
             logger.debug("*** consecutive number lock release ***")
-            self.storage._p_changed = True
             lock.release()
 
-        logger.debug("NUMBER after => %s" % storage.get(key, '-'))
-        return storage[key]
+        logger.debug("NUMBER after => %s" % self.storage.get(key, '-'))
+        return self.storage[key]
 
     def set_number(self, key, value):
         """ set a key's value
         """
-        storage = self.storage
-
         if not isinstance(value, int):
             logger.error("set_number: Value must be an integer")
             return
-
         try:
             lock.acquire()
-            storage[key] = value
+            self.storage[key] = value
         finally:
-            self.storage._p_changed = True
             lock.release()
 
-        return storage[key]
-
+        return self.storage[key]
 
     def generate_number(self, key="default"):
         """ get a number

--- a/src/senaite/core/browser/idserver/view.py
+++ b/src/senaite/core/browser/idserver/view.py
@@ -21,9 +21,9 @@
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims.idserver import get_config
-from bika.lims.numbergenerator import INumberGenerator
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from senaite.core.interfaces import INumberGenerator
 from zope.component import getUtility
 from zope.interface import Interface
 from zope.interface import implements

--- a/src/senaite/core/configure.zcml
+++ b/src/senaite/core/configure.zcml
@@ -23,6 +23,7 @@
   <include package=".registry" />
   <include package=".schema" />
   <include package=".upgrade" />
+  <include package=".utilities" />
   <include package=".z3cform" />
 
   <!-- portal skins -->

--- a/src/senaite/core/interfaces/__init__.py
+++ b/src/senaite/core/interfaces/__init__.py
@@ -75,6 +75,11 @@ class IAjaxEditForm(Interface):
         """
 
 
+class INumberGenerator(Interface):
+    """A utility to generates unique numbers by key
+    """
+
+
 class IContainer(Interface):
     """SENAITE Base Container
     """

--- a/src/senaite/core/tests/doctests/IDServer.rst
+++ b/src/senaite/core/tests/doctests/IDServer.rst
@@ -225,7 +225,7 @@ Change ID formats and create new `AnalysisRequest`:
 Re-seed and create a new `Batch`:
 
     >>> from zope.component import getUtility
-    >>> from bika.lims.numbergenerator import INumberGenerator
+    >>> from senaite.core.interfaces import INumberGenerator
     >>> ng = getUtility(INumberGenerator)
     >>> seed = ng.set_number("batch-BA", 10)
 

--- a/src/senaite/core/tests/doctests/IDServer.rst
+++ b/src/senaite/core/tests/doctests/IDServer.rst
@@ -43,7 +43,7 @@ Needed Imports:
     >>> from bika.lims import alphanumber as alpha
     >>> from bika.lims import api
     >>> from bika.lims import idserver
-    >>> from bika.lims.interfaces import INumberGenerator
+    >>> from senaite.core.interfaces import INumberGenerator
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
 

--- a/src/senaite/core/utilities/configure.zcml
+++ b/src/senaite/core/utilities/configure.zcml
@@ -3,7 +3,7 @@
     xmlns:browser="http://namespaces.zope.org/browser">
 
   <utility
-      provides="bika.lims.interfaces.INumberGenerator"
+      provides="senaite.core.interfaces.INumberGenerator"
       factory=".numbergenerator.NumberGenerator"
       />
 

--- a/src/senaite/core/utilities/configure.zcml
+++ b/src/senaite/core/utilities/configure.zcml
@@ -1,0 +1,10 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser">
+
+  <utility
+      provides="bika.lims.interfaces.INumberGenerator"
+      factory=".numbergenerator.NumberGenerator"
+      />
+
+</configure>

--- a/src/senaite/core/utilities/numbergenerator.py
+++ b/src/senaite/core/utilities/numbergenerator.py
@@ -21,9 +21,9 @@
 import thread
 
 from bika.lims import logger
-from bika.lims.interfaces import INumberGenerator
 from BTrees.OIBTree import OIBTree
 from plone import api
+from senaite.core.interfaces import INumberGenerator
 from zope.annotation.interfaces import IAnnotations
 from zope.interface import implements
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR reduces conflict errors that might occur if multiple threads are requesting new numbers at the same time.
 
## Current behavior before PR

storage was fetched before the lock was acquired

## Desired behavior after PR is merged

storage is always fetched from the annotation storage

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
