### PR TITLE
Allow to configure the position of additional value columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
-- no changes yet
+- #2272 Allow to configure the position of additional value columns
 
 
 2.4.1 (2023-03-11)

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -283,6 +283,16 @@ class AnalysesView(ListingView):
             # set a copy of the new ordered columns list
             rs["columns"] = ordered_columns[:]
 
+    def calculate_interim_columns_position(self, review_state):
+        """Calculate at which position the interim columns should be inserted
+        """
+        columns = review_state.get("columns", [])
+        if "AdditionalValues" in columns:
+            return columns.index("AdditionalValues")
+        if "Result" in columns:
+            return columns.index("Result")
+        return len(columns)
+
     @property
     @viewcache.memoize
     def senaite_theme(self):
@@ -802,20 +812,10 @@ class AnalysesView(ListingView):
         if self.allow_edit:
             new_states = []
             for state in self.review_states:
-                # InterimFields are displayed in review_state
-                # They are anyway available through View.columns though.
-                # In case of hidden fields, the calcs.py should check
-                # calcs/services
-                # for additional InterimFields!!
-                pos = "Result" in state["columns"] and \
-                      state["columns"].index("Result") or len(state["columns"])
+                pos = self.calculate_interim_columns_position(state)
                 for col_id in interim_keys:
                     if col_id not in state["columns"]:
                         state["columns"].insert(pos, col_id)
-                # retested column is added after Result.
-                pos = "Result" in state["columns"] and \
-                      state["columns"].index("Uncertainty") + 1 or len(
-                    state["columns"])
                 new_states.append(state)
             self.review_states = new_states
             # Allow selecting individual analyses

--- a/src/senaite/core/registry/schema.py
+++ b/src/senaite/core/registry/schema.py
@@ -50,6 +50,7 @@ class IWorksheetViewRegistry(ISenaiteRegistry):
         default=[
             "Pos",
             "Service",
+            "AdditionalValues",
             "DetectionLimitOperand",
             "Result",
             "Uncertainty",
@@ -109,6 +110,7 @@ class ISampleViewRegistry(ISenaiteRegistry):
         default=[
             "created",
             "Service",
+            "AdditionalValues",
             "DetectionLimitOperand",
             "Result",
             "Uncertainty",


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is complementary to https://github.com/senaite/senaite.core/pull/2265 and https://github.com/senaite/senaite.core/pull/2266 and allows to configure the position of the interim / additional result columns in the sample/worksheet analyses listings.

## Current behavior before PR

Interim columns were always placed after the result column


## Desired behavior after PR is merged

The position of the interim columns can be configured over the virtual column `AdditionalValues` in the registry 


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
