### PR TITLE
Fix UID copy method in AT->DX content migrator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2340 Fix UID copy method in AT->DX content migrator
 - #2332 Fix unauthorized error when accessing immediate results entry view with a client contact user
 - #2295 Integrate new UID reference widget
 - #2315 Apply dynamic analyses specs for new added analyses

--- a/src/senaite/core/migration/migrator.py
+++ b/src/senaite/core/migration/migrator.py
@@ -82,13 +82,14 @@ class ContentMigrator(object):
         """
         obj.reindexObject()
 
-    def copy_uid(self, obj, uid):
+    def copy_uid(self, src, target):
         """Set uid on object
         """
-        if api.is_dexterity_content(obj):
-            setattr(obj, "_plone.uuid", uid)
-        elif api.is_at_content(obj):
-            setattr(obj, "_at_uid", uid)
+        uid = api.get_uid(src)
+        if api.is_dexterity_content(target):
+            setattr(target, "_plone.uuid", uid)
+        elif api.is_at_content(target):
+            setattr(target, "_at_uid", uid)
         else:
             raise TypeError("Cannot set UID on that object")
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the parameters for the `copy_uid` method of the AT->DX content migrator to work on the source and target objects directly.

## Current behavior before PR

Method expected the target object and the UID, but got the source and the target object instead.

## Desired behavior after PR is merged

Method expects the source and the target object to copy the UID

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
