### PR TITLE
Apply dynamic analyses specs for new added analyses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2315 Apply dynamic analyses specs for new added analyses
 - #2314 Display error for required fields without value in current language
 - #2313 Log error when calculation fails
 - #2310 Added `get_relative_delta` and `get_tzinfo` in datetime API

--- a/src/bika/lims/adapters/dynamicresultsrange.py
+++ b/src/bika/lims/adapters/dynamicresultsrange.py
@@ -45,7 +45,9 @@ class DynamicResultsRange(object):
     def __init__(self, analysis):
         self.analysis = analysis
         self.analysisrequest = analysis.getRequest()
-        self.specification = self.analysisrequest.getSpecification()
+        self.specification = None
+        if self.analysisrequest:
+            self.specification = self.analysisrequest.getSpecification()
         self.dynamicspec = None
         if self.specification:
             self.dynamicspec = self.specification.getDynamicAnalysisSpec()

--- a/src/bika/lims/browser/fields/aranalysesfield.py
+++ b/src/bika/lims/browser/fields/aranalysesfield.py
@@ -28,14 +28,15 @@ from bika.lims.api.security import check_permission
 from bika.lims.interfaces import IAnalysis
 from bika.lims.interfaces import IAnalysisService
 from bika.lims.interfaces import IARAnalysesField
+from bika.lims.interfaces import IDynamicResultsRange
 from bika.lims.interfaces import ISubmitted
-from senaite.core.permissions import AddAnalysis
 from bika.lims.utils.analysis import create_analysis
 from Products.Archetypes.public import Field
 from Products.Archetypes.public import ObjectField
 from Products.Archetypes.Registry import registerField
 from senaite.core.catalog import ANALYSIS_CATALOG
 from senaite.core.catalog import SETUP_CATALOG
+from senaite.core.permissions import AddAnalysis
 from zope.interface import implements
 
 DETACHED_STATES = ["cancelled", "retracted", "rejected"]
@@ -295,6 +296,12 @@ class ARAnalysesField(ObjectField):
 
             # Set the result range to the analysis
             analysis_rr = specs.get(service_uid) or analysis.getResultsRange()
+
+            # Update dynamic analysis specifications
+            adapter = IDynamicResultsRange(analysis, None)
+            if adapter:
+                # update the result range with the dynamic values
+                analysis_rr.update(adapter())
             analysis.setResultsRange(analysis_rr)
 
             # Set default (pre)conditions

--- a/src/bika/lims/browser/fields/aranalysesfield.py
+++ b/src/bika/lims/browser/fields/aranalysesfield.py
@@ -28,7 +28,6 @@ from bika.lims.api.security import check_permission
 from bika.lims.interfaces import IAnalysis
 from bika.lims.interfaces import IAnalysisService
 from bika.lims.interfaces import IARAnalysesField
-from bika.lims.interfaces import IDynamicResultsRange
 from bika.lims.interfaces import ISubmitted
 from bika.lims.utils.analysis import create_analysis
 from Products.Archetypes.public import Field
@@ -296,12 +295,6 @@ class ARAnalysesField(ObjectField):
 
             # Set the result range to the analysis
             analysis_rr = specs.get(service_uid) or analysis.getResultsRange()
-
-            # Update dynamic analysis specifications
-            adapter = IDynamicResultsRange(analysis, None)
-            if adapter:
-                # update the result range with the dynamic values
-                analysis_rr.update(adapter())
             analysis.setResultsRange(analysis_rr)
 
             # Set default (pre)conditions

--- a/src/bika/lims/browser/fields/aranalysesfield.py
+++ b/src/bika/lims/browser/fields/aranalysesfield.py
@@ -29,13 +29,13 @@ from bika.lims.interfaces import IAnalysis
 from bika.lims.interfaces import IAnalysisService
 from bika.lims.interfaces import IARAnalysesField
 from bika.lims.interfaces import ISubmitted
+from senaite.core.permissions import AddAnalysis
 from bika.lims.utils.analysis import create_analysis
 from Products.Archetypes.public import Field
 from Products.Archetypes.public import ObjectField
 from Products.Archetypes.Registry import registerField
 from senaite.core.catalog import ANALYSIS_CATALOG
 from senaite.core.catalog import SETUP_CATALOG
-from senaite.core.permissions import AddAnalysis
 from zope.interface import implements
 
 DETACHED_STATES = ["cancelled", "retracted", "rejected"]

