### PR TITLE
Fix analyses sort order in Transposed Multi Results Form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2407 Fix analyses sort order in Transposed Multi Results Form
 - #2406 Fix missing interim fields in Transposed Multi Results Form
 - #2400 Add Transposed Multi Results Form
 - #2402 Fix user cannot enter future date for DateSampled when sampling enabled

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2406 Fix missing interim fields in Transposed Multi Results Form
 - #2400 Add Transposed Multi Results Form
 - #2402 Fix user cannot enter future date for DateSampled when sampling enabled
 - #2401 Fix OverflowError when calculating datetime.min date for left-hand TZs

--- a/src/senaite/core/browser/samples/multi_results_transposed.py
+++ b/src/senaite/core/browser/samples/multi_results_transposed.py
@@ -38,6 +38,7 @@ class MultiResultsTransposedView(AnalysesTransposedView):
         self.contentFilter = {
             "portal_type": "Analysis",
             "getPointOfCapture": ["lab", "field"],
+            "sort_on": "sortable_title",
         }
 
         self.transposed = True
@@ -46,28 +47,6 @@ class MultiResultsTransposedView(AnalysesTransposedView):
 
         self.title = _("Multi Results")
         self.description = _("")
-
-        self.headers = OrderedDict()
-        self.services = OrderedDict()
-
-        self.columns = OrderedDict((
-            ("column_key", {
-                "title": "",
-                "sortable": False}),
-            ("Result", {
-                "title": _("Result"),
-                "ajax": True,
-                "sortable": False}),
-        ))
-
-        self.review_states = [
-            {
-                "id": "default",
-                "title": _("All"),
-                "custom_transitions": [],
-                "columns": self.columns.keys(),
-            },
-        ]
 
     def make_empty_folderitem(self, **kw):
         """Create a new empty item

--- a/src/senaite/core/browser/samples/multi_results_transposed.py
+++ b/src/senaite/core/browser/samples/multi_results_transposed.py
@@ -199,7 +199,15 @@ class MultiResultsTransposedView(AnalysesTransposedView):
         # the updated Analyses.
         view.contentFilter = dict(self.contentFilter)
         view.contentFilter["getAncestorsUIDs"] = [api.get_uid(sample)]
-        return view.folderitems()
+        items = view.folderitems()
+        # Interim columns are required for rendering in senaite.app.listing and
+        # are added in the Analyses View in the `folderitems` methdod.
+        # Therefore, we add the missing columns here!
+        # https://github.com/senaite/senaite.core/issues/2405
+        for col_id, col in view.columns.items():
+            if col_id not in self.columns:
+                self.columns[col_id] = col
+        return items
 
     def get_analyses(self, full_objects=False):
         """Returns sample analyses from lab poc


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/2404

## Current behavior before PR

Analyses are not sorted properly in transposed multi results form

## Desired behavior after PR is merged

Analyses are sorted properly in transposed multi results form

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
