### PR TITLE
Fix Template select empties existing Sample Type-, Point- and Profile values in sample add form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2416 Fix Template select empties existing Sample Type-, Point- and Profile values in sample add form
 - #2414 Fix missing empty selection in result option choices when no default value is set
 - #2415 Fix sample specs get overwritten on manage analyses save
 - #2413 Fix select custom value for queryselect widget

--- a/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
@@ -577,19 +577,19 @@
       }
       this.applied_templates[arnum] = template_uid;
       field = $("#SampleType-" + arnum);
-      value = this.get_reference_field_value(value);
+      value = this.get_reference_field_value(field);
       if (!value) {
         uid = template.sample_type_uid;
         this.set_reference_field(field, uid);
       }
       field = $("#SamplePoint-" + arnum);
-      value = this.get_reference_field_value(value);
+      value = this.get_reference_field_value(field);
       if (!value) {
         uid = template.sample_point_uid;
         this.set_reference_field(field, uid);
       }
       field = $("#Profiles-" + arnum);
-      value = this.get_reference_field_value(value);
+      value = this.get_reference_field_value(field);
       if (!value) {
         uid = template.analysis_profile_uid;
         this.set_reference_field(field, uid);

--- a/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -550,21 +550,21 @@ class window.AnalysisRequestAdd
 
     # set the sample type
     field = $("#SampleType-#{arnum}")
-    value = @get_reference_field_value(value)
+    value = @get_reference_field_value(field)
     if not value
       uid = template.sample_type_uid
       @set_reference_field field, uid
 
     # set the sample point
     field = $("#SamplePoint-#{arnum}")
-    value = @get_reference_field_value(value)
+    value = @get_reference_field_value(field)
     if not value
       uid = template.sample_point_uid
       @set_reference_field field, uid
 
     # set the analysis profile
     field = $("#Profiles-#{arnum}")
-    value = @get_reference_field_value(value)
+    value = @get_reference_field_value(field)
     if not value
       uid = template.analysis_profile_uid
       @set_reference_field field, uid


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue in the Sample Add Form when a sample with an existing template is copied or when a template is selected after one of the following fields was set:

- Sample Type
- Sample Point
- Profiles

## Current behavior before PR

Existing values for `SampleType`, `SamplePoint` and `AnalysisProfile` fields are flushed

## Desired behavior after PR is merged

Existing values for `SampleType`, `SamplePoint` and `AnalysisProfile` fields are retained


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
