### PR TITLE
Prevent string results from formatting and number conversion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2259 Prevent string results from formatting and number conversion
 - #2201 Allow manual selection of units on results entry
 - #2258 Reduce conflict errors on number generation
 - #2256 Do not keep DX UID reference field back-references per default

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -859,10 +859,11 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         result = self.getResult()
                 
         # 0: The result is a StringResult, return without any formatting
-        isStringResult = self.StringResult
-        if isStringResult:
-            return '%s' % (result)
-
+        string_result = self.getStringResult() is True
+        if string_result:
+            # return without further result handling
+            return result
+    
         # 1. The result is a detection limit, return '< LDL' or '> UDL'
         dl = self.getDetectionLimitOperand()
         if dl:

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -827,6 +827,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
     def getFormattedResult(self, specs=None, decimalmark='.', sciformat=1,
                            html=True):
         """Formatted result:
+        0: If the result type is StringResult, return it without being formatted
         1. If the result is a detection limit, returns '< LDL' or '> UDL'
         2. Print ResultText of matching ResultOptions
         3. If the result is not floatable, return it without being formatted
@@ -853,6 +854,11 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             escaped: e.g: '<' and '>' (LDL and UDL for results like < 23.4).
         """
         result = self.getResult()
+                
+        # 0: The result is a StringResult, return without any formatting
+        isStringResult = self.StringResult
+        if isStringResult:
+            return '%s' % (result)
 
         # 1. The result is a detection limit, return '< LDL' or '> UDL'
         dl = self.getDetectionLimitOperand()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1614

## Current behavior before PR

StringResult containing numbers are formatted as numerical result applying the default formatting rules.

E.g. "1234,5678" becomes "1234" **after verification** (depending on the number of decimals and the decimal character).


## Desired behavior after PR is merged

StringResults should not be formatted at all.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
