### PR TITLE
Fix barcodes not rendered in the pdf when "Inside-Out" Virtual Hosting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- #2336 Fix barcodes not rendered in the pdf when "Inside-Out" Virtual Hosting
 - #2331 Little improvement of getRaw function from legacy uidreference field (#2241 port)
 - #2330 Purge remaining back-references from AnalysisRequest type (#2236 port)
 - #2329 Fix read endpoint from internal api does not return uid for uidreference (#2235 port)

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -56,6 +56,8 @@ from zope.i18n.locales import locales
 from bika.lims.interfaces import IClient
 from bika.lims.interfaces import IClientAwareMixin
 from bika.lims.api import to_date as api_to_date
+from six.moves.urllib import parse
+
 
 ModuleSecurityInfo('email.Utils').declarePublic('formataddr')
 allow_module('csv')
@@ -349,6 +351,16 @@ def isnumber(s):
     return api.is_floatable(s)
 
 
+def is_valid_url(value):
+    """Return true if the value is a well-formed url
+    """
+    try:
+        result = parse.urlparse(value)
+        return all([result.scheme, result.netloc, result.path])
+    except:  # noqa a convenient way to check if the url is ok
+        return False
+
+
 def senaite_url_fetcher(url):
     """Uses plone.subrequest to fetch an internal image resource.
 
@@ -381,6 +393,11 @@ def senaite_url_fetcher(url):
     """
 
     logger.info("Fetching URL '{}' for WeasyPrint".format(url))
+
+    if not is_valid_url(url):
+        # not a valid URL (e.g. 'data:image/bmp;base64,Qk1GG....')
+        logger.info("Not a valid URL, fallback to the default URL fetcher ...")
+        return default_url_fetcher(url)
 
     # get the pyhsical path from the URL
     request = api.get_request()

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -57,7 +57,6 @@ from bika.lims.interfaces import IClient
 from bika.lims.interfaces import IClientAwareMixin
 from bika.lims.api import to_date as api_to_date
 
-
 ModuleSecurityInfo('email.Utils').declarePublic('formataddr')
 allow_module('csv')
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When weasyprint cretaes the stickers pdf, the system relies on Zope's `request` to fetch local and remote data rendered in the html.For this, the `senaite_url_fetcher` is used. And if this function is not capable of resolving the URL, then does a fallback to weasyprint's default.

This `url_fetcher` function is not only called for url-like values from src and url attrbutes from html elements, but is also used for parsing values for `data` attribute from `object` html elements, like the following:

<object type="image/bmp" data="data:image/bmp;base64,Qk1GGA..."/>

When `senaite_url_fetcher` receives an Url, it relies on the function `request.physicalPathFromURL(url)` that returns empty and without error if the url is not a valid internal url. In such case, the function delegates to weasyprint's default.

However, if Virtual Host Monster is configured as an "Inside-Out" Virtual Hosting, (path element starting with `_vh_` in the `VirtualHostRoot`), the function `request.physicalPathFromURL(url)` resolves with a `ValueError: Url does not match virtual hosting context` instead of returning an empty value. As a result, the image in base64 is not rendered in the resulting pdf.

This change makes the system to handle this use case gracefully.

```
2023-06-15 16:29:07 INFO senaite.core Fetching URL 'data:image/bmp;base64,Qk1GGAAA..///////' for WeasyPrint
2023-06-15 16:29:07 ERROR weasyprint Failed to load image at "data:image/bmp;base64,Qk1GGAAA..///////" (ValueError: Url does not match virtual hosting context)
> /home/senaite/buildout-cache/eggs/WeasyPrint-0.42.3-py2.7.egg/weasyprint/__init__.py(143)render()-><weasypr...640cf2d0>
-> font_config)
(Pdb) where
  /home/senaite/buildout-cache/eggs/Zope2-2.13.30-py2.7.egg/ZServer/PubCore/ZServerPublisher.py(31)__init__()
-> response=b)
  /home/senaite/buildout-cache/eggs/Zope2-2.13.30-py2.7.egg/ZPublisher/Publish.py(455)publish_module()
-> environ, debug, request, response)
  /home/senaite/buildout-cache/eggs/Zope2-2.13.30-py2.7.egg/ZPublisher/Publish.py(249)publish_module_standard()
-> response = publish(request, module_name, after_list, debug=debug)
  /home/senaite/buildout-cache/eggs/Zope2-2.13.30-py2.7.egg/ZPublisher/Publish.py(138)publish()
-> request, bind=1)
  /home/senaite/buildout-cache/eggs/Zope2-2.13.30-py2.7.egg/ZPublisher/mapply.py(77)mapply()
-> if debug is not None: return debug(object,args,context)
  /home/senaite/buildout-cache/eggs/Zope2-2.13.30-py2.7.egg/ZPublisher/Publish.py(48)call_object()
-> result=apply(object,args) # Type s<cr> to step into published object.
  /home/senaite/senaite/src/senaite.core/bika/lims/browser/stickers.py(95)__call__()
-> pdfstream = self.pdf_from_post()
  /home/senaite/senaite/src/senaite.core/bika/lims/browser/stickers.py(291)pdf_from_post()
-> pdf_file = createPdf(htmlreport=reporthtml, outfile=pdf_fn)
  /home/senaite/senaite/src/senaite.core/bika/lims/utils/__init__.py(465)createPdf()
-> renderer.write_pdf(pdf_fn)
  /home/senaite/buildout-cache/eggs/WeasyPrint-0.42.3-py2.7.egg/weasyprint/__init__.py(182)write_pdf()
-> font_config=font_config).write_pdf(
> /home/senaite/buildout-cache/eggs/WeasyPrint-0.42.3-py2.7.egg/weasyprint/__init__.py(143)render()-><weasypr...640cf2d0>
-> font_config)
```

## Current behavior before PR

Stickers with empty barcodes when server is configured with "Inside-Out" Virtual Hosting

## Desired behavior after PR is merged

Stickers with barcodes when server is configured with "Inside-Out" Virtual Hosting

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
