### PR TITLE
Fix missing fields in client edit mode and listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2382 Fix missing fields in client edit mode and listing
 - #2378 Reactivate auditlog catalog mappings
 - #2377 Fix imports for moved idserver module
 - #2372 Generate unique ID for DX types on object creation

--- a/src/bika/lims/adapters/configure.zcml
+++ b/src/bika/lims/adapters/configure.zcml
@@ -38,24 +38,6 @@
       name="RegistryHiddenFieldsVisibility"
     />
 
-    <!-- Display/Hide accountancy-related fields (e.g. price, discount, etc.)
-    based on system settings (setup's "Show Prices" option) -->
-    <adapter
-      factory=".widgetvisibility.AccountancyFieldsVisibility"
-      provides="bika.lims.interfaces.IATWidgetVisibility"
-      for="bika.lims.interfaces.IClient"
-      name="AccountancyFieldsVisibility"
-    />
-
-    <!-- Display/Hide accountancy-related fields (e.g. price, discount, etc.)
-    based on system settings (setup's "Show Prices" option) -->
-    <adapter
-      factory=".widgetvisibility.AccountancyFieldsVisibility"
-      provides="bika.lims.interfaces.IATWidgetVisibility"
-      for="bika.lims.interfaces.IAnalysisRequest"
-      name="AccountancyFieldsVisibility"
-    />
-
     <!-- Display/Hide Batch field in AR Add form when creation takes place
     inside a Batch context. -->
     <adapter

--- a/src/bika/lims/adapters/widgetvisibility.py
+++ b/src/bika/lims/adapters/widgetvisibility.py
@@ -190,21 +190,6 @@ class RegistryHiddenFieldsVisibility(SenaiteATWidgetVisibility):
         return "invisible"
 
 
-class AccountancyFieldsVisibility(SenaiteATWidgetVisibility):
-    """Display/Hide fields related with Accountancy (Discount, prices, invoice)
-    """
-    def __init__(self, context):
-        super(AccountancyFieldsVisibility, self).__init__(
-            context=context, sort=3,
-            field_names=["BulkDiscount", "MemberDiscountApplies",
-                         "InvoiceExclude", "MemberDiscount"])
-
-    def isVisible(self, field, mode="view", default="visible"):
-        if not self.context.bika_setup.getShowPrices():
-            return "invisible"
-        return default
-
-
 class DateReceivedFieldVisibility(SenaiteATWidgetVisibility):
     """DateReceived is editable in sample context, only if all related analyses
     are not yet submitted and if not a secondary sample.

--- a/src/bika/lims/browser/clientfolder.py
+++ b/src/bika/lims/browser/clientfolder.py
@@ -22,23 +22,20 @@ import collections
 
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
-from bika.lims.browser.bika_listing import BikaListingView
-from senaite.core.permissions import AddClient
-from senaite.core.permissions import ManageAnalysisRequests
 from bika.lims.utils import check_permission
 from bika.lims.utils import get_email_link
 from bika.lims.utils import get_link
 from bika.lims.utils import get_registry_value
-from plone.app.content.browser.interfaces import IFolderContentsView
 from Products.CMFCore.permissions import ModifyPortalContent
+from senaite.app.listing import ListingView
 from senaite.core.catalog import CLIENT_CATALOG
-from zope.interface import implements
+from senaite.core.permissions import AddClient
+from senaite.core.permissions import ManageAnalysisRequests
 
 
-class ClientFolderContentsView(BikaListingView):
+class ClientFolderContentsView(ListingView):
     """Listing view for all Clients
     """
-    implements(IFolderContentsView)
 
     _LANDING_PAGE_REGISTRY_KEY = "bika.lims.client.default_landing_page"
     _DEFAULT_LANDING_PAGE = "analysisrequests"
@@ -61,10 +58,6 @@ class ClientFolderContentsView(BikaListingView):
             "sort_order": "ascending"
         }
 
-        self.show_select_row = False
-        self.show_select_all_checkbox = False
-        self.show_select_column = False
-        self.pagesize = 25
         self.icon = "{}/{}".format(
             self.portal_url, "++resource++bika.lims.images/client_big.png")
 
@@ -72,20 +65,20 @@ class ClientFolderContentsView(BikaListingView):
             ("title", {
                 "title": _("Name"),
                 "index": "sortable_title"},),
-            ("getClientID", {
+            ("ClientID", {
                 "title": _("Client ID")}),
             ("EmailAddress", {
                 "title": _("Email Address"),
                 "sortable": False}),
-            ("getCountry", {
+            ("Country", {
                 "toggle": False,
                 "sortable": False,
                 "title": _("Country")}),
-            ("getProvince", {
+            ("Province", {
                 "toggle": False,
                 "sortable": False,
                 "title": _("Province")}),
-            ("getDistrict", {
+            ("District", {
                 "toggle": False,
                 "sortable": False,
                 "title": _("District")}),
@@ -100,7 +93,7 @@ class ClientFolderContentsView(BikaListingView):
                 "toggle": False,
                 "sortable": False,
                 "title": _("Bulk Discount")}),
-            ("MemberDiscountApplies", {
+            ("MemberDiscount", {
                 "toggle": False,
                 "sortable": False,
                 "title": _("Member Discount")}),
@@ -171,32 +164,45 @@ class ClientFolderContentsView(BikaListingView):
         :rtype: dict
         """
         obj = api.get_object(obj)
+
         # render a link to the defined start page
         link_url = "{}/{}".format(item["url"], self.landing_page)
         item["replace"]["title"] = get_link(link_url, item["title"])
-        item["replace"]["getClientID"] = get_link(link_url, item["getClientID"])
-        # render an email link
+
+        # Client ID
+        client_id = obj.getClientID()
+        item["ClientID"] = client_id
+        if client_id:
+            item["replace"]["ClientID"] = get_link(link_url, client_id)
+
+        # Email address
         email = obj.getEmailAddress()
-        item["replace"]["EmailAddress"] = get_email_link(email)
-        # translate True/FALSE values
-        item["replace"]["BulkDiscount"] = obj.getBulkDiscount() and _("Yes") or _("No")
-        item["replace"]["MemberDiscountApplies"] = obj.getMemberDiscountApplies() and _("Yes") or _("No")
-        # render a phone link
+        item["EmailAddress"] = get_email_link(email)
+        if email:
+            item["replace"]["EmailAddress"] = get_email_link(email)
+
+        # Country, Province, District
+        item["Country"] = obj.getCountry()
+        item["Province"] = obj.getProvince()
+        item["District"] = obj.getDistrict()
+
+        # Phone
         phone = obj.getPhone()
+        item["Phone"] = phone
         if phone:
             item["replace"]["Phone"] = get_link("tel:{}".format(phone), phone)
 
+        # Fax
+        item["Fax"] = obj.getFax()
+
+        # Bulk Discount
+        bulk_discount = obj.getBulkDiscount()
+        bulk_discount_value = _("Yes") if bulk_discount else _("No")
+        item["replace"]["BulkDiscount"] = bulk_discount_value
+
+        # Member Discount
+        member_discount = obj.getMemberDiscountApplies()
+        member_discount_value = _("Yes") if member_discount else _("No")
+        item["replace"]["MemberDiscount"] = member_discount_value
+
         return item
-
-
-def client_match(client, search_term):
-    # Check if the search_term matches some common fields
-    if search_term in client.getClientID().lower():
-        return True
-    if search_term in client.Title().lower():
-        return True
-    if search_term in client.getName().lower():
-        return True
-    if search_term in client.Description().lower():
-        return True
-    return False

--- a/src/senaite/core/tests/doctests/ShowPrices.rst
+++ b/src/senaite/core/tests/doctests/ShowPrices.rst
@@ -94,8 +94,6 @@ Verify that the price and invoice fields are present when ShowPrices is enabled:
     True
     >>> True if "Total" in browser.contents else "ShowPrices is True, and Total field is missing from AR Add."
     True
-    >>> True if "Invoice Exclude" in browser.contents else "ShowPrices is True, and Invoice Exclude field is missing from AR Add."
-    True
 
 And then that the opposite is true:
 
@@ -109,8 +107,6 @@ And then that the opposite is true:
     >>> True if "VAT" not in browser.contents else "ShowPrices is False, VAT field should not be present in AR Add."
     True
     >>> True if "Total" not in browser.contents else "ShowPrices is False, Total field should not be present in AR Add."
-    True
-    >>> True if "Invoice Exclude" not in browser.contents else "ShowPrices is False, Invoice Exclude field should not be present in AR Add."
     True
 
 Disable MemberDiscountApplies, and verify that it always vanishes from AR add:
@@ -155,16 +151,3 @@ Test show/hide prices when viewing an AR.  First, create an AR:
        browser.open(ar.absolute_url())
        True if 'contentview-invoice' not in browser.contents else "Invoice Tab is visible, but ShowPrices is False."
        True
-
-Client discount fields show/hide
-................................
-
-    >>> enableShowPrices()
-    >>> browser.open(client.absolute_url() + "/edit")
-    >>> True if 'discount' in browser.contents else "Client discount field should be visible, but is not"
-    True
-
-    >>> disableShowPrices()
-    >>> browser.open(client.absolute_url() + "/edit")
-    >>> True if 'discount' not in browser.contents else "Client discount field should not be visible, but here it is"
-    True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/1899

This PR fixes missing fields in client edit mode and listing, that was caused by a side-effect of https://github.com/senaite/senaite.core/pull/2278

## Current behavior before PR

Missing fields in client edit mode and listing.

## Desired behavior after PR is merged

All fields are displayed in client edit mode and listing

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
