### PR TITLE
Fix missing empty selection in result option choices when no default value is set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2414 Fix missing empty selection in result option choices when no default value is set
 - #2413 Fix select custom value for queryselect widget
 - #2412 Layered listing searchable text adapter lookup
 - #2409 Fix empty results get interpreted as 0.0 by 2-Dimensional-CSV importer

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -1089,19 +1089,26 @@ class AnalysesView(ListingView):
             # Does interim's results list needs to be rendered?
             choices = interim_field.get("choices")
             if choices:
-                # Process the value as a list
-                interim_value = api.to_list(interim_value)
 
                 # Get the {value:text} dict
                 choices = choices.split("|")
                 choices = map(lambda ch: ch.strip().split(":"), choices)
                 choices = OrderedDict(choices)
 
+                # check if we have a valid default value
+                if choices.get(interim_value) is not None:
+                    value = interim_value
+                else:
+                    # allow empty selection and flush default value
+                    value = ""
+                    interim_allow_empty = True
+
                 # Generate the display list
                 # [{"ResultValue": value, "ResultText": text},]
                 headers = ["ResultValue", "ResultText"]
                 dl = map(lambda it: dict(zip(headers, it)), choices.items())
-                # Allow empty selection by adding an empty record to the list
+
+                # Allow empty selection if allowed
                 if interim_allow_empty:
                     empty = {"ResultValue": "", "ResultText": ""}
                     dl = [empty] + list(dl)
@@ -1109,7 +1116,7 @@ class AnalysesView(ListingView):
                 item.setdefault("choices", {})[interim_keyword] = dl
 
                 # Set the text as the formatted value
-                texts = [choices.get(v, "") for v in interim_value]
+                texts = [choices.get(v, "") for v in api.to_list(value)]
                 text = "<br/>".join(filter(None, texts))
                 interim_field["formatted_value"] = text
 
@@ -1121,10 +1128,10 @@ class AnalysesView(ListingView):
 
             elif self.is_multi_interim(interim_field):
                 # Process the value as a list
-                interim_value = api.to_list(interim_value)
+                value = api.to_list(interim_value)
 
                 # Set the text as the formatted value
-                text = "<br/>".join(filter(None, interim_value))
+                text = "<br/>".join(filter(None, value))
                 interim_field["formatted_value"] = text
 
                 if not is_editable:

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -1064,7 +1064,7 @@ class AnalysesView(ListingView):
         # Copy to prevent to avoid persistent changes
         interim_fields = deepcopy(interim_fields)
         for interim_field in interim_fields:
-            interim_keyword = interim_field.get('keyword', '')
+            interim_keyword = interim_field.get("keyword", "")
             if not interim_keyword:
                 continue
 

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -1097,20 +1097,14 @@ class AnalysesView(ListingView):
                 self.interim_columns[interim_keyword] = interim_title
 
             # Does interim's results list needs to be rendered?
-            choices = interim_field.get("choices")
+            choices = self.get_interim_choices(interim_field)
             if choices:
+                multi = self.is_multi_interim(interim_field)
 
-                # Get the {value:text} dict
-                choices = choices.split("|")
-                choices = map(lambda ch: ch.strip().split(":"), choices)
-                choices = OrderedDict(choices)
-
-                # check if we have a valid default value
-                if choices.get(interim_value) is not None:
-                    value = interim_value
-                else:
+                # Ensure empty option is available if no default value is set
+                if not interim_value and not multi:
                     # allow empty selection and flush default value
-                    value = ""
+                    interim_value = ""
                     interim_allow_empty = True
 
                 # Generate the display list
@@ -1126,22 +1120,8 @@ class AnalysesView(ListingView):
                 item.setdefault("choices", {})[interim_keyword] = dl
 
                 # Set the text as the formatted value
-                texts = [choices.get(v, "") for v in api.to_list(value)]
+                texts = [choices.get(v, "") for v in api.to_list(interim_value)]
                 text = "<br/>".join(filter(None, texts))
-                interim_field["formatted_value"] = text
-
-                if not is_editable:
-                    # Display the text instead of the value
-                    interim_field["value"] = text
-
-                item[interim_keyword] = interim_field
-
-            elif self.is_multi_interim(interim_field):
-                # Process the value as a list
-                value = api.to_list(interim_value)
-
-                # Set the text as the formatted value
-                text = "<br/>".join(filter(None, value))
                 interim_field["formatted_value"] = text
 
                 if not is_editable:

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -1024,6 +1024,16 @@ class AnalysesView(ListingView):
         """
         return api.to_list(value)
 
+    def get_interim_choices(self, interim):
+        """Parse the interim choices field
+        """
+        choices = interim.get("choices")
+        if not choices:
+            return None
+        items = choices.split("|")
+        pairs = map(lambda item: item.strip().split(":"), items)
+        return OrderedDict(pairs)
+
     def _folder_item_calculation(self, analysis_brain, item):
         """Set the analysis' calculation and interims to the item passed in.
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue for service result variables when choices are used, no default value is given and "Allow empty" is not allowed:

<img width="1708" src="https://github.com/senaite/senaite.core/assets/713193/aba0c33f-b14a-4a6c-81dc-52b7685b6562">

## Current behavior before PR

The choices in an analysis display the first result option, but it is not selected.
Therefore, the result can not be submitted.

<img width="685" src="https://github.com/senaite/senaite.core/assets/713193/7e97adc9-5f15-45b8-85c2-2a0549cd95a9">

## Desired behavior after PR is merged

The choices in an analysis display an empty result option, and a valid option need to be selected manually.

<img width="642" src="https://github.com/senaite/senaite.core/assets/713193/4b6bf712-b58f-49b8-af38-3d8d6617f45e">




--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
