### PR TITLE
Handle attribute error for unsupported label types

### DIFF
--- a/src/senaite/core/api/label.py
+++ b/src/senaite/core/api/label.py
@@ -242,7 +242,11 @@ def enable_labels_for_type(portal_type):
     :param portal_type: The portal_type to enable labeling
     """
     klass = get_klass(portal_type)
-    classImplements(klass, ICanHaveLabels)
+    try:
+        classImplements(klass, ICanHaveLabels)
+    except AttributeError:
+        # '_ImmutableDeclaration' object has no attribute 'declared'
+        logger.error("Type '{}' does not support labels".format(portal_type))
     # enable behavior for DX types
     if api.is_dx_type(portal_type):
         api.enable_behavior(portal_type, BEHAVIOR_ID)
@@ -254,7 +258,11 @@ def disable_labels_for_type(portal_type):
     :param portal_type: The portal_type to disable labeling
     """
     klass = get_klass(portal_type)
-    classDoesNotImplement(klass, ICanHaveLabels)
+    try:
+        classDoesNotImplement(klass, ICanHaveLabels)
+    except AttributeError:
+        # '_ImmutableDeclaration' object has no attribute 'declared'
+        logger.error("Type '{}' does not support labels".format(portal_type))
     # disable behavior
     if api.is_dx_type(portal_type):
         api.disable_behavior(portal_type, BEHAVIOR_ID)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is related to https://github.com/senaite/senaite.core/pull/2276 and fixes an `AttributeError` when enabling/disabling labeling for portal types

## Current behavior before PR

`AttributeError: '_ImmutableDeclaration' object has no attribute 'declared'` happens when setting the labels in Senaite Registry

## Desired behavior after PR is merged

Usupported types are ignored

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
