### PR TITLE
Keep Subject index in portal_catalog

### DIFF
--- a/src/senaite/core/setuphandlers.py
+++ b/src/senaite/core/setuphandlers.py
@@ -188,7 +188,6 @@ CATALOG_MAPPINGS = (
 REMOVE_PORTAL_CATALOG_INDEXES = (
     "Analyst",
     "SearchableText",
-    "Subject",
     "commentators",
     "getName",
     "getParentUID",


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an error that was introduced in https://github.com/senaite/senaite.core/pull/2368 when viewing/editing a default Plone page, e.g. the `front-page`.

## Current behavior before PR

Traceback occurs:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module plone.z3cform.layout, line 63, in __call__
  Module plone.z3cform.layout, line 57, in update
  Module z3c.form.form, line 162, in render
  Module zope.browserpage.viewpagetemplatefile, line 49, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module 34a5b2b8d42c68a8056d2ea828a6067e, line 115, in render
  Module 3d5ed0889b1288aace92e3a0fe95a877, line 2202, in render_titlelessform
  Module 3d5ed0889b1288aace92e3a0fe95a877, line 728, in render_fields
  Module 3d5ed0889b1288aace92e3a0fe95a877, line 150, in render_widget_rendering
  Module 3d5ed0889b1288aace92e3a0fe95a877, line 1022, in render_field
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module zope.browserpage.simpleviewclass, line 41, in __call__
  Module zope.browserpage.viewpagetemplatefile, line 81, in __call__
  Module zope.browserpage.viewpagetemplatefile, line 49, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 215, in render
  Module chameleon.template, line 192, in render
  Module 3f1ccbbd8420455fc3ff533384bb2453, line 586, in render
  Module 3f1ccbbd8420455fc3ff533384bb2453, line 456, in render_widget_wrapper
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module plone.app.z3cform.widget, line 117, in render
  Module plone.app.z3cform.widget, line 479, in _base_args
  Module plone.app.z3cform.widget, line 431, in _ajaxselect_options
  Module plone.app.z3cform.widget, line 400, in get_vocabulary
  Module plone.app.vocabularies.catalog, line 532, in __call__
  Module plone.app.vocabularies.catalog, line 498, in all_keywords
  Module Products.ZCatalog.Catalog, line 286, in getIndex
KeyError: 'Subject'
```

## Desired behavior after PR is merged

Default page is viewable/editable

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
