### PR TITLE
Add samplepoint information to worksheet slot header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.4.0 (unreleased)
 ------------------
 
+- #2268 Add samplepoint information to worksheet slot header
 - #2267 Worksheet transposed layout fixtures
 - #2266 Change worksheet analysis column order for better results capturing
 - #2265 Change sample analysis column order for better results capturing

--- a/src/bika/lims/browser/worksheet/templates/slot_header.pt
+++ b/src/bika/lims/browser/worksheet/templates/slot_header.pt
@@ -33,7 +33,7 @@
         </a>
       </td>
     </tr>
-    <tr>
+    <tr tal:condition="nocall:data/sample_type_obj">
       <td></td>
       <td>
         <!-- Sample Type Icon -->
@@ -42,6 +42,18 @@
         <a href=""
            tal:attributes="href data/sample_type_url|nothing">
           <span tal:replace="data/sample_type_title|nothing"/>
+        </a>
+      </td>
+    </tr>
+    <tr tal:condition="nocall:data/sample_point_obj">
+      <td></td>
+      <td>
+        <!-- Sample Point Icon -->
+        <img class="img" tal:replace="structure data/sample_point_img|nothing"/>
+        <!-- Parent Title Link -->
+        <a href=""
+           tal:attributes="href data/sample_point_url|nothing">
+          <span tal:replace="data/sample_point_title|nothing"/>
         </a>
       </td>
     </tr>

--- a/src/bika/lims/browser/worksheet/views/analyses.py
+++ b/src/bika/lims/browser/worksheet/views/analyses.py
@@ -507,11 +507,17 @@ class AnalysesView(BaseView):
         parent_img_text = ""
         additional_parent_icons = []
 
-        sample_type_obj = None
+        sample_type = None
         sample_type_title = ""
         sample_type_url = ""
         sample_type_img = ""
         sample_type_img_text = ""
+
+        sample_point = None
+        sample_point_title = ""
+        sample_point_url = ""
+        sample_point_img = ""
+        sample_point_img_text = ""
 
         if IDuplicateAnalysis.providedBy(obj):
             # item
@@ -538,6 +544,13 @@ class AnalysesView(BaseView):
             sample_type_url = api.get_url(sample_type)
             sample_type_img = "sampletype.png"
             sample_type_img_text = t(_("Sample Type"))
+            # sample point
+            sample_point = request.getSamplePoint()
+            if sample_point:
+                sample_point_title = request.getSamplePointTitle()
+                sample_point_url = api.get_url(sample_point)
+                sample_point_img = "samplepoint.png"
+                sample_point_img_text = t(_("Sample Point"))
         elif IReferenceAnalysis.providedBy(obj):
             # item
             sample = obj.getSample()
@@ -585,6 +598,14 @@ class AnalysesView(BaseView):
             sample_type_img = "sampletype.png"
             sample_type_img_text = t(_("Sample Type"))
 
+            # sample point
+            sample_point = request.getSamplePoint()
+            if sample_point:
+                sample_point_title = request.getSamplePointTitle()
+                sample_point_url = api.get_url(sample_point)
+                sample_point_img = "samplepoint.png"
+                sample_point_img_text = t(_("Sample Point"))
+
         return {
             # item
             "item_obj": item_obj,
@@ -600,11 +621,17 @@ class AnalysesView(BaseView):
             "parent_img": get_image(parent_img, title=parent_img_text),
             "additional_parent_icons": additional_parent_icons,
             # sample type
-            "sample_type_obj": sample_type_obj,
+            "sample_type_obj": sample_type,
             "sample_type_title": sample_type_title,
             "sample_type_url": sample_type_url,
             "sample_type_img": get_image(
                 sample_type_img, title=sample_type_img_text),
+            # sample point
+            "sample_point_obj": sample_point,
+            "sample_point_title": sample_point_title,
+            "sample_point_url": sample_point_url,
+            "sample_point_img": get_image(
+                sample_point_img, title=sample_point_img_text),
         }
 
     def render_remarks_tag(self, ar):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds the sample point information to the WS slot header if set:

<img width="473" alt="worksheet slot header" src="https://user-images.githubusercontent.com/713193/224290847-f61b64cb-8144-48af-97a8-1f5292e3fceb.png">

## Current behavior before PR

Sample point not contained in slot header for routine and duplicate analyses.

## Desired behavior after PR is merged

Sample point contained in slot header for routine and duplicate analyses.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
