### PR TITLE
Call super class before_render to call extending adapters

### DIFF
--- a/src/bika/lims/browser/publish/reports_listing.py
+++ b/src/bika/lims/browser/publish/reports_listing.py
@@ -102,6 +102,7 @@ class ReportsListingView(ListingView):
     def before_render(self):
         """Before render hook
         """
+        super(ReportsListingView, self).before_render()
         self.init_custom_transitions()
 
     def init_custom_transitions(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a regression that was introduced with https://github.com/senaite/senaite.core/pull/2279

## Current behavior before PR

Listing view adapters to extend columns are not called

## Desired behavior after PR is merged

Listing view adapters get called and allow to extend columns

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
