### PR TITLE
Collapsible analyses listings in sample view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2264 Collapsible analyses listings in sample view
 - #2262 Simplify attachment render in report options to single checkbox
 - #2259 Prevent string results from formatting and number conversion
 - #2255 Fix attachments from retracted or rejected analyses are not ignored

--- a/src/senaite/core/browser/viewlets/sampleanalyses.py
+++ b/src/senaite/core/browser/viewlets/sampleanalyses.py
@@ -37,6 +37,9 @@ class LabAnalysesViewlet(ViewletBase):
     def sample(self):
         return self.context
 
+    def is_collapsed(self):
+        return False
+
     def available(self):
         """Returns true if this sample contains at least one analysis for the
         point of capture (capture)

--- a/src/senaite/core/browser/viewlets/sampleanalyses.py
+++ b/src/senaite/core/browser/viewlets/sampleanalyses.py
@@ -22,6 +22,7 @@ from bika.lims import api
 from bika.lims import senaiteMessageFactory as _
 from plone.app.layout.viewlets import ViewletBase
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from senaite.core.registry import get_registry_record
 
 
 class LabAnalysesViewlet(ViewletBase):
@@ -38,7 +39,9 @@ class LabAnalysesViewlet(ViewletBase):
         return self.context
 
     def is_collapsed(self):
-        return False
+        name = "sampleview_collapse_{}_analysis_table".format(
+            self.capture)
+        return get_registry_record(name, default=False)
 
     def available(self):
         """Returns true if this sample contains at least one analysis for the

--- a/src/senaite/core/browser/viewlets/templates/sampleanalyses.pt
+++ b/src/senaite/core/browser/viewlets/templates/sampleanalyses.pt
@@ -1,5 +1,7 @@
 <div class="analysis-listing-table"
      tal:condition="python:view.available()"
+     tal:define="id string:table-${view/capture|other}-analyses;
+                 collapsed python:view.is_collapsed()"
      i18n:domain="senaite.core">
   <div class="row mb-4">
     <div class="col-sm-12">
@@ -7,13 +9,41 @@
       <!-- Analysis listing title and icon -->
       <h3 tal:define="icon view/icon_name|nothing;
                       title view/title|nothing"
+          class="d-inline-block"
           tal:condition="title">
         <img tal:condition="icon|nothing" tal:attributes="src string:senaite_theme/icon/${icon}"/>
-        <span i18n:translate="" tal:content="title"/>
+        <span class="align-middle" i18n:translate="" tal:content="title"/>
       </h3>
 
+      <!-- Toggle Button -->
+      <a href="#" class="text-decoration-none ml-2"
+          data-toggle="collapse"
+          tal:attributes="data-target string:#${id}">
+        <i tal:condition="collapsed" class="toggle-icon fas fa-toggle-off"></i>
+        <i tal:condition="not: collapsed" class="toggle-icon fas fa-toggle-on"></i>
+      </a>
+
       <!-- Analyis listing table -->
-      <span tal:replace="structure python:view.contents_table()"/>
+      <div tal:attributes="id id;
+                           class python:'collapse' if collapsed else 'show'">
+        <span tal:replace="structure python:view.contents_table()"/>
+      </div>
+
+      <!-- Toggle JS -->
+      <script type="text/javascript">
+       document.addEventListener("DOMContentLoaded", (event) => {
+         let id='<tal:id replace="id"></tal:id>';
+         let toggle_icon = $('a[data-target="#' + id + '"] i.toggle-icon');
+         $('#' + id).on('show.bs.collapse', function () {
+           toggle_icon.removeClass("fa-toggle-off");
+           toggle_icon.addClass("fa-toggle-on");
+         });
+         $('#' + id).on('hide.bs.collapse', function () {
+           toggle_icon.removeClass("fa-toggle-on");
+           toggle_icon.addClass("fa-toggle-off");
+         });
+       });
+      </script>
 
     </div>
   </div>

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2420</version>
+  <version>2421</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/profiles/default/registry.xml
+++ b/src/senaite/core/profiles/default/registry.xml
@@ -4,6 +4,9 @@
   <!-- SENAITE Registry -->
   <records interface="senaite.core.registry.schema.ISenaiteRegistry" />
 
+  <!-- Registry for sample view configuration -->
+  <records interface="senaite.core.registry.schema.ISampleViewRegistry" />
+
   <!-- Registry for sample header configuration -->
   <records interface="senaite.core.registry.schema.ISampleHeaderRegistry" />
 

--- a/src/senaite/core/registry/schema.py
+++ b/src/senaite/core/registry/schema.py
@@ -10,6 +10,41 @@ class ISenaiteRegistry(model.Schema):
     """
 
 
+class ISampleViewRegistry(ISenaiteRegistry):
+    """Registry settings for sample settings
+    """
+    model.fieldset(
+        "sample_view",
+        label=_(u"Sample View"),
+        description=_("Configuration for the sample view"),
+        fields=[
+            "sampleview_collapse_field_analysis_table",
+            "sampleview_collapse_lab_analysis_table",
+            "sampleview_collapse_qc_analysis_table",
+        ],
+    )
+    sampleview_collapse_field_analysis_table = schema.Bool(
+        title=_("Collapse field analysis table"),
+        description=_("Collapse field analysis table in sample view"),
+        default=False,
+        required=False,
+    )
+
+    sampleview_collapse_lab_analysis_table = schema.Bool(
+        title=_("Collapse lab analysis table"),
+        description=_("Collapse lab analysis table in sample view"),
+        default=False,
+        required=False,
+    )
+
+    sampleview_collapse_qc_analysis_table = schema.Bool(
+        title=_("Collapse qc analysis table"),
+        description=_("Collapse qc analysis table in sample view"),
+        default=True,
+        required=False,
+    )
+
+
 class ISampleHeaderRegistry(ISenaiteRegistry):
     """Registry settings for sample header configuration
     """

--- a/src/senaite/core/upgrade/v02_04_000.py
+++ b/src/senaite/core/upgrade/v02_04_000.py
@@ -766,3 +766,11 @@ def convert_attachment_report_options(tool):
         obj._p_deactivate()
 
     logger.info("Convert attachment report options [DONE]")
+
+
+def import_registry(tool):
+    """Import registry step from profiles
+    """
+    portal = tool.aq_inner.aq_parent
+    setup = portal.portal_setup
+    setup.runImportStepFromProfile(profile, "plone.app.registry")

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -186,4 +186,12 @@
       handler="senaite.core.upgrade.v02_04_000.ignore_attachments_from_invalid_analyses"
       profile="senaite.core:default"/>
 
+  <genericsetup:upgradeStep
+      title="SENAITE CORE 2.4.0: Update configuration registry"
+      description="Update configuration registry for sample section rendering"
+      source="2420"
+      destination="2421"
+      handler="senaite.core.upgrade.v02_04_000.import_registry"
+      profile="senaite.core:default"/>
+
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR allows to toggle the analysis table listings in the sample view:

<img width="1717" alt="" src="https://user-images.githubusercontent.com/713193/221977356-e2090fe9-1a01-4793-a2ac-c0b7f460ca5c.png">

Per default, the QC analysis table is collapsed. But this setting can be configured in the senaite registry:

<img width="678" alt="" src="https://user-images.githubusercontent.com/713193/221977534-018d9a00-72cd-47c1-9178-43dc727c5df1.png">

## Current behavior before PR

Analysis tables in the sample view are always shown expanded.

## Desired behavior after PR is merged

Analysis tables in the sample view can be collapsed if needed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
