### PR TITLE
Contact catalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2367 Contact catalog
 - #2366 Add fallback to sample client field value
 - #2365 New function for interim fields formatting
 - #2364 Support for fieldname-prefixed values on sample header submit

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -63,7 +63,6 @@ from Products.CMFPlone.utils import base_hasattr
 from Products.CMFPlone.utils import safe_unicode
 from Products.PlonePAS.tools.memberdata import MemberData
 from Products.ZCatalog.interfaces import ICatalogBrain
-from senaite.core.catalog import CONTACT_CATALOG
 from senaite.core.interfaces import ITemporaryObject
 from zope import globalrequest
 from zope.annotation.interfaces import IAttributeAnnotatable
@@ -1328,7 +1327,8 @@ def get_user_contact(user, contact_types=['Contact', 'LabContact']):
     if not user:
         return None
 
-    query = {'portal_type': contact_types, 'getUsername': user.id}
+    from senaite.core.catalog import CONTACT_CATALOG
+    query = {"portal_type": contact_types, "getUsername": user.id}
     brains = search(query, catalog=CONTACT_CATALOG)
     if not brains:
         return None

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -63,6 +63,7 @@ from Products.CMFPlone.utils import base_hasattr
 from Products.CMFPlone.utils import safe_unicode
 from Products.PlonePAS.tools.memberdata import MemberData
 from Products.ZCatalog.interfaces import ICatalogBrain
+from senaite.core.catalog import CONTACT_CATALOG
 from senaite.core.interfaces import ITemporaryObject
 from zope import globalrequest
 from zope.annotation.interfaces import IAttributeAnnotatable
@@ -1328,7 +1329,7 @@ def get_user_contact(user, contact_types=['Contact', 'LabContact']):
         return None
 
     query = {'portal_type': contact_types, 'getUsername': user.id}
-    brains = search(query, catalog='portal_catalog')
+    brains = search(query, catalog=CONTACT_CATALOG)
     if not brains:
         return None
 

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -1327,7 +1327,7 @@ def get_user_contact(user, contact_types=['Contact', 'LabContact']):
     if not user:
         return None
 
-    from senaite.core.catalog import CONTACT_CATALOG
+    from senaite.core.catalog import CONTACT_CATALOG  # Avoid circular import
     query = {"portal_type": contact_types, "getUsername": user.id}
     brains = search(query, catalog=CONTACT_CATALOG)
     if not brains:

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -48,6 +48,7 @@ from Products.Archetypes.interfaces import IField
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from senaite.core.catalog import CONTACT_CATALOG
 from senaite.core.p3compat import cmp
 from senaite.core.permissions import TransitionMultiResults
 from zope.annotation.interfaces import IAnnotations
