### PR TITLE
Fixed client dropdown on batch add

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2288 Fix client dropdown on batch add
 - #2282 Fix sample reports retrieval
 - #2285 Fix string results with html characters not displayed after submit
 - #2284 Fix the email sent on sample rejection is not text/html

--- a/src/bika/lims/content/batch.py
+++ b/src/bika/lims/content/batch.py
@@ -45,6 +45,7 @@ from Products.Archetypes.public import StringField
 from Products.Archetypes.public import StringWidget
 from Products.Archetypes.public import registerType
 from Products.CMFCore.utils import getToolByName
+from senaite.core.catalog import CLIENT_CATALOG
 from senaite.core.catalog import SAMPLE_CATALOG
 from zope.interface import implements
 
@@ -77,6 +78,7 @@ schema = BikaFolderSchema.copy() + Schema((
             label=_("Client"),
             size=30,
             visible=True,
+            catalog_name=CLIENT_CATALOG,
             base_query={'review_state': 'active'},
             showOn=True,
             colModel=[


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
When adding a batch the client dropdown is empty because it is still using the portal_catalog instead of the new CLIENT_CATALOG
Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR
Client dropdown on the Batch  is empty when selecting a client on adding a batch 
## Desired behavior after PR is merged
Clients should be shown on the dropdown when selecting a client on a batch

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
