### PR TITLE
Support DX type catalogs lookup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2408 Support DX type catalogs lookup
 - #2400 Add Transposed Multi Results Form
 - #2402 Fix user cannot enter future date for DateSampled when sampling enabled
 - #2401 Fix OverflowError when calculating datetime.min date for left-hand TZs

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -1120,7 +1120,7 @@ def get_catalogs_for(brain_or_object, default=PORTAL_CATALOG):
         raise APIError("Expected a portal_type string, got <%s>"
                        % type(brain_or_object))
 
-    # at this point the brain_or_object is a portal_type^
+    # at this point the brain_or_object is a portal_type
     portal_type = brain_or_object
 
     # check static portal_type -> catalog mapping first

--- a/src/senaite/core/catalog/__init__.py
+++ b/src/senaite/core/catalog/__init__.py
@@ -45,3 +45,75 @@ from senaite.core.catalog.setup_catalog import SetupCatalog
 from senaite.core.catalog.worksheet_catalog import \
     CATALOG_ID as WORKSHEET_CATALOG
 from senaite.core.catalog.worksheet_catalog import WorksheetCatalog
+
+CATALOG_MAPPINGS = (
+    # portal_type, catalog_ids
+    ("ARReport", [REPORT_CATALOG]),
+    ("ARTemplate", [SETUP_CATALOG]),
+    ("Analysis", [ANALYSIS_CATALOG]),
+    ("AnalysisCategory", [SETUP_CATALOG]),
+    ("AnalysisProfile", [SETUP_CATALOG]),
+    ("AnalysisRequest", [SAMPLE_CATALOG]),
+    ("AnalysisService", [SETUP_CATALOG]),
+    ("AnalysisSpec", [SETUP_CATALOG]),
+    ("Attachment", [SENAITE_CATALOG]),
+    ("AttachmentType", [SETUP_CATALOG]),
+    ("AutoImportLog", [AUTOIMPORTLOG_CATALOG]),
+    ("Batch", [SENAITE_CATALOG]),
+    ("BatchLabel", [SETUP_CATALOG]),
+    ("Calculation", [SETUP_CATALOG]),
+    ("Client", [CLIENT_CATALOG]),
+    ("Contact", [CONTACT_CATALOG]),
+    ("Container", [SETUP_CATALOG]),
+    ("ContainerType", [SETUP_CATALOG]),
+    ("Department", [SETUP_CATALOG]),
+    ("DuplicateAnalysis", [ANALYSIS_CATALOG]),
+    ("Instrument", [SETUP_CATALOG]),
+    ("InstrumentCalibration", [SETUP_CATALOG]),
+    ("InstrumentCertification", [SETUP_CATALOG]),
+    ("InstrumentLocation", [SETUP_CATALOG]),
+    ("InstrumentMaintenanceTask", [SETUP_CATALOG]),
+    ("InstrumentScheduledTask", [SETUP_CATALOG]),
+    ("InstrumentType", [SETUP_CATALOG]),
+    ("InstrumentValidation", [SETUP_CATALOG]),
+    ("Invoice", [SENAITE_CATALOG]),
+    ("LabContact", [CONTACT_CATALOG]),
+    ("LabProduct", [SETUP_CATALOG]),
+    ("Label", [SETUP_CATALOG]),
+    ("Laboratory", [SETUP_CATALOG]),
+    ("Manufacturer", [SETUP_CATALOG]),
+    ("Method", [SETUP_CATALOG]),
+    ("Multifile", [SETUP_CATALOG]),
+    ("Preservation", [SETUP_CATALOG]),
+    ("Pricelist", [SETUP_CATALOG]),
+    ("ReferenceAnalysis", [ANALYSIS_CATALOG]),
+    ("ReferenceDefinition", [SETUP_CATALOG]),
+    ("ReferenceSample", [SENAITE_CATALOG]),
+    ("RejectAnalysis", [ANALYSIS_CATALOG]),
+    ("SampleCondition", [SETUP_CATALOG]),
+    ("SampleMatrix", [SETUP_CATALOG]),
+    ("SamplePoint", [SETUP_CATALOG]),
+    ("SampleType", [SETUP_CATALOG]),
+    ("SamplingDeviation", [SETUP_CATALOG]),
+    ("StorageLocation", [SETUP_CATALOG]),
+    ("SubGroup", [SETUP_CATALOG]),
+    ("Supplier", [SETUP_CATALOG]),
+    ("SupplierContact", [CONTACT_CATALOG]),
+    ("Worksheet", [WORKSHEET_CATALOG]),
+    ("WorksheetTemplate", [SETUP_CATALOG]),
+)
+
+def get_catalogs_by_type(portal_type):
+    """Return the mapped catalogs by type
+
+    TODO: Provide registry setting for this mapping lookup
+
+    :param portal_type: The portal type to look up
+    """
+    if not isinstance(portal_type, str):
+        raise TypeError("Expected string type, got <%s>" % type(portal_type))
+    mapping = dict(CATALOG_MAPPINGS)
+    catalogs = mapping.get(portal_type)
+    if not catalogs:
+        return []
+    return catalogs

