### PR TITLE
Skip object reindexing when global auditlog is disabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2357 Skip object reindexing when global auditlog is disabled
 - #2354 Render all legacy resources at the end of the page
 - #2350 Display batch labels in listing
 - #2347 Remove unused inline validation view

--- a/src/bika/lims/subscribers/auditlog.py
+++ b/src/bika/lims/subscribers/auditlog.py
@@ -46,7 +46,10 @@ def reindex_object(obj):
     if auditlog_catalog is None:
         logger.warn("Auditlog catalog not found. Skipping reindex.")
         return
-    auditlog_catalog.reindexObject(obj)
+
+    setup = api.get_senaite_setup()
+    if setup.getEnableGlobalAuditlog():
+        auditlog_catalog.reindexObject(obj)
 
 
 def unindex_object(obj):

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -1281,38 +1281,7 @@ This function creates a good cache key for a generic object or brain::
     >>> key1
     'Client-client-1-...'
 
-This can be also done for a catalog result brain::
-
-    >>> portal_catalog = api.get_tool("portal_catalog")
-    >>> brains = portal_catalog({"portal_type": "Client", "UID": api.get_uid(client)})
-    >>> key2 = api.get_cache_key(brains[0])
-    >>> key2
-    'Client-client-1-...'
-
-The two keys should be equal::
-
-    >>> key1 == key2
-    True
-
-The key should change when the object get modified::
-
-    >>> client.setClientID("TESTCLIENT")
-    >>> client.processForm()
-    >>> key3 = api.get_cache_key(client)
-    >>> key3 != key1
-    True
-
-~~ important:: Workflow changes do not change the modification date!
-A custom event subscriber will update it therefore.
-
-A workflow transition should also change the cache key::
-
-    >>> _ = api.do_transition_for(client, transition="deactivate")
-    >>> api.is_active(client)
-    False
-    >>> key4 = api.get_cache_key(client)
-    >>> key4 != key3
-    True
+NOTE: Function will be deleted in senaite.core 3.0.0
 
 
 SENAITE Cache Key decorator
@@ -1341,14 +1310,17 @@ Calling the (expensive) method of the class does the calculation just once::
 
 The decorator can also handle brains::
 
+    >>> from senaite.core.catalog import CLIENT_CATALOG
     >>> instance = SENAITEClass()
-    >>> portal_catalog = api.get_tool("portal_catalog")
-    >>> brain = portal_catalog(portal_type="Client")[0]
+    >>> cat = api.get_tool(CLIENT_CATALOG)
+    >>> brain = cat(portal_type="Client")[0]
     >>> instance.get_very_expensive_calculation(brain)
     very expensive calculation
     'calculation result'
     >>> instance.get_very_expensive_calculation(brain)
     'calculation result'
+
+NOTE: Function will be deleted in senaite.core 3.0.0
 
 
 ID Normalizer


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR improves (a little bit) the performance when objects are modified or transitioned.

## Current behavior before PR

Objects are reindexed in the global auditlog catalog no matter if enabled/disabled in catalog.

## Desired behavior after PR is merged

No reindexing is performed if the global auditlog option is disabled in the setup.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
