### PR TITLE
Remove custom date rendering in sample header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2280 Remove custom date rendering in sample header
 - #2276 Senaite labels
 - #2275 Fix wrong result when both "Result options" and "String" are enabled
 - #2273 Improve performance for sample listing index

--- a/src/senaite/core/browser/viewlets/sampleheader.py
+++ b/src/senaite/core/browser/viewlets/sampleheader.py
@@ -34,8 +34,6 @@ from Products.Archetypes.interfaces import IField as IATField
 from Products.CMFCore.permissions import ModifyPortalContent
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from senaite.core import logger
-from senaite.core.api import dtime
-from senaite.core.browser.widgets.datetimewidget import DateTimeWidget
 from senaite.core.interfaces import IDataManager
 from zope import event
 from zope.component import queryAdapter

--- a/src/senaite/core/browser/viewlets/sampleheader.py
+++ b/src/senaite/core/browser/viewlets/sampleheader.py
@@ -203,17 +203,6 @@ class SampleHeaderViewlet(ViewletBase):
             if adapter is not None:
                 return adapter(field)
 
-            # TODO: Refactor to adapter
-            # Returns the localized date
-            if self.is_datetime_field(field):
-                value = field.get(self.context)
-                if not value:
-                    return None
-                return dtime.ulocalized_time(value,
-                                             long_format=True,
-                                             context=self.context,
-                                             request=self.request)
-
         return None
 
     def get_field_label(self, field, mode="view"):
@@ -303,14 +292,6 @@ class SampleHeaderViewlet(ViewletBase):
         if mode == "view":
             return False
         return field.required
-
-    def is_datetime_field(self, field):
-        """Check if the field is a date field
-        """
-        if self.is_at_field(field):
-            widget = self.get_widget(field)
-            return isinstance(widget, DateTimeWidget)
-        return False
 
     def is_at_field(self, field):
         """Check if the field is an AT field


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the custom rendering of date fields in the sample header and delegates to the widget.

## Current behavior before PR

Custom date field rendering

## Desired behavior after PR is merged

Date rendering is done by the widget

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
