### PR TITLE
Support for fieldname-prefixed values on sample header submit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2364 Support for fieldname-prefixed values on sample header submit
 - #2363 Auto-hide non-multivalued reference widget input on value selection
 - #2359 Improve sample create performance
 - #2361 Fix KeyError if registry key not found

--- a/src/senaite/core/browser/viewlets/sampleheader.py
+++ b/src/senaite/core/browser/viewlets/sampleheader.py
@@ -74,17 +74,20 @@ class SampleHeaderViewlet(ViewletBase):
         form = request.form
 
         for name, field in self.fields.items():
-            # get the raw value from the form. This shouldn't be necessary,
-            # but there are still some widgets out there with a name that
-            # follows the format <fieldname>_uid. Otherwise, we could simply
-            # pass the form object to the widget's process_form function.
+            # get the raw value from the form
             value = self.get_field_value(field, form)
             if value is _fieldname_not_in_form:
                 continue
 
+            # some legacy widgets need values with <fieldname>_ as prefix
+            prefix = "{}_".format(name)
+            extra = filter(lambda key: key.startswith(prefix), form.keys())
+            form_values = dict((key, form[key]) for key in extra)
+            form_values[name] = value
+
             # process the value as the widget would usually do
             process_value = field.widget.process_form
-            value, msgs = process_value(self.context, field, {name: value})
+            value, msgs = process_value(self.context, field, form_values)
 
             # Keep track of field-values
             field_values.update({name: value})


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Some widgets use more than one form value on submit, not only the one retrieved by the field name. For instance, the field `TemporaryIdentifierWidget` expects to recieve multiple values on it's `process_form` function (see https://github.com/senaite/senaite.patient/blob/master/src/senaite/patient/browser/widgets/temporaryidentifier.py#L30).

This Pull Request simply takes into account prefixed values from the form with same fieldname when calling the `processform` function from the widget.

## Current behavior before PR

The information for some fields is not saved properly in sample header form

## Desired behavior after PR is merged

The information for all fields is saved properly in sample header form

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
