### PR TITLE
Display error for required fields without value in current language

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2314 Display error for required fields without value in current language
 - #2313 Log error when calculation fails
 - #2310 Added `get_relative_delta` and `get_tzinfo` in datetime API
 - #2311 Properly process and validate field values from sample header on submit

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -53,7 +53,6 @@ from zope.annotation.interfaces import IAnnotations
 from zope.component import getAdapters
 from zope.component import queryAdapter
 from zope.i18n.locales import locales
-from zope.i18n import translate
 from zope.i18nmessageid import Message
 from zope.interface import alsoProvides
 from zope.interface import implements

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -44,6 +44,7 @@ from plone.memoize import view as viewcache
 from plone.memoize.volatile import DontCache
 from plone.memoize.volatile import cache
 from plone.protect.interfaces import IDisableCSRFProtection
+from Products.Archetypes.interfaces import IField
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -52,6 +53,8 @@ from zope.annotation.interfaces import IAnnotations
 from zope.component import getAdapters
 from zope.component import queryAdapter
 from zope.i18n.locales import locales
+from zope.i18n import translate
+from zope.i18nmessageid import Message
 from zope.interface import alsoProvides
 from zope.interface import implements
 from zope.publisher.interfaces import IPublishTraverse
@@ -1557,6 +1560,30 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
         return prices
 
+    def get_field(self, field_name):
+        """Returns the field from the temporary sample with the given name
+        """
+        if IField.providedBy(field_name):
+            return field_name
+
+        for field in self.get_ar_fields():
+            if field.getName() == field_name:
+                return field
+        return None
+
+    def get_field_label(self, field):
+        """Returns the translated label of the given field
+        """
+        field = self.get_field(field)
+        if not field:
+            return ""
+
+        instance = self.get_ar()
+        label = field.widget.Label(instance)
+        if isinstance(label, Message):
+            return self.context.translate(label)
+        return label
+
     def check_confirmation(self):
         """Returns a dict when user confirmation is required for the creation of
         samples. Returns None otherwise
@@ -1701,8 +1728,9 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             # If there are required fields missing, flag an error
             for field in missing:
                 fieldname = "{}-{}".format(field, num)
-                msg = _("Field '{}' is required").format(safe_unicode(field))
-                fielderrors[fieldname] = msg
+                label = self.get_field_label(field)
+                msg = self.context.translate(_("Field '{}' is required"))
+                fielderrors[fieldname] = msg.format(label)
 
             # Process and validate field values
             valid_record = dict()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the system to display the error in current language when there are missing values for required fields on Sample add form. Also, displays the labels instead of  field names

## Current behavior before PR

System displays the error in english and field names are displayed instead of their labels

![Captura de 2023-05-26 13-08-33](https://github.com/senaite/senaite.core/assets/832627/a515e926-91be-4e06-a77c-6d82d29062d9)


## Desired behavior after PR is merged

System displays the error in current language and field labels are displayed instead of field_names

![Captura de 2023-05-26 13-02-04](https://github.com/senaite/senaite.core/assets/832627/f4d9323e-12a3-4a8b-84f5-00c2e2e81ac0)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
