### PR TITLE
Add Title Index and Description Metadata to Client Catalog

### DIFF
--- a/src/senaite/core/catalog/client_catalog.py
+++ b/src/senaite/core/catalog/client_catalog.py
@@ -12,6 +12,7 @@ CATALOG_TITLE = "Senaite Client Catalog"
 
 INDEXES = BASE_INDEXES + [
     # id, indexed attribute, type
+    ("Title", "", "ZCTextIndex"),
     ("client_searchable_text", "", "ZCTextIndex"),
     ("getClientID", "", "FieldIndex"),
     ("getName", "", "FieldIndex"),
@@ -20,6 +21,7 @@ INDEXES = BASE_INDEXES + [
 
 COLUMNS = BASE_COLUMNS + [
     # attribute name
+    "Description",
     "getClientID",
     "getName",
 ]

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2505</version>
+  <version>2506</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/v02_05_000.zcml
+++ b/src/senaite/core/upgrade/v02_05_000.zcml
@@ -4,6 +4,14 @@
     i18n_domain="senaite.core">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.5.0: Additional index/metadata for client catalog"
+      description="Add searchable Title index and Description metadata for relation fields"
+      source="2505"
+      destination="2506"
+      handler=".v02_05_000.setup_catalogs"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.5.0: Fix report catalog indexes"
       description="Fix indexes in report catalog and add metadata"
       source="2504"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is related to https://github.com/senaite/senaite.core/pull/2278 and adds a Title ZCText Index and Description metadata to Client catalog.

## Current behavior before PR

Some UID reference fields do not work properly because they use the Title index for searching

## Desired behavior after PR is merged

UID reference fields search correctly when using Client Catalog

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
