### PR TITLE
Added upgrade step to fix samples in registered status

### DIFF
--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2520</version>
+  <version>2521</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/v02_05_000.py
+++ b/src/senaite/core/upgrade/v02_05_000.py
@@ -509,7 +509,9 @@ def fix_samples_registered(tool):
 
         sample = api.get_object(brain)
 
+        # get the user who registered the sample
         creator = sample.Creator()
+
         if sample.getSamplingRequired():
             # sample has not been collected yet
             changeWorkflowState(sample, SAMPLE_WORKFLOW, "to_be_sampled",
@@ -518,8 +520,8 @@ def fix_samples_registered(tool):
             continue
 
         if auto_receive:
-            user = security.get_user(sample.creator())
-            if user.has_permission(TransitionReceiveSample, sample):
+            user = security.get_user(creator)
+            if user and user.has_permission(TransitionReceiveSample, sample):
                 # Change status to sample_received
                 changeWorkflowState(sample, SAMPLE_WORKFLOW, "sample_received",
                                     actor=creator, action="receive")

--- a/src/senaite/core/upgrade/v02_05_000.py
+++ b/src/senaite/core/upgrade/v02_05_000.py
@@ -516,6 +516,7 @@ def fix_samples_registered(tool):
             # sample has not been collected yet
             changeWorkflowState(sample, SAMPLE_WORKFLOW, "to_be_sampled",
                                 actor=creator, action="to_be_sampled")
+            sample.reindexObject()
             sample._p_deactivate()
             continue
 
@@ -541,12 +542,17 @@ def fix_samples_registered(tool):
                         continue
                     changeWorkflowState(obj, ANALYSIS_WORKFLOW, "unassigned",
                                         actor=creator, action="initialize")
+                    obj.reindexObject()
+                    obj._p_deactivate()
+
+                sample.reindexObject()
                 sample._p_deactivate()
                 continue
 
         # sample_due is the default initial status of the sample
         changeWorkflowState(sample, SAMPLE_WORKFLOW, "sample_due",
                             actor=creator, action="no_sampling_workflow")
+        sample.reindexObject()
         sample._p_deactivate()
 
     logger.info("Fixing samples in 'registered' status [DONE]")

--- a/src/senaite/core/upgrade/v02_05_000.py
+++ b/src/senaite/core/upgrade/v02_05_000.py
@@ -21,10 +21,10 @@
 import transaction
 from Acquisition import aq_base
 from bika.lims import api
+from bika.lims.api import security
 from bika.lims.interfaces import IReceived
 from bika.lims.utils import changeWorkflowState
 from senaite.core import logger
-from senaite.core.api import security
 from senaite.core.api.catalog import add_index
 from senaite.core.api.catalog import del_column
 from senaite.core.api.catalog import del_index

--- a/src/senaite/core/upgrade/v02_05_000.zcml
+++ b/src/senaite/core/upgrade/v02_05_000.zcml
@@ -5,7 +5,7 @@
 
   <genericsetup:upgradeStep
       title="SENAITE.CORE 2.5.0: Fix samples in registered status"
-      description="Fixes the status of samples in registere status"
+      description="Fixes the status of samples in registered status"
       source="2520"
       destination="2521"
       handler=".v02_05_000.fix_samples_registered"

--- a/src/senaite/core/upgrade/v02_05_000.zcml
+++ b/src/senaite/core/upgrade/v02_05_000.zcml
@@ -4,6 +4,14 @@
     i18n_domain="senaite.core">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.5.0: Fix samples in registered status"
+      description="Fixes the status of samples in registere status"
+      source="2520"
+      destination="2521"
+      handler=".v02_05_000.fix_samples_registered"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.5.0: Import Workflow"
       description="Update Managed Permissions of Sample Workflow"
       source="2519"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This is a complementary Pull Request of #2424, that adds an upgrade step to fix the status of samples in "registered" status, that cannot be transitioned to any other status (side-effect of #2419).

## Current behavior before PR

Samples in "registered" status, that cannot be received

## Desired behavior after PR is merged

No samples in "registered" status

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
