### PR TITLE
Properly process and validate field values from sample header on submit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2311 Properly process and validate field values from sample header on submit
 - #2307 Rely on fields when validating submitted values on sample creation
 - #2305 Add support for dates in ANSI X3.30 and ANSI X3.43.3 formats
 - #2304 Fix dynamic sample specification not applied for new samples

--- a/src/senaite/core/browser/viewlets/sampleheader.py
+++ b/src/senaite/core/browser/viewlets/sampleheader.py
@@ -73,10 +73,17 @@ class SampleHeaderViewlet(ViewletBase):
         form = request.form
 
         for name, field in self.fields.items():
+            # get the raw value from the form. This shouldn't be necessary,
+            # but there are still some widgets out there with a name that
+            # follows the format <fieldname>_uid. Otherwise, we could simply
+            # pass the form object to the widget's process_form function.
             value = self.get_field_value(field, form)
-
             if value is _fieldname_not_in_form:
                 continue
+
+            # process the value as the widget would usually do
+            process_value = field.widget.process_form
+            value, msgs = process_value(self.context, field, {name: value})
 
             # Keep track of field-values
             field_values.update({name: value})


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the data submitted in Sample's header viewlet is properly processed by the widget and validated afterwards

## Current behavior before PR

widget's `process_form` is not used to process the field value submitted in the form, so field validators do not receive the expected data, causing them to either fail or the validation to be ignored. This also causes the need of adding custom subscribers `on_object_edited` to properly handle the values (e.g.: https://github.com/senaite/senaite.patient/blob/6e41d9c169e8e35dd1bb25a46df08754942f8b32/src/senaite/patient/subscribers/analysisrequest.py#L62-L69)

## Desired behavior after PR is merged

widget's `process_form` is used to process the field value submitted in the form, so field validators always receive the expected data

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
