### PR TITLE
Fix order of choices for interims on data entry is not preserved

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2410 Fix order of choices for interims on data entry is not preserved
 - #2408 Support DX type catalogs lookup
 - #2407 Fix analyses sort order in Transposed Multi Results Form
 - #2406 Fix missing interim fields in Transposed Multi Results Form

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -1094,7 +1094,8 @@ class AnalysesView(ListingView):
 
                 # Get the {value:text} dict
                 choices = choices.split("|")
-                choices = dict(map(lambda ch: ch.strip().split(":"), choices))
+                choices = map(lambda ch: ch.strip().split(":"), choices)
+                choices = OrderedDict(choices)
 
                 # Generate the display list
                 # [{"ResultValue": value, "ResultText": text},]


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the order of options from interim fields is preserved when rendering the select or similar components

## Current behavior before PR

The order of options is not preserved

![Captura de 2023-10-20 09-46-39](https://github.com/senaite/senaite.core/assets/832627/eadc32f6-4169-43be-b4a7-be2ee941a475)

## Desired behavior after PR is merged

The order of options is preserved

![Captura de 2023-10-20 09-47-25](https://github.com/senaite/senaite.core/assets/832627/4524a03e-02a4-4d23-bfa7-24277dec92ba)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
