### PR TITLE
Simplify attachment render in report options to single checkbox

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2262 Simplify attachment render in report options to single checkbox
 - #2259 Prevent string results from formatting and number conversion
 - #2255 Fix attachments from retracted or rejected analyses are not ignored
 - #2201 Allow manual selection of units on results entry

--- a/src/bika/lims/browser/analysisreport.py
+++ b/src/bika/lims/browser/analysisreport.py
@@ -97,7 +97,7 @@ class AnalysisReportInfoView(BrowserView):
         filename = f.filename
         filesize = self.get_filesize(f)
         mimetype = f.getContentType()
-        report_option = attachment.getReportOption()
+        render_in_report = attachment.getRenderInReport()
 
         return {
             "obj": attachment,
@@ -108,5 +108,5 @@ class AnalysisReportInfoView(BrowserView):
             "filesize": filesize,
             "filename": filename,
             "mimetype": mimetype,
-            "report_option": report_option,
+            "render_in_report": render_in_report,
         }

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1098,7 +1098,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         return {
             "AttachmentFile": fileupload,
             "AttachmentType": "",
-            "ReportOption": "",
+            "RenderInReport": False,
             "AttachmentKeys": "",
             "Service": "",
         }

--- a/src/bika/lims/browser/publish/emailview.py
+++ b/src/bika/lims/browser/publish/emailview.py
@@ -568,8 +568,32 @@ class EmailView(BrowserView):
     def get_report_data(self, report):
         """Report data to be used in the template
         """
-        sample = report.getAnalysisRequest()
+        primary_sample = report.getAnalysisRequest()
+        samples = report.getContainedAnalysisRequests() or [primary_sample]
+        attachments_data = []
 
+        for sample in samples:
+            for attachment in self.get_all_sample_attachments(sample):
+                attachment_data = self.get_attachment_data(sample, attachment)
+                attachments_data.append(attachment_data)
+
+        pdf = self.get_pdf(report)
+        filesize = "{} Kb".format(self.get_filesize(pdf))
+        filename = self.get_report_filename(report)
+
+        return {
+            "primary_sample": primary_sample,
+            "attachments": attachments_data,
+            "pdf": pdf,
+            "obj": report,
+            "uid": api.get_uid(report),
+            "filesize": filesize,
+            "filename": filename,
+        }
+
+    def get_all_sample_attachments(self, sample):
+        """return all valid attachments of the given sample
+        """
         # ignore attachments from cancelled, retracted and rejected analyses
         analyses = []
         skip = ["cancelled", "rejected", "retracted"]
@@ -583,26 +607,9 @@ class EmailView(BrowserView):
             sample.getAttachment(),
             *map(lambda an: an.getAttachment(), analyses))
 
-        attachments_data = []
-        for attachment in attachments:
-            attachment_data = self.get_attachment_data(attachment)
-            attachments_data.append(attachment_data)
+        return list(attachments)
 
-        pdf = self.get_pdf(report)
-        filesize = "{} Kb".format(self.get_filesize(pdf))
-        filename = self.get_report_filename(report)
-
-        return {
-            "sample": sample,
-            "attachments": attachments_data,
-            "pdf": pdf,
-            "obj": report,
-            "uid": api.get_uid(report),
-            "filesize": filesize,
-            "filename": filename,
-        }
-
-    def get_attachment_data(self, attachment):
+    def get_attachment_data(self, sample, attachment):
         """Attachments data to be used in the template
         """
         f = attachment.getAttachmentFile()
