### PR TITLE
Log error when calculation fails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2313 Log error when calculation fails
 - #2310 Added `get_relative_delta` and `get_tzinfo` in datetime API
 - #2311 Properly process and validate field values from sample header on submit
 - #2307 Rely on fields when validating submitted values on sample creation

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -594,7 +594,6 @@ class AbstractAnalysis(AbstractBaseAnalysis):
                 converter = "s" if str_result else "f"
                 formula = formula.replace("[" + keyword + "]", "%(" + keyword + ")" + converter)
 
-
         # convert any remaining placeholders, e.g. from interims etc.
         # NOTE: we assume remaining values are all floatable!
         formula = formula.replace("[", "%(").replace("]", ")f")
@@ -607,16 +606,12 @@ class AbstractAnalysis(AbstractBaseAnalysis):
                             'context': self},
                            {'mapping': mapping})
             result = eval(formula, calc._getGlobals())
-        except TypeError:
-            self.setResult("NA")
-            return True
         except ZeroDivisionError:
             self.setResult('0/0')
             return True
-        except KeyError:
-            self.setResult("NA")
-            return True
-        except ImportError:
+        except (KeyError, TypeError, ImportError) as e:
+            msg = "Cannot eval formula ({}): {}".format(e.message, formula)
+            logger.error(msg)
             self.setResult("NA")
             return True
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When a calculation fails, the system assigns `NA` as as result, but no error is reported, which sometimes might make really difficult to track back the reason of an issue.

## Current behavior before PR

System does not log error when a calculation fails

## Desired behavior after PR is merged

System does log error when a calculation fails

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
