### PR TITLE
Run tests in Python 2.7 container

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,8 @@ env:
 jobs:
   build-and-test:
     runs-on: 'ubuntu-20.04'
+    container:
+      image: python:2.7.18-buster
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4


### PR DESCRIPTION
## Description

Python 2.7 was removed from `setup-python` action: https://github.com/actions/setup-python/issues/672

This PR uses therefore a Docker container for the tests as described here: https://github.com/actions/setup-python/issues/672