### PR TITLE
Fix dynamic sample specification not applied for new samples

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2304 Fix dynamic sample specification not applied for new samples
 - #2303 Fix managed permission of analysis workflow for lab roles
 - #2301 Use client groups for local role sharing
 - #2300 Re-add searchable text provider adapters for sample catalog listing_searchable_text index

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -84,12 +84,19 @@ def create_analysisrequest(client, request, values, analyses=None,
     # Remove the Analyses from values. We will add them manually
     values.update({"Analyses": []})
 
+    # Remove the specificaton to set it *after* the analyses have been added
+    specification = values.pop("Specification", None)
+
     # Create the Analysis Request and submit the form
     ar = _createObjectByType('AnalysisRequest', client, tmpID())
     ar.processForm(REQUEST=request, values=values)
 
     # Set the analyses manually
     ar.setAnalyses(service_uids, prices=prices, specs=results_ranges)
+
+    # Explicitly set the specification to the sample
+    if specification:
+        ar.setSpecification(specification)
 
     # Handle hidden analyses from template and profiles
     # https://github.com/senaite/senaite.core/issues/1437


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue where the dynamic analysis specifications are not correctly set for new created samples.

## Current behavior before PR

Sample specification is applied *before* analyses are created in the sample.

## Desired behavior after PR is merged

Sample specification is applied *after* analyses are created in the sample.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
