### PR TITLE
Fix KeyError in Worksheet analyses listing

### DIFF
--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -809,12 +809,15 @@ class AnalysesView(ListingView):
 
         # Display method and instrument columns only if at least one of the
         # analyses requires them to be displayed for selection
-        self.columns["Method"]["toggle"] = self.is_method_column_required()
+        show_method_column = self.is_method_column_required()
+        if "Method" in self.columns:
+            self.columns["Method"]["toggle"] = show_method_column
 
         show_instrument_column = self.is_instrument_column_required()
         if "Instrument" in self.columns:
             self.columns["Instrument"]["toggle"] = show_instrument_column
 
+        # show unit selection column only if required
         show_unit_column = self.is_unit_selection_column_required()
         if "Unit" in self.columns:
             self.columns["Unit"]["toggle"] = show_unit_column

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -810,8 +810,14 @@ class AnalysesView(ListingView):
         # Display method and instrument columns only if at least one of the
         # analyses requires them to be displayed for selection
         self.columns["Method"]["toggle"] = self.is_method_column_required()
-        self.columns["Instrument"]["toggle"] = self.is_instrument_column_required()
-        self.columns["Unit"]["toggle"] = self.is_unit_selection_column_required()
+
+        show_instrument_column = self.is_instrument_column_required()
+        if "Instrument" in self.columns:
+            self.columns["Instrument"]["toggle"] = show_instrument_column
+
+        show_unit_column = self.is_unit_selection_column_required()
+        if "Unit" in self.columns:
+            self.columns["Unit"]["toggle"] = show_unit_column
 
         return items
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the following traceback in worksheet `manage_results` view:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.app.listing.view, line 248, in __call__
  Module senaite.app.listing.ajax, line 112, in handle_subpath
  Module senaite.core.decorators, line 22, in decorator
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 470, in ajax_folderitems
  Module senaite.app.listing.decorators, line 88, in wrapper
  Module senaite.app.listing.ajax, line 348, in get_folderitems
  Module bika.lims.browser.worksheet.views.analyses, line 257, in folderitems
  Module bika.lims.browser.analyses.view, line 814, in folderitems
KeyError: 'Unit'
````

This issue was introduced in https://github.com/senaite/senaite.core/pull/2201


## Current behavior before PR

Traceback in Worksheet `manage_results` view occurs

## Desired behavior after PR is merged

No traceback in Worksheet `manage_results` view occur

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
