### PR TITLE
Fix empty results get interpreted as 0.0 by 2-Dimensional-CSV importer

### DIFF
--- a/src/senaite/core/exportimport/instruments/generic/samples/2dimension.csv
+++ b/src/senaite/core/exportimport/instruments/generic/samples/2dimension.csv
@@ -1,4 +1,4 @@
 ,Pentachloronitrobenzene,Mg,Ca,pest1,pest2,pest3,end
-1-0001-R01,-----,2,,1,1,1,
+1-0001-R01,-----,2,0,1,1,1,
 1-0002-R01,ND,5,6,0,0,0,
 end,,,,,,,

--- a/src/senaite/core/exportimport/instruments/generic/two_dimension.py
+++ b/src/senaite/core/exportimport/instruments/generic/two_dimension.py
@@ -251,12 +251,19 @@ class TwoDimensionCSVParser(InstrumentCSVResultsFileParser):
 
     def get_result(self, column_name, result, line):
         result = str(result)
-        if result.startswith('--') or result == '' or result == 'ND':
+
+        # allow empty values
+        if len(result) == 0:
+            return
+
+        # XXX: Probably this does not belong to here either
+        if result.startswith("--") or result == "ND":
             return 0.0
 
         if api.is_floatable(result):
             result = api.to_float(result)
             return result > 0.0 and result or 0.0
+
         self.err("No valid number ${result} in column (${column_name})",
                  mapping={"result": result,
                           "column_name": column_name},

--- a/src/senaite/core/tests/files/instruments/generic.two_dimension.csv
+++ b/src/senaite/core/tests/files/instruments/generic.two_dimension.csv
@@ -1,4 +1,4 @@
 ,Pentachloronitrobenzene,Mg,Ca,pest1,pest2,pest3,end
-H2O-0001,-----,2,,1,1,1,
+H2O-0001,-----,2,0,1,1,1,
 AP-0002,ND,5,6,0,0,0,
 end,,,,,,,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an edge case where empty values in the import CSV get set to `0.0`.

## Example

import.csv:

```csv
ID,ALT,AST,TIBC,end
0000688,15,,45,
end
```

<img width="647" alt="Import Log" src="https://github.com/senaite/senaite.core/assets/713193/77dd7b06-d005-409f-8392-48ba185dcd17">


<img width="931" alt="0000688 Import" src="https://github.com/senaite/senaite.core/assets/713193/2fd47697-455f-4775-a55d-add33370d33d">

## Current behavior before PR

Empty results get interpreted as `0.0` when using the 2-Dimension-CSV Interface

## Desired behavior after PR is merged

Empty results are kept empty when using the 2-Dimension-CSV Interface

<img width="634" alt="Import Log 2" src="https://github.com/senaite/senaite.core/assets/713193/410e1bb3-fd81-4a9e-903e-7516cef987e2">
<img width="1006" alt="0000689 Import" src="https://github.com/senaite/senaite.core/assets/713193/82681699-54c9-402c-ba5e-bcfe325dc04e">



--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
