### PR TITLE
Fix unauthorized error when accessing immediate results entry view with a client contact user

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2332 Fix unauthorized error when accessing immediate results entry view with a client contact user
 - #2295 Integrate new UID reference widget
 - #2315 Apply dynamic analyses specs for new added analyses
 - #2314 Display error for required fields without value in current language

--- a/src/senaite/core/adapters/sample.py
+++ b/src/senaite/core/adapters/sample.py
@@ -45,7 +45,7 @@ class WorkflowActionMultiResultsAdapter(RequestContextAware):
     def __call__(self, action, uids):
         """Redirects the user to the multi results form
         """
-        portal_url = api.get_url(api.get_portal())
-        url = "{}/samples/multi_results?uids={}".format(
-            portal_url, ",".join(uids))
+        context_url = api.get_url(self.context)
+        url = "{}/multi_results?uids={}".format(
+            context_url, ",".join(uids))
         return self.redirect(redirect_url=url)

--- a/src/senaite/core/browser/samples/configure.zcml
+++ b/src/senaite/core/browser/samples/configure.zcml
@@ -19,12 +19,22 @@
       permission="senaite.core.permissions.TransitionDispatchSample"
       layer="senaite.core.interfaces.ISenaiteCore" />
 
-  <!-- Multi results view -->
+  <!-- Multi results view
+
+       NOTE:
+
+       We use the permission `zope2.View` to allow client contacts with local
+       (shared) roles to access the view from the global samples listing.
+
+       Otherwise we would need to add a check in the samples listing view to
+       redirect the client contact into the right client context for each access,
+       which would probably have a negative impact on the performance.
+  -->
   <browser:page
       for="*"
       name="multi_results"
       class=".multi_results.MultiResultsView"
-      permission="senaite.core.permissions.TransitionMultiResults"
+      permission="zope2.View"
       layer="senaite.core.interfaces.ISenaiteCore" />
 
   <!-- Manage Sample Fields -->

--- a/src/senaite/core/browser/samples/multi_results.py
+++ b/src/senaite/core/browser/samples/multi_results.py
@@ -40,7 +40,6 @@ class MultiResultsView(BrowserView):
         super(MultiResultsView, self).__init__(context, request)
         self.context = context
         self.request = request
-        self.portal = api.get_portal()
 
     def __call__(self):
         return self.template()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an insufficient privileges issue for client contact users with shared local roles when accessing the multi results view.

## Current behavior before PR

Insufficient Privileges occurs for client contact users when creating a new sample when the setup option "Immediate results entry" is enabled.

Traceback:

```
    2023-06-08 11:35:12,452 DEBUG   [ImplPython:845][waitress-0] Unauthorized: Your user account does not have the required permission.  Access to 'multi_results' of (Client at /senaite/clients/client-19) denied. Your user account, ramontest, exists at /senaite/acl_users. Access requires senaite_core__Transition__Multi_Results_Permission, granted to the following roles: ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Sampler', 'Verifier']. Your roles in this context are ['Authenticated', 'Client', 'Member', 'Owner'].
    2023-06-08 11:35:12,453 DEBUG   [ImplPython:845][waitress-0] Unauthorized: Your user account does not have the required permission.  Access to 'multi_results' of (Client at /senaite/clients/client-19) denied. Your user account, Anonymous User, exists at /acl_users. Access requires senaite_core__Transition__Multi_Results_Permission, granted to the following roles: ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Sampler', 'Verifier']. Your roles in this context are ['Anonymous'].
    2023-06-08 11:35:12,455 DEBUG   [chameleon.loader:143][waitress-0] loading module from cache: 7d9ffcbbc911d56288015b0685a7b329.py.
    2023-06-08 11:35:12,456 DEBUG   [ImplPython:845][waitress-0] Unauthorized: Your user account does not have the required permission.  Access to '@@bootstrapview' of (Client at /senaite/clients/client-19) denied. Your user account, Anonymous User, exists at (unknown). Access requires View_Permission, granted to the following roles: ['Analyst', 'LabClerk', 'LabManager', 'Manager', 'Owner', 'Preserver', 'Publisher', 'RegulatoryInspector', 'Sampler', 'SamplingCoordinator', 'Verifier']. Your roles in this context are ['Anonymous'].
    2023-06-08 11:35:12,458 DEBUG   [txn.123145449070592:567][waitress-0] abort
    2023-06-08 11:35:12,459 ERROR   [Zope.SiteErrorLog:252][waitress-0] 1686216912.460.246721356438 http://127.0.0.1:8080/senaite/clients/client-19/multi_results
    Traceback (innermost last):
    Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
    Module ZPublisher.WSGIPublisher, line 385, in publish_module
    Module ZPublisher.WSGIPublisher, line 264, in publish
    Module ZPublisher.BaseRequest, line 644, in traverse
    Module ZPublisher.HTTPResponse, line 1040, in unauthorized
```

## Desired behavior after PR is merged

Client contact users with the right roles assigned are allowed to access the multi results view.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
