### PR TITLE
Add support for dates in ANSI X3.30 and ANSI X3.43.3 formats

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2305 Add support for dates in ANSI X3.30 and ANSI X3.43.3 formats
 - #2304 Fix dynamic sample specification not applied for new samples
 - #2303 Fix managed permission of analysis workflow for lab roles
 - #2301 Use client groups for local role sharing

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -129,7 +129,13 @@ def to_DT(dt):
     elif is_str(dt):
         try:
             return DateTime(dt)
-        except (DateError, TimeError, SyntaxError, IndexError):
+        except (DateError, TimeError):
+            try:
+                dt = ansi_to_dt(dt)
+                return to_DT(dt)
+            except ValueError:
+                return None
+        except (SyntaxError, IndexError):
             return None
     elif is_dt(dt):
         return DateTime(dt.isoformat())
@@ -162,6 +168,27 @@ def to_dt(dt):
         return datetime(dt.year, dt.month, dt.day)
     else:
         return None
+
+
+def ansi_to_dt(dt):
+    """The YYYYMMDD format is defined by ANSI X3.30. Therfore, 2 December 1,
+    1989 would be represented as 19891201. When times are transmitted, they
+    shall be represented as HHMMSS, and shall be linked to dates as specified
+    by ANSI X3.43.3 Date and time together shall be specified as up to a
+    14-character string: YYYYMMDD[HHMMSS]
+
+    :param DateTime/datetime/str:
+    :return:
+    """
+    if not is_str(dt):
+        raise TypeError("Type is not supported")
+    if len(dt) == 8:
+        date_format = "%Y%m%d"
+    elif len(dt) == 14:
+        date_format = "%Y%m%d%H%M%S"
+    else:
+        raise ValueError("No ANSI format date")
+    return datetime.strptime(dt, date_format)
 
 
 def get_timezone(dt, default="Etc/GMT"):

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -171,13 +171,12 @@ def to_dt(dt):
 
 
 def ansi_to_dt(dt):
-    """The YYYYMMDD format is defined by ANSI X3.30. Therfore, 2 December 1,
+    """The YYYYMMDD format is defined by ANSI X3.30. Therefore, 2 December 1,
     1989 would be represented as 19891201. When times are transmitted, they
     shall be represented as HHMMSS, and shall be linked to dates as specified
     by ANSI X3.43.3 Date and time together shall be specified as up to a
     14-character string: YYYYMMDD[HHMMSS]
-
-    :param DateTime/datetime/str:
+    :param str:
     :return:
     """
     if not is_str(dt):

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -493,3 +493,65 @@ standard ISO format, while TranslationService fails:
 
     >>> dtime.to_localized_time(dt, long_format=True)
     '1889-12-14 00:00'
+
+
+Support for ANSI X3.30 and ANSI X3.43.3
+.......................................
+
+The YYYYMMDD format is defined by ANSI X3.30. Therefore 2 December 1, 1989
+would be represented as 19891201. When times are transmitted (ASTM), they
+shall be represented as HHMMSS, and shall be linked to dates as specified by
+ANSI X3.43.3 Date and time together shall be specified as up to a 14-character
+string (YYYYMMDD[HHMMSS]
+
+    >>> dt = "19891201"
+    >>> dtime.ansi_to_dt(dt)
+    datetime.datetime(1989, 12, 1, 0, 0)
+
+    >>> dtime.to_DT(dt)
+    DateTime('1989/12/01 00:00:00 GMT+0')
+
+    >>> dt = "19891201131405"
+    >>> dtime.ansi_to_dt(dt)
+    datetime.datetime(1989, 12, 1, 13, 14, 5)
+
+    >>> dtime.to_DT(dt)
+    DateTime('1989/12/01 13:14:05 GMT+0')
+
+    >>> dt = "17891201131405"
+    >>> dtime.ansi_to_dt(dt)
+     datetime.datetime(1789, 12, 1, 13, 14, 5)
+
+    >>> dtime.to_DT(dt)
+    DateTime('1789/12/01 13:14:05 GMT+0')
+
+    >>> dt = "17891201132505"
+    >>> dtime.ansi_to_dt(dt)
+    datetime.datetime(1789, 12, 1, 13, 25, 5)
+
+    >>> dtime.to_DT(dt)
+    DateTime('1789/12/01 13:25:05 GMT+0')
+
+    >>> # No ANSI format
+    >>> dt = "230501"
+    >>> dtime.ansi_to_dt(dt)
+    Traceback (most recent call last):
+    ...
+    ValueError: No ANSI format date
+
+    >>> # Month 13
+    >>> dt = "17891301132505"
+    >>> dtime.ansi_to_dt(dt)
+    Traceback (most recent call last):
+    ...
+    ValueError: unconverted data remains: 5
+
+    >>> # Month 2, day 30
+    >>> dt = "20030230123408"
+    >>> dtime.ansi_to_dt(dt)
+    Traceback (most recent call last):
+    ...
+    ValueError: day is out of range for month
+
+    >>> dtime.to_DT(dt) is None
+    True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the SENAITE's dtime api to support ANSI X3.30 and ANSI X3.43.3 formats, that are commonly used in astm transmissions.

## Current behavior before PR

ANSI X3.30 and ANSI X3.43.3 formats not supported by default

## Desired behavior after PR is merged

ANSI X3.30 and ANSI X3.43.3 formats are supported by default

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
