### PR TITLE
Add Transposed Multi Results Form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2400 Add Transposed Multi Results Form
 - #2397 Fix district is not displayed in old address widget
 - #2395 Fix DateTimeError for non-valid/old timezones
 - #2396 Add after sequential transition event handler

--- a/src/bika/lims/browser/worksheet/views/analyses.py
+++ b/src/bika/lims/browser/worksheet/views/analyses.py
@@ -117,6 +117,24 @@ class AnalysesView(BaseView):
                 "title": _("State")}),
         ))
 
+        self.review_states = [
+            {
+                "id": "default",
+                "title": _("All"),
+                "contentFilter": {},
+                "custom_transitions": [],
+                "columns": self.columns.keys(),
+                "confirm_messages": {
+                    "reject": _(
+                        "This operation can not be undone. Are you sure "
+                        "you want to reject the selected analyses?"
+                    )
+                }
+            },
+        ]
+
+    def update(self):
+        super(AnalysesView, self).update()
         # Inject Remarks column for listing
         if self.is_analysis_remarks_enabled():
             self.columns["Remarks"] = {
@@ -136,24 +154,6 @@ class AnalysesView(BaseView):
             "help": _("Set remarks for selected analyses")
         }
 
-        self.review_states = [
-            {
-                "id": "default",
-                "title": _("All"),
-                "contentFilter": {},
-                "custom_transitions": [],
-                "columns": self.columns.keys(),
-                "confirm_messages": {
-                    "reject": _(
-                        "This operation can not be undone. Are you sure "
-                        "you want to reject the selected analyses?"
-                    )
-                }
-            },
-        ]
-
-    def update(self):
-        super(AnalysesView, self).update()
         self.reorder_analysis_columns()
 
     def before_render(self):
