### PR TITLE
Fix KeyError if registry key not found

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2361 Fix KeyError if registry key not found
 - #2358 Add confirmation when unlinking reference
 - #2357 Skip object reindexing when global auditlog is disabled
 - #2354 Render all legacy resources at the end of the page

--- a/src/senaite/core/registry/__init__.py
+++ b/src/senaite/core/registry/__init__.py
@@ -62,10 +62,10 @@ def get_registry_record(name, default=None):
     """
     registry = get_registry()
     for interface in get_registry_interfaces():
-        proxy = registry.forInterface(interface)
         try:
+            proxy = registry.forInterface(interface)
             return getattr(proxy, name)
-        except AttributeError:
+        except (AttributeError, KeyError):
             pass
     return default
 

--- a/src/senaite/core/registry/__init__.py
+++ b/src/senaite/core/registry/__init__.py
@@ -19,10 +19,11 @@
 # Some rights reserved, see README and LICENSE.
 
 from plone.registry.interfaces import IRegistry
+from senaite.core import logger
 from senaite.core.registry.schema import ISenaiteRegistry
 from zope.component import getUtility
-from zope.schema._bootstrapinterfaces import WrongType
 from zope.dottedname.resolve import resolve
+from zope.schema._bootstrapinterfaces import WrongType
 
 
 def get_registry():
@@ -65,8 +66,8 @@ def get_registry_record(name, default=None):
         try:
             proxy = registry.forInterface(interface)
             return getattr(proxy, name)
-        except (AttributeError, KeyError):
-            pass
+        except (AttributeError, KeyError) as exc:
+            logger.error(exc)
     return default
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a `KeyError` if a registry was not found in SENAITE registry.

## Current behavior before PR

KeyError occured:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.app.listing.view, line 253, in __call__
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module 7e72112bcf4a9afe1cacbff1c4bb3ccb, line 321, in render
  Module 5d335aff98fbc4f482a851a9b988273a, line 1428, in render_master
  Module 5d335aff98fbc4f482a851a9b988273a, line 407, in render_content
  Module 7e72112bcf4a9afe1cacbff1c4bb3ccb, line 259, in __fill_content_core
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module senaite.app.listing.view, line 331, in contents_table
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 215, in render
  Module chameleon.template, line 192, in render
  Module d4f00f9ce29148f0dbffd965c8491481, line 418, in render
  Module zope.tales.pythonexpr, line 73, in __call__
   - __traceback_info__: (view.ajax_transitions_enabled())
  Module <string>, line 1, in <module>
  Module plone.memoize.view, line 59, in memogetter
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.ajax, line 321, in ajax_transitions_enabled
  Module senaite.core.registry, line 67, in get_registry_record
  Module plone.registry.registry, line 82, in forInterface
KeyError: 'Interface `senaite.app.listing.controlpanel.IListingRegistry` defines a field `listing_active_ajax_transitions`, for which there is no record.'
```

## Desired behavior after PR is merged

Error is only logged.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
