### PR TITLE
Fix the email sent on sample rejection is not text/html

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2284 Fix the email sent on sample rejection is not text/html
 - #2279 Allow all custom transitions in sample report listing
 - #2280 Remove custom date rendering in sample header
 - #2278 Client catalog

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -594,4 +594,5 @@ def get_rejection_mail(sample, rejection_pdf=None):
         to_addr=_to,
         subj=_("%s has been rejected") % api.get_id(sample),
         body=email_body,
+        html=True,
         attachments=attachments)

--- a/src/senaite/core/tests/doctests/API_mail.rst
+++ b/src/senaite/core/tests/doctests/API_mail.rst
@@ -232,3 +232,43 @@ This function composes a new MIME message:
     5/sfV5M/kISv300AAAAASUVORK5CYII=
     ...
     <BLANKLINE>
+
+By default, the body is not encoded as html:
+
+    >>> body = "<p>Check out the new SENAITE website: $url</p>"
+    >>> message = compose_email("from@senaite.com",
+    ...                         ["to@senaite.com", "to2@senaite.com"],
+    ...                         "Test Émail",
+    ...                         body,
+    ...                         attachments=[filepath],
+    ...                         url="https://www.senaite.com")
+
+    >>> print(message)
+    From ...
+    ...
+    MIME-Version: 1.0
+    Content-Type: text/plain; charset="utf-8"
+    Content-Transfer-Encoding: quoted-printable
+    <BLANKLINE>
+    <p>Check out the new SENAITE website: https://www.senaite.com</p>
+    ...
+
+Unless the html parameter is set to True:
+
+    >>> message = compose_email("from@senaite.com",
+    ...                         ["to@senaite.com", "to2@senaite.com"],
+    ...                         "Test Émail",
+    ...                         body,
+    ...                         html=True,
+    ...                         attachments=[filepath],
+    ...                         url="https://www.senaite.com")
+
+    >>> print(message)
+    From ...
+    ...
+    MIME-Version: 1.0
+    Content-Type: text/html; charset="utf-8"
+    Content-Transfer-Encoding: quoted-printable
+    <BLANKLINE>
+    <p>Check out the new SENAITE website: https://www.senaite.com</p>
+    ...


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the content type of the body of the email that is sent automatically to the client contact on sample rejection is `text/html`.

## Current behavior before PR

![225860665-b555824e-88c7-4b7c-bd4e-b21d4d5ecaaa](https://user-images.githubusercontent.com/832627/228493169-68561260-5674-4efa-9166-ee38aa81f02b.png)


## Desired behavior after PR is merged

HTML elements are rendered accordingly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