--- a/src/senaite/core/setuphandlers.py
+++ b/src/senaite/core/setuphandlers.py
@@ -35,16 +35,8 @@ from senaite.core.api.catalog import del_index
 from senaite.core.api.catalog import get_columns
 from senaite.core.api.catalog import get_indexes
 from senaite.core.api.catalog import reindex_index
-from senaite.core.catalog import ANALYSIS_CATALOG
 from senaite.core.catalog import AUDITLOG_CATALOG
-from senaite.core.catalog import AUTOIMPORTLOG_CATALOG
-from senaite.core.catalog import CLIENT_CATALOG
-from senaite.core.catalog import CONTACT_CATALOG
-from senaite.core.catalog import REPORT_CATALOG
-from senaite.core.catalog import SAMPLE_CATALOG
-from senaite.core.catalog import SENAITE_CATALOG
-from senaite.core.catalog import SETUP_CATALOG
-from senaite.core.catalog import WORKSHEET_CATALOG
+from senaite.core.catalog import CATALOG_MAPPINGS
 from senaite.core.catalog import AnalysisCatalog
 from senaite.core.catalog import AuditlogCatalog
 from senaite.core.catalog import AutoImportLogCatalog
@@ -126,63 +118,6 @@ INDEXES = (
 
 COLUMNS = (
     # catalog, column name
-)
-
-CATALOG_MAPPINGS = (
-    # portal_type, catalog_ids
-    ("ARReport", [REPORT_CATALOG]),
-    ("ARTemplate", [SETUP_CATALOG]),
-    ("Analysis", [ANALYSIS_CATALOG]),
-    ("AnalysisCategory", [SETUP_CATALOG]),
-    ("AnalysisProfile", [SETUP_CATALOG]),
-    ("AnalysisRequest", [SAMPLE_CATALOG]),
-    ("AnalysisService", [SETUP_CATALOG]),
-    ("AnalysisSpec", [SETUP_CATALOG]),
-    ("Attachment", [SENAITE_CATALOG]),
-    ("AttachmentType", [SETUP_CATALOG]),
-    ("AutoImportLog", [AUTOIMPORTLOG_CATALOG]),
-    ("Batch", [SENAITE_CATALOG]),
-    ("BatchLabel", [SETUP_CATALOG]),
-    ("Calculation", [SETUP_CATALOG]),
-    ("Client", [CLIENT_CATALOG]),
-    ("Contact", [CONTACT_CATALOG]),
-    ("Container", [SETUP_CATALOG]),
-    ("ContainerType", [SETUP_CATALOG]),
-    ("Department", [SETUP_CATALOG]),
-    ("DuplicateAnalysis", [ANALYSIS_CATALOG]),
-    ("Instrument", [SETUP_CATALOG]),
-    ("InstrumentCalibration", [SETUP_CATALOG]),
-    ("InstrumentCertification", [SETUP_CATALOG]),
-    ("InstrumentLocation", [SETUP_CATALOG]),
-    ("InstrumentMaintenanceTask", [SETUP_CATALOG]),
-    ("InstrumentScheduledTask", [SETUP_CATALOG]),
-    ("InstrumentType", [SETUP_CATALOG]),
-    ("InstrumentValidation", [SETUP_CATALOG]),
-    ("Invoice", [SENAITE_CATALOG]),
-    ("LabContact", [CONTACT_CATALOG]),
-    ("LabProduct", [SETUP_CATALOG]),
-    ("Label", [SETUP_CATALOG]),
-    ("Laboratory", [SETUP_CATALOG]),
-    ("Manufacturer", [SETUP_CATALOG]),
-    ("Method", [SETUP_CATALOG]),
-    ("Multifile", [SETUP_CATALOG]),
-    ("Preservation", [SETUP_CATALOG]),
-    ("Pricelist", [SETUP_CATALOG]),
-    ("ReferenceAnalysis", [ANALYSIS_CATALOG]),
-    ("ReferenceDefinition", [SETUP_CATALOG]),
-    ("ReferenceSample", [SENAITE_CATALOG]),
-    ("RejectAnalysis", [ANALYSIS_CATALOG]),
-    ("SampleCondition", [SETUP_CATALOG]),
-    ("SampleMatrix", [SETUP_CATALOG]),
-    ("SamplePoint", [SETUP_CATALOG]),
-    ("SampleType", [SETUP_CATALOG]),
-    ("SamplingDeviation", [SETUP_CATALOG]),
-    ("StorageLocation", [SETUP_CATALOG]),
-    ("SubGroup", [SETUP_CATALOG]),
-    ("Supplier", [SETUP_CATALOG]),
-    ("SupplierContact", [CONTACT_CATALOG]),
-    ("Worksheet", [WORKSHEET_CATALOG]),
-    ("WorksheetTemplate", [SETUP_CATALOG]),
 )
 
 REMOVE_PORTAL_CATALOG_INDEXES = (

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -768,6 +768,19 @@ Dexterity contents that provide IMulitCatalogBehavior should work as well:
     [<CatalogTool at /plone/portal_catalog>]
 
 
+Getting the FTI for a portal type
+.................................
+
+This function provides the dynamic type information for a given portal type:
+
+    >>> api.get_fti("Client")
+    <DynamicViewTypeInformation at /plone/portal_types/Client>
+
+    >>> api.get_fti("Label")
+    <DexterityFTI at /plone/portal_types/Label>
+
+
+
 Getting an Attribute of an Object
 .................................
 

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -744,17 +744,28 @@ Or provide a correct query::
 Getting the registered Catalogs
 ...............................
 
-SENAITE LIMS uses multiple catalogs registered via the Archetype Tool. This
-function returns a list of registered catalogs for a brain or object::
+SENAITE LIMS uses **multiple catalogs** for different content types.
+This function returns a list of registered catalogs for a brain, object, UID or portal_type.
+
+Get the mapped catalogs for an AT content type:
 
     >>> api.get_catalogs_for(client)
-    [...]
+    [<ClientCatalog at /plone/senaite_catalog_client>]
 
-    >>> api.get_catalogs_for(instrument1)
-    [...]
+Passing in the portal_type should return the same:
 
-    >>> api.get_catalogs_for(analysiscategory1)
-    [...]
+    >>> api.get_catalogs_for(api.get_portal_type(client))
+    [<ClientCatalog at /plone/senaite_catalog_client>]
+
+Even if we pass in the UID, we should get the same results:
+
+    >>> api.get_catalogs_for(api.get_uid(client))
+    [<ClientCatalog at /plone/senaite_catalog_client>]
+
+Dexterity contents that provide IMulitCatalogBehavior should work as well:
+
+    >>> api.get_catalogs_for(senaite_setup)
+    [<CatalogTool at /plone/portal_catalog>]
 
 
 Getting an Attribute of an Object


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds DX type support to the `get_catalogs_for` API function.

This also fixes an issue in `senaite.jsonapi`, where DX type lookups returned no items!

## Current behavior before PR

Only catalogs of AT based contents were considered

## Desired behavior after PR is merged

Catalogs of AT and DX based contents are looked up accordingly.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
