### PR TITLE
Fix OverflowError when calculating datetime.min date for left-hand TZs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2401 Fix OverflowError when calculating datetime.min date for left-hand TZs
 - #2399 Support for min/max in DateTimeWidget, and drop _nopast and _nofuture
 - #2397 Fix district is not displayed in old address widget
 - #2395 Fix DateTimeError for non-valid/old timezones

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -65,7 +65,6 @@ from Products.CMFPlone.utils import safe_unicode
 from Products.PlonePAS.tools.memberdata import MemberData
 from Products.ZCatalog.interfaces import ICatalogBrain
 from senaite.core.interfaces import ITemporaryObject
-from zope import deprecation
 from zope import globalrequest
 from zope.annotation.interfaces import IAttributeAnnotatable
 from zope.component import getUtility

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -37,7 +37,6 @@ from bika.lims.interfaces import IClient
 from bika.lims.interfaces import IContact
 from bika.lims.interfaces import ILabContact
 from DateTime import DateTime
-from DateTime.interfaces import DateTimeError
 from plone import api as ploneapi
 from plone.api.exc import InvalidParameterError
 from plone.app.layout.viewlets.content import ContentHistoryView
@@ -66,6 +65,7 @@ from Products.CMFPlone.utils import safe_unicode
 from Products.PlonePAS.tools.memberdata import MemberData
 from Products.ZCatalog.interfaces import ICatalogBrain
 from senaite.core.interfaces import ITemporaryObject
+from zope import deprecation
 from zope import globalrequest
 from zope.annotation.interfaces import IAttributeAnnotatable
 from zope.component import getUtility
@@ -1475,19 +1475,14 @@ def to_date(value, default=None):
     :type value: str, DateTime or datetime
     :return: The DateTime representation of the value passed in or default
     """
-    if isinstance(value, DateTime):
-        return value
-    if not value:
-        if default is None:
-            return None
-        return to_date(default)
-    try:
-        if isinstance(value, str) and '.' in value:
-            # https://docs.plone.org/develop/plone/misc/datetime.html#datetime-problems-and-pitfalls
-            return DateTime(value, datefmt='international')
-        return DateTime(value)
-    except (TypeError, ValueError, DateTimeError):
-        return to_date(default)
+    # prevent circular dependencies
+    from senaite.core.api.dtime import to_DT
+    deprecation.deprecated("bika.lims.api.to_date",
+                           "Use senaite.core.api.dtime.to_DT instead")
+    date = to_DT(value)
+    if not date:
+        return to_DT(default)
+    return date
 
 
 def to_minutes(days=0, hours=0, minutes=0, seconds=0, milliseconds=0,

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -1475,10 +1475,16 @@ def to_date(value, default=None):
     :type value: str, DateTime or datetime
     :return: The DateTime representation of the value passed in or default
     """
+
+    # cannot use bika.lims.deprecated (circular dependencies)
+    import warnings
+    warnings.simplefilter("always", DeprecationWarning)
+    warn = "Deprecated: use senaite.core.api.dtime.to_DT instead"
+    warnings.warn(warn, category=DeprecationWarning, stacklevel=2)
+    warnings.simplefilter("default", DeprecationWarning)
+
     # prevent circular dependencies
     from senaite.core.api.dtime import to_DT
-    deprecation.deprecated("bika.lims.api.to_date",
-                           "Use senaite.core.api.dtime.to_DT instead")
     date = to_DT(value)
     if not date:
         return to_DT(default)

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 import os
+import re
 import time
 from datetime import date
 from datetime import datetime
