### PR TITLE
Reactivate auditlog catalog mappings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2378 Reactivate auditlog catalog mappings
 - #2372 Generate unique ID for DX types on object creation
 - #2370 Override default DX add form to obtain renamed IDs correctly
 - #2368 Drop usage of portal_catalog tool

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2516</version>
+  <version>2517</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/v02_05_000.py
+++ b/src/senaite/core/upgrade/v02_05_000.py
@@ -38,6 +38,7 @@ from senaite.core.registry import get_registry_record
 from senaite.core.setuphandlers import CATALOG_MAPPINGS
 from senaite.core.setuphandlers import _run_import_step
 from senaite.core.setuphandlers import add_dexterity_items
+from senaite.core.setuphandlers import setup_auditlog_catalog_mappings
 from senaite.core.setuphandlers import setup_catalog_mappings
 from senaite.core.setuphandlers import setup_core_catalogs
 from senaite.core.setuphandlers import setup_portal_catalog
@@ -231,6 +232,7 @@ def setup_catalogs(tool):
 
     setup_catalog_mappings(portal)
     setup_core_catalogs(portal)
+    setup_auditlog_catalog_mappings(portal)
 
     logger.info("Setup Catalogs [DONE]")
 

--- a/src/senaite/core/upgrade/v02_05_000.zcml
+++ b/src/senaite/core/upgrade/v02_05_000.zcml
@@ -4,6 +4,14 @@
     i18n_domain="senaite.core">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.5.0: Setup auditlog catalog mappings"
+      description="Setup auditlog catalog mappings"
+      source="2516"
+      destination="2517"
+      handler=".v02_05_000.setup_catalogs"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.5.0: Fix type information for DX types"
       description="Reimport typeinfo profile"
       source="2515"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR reactivates the auditlog catalog mappings in `archetype_tool`

## Current behavior before PR

Catalog mapping for `senaite_catalog_auditlog` was missing for some types.

## Desired behavior after PR is merged

Catalog mapping for `senaite_catalog_auditlog` is active for all types.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
