### PR TITLE
Fix ValueError when displaying dates before 1900 (by datetimewidget)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
-- #2292 Make datetimewidget to display dates before 1900 in iso format
+- #2292 Fix ValueError when displaying dates before 1900 (by datetimewidget)
 - #2288 Fix client dropdown on batch add
 - #2282 Fix sample reports retrieval
 - #2285 Fix string results with html characters not displayed after submit

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2292 Make datetimewidget to display dates before 1900 in iso format
 - #2288 Fix client dropdown on batch add
 - #2282 Fix sample reports retrieval
 - #2285 Fix string results with html characters not displayed after submit

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -29,6 +29,7 @@ import six
 import pytz
 from bika.lims import logger
 from bika.lims.api import APIError
+from bika.lims.api import get_tool
 from DateTime import DateTime
 from DateTime.DateTime import DateError
 from DateTime.DateTime import SyntaxError
@@ -364,12 +365,12 @@ def to_localized_time(dt, long_format=None, time_only=None,
     :returns: The formatted date as string
     :rtype: string
     """
-    dt = to_DT(dt)
     if not dt:
         return default
 
     try:
-        time_str = ulocalized_time(
+        ts = get_tool("translation_service")
+        time_str = ts.ulocalized_time(
             dt, long_format, time_only, context, "senaite.core", request)
     except ValueError:
         # Handle dates < 1900
@@ -392,5 +393,5 @@ def to_localized_time(dt, long_format=None, time_only=None,
                 formatstring = "%H:%M"  # 03:14
             else:
                 formatstring = "[INTERNAL ERROR]"
-        time_str = date_to_string(dt, formatstring)
+        time_str = date_to_string(dt, formatstring, default=default)
     return time_str

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -34,7 +34,6 @@ from DateTime import DateTime
 from DateTime.DateTime import DateError
 from DateTime.DateTime import SyntaxError
 from DateTime.DateTime import TimeError
-from Products.CMFPlone.i18nl10n import ulocalized_time
 from zope.i18n import translate
 
 

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -13,6 +13,7 @@ Test Setup
 
 Imports:
 
+    >>> from bika.lims.api import get_tool
     >>> from senaite.core.api import dtime
 
 Define some variables:
@@ -436,3 +437,59 @@ Check 24h vs 12h format:
     >>> dt = datetime.strptime(DATE, DATEFORMAT)
     >>> dtime.date_to_string(dt, fmt="%Y-%m-%d %I:%M %p")
     '1755-08-01 11:01 PM'
+
+
+Localization
+............
+
+Values returned by TranslationService and dtime's ulocalized_time are
+consistent:
+
+    >>> ts = get_tool("translation_service")
+    >>> dt = "2022-12-14"
+    >>> ts.ulocalized_time(dt, long_format=True, domain="senaite.core")
+    '2022-12-14 01:00'
+    >>> dtime.to_localized_time(dt, long_format=True)
+    '2022-12-14 01:00'
+
+    >>> dt = datetime(2022,12,14)
+    >>> ts.ulocalized_time(dt, long_format=True, domain="senaite.core")
+    '2022-12-14 00:00'
+    >>> dtime.to_localized_time(dt, long_format=True)
+    '2022-12-14 00:00'
+
+    >>> dt = DateTime(2022,12,14)
+    >>> ts.ulocalized_time(dt, long_format=True, domain="senaite.core")
+    '2022-12-14 00:00'
+    >>> dtime.to_localized_time(dt, long_format=True)
+    '2022-12-14 00:00'
+
+But when a date with a year before 1900 is used, dtime's does fallback to
+standard ISO format, while TranslationService fails:
+
+    >>> dt = "1889-12-14"
+    >>> ts.ulocalized_time(dt, long_format=True, domain="senaite.core")
+    Traceback (most recent call last):
+    ...
+    ValueError: year=1889 is before 1900; the datetime strftime() methods require year >= 1900
+
+    >>> dtime.to_localized_time(dt, long_format=True)
+    '1889-12-14 00:00'
+
+    >>> dt = datetime(1889,12,14)
+    >>> ts.ulocalized_time(dt, long_format=True, domain="senaite.core")
+    Traceback (most recent call last):
+    ...
+    ValueError: year=1889 is before 1900; the datetime strftime() methods require year >= 1900
+
+    >>> dtime.to_localized_time(dt, long_format=True)
+    '1889-12-14 00:00'
+
+    >>> dt = DateTime(1889,12,14)
+    >>> ts.ulocalized_time(dt, long_format=True, domain="senaite.core")
+    Traceback (most recent call last):
+    ...
+    ValueError: year=1889 is before 1900; the datetime strftime() methods require year >= 1900
+
+    >>> dtime.to_localized_time(dt, long_format=True)
+    '1889-12-14 00:00'

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -446,23 +446,24 @@ Values returned by TranslationService and dtime's ulocalized_time are
 consistent:
 
     >>> ts = get_tool("translation_service")
-    >>> dt = "2022-12-14"
-    >>> ts.ulocalized_time(dt, long_format=True, domain="senaite.core")
-    '2022-12-14 01:00'
-    >>> dtime.to_localized_time(dt, long_format=True)
-    '2022-12-14 01:00'
+    >>> ts_dt = ts.ulocalized_time(dt, long_format=True, domain="senaite.core")
+    >>> dt_dt = dtime.to_localized_time(dt, long_format=True)
+    >>> ts_dt == dt_dt
+    True
 
     >>> dt = datetime(2022,12,14)
-    >>> ts.ulocalized_time(dt, long_format=True, domain="senaite.core")
+    >>> ts_dt = ts.ulocalized_time(dt, long_format=True, domain="senaite.core")
     '2022-12-14 00:00'
-    >>> dtime.to_localized_time(dt, long_format=True)
-    '2022-12-14 00:00'
+    >>> dt_dt = dtime.to_localized_time(dt, long_format=True)
+    >>> ts_dt == dt_dt
+    True
 
     >>> dt = DateTime(2022,12,14)
-    >>> ts.ulocalized_time(dt, long_format=True, domain="senaite.core")
+    >>> ts_dt = ts.ulocalized_time(dt, long_format=True, domain="senaite.core")
     '2022-12-14 00:00'
-    >>> dtime.to_localized_time(dt, long_format=True)
-    '2022-12-14 00:00'
+    >>> dt_dt = dtime.to_localized_time(dt, long_format=True)
+    >>> ts_dt == dt_dt
+    True
 
 But when a date with a year before 1900 is used, dtime's does fallback to
 standard ISO format, while TranslationService fails:

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -446,6 +446,7 @@ Values returned by TranslationService and dtime's ulocalized_time are
 consistent:
 
     >>> ts = get_tool("translation_service")
+    >>> dt = "2022-12-14"
     >>> ts_dt = ts.ulocalized_time(dt, long_format=True, domain="senaite.core")
     >>> dt_dt = dtime.to_localized_time(dt, long_format=True)
     >>> ts_dt == dt_dt
@@ -453,14 +454,12 @@ consistent:
 
     >>> dt = datetime(2022,12,14)
     >>> ts_dt = ts.ulocalized_time(dt, long_format=True, domain="senaite.core")
-    '2022-12-14 00:00'
     >>> dt_dt = dtime.to_localized_time(dt, long_format=True)
     >>> ts_dt == dt_dt
     True
 
     >>> dt = DateTime(2022,12,14)
     >>> ts_dt = ts.ulocalized_time(dt, long_format=True, domain="senaite.core")
-    '2022-12-14 00:00'
     >>> dt_dt = dtime.to_localized_time(dt, long_format=True)
     >>> ts_dt == dt_dt
     True

--- a/src/senaite/core/z3cform/widgets/datetimewidget.py
+++ b/src/senaite/core/z3cform/widgets/datetimewidget.py
@@ -172,8 +172,8 @@ class DatetimeWidget(HTMLInputWidget, Widget):
         """Convert time to localized time
         """
         dt = self.to_datetime(time)
-        long_fmt = True if self.show_time else False
-        return dtime.to_localized_time(dt, long_fmt, time_only, self.context)
+        long_format = True if self.show_time else False
+        return dtime.to_localized_time(dt, long_format, time_only)
 
     def get_display_value(self):
         """Returns the localized date value

--- a/src/senaite/core/z3cform/widgets/datetimewidget.py
+++ b/src/senaite/core/z3cform/widgets/datetimewidget.py
@@ -195,9 +195,9 @@ class DatetimeWidget(HTMLInputWidget, Widget):
             if "year >= 1900" not in err.message:
                 raise
 
-            # Python uses the platform C library’s strftime implementation
-            # that does not allow dates before 1900.
-            # Fallback to hardcoded iso style and rely on or own api
+            # Python uses the platform C library’s strftime implementation,
+            # that does not allow dates before 1900. Fallback to hardcoded iso
+            # style and rely on our dime api
             logger.warn(err.message)
             fmt = '%Y-%m-%d %H:%M' if self.show_time else '%Y-%m-%d'
             return dtime.date_to_string(value, fmt)

--- a/src/senaite/core/z3cform/widgets/datetimewidget.py
+++ b/src/senaite/core/z3cform/widgets/datetimewidget.py
@@ -22,7 +22,6 @@ from datetime import datetime
 from datetime import timedelta
 
 from bika.lims import api
-from senaite.core import logger
 from senaite.core.api import dtime
 from senaite.core.interfaces import ISenaiteFormLayer
 from senaite.core.schema.interfaces import IDatetimeField
@@ -173,10 +172,8 @@ class DatetimeWidget(HTMLInputWidget, Widget):
         """Convert time to localized time
         """
         dt = self.to_datetime(time)
-        ts = api.get_tool("translation_service")
-        long_format = True if self.show_time else False
-        return ts.ulocalized_time(
-            dt, long_format, time_only, self.context, domain="senaite.core")
+        long_fmt = True if self.show_time else False
+        return dtime.to_localized_time(dt, long_fmt, time_only, self.context)
 
     def get_display_value(self):
         """Returns the localized date value
@@ -188,19 +185,7 @@ class DatetimeWidget(HTMLInputWidget, Widget):
             value = dm.query()
         if not dtime.is_date(value):
             return None
-
-        try:
-            return self.to_localized_time(value)
-        except ValueError as err:
-            if "year >= 1900" not in err.message:
-                raise
-
-            # Python uses the platform C library’s strftime implementation,
-            # that does not allow dates before 1900. Fallback to hardcoded iso
-            # style and rely on our dime api
-            logger.warn(err.message)
-            fmt = '%Y-%m-%d %H:%M' if self.show_time else '%Y-%m-%d'
-            return dtime.date_to_string(value, fmt)
+        return self.to_localized_time(value)
 
     def to_datetime(self, value):
         """convert date string to datetime object with tz


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the date time widget to not fail when displaying dates before year 1900 (see https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior)

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module plone.autoform.view, line 42, in __call__
  Module plone.autoform.view, line 33, in render
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module 5703504060db8b032e75bdc7efdfea0e, line 517, in render
  Module 8c1fb1e2e89fbd61ab31092e1ef695c4, line 1449, in render_master
  Module 8c1fb1e2e89fbd61ab31092e1ef695c4, line 407, in render_content
  Module 5703504060db8b032e75bdc7efdfea0e, line 502, in __fill_content_core
  Module 5703504060db8b032e75bdc7efdfea0e, line 151, in render_content_core
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module zope.browserpage.simpleviewclass, line 41, in __call__
  Module zope.browserpage.viewpagetemplatefile, line 81, in __call__
  Module zope.browserpage.viewpagetemplatefile, line 49, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module 732033e5f2228c2cee7d4e884289387a, line 586, in render
  Module 732033e5f2228c2cee7d4e884289387a, line 456, in render_widget_wrapper
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module z3c.form.widget, line 154, in render
  Module zope.browserpage.viewpagetemplatefile, line 49, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 215, in render
  Module chameleon.template, line 192, in render
  Module 39e27c6e61b8733fff01db0a8a115ffd, line 184, in render
  Module zope.tales.pythonexpr, line 73, in __call__
   - __traceback_info__: (view.get_display_value())
  Module <string>, line 1, in <module>
  Module senaite.core.z3cform.widgets.datetimewidget, line 190, in get_display_value
  Module senaite.core.z3cform.widgets.datetimewidget, line 178, in to_localized_time
  Module Products.CMFPlone.TranslationServiceTool, line 98, in ulocalized_time
  Module Products.CMFPlone.i18nl10n, line 208, in ulocalized_time
  Module DateTime.DateTime, line 1568, in strftime
ValueError: year=1194 is before 1900; the datetime strftime() methods require year >= 1900

```

## Desired behavior after PR is merged

Dates before 1900 are displayed (in iso-like format) without error

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
