### PR TITLE
Rely on fields when validating submitted values on sample creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
-- #2307 Validate non-future and non-past dates on add sample
+- #2307 Rely on fields when validating submitted values on sample creation
 - #2305 Add support for dates in ANSI X3.30 and ANSI X3.43.3 formats
 - #2304 Fix dynamic sample specification not applied for new samples
 - #2303 Fix managed permission of analysis workflow for lab roles

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2307 Validate non-future and non-past dates on add sample
 - #2305 Add support for dates in ANSI X3.30 and ANSI X3.43.3 formats
 - #2304 Fix dynamic sample specification not applied for new samples
 - #2303 Fix managed permission of analysis workflow for lab roles

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1704,28 +1704,23 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                 msg = _("Field '{}' is required").format(safe_unicode(field))
                 fielderrors[fieldname] = msg
 
-            # Process valid record
+            # Process and validate field values
             valid_record = dict()
-            for fieldname, fieldvalue in six.iteritems(record):
-                # clean empty
-                if fieldvalue in ['', None]:
-                    continue
-
-                valid_record[fieldname] = fieldvalue
-
-            # Validate field values
             tmp_sample = self.get_ar()
             for field in fields:
                 field_name = field.getName()
-                field_value = valid_record.get(field_name)
-                if not field_value:
+                field_value = record.get(field_name)
+                if field_value in ['', None]:
                     continue
 
                 # process the value as the widget would usually do
                 process_value = field.widget.process_form
-                value, msgs = process_value(tmp_sample, field, valid_record)
+                value, msgs = process_value(tmp_sample, field, record)
                 if not value:
                     continue
+
+                # store the processed value as the valid record
+                valid_record[field_name] = value
 
                 # validate the value
                 error = field.validate(value, tmp_sample)

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1587,9 +1587,6 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         no_future = getattr(widget, "datepicker_nofuture", False)
         if self.is_true(no_future):
             return datetime.now()
-        two_months = getattr(widget, "datepicker_2months", False)
-        if self.is_true(two_months):
-            return datetime.now() + relativedelta(months=2)
         return default
 
     def check_confirmation(self):

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1710,6 +1710,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                 # clean empty
                 if fieldvalue in ['', None]:
                     continue
+
                 valid_record[fieldname] = fieldvalue
 
             # Validate field values
@@ -1720,7 +1721,14 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                 if not field_value:
                     continue
 
-                error = field.validate(field_value, tmp_sample)
+                # process the value as the widget would usually do
+                process_value = field.widget.process_form
+                value, msgs = process_value(tmp_sample, field, valid_record)
+                if not value:
+                    continue
+
+                # validate the value
+                error = field.validate(value, tmp_sample)
                 if error:
                     field_name = "{}-{}".format(field_name, num)
                     fielderrors[field_name] = error

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -21,7 +21,6 @@
 import json
 from collections import OrderedDict
 from datetime import datetime
-from dateutil import relativedelta
 
 import six
 

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1704,26 +1704,16 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                 fielderrors["NumSamples"] = self.context.translate(msg)
 
             # Validate non-past and non-future dates
+            tmp_sample = self.get_ar()
             for field in filter(self.is_date_field, fields):
                 field_name = field.getName()
-                dt_value = api.to_date(record.get(field_name))
-                if not dt_value:
+                field_value = record.get(field_name)
+                if not field_value:
                     # required fields are handled later
                     continue
 
-                max_dt = self.get_max_dt(field)
-                if max_dt and dt_value > DateTime(max_dt):
-                    fielderrors[field_name] = _(
-                        "{}: in the future or earlier than expected"
-                    ).format(field_name)
-                    continue
-
-                min_dt = self.get_min_dt(field)
-                if min_dt and dt_value < DateTime(min_dt):
-                    fielderrors[field_name] = _(
-                        "{}: in the past or older than expected"
-                    ).format(field_name)
-
+                # validate the field against a temp sample obj
+                msg = field.validate(field_value, tmp_sample)
             # Missing required fields
             missing = [f for f in required_fields if not record.get(f, None)]
 

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -21,6 +21,7 @@
 import json
 from collections import OrderedDict
 from datetime import datetime
+from dateutil import relativedelta
 
 import six
 
@@ -1557,6 +1558,40 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
         return prices
 
