### PR TITLE
Python 2.7 compatibility for GitHub action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,13 +21,14 @@ jobs:
         run: |
           pip install virtualenv
           virtualenv -p `which python` .
+          bin/pip install --upgrade pip
           bin/pip install -r requirements.txt
           bin/buildout -N -t 3 annotate
           bin/buildout -N -t 3
       - name: lint
         run: |
           bin/pip install flake8
-          bin/flake8 --config ci_flake8.cfg src/{bika,senaite}/
+          bin/flake8 --config ci_flake8.cfg src/senaite/
       - name: test
         run: |
           bin/test -s senaite.core.tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,20 +7,14 @@ env:
 jobs:
   build-and-test:
     runs-on: 'ubuntu-20.04'
+    container:
+      image: python:2.7.18-buster
     steps:
       - uses: actions/checkout@v3
-      # Taken from https://github.com/xenserver-next/python-libs/blob/master/.github/workflows/main.yml
-      - name: Setup Python 2.7.18
-        # uses: actions/setup-python@v4 due to https://github.com/actions/setup-python/issues/672:
-        # https://github.com/MatteoH2O1999/setup-python
-        # This action tries to build from source all Python versions that actions/setup-python
-        # does not support. It also allows to cache built versions so that after the first run,
-        # installation time is really low. Hope it works also with 20.04, else it needs more changes:
-        uses: MatteoH2O1999/setup-python@v1
+      - uses: actions/setup-python@v4
         with:
-          python-version: 2.7.18
-          allow-build: info
-          cache-build: true
+          python-version: '2.7.18'
+          cache: 'pip'
       - name: cache eggs
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,25 +9,25 @@ jobs:
     runs-on: 'ubuntu-20.04'
     container:
       image: python:2.7.18-buster
-      steps:
-        - uses: actions/checkout@v3
-        - name: cache eggs
-          uses: actions/cache@v3
-          with:
-            key: eggs-cache-${{ hashFiles('buildout.cfg', 'requirements.txt') }}
-            path: |
-              eggs/
-        - name: install
-          run: |
-            pip install virtualenv
-            virtualenv -p `which python` .
-            bin/pip install -r requirements.txt
-            bin/buildout -N -t 3 annotate
-            bin/buildout -N -t 3
-        - name: lint
-          run: |
-            bin/pip install flake8
-            bin/flake8 --config ci_flake8.cfg src/{bika,senaite}/
-        - name: test
-          run: |
-            bin/test -s senaite.core.tests
+    steps:
+      - uses: actions/checkout@v3
+      - name: cache eggs
+        uses: actions/cache@v3
+        with:
+          key: eggs-cache-${{ hashFiles('buildout.cfg', 'requirements.txt') }}
+          path: |
+            eggs/
+      - name: install
+        run: |
+          pip install virtualenv
+          virtualenv -p `which python` .
+          bin/pip install -r requirements.txt
+          bin/buildout -N -t 3 annotate
+          bin/buildout -N -t 3
+      - name: lint
+        run: |
+          bin/pip install flake8
+          bin/flake8 --config ci_flake8.cfg src/{bika,senaite}/
+      - name: test
+        run: |
+          bin/test -s senaite.core.tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,6 +28,7 @@ jobs:
       - name: lint
         run: |
           bin/pip install flake8
+          bin/flake8 --config ci_flake8.cfg src/bika/
           bin/flake8 --config ci_flake8.cfg src/senaite/
       - name: test
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,29 +9,25 @@ jobs:
     runs-on: 'ubuntu-20.04'
     container:
       image: python:2.7.18-buster
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '2.7.18'
-          cache: 'pip'
-      - name: cache eggs
-        uses: actions/cache@v3
-        with:
-          key: eggs-cache-${{ hashFiles('buildout.cfg', 'requirements.txt') }}
-          path: |
-            eggs/
-      - name: install
-        run: |
-          pip install virtualenv
-          virtualenv -p `which python` .
-          bin/pip install -r requirements.txt
-          bin/buildout -N -t 3 annotate
-          bin/buildout -N -t 3
-      - name: lint
-        run: |
-          bin/pip install flake8
-          bin/flake8 --config ci_flake8.cfg src/{bika,senaite}/
-      - name: test
-        run: |
-          bin/test -s senaite.core.tests
+      steps:
+        - uses: actions/checkout@v3
+        - name: cache eggs
+          uses: actions/cache@v3
+          with:
+            key: eggs-cache-${{ hashFiles('buildout.cfg', 'requirements.txt') }}
+            path: |
+              eggs/
+        - name: install
+          run: |
+            pip install virtualenv
+            virtualenv -p `which python` .
+            bin/pip install -r requirements.txt
+            bin/buildout -N -t 3 annotate
+            bin/buildout -N -t 3
+        - name: lint
+          run: |
+            bin/pip install flake8
+            bin/flake8 --config ci_flake8.cfg src/{bika,senaite}/
+        - name: test
+          run: |
+            bin/test -s senaite.core.tests


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Python 2.7 is no longer supported by `setup-python`: https://github.com/actions/setup-python/issues/672

## Current behavior before PR

Build fails

## Desired behavior after PR is merged

Build passes with Python 2.7

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
