### PR TITLE
Re-add searchable text provider adapters for sample catalog listing_searchable_text index

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2300 Re-add searchable text provider adapters for sample catalog listing_searchable_text index
 - #2298 Move all permissions into senaite.core
 - #2299 Fix KeyError: 'prefs_main_template' after installation
 - #2292 Fix ValueError when displaying dates before 1900 (by datetimewidget)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds again the hooks for searchable text provider adapters that were removed in  https://github.com/senaite/senaite.core/pull/2273

Also see comment here: https://github.com/senaite/senaite.core/pull/2273#issuecomment-1488157643
 
## Current behavior before PR

Searchable text provider adapters were not called anymore for the `listing_searchable_text` index of sample catalog.

## Desired behavior after PR is merged

Searchable text provider adapters are called again for the `listing_searchable_text` index of sample catalog.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