@@ -401,7 +402,7 @@ class AnalysisRequestAddView(BrowserView):
         :returns: The default contact for the AR
         :rtype: Client object or None
         """
-        catalog = api.get_tool("portal_catalog")
+        catalog = api.get_tool(CONTACT_CATALOG)
         client = client or self.get_client()
         path = api.get_path(self.context)
         if client:

--- a/src/bika/lims/browser/client/views/contacts.py
+++ b/src/bika/lims/browser/client/views/contacts.py
@@ -24,8 +24,10 @@ from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.interfaces import IContacts
-from bika.lims.utils import get_link, get_email_link
+from bika.lims.utils import get_email_link
+from bika.lims.utils import get_link
 from bika.lims.vocabularies import CatalogVocabulary
+from senaite.core.catalog import CONTACT_CATALOG
 from zope.interface import implements
 
 
@@ -34,7 +36,7 @@ class ClientContactsView(BikaListingView):
 
     def __init__(self, context, request):
         super(ClientContactsView, self).__init__(context, request)
-        self.catalog = "portal_catalog"
+        self.catalog = CONTACT_CATALOG
         self.contentFilter = {
             'portal_type': 'Contact',
             'sort_on': 'sortable_title',

--- a/src/bika/lims/browser/supplier.py
+++ b/src/bika/lims/browser/supplier.py
@@ -26,6 +26,7 @@ from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.browser.referencesample import ReferenceSamplesView
 from bika.lims.controlpanel.bika_instruments import InstrumentsView
 from bika.lims.utils import get_link
+from senaite.core.catalog import CONTACT_CATALOG
 
 
 class SupplierInstrumentsView(InstrumentsView):
@@ -80,7 +81,7 @@ class ContactsView(BikaListingView):
     def __init__(self, context, request):
         super(ContactsView, self).__init__(context, request)
 
-        self.catalog = "portal_catalog"
+        self.catalog = CONTACT_CATALOG
 
         self.contentFilter = {
             "portal_type": "SupplierContact",

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -124,6 +124,7 @@ from senaite.core.browser.fields.datetime import DateTimeField
 from senaite.core.browser.fields.records import RecordsField
 from senaite.core.catalog import ANALYSIS_CATALOG
 from senaite.core.catalog import CLIENT_CATALOG
+from senaite.core.catalog import CONTACT_CATALOG
 from senaite.core.catalog import SAMPLE_CATALOG
 from senaite.core.catalog import SENAITE_CATALOG
 from senaite.core.catalog import WORKSHEET_CATALOG
@@ -157,7 +158,7 @@ schema = BikaSchema.copy() + Schema((
                 'add': 'edit',
                 'header_table': 'prominent',
             },
-            catalog_name="portal_catalog",
+            catalog_name=CONTACT_CATALOG,
             base_query={"is_active": True,
                         "sort_limit": 50,
                         "sort_on": "sortable_title",
@@ -191,7 +192,7 @@ schema = BikaSchema.copy() + Schema((
                 'add': 'edit',
                 'header_table': 'prominent',
             },
-            catalog_name="portal_catalog",
+            catalog_name=CONTACT_CATALOG,
             base_query={"is_active": True,
                         "sort_on": "sortable_title",
                         "getParentUID": "",

--- a/src/bika/lims/content/contact.py
+++ b/src/bika/lims/content/contact.py
@@ -27,7 +27,6 @@ from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
 from bika.lims.api import is_active
 from bika.lims.browser.fields import UIDReferenceField
-from senaite.core.browser.widgets.referencewidget import ReferenceWidget
 from bika.lims.config import PROJECTNAME
 from bika.lims.content.person import Person
 from bika.lims.interfaces import IClient
@@ -38,9 +37,10 @@ from Products.Archetypes import atapi
 from Products.Archetypes.utils import DisplayList
 from Products.CMFCore.permissions import ModifyPortalContent
 from Products.CMFPlone.utils import safe_unicode
+from senaite.core.browser.widgets.referencewidget import ReferenceWidget
+from senaite.core.catalog import CONTACT_CATALOG
 from senaite.core.p3compat import cmp
 from zope.interface import implements
-
 
 schema = Person.schema.copy() + atapi.Schema((
     UIDReferenceField(
@@ -80,9 +80,9 @@ class Contact(Person):
         """
 
         # Check if the User is linked already
-        pc = api.portal.get_tool("portal_catalog")
-        contacts = pc(portal_type=cls.portal_type,
-                      getUsername=username)
+        cat = api.portal.get_tool(CONTACT_CATALOG)
+        contacts = cat(portal_type=cls.portal_type,
+                       getUsername=username)
 
         # No Contact assigned to this username
         if len(contacts) == 0:

--- a/src/bika/lims/content/suppliercontact.py
+++ b/src/bika/lims/content/suppliercontact.py
@@ -22,8 +22,9 @@ from AccessControl import ClassSecurityInfo
 from bika.lims.config import PROJECTNAME
 from bika.lims.content.person import Person
 from bika.lims.interfaces import IDeactivable
-from zope.interface import implements
+from bika.lims.interfaces import ISupplierContact
 from Products.Archetypes.public import registerType
+from zope.interface import implements
 
 schema = Person.schema.copy()
 
