### PR TITLE
Convert value of max number of samples to integer

### DIFF
--- a/src/bika/lims/content/bikasetup.py
+++ b/src/bika/lims/content/bikasetup.py
@@ -1192,7 +1192,7 @@ class BikaSetup(folder.ATFolder):
         # setup is `None` during initial site content structure installation
         if setup:
             # we get a string value here!
-            value = api.to_float(value, default=10.0)
+            value = api.to_int(value, default=10)
             setup.setMaxNumberOfSamplesAdd(value)
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is complementary for https://github.com/senaite/senaite.core/pull/2252

## Current behavior before PR

Value is stored as float in the new setup, which makes it fail when saved there

## Desired behavior after PR is merged

Value is stored as int in the new setup


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
