### PR TITLE
Fix KeyError: 'prefs_main_template' after installation 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2299 Fix KeyError: 'prefs_main_template' after installation
 - #2292 Fix ValueError when displaying dates before 1900 (by datetimewidget)
 - #2297 Fix wrong characters on sample invalidation emails
 - #2288 Fix client dropdown on batch add

--- a/src/bika/lims/profiles/default/skins.xml
+++ b/src/bika/lims/profiles/default/skins.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
-<object name="portal_skins"
-        meta_type="Plone Skins Tool"
-        allow_any="False"
-        cookie_persistence="False"
-        default_skin="Sunburst Theme"
+<object name="portal_skins" meta_type="Plone Skins Tool" allow_any="False"
+        cookie_persistence="False" default_skin="Plone Default"
         request_varname="plone_skin">
 
   <object name="bika"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the following error that occurs after an initial installation:

```
2023-04-16 12:00:51,964 ERROR   [Zope.SiteErrorLog:252][waitress-0] 1681639251.960.77187066482 http://localhost:8080/senaite2/@@lims-setup
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.core.browser.controlpanel.setupview, line 42, in __call__
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 215, in render
  Module chameleon.template, line 192, in render
  Module ab3b2a6419a574e0affffac98e11632f, line 551, in render
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 217, in _eval
  Module zope.tales.expressions, line 153, in _eval
  Module Products.PageTemplates.Expressions, line 131, in trustedBoboAwareZopeTraverse
  Module OFS.Traversable, line 343, in unrestrictedTraverse
   - __traceback_info__: ([], 'prefs_main_template')
KeyError: 'prefs_main_template'

 - Expression: "here/prefs_main_template/macros/master"
 - Filename:   ... senaite/core/browser/controlpanel/templates/setupview.pt
 - Location:   (line 6: col 23)
 - Source:     ... al:use-macro="here/prefs_main_template/macros/master"
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  repeat: <Products.PageTemplates.engine.RepeatDictWrapper object at 0x1175b2410>
               template: <Products.Five.browser.pagetemplatefile.ViewPageTemplateFile object at 0x1165c6f50>
               views: <Products.Five.browser.pagetemplatefile.ViewMapper object at 0x1155e0650>
               request: <WSGIRequest, URL=http://localhost:8080/senaite2/@@lims-setup>
               args: ()
               here: <PloneSite at /senaite2>
               user: <PropertiedUser 'admin'>
               nothing: None
               translate: <function translate at 0x11869c250>
               container: <PloneSite at /senaite2>
               root: <Application at >
               modules: <Products.PageTemplates.ZRPythonExpr._SecureModuleImporter object at 0x10ca7fcd0>
               traverse_subpath: []
               default: <DEFAULT>
               loop: {}
               context: <PloneSite at /senaite2>
               view: <Products.Five.browser.metaconfigure.SetupView object at 0x115afed50>
               target_language: None
               macroname: u'master'
               options: {}
               attrs: {}
```


## Current behavior before PR

Traceback happens when navigating to the site setup or lims setup after initial installation

## Desired behavior after PR is merged

No traceback happens after initial installation

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
