### PR TITLE
Move upgrade step 2418 after 2419

### DIFF
--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2419</version>
+  <version>2420</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -715,7 +715,11 @@ def ignore_attachments_from_invalid_analyses(tool):
 
         # Ignore attachments of this analysis in results report
         for attachment in obj.getAttachment():
-            attachment.setReportOption("i")
+            # set the value of the removed schema field directly for
+            # backwards compatibility and consistency
+            attachment.ReportOption = "i"
+            # set the new schema field value
+            attachment.setRenderInReport(False)
             attachment._p_deactivate()
 
         # Flush the object from memory

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -165,16 +165,8 @@
       title="SENAITE CORE 2.4.0: Ensure sample client fields are set"
       description="Iterate through all samples and check if the `Client` schema field is set"
       source="2416"
-      destination="2417"
-      handler="senaite.core.upgrade.v02_04_000.ensure_sample_client_fields_are_set"
-      profile="senaite.core:default"/>
-
-  <genericsetup:upgradeStep
-      title="SENAITE CORE 2.4.0: Ignore attachments from invalid analyses"
-      description="Ignore attachments from invalid analyses"
-      source="2417"
       destination="2418"
-      handler="senaite.core.upgrade.v02_04_000.ignore_attachments_from_invalid_analyses"
+      handler="senaite.core.upgrade.v02_04_000.ensure_sample_client_fields_are_set"
       profile="senaite.core:default"/>
 
   <genericsetup:upgradeStep
@@ -183,6 +175,15 @@
       source="2418"
       destination="2419"
       handler="senaite.core.upgrade.v02_04_000.convert_attachment_report_options"
+      profile="senaite.core:default"/>
+
+  <!-- NOTE: This step was previously 2418, but needs to run *after* 2419 -->
+  <genericsetup:upgradeStep
+      title="SENAITE CORE 2.4.0: Ignore attachments from invalid analyses"
+      description="Ignore attachments from invalid analyses"
+      source="2419"
+      destination="2420"
+      handler="senaite.core.upgrade.v02_04_000.ignore_attachments_from_invalid_analyses"
       profile="senaite.core:default"/>
 
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

With PR https://github.com/senaite/senaite.core/pull/2262 the schema field `ReportOption` was removed and a new `RenderInReport` introduced.

If upgrade step `2418` was not yet run, the provided upgrade conversion step `2419` from https://github.com/senaite/senaite.core/pull/2262 wrote back the original values to the new `RenderInReport` field, which means that attachments of invalid/retracted analyses were rendered again in reports

## Current behavior before PR

Attachments of non-valid analyses are rendered again in the report after `2419` was run

## Desired behavior after PR is merged

Attachments of non-valid analyses are ignored in reports after `2420` is run

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
