### PR TITLE
Remove Travis shield and use Github's actions instead

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@
 .. image:: https://img.shields.io/pypi/v/senaite.core.svg?style=flat-square
     :target: https://pypi.python.org/pypi/senaite.core
 
-.. image:: https://img.shields.io/travis/com/senaite/senaite.core/2.x.svg?style=flat-square
-    :target: https://app.travis-ci.com/github/senaite/senaite.core
+.. image:: https://img.shields.io/github/actions/workflow/status/senaite/senaite.core/build-and-test.yml?branch=2.x
+    :target: https://github.com/senaite/senaite.core/actions/workflows/build-and-test.yml?query=branch:2.x
 
 .. image:: https://img.shields.io/scrutinizer/g/senaite/senaite.core/2.x.svg?style=flat-square
     :target: https://scrutinizer-ci.com/g/senaite/senaite.core/?branch=2.x


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR replaces the "build" shield from travis to Github's ations. It also updates the build link, so only the _actions_ for 2.x are displayed when clicked


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
