### PR TITLE
Fix display of orphan method instruments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2392 Fix display of orphan method instruments
 - #2387 Improve memory usage when rebuilding a catalog
 - #2389 Added i18n.translate function with multiple domains support
 - #2386 Add dynamic search index lookup for referencewidget and added default catalog metadata columns

--- a/src/bika/lims/content/method.py
+++ b/src/bika/lims/content/method.py
@@ -23,7 +23,6 @@ from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.fields import UIDReferenceField
 from bika.lims.browser.fields.uidreferencefield import get_backreferences
-from senaite.core.browser.widgets.referencewidget import ReferenceWidget
 from bika.lims.catalog import SETUP_CATALOG
 from bika.lims.config import PROJECTNAME
 from bika.lims.content.bikaschema import BikaSchema
@@ -43,6 +42,7 @@ from Products.Archetypes.public import TextField
 from Products.Archetypes.public import registerType
 from Products.Archetypes.utils import DisplayList
 from Products.Archetypes.Widget import RichWidget
+from senaite.core.browser.widgets.referencewidget import ReferenceWidget
 from zope.interface import implements
 
 schema = BikaSchema.copy() + Schema((
@@ -180,14 +180,28 @@ class Method(BaseFolder):
     def getInstruments(self):
         """Instruments capable to perform this method
         """
-        uc = api.get_tool("uid_catalog")
-        uids = self.getRawInstruments()
-        return [api.get_object(brain) for brain in uc(UID=uids)]
+        instruments = map(api.get_object, self.getRawInstruments())
+        return list(instruments)
 
     def getRawInstruments(self):
         """List of Instrument UIDs capable to perform this method
         """
-        return get_backreferences(self, "InstrumentMethods")
+        backrefs = get_backreferences(self, "InstrumentMethods")
+        # XXX: The backrefs might contain UIDs of deactivated instruments,
+        #      which will show up in the UI as just their UID.
+        active_instrument_uids = filter(
+            lambda uid: api.get_review_status(uid) == "active", backrefs)
+        # TODO: Actually, this should to be corrected in a transition event
+        #       for instruments to remove the backreference of each method
+        #       with a reference to the specific instrument.
+        #
+        #       However, this would happen silently and the user would not be
+        #       notified about this "side-effect".
+        #
+        #       Therefore, we leave the linked object in the backrefs, but
+        #       filter it out for now, until we have a better approach how to
+        #       handle this with user notification!
+        return active_instrument_uids
 
     def setInstruments(self, value):
         """Set the method on the selected instruments


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the display and retrieval of linked method instruments.
<img width="1311" alt="Method -  Instruments" src="https://github.com/senaite/senaite.core/assets/713193/2d3c90ed-f6b7-424d-ba70-ba93c263499b">



## Current behavior before PR

Deactivated instruments are still listed in methods by their UID and retrieved as objects when the `getInstruments` accessor is used.

## Desired behavior after PR is merged

Deactivated instruments are no longer listed in methods by their UID and not retrieved as objects when the `getInstruments` accessor is used.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
