### PR TITLE
Fix import in JSON API error handler

### DIFF
--- a/src/bika/lims/jsonapi/__init__.py
+++ b/src/bika/lims/jsonapi/__init__.py
@@ -36,7 +36,7 @@ import traceback
 def handle_errors(f):
     """ simple JSON error handler
     """
-    from plone.jsonapi.core.helpers import error
+    from plone.jsonapi.core.browser.helpers import error
 
     def decorator(*args, **kwargs):
         try:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an import error that occurs in the error handler.
The original imported function is located here:

https://github.com/collective/plone.jsonapi.core/blob/master/src/plone/jsonapi/core/browser/helpers.py#L7

## Current behavior before PR

Import error occurs

## Desired behavior after PR is merged

No import error occurs

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