@@ -184,13 +184,20 @@ class AnalysesView(BaseView):
 
         XXX: Convert maybe better to a real WF transition with a guard
         """
-        # Disable analysis remarks transition when global analysis remarks are disabled
+        # Disable analysis remarks transition if disabled in global setup
         if not self.is_analysis_remarks_enabled():
             return False
-        for analysis in self.context.getAnalyses():
+        for analysis in self.get_analyses():
             if check_permission(FieldEditAnalysisRemarks, analysis):
                 return True
         return False
+
+    def get_analyses(self, full_objects=False):
+        """Return all analyses of the current view
+
+        :returns: List of analyses
+        """
+        return self.context.getAnalyses(full_objects=full_objects)
 
     @view.memoize
     def is_analysis_remarks_enabled(self):

--- a/src/senaite/core/browser/modals/configure.zcml
+++ b/src/senaite/core/browser/modals/configure.zcml
@@ -24,7 +24,7 @@
 
   <browser:page
       name="set_analysis_remarks_modal"
-      for="bika.lims.interfaces.IWorksheet"
+      for="*"
       class=".remarks.SetAnalysisRemarksModal"
       permission="senaite.core.permissions.FieldEditAnalysisRemarks"
       layer="senaite.core.interfaces.ISenaiteCore"

--- a/src/senaite/core/browser/samples/configure.zcml
+++ b/src/senaite/core/browser/samples/configure.zcml
@@ -52,7 +52,7 @@
   <browser:page
       for="*"
       name="multi_results_classic"
-      class=".multi_results.MultiResultsView"
+      class=".multi_results_classic.MultiResultsClassicView"
       permission="zope2.View"
       layer="senaite.core.interfaces.ISenaiteCore" />
 

--- a/src/senaite/core/browser/samples/configure.zcml
+++ b/src/senaite/core/browser/samples/configure.zcml
@@ -51,14 +51,14 @@
   -->
   <browser:page
       for="*"
-      name="multi_results"
+      name="multi_results_classic"
       class=".multi_results.MultiResultsView"
       permission="zope2.View"
       layer="senaite.core.interfaces.ISenaiteCore" />
 
   <browser:page
       for="*"
-      name="multi_results_transposed"
+      name="multi_results"
       class=".multi_results_transposed.MultiResultsTransposedView"
       permission="zope2.View"
       layer="senaite.core.interfaces.ISenaiteCore" />

--- a/src/senaite/core/browser/samples/configure.zcml
+++ b/src/senaite/core/browser/samples/configure.zcml
@@ -56,6 +56,13 @@
       permission="zope2.View"
       layer="senaite.core.interfaces.ISenaiteCore" />
 
+  <browser:page
+      for="*"
+      name="multi_results_transposed"
+      class=".multi_results_transposed.MultiResultsTransposedView"
+      permission="zope2.View"
+      layer="senaite.core.interfaces.ISenaiteCore" />
+
   <!-- Manage Sample Fields -->
   <browser:page
       for="*"

--- a/src/senaite/core/browser/samples/multi_results.py
+++ b/src/senaite/core/browser/samples/multi_results.py
@@ -41,6 +41,10 @@ class MultiResultsView(BrowserView):
         self.context = context
         self.request = request
 
+        self.classic = True
+        self.transposed_url = "{}/multi_results?uids={}".format(
+            self.context.absolute_url(), self.request.form.get("uids"))
+
     def __call__(self):
         return self.template()
 

--- a/src/senaite/core/browser/samples/multi_results_classic.py
+++ b/src/senaite/core/browser/samples/multi_results_classic.py
@@ -31,13 +31,13 @@ from senaite.core import logger
 OFF_VALUES = ["0", "off", "no"]
 
 
-class MultiResultsView(BrowserView):
+class MultiResultsClassicView(BrowserView):
     """Allows to edit results of multiple samples
     """
     template = ViewPageTemplateFile("templates/multi_results.pt")
 
     def __init__(self, context, request):
-        super(MultiResultsView, self).__init__(context, request)
+        super(MultiResultsClassicView, self).__init__(context, request)
         self.context = context
         self.request = request
 

--- a/src/senaite/core/browser/samples/multi_results_transposed.py
+++ b/src/senaite/core/browser/samples/multi_results_transposed.py
@@ -8,6 +8,7 @@ from bika.lims.browser.analyses import AnalysesView
 from bika.lims.browser.worksheet.views import AnalysesTransposedView
 from bika.lims.interfaces import IAnalysisRequest
 from bika.lims.utils import get_link
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from senaite.core import logger
 from senaite.core.i18n import translate as t
 from six.moves.urllib.parse import parse_qs
@@ -16,15 +17,20 @@ from six.moves.urllib.parse import parse_qs
 class MultiResultsTransposedView(AnalysesTransposedView):
     """Transposed multi results view
     """
+    template = ViewPageTemplateFile("templates/multi_results.pt")
+
     def __init__(self, context, request):
         AnalysesView.__init__(self, context, request)
-
         self.allow_edit = True
         self.expand_all_categories = False
         self.show_categories = False
         self.show_column_toggles = False
         self.show_search = False
         self.show_select_column = True
+
+        self.transposed = True
+        self.classic_url = "{}/multi_results_classic?uids={}".format(
+            self.context.absolute_url(), self.request.form.get("uids"))
 
         self.title = _("Multi Results")
         self.description = _("")

--- a/src/senaite/core/browser/samples/multi_results_transposed.py
+++ b/src/senaite/core/browser/samples/multi_results_transposed.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+
+from collections import OrderedDict
+
+from bika.lims import api
+from bika.lims import bikaMessageFactory as _
+from bika.lims.browser.analyses import AnalysesView
+from bika.lims.interfaces import IAnalysisRequest
+from bika.lims.utils import get_link
+from senaite.app.listing import ListingView
+from senaite.app.listing.interfaces import ITransposedListingView
+from senaite.core import logger
+from six.moves.urllib.parse import parse_qs
+from zope.interface import implementer
+
+
+@implementer(ITransposedListingView)
+class MultiResultsTransposedView(ListingView):
+    """Transposed multi results view
+    """
+    def __init__(self, context, request):
+        super(MultiResultsTransposedView, self).__init__(context, request)
+
+        self.allow_edit = True
+        self.expand_all_categories = False
+        self.show_categories = False
+        self.show_column_toggles = False
+        self.show_search = False
+        self.show_select_column = True
+        self.title = _("Multi Results")
+
+        self.services = OrderedDict()
+
+        self.columns = OrderedDict((
+            ("column_key", {
+                "title": _("Analysis"),
+                "sortable": False}),
+            ("Result", {
+                "title": _("Result"),
+                "input_width": "6",
+                "input_class": "ajax_calculate numeric",
+                "ajax": True,
+                "sortable": False}),
+        ))
+
+    def make_empty_folderitem(self, **kw):
+        """Create a new empty item
+        """
+        item = super(
+            MultiResultsTransposedView, self).make_empty_folderitem(**kw)
+        item["transposed_keys"] = []
+        item.update(**kw)
+        return item
+
+    def transpose_item(self, item, pos):
+        """Transpose the folderitem
+        """
+        obj = item["obj"]
+        service = item["Service"]
+        keyword = obj.getKeyword
+
+        # Skip retracted folderitems and display only the retest
+        review_state = item["review_state"]
+        if review_state in ["retracted"]:
+            return item
+
+        # remember the services, e.g. Calcium, Magnesium, Total Hardness etc.
+        if keyword not in self.services:
+            transposed_item = self.make_empty_folderitem(
+                column_key=keyword, item_key="Result")
+            # Append info link after the service
+            transposed_item["after"]["column_key"] = get_link(
+                "analysisservice_info?service_uid={}&analysis_uid={}"
+                .format(item["service_uid"], item["uid"]),
+                value="<i class='fas fa-info-circle'></i>",
+                css_class="overlay_panel")
+            transposed_item["replace"]["column_key"] = service
+            self.services[keyword] = transposed_item
+
+        # append all regular items that belong to this service
+        if pos not in self.services[keyword]:
+            # Add the item below its position
+            self.services[keyword][pos] = item
+            # Track the new transposed key for this item
+            self.services[keyword]["transposed_keys"].append(pos)
+
+        return item
+
+    def folderitems(self):
+        """Prepare transposed analyses folderitems
+
+        NOTE: This method is called by a separate Ajax request, which creates
+              a new view instance!
+
+              Therefore, we do all dynamic modifications to the columns etc.
+              right here to avoid expensive operations called multiple times!
+        """
+        samples = self.get_samples()
+
+        for num, sample in enumerate(samples):
+            slot = str(num + 1)
+            # Add a new column for the sample
+            self.columns[slot] = {
+                "title": sample.getId(),
+                "type": "transposed",
+                "sortable": False,
+            }
+            for item in self.get_sample_folderitems(sample):
+                transposed = self.transpose_item(item, slot)
+
+        # show service and sample columns
+        slots = [str(i + 1) for i in range(len(samples))]
+        self.review_states[0]["columns"] = ["column_key"] + slots
+
+        # the collected services (Iron, Copper, Calcium...)
+        transposed = OrderedDict(reversed(self.services.items()))
+
+        # listing fixtures
+        self.total = len(transposed.keys())
+
+        # return the transposed rows
+        return transposed.values()
+
+    def get_sample_folderitems(self, sample):
+        """Get the folderitems for the given sample
+        """
+        view = AnalysesView(sample, self.request)
+        view.contentFilter["getAncestorsUIDs"] = [api.get_uid(sample)]
+        return view.folderitems()
+
+    def get_samples(self):
+        """Extract the samples from the request UIDs
+
+        This might be either a samples container or a sample context
+        """
+
+        # fetch objects from request
+        objs = self.get_objects_from_request()
+
+        samples = []
+
+        for obj in objs:
+            # when coming from the samples listing
+            if IAnalysisRequest.providedBy(obj):
+                samples.append(obj)
+
+        # when coming from the WF menu inside a sample
+        if IAnalysisRequest.providedBy(self.context):
+            samples.append(self.context)
+
+        return self.uniquify_items(samples)
+
+    def uniquify_items(self, items):
+        """Uniquify the items with sort order
+        """
+        unique = []
+        for item in items:
+            if item in unique:
+                continue
+            unique.append(item)
+        return unique
+
+    def get_objects_from_request(self):
+        """Returns a list of objects coming from the "uids" request parameter
+        """
+        unique_uids = self.get_uids_from_request()
+        return filter(None, map(self.get_object_by_uid, unique_uids))
+
+    def get_uids_from_request(self):
+        """Return a list of uids from the request
+        """
+        qs = self.request.get_header("query_string")
+        params = dict(parse_qs(qs))
+        uids = params.get("uids", [""])[0]
+        if api.is_string(uids):
+            uids = uids.split(",")
+        unique_uids = OrderedDict().fromkeys(uids).keys()
+        return filter(api.is_uid, unique_uids)
+
+    def get_object_by_uid(self, uid):
+        """Get the object by UID
+        """
+        logger.debug("get_object_by_uid::UID={}".format(uid))
+        obj = api.get_object_by_uid(uid, None)
+        if obj is None:
+            logger.warn("!! No object found for UID #{} !!")
+        return obj

--- a/src/senaite/core/browser/samples/multi_results_transposed.py
+++ b/src/senaite/core/browser/samples/multi_results_transposed.py
@@ -167,10 +167,13 @@ class MultiResultsTransposedView(AnalysesTransposedView):
         return view.folderitems()
 
     def get_analyses(self, full_objects=False):
-        """Returns all sample analyses
+        """Returns sample analyses from lab poc
         """
