### PR TITLE
Force beore/after update subscribers for upgrade step 2502

### DIFF
--- a/src/senaite/core/upgrade/v02_05_000.py
+++ b/src/senaite/core/upgrade/v02_05_000.py
@@ -72,6 +72,7 @@ def rebuild_sample_zctext_index_and_lexicon(tool):
     reindex_index(SAMPLE_CATALOG, index)
 
 
+@upgradestep(product, version)
 def setup_labels(tool):
     """Setup labels for SENAITE
     """
@@ -118,6 +119,7 @@ def uncatalog_type(portal_type, catalog="portal_catalog", **kw):
     brains = api.search(query, catalog=catalog)
     for brain in brains:
         uncatalog_brain(brain)
+
 
 def setup_catalogs(tool):
     """Setup all core catalogs and ensure all indexes are present


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The upgrade step 2502 import steps from senaite.core profile that quite often are overwritten by other add-ons, such as "typeinfo" or "workflow".

This change ensures the BeforeUpgradeStep and AfterUpgradeStep events are called after 2502, so add-ons can re-import or modify the changes caused by the import of senaite.core steps.

## Current behavior before PR

`BeforeUpgradeStepEvent` and `AfterUpgradeStepEvent` are not called for upgrade step 2502

## Desired behavior after PR is merged

`BeforeUpgradeStepEvent` and `AfterUpgradeStepEvent` are called for upgrade step 2502

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
