### PR TITLE
Fix sample specs get overwritten on manage analyses save

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2415 Fix sample specs get overwritten on manage analyses save
 - #2413 Fix select custom value for queryselect widget
 - #2412 Layered listing searchable text adapter lookup
 - #2409 Fix empty results get interpreted as 0.0 by 2-Dimensional-CSV importer

--- a/src/bika/lims/browser/workflow/analysisrequest.py
+++ b/src/bika/lims/browser/workflow/analysisrequest.py
@@ -439,10 +439,17 @@ class WorkflowActionSaveAnalysesAdapter(WorkflowActionGenericAdapter):
         hidden = map(lambda o: {
             "uid": api.get_uid(o), "hidden": self.is_hidden(o)
         }, services)
-        specs = map(lambda service: self.get_specs(service), services)
+
+        # Do not overwrite default result ranges set throuh sample
+        # specification field unless the edition of specs at analysis
+        # level is explicitely allowed
+        specs = []
+        if self.is_ar_specs_enabled:
+            specs = map(lambda service: self.get_specs(service), services)
 
         # Set new analyses to the sample
         sample.setAnalysisServicesSettings(hidden)
+        import pdb;pdb.set_trace()
         sample.setAnalyses(uids, prices=prices, specs=specs, hidden=hidden)
 
         # Just in case new analyses have been added while the Sample was in a
@@ -458,6 +465,14 @@ class WorkflowActionSaveAnalysesAdapter(WorkflowActionGenericAdapter):
 
         # Redirect the user to success page
         self.success([sample])
+
+    @property
+    def is_ar_specs_enabled(self):
+        """Returns whether the assignment of specs at analysis level within
+        sample context is enabled or not
+        """
+        setup = api.get_setup()
+        return setup.getEnableARSpecs()
 
     def is_hidden(self, service):
         """Returns whether the request Hidden param for the given obj is True

--- a/src/bika/lims/browser/workflow/analysisrequest.py
+++ b/src/bika/lims/browser/workflow/analysisrequest.py
@@ -440,7 +440,7 @@ class WorkflowActionSaveAnalysesAdapter(WorkflowActionGenericAdapter):
             "uid": api.get_uid(o), "hidden": self.is_hidden(o)
         }, services)
 
-        # Do not overwrite default result ranges set throuh sample
+        # Do not overwrite default result ranges set through sample
         # specification field unless the edition of specs at analysis
         # level is explicitely allowed
         specs = []
@@ -449,7 +449,6 @@ class WorkflowActionSaveAnalysesAdapter(WorkflowActionGenericAdapter):
 
         # Set new analyses to the sample
         sample.setAnalysisServicesSettings(hidden)
-        import pdb;pdb.set_trace()
         sample.setAnalyses(uids, prices=prices, specs=specs, hidden=hidden)
 
         # Just in case new analyses have been added while the Sample was in a


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request prevents the message "*Ranges for some analyses are different from the Specification*" to be displayed when adding analyses manually on a Sample with specifications already set and with the setting "*Enable Sample Specifications*" disabled. The message "result range is different from specification" is also displayed next to analyses.

If the setting "*Enable Sample Specifications*" is disabled, the system must not overwrite the specifications set for a given analysis through the "Specification" field.

![276761264-4804fd54-45f4-4fbc-a4a4-676790a71a54](https://github.com/senaite/senaite.core/assets/832627/a3a4b93d-096d-46c8-97bb-0fe0686fee54)

![276761487-10978fb7-172f-47ee-bcc8-e8b6c3e3b252](https://github.com/senaite/senaite.core/assets/832627/82577a46-db0a-4d2d-83b5-3f84df4024eb)


## Current behavior before PR

Sample results ranges are overwritten when adding analyses manually, even though the setting "*Enable Sample Specifications*" is disabled.

## Desired behavior after PR is merged

Sample results ranges are not overwritten when adding analyses manually and with the setting "*Enable Sample Specifications*" disabled.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
