### PR TITLE
Change worksheet analysis column order for better results capturing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2266 Change worksheet analysis column order for better results capturing
 - #2265 Change sample analysis column order for better results capturing
 - #2264 Collapsible analyses listings in sample view
 - #2262 Simplify attachment render in report options to single checkbox

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -263,7 +263,8 @@ class AnalysesView(ListingView):
         :returns: List of column keys
         """
         name = "sampleview_analysis_columns_order"
-        return get_registry_record(name, default=[])
+        columns_order = get_registry_record(name, default=[]) or []
+        return columns_order
 
     def reorder_analysis_columns(self):
         """Reorder analysis columns based on registry configuration

--- a/src/bika/lims/browser/worksheet/views/analyses.py
+++ b/src/bika/lims/browser/worksheet/views/analyses.py
@@ -163,13 +163,14 @@ class AnalysesView(BaseView):
             for state in self.review_states:
                 state["custom_transitions"] = [self.set_analysis_remarks_modal]
 
+    @view.memoize
     def get_default_columns_order(self):
         """Return the default column order from the registry
 
         :returns: List of column keys
         """
         name = "worksheetview_analysis_columns_order"
-        columns_order = get_registry_record(name, default=[])
+        columns_order = get_registry_record(name, default=[]) or []
         # Always put `Pos` column first
         try:
             columns_order.remove("Pos")

--- a/src/bika/lims/browser/worksheet/views/analyses.py
+++ b/src/bika/lims/browser/worksheet/views/analyses.py
@@ -163,7 +163,6 @@ class AnalysesView(BaseView):
             for state in self.review_states:
                 state["custom_transitions"] = [self.set_analysis_remarks_modal]
 
-    @view.memoize
     def get_default_columns_order(self):
         """Return the default column order from the registry
 

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2422</version>
+  <version>2423</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/profiles/default/registry.xml
+++ b/src/senaite/core/profiles/default/registry.xml
@@ -4,6 +4,9 @@
   <!-- SENAITE Registry -->
   <records interface="senaite.core.registry.schema.ISenaiteRegistry" />
 
+  <!-- Registry for worksheet view configuration -->
+  <records interface="senaite.core.registry.schema.IWorksheetViewRegistry" />
+
   <!-- Registry for sample view configuration -->
   <records interface="senaite.core.registry.schema.ISampleViewRegistry" />
 

--- a/src/senaite/core/registry/schema.py
+++ b/src/senaite/core/registry/schema.py
@@ -10,13 +10,49 @@ class ISenaiteRegistry(model.Schema):
     """
 
 
+class IWorksheetViewRegistry(ISenaiteRegistry):
+    """View settings for worksheets
+    """
+    model.fieldset(
+        "worksheet_view",
+        label=_(u"Worksheet View"),
+        description=_("Worksheet view configuration"),
+        fields=[
+            "worksheetview_analysis_columns_order",
+        ],
+    )
+
+    worksheetview_analysis_columns_order = schema.List(
+        title=_(u"Analysis columns order"),
+        description=_(
+            u"Default column order for worksheet analysis listings"
+        ),
+        value_type=schema.ASCIILine(title=u"Column"),
+        required=False,
+        default=[
+            "Pos",
+            "Service",
+            "DetectionLimitOperand",
+            "Result",
+            "Uncertainty",
+            "Specification",
+            "retested",
+            "Method",
+            "Instrument",
+            "Attachments",
+            "DueDate",
+            "state_title",
+        ]
+    )
+
+
 class ISampleViewRegistry(ISenaiteRegistry):
-    """Registry settings for sample settings
+    """View settings for samples
     """
     model.fieldset(
         "sample_view",
         label=_(u"Sample View"),
-        description=_("Configuration for the sample view"),
+        description=_("Sample view configuration"),
         fields=[
             "sampleview_collapse_field_analysis_table",
             "sampleview_collapse_lab_analysis_table",

--- a/src/senaite/core/upgrade/v02_04_000.zcml
+++ b/src/senaite/core/upgrade/v02_04_000.zcml
@@ -202,4 +202,12 @@
       handler="senaite.core.upgrade.v02_04_000.import_registry"
       profile="senaite.core:default"/>
 
+  <genericsetup:upgradeStep
+      title="SENAITE CORE 2.4.0: Update configuration registry"
+      description="Update configuration registry for worksheet analyses columns config"
+      source="2422"
+      destination="2423"
+      handler="senaite.core.upgrade.v02_04_000.import_registry"
+      profile="senaite.core:default"/>
+
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR applies a similar column order for worksheet analyses that was introduced in the PR https://github.com/senaite/senaite.core/pull/2265

The default order can be changed via the SENAITE registry.

## Current behavior before PR

Result/Interim columns might be shifted out of the screen when long instrument/method selection fields are rendered before

## Desired behavior after PR is merged

Analysis Interims and Results come right after the Service. Other columns are reordered from most to least important.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