@@ -614,6 +621,7 @@ class EmailView(BrowserView):
         render_in_report = attachment.getRenderInReport()
 
         return {
+            "sample": sample,
             "obj": attachment,
             "attachment_type": attachment_type,
             "attachment_keys": attachment_keys,

--- a/src/bika/lims/browser/publish/emailview.py
+++ b/src/bika/lims/browser/publish/emailview.py
@@ -586,9 +586,6 @@ class EmailView(BrowserView):
         attachments_data = []
         for attachment in attachments:
             attachment_data = self.get_attachment_data(attachment)
-            if attachment_data.get("report_option") == "i":
-                # attachment to be ignored from results report
-                continue
             attachments_data.append(attachment_data)
 
         pdf = self.get_pdf(report)

--- a/src/bika/lims/browser/publish/emailview.py
+++ b/src/bika/lims/browser/publish/emailview.py
@@ -611,7 +611,7 @@ class EmailView(BrowserView):
         filename = f.filename
         filesize = self.get_filesize(f)
         mimetype = f.getContentType()
-        report_option = attachment.getReportOption()
+        render_in_report = attachment.getRenderInReport()
 
         return {
             "obj": attachment,
@@ -622,7 +622,7 @@ class EmailView(BrowserView):
             "filesize": filesize,
             "filename": filename,
             "mimetype": mimetype,
-            "report_option": report_option,
+            "render_in_report": render_in_report,
         }
 
     def get_recipients_data(self, reports):

--- a/src/bika/lims/browser/publish/templates/email.pt
+++ b/src/bika/lims/browser/publish/templates/email.pt
@@ -147,7 +147,7 @@
                  class="attachments well row">
               <tal:reports repeat="report view/reports_data">
                 <input type="hidden" name="uids:list" tal:attributes="value report/uid"/>
-                <div class="attachment col-xs-12 col-sm-4 col-md-3 col-lg-2">
+                <div class="attachment d-inline-block pr-4">
                   <a href="#"
                      class="report-link"
                      target="_blank"
@@ -162,12 +162,12 @@
             </div>
 
             <div id="additional-attachments-container"
-                 class="attachments well row"
+                 class="attachments row"
                  tal:condition="python:any(attachments)">
               <!-- Additional Attachments -->
               <tal:reports repeat="report view/reports_data">
                 <tal:attachments repeat="attachment report/attachments">
-                  <div class="attachment col-xs-12 col-sm-4 col-md-3 col-lg-2">
+                  <div class="attachment d-inline-block pr-4">
                     <input type="checkbox" name="attachment_uids:list" tal:attributes="value attachment/uid"/>
                     <a href="#"
                        class="attachment-link"
@@ -183,7 +183,7 @@
                       <div class="attachment-info small">
                         <span tal:content="attachment/attachment_keys"/>
                         <span i18n:translate="">in</span>
-                        <span tal:content="report/sample/getId"/>
+                        <span tal:content="attachment/sample/getId"/>
                         <div class="fileinfo">
                           <span class="filetype" tal:content="attachment/mimetype"/>
                           <span class="filesize" tal:content="string:${attachment/filesize}kB"/>

--- a/src/bika/lims/config.py
+++ b/src/bika/lims/config.py
@@ -72,10 +72,6 @@ STD_TYPES = DisplayList((
     ('c', _('Control')),
     ('b', _('Blank')),
 ))
-ATTACHMENT_REPORT_OPTIONS = DisplayList((
-    ('r', _('Render in Report')),
-    ('i', _('Ignore in Report')),
-))
 GENDERS = DisplayList((
     ('male', _('Male')),
     ('female', _('Female')),

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -2394,7 +2394,7 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
             # create a new attachment
             attachment = self.createAttachment(filedata, filename)
             # ignore the attachment in report
-            attachment.setReportOption("i")
+            attachment.setRenderInReport(False)
             # remove the image data base64 prefix
             html = html.replace(data_type, "")
             # remove the base64 image data with the attachment link

--- a/src/bika/lims/content/attachment.py
+++ b/src/bika/lims/content/attachment.py
@@ -21,12 +21,12 @@
 from AccessControl import ClassSecurityInfo
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
+from bika.lims import deprecated
 from bika.lims import logger
 from bika.lims.browser.fields import UIDReferenceField
 from bika.lims.browser.fields.uidreferencefield import get_backreferences
 from bika.lims.browser.widgets import DateTimeWidget
 from bika.lims.browser.widgets import ReferenceWidget
-from bika.lims.config import ATTACHMENT_REPORT_OPTIONS
 from bika.lims.config import PROJECTNAME
 from bika.lims.content.bikaschema import BikaSchema
 from bika.lims.content.clientawaremixin import ClientAwareMixin
@@ -34,14 +34,14 @@ from bika.lims.interfaces.analysis import IRequestAnalysis
 from DateTime import DateTime
 from plone.app.blob.field import FileField
 from Products.Archetypes.atapi import BaseFolder
+from Products.Archetypes.atapi import BooleanField
+from Products.Archetypes.atapi import BooleanWidget
 from Products.Archetypes.atapi import DateTimeField
 from Products.Archetypes.atapi import FileWidget
 from Products.Archetypes.atapi import Schema
-from Products.Archetypes.atapi import SelectionWidget
 from Products.Archetypes.atapi import StringField
 from Products.Archetypes.atapi import StringWidget
 from Products.Archetypes.atapi import registerType
-
 
 schema = BikaSchema.copy() + Schema((
 
@@ -61,16 +61,14 @@ schema = BikaSchema.copy() + Schema((
         ),
     ),
 
-    StringField(
-        "ReportOption",
-        searchable=True,
-        vocabulary=ATTACHMENT_REPORT_OPTIONS,
-        widget=SelectionWidget(
-            label=_("Report Options"),
-            checkbox_bound=0,
-            format="select",
+    BooleanField(
+        "RenderInReport",
+        default=True,
+        widget=BooleanWidget(
+            label=_("Render attachment in report"),
+            description=_(
+                "Only images can be rendered in the report directly"),
             visible=True,
-            default="r",
         ),
     ),
 
@@ -237,6 +235,21 @@ class Attachment(BaseFolder, ClientAwareMixin):
         """
         att_file = self.getAttachmentFile()
         return att_file.filename
+
+    @deprecated(comment="Removed in 3.x", replacement="getRenderInReport")
+    def getReportOption(self):
+        """BBB: returns "r" if RenderInReport is True, otherwise "i"
+        """
+        if not self.getRenderInReport():
+            return "i"
+        return "r"
+
+    @deprecated(comment="Removed in 3.x", replacement="setRenderInReport")
+    def setReportOption(self, value):
+        """BBB: set RenderInReport to True if the passed in value is "r",
+                and for all other values to False
+        """
+        self.setRenderInReport(value == "r")
 
 
 registerType(Attachment, PROJECTNAME)

--- a/src/bika/lims/workflow/analysis/events.py
+++ b/src/bika/lims/workflow/analysis/events.py
@@ -164,7 +164,7 @@ def after_retract(analysis):
 
     # Ignore attachments of this analysis in results report
     for attachment in analysis.getAttachment():
-        attachment.setReportOption("i")
+        attachment.setRenderInReport(False)
 
     # Retract our dependents (analyses that depend on this analysis)
     cascade_to_dependents(analysis, "retract")
@@ -192,7 +192,7 @@ def after_reject(analysis):
 
     # Ignore attachments of this analysis in results report
     for attachment in analysis.getAttachment():
-        attachment.setReportOption("i")
+        attachment.setRenderInReport(False)
 
     # Reject our dependents (analyses that depend on this analysis)
     cascade_to_dependents(analysis, "reject")

--- a/src/senaite/core/browser/attachment/attachment.py
+++ b/src/senaite/core/browser/attachment/attachment.py
@@ -89,6 +89,16 @@ class AttachmentsView(BrowserView):
         # call the endpoint
         return action()
 
+    def get_redirect_url(self):
+        """Get the redirect URL depending on the context
+        """
+        url = self.context.absolute_url()
+        # workaround for Worksheets
+        if self.request["HTTP_REFERER"].endswith("manage_results"):
+            url = "{}/manage_results".format(url)
+        # we use this request parameter to keep the attachments viewlet open
+        return "{}?show_attachments=1".format(url)
+
     def add_status_message(self, message, level="info"):
         """Set a portal status message
         """
@@ -128,8 +138,7 @@ class AttachmentsView(BrowserView):
             self.add_status_message(_("Attachment(s) updated"))
         # set the attachments order to the annotation storage
         self.set_attachments_order(order)
-        # redirect back to the default view
-        return self.request.response.redirect(self.context.absolute_url())
+        return self.request.response.redirect(self.get_redirect_url())
 
     def action_add_to_ws(self):
         """Form action to add a new attachment in a worksheet
@@ -215,11 +224,7 @@ class AttachmentsView(BrowserView):
                 _("Please select an analysis or service for the attachment"),
                 level="warning")
 
-        if self.request['HTTP_REFERER'].endswith('manage_results'):
-            self.request.response.redirect('{}/manage_results'.format(
-                self.context.absolute_url()))
-        else:
-            self.request.response.redirect(self.context.absolute_url())
+        return self.request.response.redirect(self.get_redirect_url())
 
     def action_add(self):
         """Form action to add a new attachment
@@ -275,11 +280,7 @@ class AttachmentsView(BrowserView):
             self.add_status_message(
                 _("Attachment added to the current sample"))
 
-        if self.request["HTTP_REFERER"].endswith("manage_results"):
-            self.request.response.redirect('{}/manage_results'.format(
-                self.context.absolute_url()))
-        else:
-            self.request.response.redirect(self.context.absolute_url())
+        return self.request.response.redirect(self.get_redirect_url())
 
     def create_attachment(self, container, attachment_file, **kw):
         """Create an Attachment object in the given container

--- a/src/senaite/core/browser/attachment/attachment.py
+++ b/src/senaite/core/browser/attachment/attachment.py
@@ -29,7 +29,6 @@ from bika.lims import logger
 from bika.lims import senaiteMessageFactory as _
 from bika.lims.api import security
 from bika.lims.catalog import SETUP_CATALOG
-from bika.lims.config import ATTACHMENT_REPORT_OPTIONS
 from bika.lims.interfaces.analysis import IRequestAnalysis
 from BTrees.OOBTree import OOBTree
 from plone import protect
@@ -367,19 +366,23 @@ class AttachmentsView(BrowserView):
         attachment_uid = api.get_uid(attachment)
         attachment_file = attachment.getAttachmentFile()
         attachment_type = attachment.getAttachmentType()
-        report_option = attachment.getReportOption()
-        report_option_value = ATTACHMENT_REPORT_OPTIONS.getValue(report_option)
+        attachment_type_uid = ""
+        attachment_type_title = ""
+        render_in_report = attachment.getRenderInReport()
+
+        if attachment_type:
+            attachment_type_uid = api.get_uid(attachment_type)
+            attachment_type_title = api.get_title(attachment_type)
 
         return {
             "keywords": attachment.getAttachmentKeys(),
             "size": self.get_attachment_size(attachment),
             "name": attachment_file.filename,
-            "type_uid": api.get_uid(attachment_type) if attachment_type else "",
-            "type": api.get_title(attachment_type) if attachment_type else "",
+            "type_uid": attachment_type_uid,
+            "type": attachment_type_title,
             "absolute_url": attachment.absolute_url(),
             "UID": attachment_uid,
-            "report_option": report_option,
-            "report_option_value": report_option_value,
+            "render_in_report": render_in_report,
             "analysis": "",
         }
 
@@ -442,11 +445,6 @@ class AttachmentsView(BrowserView):
             "sort_order": "ascending"
         }
         return api.search(query, SETUP_CATALOG)
-
-    def get_attachment_report_options(self):
-        """Returns the valid attachment report options
-        """
-        return ATTACHMENT_REPORT_OPTIONS.items()
 
     @view.memoize
     def get_analyses(self):

--- a/src/senaite/core/browser/attachment/attachment.py
+++ b/src/senaite/core/browser/attachment/attachment.py
@@ -142,7 +142,7 @@ class AttachmentsView(BrowserView):
         analysis_uid = form.get("Analysis", None)
         attachment_type = form.get("AttachmentType", "")
         attachment_keys = form.get("AttachmentKeys", "")
-        report_option = form.get("ReportOption", "r")
+        render_in_report = form.get("RenderInReport", True)
 
         # nothing to do if the attachment file is missing
         if attachment_file is None:
@@ -160,7 +160,7 @@ class AttachmentsView(BrowserView):
                 attachment_file,
                 AttachmentType=attachment_type,
                 AttachmentKeys=attachment_keys,
-                ReportOption=report_option)
+                RenderInReport=render_in_report)
 
             others = analysis.getAttachment()
             attachments = []
@@ -190,7 +190,7 @@ class AttachmentsView(BrowserView):
                     attachment_file,
                     AttachmentType=attachment_type,
                     AttachmentKeys=attachment_keys,
-                    ReportOption=report_option)
+                    RenderInReport=render_in_report)
 
                 others = analysis.getAttachment()
                 attachments = []
@@ -232,7 +232,7 @@ class AttachmentsView(BrowserView):
         attachment_file = form.get("AttachmentFile_file", None)
         attachment_type = form.get("AttachmentType", "")
         attachment_keys = form.get("AttachmentKeys", "")
-        report_option = form.get("ReportOption", "r")
+        render_in_report = form.get("RenderInReport", True)
 
         # nothing to do if the attachment file is missing
         if attachment_file is None:
@@ -246,7 +246,7 @@ class AttachmentsView(BrowserView):
             attachment_file,
             AttachmentType=attachment_type,
             AttachmentKeys=attachment_keys,
-            ReportOption=report_option)
+            RenderInReport=render_in_report)
 
         # append the new UID to the end of the current order
         self.set_attachments_order(api.get_uid(attachment))