--- a/src/bika/lims/content/abstractroutineanalysis.py
+++ b/src/bika/lims/content/abstractroutineanalysis.py
@@ -283,7 +283,7 @@ class AbstractRoutineAnalysis(AbstractAnalysis, ClientAwareMixin):
         NOTE: This custom setter also applies dynamic specifications
 
         :param spec: The result range to set
-        :param update_dynamic_spec: If True, any dynamic specifications will be updated
+        :param update_dynamic_spec: If True, dynamic specifications are update
         """
         adapter = IDynamicResultsRange(self, None)
         if adapter and update_dynamic_spec:

--- a/src/bika/lims/content/abstractroutineanalysis.py
+++ b/src/bika/lims/content/abstractroutineanalysis.py
@@ -32,6 +32,7 @@ from bika.lims.content.attachment import Attachment
 from bika.lims.content.clientawaremixin import ClientAwareMixin
 from bika.lims.interfaces import IAnalysis
 from bika.lims.interfaces import ICancellable
+from bika.lims.interfaces import IDynamicResultsRange
 from bika.lims.interfaces import IInternalUse
 from bika.lims.interfaces import IRoutineAnalysis
 from bika.lims.interfaces.analysis import IRequestAnalysis
@@ -274,6 +275,19 @@ class AbstractRoutineAnalysis(AbstractAnalysis, ClientAwareMixin):
         :rtype: dict
         """
         return self.getField("ResultsRange").get(self)
+
+    @security.private
+    def setResultsRange(self, spec, update_dynamic_ranges=True):
+        """Set the results frange for this routine analysis
+
+        This custom setter applies as well the dynamic range if set
+        """
+        adapter = IDynamicResultsRange(self, None)
+        if adapter and update_dynamic_ranges:
+            # update the result range with the dynamic values
+            spec.update(adapter())
+        field = self.getField("ResultsRange")
+        field.set(self, spec)
 
     @security.public
     def getSiblings(self, with_retests=False):

--- a/src/bika/lims/content/abstractroutineanalysis.py
+++ b/src/bika/lims/content/abstractroutineanalysis.py
@@ -277,13 +277,16 @@ class AbstractRoutineAnalysis(AbstractAnalysis, ClientAwareMixin):
         return self.getField("ResultsRange").get(self)
 
     @security.private
-    def setResultsRange(self, spec, update_dynamic_ranges=True):
-        """Set the results frange for this routine analysis
+    def setResultsRange(self, spec, update_dynamic_spec=True):
+        """Set the results range for this routine analysis
 
-        This custom setter applies as well the dynamic range if set
+        NOTE: This custom setter also applies dynamic specifications
+
+        :param spec: The result range to set
+        :param update_dynamic_spec: If True, any dynamic specifications will be updated
         """
         adapter = IDynamicResultsRange(self, None)
-        if adapter and update_dynamic_ranges:
+        if adapter and update_dynamic_spec:
             # update the result range with the dynamic values
             spec.update(adapter())
         field = self.getField("ResultsRange")

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -56,7 +56,6 @@ from bika.lims.interfaces import IAnalysisRequestWithPartitions
 from bika.lims.interfaces import IBatch
 from bika.lims.interfaces import ICancellable
 from bika.lims.interfaces import IClient
-from bika.lims.interfaces import IDynamicResultsRange
 from bika.lims.interfaces import ISubmitted
 from senaite.core.permissions import FieldEditBatch
 from senaite.core.permissions import FieldEditClient
@@ -1404,11 +1403,6 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
             if not ISubmitted.providedBy(analysis):
                 service_uid = analysis.getRawAnalysisService()
                 result_range = field.get(self, search_by=service_uid)
-                # check if we have an dynamic results range adapter
-                adapter = IDynamicResultsRange(analysis, None)
-                if adapter:
-                    # update the result range with the dynamic values
-                    result_range.update(adapter())
                 analysis.setResultsRange(result_range)
                 analysis.reindexObject()
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR applies dynamic analyses specs for new added analyses

## Current behavior before PR

Dynamic Analysis Specifications only applied to Analyses when the Specification is assigned to the Sample.

## Desired behavior after PR is merged

Dynamic Analysis Specifications applied to Analyses when the Specification is assigned to the Sample *and* when new Analyses are added to the Sample

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
