### PR TITLE
Add fallback to sample client field value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
-- #2366 Avoid acquisition chain traversal when getting the sample client
+- #2366 Add fallback to sample client field value
 - #2365 New function for interim fields formatting
 - #2364 Support for fieldname-prefixed values on sample header submit
 - #2363 Auto-hide non-multivalued reference widget input on value selection

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2366 Avoid acquisition chain traversal when getting the sample client
 - #2365 New function for interim fields formatting
 - #2364 Support for fieldname-prefixed values on sample header submit
 - #2363 Auto-hide non-multivalued reference widget input on value selection

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -1441,11 +1441,18 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
         Sample Add form, but cannot be changed afterwards. The Sample is
         created directly inside the selected client folder on submit
         """
-        if IClient.providedBy(self.aq_parent):
-            return self.aq_parent
-        if IBatch.providedBy(self.aq_parent):
-            return self.aq_parent.getClient()
-        return None
+        # return the field value
+        field = self.getField("Client")
+        client = field.get(self)
+        # BBB: client field was not set properly in previous versions!
+        if not client:
+            logger.warning("Client not set for %s" % self.getId())
+            parent = api.get_parent(self)
+            if IClient.providedBy(parent):
+                client = parent
+            elif IBatch.providedBy(parent):
+                client = parent.getClient()
+        return client
 
     @deprecated("Will be removed in SENAITE 3.0")
     def getProfilesURL(self):

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -1441,7 +1441,7 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
         Sample Add form, but cannot be changed afterwards. The Sample is
         created directly inside the selected client folder on submit
         """
-        parent = api.get_parent(self)
+        parent = self.aq_parent
         if IClient.providedBy(parent):
             return parent
         elif IBatch.providedBy(parent):

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -1441,18 +1441,14 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
         Sample Add form, but cannot be changed afterwards. The Sample is
         created directly inside the selected client folder on submit
         """
-        # return the field value
+        parent = api.get_parent(self)
+        if IClient.providedBy(parent):
+            return parent
+        elif IBatch.providedBy(parent):
+            return parent.getClient()
+        # Fallback to UID reference field value
         field = self.getField("Client")
-        client = field.get(self)
-        # BBB: client field was not set properly in previous versions!
-        if not client:
-            logger.warning("Client not set for %s" % self.getId())
-            parent = api.get_parent(self)
-            if IClient.providedBy(parent):
-                client = parent
-            elif IBatch.providedBy(parent):
-                client = parent.getClient()
-        return client
+        return field.get(self)
 
     @deprecated("Will be removed in SENAITE 3.0")
     def getProfilesURL(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the `getClient` method of samples to lookup the field value first before traversing the acquisition chain.

## Current behavior before PR

The acquisition chain of the sample is used to retrieve the client contact

## Desired behavior after PR is merged

The field value of the sample is used first

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