@@ -126,11 +127,20 @@ def to_DT(dt):
     :param dt: DateTime/datetime/date
     :returns: DateTime object
     """
+    INTERNATIONAL_FMT = re.compile(
+        r"^\s*(3[01]|[12][0-9]|0?[1-9])\.(1[012]|0?[1-9])\.(\d{2,4})\s*"
+    )
     if is_DT(dt):
         return dt
     elif is_str(dt):
+        kwargs = {}
+        if re.match(INTERNATIONAL_FMT, dt):
+            # This will fail silently and you get a wrong date:
+            # dt = DateTime("02.07.2010") # Parses like US date 02/07/2010
+            # https://github.com/zopefoundation/DateTime/blob/master/src/DateTime/DateTime.py#L641-L645
+            kwargs["datefmt"] = "international"
         try:
-            return DateTime(dt)
+            return DateTime(dt, **kwargs)
         except (DateError, TimeError):
             try:
                 dt = ansi_to_dt(dt)

--- a/src/senaite/core/browser/fields/datetime.py
+++ b/src/senaite/core/browser/fields/datetime.py
@@ -180,14 +180,14 @@ class DateTimeField(BaseField):
         # maybe a callable
         if callable(thing):
             value = thing()
-            return api.to_date(value)
+            return dtime.to_DT(value)
 
         # maybe an instance attribute
         if hasattr(instance, thing):
             value = getattr(instance, thing)
             if callable(value):
                 value = value()
-            return api.to_date(value)
+            return dtime.to_DT(value)
 
         # maybe an instance fieldname
         if api.is_string(thing):
@@ -195,7 +195,7 @@ class DateTimeField(BaseField):
             field = fields.get(thing)
             if field:
                 value = field.get(instance)
-                return api.to_date(value)
+                return dtime.to_DT(value)
 
         return None
 

--- a/src/senaite/core/browser/fields/datetime.py
+++ b/src/senaite/core/browser/fields/datetime.py
@@ -170,7 +170,7 @@ class DateTimeField(BaseField):
         if not thing:
             return None
 
-        date = api.to_date(thing)
+        date = dtime.to_DT(thing)
         if api.is_date(date):
             return date
 

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -176,13 +176,13 @@ Timezone naive datetimes are converterd to `GMT+0`:
 
 International format is automatically detected and supported:
 
-    >>> dtime.to_DT("02.07.2010 17:50:34")
+    >>> dtime.to_DT("02.07.2010 17:50:34 GMT+2")
     DateTime('2010/07/02 17:50:34 GMT+2')
 
-    >>> dtime.to_DT("13.12.2018 17:50:34")
+    >>> dtime.to_DT("13.12.2018 17:50:34 GMT+1")
     DateTime('2018/12/13 17:50:34 GMT+1')
 
-    >>> dtime.to_DT("12.13.2018 17:50:34")
+    >>> dtime.to_DT("12.13.2018 17:50:34 GMT+1")
     DateTime('2018/12/13 17:50:34 GMT+1')
 
 Timezone aware datetimes are converterd to `GMT+<tzoffset>`

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -174,6 +174,16 @@ Timezone naive datetimes are converterd to `GMT+0`:
     >>> dtime.to_DT(date.fromtimestamp(0))
     DateTime('1970/01/01 00:00:00 GMT+0')
 
+International format is automatically detected and supported:
+
+    >>> dtime.to_DT("02.07.2010 17:50:34")
+    DateTime('2010/07/02 17:50:34 GMT+2')
+
+    >>> dtime.to_DT("13.12.2018 17:50:34")
+    DateTime('2018/12/13 17:50:34 GMT+1')
+
+    >>> dtime.to_DT("12.13.2018 17:50:34")
+    DateTime('2018/12/13 17:50:34 GMT+1')
 
 Timezone aware datetimes are converterd to `GMT+<tzoffset>`
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes the following issue when validating a `max_date` in a Timezone that is before GMT+0:

```
Pdb++) value
'2023-10-02T00:00'
(Pdb++) max_date
DateTime('9999/12/31 23:59:59.999999 US/Central')
(Pdb++) dtime.to_ansi(value)
'20231002000000'
(Pdb++) dtime.to_ansi(max_date)
*** OverflowError: date value out of range
(Pdb++) dtime.to_ansi(dtime.datetime.min)
'00010101000000'
(Pdb++) dtime.to_ansi(dtime.datetime.max)
'99991231235959'
```

## Current behavior before PR

Traceback when validating max dates in TZ that are on the left-hand of GMT+0

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module bika.lims.decorators, line 51, in decorator
  Module bika.lims.browser.analysisrequest.add2, line 708, in __call__
  Module bika.lims.browser.analysisrequest.add2, line 1753, in ajax_submit
  Module senaite.core.browser.fields.datetime, line 77, in validate
  Module senaite.core.browser.fields.datetime, line 117, in validate_max_date
  Module senaite.core.api.dtime, line 205, in to_ansi
  Module senaite.core.api.dtime, line 166, in to_dt
  Module senaite.core.api.dtime, line 320, in to_zone
  Module pytz.tzinfo, line 328, in localize
  Module pytz.tzinfo, line 254, in normalize
OverflowError: date value out of range
```


## Desired behavior after PR is merged

No traceback when validating max dates in TZ that are on the left-hand of GMT+0

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