+    def is_true(self, val):
+        """Returns whether val evaluates to True
+        """
+        val = str(val).strip().lower()
+        return val in ["y", "yes", "1", "true", "on"]
+
+    def is_date_field(self, field):
+        """Returns whether the field is for storing a date or datetime
+        """
+        return field.type in ["date", "datetime", "datetime_ng"]
+
+    def get_min_dt(self, field, default=None):
+        """Returns the minimum datetime supported for the given field
+        """
+        # find-out from the widget
+        widget = getattr(field, "widget", None)
+        no_past = getattr(widget, "datepicker_nopast", False)
+        if self.is_true(no_past):
+            return datetime.now()
+        return default
+
+    def get_max_dt(self, field, default=None):
+        """Returns the maximum datetime supported for the given field
+        """
+        # find-out from the widget
+        widget = getattr(field, "widget", None)
+        no_future = getattr(widget, "datepicker_nofuture", False)
+        if self.is_true(no_future):
+            return datetime.now()
+        two_months = getattr(widget, "datepicker_2months", False)
+        if self.is_true(two_months):
+            return datetime.now() + relativedelta(months=2)
+        return default
+
     def check_confirmation(self):
         """Returns a dict when user confirmation is required for the creation of
         samples. Returns None otherwise
@@ -1671,6 +1706,27 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                             "max_num_samples": max_samples_record,
                         })
                 fielderrors["NumSamples"] = self.context.translate(msg)
+
+            # Validate non-past and non-future dates
+            for field in filter(self.is_date_field, fields):
+                field_name = field.getName()
+                dt_value = api.to_date(record.get(field_name))
+                if not dt_value:
+                    # required fields are handled later
+                    continue
+
+                max_dt = self.get_max_dt(field)
+                if max_dt and dt_value > DateTime(max_dt):
+                    fielderrors[field_name] = _(
+                        "{}: in the future or earlier than expected"
+                    ).format(field_name)
+                    continue
+
+                min_dt = self.get_min_dt(field)
+                if min_dt and dt_value < DateTime(min_dt):
+                    fielderrors[field_name] = _(
+                        "{}: in the past or older than expected"
+                    ).format(field_name)
 
             # Missing required fields
             missing = [f for f in required_fields if not record.get(f, None)]

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -177,7 +177,7 @@ def ansi_to_dt(dt):
     by ANSI X3.43.3 Date and time together shall be specified as up to a
     14-character string: YYYYMMDD[HHMMSS]
     :param str:
-    :return:
+    :return: datetime object
     """
     if not is_str(dt):
         raise TypeError("Type is not supported")
@@ -188,6 +188,19 @@ def ansi_to_dt(dt):
     else:
         raise ValueError("No ANSI format date")
     return datetime.strptime(dt, date_format)
+
+
+def to_ansi(dt, with_time=True):
+    """Returns the date in ANSI X3.30/X4.43.3) format
+    :param dt: DateTime/datetime/date
+    :param with_time: if true, returns YYYYMMDDHHMMSS. YYYYMMDD otherwise
+    :returns: str that represents the datetime in ANSI format
+    """
+    dt = to_dt(dt)
+    ansi = "{:04d}{:02d}{:02d}".format(dt.year, dt.month, dt.day)
+    if not with_time:
+        return ansi
+    return "{}{:02d}{:02d}{:02d}".format(ansi, dt.hour, dt.minute, dt.second)
 
 
 def get_timezone(dt, default="Etc/GMT"):

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -190,15 +190,18 @@ def ansi_to_dt(dt):
     return datetime.strptime(dt, date_format)
 
 
-def to_ansi(dt, with_time=True):
+def to_ansi(dt, show_time=True):
     """Returns the date in ANSI X3.30/X4.43.3) format
     :param dt: DateTime/datetime/date
-    :param with_time: if true, returns YYYYMMDDHHMMSS. YYYYMMDD otherwise
+    :param show_time: if true, returns YYYYMMDDHHMMSS. YYYYMMDD otherwise
     :returns: str that represents the datetime in ANSI format
     """
     dt = to_dt(dt)
+    if dt is None:
+        return None
+
     ansi = "{:04d}{:02d}{:02d}".format(dt.year, dt.month, dt.day)
-    if not with_time:
+    if not show_time:
         return ansi
     return "{}{:02d}{:02d}{:02d}".format(ansi, dt.hour, dt.minute, dt.second)
 

--- a/src/senaite/core/browser/fields/datetime.py
+++ b/src/senaite/core/browser/fields/datetime.py
@@ -53,9 +53,11 @@ class DateTimeField(BaseField):
     security = ClassSecurityInfo()
 
     def validate(self, value, instance, errors=None, **kwargs):
