### PR TITLE
Render all legacy resources at the end of the page

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2354 Render all legacy resources at the end of the page
 - #2350 Display batch labels in listing
 - #2347 Remove unused inline validation view
 - #2346 Fix unauthorized error when accessing dispatch/partition sample view with shared client role

--- a/src/senaite/core/browser/main_template/templates/main_template.pt
+++ b/src/senaite/core/browser/main_template/templates/main_template.pt
@@ -44,14 +44,10 @@
       <!-- <link tal:replace="structure provider:plone.htmlhead.links" /> -->
       <!-- <metal:styleslot define-slot="style_slot" /> -->
 
-      <!-- SENAITE legacy resouces -->
-      <metal:resources define-slot="senaite_legacy_resources" />
-      <!-- SENAITE legacy JS -->
-      <metal:resources define-slot="senaite_legacy_js" />
-      <!-- SENAITE legacy CSS -->
-      <metal:resources define-slot="senaite_legacy_css" />
+      <!-- NOTE: All Legacy JS/CSS are rendered at the bottom of the page! -->
 
-      <meta name="generator" content="Plone - http://plone.com" />
+      <meta name="generator" content="SENAITE - https://www.senaite.com" />
+
       <meta name="viewport"
             tal:define="viewportvalues bootstrapview/get_viewport_values"
             tal:attributes="content viewportvalues"
@@ -185,6 +181,20 @@
         </div>
 
       </div>
+
+      <!-- NOTE:
+           We define all legacy resource slots at the bottom to ensure these are
+           loaded *after* the JS/CSS from the resources viewlet (rendered in the
+           IHtmlHead viewlet manager) and the HTML is completely loaded.
+      -->
+
+      <!-- SENAITE legacy resouces -->
+      <metal:resources define-slot="senaite_legacy_resources" />
+      <!-- SENAITE legacy JS -->
+      <metal:resources define-slot="senaite_legacy_js" />
+      <!-- SENAITE legacy CSS -->
+      <metal:resources define-slot="senaite_legacy_css" />
+
     </body>
   </html>
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR moves the legacy resource slots at the end of the page to ensure these are loaded *after* the JS/CSS from the resources viewlet (rendered in the `IHtmlHead` viewlet manager) and the HTML is completely loaded.

## Current behavior before PR

Some JS/CSS are not always loaded when reloading the sample add form

## Desired behavior after PR is merged

Legacy JS/CSS are loaded at the end of the page to ensure the all other resources and HTML is loaded completely before.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
