### PR TITLE
Fix IndexError when importing setupdata

### DIFF
--- a/src/senaite/core/exportimport/setupdata/__init__.py
+++ b/src/senaite/core/exportimport/setupdata/__init__.py
@@ -41,6 +41,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import _createObjectByType
 from Products.CMFPlone.utils import safe_unicode
 from senaite.core.catalog import CLIENT_CATALOG
+from senaite.core.catalog import SETUP_CATALOG
 from senaite.core.exportimport.dataimport import SetupDataSetList as SDL
 from zope.event import notify
 from zope.interface import implements
@@ -1688,8 +1689,8 @@ class Analysis_Specifications(WorksheetImporter):
 
     def Import(self):
         bucket = {}
-        pc = getToolByName(self.context, "portal_catalog")
-        bsc = getToolByName(self.context, "senaite_catalog_setup")
+        client_catalog = getToolByName(self.context, CLIENT_CATALOG)
+        setup_catalog = getToolByName(self.context, SETUP_CATALOG)
         # collect up all values into the bucket
         for row in self.get_rows(3):
             title = row.get("Title", False)
@@ -1716,12 +1717,14 @@ class Analysis_Specifications(WorksheetImporter):
                 if parent == "lab":
                     folder = self.context.bika_setup.bika_analysisspecs
                 else:
-                    proxy = pc(portal_type="Client", getName=safe_unicode(parent))[0]
+                    proxy = client_catalog(
+                        portal_type="Client", getName=safe_unicode(parent))[0]
                     folder = proxy.getObject()
                 st = bucket[parent][title]["sampletype"]
                 resultsrange = bucket[parent][title]["resultsrange"]
                 if st:
-                    st_uid = bsc(portal_type="SampleType", title=safe_unicode(st))[0].UID
+                    st_uid = setup_catalog(
+                        portal_type="SampleType", title=safe_unicode(st))[0].UID
                 obj = _createObjectByType("AnalysisSpec", folder, tmpID())
                 obj.edit(title=title)
                 obj.setResultsRange(resultsrange)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a regression that was introduced with https://github.com/senaite/senaite.core/pull/2278

Thanks @giftfelix4848 for reporting!

## Current behavior before PR

Traceback occurs on data import:

```
2023-03-28 18:30:51,053 ERROR   [senaite.core:66][waitress-2] Traceback (most recent call last):
  File "/home/senaite/senaitelims/src/senaite.core/src/senaite/core/browser/form/adapters/data_import.py", line 61, in handle_data_import
    LoadSetupData(self.context, self.request)()
  File "/home/senaite/senaitelims/src/senaite.core/src/senaite/core/exportimport/load_setup_data.py", line 119, in __call__
    adapter(self, workbook, self.dataset_project, self.dataset_name)
  File "/home/senaite/senaitelims/src/senaite.core/src/senaite/core/exportimport/setupdata/__init__.py", line 116, in __call__
    self.Import()
  File "/home/senaite/senaitelims/src/senaite.core/src/senaite/core/exportimport/setupdata/__init__.py", line 1719, in Import
    proxy = pc(portal_type="Client", getName=safe_unicode(parent))[0]
  File "/home/senaite/senaitelims/eggs/cp27mu/Zope-4.8.7-py2.7.egg/ZTUtils/Lazy.py", line 140, in __getitem__
    raise IndexError(index)
IndexError: 0
```

## Desired behavior after PR is merged

Setupdata can be imported successfully

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
