### PR TITLE
Catalog multiplex processor compatibility

### DIFF
--- a/src/senaite/core/patches/catalog.py
+++ b/src/senaite/core/patches/catalog.py
@@ -75,6 +75,10 @@ def in_portal_catalog(obj):
 
     # already handled in our catalog multiplex processor
     if IMultiCatalogBehavior.providedBy(obj):
+        # BBB: Fallback for unset catalogs mapping, e.g. for DataBoxes
+        catalogs = getattr(obj, "_catalogs", [])
+        if len(catalogs) == 0:
+            return True
         return False
 
     # check our static mapping from setuphandlers


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is related to https://github.com/senaite/senaite.core/pull/2368 and adds backwards compatibility for DX contents that have the `IMultiCatalogBehavior` behavior set, but do not have any catalogs set in `_catalogs`.

## Current behavior before PR

Objects are not indexed

## Desired behavior after PR is merged

Objects are indexed in `portal_catalog`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
