### PR TITLE
Fix date field validator for empty values

### DIFF
--- a/src/senaite/core/browser/fields/datetime.py
+++ b/src/senaite/core/browser/fields/datetime.py
@@ -64,6 +64,10 @@ class DateTimeField(BaseField):
         if error:
             return error
 
+        # Return immediately if we have no value and the field is not required
+        if not value and not self.required:
+            return
+
         # Validate value is after min date
         error = self.validate_min_date(value, instance, errors=errors)
         if error:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the failing validation that was introduced with https://github.com/senaite/senaite.core/pull/2307 for non-required date fields w/o a value set.

## Current behavior before PR

Optional date fields w/o a value fail validation in sample header form

## Desired behavior after PR is merged

Optional date fields w/o a value won't fail validation in sample header form

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
