### PR TITLE
Layered listing searchable text adapter lookup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2412 Layered listing searchable text adapter lookup
 - #2409 Fix empty results get interpreted as 0.0 by 2-Dimensional-CSV importer
 - #2410 Fix order of choices for interims on data entry is not preserved
 - #2408 Support DX type catalogs lookup

--- a/src/senaite/core/catalog/indexer/sample.py
+++ b/src/senaite/core/catalog/indexer/sample.py
@@ -22,6 +22,7 @@ from bika.lims import api
 from bika.lims.interfaces import IAnalysisRequest
 from bika.lims.interfaces import IListingSearchableTextProvider
 from plone.indexer import indexer
+from senaite.core import logger
 from senaite.core.catalog import SAMPLE_CATALOG
 from senaite.core.interfaces import ISampleCatalog
 from zope.component import getAdapters
@@ -118,10 +119,24 @@ def listing_searchable_text(instance):
         batch = obj.getBatch()
         entries.add(batch.getId() if batch else '')
 
+    catalog = api.get_tool(SAMPLE_CATALOG)
+    text_providers = getAdapters((instance, api.get_request(), catalog),
+                                 IListingSearchableTextProvider)
+    # BBB
+    bbb_text_providers = getAdapters((instance, catalog),
+                                     IListingSearchableTextProvider)
+
+    # combine the adapters for backwards compatibility
+    adapters = list(text_providers) + list(bbb_text_providers)
+
     # Allow to extend search tokens via adapters
-    for name, adapter in getAdapters((instance, api.get_tool(SAMPLE_CATALOG)),
-                                     IListingSearchableTextProvider):
-        value = adapter()
+    for name, adapter in adapters:
+        try:
+            value = adapter()
+        except (AttributeError, TypeError, api.APIError) as exc:
+            logger.error(exc)
+            value = []
+
         if isinstance(value, (list, tuple)):
             values = map(api.to_searchable_text_metadata, value)
             entries.update(values)

--- a/src/senaite/core/catalog/utils.py
+++ b/src/senaite/core/catalog/utils.py
@@ -24,6 +24,7 @@ from bika.lims.interfaces import IListingSearchableTextProvider
 from Products.CMFPlone.CatalogTool import \
     sortable_title as plone_sortable_title
 from Products.CMFPlone.utils import safe_callable
+from senaite.core import logger
 from zope.component import getAdapters
 
 
@@ -65,10 +66,23 @@ def get_searchable_text_tokens(instance, catalog_name,
         field_value = api.to_searchable_text_metadata(field_value)
         entries.add(field_value)
 
+    text_providers = getAdapters((instance, api.get_request(), catalog),
+                                 IListingSearchableTextProvider)
+    # BBB
+    bbb_text_providers = getAdapters((instance, catalog),
+                                     IListingSearchableTextProvider)
+
+    # combine the adapters for backwards compatibility
+    adapters = list(text_providers) + list(bbb_text_providers)
+
     # Extend metadata entries with pluggable text providers
-    for name, adapter in getAdapters((instance, catalog),
-                                     IListingSearchableTextProvider):
-        value = adapter()
+    for name, adapter in adapters:
+        try:
+            value = adapter()
+        except (AttributeError, TypeError, api.APIError) as exc:
+            logger.error(exc)
+            value = []
+
         if isinstance(value, (list, tuple)):
             values = map(api.to_searchable_text_metadata, value)
             entries.update(values)

--- a/src/senaite/core/catalog/utils.py
+++ b/src/senaite/core/catalog/utils.py
@@ -19,7 +19,6 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims import api
-from bika.lims import logger
 from bika.lims.interfaces import IListingSearchableTextProvider
 from Products.CMFPlone.CatalogTool import \
     sortable_title as plone_sortable_title


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the signature for listing searchable text adapters to include the request layer as well:

```python
text_providers = getAdapters((instance, api.get_request(), catalog),
                             IListingSearchableTextProvider)
```
This avoids an adapter registration clash with add-ons that are not installed:

```
For: ('adapter', (<InterfaceClass bika.lims.interfaces.IAnalysisRequest>, <InterfaceClass senaite.core.interfaces.catalog.ISampleCatalog>), <InterfaceClass bika.lims.interfaces.IListingSearchableTextProvider>, u'')
    File "senaite/patient/catalog/indexer/configure.zcml", line 10.2-14.55
        <adapter
            for="bika.lims.interfaces.IAnalysisRequest
                 senaite.core.interfaces.ISampleCatalog"
            provides="bika.lims.interfaces.IListingSearchableTextProvider"
            factory=".sample.ListingSearchableTextProvider"/>
    File "my.lims/src/my/lims/adapters/configure.zcml", line 8.4-8.72
          <adapter factory=".searchable_text.ListingSearchableTextProvider" />
```

## Current behavior before PR

Searchable text adapters are called from any add-on (even if not installed).

## Desired behavior after PR is merged

Searchable text adapters are called only for active add-ons and are registered with the request as well.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
