### PR TITLE
Allow empty analysis method selection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2393 Allow empty analysis method selection
 - #2392 Fix display of orphan method instruments
 - #2388 Fix QC sample IDs are the same accross worksheets
 - #2387 Improve memory usage when rebuilding a catalog

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -487,16 +487,22 @@ class AnalysesView(ListingView):
         :type analysis_brain: CatalogBrain
         :returns: A list of dicts
         """
-        obj = self.get_object(analysis_brain)
-        methods = obj.getAllowedMethods()
-        if not methods:
-            return [{"ResultValue": "", "ResultText": _("None")}]
         vocab = []
+        obj = self.get_object(analysis_brain)
+        default_method = obj.getMethod()
+        methods = obj.getAllowedMethods()
+        empty_option = {"ResultValue": "", "ResultText": _("None")}
         for method in methods:
             vocab.append({
                 "ResultValue": api.get_uid(method),
                 "ResultText": api.get_title(method),
             })
+        # allow empty option if we have no allowed methods
+        if not methods:
+            vocab = [empty_option]
+        # allow empty option if the default method is set to "None"
+        elif default_method is None:
+            vocab.insert(0, empty_option)
         return vocab
 
     def get_unit_vocabulary(self, analysis_brain):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/2312

This PR allows to select no method if the default method is set to "None".

Furthermore, it fixes a side-effect if the default method is set to "None" and at least one method is selected in the list of allowed analyses methods.

In this case, the analysis method is not saved if the analysis result is submitted (unless the method displayed method is selected again from the list).

## Current behavior before PR

If a service is configured with at least one allowed method, but with "None" as the default method, the selection shows only the selected methods (without empty option available).

If the result is submitted in such a case, the method saved as `Manual`.

## Desired behavior after PR is merged

Empty option is displayed in the method selection if the default method is configured as "None".

The side-effect is also fixed, because the user has to select explicitly the method, or need to configure the service properly.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
