### PR TITLE
Fix AttributeError when setting DX date fields

### DIFF
--- a/src/senaite/core/z3cform/widgets/datetimewidget.py
+++ b/src/senaite/core/z3cform/widgets/datetimewidget.py
@@ -235,6 +235,10 @@ class DatetimeWidget(HTMLInputWidget, BaseWidget):
             self._min = func(context) if func else datetime.min
         return self._min
 
+    @min.setter
+    def min(self, value):
+        self._min = value
+
     @property
     def max(self):
         """Returns the maximum date allowed for selection in the widget
@@ -244,6 +248,10 @@ class DatetimeWidget(HTMLInputWidget, BaseWidget):
             context = self.get_context()
             self._max = func(context) if func else datetime.max
         return self._max
+
+    @max.setter
+    def max(self, value):
+        self._max = value
 
     @property
     def portal(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue that was introduced in https://github.com/senaite/senaite.core/pull/2399

## Current behavior before PR

If a field has the widget directives `min` or `max` set, the following error occurs:

```
Traceback (innermost last):
Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
Module ZPublisher.WSGIPublisher, line 385, in publish_module
Module ZPublisher.WSGIPublisher, line 288, in publish
Module ZPublisher.mapply, line 85, in mapply
Module ZPublisher.WSGIPublisher, line 63, in call_object
Module plone.z3cform.layout, line 63, in call
Module plone.z3cform.layout, line 47, in update
Module plone.dexterity.browser.add, line 138, in update
Module plone.z3cform.fieldsets.extensible, line 65, in update
Module plone.z3cform.patch, line 30, in GroupForm_update
Module z3c.form.group, line 132, in update
Module z3c.form.form, line 136, in updateWidgets
Module z3c.form.field, line 254, in update
Module plone.autoform.widgets, line 82, in call

traceback_info: ParameterizedWidget, processing:
field "birthdate"
widget: <class 'senaite.core.z3cform.widgets.datetimewidget.DatetimeWidget'>
params: {'show_time': False, 'max': 'current'}
calling factory, then wrapping with FieldWidget
AttributeError: can't set attribute
```

## Desired behavior after PR is merged

No error occurs if `min` or `max` widget directives are set.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
