### PR TITLE
Fix missing interim fields in Transposed Multi Results Form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2406 Fix missing interim fields in Transposed Multi Results Form
 - #2400 Add Transposed Multi Results Form
 - #2402 Fix user cannot enter future date for DateSampled when sampling enabled
 - #2401 Fix OverflowError when calculating datetime.min date for left-hand TZs

--- a/src/senaite/core/browser/samples/multi_results_transposed.py
+++ b/src/senaite/core/browser/samples/multi_results_transposed.py
@@ -199,7 +199,15 @@ class MultiResultsTransposedView(AnalysesTransposedView):
         # the updated Analyses.
         view.contentFilter = dict(self.contentFilter)
         view.contentFilter["getAncestorsUIDs"] = [api.get_uid(sample)]
-        return view.folderitems()
+        items = view.folderitems()
+        # Interim columns are required for rendering in senaite.app.listing and
+        # are added in the Analyses View in the `folderitems` methdod.
+        # Therefore, we add the missing columns here!
+        # https://github.com/senaite/senaite.core/issues/2405
+        for col_id, col in view.columns.items():
+            if col_id not in self.columns:
+                self.columns[col_id] = col
+        return items
 
     def get_analyses(self, full_objects=False):
         """Returns sample analyses from lab poc


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/2405

## Current behavior before PR

Interim fields are missing in transposed multi-results view

## Desired behavior after PR is merged

Interim fields are rendered in transposed multi-results view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
