### PR TITLE
Display batch labels in listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2350 Display batch labels in listing
 - #2347 Remove unused inline validation view
 - #2346 Fix unauthorized error when accessing dispatch/partition sample view with shared client role
 - #2343 Allow to define the sorting criteria for Result Options

--- a/src/bika/lims/browser/batchfolder.py
+++ b/src/bika/lims/browser/batchfolder.py
@@ -66,6 +66,9 @@ class BatchFolderContentsView(ListingView):
             ("BatchID", {
                 "title": _("Batch ID"),
                 "index": "getId", }),
+            ("BatchLabels", {
+                "title": _("Batch Labels"),
+                "sortable": False, }),
             ("Description", {
                 "title": _("Description"),
                 "sortable": False, }),
@@ -156,6 +159,15 @@ class BatchFolderContentsView(ListingView):
             return False
         return True
 
+    def to_pretty_label(self, label):
+        """Make a pretty label for the given label string
+
+        :param label: text batch label
+        :returns: Bootstrap HTML batch label
+        """
+        tpl = u"<span class='badge badge-secondary mr-1'>{}</span>"
+        return tpl.format(api.safe_unicode(label))
+
     def folderitem(self, obj, item, index):
         """Applies new properties to the item (Batch) that is currently being
         rendered as a row in the list
@@ -178,6 +190,7 @@ class BatchFolderContentsView(ListingView):
         client = obj.getClient()
         created = api.get_creation_date(obj)
         date = obj.getBatchDate()
+        batch_labels = obj.getLabelNames()
 
         # total sample progress
         progress = obj.getProgress()
@@ -191,6 +204,12 @@ class BatchFolderContentsView(ListingView):
         item["replace"]["Title"] = get_link(url, title)
         item["created"] = self.ulocalized_time(created, long_format=True)
         item["BatchDate"] = self.ulocalized_time(date, long_format=True)
+        item["BatchLabels"] = ""
+
+        if batch_labels:
+            item["BatchLabels"] = ",".join(batch_labels)
+            item["replace"]["BatchLabels"] = "".join(map(
+                self.to_pretty_label, batch_labels))
 
         if client:
             client_url = api.get_url(client)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds a new column "Batch Label" to the batch listing views.

## Current behavior before PR

Batch labels not displayed in batch listing views

## Desired behavior after PR is merged

Batch labels displayed in batch listing views

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
