### PR TITLE
Fix district is not displayed in old address widget

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2397 Fix district is not displayed in old address widget
 - #2396 Add after sequential transition event handler
 - #2394 Ajax support for transitions retract and retest
 - #2393 Allow empty analysis method selection

--- a/src/bika/lims/skins/bika/bika_widgets/addresswidget.pt
+++ b/src/bika/lims/skins/bika/bika_widgets/addresswidget.pt
@@ -95,6 +95,20 @@
                                         id string:${fieldName}.district"
                         tal:define="values python:widget.getDistricts(defcountry, state)">
                   <option value=''></option>
+
+                  <!--
+                  For some countries, districts that come from pycountry do not
+                  match with those that were hardcoded in code and available
+                  before https://github.com/senaite/senaite.core/pull/1961
+                  We simply display the original value if not present
+                  -->
+                  <option tal:define="districts python:[val[2] for val in values];
+                                      missing python:district and district not in districts"
+                          tal:condition="missing"
+                          tal:attributes="value python:district"
+                          tal:content="python:district"
+                          selected="selected"/>
+
                   <tal:x tal:repeat="value values">
                     <option tal:content="python:value[2]"
                             tal:attributes="value python:value[2];


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Since https://github.com/senaite/senaite.core/pull/1961 , SENAITE relies on [`pycountry`](https://pypi.org/project/pycountry/) to retrieve country subdivisions, districts and states included. For countries subdivisions, `pycountry` adheres to [ISO3166-2](https://www.iso.org/iso-3166-country-codes.html#2012_iso3166-2). Until then, the subdivisions were hardcoded at `senaite.core.locales.__init__`.

This Pull Request makes old district visible in AT's address widget, when assigned but not returned by `pycountry`

## Current behavior before PR

No district is displayed

![Captura de 2023-10-02 10-42-43](https://github.com/senaite/senaite.core/assets/832627/e118f8d5-cc68-4382-a848-bf57ff1cd826)


## Desired behavior after PR is merged

District is displayed

![Captura de 2023-10-02 10-43-11](https://github.com/senaite/senaite.core/assets/832627/1b4988f3-a38b-4c0a-88ad-157bcc7d8363)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