-        analyses = map(lambda s: s.getAnalyses(full_objects=full_objects),
-                       self.get_samples())
+        params = {
+            "full_objects": full_objects,
+            "getPointOfCapture": "lab",
+        }
+        analyses = map(lambda s: s.getAnalyses(**params), self.get_samples())
         # return a flat list of analyses
         return list(chain(*analyses))
 

--- a/src/senaite/core/browser/samples/multi_results_transposed.py
+++ b/src/senaite/core/browser/samples/multi_results_transposed.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from collections import OrderedDict
+from itertools import chain
 
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
@@ -165,6 +166,14 @@ class MultiResultsTransposedView(AnalysesTransposedView):
         view = AnalysesView(sample, self.request)
         view.contentFilter["getAncestorsUIDs"] = [api.get_uid(sample)]
         return view.folderitems()
+
+    def get_analyses(self, full_objects=False):
+        """Returns all sample analyses
+        """
+        analyses = map(lambda s: s.getAnalyses(full_objects=full_objects),
+                       self.get_samples())
+        # return a flat list of analyses
+        return list(chain(*analyses))
 
     def get_samples(self):
         """Extract the samples from the request UIDs

--- a/src/senaite/core/browser/samples/multi_results_transposed.py
+++ b/src/senaite/core/browser/samples/multi_results_transposed.py
@@ -65,14 +65,18 @@ class MultiResultsTransposedView(AnalysesTransposedView):
     def transpose_item(self, item, pos):
         """Transpose the folderitem
         """
-        obj = item["obj"]
+        obj = api.get_object(item["obj"])
         service = item["Service"]
-        keyword = obj.getKeyword
+        keyword = obj.getKeyword()
         item["Pos"] = pos
 
-        # Skip retracted folderitems and display only the retest
+        # skip retracted analyses
         review_state = item["review_state"]
         if review_state in ["retracted"]:
+            return item
+
+        # show only retests
+        if obj.getRetest():
             return item
 
         # remember the column headers of the first row

--- a/src/senaite/core/browser/samples/multi_results_transposed.py
+++ b/src/senaite/core/browser/samples/multi_results_transposed.py
@@ -21,7 +21,8 @@ class MultiResultsTransposedView(AnalysesTransposedView):
     template = ViewPageTemplateFile("templates/multi_results.pt")
 
     def __init__(self, context, request):
-        AnalysesView.__init__(self, context, request)
+        super(MultiResultsTransposedView, self).__init__(context, request)
+
         self.allow_edit = True
         self.expand_all_categories = False
         self.show_categories = False
@@ -45,8 +46,6 @@ class MultiResultsTransposedView(AnalysesTransposedView):
                 "sortable": False}),
             ("Result", {
                 "title": _("Result"),
-                "input_width": "6",
-                "input_class": "ajax_calculate numeric",
                 "ajax": True,
                 "sortable": False}),
         ))

--- a/src/senaite/core/browser/samples/templates/multi_results.pt
+++ b/src/senaite/core/browser/samples/templates/multi_results.pt
@@ -12,16 +12,31 @@
 
     <!-- Title -->
     <metal:title fill-slot="content-title">
-      <h2 i18n:translate="">
-        Manage Analyses Results
+      <h2 i18n:translate="" class="d-inline align-middle">
+        Edit Multiple Analyses Results
       </h2>
+      <span class="d-inline">
+        <!-- switch to transposed view -->
+        <a href="#"
+           class="btn btn-link"
+           tal:attributes="href view/transposed_url"
+           tal:condition="view/classic|nothing">
+          <i class="fas fa-sync"></i>
+          <span i18n:translate="">Switch to transposed view</span>
+        </a>
+        <!-- switch to classic view -->
+        <a href="#"
+           class="btn btn-link"
+           tal:attributes="href view/classic_url"
+           tal:condition="view/transposed|nothing">
+          <i class="fas fa-sync"></i>
+          <span i18n:translate="">Switch to classic view</span>
+        </a>
+      </span>
     </metal:title>
 
     <!-- Description -->
     <metal:description fill-slot="content-description">
-      <p class="text-secondary" i18n:translate="">
-        Enter or view the analyses results of multiple samples.
-      </p>
     </metal:description>
 
     <!-- Content -->
@@ -36,7 +51,11 @@
         </a>
       </div>
 
-      <div class="multi-results-container">
+      <div class="multi-results-transposed-container" tal:condition="view/transposed|nothing">
+        <div tal:content="structure python:view.contents_table()"/>
+      </div>
+
+      <div class="multi-results-container" tal:condition="view/classic|nothing">
         <div class="sample"
              tal:attributes="data-uid python:sample.UID()"
              tal:define="portal context/@@plone_portal_state/portal;


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**☝️ NOTE:** Optionally merge https://github.com/senaite/senaite.app.listing/pull/122 first for a better usability!

This PR adds a transposed multi results edit form into SENAITE:

<img width="1827" alt="Multi Results Transposed" src="https://github.com/senaite/senaite.core/assets/713193/3b69ec64-496e-4344-89ed-86bb9cb4b6b5">


## Current behavior before PR

Classic multi results do not perform well when many samples/analyses need to be handled

## Desired behavior after PR is merged

The new transposed multi results view allows to edit all analyses in a single table similar to the worksheet transposed view.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
