### PR TITLE
Handle nonexisting UIDs gracefully in referencewidget

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2341 Handle nonexisting UIDs gracefully in referencewidget
 - #2340 Fix UID copy method in AT->DX content migrator
 - #2332 Fix unauthorized error when accessing immediate results entry view with a client contact user
 - #2295 Integrate new UID reference widget

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2340 Fix UID copy method in AT->DX content migrator
 - #2332 Fix unauthorized error when accessing immediate results entry view with a client contact user
 - #2295 Integrate new UID reference widget
 - #2315 Apply dynamic analyses specs for new added analyses

--- a/src/senaite/core/browser/widgets/referencewidget.py
+++ b/src/senaite/core/browser/widgets/referencewidget.py
@@ -274,7 +274,12 @@ class ReferenceWidget(QuerySelectWidget):
         regex = r"\{(.*?)\}"
         names = re.findall(regex, template)
 
-        obj = api.get_object(uid)
+        try:
+            obj = api.get_object(uid)
+        except api.APIError:
+            logger.error("No object found for UID {}".format(uid))
+            return None
+
         data = {
             "uid": api.get_uid(obj),
             "url": api.get_url(obj),

--- a/src/senaite/core/migration/migrator.py
+++ b/src/senaite/core/migration/migrator.py
@@ -82,13 +82,14 @@ class ContentMigrator(object):
         """
         obj.reindexObject()
 
-    def copy_uid(self, obj, uid):
+    def copy_uid(self, src, target):
         """Set uid on object
         """
-        if api.is_dexterity_content(obj):
-            setattr(obj, "_plone.uuid", uid)
-        elif api.is_at_content(obj):
-            setattr(obj, "_at_uid", uid)
+        uid = api.get_uid(src)
+        if api.is_dexterity_content(target):
+            setattr(target, "_plone.uuid", uid)
+        elif api.is_at_content(target):
+            setattr(target, "_at_uid", uid)
         else:
             raise TypeError("Cannot set UID on that object")
 

--- a/src/senaite/core/z3cform/widgets/uidreference/widget.py
+++ b/src/senaite/core/z3cform/widgets/uidreference/widget.py
@@ -134,7 +134,12 @@ class UIDReferenceWidget(QuerySelectWidget):
         template = self.get_display_template(context, self.field)
         names = re.findall(regex, template)
 
-        obj = api.get_object(uid)
+        try:
+            obj = api.get_object(uid)
+        except api.APIError:
+            logger.error("No object found for UID {}".format(uid))
+            return None
+
         data = {
             "uid": api.get_uid(obj),
             "url": api.get_url(obj),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Merge #2340 first**

This PR handles non existing UIDs gracefully in the referencewidget.

## Current behavior before PR

Reference widget fails with an error if the UID could not be rendered

## Desired behavior after PR is merged

Reference widget does not fail and displays the raw UID instead.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
