### PR TITLE
Improve sample create performance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2359 Improve sample create performance
 - #2358 Add confirmation when unlinking reference
 - #2357 Skip object reindexing when global auditlog is disabled
 - #2354 Render all legacy resources at the end of the page

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -1752,6 +1752,10 @@ def is_temporary(obj):
         return True
 
     if is_at_content(obj):
+        # Checks if the `creationFlag` is set
+        if obj.checkCreationFlag():
+            return True
+
         # Checks to see if we are created inside the portal_factory. We don't
         # rely here on AT's isFactoryContained because the function is patched
         meta_type = getattr(aq_base(parent), "meta_type", "")

--- a/src/bika/lims/api/snapshot.py
+++ b/src/bika/lims/api/snapshot.py
@@ -144,7 +144,7 @@ def get_snapshot_version(obj, snapshot):
 
     :param obj: Content object
     :param snapshot: Snapshot dictionary
-    :returns: Index where the object is lcated
+    :returns: Index where the object is located
     """
     snapshots = get_snapshots(obj)
     if snapshot not in snapshots:

--- a/src/bika/lims/api/snapshot.py
+++ b/src/bika/lims/api/snapshot.py
@@ -147,6 +147,8 @@ def get_snapshot_version(obj, snapshot):
     :returns: Index where the object is lcated
     """
     snapshots = get_snapshots(obj)
+    if snapshot not in snapshots:
+        return -1
     return snapshots.index(snapshot)
 
 

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -1326,19 +1326,6 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
     displayContentsTab = False
     schema = schema
 
-    _at_rename_after_creation = True
-
-    def _renameAfterCreation(self, check_auto_id=False):
-        """Rename hook called by processForm
-        """
-        # https://github.com/senaite/senaite.core/issues/1327
-        primary = self.getPrimaryAnalysisRequest()
-        if primary:
-            logger.info("Secondary sample detected: Skipping ID generation")
-            return False
-        from bika.lims.idserver import renameAfterCreation
-        renameAfterCreation(self)
-
     def _getCatalogTool(self):
         from bika.lims.catalog import getCatalog
         return getCatalog(self)

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -28,7 +28,6 @@ from bika.lims import logger
 from bika.lims.api.mail import compose_email
 from bika.lims.api.mail import is_valid_email_address
 from bika.lims.api.mail import send_email
-from bika.lims.catalog import SETUP_CATALOG
 from bika.lims.idserver import renameAfterCreation
 from bika.lims.interfaces import IAnalysisRequest
 from bika.lims.interfaces import IAnalysisRequestRetest
@@ -48,6 +47,7 @@ from Products.Archetypes.config import UID_CATALOG
 from Products.Archetypes.event import ObjectInitializedEvent
 from Products.CMFPlone.utils import _createObjectByType
 from Products.CMFPlone.utils import safe_unicode
+from senaite.core.catalog import SETUP_CATALOG
 from senaite.core.permissions.sample import can_receive
 from senaite.core.workflow import ANALYSIS_WORKFLOW
 from senaite.core.workflow import SAMPLE_WORKFLOW
