### PR TITLE
Worksheet transposed layout fixtures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2267 Worksheet transposed layout fixtures
 - #2266 Change worksheet analysis column order for better results capturing
 - #2265 Change sample analysis column order for better results capturing
 - #2264 Collapsible analyses listings in sample view

--- a/src/bika/lims/browser/worksheet/views/analyses.py
+++ b/src/bika/lims/browser/worksheet/views/analyses.py
@@ -487,6 +487,7 @@ class AnalysesView(BaseView):
         template = ViewPageTemplateFile("../templates/slot_header.pt")
         return template(self, data=data)
 
+    @view.memoize
     def get_slot_header_data(self, obj):
         """Prepare the data for the slot header template
         """

--- a/src/bika/lims/browser/worksheet/views/analyses_transposed.py
+++ b/src/bika/lims/browser/worksheet/views/analyses_transposed.py
@@ -25,11 +25,14 @@ from bika.lims.browser.worksheet.views import AnalysesView
 from bika.lims.utils import get_link
 from bika.lims.utils import t
 from plone.memoize import view
+from senaite.app.listing.interfaces import ITransposedListingView
+from zope.interface import implements
 
 
 class AnalysesTransposedView(AnalysesView):
     """Transposed Manage Results View for Worksheet Analyses
     """
+    implements(ITransposedListingView)
 
     def __init__(self, context, request):
         super(AnalysesTransposedView, self).__init__(context, request)

--- a/src/bika/lims/browser/worksheet/views/analyses_transposed.py
+++ b/src/bika/lims/browser/worksheet/views/analyses_transposed.py
@@ -107,8 +107,6 @@ class AnalysesTransposedView(AnalysesView):
 
         # append all regular items that belong to this service
         if pos not in self.services[keyword]:
-            # XXX Needed placeholder render the select checkbox
-            # item["before"]["Result"] = None
             # Add the item below its position
             self.services[keyword][pos] = item
             # Track the new transposed key for this item


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Please test together with https://github.com/senaite/senaite.app.listing/pull/104 and merge https://github.com/senaite/senaite.app.listing/pull/104 before this one (because of the marker interface import).

## Current behavior before PR

Slots (folderitems) are grouped by service titles and might therefore be overwritten.

## Desired behavior after PR is merged

Slots (folderitems) are grouped by service keyword to avoid the overwriting behaviour

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