--- a/src/senaite/core/browser/viewlets/attachments.py
+++ b/src/senaite/core/browser/viewlets/attachments.py
@@ -36,6 +36,13 @@ class AttachmentsViewlet(ViewletBase):
     """
     template = ViewPageTemplateFile("templates/attachments.pt")
 
+    def toggle_css_class(self):
+        """CSS toggle class selector to keep attachments viewlet open
+        """
+        if self.request.get("show_attachments", False):
+            return "show"
+        return "collapse"
+
     def get_attachments_view(self):
         # refactored functionality into this separate Browser view, to be able
         # to have a form submit target.

--- a/src/senaite/core/browser/viewlets/templates/attachments.pt
+++ b/src/senaite/core/browser/viewlets/templates/attachments.pt
@@ -204,7 +204,7 @@
                 <th class="pr-3" i18n:translate="">Type</th>
                 <th class="pr-3" i18n:translate="">Analysis</th>
                 <th class="pr-3" i18n:translate="">Keywords</th>
-                <th class="pr-3" i18n:translate="">Report Option</th>
+                <th class="pr-3" i18n:translate="">Render in report</th>
               </tr>
             </thead>
             <tbody>
@@ -275,12 +275,12 @@
                   <!-- Attachment Keywords -->
                   <input class="form-control" name="AttachmentKeys"/>
                 </td>
-                <td>
+                <td class="text-center">
                   <input type="checkbox"
-                         name="RenderInReport"
+                         name="RenderInReport:boolean"
                          tal:attributes="value python:True;"/>
                   <input type="hidden"
-                         name="RenderInReport"
+                         name="RenderInReport:boolean:default"
                          tal:attributes="value python:False;"/>
                 </td>
               </tr>

--- a/src/senaite/core/browser/viewlets/templates/attachments.pt
+++ b/src/senaite/core/browser/viewlets/templates/attachments.pt
@@ -69,7 +69,7 @@
                 <!-- Please do not move this column to be the first, because the
                       :records converter will somehow offset the True/False value of
                       the checkbox by -1 (the record before will be deleted) -->
-                <th class="pr-3" tal:condition="can_delete">Delete</th>
+                <th class="pr-3" i18n:translate="" tal:condition="can_delete">Remove</th>
               </tr>
             </thead>
             <tbody>

--- a/src/senaite/core/browser/viewlets/templates/attachments.pt
+++ b/src/senaite/core/browser/viewlets/templates/attachments.pt
@@ -65,7 +65,7 @@
                 <th class="pr-3" i18n:translate="">Size</th>
                 <th class="pr-3" i18n:translate="">Analysis</th>
                 <th class="pr-3" i18n:translate="">Keywords</th>
-                <th class="pr-3" i18n:translate="">Render in report</th>
+                <th class="pr-3" i18n:translate="">Render in Report</th>
                 <!-- Please do not move this column to be the first, because the
                       :records converter will somehow offset the True/False value of
                       the checkbox by -1 (the record before will be deleted) -->
@@ -203,7 +203,7 @@
                 <th class="pr-3" i18n:translate="">Type</th>
                 <th class="pr-3" i18n:translate="">Analysis</th>
                 <th class="pr-3" i18n:translate="">Keywords</th>
-                <th class="pr-3" i18n:translate="">Render in report</th>
+                <th class="pr-3" i18n:translate="">Render in Report</th>
               </tr>
             </thead>
             <tbody>

--- a/src/senaite/core/browser/viewlets/templates/attachments.pt
+++ b/src/senaite/core/browser/viewlets/templates/attachments.pt
@@ -41,9 +41,7 @@
                      can_edit attachments_view/can_edit_attachments;
                      can_delete attachments_view/can_delete_attachments;
                      attachments attachments_view/get_sorted_attachments;
-                     attachment_types attachments_view/get_attachment_types;
-                     report_options attachments_view/get_attachment_report_options">
-
+                     attachment_types attachments_view/get_attachment_types;">
       <!-- Attachments List -->
       <div id="attachments_update" class="ar_attachments_list">
 
@@ -67,7 +65,7 @@
                 <th class="pr-3" i18n:translate="">Size</th>
                 <th class="pr-3" i18n:translate="">Analysis</th>
                 <th class="pr-3" i18n:translate="">Keywords</th>
-                <th class="pr-3" i18n:translate="">Report Option</th>
+                <th class="pr-3" i18n:translate="">Render in report</th>
                 <!-- Please do not move this column to be the first, because the
                       :records converter will somehow offset the True/False value of
                       the checkbox by -1 (the record before will be deleted) -->
@@ -130,23 +128,18 @@
                         tal:content="attachment/keywords"/>
                 </td>
 
-                <td class="attachment-report-option">
-                  <!-- Attachment Report Option
-                        i=Ignore in Report
-                        r=Render in Report (default)
-                    -->
-                  <select name="ReportOption"
-                          class="form-control"
-                          tal:condition="can_edit"
-                          tal:attributes="name string:attachments.ReportOption:records;
-                                          data-attachment-uid string:${attachment/UID}">
-                    <option tal:repeat="item report_options"
-                            tal:attributes="value python:item[0];
-                                            selected python:item[0]==attachment['report_option']"
-                            tal:content="python: item[1]"/>
-                  </select>
-                  <span tal:condition="not:can_edit"
-                        tal:content="attachment/report_option_value"/>
+                <td class="attachment-render-in-report text-center"
+                    tal:define="render_in_report python:attachment.get('render_in_report', False)">
+                  <input type="checkbox"
+                          tal:attributes="name string:attachments.RenderInReport:records:boolean;
+                                          checked python:render_in_report;
+                                          value python:render_in_report;"/>
+                  <input type="hidden"
+                         tal:attributes="name string:attachments.RenderInReport:records:boolean:default;
+                                         value python:False;"/>
+                  <span i18n:translate=""
+                        tal:condition="not:can_edit"
+                        tal:content="python:'Yes' if attachment.get('can_edit') else 'No'"/>
                 </td>
 
                 <td class="attachment-delete" tal:condition="can_delete">
@@ -283,16 +276,12 @@
                   <input class="form-control" name="AttachmentKeys"/>
                 </td>
                 <td>
-                <!-- Attachment Report Option
-                      a=Attach to Report (default)
-                      i=Ignore in Report
-                      r=Render in Report
-                    -->
-                  <select name="ReportOption" class="form-control">
-                    <option tal:repeat="item report_options"
-                            tal:attributes="value python:item[0];"
-                            tal:content="python: item[1]"/>
-                  </select>
+                  <input type="checkbox"
+                         name="RenderInReport"
+                         tal:attributes="value python:True;"/>
+                  <input type="hidden"
+                         name="RenderInReport"
+                         tal:attributes="value python:False;"/>
                 </td>
               </tr>
             </tbody>

--- a/src/senaite/core/browser/viewlets/templates/attachments.pt
+++ b/src/senaite/core/browser/viewlets/templates/attachments.pt
@@ -11,7 +11,7 @@
   </button>
 
   <div id="ar-attachments-panel"
-       class="collapse card p-2 mb-3 bg-light"
+       tal:attributes="class string:card p-2 mb-3 bg-light ${view/toggle_css_class}"
        tal:define="attachments_view python:view.get_attachments_view()">
 
     <script type="text/javascript">
@@ -131,9 +131,8 @@
                 <td class="attachment-render-in-report text-center"
                     tal:define="render_in_report python:attachment.get('render_in_report', False)">
                   <input type="checkbox"
-                          tal:attributes="name string:attachments.RenderInReport:records:boolean;
-                                          checked python:render_in_report;
-                                          value python:render_in_report;"/>
+                         tal:attributes="name string:attachments.RenderInReport:records:boolean;
+                                         checked python:render_in_report;"/>
                   <input type="hidden"
                          tal:attributes="name string:attachments.RenderInReport:records:boolean:default;
                                          value python:False;"/>

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2418</version>
+  <version>2419</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -715,9 +715,7 @@ def ignore_attachments_from_invalid_analyses(tool):
 
         # Ignore attachments of this analysis in results report
         for attachment in obj.getAttachment():
-            report_option = attachment.getReportOption()
-            if report_option != "i":
-                attachment.setReportOption("i")
+            attachment.setReportOption("i")
             attachment._p_deactivate()
 
         # Flush the object from memory

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -27,6 +27,7 @@ from bika.lims.browser.fields.uidreferencefield import get_storage
 from bika.lims.interfaces import IRejected
 from bika.lims.interfaces import IRetracted
 from Products.Archetypes.config import REFERENCE_CATALOG
+from Products.Archetypes.config import UID_CATALOG
 from Products.BTreeFolder2.BTreeFolder2 import BTreeFolder2Base
 from senaite.core import logger
 from senaite.core.catalog import ANALYSIS_CATALOG
@@ -723,3 +724,43 @@ def ignore_attachments_from_invalid_analyses(tool):
         obj._p_deactivate()
 
     logger.info("Flag attachments to ignore [DONE]")
+
+
+def convert_attachment_report_options(tool):
+    """Convert raw ReportOption for new RenderInReport boolean field
+    """
+    logger.info("Convert attachment report options ...")
+    query = {
+        "portal_type": ["Attachment"],
+    }
+    brains = api.search(query, UID_CATALOG)
+    total = len(brains)
+
+    for num, brain in enumerate(brains):
+        if num and num % 100 == 0:
+            logger.info("Processed objects: {}/{}".format(num, total))
+
+        if num and num % 1000 == 0:
+            # reduce memory size of the transaction
+            transaction.savepoint()
+
+        try:
+            obj = api.get_object(brain)
+        except AttributeError:
+            obj = None
+
+        if not obj:
+            uncatalog_brain(brain)
+            continue
+
+        raw_value = getattr(obj, "ReportOption", None)
+        if raw_value is not None:
+            value = raw_value == "r"
+            logger.info("Convert report otion {} -> {} for {}".format(
+                raw_value, value, api.get_path(obj)))
+            obj.setRenderInReport(value)
+
+        # Flush the object from memory
+        obj._p_deactivate()
+
+    logger.info("Convert attachment report options [DONE]")

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -177,4 +177,12 @@
       handler="senaite.core.upgrade.v02_04_000.ignore_attachments_from_invalid_analyses"
       profile="senaite.core:default"/>
 
+  <genericsetup:upgradeStep
+      title="SENAITE CORE 2.4.0: Convert attachment report options to boolean"
+      description="Convert attachment report option value for new schema field RenderInReport to True/False values"
+      source="2418"
+      destination="2419"
+      handler="senaite.core.upgrade.v02_04_000.convert_attachment_report_options"
+      profile="senaite.core:default"/>
+
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR simplifies the attachment "render in report" logic to be a simply checkbox instead of an option field.

<img width="1336" alt="attachments" src="https://user-images.githubusercontent.com/713193/220967892-25deccd4-24c4-4d0a-af48-df96721590db.png">

This PR also implements the request of https://github.com/senaite/senaite.impress/issues/38

<img width="1255" alt="email view" src="https://user-images.githubusercontent.com/713193/220968915-4eb2d1fe-ee08-4d90-90a0-3719b3d3e94c.png">

## Current behavior before PR

The user can choose between "Render in Report" and "Ignore in Report" which might be confusing.

## Desired behavior after PR is merged

There is only a sinlge checkbox if the attachment should be rendered in the report, otherwise it will be ignored.

All valid attachments can be manually attached to the publication email

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
