### PR TITLE
Add listing adapter for sample workflow "receive" transition

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2379 Add listing adapter for sample workflow "receive" transition
 - #2378 Reactivate auditlog catalog mappings
 - #2377 Fix imports for moved idserver module
 - #2372 Generate unique ID for DX types on object creation

--- a/src/senaite/core/browser/configure.zcml
+++ b/src/senaite/core/browser/configure.zcml
@@ -27,6 +27,7 @@
   <include package=".idserver"/>
   <include package=".install"/>
   <include package=".label"/>
+  <include package=".listing"/>
   <include package=".login"/>
   <include package=".main_template"/>
   <include package=".modals"/>

--- a/src/senaite/core/browser/listing/configure.zcml
+++ b/src/senaite/core/browser/listing/configure.zcml
@@ -1,0 +1,19 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
+    xmlns:browser="http://namespaces.zope.org/browser">
+
+
+  <configure zcml:installed="senaite.app.listing">
+
+    <!-- Custom listing adapter for sample transition "receive" -->
+    <adapter
+        for="senaite.app.listing.interfaces.IAjaxListingView
+            bika.lims.interfaces.IAnalysisRequest
+            senaite.core.interfaces.ISenaiteCore"
+        factory=".workflow.SampleReceiveWorkflowTransition"
+        name="receive"
+        />
+    </configure>
+
+</configure>

--- a/src/senaite/core/browser/listing/configure.zcml
+++ b/src/senaite/core/browser/listing/configure.zcml
@@ -3,17 +3,17 @@
     xmlns:zcml="http://namespaces.zope.org/zcml"
     xmlns:browser="http://namespaces.zope.org/browser">
 
-
-  <configure zcml:installed="senaite.app.listing">
+  <configure zcml:condition="installed senaite.app.listing">
 
     <!-- Custom listing adapter for sample transition "receive" -->
     <adapter
         for="senaite.app.listing.interfaces.IAjaxListingView
-            bika.lims.interfaces.IAnalysisRequest
-            senaite.core.interfaces.ISenaiteCore"
+             bika.lims.interfaces.IAnalysisRequest
+             senaite.core.interfaces.ISenaiteCore"
         factory=".workflow.SampleReceiveWorkflowTransition"
         name="receive"
         />
-    </configure>
+
+  </configure>
 
 </configure>

--- a/src/senaite/core/browser/listing/workflow.py
+++ b/src/senaite/core/browser/listing/workflow.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+from bika.lims import api
+from senaite.app.listing.adapters.workflow import ListingWorkflowTransition
+from senaite.app.listing.interfaces import IListingWorkflowTransition
+from zope.interface import implementer
+
+
+@implementer(IListingWorkflowTransition)
+class SampleReceiveWorkflowTransition(ListingWorkflowTransition):
+    """Adapter to execute the workflow transitions "receive" for samples
+    """
+    def __init__(self, view, context, request):
+        super(SampleReceiveWorkflowTransition, self).__init__(
+            view, context, request)
+        self.back_url = request.get_header("referer")
+
+    def get_redirect_url(self):
+        """Redirect after sample receive transition
+        """
+        if self.is_auto_partition_required():
+            # Redirect to the partitioning view
+            uid = api.get_uid(self.context)
+            url = "{}/partition_magic?uids={}".format(self.back_url, uid)
+            return url
+
+        if self.is_auto_print_stickers_enabled():
+            # Redirect to the auto-print stickers view
+            uid = api.get_uid(self.context)
+            url = "{}/sticker?autoprint=1&items={}".format(self.back_url, uid)
+            return url
+
+        # return default value
+        return super(SampleReceiveWorkflowTransition, self).get_redirect_url()
+
+    def is_auto_partition_required(self):
+        """Returns whether the sample needs to be partitioned
+        """
+        template = self.context.getTemplate()
+        return template and template.getAutoPartition()
+
+    def is_auto_print_stickers_enabled(self):
+        """Returns whether the auto print of stickers on reception is enabled
+        """
+        setup = api.get_setup()
+        return "receive" in setup.getAutoPrintStickers()

--- a/src/senaite/core/browser/listing/workflow.py
+++ b/src/senaite/core/browser/listing/workflow.py
@@ -8,7 +8,7 @@ from zope.interface import implementer
 
 @implementer(IListingWorkflowTransition)
 class SampleReceiveWorkflowTransition(ListingWorkflowTransition):
-    """Adapter to execute the workflow transitions "receive" for samples
+    """Adapter to execute the workflow transition "receive" for samples
     """
     def __init__(self, view, context, request):
         super(SampleReceiveWorkflowTransition, self).__init__(


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**☝️ NOTE:** Please merge https://github.com/senaite/senaite.app.listing/pull/115 first

This PR adds a custom listing adapter to handle the WF receive transition for samples and provide a redirect URL if auto-print stickers on receive is enabled or if auto-partitioning is needed from the template.

## Current behavior before PR

No redirects possible for ajax receive transition

## Desired behavior after PR is merged

Redirects possible after all objects are received

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
