### PR TITLE
Improve logging for registry

### DIFF
--- a/src/senaite/core/registry/__init__.py
+++ b/src/senaite/core/registry/__init__.py
@@ -66,8 +66,14 @@ def get_registry_record(name, default=None):
         try:
             proxy = registry.forInterface(interface)
             return getattr(proxy, name)
-        except (AttributeError, KeyError) as exc:
-            logger.error(exc)
+        except (AttributeError, KeyError):
+            pass
+
+    interfaces = map(lambda i: i.__identifier__, get_registry_interfaces())
+    logger.error("No registry record found for '{}' in interfaces '{}'. "
+                 "Returning default value: '{}'. Upgrade step not run?"
+                 .format(name, interfaces, default))
+
     return default
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR reduces and improves the logging that was introduced in #2361.

## Current behavior before PR

Error log was written for each looked up interface

## Desired behavior after PR is merged

Error log is written only if the key was not found in any of the registry interfaces

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
