### PR TITLE
Fix imports for moved idserver module

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2377 Fix imports for moved idserver module
 - #2372 Generate unique ID for DX types on object creation
 - #2370 Override default DX add form to obtain renamed IDs correctly
 - #2368 Drop usage of portal_catalog tool

--- a/src/bika/lims/content/analysiscategory.py
+++ b/src/bika/lims/content/analysiscategory.py
@@ -99,7 +99,7 @@ class AnalysisCategory(BaseContent):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def workflow_script_deactivate(self):

--- a/src/bika/lims/content/analysisprofile.py
+++ b/src/bika/lims/content/analysisprofile.py
@@ -158,7 +158,7 @@ class AnalysisProfile(BaseContent, ClientAwareMixin):
 
     _at_rename_after_creation = True
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def getAnalysisServiceSettings(self, uid):

--- a/src/bika/lims/content/analysisservice.py
+++ b/src/bika/lims/content/analysisservice.py
@@ -307,7 +307,7 @@ class AnalysisService(AbstractBaseAnalysis):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
 
         return renameAfterCreation(self)
 

--- a/src/bika/lims/content/analysisspec.py
+++ b/src/bika/lims/content/analysisspec.py
@@ -115,7 +115,7 @@ class AnalysisSpec(BaseFolder, HistoryAwareMixin, ClientAwareMixin,
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def Title(self):

--- a/src/bika/lims/content/arreport.py
+++ b/src/bika/lims/content/arreport.py
@@ -149,7 +149,7 @@ class ARReport(BaseFolder, ClientAwareMixin):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
 

--- a/src/bika/lims/content/artemplate.py
+++ b/src/bika/lims/content/artemplate.py
@@ -293,7 +293,7 @@ class ARTemplate(BaseContent, ClientAwareMixin, SampleTypeAwareMixin):
     implements(IARTemplate, IDeactivable)
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     security.declarePublic("AnalysisProfiles")

--- a/src/bika/lims/content/attachment.py
+++ b/src/bika/lims/content/attachment.py
@@ -105,7 +105,7 @@ class Attachment(BaseFolder, ClientAwareMixin):
     def _renameAfterCreation(self, check_auto_id=False):
         """Rename with the IDServer
         """
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     @security.public

--- a/src/bika/lims/content/attachmenttype.py
+++ b/src/bika/lims/content/attachmenttype.py
@@ -45,7 +45,7 @@ class AttachmentType(BaseContent):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
 

--- a/src/bika/lims/content/autoimportlog.py
+++ b/src/bika/lims/content/autoimportlog.py
@@ -72,7 +72,7 @@ class AutoImportLog(BaseContent):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def getInstrumentUID(self):

--- a/src/bika/lims/content/batch.py
+++ b/src/bika/lims/content/batch.py
@@ -152,7 +152,7 @@ class Batch(ATFolder, ClientAwareMixin):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def getClient(self):

--- a/src/bika/lims/content/batchlabel.py
+++ b/src/bika/lims/content/batchlabel.py
@@ -38,7 +38,7 @@ class BatchLabel(BaseContent):
 
     _at_rename_after_creation = True
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
 registerType(BatchLabel, PROJECTNAME)

--- a/src/bika/lims/content/calculation.py
+++ b/src/bika/lims/content/calculation.py
@@ -178,7 +178,7 @@ class Calculation(BaseFolder, HistoryAwareMixin):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def setInterimFields(self, value):

--- a/src/bika/lims/content/client.py
+++ b/src/bika/lims/content/client.py
@@ -176,7 +176,7 @@ class Client(Organisation):
     GROUP_KEY = "_client_group_id"
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     @property

--- a/src/bika/lims/content/contact.py
+++ b/src/bika/lims/content/contact.py
@@ -195,7 +195,7 @@ class Contact(Person):
         return aq_parent(aq_inner(self))
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     @security.private

--- a/src/bika/lims/content/container.py
+++ b/src/bika/lims/content/container.py
@@ -116,7 +116,7 @@ class Container(BaseContent):
 
     _at_rename_after_creation = True
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def getJSCapacity(self, **kw):

--- a/src/bika/lims/content/containertype.py
+++ b/src/bika/lims/content/containertype.py
@@ -41,7 +41,7 @@ class ContainerType(BaseContent):
 
     _at_rename_after_creation = True
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def getContainers(self):

--- a/src/bika/lims/content/department.py
+++ b/src/bika/lims/content/department.py
@@ -87,7 +87,7 @@ class Department(BaseContent):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def getDepartment(self):

--- a/src/bika/lims/content/identifiertype.py
+++ b/src/bika/lims/content/identifiertype.py
@@ -58,7 +58,7 @@ class IdentifierType(BaseContent):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def getPortalTypes(self):

--- a/src/bika/lims/content/instrument.py
+++ b/src/bika/lims/content/instrument.py
@@ -352,7 +352,7 @@ class Instrument(ATFolder):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def Title(self):

--- a/src/bika/lims/content/instrumentcalibration.py
+++ b/src/bika/lims/content/instrumentcalibration.py
@@ -180,7 +180,7 @@ class InstrumentCalibration(BaseFolder):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def getLabContacts(self):

--- a/src/bika/lims/content/instrumentcertification.py
+++ b/src/bika/lims/content/instrumentcertification.py
@@ -205,7 +205,7 @@ class InstrumentCertification(BaseFolder):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     @security.protected("Modify portal content")

--- a/src/bika/lims/content/instrumentlocation.py
+++ b/src/bika/lims/content/instrumentlocation.py
@@ -46,7 +46,7 @@ class InstrumentLocation(BaseContent):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
 atapi.registerType(InstrumentLocation, PROJECTNAME)

--- a/src/bika/lims/content/instrumentmaintenancetask.py
+++ b/src/bika/lims/content/instrumentmaintenancetask.py
@@ -153,7 +153,7 @@ class InstrumentMaintenanceTask(BaseFolder):
 
     _at_rename_after_creation = True
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def getMaintenanceTypes(self):

--- a/src/bika/lims/content/instrumentscheduledtask.py
+++ b/src/bika/lims/content/instrumentscheduledtask.py
@@ -109,7 +109,7 @@ class InstrumentScheduledTask(BaseFolder):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def getTaskTypes(self):

--- a/src/bika/lims/content/instrumenttype.py
+++ b/src/bika/lims/content/instrumenttype.py
@@ -38,7 +38,7 @@ class InstrumentType(BaseContent):
 
     _at_rename_after_creation = True
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
 registerType(InstrumentType, PROJECTNAME)

--- a/src/bika/lims/content/instrumentvalidation.py
+++ b/src/bika/lims/content/instrumentvalidation.py
@@ -163,7 +163,7 @@ class InstrumentValidation(BaseFolder):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def getLabContacts(self):

--- a/src/bika/lims/content/invoice.py
+++ b/src/bika/lims/content/invoice.py
@@ -76,7 +76,7 @@ class Invoice(BaseFolder):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def Title(self):

--- a/src/bika/lims/content/labcontact.py
+++ b/src/bika/lims/content/labcontact.py
@@ -99,7 +99,7 @@ class LabContact(Contact):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def Title(self):

--- a/src/bika/lims/content/labproduct.py
+++ b/src/bika/lims/content/labproduct.py
@@ -82,7 +82,7 @@ class LabProduct(BaseContent):
 
     _at_rename_after_creation = True
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def getTotalPrice(self):

--- a/src/bika/lims/content/manufacturer.py
+++ b/src/bika/lims/content/manufacturer.py
@@ -38,7 +38,7 @@ class Manufacturer(BaseContent):
 
     _at_rename_after_creation = True
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
 registerType(Manufacturer, PROJECTNAME)

--- a/src/bika/lims/content/method.py
+++ b/src/bika/lims/content/method.py
@@ -175,7 +175,7 @@ class Method(BaseFolder):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def getInstruments(self):

--- a/src/bika/lims/content/multifile.py
+++ b/src/bika/lims/content/multifile.py
@@ -88,7 +88,7 @@ class Multifile(BaseContent):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         # ResourceLockedError: Object "multifile..." is locked via WebDAV
         self.wl_clearLocks()
         renameAfterCreation(self)

--- a/src/bika/lims/content/preservation.py
+++ b/src/bika/lims/content/preservation.py
@@ -67,7 +67,7 @@ class Preservation(BaseContent):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
 registerType(Preservation, PROJECTNAME)

--- a/src/bika/lims/content/pricelist.py
+++ b/src/bika/lims/content/pricelist.py
@@ -114,7 +114,7 @@ class Pricelist(BaseFolder):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     @security.public

--- a/src/bika/lims/content/referencedefinition.py
+++ b/src/bika/lims/content/referencedefinition.py
@@ -82,7 +82,7 @@ class ReferenceDefinition(BaseContent):
 
     _at_rename_after_creation = True
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
 registerType(ReferenceDefinition, PROJECTNAME)

--- a/src/bika/lims/content/referencesample.py
+++ b/src/bika/lims/content/referencesample.py
@@ -184,7 +184,7 @@ class ReferenceSample(BaseFolder):
 
     _at_rename_after_creation = True
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     security.declarePublic('current_date')

--- a/src/bika/lims/content/samplecondition.py
+++ b/src/bika/lims/content/samplecondition.py
@@ -46,7 +46,7 @@ class SampleCondition(BaseFolder):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
 registerType(SampleCondition, PROJECTNAME)

--- a/src/bika/lims/content/samplematrix.py
+++ b/src/bika/lims/content/samplematrix.py
@@ -41,7 +41,7 @@ class SampleMatrix(BaseFolder):
 
     _at_rename_after_creation = True
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
 registerType(SampleMatrix, PROJECTNAME)

--- a/src/bika/lims/content/samplepoint.py
+++ b/src/bika/lims/content/samplepoint.py
@@ -139,7 +139,7 @@ class SamplePoint(BaseContent, HistoryAwareMixin, ClientAwareMixin,
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def Title(self):

--- a/src/bika/lims/content/sampletype.py
+++ b/src/bika/lims/content/sampletype.py
@@ -230,7 +230,7 @@ class SampleType(BaseContent, HistoryAwareMixin, SampleTypeAwareMixin):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def Title(self):

--- a/src/bika/lims/content/samplingdeviation.py
+++ b/src/bika/lims/content/samplingdeviation.py
@@ -40,7 +40,7 @@ class SamplingDeviation(BaseFolder):
 
     _at_rename_after_creation = True
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
 registerType(SamplingDeviation, PROJECTNAME)

--- a/src/bika/lims/content/storagelocation.py
+++ b/src/bika/lims/content/storagelocation.py
@@ -101,7 +101,7 @@ class StorageLocation(BaseContent, HistoryAwareMixin):
 
     _at_rename_after_creation = True
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def Title(self):

--- a/src/bika/lims/content/subgroup.py
+++ b/src/bika/lims/content/subgroup.py
@@ -54,7 +54,7 @@ class SubGroup(BaseContent):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
 

--- a/src/bika/lims/content/supplier.py
+++ b/src/bika/lims/content/supplier.py
@@ -102,7 +102,7 @@ class Supplier(Organisation):
     security = ClassSecurityInfo()
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
 

--- a/src/bika/lims/content/suppliercontact.py
+++ b/src/bika/lims/content/suppliercontact.py
@@ -50,7 +50,7 @@ class SupplierContact(Person):
     security = ClassSecurityInfo()
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
 

--- a/src/bika/lims/content/worksheet.py
+++ b/src/bika/lims/content/worksheet.py
@@ -30,7 +30,7 @@ from bika.lims.browser.widgets import RemarksWidget
 from bika.lims.config import PROJECTNAME
 from bika.lims.config import DEFAULT_WORKSHEET_LAYOUT
 from bika.lims.content.bikaschema import BikaSchema
-from bika.lims.idserver import renameAfterCreation
+from senaite.core.idserver import renameAfterCreation
 from bika.lims.interfaces import IAnalysisRequest
 from bika.lims.interfaces import IDuplicateAnalysis
 from bika.lims.interfaces import IReferenceAnalysis
@@ -153,7 +153,7 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     def Title(self):

--- a/src/bika/lims/content/worksheettemplate.py
+++ b/src/bika/lims/content/worksheettemplate.py
@@ -156,7 +156,7 @@ class WorksheetTemplate(BaseContent):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from bika.lims.idserver import renameAfterCreation
+        from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
 
     @security.public

--- a/src/bika/lims/jsonapi/create.py
+++ b/src/bika/lims/jsonapi/create.py
@@ -21,7 +21,7 @@
 import transaction
 from AccessControl import Unauthorized
 from AccessControl import getSecurityManager
-from bika.lims.idserver import renameAfterCreation
+from senaite.core.idserver import renameAfterCreation
 from bika.lims.jsonapi import set_fields_from_request
 from bika.lims.utils import tmpID
 from plone.jsonapi.core import router

--- a/src/senaite/core/exportimport/instruments/resultsimport.py
+++ b/src/senaite/core/exportimport/instruments/resultsimport.py
@@ -24,7 +24,7 @@ import six
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
-from bika.lims.idserver import renameAfterCreation
+from senaite.core.idserver import renameAfterCreation
 from bika.lims.interfaces import IRoutineAnalysis
 from bika.lims.utils import t
 from Products.CMFCore.utils import getToolByName

--- a/src/senaite/core/exportimport/setupdata/__init__.py
+++ b/src/senaite/core/exportimport/setupdata/__init__.py
@@ -26,7 +26,7 @@ import transaction
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
-from bika.lims.idserver import renameAfterCreation
+from senaite.core.idserver import renameAfterCreation
 from bika.lims.interfaces import ISetupDataSetList
 from bika.lims.utils import getFromString
 from bika.lims.utils import t


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is releavant https://github.com/senaite/senaite.core/pull/2372 and fixes the imports to `renameAfterCreation` to avoid deprecation warnings.

## Current behavior before PR

This import is used:
`from bika.lims.idserver import renameAfterCreation`

## Desired behavior after PR is merged

This import is used:
`from senaite.core.idserver import renameAfterCreation`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
