### PR TITLE
Fix string results with html characters not displayed after submit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2285 Fix string results with html characters not displayed after submit
 - #2284 Fix the email sent on sample rejection is not text/html
 - #2279 Allow all custom transitions in sample report listing
 - #2280 Remove custom date rendering in sample header

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -882,7 +882,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
 
         # If string result, return without any formatting
         if self.getStringResult():
-            return result
+            return cgi.escape(result) if html else result
 
         # If a detection limit, return '< LDL' or '> UDL'
         dl = self.getDetectionLimitOperand()

--- a/src/senaite/core/tests/doctests/StringResult.rst
+++ b/src/senaite/core/tests/doctests/StringResult.rst
@@ -83,6 +83,11 @@ enabled, the system returns the string value "as-is" without any processing:
     >>> sample = new_sample([Cu])
 
     >>> cu = get_analysis(sample, Cu)
+    >>> cu.setResult(1.23456789)
+    >>> cu.getResult()
+    '1.23456789'
+    >>> cu.getFormattedResult()
+    '1.23456789'
     >>> cu.setResult('0')
     >>> cu.getResult()
     '0'

--- a/src/senaite/core/tests/doctests/StringResult.rst
+++ b/src/senaite/core/tests/doctests/StringResult.rst
@@ -1,0 +1,110 @@
+String Result
+-------------
+
+An analysis can be configured so the captured value is treated as an string
+and not processed internally.
+
+Running this test from the buildout directory::
+
+    bin/test test_textual_doctests -t StringResult
+
+
+Test Setup
+..........
+
+Needed Imports:
+
+    >>> from bika.lims import api
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+    >>> from DateTime import DateTime
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+
+Functional Helpers:
+
+    >>> def start_server():
+    ...     from Testing.ZopeTestCase.utils import startZServer
+    ...     ip, port = startZServer()
+    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
+
+    >>> def timestamp(format="%Y-%m-%d"):
+    ...     return DateTime().strftime(format)
+
+    >>> def new_sample(services):
+    ...     values = {
+    ...         'Client': client.UID(),
+    ...         'Contact': contact.UID(),
+    ...         'DateSampled': date_now,
+    ...         'SampleType': sampletype.UID()}
+    ...     service_uids = map(api.get_uid, services)
+    ...     ar = create_analysisrequest(client, request, values, service_uids)
+    ...     transitioned = do_action_for(ar, "receive")
+    ...     return ar
+
+    >>> def get_analysis(sample, service):
+    ...     service_uid = api.get_uid(service)
+    ...     for analysis in sample.getAnalyses(full_objects=True):
+    ...         if analysis.getServiceUID() == service_uid:
+    ...             return analysis
+    ...     return None
+
+    >>> def submit_analyses(ar, result="13"):
+    ...     for analysis in ar.getAnalyses(full_objects=True):
+    ...         analysis.setResult(result)
+    ...         do_action_for(analysis, "submit")
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = api.get_setup()
+    >>> date_now = DateTime().strftime("%Y-%m-%d")
+
+We need to create some basic objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
+    >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH", MemberDiscountApplies=True)
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(setup.bika_sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.bika_departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = api.create(setup.bika_analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> Cu = api.create(setup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID())
+    >>> Cu.setStringResult(True)
+
+Test string result
+..................
+
+When a result is captured and the analysis has the StringResult setting,
+enabled, the system returns the string value "as-is" without any processing:
+
+    >>> sample = new_sample([Cu])
+
+    >>> cu = get_analysis(sample, Cu)
+    >>> cu.setResult('0')
+    >>> cu.getResult()
+    '0'
+    >>> cu.getFormattedResult()
+    '0'
+
+    >>> cu.setResult('This is a result')
+    >>> cu.getResult()
+    'This is a result'
+    >>> cu.getFormattedResult()
+    'This is a result'
+
+If the result contains html characters, `getFormattedResult` escape them
+by default:
+
+    >>> cu.setResult('< Detection Limit')
+    >>> cu.getResult()
+    '< Detection Limit'
+    >>> cu.getFormattedResult()
+    '&lt; Detection Limit'
+
+Unless the parameter `html` is set to False:
+
+    >>> cu.getFormattedResult(html=False)
+    '< Detection Limit'


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that html characters are escaped when displaying a result of a test with the setting "StringResult" enabled

## Current behavior before PR

Results with special characters (e.g. `<`) are not displayed after submit

Before submit:

![224707383-fcb32f32-d093-492c-82cf-ff2b9f11e5c2](https://user-images.githubusercontent.com/832627/228515063-59ee9b42-9244-49e9-8556-5316b99adef3.png)

After submit:

![224707422-04758b72-ee4c-43b5-b802-dce76919f2f8](https://user-images.githubusercontent.com/832627/228515109-501ff660-bb8a-4b13-9adc-3d12cb6cf828.png)


## Desired behavior after PR is merged

Result is displayed, with the special hmtl characters escaped

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
