### PR TITLE
Support for min/max in DateTimeWidget, and drop _nopast and _nofuture

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2399 Support for min/max in DateTimeWidget, and drop _nopast and _nofuture
 - #2397 Fix district is not displayed in old address widget
 - #2395 Fix DateTimeError for non-valid/old timezones
 - #2396 Add after sequential transition event handler

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -1063,6 +1063,7 @@ schema = BikaSchema.copy() + Schema((
         widget=DateTimeWidget(
             label=_("Date Sample Received"),
             show_time=True,
+            min="DateSampled",
             max="current",
             description=_("The date when the sample was received"),
             render_own_label=True,

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -436,7 +436,7 @@ schema = BikaSchema.copy() + Schema((
             description=_("The date when the sample was taken"),
             size=20,
             show_time=True,
-            datepicker_nofuture=1,
+            max="created",
             visible={
                 'add': 'edit',
                 'secondary': 'disabled',
@@ -493,7 +493,7 @@ schema = BikaSchema.copy() + Schema((
             description=_("The date when the sample will be taken"),
             size=20,
             show_time=True,
-            datepicker_nopast=1,
+            min="created",
             render_own_label=True,
             visible={
                 'add': 'edit',
@@ -1051,7 +1051,7 @@ schema = BikaSchema.copy() + Schema((
         widget=DateTimeWidget(
             label=_("Date Sample Received"),
             show_time=True,
-            datepicker_nofuture=1,
+            max="current",
             description=_("The date when the sample was received"),
             render_own_label=True,
         ),

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -492,6 +492,7 @@ schema = BikaSchema.copy() + Schema((
     DateTimeField(
         'SamplingDate',
         mode="rw",
+        min="created",
         read_permission=View,
         write_permission=FieldEditSamplingDate,
         widget=DateTimeWidget(
@@ -505,7 +506,6 @@ schema = BikaSchema.copy() + Schema((
             ),
             size=20,
             show_time=True,
-            min="created",
             render_own_label=True,
             visible={
                 'add': 'edit',

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -432,8 +432,14 @@ schema = BikaSchema.copy() + Schema((
         read_permission=View,
         write_permission=FieldEditDateSampled,
         widget=DateTimeWidget(
-            label=_("Date Sampled"),
-            description=_("The date when the sample was taken"),
+            label=_(
+                "label_sample_datesampled",
+                default="Date Sampled"
+            ),
+            description=_(
+                "description_sample_datesampled",
+                default="The date when the sample was taken"
+            ),
             size=20,
             show_time=True,
             max="created",
@@ -489,8 +495,14 @@ schema = BikaSchema.copy() + Schema((
         read_permission=View,
         write_permission=FieldEditSamplingDate,
         widget=DateTimeWidget(
-            label=_("Expected Sampling Date"),
-            description=_("The date when the sample will be taken"),
+            label=_(
+                "label_sample_samplingdate",
+                default="Expected Sampling Date"
+            ),
+            description=_(
+                "label_sample_samplingdate",
+                default="The date when the sample will be taken"
+            ),
             size=20,
             show_time=True,
             min="created",

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -429,6 +429,7 @@ schema = BikaSchema.copy() + Schema((
     DateTimeField(
         'DateSampled',
         mode="rw",
+        max="created",
         read_permission=View,
         write_permission=FieldEditDateSampled,
         widget=DateTimeWidget(
@@ -442,7 +443,6 @@ schema = BikaSchema.copy() + Schema((
             ),
             size=20,
             show_time=True,
-            max="created",
             visible={
                 'add': 'edit',
                 'secondary': 'disabled',
@@ -1058,13 +1058,13 @@ schema = BikaSchema.copy() + Schema((
     DateTimeField(
         'DateReceived',
         mode="rw",
+        min="DateSampled",
+        max="current",
         read_permission=View,
         write_permission=FieldEditDateReceived,
         widget=DateTimeWidget(
             label=_("Date Sample Received"),
             show_time=True,
-            min="DateSampled",
-            max="current",
             description=_("The date when the sample was received"),
             render_own_label=True,
         ),

--- a/src/senaite/core/browser/fields/datetime.py
+++ b/src/senaite/core/browser/fields/datetime.py
@@ -84,10 +84,10 @@ class DateTimeField(BaseField):
         if errors is None:
             errors = {}
 
-        # self.get_min_date always returns an offset-naive datetime, but the
-        # value is offset-aware. We need to add the TZ, otherwise we get a:
+        # self.get_min always returns an offset-naive datetime, but the value
+        # is offset-aware. We need to add the TZ, otherwise we get a:
         #   TypeError: can't compare offset-naive and offset-aware datetimes
-        min_date = self.get_min_date(instance)
+        min_date = self.get_min(instance)
         if dtime.to_ansi(value) >= dtime.to_ansi(min_date):
             return None
 
@@ -110,10 +110,10 @@ class DateTimeField(BaseField):
         if errors is None:
             errors = {}
 
-        # self.get_max_date always returns an offset-naive datetime, but the
-        # value is offset-aware. We need to add the TZ, otherwise we get a:
+        # self.get_max always returns an offset-naive datetime, but the value
+        # is offset-aware. We need to add the TZ, otherwise we get a:
         #   TypeError: can't compare offset-naive and offset-aware datetimes
-        max_date = self.get_max_date(instance)
+        max_date = self.get_max(instance)
         if dtime.to_ansi(value) <= dtime.to_ansi(max_date):
             return None
 
@@ -152,13 +152,13 @@ class DateTimeField(BaseField):
         return dtime.to_localized_time(dt, long_format=self.show_time,
                                        context=instance, request=request)
 
-    def get_min_date(self, instance):
+    def get_min(self, instance):
         """Returns the minimum datetime supported by this field and instance
         """
         min_date = self.resolve_date(self.min, instance)
         return min_date or dtime.datetime.min
 
-    def get_max_date(self, instance):
+    def get_max(self, instance):
         """Returns the maximum datetime supported for this field and instance
         """
         max_date = self.resolve_date(self.max, instance)

--- a/src/senaite/core/browser/fields/datetime.py
+++ b/src/senaite/core/browser/fields/datetime.py
@@ -34,6 +34,8 @@ from bika.lims import api
 WIDGET_NOPAST = "datepicker_nopast"
 WIDGET_NOFUTURE = "datepicker_nofuture"
 WIDGET_SHOWTIME = "show_time"
+WIDGET_MIN_DATE = "min_date"
+WIDGET_MAX_DATE = "max_date"
 
 
 class DateTimeField(BaseField):
@@ -87,15 +89,19 @@ class DateTimeField(BaseField):
         # self.min always returns an offset-naive datetime, but the value
         # is offset-aware. We need to add the TZ, otherwise we get a:
         #   TypeError: can't compare offset-naive and offset-aware datetimes
-        if dtime.to_ansi(value) >= dtime.to_ansi(self.min):
+        min_date = self.get_min_datetime(instance)
+        if dtime.to_ansi(value) >= dtime.to_ansi(min_date):
             return None
+
+        # Get the minimum date to compare with
+        min_date = self.get_min_date(instance)
 
         error = _(
             u"error_datetime_before_min",
             default=u"${name} is before ${min_date}, please correct.",
             mapping={
                 "name": self.get_label(instance),
-                "min_date": self.localize(self.min, instance)
+                "min_date": self.localize(min_date, instance)
             }
         )
 
@@ -150,14 +156,36 @@ class DateTimeField(BaseField):
         return dtime.to_localized_time(dt, long_format=self.show_time,
                                        context=instance, request=request)
 
-    @property
-    def min(self):
-        """Returns the minimum datetime supported by this field
+    def get_min_datetime(self, instance):
+        """Returns the minimum datetime supported by this field and instance
         """
         no_past = getattr(self.widget, WIDGET_NOPAST, False)
-        if self.is_true(no_past):
+        if not self.is_true(no_past):
+            return dtime.datetime.min
+
+        min_date_raw = getattr(self.widget, WIDGET_MIN_DATE, None)
+        if not min_date_raw:
+            # default to current date time
             return dtime.datetime.now()
-        return dtime.datetime.min
+
+        min_date = api.to_date(min_date_raw)
+        if api.is_date(min_date):
+            return min_date
+
+        elif callable(min_date_raw):
+            min_date = api.to_date(min_date_raw())
+
+        elif hasattr(instance, min_date_raw):
+            min_date_raw = getattr(instance, min_date_raw)
+            if callable(min_date_raw):
+                min_date = min_date_raw()
+            min_date = api.to_date(min_date)
+
+        if not api.is_date(min_date):
+            raise ValueError("Cannot resolve a datetime from '{}'"
+                             .format(repr(min_date_raw)))
+
+        return min_date
 
     @property
     def max(self):

--- a/src/senaite/core/browser/fields/datetime.py
+++ b/src/senaite/core/browser/fields/datetime.py
@@ -31,7 +31,6 @@ from zope.i18nmessageid import Message
 from bika.lims import _
 from bika.lims import api
 
-
 WIDGET_SHOWTIME = "show_time"
 
 

--- a/src/senaite/core/browser/widgets/datetimewidget.py
+++ b/src/senaite/core/browser/widgets/datetimewidget.py
@@ -90,29 +90,24 @@ class DateTimeWidget(TypesWidget):
         :param context: The current context of the field
         :param field: The current field of the widget
         """
-        min_date = self.get_min_date(context, field)
-        max_date = self.get_max_date(context, field)
+        min_date = self.get_min(context, field)
+        max_date = self.get_max(context, field)
         return {
             "min": dtime.date_to_string(min_date),
             "max": dtime.date_to_string(max_date)
         }
 
-    def get_min_date(self, context, field):
+    def get_min(self, context, field):
         """Returns the minimum date allowed for selection in the widget
         """
-        func = getattr(field, "get_min_date", None)
-        if not func:
-            return datetime.min
-        return func(context)
+        func = getattr(field, "get_min", None)
+        return func(context) if func else datetime.min
 
-
-    def get_max_date(self, context, field):
+    def get_max(self, context, field):
         """Returns the minimum date allowed for selection in the widget
         """
-        func = getattr(field, "get_max_date", None)
-        if not func:
-            return datetime.max
-        return func(context)
+        func = getattr(field, "get_max", None)
+        return func(context) if func else datetime.max
 
 
 InitializeClass(DateTimeWidget)

--- a/src/senaite/core/browser/widgets/datetimewidget.py
+++ b/src/senaite/core/browser/widgets/datetimewidget.py
@@ -90,14 +90,29 @@ class DateTimeWidget(TypesWidget):
         :param context: The current context of the field
         :param field: The current field of the widget
         """
-        min_date = getattr(field, "get_min_date", None)
-        min_date = min_date(context) if callable(min_date) else datetime.min
-        max_date = getattr(field, "get_max_date", None)
-        max_date = max_date(context) if callable(max_date) else datetime.max
+        min_date = self.get_min_date(context, field)
+        max_date = self.get_max_date(context, field)
         return {
             "min": dtime.date_to_string(min_date),
             "max": dtime.date_to_string(max_date)
         }
+
+    def get_min_date(self, context, field):
+        """Returns the minimum date allowed for selection in the widget
+        """
+        func = getattr(field, "get_min_date", None)
+        if not func:
+            return datetime.min
+        return func(context)
+
+
+    def get_max_date(self, context, field):
+        """Returns the minimum date allowed for selection in the widget
+        """
+        func = getattr(field, "get_max_date", None)
+        if not func:
+            return datetime.max
+        return func(context)
 
 
 InitializeClass(DateTimeWidget)

--- a/src/senaite/core/browser/widgets/datetimewidget.py
+++ b/src/senaite/core/browser/widgets/datetimewidget.py
@@ -132,6 +132,14 @@ class DateTimeWidget(TypesWidget):
             value = getattr(instance, thing)
             return self.to_date(value, instance, default)
 
+        if api.is_string(thing):
+            obj = api.get_object(instance, None)
+            fields = obj and api.get_fields(instance) or {}
+            field = fields.get(thing)
+            if field:
+                value = field.get(instance)
+                return self.to_date(value, instance, default)
+
         return default
 
 

--- a/src/senaite/core/browser/widgets/datetimewidget.py
+++ b/src/senaite/core/browser/widgets/datetimewidget.py
@@ -104,14 +104,14 @@ class DateTimeWidget(TypesWidget):
     def get_min_date(self, instance):
         """Returns the minimum datetime supported by this widget and instance
         """
-        return self.to_date(self.min, instance, dtime.datetime.min)
+        return self.resolve_date(self.min, instance, dtime.datetime.min)
 
     def get_max_date(self, instance):
         """Returns the maximum datetime supported for this widget and instance
         """
-        return self.to_date(self.max, instance, dtime.datetime.max)
+        return self.resolve_date(self.max, instance, dtime.datetime.max)
 
-    def to_date(self, thing, instance, default):
+    def resolve_date(self, thing, instance, default):
         """Resolves the thing passed in to a DateTime object or None
         """
         if not thing:
@@ -126,11 +126,11 @@ class DateTimeWidget(TypesWidget):
 
         if callable(thing):
             value = thing()
-            return self.to_date(value, instance, default)
+            return self.resolve_date(value, instance, default)
 
         if hasattr(instance, thing):
             value = getattr(instance, thing)
-            return self.to_date(value, instance, default)
+            return self.resolve_date(value, instance, default)
 
         if api.is_string(thing):
             obj = api.get_object(instance, None)
@@ -138,7 +138,7 @@ class DateTimeWidget(TypesWidget):
             field = fields.get(thing)
             if field:
                 value = field.get(instance)
-                return self.to_date(value, instance, default)
+                return self.resolve_date(value, instance, default)
 
         return default
 

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/datetimewidget.pt
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/datetimewidget.pt
@@ -37,7 +37,7 @@
               type="date"
               class="form-control form-control-sm"
               tal:attributes="
-                    python:widget.attrs();
+                    python:widget.attrs(context);
                     target fieldName;
                     name string:${fieldName}-date;
                     value python:widget.get_date(value) if value else '';"/>

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/datetimewidget.pt
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/datetimewidget.pt
@@ -36,11 +36,12 @@
             <input
               type="date"
               class="form-control form-control-sm"
+              tal:define="widget_attrs python:widget.attrs(context, field);"
               tal:attributes="
-                    python:widget.attrs(context);
                     target fieldName;
                     name string:${fieldName}-date;
-                    value python:widget.get_date(value) if value else '';"/>
+                    value python:widget.get_date(value) if value else '';
+                    python:widget_attrs;"/>
             <!-- time -->
             <input
               type="time"

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/recordswidget.pt
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/recordswidget.pt
@@ -201,26 +201,6 @@
                                           tabindex tabindex/next|nothing;"/>
                       </tal:string>
 
-                      <!-- datepicker_nofuture -->
-
-                      <tal:string condition="python: type == 'datepicker_nofuture'">
-                        <input
-                          type="text"
-                          name=""
-                          value=""
-                          size="30"
-                          tabindex="#"
-                          tal:attributes="class string:datepicker_nofuture form-control form-control-sm;
-                                          name string:${fieldName}.${key}:records:ignore_empty;
-                                          title description;
-                                          id string:${fieldName}-${key}-${repeat/idx/index};
-                                          value python:field.getSubfieldValue(values, idx, key);
-                                          size python:field.getSubfieldSize(key);
-                                          maxlength maxlength|nothing;
-                                          readonly python:hasattr(field, 'subfield_readonly') and field.subfield_readonly.get(key, False) or False;
-                                          tabindex tabindex/next|nothing;"/>
-                      </tal:string>
-
                       <!-- int -->
 
                       <tal:number condition="python: type == 'int'">

--- a/src/senaite/core/z3cform/widgets/basewidget.py
+++ b/src/senaite/core/z3cform/widgets/basewidget.py
@@ -49,9 +49,6 @@ class BaseWidget(Widget):
         NOTE: If we are in the ++add++ form, `self.context` is the container!
               Therefore, we create one here to have access to the methods.
         """
-        if not self.context:
-            return None
-
         schema_iface = self.field.interface
         if schema_iface and schema_iface.providedBy(self.context):
             return self.context
@@ -64,6 +61,9 @@ class BaseWidget(Widget):
         if api.is_object(context):
             if api.get_portal_type(context) == portal_type:
                 return context
+
+        if not self.context:
+            return None
 
         # Hack alert!
         # we are in ++add++ form and have no context!

--- a/src/senaite/core/z3cform/widgets/basewidget.py
+++ b/src/senaite/core/z3cform/widgets/basewidget.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2023 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.lims import api
+from plone.z3cform.fieldsets.interfaces import IDescriptiveGroup
+from z3c.form.interfaces import ISubForm
+from z3c.form.widget import Widget
+from zope.component import getUtility
+from zope.component.interfaces import IFactory
+
+
+class BaseWidget(Widget):
+
+    def get_form(self):
+        """Return the current form of the widget
+        """
+        form = self.form
+        # form is a fieldset group
+        if IDescriptiveGroup.providedBy(form):
+            form = form.parentForm
+        # form is a subform (e.g. DataGridFieldObjectSubForm)
+        if ISubForm.providedBy(form):
+            form = form.parentForm
+        return form
+
+    def get_context(self):
+        """Get the current context
+
+        NOTE: If we are in the ++add++ form, `self.context` is the container!
+              Therefore, we create one here to have access to the methods.
+        """
+        schema_iface = self.field.interface
+        if schema_iface and schema_iface.providedBy(self.context):
+            return self.context
+
+        # we might be in a subform, so try first to retrieve the object from
+        # the base form itself first
+        form = self.get_form()
+        portal_type = getattr(form, "portal_type", None)
+        context = getattr(form, "context", None)
+        if api.is_object(context):
+            if api.get_portal_type(context) == portal_type:
+                return context
+
+        # Hack alert!
+        # we are in ++add++ form and have no context!
+        # Create a temporary object to be able to access class methods
+        if not portal_type:
+            portal_type = api.get_portal_type(self.context)
+        portal_types = api.get_tool("portal_types")
+        fti = portal_types[portal_type]
+        factory = getUtility(IFactory, fti.factory)
+        context = factory("temporary")
+        # mark the context as temporary
+        context._temporary_ = True
+        # hook into acquisition chain
+        context = context.__of__(self.context)
+        return context

--- a/src/senaite/core/z3cform/widgets/basewidget.py
+++ b/src/senaite/core/z3cform/widgets/basewidget.py
@@ -49,7 +49,7 @@ class BaseWidget(Widget):
         NOTE: If we are in the ++add++ form, `self.context` is the container!
               Therefore, we create one here to have access to the methods.
         """
-        schema_iface = self.field.interface
+        schema_iface = self.field.interface if self.field else None
         if schema_iface and schema_iface.providedBy(self.context):
             return self.context
 

--- a/src/senaite/core/z3cform/widgets/basewidget.py
+++ b/src/senaite/core/z3cform/widgets/basewidget.py
@@ -31,6 +31,9 @@ class BaseWidget(Widget):
     def get_form(self):
         """Return the current form of the widget
         """
+        if not self.form:
+            return None
+
         form = self.form
         # form is a fieldset group
         if IDescriptiveGroup.providedBy(form):
@@ -46,6 +49,9 @@ class BaseWidget(Widget):
         NOTE: If we are in the ++add++ form, `self.context` is the container!
               Therefore, we create one here to have access to the methods.
         """
+        if not self.context:
+            return None
+
         schema_iface = self.field.interface
         if schema_iface and schema_iface.providedBy(self.context):
             return self.context

--- a/src/senaite/core/z3cform/widgets/datetimewidget.py
+++ b/src/senaite/core/z3cform/widgets/datetimewidget.py
@@ -17,7 +17,7 @@
 #
 # Copyright 2018-2023 by it's authors.
 # Some rights reserved, see README and LICENSE.
-from collections import OrderedDict
+
 from datetime import datetime
 
 from bika.lims import api

--- a/src/senaite/core/z3cform/widgets/datetimewidget.py
+++ b/src/senaite/core/z3cform/widgets/datetimewidget.py
@@ -221,8 +221,8 @@ class DatetimeWidget(HTMLInputWidget, BaseWidget):
         :returns: dictionary of HTML attributes
         """
         return {
-            "min": self.min,
-            "max": self.max,
+            "min": dtime.date_to_string(self.min),
+            "max": dtime.date_to_string(self.max),
         }
 
     @property
@@ -230,7 +230,7 @@ class DatetimeWidget(HTMLInputWidget, BaseWidget):
         """Returns the minimum date allowed for selection in the widget
         """
         if self._min is None:
-            func = getattr(self.field, "get_min_date", None)
+            func = getattr(self.field, "get_min", None)
             context = self.get_context()
             self._min = func(context) if func else datetime.min
         return self._min
@@ -240,7 +240,7 @@ class DatetimeWidget(HTMLInputWidget, BaseWidget):
         """Returns the maximum date allowed for selection in the widget
         """
         if self._max is None:
-            func = getattr(self.field, "get_max_date", None)
+            func = getattr(self.field, "get_max", None)
             context = self.get_context()
             self._max = func(context) if func else datetime.max
         return self._max

--- a/src/senaite/core/z3cform/widgets/datetimewidget.py
+++ b/src/senaite/core/z3cform/widgets/datetimewidget.py
@@ -17,7 +17,7 @@
 #
 # Copyright 2018-2023 by it's authors.
 # Some rights reserved, see README and LICENSE.
-
+from collections import OrderedDict
 from datetime import datetime
 
 from bika.lims import api

--- a/src/senaite/core/z3cform/widgets/datetimewidget.txt
+++ b/src/senaite/core/z3cform/widgets/datetimewidget.txt
@@ -63,7 +63,7 @@ If we render the widget we get the HTML:
     >>> print(widget.render().replace('\n', ''))
     <div class="input-group flex-nowrap d-inline-flex w-auto datetimewidget">
       <!-- date -->
-      <input type="date" class="form-control form-control-sm" name="None-date" value="2021-12-24"/>
+      <input type="date" class="form-control form-control-sm" max="9999-12-31" min="1-01-01" name="None-date" value="2021-12-24"/>
       <!-- time -->
       <input type="time" class="form-control form-control-sm" name="None-time" value="00:00"/>
     </div>
@@ -79,7 +79,7 @@ Render without the time component:
     >>> print(widget.render().replace('\n', ''))
     <div class="input-group flex-nowrap d-inline-flex w-auto datetimewidget">
       <!-- date -->
-      <input type="date" class="form-control form-control-sm" name="None-date" value="2021-12-24"/>
+      <input type="date" class="form-control form-control-sm" max="9999-12-31" min="1-01-01" name="None-date" value="2021-12-24"/>
       <!-- time -->
     </div>
     <!-- datetime value (outside to avoid style issues) -->

--- a/src/senaite/core/z3cform/widgets/queryselect/widget.py
+++ b/src/senaite/core/z3cform/widgets/queryselect/widget.py
@@ -23,20 +23,16 @@ import string
 
 from bika.lims import api
 from bika.lims import logger
-from plone.z3cform.fieldsets.interfaces import IDescriptiveGroup
 from Products.CMFPlone.utils import base_hasattr
 from senaite.core.interfaces import ISenaiteFormLayer
 from senaite.core.z3cform.interfaces import IQuerySelectWidget
+from senaite.core.z3cform.widgets.basewidget import BaseWidget
 from z3c.form.browser import widget
 from z3c.form.converter import TextLinesConverter
 from z3c.form.interfaces import IDataConverter
 from z3c.form.interfaces import IFieldWidget
-from z3c.form.interfaces import ISubForm
 from z3c.form.widget import FieldWidget
-from z3c.form.widget import Widget
 from zope.component import adapter
-from zope.component import getUtility
-from zope.component.interfaces import IFactory
 from zope.interface import implementer
 from zope.interface import implementer_only
 from zope.schema.interfaces import IField
@@ -75,7 +71,7 @@ class QuerySelectDataConverter(TextLinesConverter):
 
 
 @implementer_only(IQuerySelectWidget)
-class QuerySelectWidget(widget.HTMLInputWidget, Widget):
+class QuerySelectWidget(widget.HTMLInputWidget, BaseWidget):
     """A widget to select one or more items from catalog search
     """
     klass = u"senaite-queryselect-widget-input"
@@ -83,52 +79,6 @@ class QuerySelectWidget(widget.HTMLInputWidget, Widget):
     def update(self):
         super(QuerySelectWidget, self).update()
         widget.addFieldClass(self)
-
-    def get_form(self):
-        """Return the current form of the widget
-        """
-        form = self.form
-        # form is a fieldset group
-        if IDescriptiveGroup.providedBy(form):
-            form = form.parentForm
-        # form is a subform (e.g. DataGridFieldObjectSubForm)
-        if ISubForm.providedBy(form):
-            form = form.parentForm
-        return form
-
-    def get_context(self):
-        """Get the current context
-
-        NOTE: If we are in the ++add++ form, `self.context` is the container!
-              Therefore, we create one here to have access to the methods.
-        """
-        schema_iface = self.field.interface
-        if schema_iface and schema_iface.providedBy(self.context):
-            return self.context
-
-        # we might be in a subform, so try first to retrieve the object from
-        # the base form itself first
-        form = self.get_form()
-        portal_type = getattr(form, "portal_type", None)
-        context = getattr(form, "context", None)
-        if api.is_object(context):
-            if api.get_portal_type(context) == portal_type:
-                return context
-
-        # Hack alert!
-        # we are in ++add++ form and have no context!
-        # Create a temporary object to be able to access class methods
-        if not portal_type:
-            portal_type = api.get_portal_type(self.context)
-        portal_types = api.get_tool("portal_types")
-        fti = portal_types[portal_type]
-        factory = getUtility(IFactory, fti.factory)
-        context = factory("temporary")
-        # mark the context as temporary
-        context._temporary_ = True
-        # hook into acquisition chain
-        context = context.__of__(self.context)
-        return context
 
     def get_input_widget_attributes(self):
         """Return input widget attributes for the ReactJS component


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request allows to define the date since the value is permitted, as well as the maximum date.

## Current behavior before PR

Is not possible to save past dates (compared to current time) for fields that have the flag `datepicker_nopast` enabled 


![image](https://github.com/labsanmartin/lsm.lims/assets/2072052/8efe5e68-9181-4349-a10a-c8a6b015a602)

## Desired behavior after PR is merged

The desired minimum date can be specified in the field

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
