### PR TITLE
Override default DX add form to obtain renamed IDs correctly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2370 Override default DX add form to obtain renamed IDs correctly
 - #2368 Drop usage of portal_catalog tool
 - #2369 Allow to set a custom comment for when a result is out of range
 - #2367 Contact catalog

--- a/src/senaite/core/browser/controlpanel/samplecontainers.py
+++ b/src/senaite/core/browser/controlpanel/samplecontainers.py
@@ -24,6 +24,7 @@ from bika.lims import api
 from bika.lims import senaiteMessageFactory as _
 from bika.lims.utils import get_link_for
 from senaite.app.listing import ListingView
+from senaite.core.catalog import SETUP_CATALOG
 
 
 class SampleContainersView(ListingView):
@@ -32,6 +33,8 @@ class SampleContainersView(ListingView):
 
     def __init__(self, context, request):
         super(SampleContainersView, self).__init__(context, request)
+
+        self.catalog = SETUP_CATALOG
 
         self.contentFilter = {
             "portal_type": "SampleContainer",

--- a/src/senaite/core/browser/dexterity/add.py
+++ b/src/senaite/core/browser/dexterity/add.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+
+from AccessControl import Unauthorized
+from Acquisition import aq_base
+from Acquisition import aq_inner
+from plone.app.uuid.utils import uuidToObject
+from plone.dexterity.browser.add import DefaultAddForm as BaseAddForm
+from plone.dexterity.browser.add import DefaultAddView as BaseAddView
+from plone.dexterity.interfaces import IDexterityFTI
+from plone.uuid.interfaces import IUUID
+from zope.component import getUtility
+from zope.container.interfaces import INameChooser
+
+
+class DefaultAddForm(BaseAddForm):
+    """Patched Add Form to handle renameAfterCreation of DX objects
+    """
+
+    def add(self, object):
+        """Patched add method to use our own addContentToContainer
+        """
+        fti = getUtility(IDexterityFTI, name=self.portal_type)
+        new_object = addContentToContainer(self.container, object)
+
+        if fti.immediate_view:
+            self.immediate_view = "/".join(
+                [self.container.absolute_url(), new_object.id, fti.immediate_view]
+            )
+        else:
+            self.immediate_view = "/".join(
+                [self.container.absolute_url(), new_object.id]
+            )
+
+
+class DefaultAddView(BaseAddView):
+    form = DefaultAddForm
+
+
+def addContentToContainer(container, object, checkConstraints=True):
+    """Add an object to a container (patched)
+
+    original code located in `plone.dexterity.utils module`
+
+    The patched version of this function uses the object ID to get the object
+    from the container instead of the return value of
+
+    `container._setObject(name, object)`
+
+    This ensures we have the generated ID the object was renamed to *after* the
+    object was added to the container!
+    """
+    if not hasattr(aq_base(object), "portal_type"):
+        raise ValueError("object must have its portal_type set")
+
+    container = aq_inner(container)
+    if checkConstraints:
+        container_fti = container.getTypeInfo()
+
+        fti = getUtility(IDexterityFTI, name=object.portal_type)
+        if not fti.isConstructionAllowed(container):
+            raise Unauthorized("Cannot create %s" % object.portal_type)
+
+        if container_fti is not None and not container_fti.allowType(
+            object.portal_type
+        ):
+            raise ValueError("Disallowed subobject type: %s" % object.portal_type)
+
+    name = getattr(aq_base(object), "id", None)
+    name = INameChooser(container).chooseName(name, object)
+    object.id = name
+
+    container._setObject(name, object)
+    try:
+        # PATCH HERE: Use object.id to ensure we have the renamed object ID
+        return container._getOb(object.id)
+    except AttributeError:
+        uuid = IUUID(object)
+        return uuidToObject(uuid)

--- a/src/senaite/core/browser/dexterity/configure.zcml
+++ b/src/senaite/core/browser/dexterity/configure.zcml
@@ -4,6 +4,21 @@
     xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="plone">
 
+  <!-- Standard add view and form - invoked from ++add++ traverser -->
+  <adapter
+      for="Products.CMFCore.interfaces.IFolderish
+           senaite.core.interfaces.ISenaiteFormLayer
+           plone.dexterity.interfaces.IDexterityFTI"
+      provides="zope.publisher.interfaces.browser.IBrowserPage"
+      factory=".add.DefaultAddView"
+      />
+  <class class=".add.DefaultAddView">
+    <require
+        permission="cmf.AddPortalContent"
+        interface="zope.publisher.interfaces.browser.IBrowserPage"
+        />
+  </class>
+
   <!-- Override form/field/widget macros for edit mode -->
   <browser:page
       name="ploneform-macros"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a side-effect of the `portal-catalog` patch introduced in https://github.com/senaite/senaite.core/pull/2368

## Current behavior before PR

DX contents could not be created and failed with the traceback:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module plone.z3cform.layout, line 63, in __call__
  Module plone.z3cform.layout, line 47, in update
  Module plone.dexterity.browser.add, line 138, in update
  Module plone.z3cform.fieldsets.extensible, line 65, in update
  Module plone.z3cform.patch, line 30, in GroupForm_update
  Module z3c.form.group, line 145, in update
  Module plone.app.z3cform.csrf, line 22, in execute
  Module z3c.form.action, line 98, in execute
  Module z3c.form.button, line 315, in __call__
  Module z3c.form.button, line 170, in __call__
  Module plone.dexterity.browser.add, line 116, in handleAdd
  Module z3c.form.form, line 265, in createAndAdd
  Module plone.dexterity.browser.add, line 95, in add
AttributeError: 'NoneType' object has no attribute 'id'
```

## Desired behavior after PR is merged

DX contents can be created

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
