### PR TITLE
Fix sample-header flushes multi-reference fields

### DIFF
--- a/src/senaite/core/browser/viewlets/sampleheader.py
+++ b/src/senaite/core/browser/viewlets/sampleheader.py
@@ -132,13 +132,17 @@ class SampleHeaderViewlet(ViewletBase):
         # https://github.com/bikalims/bika.lims/issues/2270
         uid_fieldname = "{}_uid".format(fieldname)
         if uid_fieldname in form:
-            # allow to reset the reference
-            if not fieldvalue:
-                value = ""
-            else:
-                value = form[uid_fieldname]
+            # get the value from the corresponding `uid_<fieldname>` key
+            value = form[uid_fieldname]
+
+            # extract the assigned UIDs for multi-reference fields
             if field.multiValued:
                 value = filter(None, value.split(","))
+
+            # allow to flush single reference fields
+            if not field.multiValued and not fieldvalue:
+                value = ""
+
             return value
 
         # other fields


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a side-effect of https://github.com/senaite/senaite.core/pull/2253

## Current behavior before PR

Multi-reference fields are flushed on save

## Desired behavior after PR is merged

Multi-reference fields keep their original value

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
