### PR TITLE
Check permission when automatic sample reception is enabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2419 Check permission when automatic sample reception is enabled
 - #2416 Fix Template select empties existing Sample Type-, Point- and Profile values in sample add form
 - #2414 Fix missing empty selection in result option choices when no default value is set
 - #2415 Fix sample specs get overwritten on manage analyses save

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -142,7 +142,7 @@ def create_analysisrequest(client, request, values, analyses=None,
             changeWorkflowState(ar, SAMPLE_WORKFLOW, "to_be_sampled",
                                 action="to_be_sampled")
         elif setup.getAutoreceiveSamples():
-            receive_sample(ar)
+            receive_sample(ar, check_permission=True)
         else:
             changeWorkflowState(ar, SAMPLE_WORKFLOW, "sample_due",
                                 action="no_sampling_workflow")

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2519</version>
+  <version>2520</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
+++ b/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
@@ -121,7 +121,7 @@
     <permission-map name="senaite.core: Transition: Invalidate" acquired="False"/>
     <permission-map name="senaite.core: Transition: Preserve Sample" acquired="False"/>
     <permission-map name="senaite.core: Transition: Publish Results" acquired="False"/>
-    <permission-map name="senaite.core: Transition: Receive Sample" acquired="False"/>
+    <permission-map name="senaite.core: Transition: Receive Sample" acquired="True"/>
     <permission-map name="senaite.core: Transition: Reject Sample" acquired="False"/>
     <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
     <permission-map name="senaite.core: Transition: Sample Sample" acquired="False"/>

--- a/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
+++ b/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
@@ -214,6 +214,9 @@
     <permission-map name="senaite.core: Transition: Preserve Sample" acquired="False"/>
     <permission-map name="senaite.core: Transition: Publish Results" acquired="False"/>
     <permission-map name="senaite.core: Transition: Receive Sample" acquired="False"/>
+    <!-- This is required to enable permission checking during sample creation
+         if automatic sample reception is enabled:
+         https://github.com/senaite/senaite.core/pull/2419 -->
     <permission-map name="senaite.core: Transition: Reject Sample" acquired="True"/>
     <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
     <permission-map name="senaite.core: Transition: Sample Sample" acquired="True"/>

--- a/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
+++ b/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
@@ -121,6 +121,9 @@
     <permission-map name="senaite.core: Transition: Invalidate" acquired="False"/>
     <permission-map name="senaite.core: Transition: Preserve Sample" acquired="False"/>
     <permission-map name="senaite.core: Transition: Publish Results" acquired="False"/>
+    <!-- This is required to enable permission checking during sample creation
+         if automatic sample reception is enabled:
+         https://github.com/senaite/senaite.core/pull/2419 -->
     <permission-map name="senaite.core: Transition: Receive Sample" acquired="True"/>
     <permission-map name="senaite.core: Transition: Reject Sample" acquired="False"/>
     <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
@@ -214,9 +217,6 @@
     <permission-map name="senaite.core: Transition: Preserve Sample" acquired="False"/>
     <permission-map name="senaite.core: Transition: Publish Results" acquired="False"/>
     <permission-map name="senaite.core: Transition: Receive Sample" acquired="False"/>
-    <!-- This is required to enable permission checking during sample creation
-         if automatic sample reception is enabled:
-         https://github.com/senaite/senaite.core/pull/2419 -->
     <permission-map name="senaite.core: Transition: Reject Sample" acquired="True"/>
     <permission-map name="senaite.core: Transition: Retract" acquired="False"/>
     <permission-map name="senaite.core: Transition: Sample Sample" acquired="True"/>

--- a/src/senaite/core/upgrade/v02_05_000.zcml
+++ b/src/senaite/core/upgrade/v02_05_000.zcml
@@ -4,6 +4,14 @@
     i18n_domain="senaite.core">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.5.0: Import Workflow"
+      description="Update Managed Permissions of Sample Workflow"
+      source="2519"
+      destination="2520"
+      handler=".v02_05_000.import_workflow"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.5.0: Reindex control analyses"
       description="Reindex all control analyses to fix stale `getReferenceAnalysesGroupID` index"
       source="2518"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/2418

This PR fixes a permission issue when automatic sample reception is enabled in the setup

## Current behavior before PR

Samples are always transitioned to `sample_receive`, no matter if the user has the permission `senaite.core: Transition: Receive Sample` granted or not.

## Desired behavior after PR is merged

Samples are only transitioned to `sample_receive` if the user has the permission `senaite.core: Transition: Receive Sample` granted.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
