### PR TITLE
Fix sample remains in "registered" status after creation when user cannot receive

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2424 Fix sample in "registered" after creation when user cannot receive
 - #2421 Fix hanging sampletype listing view in setup
 - #2420 Fix page reload in multi results classic view
 - #2419 Check permission when automatic sample reception is enabled

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -137,13 +137,18 @@ def create_analysisrequest(client, request, values, analyses=None,
 
     if not IReceived.providedBy(ar):
         setup = api.get_setup()
-        # Sampling is required
         if ar.getSamplingRequired():
+            # sample has not been collected yet
             changeWorkflowState(ar, SAMPLE_WORKFLOW, "to_be_sampled",
                                 action="to_be_sampled")
-        elif setup.getAutoreceiveSamples():
-            receive_sample(ar, check_permission=True)
+
+        elif setup.getAutoreceiveSamples() and can_receive(ar):
+            # auto-receive the sample, but only if the user (that might be
+            # a client) has enough privileges. Otherwise, sample_due
+            receive_sample(ar)
+
         else:
+            # sample_due is the default initial status of the sample
             changeWorkflowState(ar, SAMPLE_WORKFLOW, "sample_due",
                                 action="no_sampling_workflow")
 

--- a/src/senaite/core/tests/doctests/SampleAutoReceive.rst
+++ b/src/senaite/core/tests/doctests/SampleAutoReceive.rst
@@ -1,0 +1,104 @@
+Sample - Auto-receive
+---------------------
+
+When the setup setting "Auto-receive samples" is enabled, the system
+automatically transitions the sample to "received" status on creation, as long
+as the user has the permission `senaite.core: Transition: Receive` granted.
+
+Test Setup
+..........
+
+Running this test from the buildout directory:
+
+    bin/test -t SampleAutoReceive
+
+Needed Imports:
+
+    >>> from bika.lims import api
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+    >>> from DateTime import DateTime
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+
+Functional Helpers:
+
+    >>> def new_sample(services):
+    ...     values = {
+    ...         'Client': client.UID(),
+    ...         'Contact': contact.UID(),
+    ...         'DateSampled': date_now,
+    ...         'SampleType': sampletype.UID()}
+    ...     uids = map(api.get_uid, services)
+    ...     sample = create_analysisrequest(client, request, values, uids)
+    ...     return sample
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = portal.bika_setup
+    >>> date_now = DateTime().strftime("%Y-%m-%d")
+
+Create some baseline objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
+    >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH", MemberDiscountApplies=True)
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(setup.bika_sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.bika_departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = api.create(setup.bika_analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> Cu = api.create(setup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID(), Accredited=True)
+    >>> Fe = api.create(setup.bika_analysisservices, "AnalysisService", title="Iron", Keyword="Fe", Price="10", Category=category.UID())
+    >>> Au = api.create(setup.bika_analysisservices, "AnalysisService", title="Gold", Keyword="Au", Price="20", Category=category.UID())
+
+
+Sample auto-receive enabled
+...........................
+
+This test validates that when "Auto-receive samples" setting is enabled, the
+sample **does** transition automatically to "received" status.
+
+Enable the automatic reception of samples:
+
+    >>> setup.setAutoreceiveSamples(True)
+    >>> setup.getAutoreceiveSamples()
+    True
+
+Create a Sample:
+
+    >>> sample = new_sample([Cu, Fe, Au])
+
+The status of the analyses is "received":
+
+    >>> api.get_review_status(sample)
+    'sample_received'
+
+
+Sample auto-receive disabled
+.................................
+
+This test validates that when "Auto-receive samples" setting is disabled, the
+sample does not transition automatically to "received" status.
+
+Disable the automatic reception of samples:
+
+    >>> setup.setAutoreceiveSamples(False)
+    >>> setup.getAutoreceiveSamples()
+    False
+
+Create a Sample:
+
+    >>> sample = new_sample([Cu, Fe, Au])
+
+The sample remains in "sample_due" status:
+
+    >>> api.get_review_status(sample)
+    'sample_due'
+
+Manual reception of the sample is required:
+
+    >>> success = do_action_for(sample, "receive")
+    >>> api.get_review_status(sample)
+    'sample_received'

--- a/src/senaite/core/tests/doctests/SampleAutoReceive.rst
+++ b/src/senaite/core/tests/doctests/SampleAutoReceive.rst
@@ -15,6 +15,9 @@ Running this test from the buildout directory:
 Needed Imports:
 
     >>> from bika.lims import api
+    >>> from bika.lims.api.security import get_valid_roles_for
+    >>> from bika.lims.api.security import revoke_permission_for
+    >>> from bika.lims.permissions import TransitionReceiveSample
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
     >>> from DateTime import DateTime
@@ -102,3 +105,32 @@ Manual reception of the sample is required:
     >>> success = do_action_for(sample, "receive")
     >>> api.get_review_status(sample)
     'sample_received'
+
+
+Sample auto-receive enabled, but user without enough privileges
+...............................................................
+
+This test validates that when "Auto-receive samples" setting is enabled, but
+the user does not have enough the permission
+`senaite.core: Transition: Receive` granted, the sample does not transition
+automatically to "received" status but to "sample_due".
+
+Enable the automatic reception of samples:
+
+    >>> setup.setAutoreceiveSamples(True)
+    >>> setup.getAutoreceiveSamples()
+    True
+
+Revoke the permission for all roles and client:
+
+    >>> roles = get_valid_roles_for(client)
+    >>> revoke_permission_for(client, TransitionReceiveSample, roles)
+
+Create a Sample:
+
+    >>> sample = new_sample([Cu, Fe, Au])
+
+The status of the analyses is "sample_due":
+
+    >>> api.get_review_status(sample)
+    'sample_due'


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that sample transitions to `sample_due` on creation when the setting `Auto-receive samples` is enabled, but the current user (e.g. a client) does not have the permission `senaite.core: Transition: Receive` granted.

Linked issue: https://github.com/senaite/senaite.core/issues/2418#issuecomment-1809998869

## Current behavior before PR

If the user does not have the permission `senaite.core: Transition: Receive` granted, the sample remains on `registered` status instead of transitioning to `sample_due`.

## Desired behavior after PR is merged

If the user does not have the permission `senaite.core: Transition: Receive` granted, the sample transitions to `sample_due`.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