-        if errors is None:
-            errors = {}
-
+        """Validate passed-in value using all field validators plus the
+        validators for minimum and maximum date values
+        Return None if all validations pass; otherwise, return the message of
+        of the validation failure translated to current language
+        """
         # Rely on the super-class first
         error = super(DateTimeField, self).validate(
             value, instance, errors=errors, **kwargs)

--- a/src/senaite/core/browser/fields/datetime.py
+++ b/src/senaite/core/browser/fields/datetime.py
@@ -81,7 +81,7 @@ class DateTimeField(BaseField):
         # self.min always returns an offset-naive datetime, but the value
         # is offset-aware. We need to add the TZ, otherwise we get a:
         #   TypeError: can't compare offset-naive and offset-aware datetimes
-        if dtime.to_timestamp(value) >= dtime.to_timestamp(self.min):
+        if dtime.to_ansi(value) >= dtime.to_ansi(self.min):
             return None
 
         error = _(
@@ -106,7 +106,7 @@ class DateTimeField(BaseField):
         # self.max always returns an offset-naive datetime, but the value
         # is offset-aware. We need to add the TZ, otherwise we get a:
         #   TypeError: can't compare offset-naive and offset-aware datetimes
-        if dtime.to_timestamp(value) <= dtime.to_timestamp(self.max):
+        if dtime.to_ansi(value) <= dtime.to_ansi(self.max):
             return None
 
         error = _(

--- a/src/senaite/core/browser/fields/datetime.py
+++ b/src/senaite/core/browser/fields/datetime.py
@@ -23,7 +23,17 @@ from App.class_init import InitializeClass
 from Products.Archetypes.public import DateTimeField as BaseField
 from Products.Archetypes.Registry import registerField
 from Products.Archetypes.Registry import registerPropertyType
+from senaite.core.api import dtime
 from senaite.core.browser.widgets.datetimewidget import DateTimeWidget
+from zope.i18n import translate
+from zope.i18nmessageid import Message
+
+from bika.lims import _
+from bika.lims import api
+
+WIDGET_NOPAST = "datepicker_nopast"
+WIDGET_NOFUTURE = "datepicker_nofuture"
+WIDGET_SHOWTIME = "show_time"
 
 
 class DateTimeField(BaseField):
@@ -41,6 +51,123 @@ class DateTimeField(BaseField):
         "with_date": 1,  # set to False if you want time only objects
         })
     security = ClassSecurityInfo()