@@ -42,11 +43,9 @@ schema["title"].widget.visible = False
 class SupplierContact(Person):
     """Supplier Contact content
     """
-    implements(IDeactivable)
+    implements(ISupplierContact, IDeactivable)
 
     _at_rename_after_creation = True
-    displayContentsTab = False
-    isPrincipiaFolderish = 0
     schema = schema
     security = ClassSecurityInfo()
 

--- a/src/bika/lims/controlpanel/bika_labcontacts.py
+++ b/src/bika/lims/controlpanel/bika_labcontacts.py
@@ -35,6 +35,7 @@ from plone.app.folder.folder import ATFolder
 from plone.app.folder.folder import ATFolderSchema
 from senaite.core.interfaces import IHideActionsMenu
 from zope.interface.declarations import implements
+from senaite.core.catalog import CONTACT_CATALOG
 
 
 # TODO: Separate content and view into own modules!
@@ -45,7 +46,7 @@ class LabContactsView(BikaListingView):
     def __init__(self, context, request):
         super(LabContactsView, self).__init__(context, request)
 
-        self.catalog = "senaite_catalog_setup"
+        self.catalog = CONTACT_CATALOG
         self.contentFilter = {
             "portal_type": "LabContact",
             "sort_on": "sortable_title",

--- a/src/bika/lims/interfaces/__init__.py
+++ b/src/bika/lims/interfaces/__init__.py
@@ -429,6 +429,11 @@ class ILabContact(Interface):
     """
 
 
+class ISupplierContact(Interface):
+    """Marker interface for a supplier contact
+    """
+
+
 class IManufacturer(Interface):
     """Marker interface for Manufacturer
     """

--- a/src/bika/lims/utils/__init__.py
+++ b/src/bika/lims/utils/__init__.py
@@ -21,13 +21,12 @@
 import mimetypes
 import os
 import re
-import six
 import tempfile
 from email import Encoders
 from email.MIMEBase import MIMEBase
-from six.moves.urllib.request import urlopen
 from time import time
 
+import six
 from AccessControl import ModuleSecurityInfo
 from AccessControl import allow_module
 from AccessControl import getSecurityManager
@@ -48,7 +47,9 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFCore.WorkflowCore import WorkflowException
 from Products.CMFPlone.utils import safe_unicode
 from Products.DCWorkflow.events import AfterTransitionEvent
+from senaite.core.catalog import CONTACT_CATALOG
 from senaite.core.p3compat import cmp
+from six.moves.urllib.request import urlopen
 from weasyprint import CSS
 from weasyprint import HTML
 from weasyprint import default_url_fetcher
@@ -595,31 +596,29 @@ def getFromString(obj, string, default=None):
 
 
 def user_fullname(obj, userid):
-    """
-    Returns the user full name as string.
+    """Returns the user full name as string.
     """
     member = obj.portal_membership.getMemberById(userid)
     if member is None:
         return userid
-    member_fullname = member.getProperty('fullname')
-    portal_catalog = getToolByName(obj, 'portal_catalog')
-    c = portal_catalog(portal_type='Contact', getUsername=userid)
-    contact_fullname = c[0].getObject().getFullname() if c else None
+    member_fullname = member.getProperty("fullname")
+    catalog = api.get_tool(CONTACT_CATALOG)
+    res = catalog(portal_type="Contact", getUsername=userid)
+    contact_fullname = res[0].getObject().getFullname() if res else None
     return contact_fullname or member_fullname or userid
 
 
 def user_email(obj, userid):
-    """
-    This function returns the user email as string.
+    """This function returns the user email as string.
     """
     member = obj.portal_membership.getMemberById(userid)
     if member is None:
         return userid
-    member_email = member.getProperty('email')
-    portal_catalog = getToolByName(obj, 'portal_catalog')
-    c = portal_catalog(portal_type='Contact', getUsername=userid)
-    contact_email = c[0].getObject().getEmailAddress() if c else None
-    return contact_email or member_email or ''
+    member_email = member.getProperty("email")
+    catalog = api.get_tool(CONTACT_CATALOG)
+    res = catalog(portal_type="Contact", getUsername=userid)
+    contact_email = res[0].getObject().getEmailAddress() if res else None
+    return contact_email or member_email or ""
 
 
 def measure_time(func_to_measure):

--- a/src/senaite/core/adapters/localroles.py
+++ b/src/senaite/core/adapters/localroles.py
@@ -19,12 +19,13 @@
 # Some rights reserved, see README and LICENSE.
 
 import six
-from bika.lims import api
 from bika.lims import APIError
+from bika.lims import api
 from bika.lims import logger
 from borg.localrole.default_adapter import DefaultLocalRoleAdapter
 from plone.memoize.request import cache
 from senaite.core.behaviors import IClientShareableBehavior
+from senaite.core.catalog import CONTACT_CATALOG
 from senaite.core.interfaces import IDynamicLocalRoles
 from zope.component import getAdapters
 from zope.interface import implementer
@@ -140,7 +141,7 @@ class ClientShareableLocalRoles(object):
             "getUsername": principal_id,
             "getParentUID": clients,
         }
-        brains = api.search(query, catalog="portal_catalog")
+        brains = api.search(query, catalog=CONTACT_CATALOG)
         if len(brains) == 0:
             return []
 

--- a/src/senaite/core/catalog/__init__.py
+++ b/src/senaite/core/catalog/__init__.py
@@ -30,6 +30,8 @@ from senaite.core.catalog.autoimportlog_catalog import \
 from senaite.core.catalog.autoimportlog_catalog import AutoImportLogCatalog
 from senaite.core.catalog.client_catalog import CATALOG_ID as CLIENT_CATALOG
 from senaite.core.catalog.client_catalog import ClientCatalog
+from senaite.core.catalog.contact_catalog import CATALOG_ID as CONTACT_CATALOG
+from senaite.core.catalog.contact_catalog import ContactCatalog
 from senaite.core.catalog.label_catalog import CATALOG_ID as LABEL_CATALOG
 from senaite.core.catalog.label_catalog import LabelCatalog
 from senaite.core.catalog.report_catalog import CATALOG_ID as REPORT_CATALOG

--- a/src/senaite/core/catalog/base_catalog.py
+++ b/src/senaite/core/catalog/base_catalog.py
@@ -135,7 +135,8 @@ class BaseCatalog(CatalogTool):
         """
         mapped_catalog_types = self.mapped_catalog_types
         mapped_at_types = self.get_mapped_at_types()
-        return mapped_catalog_types + mapped_at_types
+        all_types = set(mapped_catalog_types + mapped_at_types)
+        return list(all_types)
 
     def log_progress(self):
         """Log reindex progress

--- a/src/senaite/core/catalog/contact_catalog.py
+++ b/src/senaite/core/catalog/contact_catalog.py
@@ -13,7 +13,7 @@ CATALOG_TITLE = "Senaite Contact Catalog"
 INDEXES = BASE_INDEXES + [
     # id, indexed attribute, type
     ("Title", "", "ZCTextIndex"),  # needed for reference fields
-    ("contact_searchable_text", "", "ZCTextIndex"),
+    ("listing_searchable_text", "", "ZCTextIndex"),
     ("getFullname", "", "FieldIndex"),
     ("getParentUID", "", "FieldIndex"),
     ("getUsername", "", "FieldIndex"),

--- a/src/senaite/core/catalog/contact_catalog.py
+++ b/src/senaite/core/catalog/contact_catalog.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+from App.class_init import InitializeClass
+from senaite.core.catalog.base_catalog import COLUMNS as BASE_COLUMNS
+from senaite.core.catalog.base_catalog import INDEXES as BASE_INDEXES
+from senaite.core.catalog.base_catalog import BaseCatalog
+from senaite.core.interfaces import IContactCatalog
+from zope.interface import implementer
+
+CATALOG_ID = "senaite_catalog_contact"
+CATALOG_TITLE = "Senaite Contact Catalog"
+
+INDEXES = BASE_INDEXES + [
+    # id, indexed attribute, type
+    ("Title", "", "ZCTextIndex"),  # needed for reference fields
+    ("contact_searchable_text", "", "ZCTextIndex"),
+    ("sortable_title", "", "FieldIndex"),
+    ("getFullname", "", "FieldIndex"),
+    ("getUsername", "", "FieldIndex"),
+]
+
+COLUMNS = BASE_COLUMNS + [
+    # attribute name
+]
+
+TYPES = [
+    # portal_type name
+    "Contact",
+    "LabContact",
+    "SupplierContact",
+]
+
+
+@implementer(IContactCatalog)
+class ContactCatalog(BaseCatalog):
+    """Catalog for contact objects
+    """
+    def __init__(self):
+        BaseCatalog.__init__(self, CATALOG_ID, title=CATALOG_TITLE)
+
+    @property
+    def mapped_catalog_types(self):
+        return TYPES
+
+
+InitializeClass(ContactCatalog)

--- a/src/senaite/core/catalog/contact_catalog.py
+++ b/src/senaite/core/catalog/contact_catalog.py
@@ -14,9 +14,10 @@ INDEXES = BASE_INDEXES + [
     # id, indexed attribute, type
     ("Title", "", "ZCTextIndex"),  # needed for reference fields
     ("contact_searchable_text", "", "ZCTextIndex"),
-    ("sortable_title", "", "FieldIndex"),
     ("getFullname", "", "FieldIndex"),
+    ("getParentUID", "", "FieldIndex"),
     ("getUsername", "", "FieldIndex"),
+    ("sortable_title", "", "FieldIndex"),
 ]
 
 COLUMNS = BASE_COLUMNS + [

--- a/src/senaite/core/catalog/indexer/configure.zcml
+++ b/src/senaite/core/catalog/indexer/configure.zcml
@@ -10,6 +10,11 @@
   <!-- Client Indexer -->
   <adapter name="client_searchable_text" factory=".client.client_searchable_text"/>
 
+  <!-- Contact Indexer -->
+  <adapter name="contact_searchable_text" factory=".contact.contact_searchable_text"/>
+  <adapter name="getParentUID" factory=".contact.getParentUID"/>
+  <adapter name="sortable_title" factory=".contact.sortable_title"/>
+
   <!-- Label Indexer -->
   <adapter name="labels" factory=".label.labels"/>
   <adapter name="listing_searchable_text" factory=".label.listing_searchable_text"/>
@@ -55,9 +60,6 @@
   <adapter name="price_total" factory=".senaitesetup.price_total"/>
   <adapter name="sampletype_title" factory=".senaitesetup.sampletype_title"/>
   <adapter name="sampletype_uid" factory=".senaitesetup.sampletype_uid"/>
-
-  <!-- Contact Indexer -->
-  <adapter name="sortable_title" factory=".contact.sortable_title"/>
 
   <!-- Organization Indexer -->
   <adapter name="title" factory=".organisation.title"/>

--- a/src/senaite/core/catalog/indexer/configure.zcml
+++ b/src/senaite/core/catalog/indexer/configure.zcml
@@ -11,7 +11,7 @@
   <adapter name="client_searchable_text" factory=".client.client_searchable_text"/>
 
   <!-- Contact Indexer -->
-  <adapter name="contact_searchable_text" factory=".contact.contact_searchable_text"/>
+  <adapter name="listing_searchable_text" factory=".contact.listing_searchable_text"/>
   <adapter name="getParentUID" factory=".contact.getParentUID"/>
   <adapter name="sortable_title" factory=".contact.sortable_title"/>
 

--- a/src/senaite/core/catalog/indexer/contact.py
+++ b/src/senaite/core/catalog/indexer/contact.py
@@ -63,6 +63,13 @@ def listing_searchable_text(instance):
         instance.getUsername(),
     ]
 
+    department = instance.getDepartment()  # part of person base class
+    if isinstance(department, list):  # override in labcontact
+        department_titles = map(api.get_title, department)
+        tokens.extend(department_titles)
+    elif api.is_string(department):
+        tokens.append(department)
+
     # remove duplicates and filter out emtpies
     tokens = filter(None, set(tokens))
 

--- a/src/senaite/core/catalog/indexer/contact.py
+++ b/src/senaite/core/catalog/indexer/contact.py
@@ -55,7 +55,6 @@ def contact_searchable_text(instance):
         instance.getBusinessPhone(),
         instance.getCity(),
         instance.getCountry(),
-        instance.getDepartment(),
         instance.getEmailAddress(),
         instance.getFullname(),
         instance.getHomePhone(),

--- a/src/senaite/core/catalog/indexer/contact.py
+++ b/src/senaite/core/catalog/indexer/contact.py
@@ -47,7 +47,7 @@ def getParentUID(instance):
 @indexer(IContact, IContactCatalog)
 @indexer(ILabContact, IContactCatalog)
 @indexer(ISupplierContact, IContactCatalog)
-def contact_searchable_text(instance):
+def listing_searchable_text(instance):
     """Extract search tokens for ZC text index
     """
 

--- a/src/senaite/core/catalog/indexer/contact.py
+++ b/src/senaite/core/catalog/indexer/contact.py
@@ -18,10 +18,54 @@
 # Copyright 2018-2023 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from bika.lims import api
+from bika.lims.interfaces import IClient
 from bika.lims.interfaces import IContact
+from bika.lims.interfaces import ILabContact
+from bika.lims.interfaces import ISupplierContact
 from plone.indexer import indexer
+from senaite.core.interfaces.catalog import IContactCatalog
 
 
-@indexer(IContact)
+@indexer(IContact, IContactCatalog)
+@indexer(ILabContact, IContactCatalog)
+@indexer(ISupplierContact, IContactCatalog)
 def sortable_title(instance):
     return instance.getFullname().lower()
+
+
+@indexer(IContact, IContactCatalog)
+@indexer(ILabContact, IContactCatalog)
+@indexer(ISupplierContact, IContactCatalog)
+def getParentUID(instance):
+    parent = instance.aq_parent
+    if not IClient.providedBy(parent):
+        return None
+    return parent.UID()
+
+
+@indexer(IContact, IContactCatalog)
+@indexer(ILabContact, IContactCatalog)
+@indexer(ISupplierContact, IContactCatalog)
+def contact_searchable_text(instance):
+    """Extract search tokens for ZC text index
+    """
+
+    tokens = [
+        instance.getBusinessPhone(),
+        instance.getCity(),
+        instance.getCountry(),
+        instance.getDepartment(),
+        instance.getEmailAddress(),
+        instance.getFullname(),
+        instance.getHomePhone(),
+        instance.getJobTitle(),
+        instance.getMobilePhone(),
+        instance.getUsername(),
+    ]
+
+    # remove duplicates and filter out emtpies
+    tokens = filter(None, set(tokens))
+
+    # return a single unicode string with all the concatenated tokens
+    return u" ".join(map(api.safe_unicode, tokens))

--- a/src/senaite/core/interfaces/catalog.py
+++ b/src/senaite/core/interfaces/catalog.py
@@ -74,3 +74,8 @@ class ILabelCatalog(ISenaiteCatalogObject):
 class IClientCatalog(ISenaiteCatalogObject):
     """Marker interface for Senaite client catalog
     """
+
+
+class IContactCatalog(ISenaiteCatalogObject):
+    """Marker interface for Senaite contact catalog
+    """

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2513</version>
+  <version>2514</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/setuphandlers.py
+++ b/src/senaite/core/setuphandlers.py
@@ -37,6 +37,7 @@ from senaite.core.catalog import ANALYSIS_CATALOG
 from senaite.core.catalog import AUDITLOG_CATALOG
 from senaite.core.catalog import AUTOIMPORTLOG_CATALOG
 from senaite.core.catalog import CLIENT_CATALOG
+from senaite.core.catalog import CONTACT_CATALOG
 from senaite.core.catalog import REPORT_CATALOG
 from senaite.core.catalog import SAMPLE_CATALOG
 from senaite.core.catalog import SENAITE_CATALOG
@@ -45,8 +46,9 @@ from senaite.core.catalog import WORKSHEET_CATALOG
 from senaite.core.catalog import AnalysisCatalog
 from senaite.core.catalog import AuditlogCatalog
 from senaite.core.catalog import AutoImportLogCatalog
-from senaite.core.catalog import LabelCatalog
 from senaite.core.catalog import ClientCatalog
+from senaite.core.catalog import ContactCatalog
+from senaite.core.catalog import LabelCatalog
 from senaite.core.catalog import ReportCatalog
 from senaite.core.catalog import SampleCatalog
 from senaite.core.catalog import SenaiteCatalog
@@ -109,6 +111,7 @@ CATALOGS = (
     AuditlogCatalog,
     AutoImportLogCatalog,
     ClientCatalog,
+    ContactCatalog,
     LabelCatalog,
     ReportCatalog,
     SampleCatalog,
@@ -157,7 +160,7 @@ CATALOG_MAPPINGS = (
     ("BatchLabel", [SETUP_CATALOG, PORTAL_CATALOG]),
     ("Calculation", [SETUP_CATALOG, PORTAL_CATALOG]),
     ("Client", [CLIENT_CATALOG]),
-    ("Contact", [PORTAL_CATALOG]),
+    ("Contact", [CONTACT_CATALOG]),
     ("Container", [SETUP_CATALOG, PORTAL_CATALOG]),
     ("ContainerType", [SETUP_CATALOG, PORTAL_CATALOG]),
     ("Department", [SETUP_CATALOG, PORTAL_CATALOG]),
@@ -171,7 +174,7 @@ CATALOG_MAPPINGS = (
     ("InstrumentType", [SETUP_CATALOG, PORTAL_CATALOG]),
     ("InstrumentValidation", [SETUP_CATALOG, PORTAL_CATALOG]),
     ("Invoice", [SENAITE_CATALOG, PORTAL_CATALOG]),
-    ("LabContact", [SETUP_CATALOG, PORTAL_CATALOG]),
+    ("LabContact", [CONTACT_CATALOG]),
     ("LabProduct", [SETUP_CATALOG, PORTAL_CATALOG]),
     ("Label", [SETUP_CATALOG]),
     ("Laboratory", [SETUP_CATALOG, PORTAL_CATALOG]),
@@ -192,7 +195,7 @@ CATALOG_MAPPINGS = (
     ("StorageLocation", [SETUP_CATALOG, PORTAL_CATALOG]),
     ("SubGroup", [SETUP_CATALOG, PORTAL_CATALOG]),
     ("Supplier", [SETUP_CATALOG, PORTAL_CATALOG]),
-    ("SupplierContact", [SETUP_CATALOG, PORTAL_CATALOG]),
+    ("SupplierContact", [CONTACT_CATALOG]),
     ("Worksheet", [WORKSHEET_CATALOG, PORTAL_CATALOG]),
     ("WorksheetTemplate", [SETUP_CATALOG, PORTAL_CATALOG]),
 )

--- a/src/senaite/core/tests/test_duplicate-analysis.py
+++ b/src/senaite/core/tests/test_duplicate-analysis.py
@@ -28,6 +28,7 @@ from plone.app.testing import setRoles
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import _createObjectByType
 from senaite.core.tests.base import DataTestCase
+from senaite.core.catalog import CONTACT_CATALOG
 
 
 class TestAddDuplicateAnalysis(DataTestCase):
@@ -72,8 +73,8 @@ class TestAddDuplicateAnalysis(DataTestCase):
         wsfolder = self.portal.worksheets
         ws = _createObjectByType("Worksheet", wsfolder, tmpID())
         ws.processForm()
-        bsc = getToolByName(self.portal, 'senaite_catalog_setup')
-        lab_contacts = [o.getObject() for o in bsc(portal_type="LabContact")]
+        cat = getToolByName(self.portal, CONTACT_CATALOG)
+        lab_contacts = [o.getObject() for o in cat(portal_type="LabContact")]
         lab_contact = [o for o in lab_contacts if o.getUsername() == 'analyst1']
         self.assertEquals(len(lab_contact), 1)
         lab_contact = lab_contact[0]

--- a/src/senaite/core/upgrade/v02_05_000.py
+++ b/src/senaite/core/upgrade/v02_05_000.py
@@ -28,8 +28,10 @@ from senaite.core.api.catalog import del_index
 from senaite.core.api.catalog import reindex_index
 from senaite.core.catalog import ANALYSIS_CATALOG
 from senaite.core.catalog import CLIENT_CATALOG
+from senaite.core.catalog import CONTACT_CATALOG
 from senaite.core.catalog import REPORT_CATALOG
 from senaite.core.catalog import SAMPLE_CATALOG
+from senaite.core.catalog import SETUP_CATALOG
 from senaite.core.config import PROJECTNAME as product
 from senaite.core.permissions import ManageBika
 from senaite.core.registry import get_registry_record
@@ -40,6 +42,8 @@ from senaite.core.setuphandlers import setup_core_catalogs
 from senaite.core.upgrade import upgradestep
 from senaite.core.upgrade.utils import UpgradeUtils
 from senaite.core.upgrade.utils import uncatalog_brain
+
+PORTAL_CATALOG = "portal_catalog"
 
 version = "2.5.0"  # Remember version number in metadata.xml and setup.py
 profile = "profile-{0}:default".format(product)
@@ -136,6 +140,31 @@ def setup_client_catalog(tool):
     uncatalog_type("Client", catalog="portal_catalog")
 
     logger.info("Setup Client Catalog [DONE]")
+
+
+def setup_contact_catalog(tool):
+    """Setup contact catalog
+    """
+    logger.info("Setup Contact Catalog ...")
+    portal = api.get_portal()
+
+    # setup and rebuild client_catalog
+    setup_catalog_mappings(portal)
+    setup_core_catalogs(portal)
+    contact_catalog = api.get_tool(CONTACT_CATALOG)
+    contact_catalog.clearFindAndRebuild()
+
+    # portal_catalog cleanup
+    uncatalog_type("Contact", catalog=PORTAL_CATALOG)
+    uncatalog_type("LabContact", catalog=PORTAL_CATALOG)
+    uncatalog_type("SupplierContact", catalog=PORTAL_CATALOG)
+
+    # senaite_catalog_setup cleaup
+    uncatalog_type("Contact", catalog=SETUP_CATALOG)
+    uncatalog_type("LabContact", catalog=SETUP_CATALOG)
+    uncatalog_type("SupplierContact", catalog=SETUP_CATALOG)
+
+    logger.info("Setup Contact Catalog [DONE]")
 
 
 def uncatalog_type(portal_type, catalog="portal_catalog", **kw):

--- a/src/senaite/core/upgrade/v02_05_000.zcml
+++ b/src/senaite/core/upgrade/v02_05_000.zcml
@@ -4,6 +4,14 @@
     i18n_domain="senaite.core">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.5.0: Setup Contact Catalog"
+      description="Create contact catalog and clean up contact related indexes and metadata from portal catalog"
+      source="2513"
+      destination="2514"
+      handler=".v02_05_000.setup_contact_catalog"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.5.0: Remove legacy reports"
       description="Remove legacy reports"
       source="2512"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR introduces a new catalog for `Contact`, `LabContact` and `SupplierContact`.

## Current behavior before PR

`Contact` is still indexed in `portal_catalog` and `LabContact` and `SupplierContact` are in `senaite_catalog_setup`.

## Desired behavior after PR is merged

All contact types are indexed in the `ContactCatalog`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