@@ -148,6 +148,8 @@ def create_analysisrequest(client, request, values, analyses=None,
 
     renameAfterCreation(ar)
     ar.unmarkCreationFlag()
+    # explicit reindexing after creation flag is unset
+    ar.reindexObject()
     event.notify(ObjectInitializedEvent(ar))
 
     # If rejection reasons have been set, reject the sample automatically

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -457,16 +457,8 @@ def create_partition(analysis_request, request, analyses, sample_type=None,
     partition.reindexObject(idxs="getDateReceived")
 
     # Always set partition to received state
-    changeWorkflowState(partition, SAMPLE_WORKFLOW, "sample_received")
-    alsoProvides(partition, IReceived)
+    receive_sample(partition)
 
-    # And initialize the analyses the partition contains. This is required
-    # here because the transition "initialize" of analyses rely on a guard,
-    # so the initialization can only be performed when the sample has been
-    # received (DateReceived is set)
-    for analysis in partition.getAnalyses(full_objects=True):
-        doActionFor(analysis, "initialize")
-        analysis.reindexObject()
     return partition
 
 

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -122,20 +122,19 @@ def create_analysisrequest(client, request, values, analyses=None,
         # Set dates to match with those from the primary
         ar.setDateSampled(primary.getDateSampled())
         ar.setSamplingDate(primary.getSamplingDate())
-        ar.setDateReceived(primary.getDateReceived())
 
         # Force the transition of the secondary to received and set the
         # description/comment in the transition accordingly.
-        if primary.getDateReceived():
-            receive_sample(ar)
+        date_received = primary.getDateReceived()
+        if date_received:
+            receive_sample(ar, date_received=date_received)
 
     partition = ar.isPartition()
     if partition:
-        # Always set partition to received state
-        receive_sample(ar)
-        # set the received date according to the parent
+        # Always set partition to received
         root = ar.getParentAnalysisRequest()
-        ar.setDateReceived(root.getDateReceived())
+        date_received = root.getDateReceived()
+        receive_sample(ar, date_received=date_received)
 
     if not IReceived.providedBy(ar):
         setup = api.get_setup()
@@ -178,7 +177,7 @@ def reindex(obj, recursive=False):
             reindex(child)
 
 
-def receive_sample(sample, check_permission=False):
+def receive_sample(sample, check_permission=False, date_received=None):
     """Receive the sample without transition
     """
 
@@ -194,7 +193,9 @@ def receive_sample(sample, check_permission=False):
     # Mark the secondary as received
     alsoProvides(sample, IReceived)
     # Manually set the received date
-    sample.setDateReceived(DateTime())
+    if not date_received:
+        date_received = DateTime()
+    sample.setDateReceived(date_received)
 
     # Initialize analyses
     # NOTE: We use here `objectValues` instead of `getAnalyses`,

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -122,7 +122,10 @@ def create_analysisrequest(client, request, values, analyses=None,
         # Force the transition of the secondary to received and set the
         # description/comment in the transition accordingly.
         if primary.getDateReceived():
-            receive_sample(ar)
+            # We skip here the permission check because the sample is in
+            # "registered" state, where the permission to receive is granted to
+            # no one.
+            receive_sample(ar, check_permission=False)
 
     if not IReceived.providedBy(ar):
         setup = api.get_setup()
@@ -147,10 +150,10 @@ def create_analysisrequest(client, request, values, analyses=None,
     return ar
 
 
-def receive_sample(sample):
+def receive_sample(sample, check_permission=True):
     """Receive the sample without transition
     """
-    if not can_receive(sample):
+    if check_permission and not can_receive(sample):
         return False
 
     changeWorkflowState(sample, SAMPLE_WORKFLOW, "sample_received",

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -135,13 +135,13 @@ def create_analysisrequest(client, request, values, analyses=None,
             changeWorkflowState(ar, SAMPLE_WORKFLOW, "sample_due",
                                 action="no_sampling_workflow")
 
-    # If rejection reasons have been set, reject the sample automatically
-    if rejection_reasons:
-        do_rejection(ar)
-
     renameAfterCreation(ar)
     ar.unmarkCreationFlag()
     event.notify(ObjectInitializedEvent(ar))
+
+    # If rejection reasons have been set, reject the sample automatically
+    if rejection_reasons:
+        do_rejection(ar)
 
     return ar
 

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -127,6 +127,9 @@ def create_analysisrequest(client, request, values, analyses=None,
     if partition:
         # Always set partition to received state
         receive_sample(ar)
+        # set the received date according to the parent
+        root = ar.getParentAnalysisRequest()
+        ar.setDateReceived(root.getDateReceived())
 
     if not IReceived.providedBy(ar):
         setup = api.get_setup()
@@ -446,20 +449,12 @@ def create_partition(analysis_request, request, analyses, sample_type=None,
 
     # Populate the root's ResultsRanges to partitions
     results_ranges = ar.getResultsRange() or []
+
     partition = create_analysisrequest(client,
                                        request=request,
                                        values=record,
                                        analyses=services,
                                        results_ranges=results_ranges)
-
-    # Reindex Parent Analysis Request
-    ar.reindexObject(idxs=["isRootAncestor"])
-
-    # Manually set the Date Received to match with its parent. This is
-    # necessary because crar calls to processForm, so DateReceived is not
-    # set because the partition has not been received yet
-    partition.setDateReceived(ar.getDateReceived())
-    partition.reindexObject(idxs="getDateReceived")
 
     return partition
 

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -122,10 +122,7 @@ def create_analysisrequest(client, request, values, analyses=None,
         # Force the transition of the secondary to received and set the
         # description/comment in the transition accordingly.
         if primary.getDateReceived():
-            # We skip here the permission check because the sample is in
-            # "registered" state, where the permission to receive is granted to
-            # no one.
-            receive_sample(ar, check_permission=False)
+            receive_sample(ar)
 
     if not IReceived.providedBy(ar):
         setup = api.get_setup()
@@ -150,9 +147,13 @@ def create_analysisrequest(client, request, values, analyses=None,
     return ar
 
 
-def receive_sample(sample, check_permission=True):
+def receive_sample(sample, check_permission=False):
     """Receive the sample without transition
     """
+
+    # NOTE: In `sample_registered` state we do not grant any roles the
+    #       permission to receive a sample! Not sure if this can be ignored
+    #       when the LIMS is configured to auto-receive samples?
     if check_permission and not can_receive(sample):
         return False
 

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -123,6 +123,11 @@ def create_analysisrequest(client, request, values, analyses=None,
         if primary.getDateReceived():
             receive_sample(ar)
 
+    partition = ar.isPartition()
+    if partition:
+        # Always set partition to received state
+        receive_sample(ar)
+
     if not IReceived.providedBy(ar):
         setup = api.get_setup()
         # Sampling is required
@@ -455,9 +460,6 @@ def create_partition(analysis_request, request, analyses, sample_type=None,
     # set because the partition has not been received yet
     partition.setDateReceived(ar.getDateReceived())
     partition.reindexObject(idxs="getDateReceived")
-
-    # Always set partition to received state
-    receive_sample(partition)
 
     return partition
 

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -89,6 +89,9 @@ def create_analysisrequest(client, request, values, analyses=None,
 
     # Create the Analysis Request and submit the form
     ar = _createObjectByType("AnalysisRequest", client, tmpID())
+    # NOTE: We call here `_processForm` (with underscore) to manually unmark
+    #       the creation flag and trigger the `ObjectInitializedEvent`, which
+    #       is used for snapshot creation.
     ar._processForm(REQUEST=request, values=values)
 
     # Set the analyses manually

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -90,7 +90,7 @@ def create_analysisrequest(client, request, values, analyses=None,
 
     # Create the Analysis Request and submit the form
     ar = _createObjectByType('AnalysisRequest', client, tmpID())
-    ar.processForm(REQUEST=request, values=values)
+    ar._processForm(REQUEST=request, values=values)
 
     # Set the analyses manually
     ar.setAnalyses(service_uids, prices=prices, specs=results_ranges)
@@ -146,6 +146,10 @@ def create_analysisrequest(client, request, values, analyses=None,
             if rejection_reasons:
                 do_rejection(ar)
 
+            renameAfterCreation(ar)
+            ar.unmarkCreationFlag()
+            event.notify(ObjectInitializedEvent(ar))
+
             # In "received" state already
             return ar
 
@@ -157,6 +161,10 @@ def create_analysisrequest(client, request, values, analyses=None,
     # If rejection reasons have been set, reject the sample automatically
     if rejection_reasons:
         do_rejection(ar)
+
+    renameAfterCreation(ar)
+    ar.unmarkCreationFlag()
+    event.notify(ObjectInitializedEvent(ar))
 
     return ar
 

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -22,14 +22,6 @@ import itertools
 from string import Template
 
 import six
-from Products.Archetypes.config import UID_CATALOG
-from Products.CMFPlone.utils import _createObjectByType
-from Products.CMFPlone.utils import safe_unicode
-from senaite.core.workflow import ANALYSIS_WORKFLOW
-from senaite.core.workflow import SAMPLE_WORKFLOW
-from zope.interface import alsoProvides
-from zope.lifecycleevent import modified
-
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
@@ -53,6 +45,15 @@ from bika.lims.workflow import ActionHandlerPool
 from bika.lims.workflow import doActionFor
 from bika.lims.workflow import push_reindex_to_actions_pool
 from bika.lims.workflow.analysisrequest import do_action_to_analyses
+from Products.Archetypes.config import UID_CATALOG
+from Products.Archetypes.event import ObjectInitializedEvent
+from Products.CMFPlone.utils import _createObjectByType
+from Products.CMFPlone.utils import safe_unicode
+from senaite.core.workflow import ANALYSIS_WORKFLOW
+from senaite.core.workflow import SAMPLE_WORKFLOW
+from zope import event
+from zope.interface import alsoProvides
+from zope.lifecycleevent import modified
 
 
 def create_analysisrequest(client, request, values, analyses=None,

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -44,7 +44,6 @@ from bika.lims.utils import tmpID
 from bika.lims.workflow import ActionHandlerPool
 from bika.lims.workflow import doActionFor
 from bika.lims.workflow import push_reindex_to_actions_pool
-from bika.lims.workflow.analysisrequest import do_action_to_analyses
 from Products.Archetypes.config import UID_CATALOG
 from Products.Archetypes.event import ObjectInitializedEvent
 from Products.CMFPlone.utils import _createObjectByType
@@ -164,7 +163,13 @@ def receive_sample(sample, check_permission=False):
     alsoProvides(sample, IReceived)
 
     # Initialize analyses
-    do_action_to_analyses(sample, "initialize")
+    # NOTE: We use here `objectValues` instead of `getAnalyses`,
+    #       because the Analyses are not yet indexed!
+    for obj in sample.objectValues():
+        if obj.portal_type != "Analysis":
+            continue
+        changeWorkflowState(obj, ANALYSIS_WORKFLOW, "unassigned",
+                            action="initialize")
 
     return True
 

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -89,6 +89,8 @@ def create_analysisrequest(client, request, values, analyses=None,
 
     # Create the Analysis Request and submit the form
     ar = _createObjectByType("AnalysisRequest", client, tmpID())
+    # mark the sample as temporary to avoid indexing
+    api.mark_temporary(ar)
     # NOTE: We call here `_processForm` (with underscore) to manually unmark
     #       the creation flag and trigger the `ObjectInitializedEvent`, which
     #       is used for snapshot creation.
@@ -147,9 +149,13 @@ def create_analysisrequest(client, request, values, analyses=None,
                                 action="no_sampling_workflow")
 
     renameAfterCreation(ar)
+    # AT only
     ar.unmarkCreationFlag()
-    # explicit reindexing after creation flag is unset
+    # unmark the sample as temporary
+    api.unmark_temporary(ar)
+    # explicit reindexing after sample finalization
     ar.reindexObject()
+    # notify object initialization (also creates a snapshot)
     event.notify(ObjectInitializedEvent(ar))
 
     # If rejection reasons have been set, reject the sample automatically

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -456,6 +456,9 @@ def create_partition(analysis_request, request, analyses, sample_type=None,
                                        analyses=services,
                                        results_ranges=results_ranges)
 
+    # Reindex Parent Analysis Request
+    ar.reindexObject(idxs=["isRootAncestor"])
+
     return partition
 
 

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -53,7 +53,6 @@ from senaite.core.workflow import ANALYSIS_WORKFLOW
 from senaite.core.workflow import SAMPLE_WORKFLOW
 from zope import event
 from zope.interface import alsoProvides
-from zope.lifecycleevent import modified
 
 
 def create_analysisrequest(client, request, values, analyses=None,

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -129,11 +129,10 @@ def create_analysisrequest(client, request, values, analyses=None,
         if date_received:
             receive_sample(ar, date_received=date_received)
 
-    partition = ar.isPartition()
-    if partition:
+    parent_sample = ar.getParentAnalysisRequest()
+    if parent_sample:
         # Always set partition to received
-        root = ar.getParentAnalysisRequest()
-        date_received = root.getDateReceived()
+        date_received = parent_sample.getDateReceived()
         receive_sample(ar, date_received=date_received)
 
     if not IReceived.providedBy(ar):
@@ -142,7 +141,7 @@ def create_analysisrequest(client, request, values, analyses=None,
         if ar.getSamplingRequired():
             changeWorkflowState(ar, SAMPLE_WORKFLOW, "to_be_sampled",
                                 action="to_be_sampled")
-        elif not ar.getSamplingRequired() and setup.getAutoreceiveSamples():
+        elif setup.getAutoreceiveSamples():
             receive_sample(ar)
         else:
             changeWorkflowState(ar, SAMPLE_WORKFLOW, "sample_due",

--- a/src/senaite/core/interfaces/__init__.py
+++ b/src/senaite/core/interfaces/__init__.py
@@ -91,6 +91,16 @@ class IItem(Interface):
     """
 
 
+class ITemporaryObject(Interface):
+    """Marker interface for temporary objects
+
+    This is similar to the `creationFlag`, but skips indexing for any object
+    that implements this interface.
+
+    Also see: `senaite.core.patches.catalog.catlog_object`
+    """
+
+
 class ISetup(Interface):
     """Marker interface for setup folder
     """

--- a/src/senaite/core/permissions/sample/__init__.py
+++ b/src/senaite/core/permissions/sample/__init__.py
@@ -3,9 +3,16 @@
 from bika.lims.api.security import check_permission
 
 from .permissions import TransitionPublishResults
+from .permissions import TransitionReceiveSample
 
 
 def can_publish(context):
     """Checks if publication is allowed
     """
     return check_permission(TransitionPublishResults, context)
+
+
+def can_receive(context):
+    """Checks if a sample can be received
+    """
+    return check_permission(TransitionReceiveSample, context)

--- a/src/senaite/core/tests/doctests/API_snapshot.rst
+++ b/src/senaite/core/tests/doctests/API_snapshot.rst
@@ -176,7 +176,7 @@ To check the number of snapshots (versions) an object has, we can call
 `get_snapshot_count`:
 
     >>> get_snapshot_count(sample)
-    2
+    1
 
     >>> get_snapshot_count(setup)
     0
@@ -218,13 +218,15 @@ Get the version of a snapshot
 
 The index (version) of each snapshot can be retrieved:
 
-    >>> snap1 = get_snapshot_by_version(sample, 0)
-    >>> get_snapshot_version(sample, snap1)
+    >>> snap0 = get_snapshot_by_version(sample, 0)
+    >>> get_snapshot_version(sample, snap0)
     0
 
-    >>> snap2 = get_snapshot_by_version(sample, 1)
-    >>> get_snapshot_version(sample, snap2)
-    1
+Non existing versions return -1:
+
+    >>> snap1 = get_snapshot_by_version(sample, 1)
+    >>> get_snapshot_version(sample, snap1)
+    -1
 
 
 Get the last snapshot taken
@@ -232,9 +234,9 @@ Get the last snapshot taken
 
 To get the latest snapshot, we can call `get_last_snapshot`:
 
-   >>> snap = get_last_snapshot(sample)
-   >>> get_snapshot_version(sample, snap)
-   1
+   >>> last_snap = get_last_snapshot(sample)
+   >>> get_snapshot_version(sample, last_snap)
+   0
 
 
 Get the metadata of a snapshot
@@ -242,7 +244,7 @@ Get the metadata of a snapshot
 
 Each snapshot contains metadata which can be retrieved:
 
-   >>> metadata = get_snapshot_metadata(snap)
+   >>> metadata = get_snapshot_metadata(last_snap)
    >>> metadata
    {...}
 
@@ -261,7 +263,7 @@ Take a new Snapshot
 Snapshots can be taken programatically with the function `take_snapshot`:
 
     >>> get_version(sample)
-    1
+    0
 
 Now we take a new snapshot:
 
@@ -270,7 +272,7 @@ Now we take a new snapshot:
 The version should be increased:
 
     >>> get_version(sample)
-    2
+    1
 
 The new snapshot should be the most recent snapshot now:
 
@@ -285,25 +287,24 @@ Comparing Snapshots
 
 The changes of two snapshots can be compared with `compare_snapshots`:
 
-   >>> snap0 = get_snapshot_by_version(sample, 2)
+   >>> snap1 = get_snapshot_by_version(sample, 1)
 
 Add 2 more analyses (Mg and Ca):
 
    >>> sample.edit(Analyses=[Cu, Fe, Au, Mg, Ca])
-   >>> new_snapshot = take_snapshot(sample)
-   >>> snap1 = get_snapshot_by_version(sample, 3)
+   >>> snap2 = take_snapshot(sample)
 
 Passing the `raw=True` keyword returns the raw field changes, e.g. in this case,
 the field `Analyses` is a `UIDReferenceField` which contained initially 3 values
 and after adding 2 analyses, 2 UID more references:
 
-   >>> diff_raw = compare_snapshots(snap0, snap1, raw=True)
+   >>> diff_raw = compare_snapshots(snap1, snap2, raw=True)
    >>> diff_raw["Analyses"]
-   [([u'...', u'...', u'...'], [u'...', u'...', u'...', u'...', u'...'])]
+   [([u'...', u'...', u'...'], ['...', '...', '...', '...', '...'])]
 
 It is also possible to process the values to get a more human readable diff:
 
-   >>> diff = compare_snapshots(snap0, snap1, raw=False)
+   >>> diff = compare_snapshots(snap1, snap2, raw=False)
    >>> diff["Analyses"]
    [('Aurum; Copper; Iron', 'Aurum; Calcium; Copper; Iron; Magnesium')]
 
@@ -341,12 +342,12 @@ The object no longer supports snapshots now:
 Object modification events create then no snapshots anymore:
 
     >>> get_version(sample)
-    4
+    3
 
     >>> modified(sample)
 
     >>> get_version(sample)
-    4
+    3
 
 Resuming the snapshots will enable snapshots for a given object:
 
@@ -362,7 +363,7 @@ Object modification events create new snapshots again:
     >>> modified(sample)
 
     >>> get_version(sample)
-    5
+    4
 
 Unregister event subscribers:
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the utility function `create_analysisrequest` to use the private `_processForm` method instead of `processForm` to handle the events and renaming manually.

In my test this improves the performance from `12.40` to `8.71` seconds when creating 10 samples, which is about 30%.

The reason for this improvement is mainly caused by postponing the `ObjectInitialized` event for snapshot creation and keeping the creation flag until the end to avoid to early indexing.

Another improvement was achieved to reduce the time to `6.38` by setting the WF states without transitions, which cuts down the sample creation process by almost 50%.

## Current behavior before PR

Renaming of samples was still done implicitly by `_renameAfterCreation` method

## Desired behavior after PR is merged

Renaming is done explicitly by `create_analysisrequest` and the `ObjectInitializedEvent` is called after the renaming was done.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
