### PR TITLE
Fix client group ID

### DIFF
--- a/src/bika/lims/content/client.py
+++ b/src/bika/lims/content/client.py
@@ -184,8 +184,41 @@ class Client(Organisation):
         """Client group ID
         """
         if not hasattr(self, self.GROUP_KEY):
-            setattr(self, self.GROUP_KEY, self.getClientID() or self.getId())
+            setattr(self, self.GROUP_KEY, self._get_group_id())
         return getattr(self, self.GROUP_KEY)
+
+    def _get_group_id(self):
+        """Get a valid group ID
+        """
+        # Try first the client ID
+        client_id = self.getClientID()
+        if self.is_valid_group_id(client_id):
+            return client_id
+
+        # Use the context ID
+        context_id = self.getId()
+        if self.is_valid_group_id(context_id):
+            return context_id
+
+        # Use the ID + prefix
+        prefix_id = "group_%s" % client_id or context_id
+        count = 0
+        while not self.is_valid_group_id(prefix_id):
+            count += 1
+            prefix_id = "group_%s_%s" % (count, client_id or context_id)
+
+        return prefix_id
+
+    def is_valid_group_id(self, group_id):
+        """Check if the group ID is valid
+
+        :param group_id: The group ID to validate
+        """
+        portal = api.get_portal()
+        # Check if the ID is already used by a user login
+        if get_member_by_login_name(portal, group_id, False):
+            return False
+        return True
 
     @security.public
     def get_group(self):

--- a/src/bika/lims/content/client.py
+++ b/src/bika/lims/content/client.py
@@ -19,27 +19,12 @@
 # Some rights reserved, see README and LICENSE.
 
 import six
-
 from AccessControl import ClassSecurityInfo
 from AccessControl import Unauthorized
-from bika.lims.browser.fields import UIDReferenceField
-from Products.ATContentTypes.content import schemata
-from Products.Archetypes.public import BooleanField
-from Products.Archetypes.public import BooleanWidget
-from Products.Archetypes.public import Schema
-from Products.Archetypes.public import SelectionWidget
-from Products.Archetypes.public import StringField
-from Products.Archetypes.public import StringWidget
-from Products.Archetypes.public import registerType
-from Products.CMFCore import permissions
-from Products.CMFCore.PortalFolder import PortalFolderBase as PortalFolder
-from Products.CMFCore.utils import _checkPermission
-from zope.interface import implements
-
 from bika.lims import _
 from bika.lims import api
 from bika.lims.browser.fields import EmailsField
-from senaite.core.browser.widgets.referencewidget import ReferenceWidget
+from bika.lims.browser.fields import UIDReferenceField
 from bika.lims.catalog.bikasetup_catalog import SETUP_CATALOG
 from bika.lims.config import DECIMAL_MARKS
 from bika.lims.config import PROJECTNAME
@@ -47,6 +32,20 @@ from bika.lims.content.attachment import Attachment
 from bika.lims.content.organisation import Organisation
 from bika.lims.interfaces import IClient
 from bika.lims.interfaces import IDeactivable
+from Products.Archetypes.public import BooleanField
+from Products.Archetypes.public import BooleanWidget
+from Products.Archetypes.public import Schema
+from Products.Archetypes.public import SelectionWidget
+from Products.Archetypes.public import StringField
+from Products.Archetypes.public import StringWidget
+from Products.Archetypes.public import registerType
+from Products.ATContentTypes.content import schemata
+from Products.CMFCore import permissions
+from Products.CMFCore.PortalFolder import PortalFolderBase as PortalFolder
+from Products.CMFCore.utils import _checkPermission
+from Products.CMFPlone.RegistrationTool import get_member_by_login_name
+from senaite.core.browser.widgets.referencewidget import ReferenceWidget
+from zope.interface import implements
 
 schema = Organisation.schema.copy() + Schema((
     StringField(

--- a/src/bika/lims/content/client.py
+++ b/src/bika/lims/content/client.py
@@ -214,10 +214,19 @@ class Client(Organisation):
 
         :param group_id: The group ID to validate
         """
+        # Check for string
+        if not api.is_string(group_id):
+            return False
+
+        # Check for empty string
+        if not len(group_id) > 0:
+            return False
+
         portal = api.get_portal()
         # Check if the ID is already used by a user login
         if get_member_by_login_name(portal, group_id, False):
             return False
+
         return True
 
     @security.public


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an `AttributeError` in upgrade step `2508` that was introduced in https://github.com/senaite/senaite.core/pull/2301

## Current behavior before PR

`AttributeError` raised if the desired group ID is already used by a user login.

## Desired behavior after PR is merged

Group ID is validated to avoid a clash with the user id

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