+
+    def validate(self, value, instance, errors=None, **kwargs):
+        if errors is None:
+            errors = {}
+
+        # Rely on the super-class first
+        error = super(DateTimeField, self).validate(
+            value, instance, errors=errors, **kwargs)
+        if error:
+            return error
+
+        # Validate value is after min date
+        error = self.validate_min_date(value, instance, errors=errors)
+        if error:
+            return error
+
+        # Validate value is before max date
+        error = self.validate_max_date(value, instance, errors=errors)
+        if error:
+            return error
+
+    def validate_min_date(self, value, instance, errors=None):
+        """Validates the passed-in value against the field's minimum date
+        """
+        if errors is None:
+            errors = {}
+
+        # self.min always returns an offset-naive datetime, but the value
+        # is offset-aware. We need to add the TZ, otherwise we get a:
+        #   TypeError: can't compare offset-naive and offset-aware datetimes
+        if dtime.to_timestamp(value) >= dtime.to_timestamp(self.min):
+            return None
+
+        error = _(
+            u"error_datetime_before_min",
+            default=u"${name} is before ${min_date}, please correct.",
+            mapping={
+                "name": self.get_label(instance),
+                "min_date": self.localize(self.min, instance)
+            }
+        )
+
+        field_name = self.getName()
+        errors[field_name] = translate(error, context=api.get_request())
+        return errors[field_name]
+
+    def validate_max_date(self, value, instance, errors=None):
+        """Validates the passed-in value against the field's maximum date
+        """
+        if errors is None:
+            errors = {}
+
+        # self.max always returns an offset-naive datetime, but the value
+        # is offset-aware. We need to add the TZ, otherwise we get a:
+        #   TypeError: can't compare offset-naive and offset-aware datetimes
+        if dtime.to_timestamp(value) <= dtime.to_timestamp(self.max):
+            return None
+
+        error = _(
+            u"error_datetime_after_max",
+            default=u"${name} is after ${max_date}, please correct.",
+            mapping={
+                "name": self.get_label(instance),
+                "max_date": self.localize(self.max, instance)
+            }
+        )
+
+        field_name = self.getName()
+        errors[field_name] = translate(error, context=api.get_request())
+        return errors[field_name]
+
+    def is_true(self, val):
+        """Returns whether val evaluates to True
+        """
+        val = str(val).strip().lower()
+        return val in ["y", "yes", "1", "true", "on"]
+
+    def get_label(self, instance):
+        """Returns the translated label of this field for the given instance
+        """
+        request = api.get_request()
+        label = self.widget.Label(instance)
+        if isinstance(label, Message):
+            return translate(label, context=request)
+        return label
+
+    def localize(self, dt, instance):
+        """Returns the dt to localized time
+        """
+        request = api.get_request()
+        return dtime.to_localized_time(dt, long_format=self.show_time,
+                                       context=instance, request=request)
+
+    @property
+    def min(self):
+        """Returns the minimum datetime supported by this field
+        """
+        no_past = getattr(self.widget, WIDGET_NOPAST, False)
+        if self.is_true(no_past):
+            return dtime.datetime.now()
+        return dtime.datetime.min
+
+    @property
+    def max(self):
+        """Returns the maximum datetime supported for this field
+        """
+        no_future = getattr(self.widget, WIDGET_NOFUTURE, False)
+        if self.is_true(no_future):
+            return dtime.datetime.now()
+        return dtime.datetime.max
+
+    @property
+    def show_time(self):
+        """Returns whether the time is displayed by the widget
+        """
+        show_time = getattr(self.widget, WIDGET_SHOWTIME, False)
+        return self.is_true(show_time)
 
 
 InitializeClass(DateTimeField)

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -555,3 +555,67 @@ string (YYYYMMDD[HHMMSS]
 
     >>> dtime.to_DT(dt) is None
     True
+
+We can also the other way round conversion. Simply giving a date in ant valid
+string format:
+
+    >>> dt = "1989-12-01"
+    >>> dtime.to_ansi(dt, show_time=False)
+    '19891201'
+
+    >>> dtime.to_ansi(dt, show_time=True)
+    '19891201000000'
+
+    >>> dt = "19891201"
+    >>> dtime.to_ansi(dt, show_time=False)
+    '19891201'
+
+    >>> dtime.to_ansi(dt, show_time=True)
+    '19891201000000'
+
+Or using datetime or DateTime as the input parameter:
+
+    >>> dt = "19891201131405"
+    >>> dt = dtime.ansi_to_dt(dt)
+    >>> dtime.to_ansi(dt, show_time=False)
+    '19891201'
+
+    >>> dtime.to_ansi(dt, show_time=True)
+    '19891201131405'
+
+    >>> DT = dtime.to_DT(dt)
+    >>> dtime.to_ansi(DT, show_time=False)
+    '19891201'
+
+    >>> dtime.to_ansi(DT, show_time=True)
+    '19891201131405'
+
+We even suport dates that are long before epoch:
+
+    >>> min_date = dtime.datetime.min
+    >>> min_date
+    datetime.datetime(1, 1, 1, 0, 0)
+
+    >>> dtime.to_ansi(min_date)
+    '00010101000000'
+
+Or long after epoch:
+
+    >>> max_date = dtime.datetime.max
+    >>> max_date
+    datetime.datetime(9999, 12, 31, 23, 59, 59, 999999)
+
+    >>> dtime.to_ansi(max_date)
+    '99991231235959'
+
+Still, invalid dates return None:
+
+    >>> # Month 13
+    >>> dt = "17891301132505"
+    >>> dtime.to_ansi(dt) is None
+    True
+
+    >>> # Month 2, day 30
+    >>> dt = "20030230123408"
+    >>> dtime.to_ansi(dt) is None
+    True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that values submitted in sample add form are validated in accordance with the field types and the validators assigned.

Although the Date/Time widget does not display future dates when the widget is configured with the option `no_future`, user can easily bypass this by typing a future date manually in the input field:

![Captura de 2023-05-09 14-44-18](https://github.com/senaite/senaite.core/assets/832627/572d2962-bb50-4eff-b883-f79c214e5d75)

This Pull Request guarantees that even if the date is typed manually, the entered value is consistent with the widget configuration.

## Current behavior before PR

User can manually enter future dates for e.g. DateSampled in Add sample form

## Desired behavior after PR is merged

System complains if the date entered is not valid

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
