### PR TITLE
Fix ±0 is displayed for results within a range without uncertainty set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2426 Fix ±0 is displayed for results within a range without uncertainty set
 - #2424 Fix sample in "registered" after creation when user cannot receive
 - #2422 Fix Maximum number of Iterations Exceeded when no catalogs set for AT type
 - #2421 Fix hanging sampletype listing view in setup

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -523,17 +523,24 @@ Uncertainties = RecordsField(
     widget=RecordsWidget(
         label=_("Uncertainty"),
         description=_(
-            "Specify the uncertainty value for a given range, e.g. for "
-            "results in a range with minimum of 0 and maximum of 10, "
-            "where the uncertainty value is 0.5 - a result of 6.67 will be "
-            "reported as 6.67 +- 0.5. You can also specify the uncertainty "
-            "value as a percentage of the result value, by adding a '%' to "
-            "the value entered in the 'Uncertainty Value' column, e.g. for "
-            "results in a range with minimum of 10.01 and a maximum of 100, "
-            "where the uncertainty value is 2% - a result of 100 will be "
-            "reported as 100 +- 2. Please ensure successive ranges are "
-            "continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, "
-            "20.01 - 30 .00 etc."),
+            u"description_analysis_uncertainty",
+            default=u"Specify the uncertainty value for a given range, e.g. "
+                    u"for results in a range with minimum of 0 and maximum of "
+                    u"10, where the uncertainty value is 0.5 - a result of "
+                    u"6.67 will be reported as 6.67 ± 0.5.<br/>"
+                    u"You can also specify the uncertainty value as a "
+                    u"percentage of the result value, by adding a '%' to the "
+                    u"value entered in the 'Uncertainty Value' column, e.g. "
+                    u"for results in a range with minimum of 10.01 and a "
+                    u"maximum of 100, where the uncertainty value is 2%, a "
+                    u"result of 100 will be reported as 100 ± 2.<br/>"
+                    u"If you don't want uncertainty to be displayed for a "
+                    u"given range, set 0 (or a value below 0) as the "
+                    u"Uncertainty value.<br/>"
+                    u"Please ensure successive ranges are continuous, e.g. "
+                    u"0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30.00"
+                    u" etc."
+        ),
     )
 )
 

--- a/src/bika/lims/utils/analysis.py
+++ b/src/bika/lims/utils/analysis.py
@@ -221,8 +221,8 @@ def format_uncertainty(analysis, decimalmark=".", sciformat=1):
     the uncertainty neither the result. The fixed length precision is
     used instead.
 
-    If the result is not floatable or no uncertainty defined, returns
-    an empty string.
+    If the result is not floatable, the uncertainty is not defined or its value
+    is not above 0, an empty string is returned.
 
     The default decimal mark '.' will be replaced by the decimalmark
     specified.
@@ -244,8 +244,8 @@ def format_uncertainty(analysis, decimalmark=".", sciformat=1):
         pass
 
     uncertainty = analysis.getUncertainty()
-
-    if not uncertainty:
+    if api.to_float(uncertainty, default=0) <= 0:
+        # uncertainty is not defined or not above 0
         return ""
 
     # always convert exponential notation to decimal

--- a/src/senaite/core/tests/doctests/Uncertainties.rst
+++ b/src/senaite/core/tests/doctests/Uncertainties.rst
@@ -383,6 +383,35 @@ Test the range 10-20 with an unertainty value of 5% of the result:
     >>> au.getUncertainty()
     '0.75'
 
+If the uncertainty value is value is not above 0, no formatted uncertainty is
+returned. The use of `0` as an uncertainty value is useful for when the result
+is between the detection limit and the quantification limit. In such case,
+uncertainty mustn't be displayed. Likewise, there might be other scenarios in
+which the user do not want to display uncertainty for a given result range:
+
+    >>> uncertainties = [
+    ...    {"intercept_min":  "0.2", "intercept_max":  "100000", "errorvalue": "5.3%"},
+    ...    {"intercept_min":  "0.08", "intercept_max": "0.19", "errorvalue": "0"},
+    ... ]
+
+    >>> au.setUncertainties(uncertainties)
+    >>> au.setResult(0.3)
+    >>> au.getUncertainty()
+    '0.0159'
+    >>> format_uncertainty(au)
+    '0.02'
+
+    >>> au.setResult(0.05)
+    >>> au.getUncertainty() is None
+    True
+    >>> format_uncertainty(au)
+    ''
+
+    >>> au.setResult(0.10)
+    >>> au.getUncertainty()
+    '0'
+    >>> format_uncertainty(au)
+    ''
 
 Test exponential format
 .......................

--- a/src/senaite/core/tests/doctests/Uncertainties.rst
+++ b/src/senaite/core/tests/doctests/Uncertainties.rst
@@ -383,11 +383,11 @@ Test the range 10-20 with an unertainty value of 5% of the result:
     >>> au.getUncertainty()
     '0.75'
 
-If the uncertainty value is value is not above 0, no formatted uncertainty is
-returned. The use of `0` as an uncertainty value is useful for when the result
-is between the detection limit and the quantification limit. In such case,
-uncertainty mustn't be displayed. Likewise, there might be other scenarios in
-which the user do not want to display uncertainty for a given result range:
+If the uncertainty value is not above 0, no formatted uncertainty is returned.
+The use of `0` as an uncertainty value is useful for when the result is between
+the detection limit and the quantification limit. In such case, uncertainty
+mustn't be displayed. Likewise, there might be other scenarios in which the
+user do not want to display uncertainty for a given result range:
 
     >>> uncertainties = [
     ...    {"intercept_min":  "0.2", "intercept_max":  "100000", "errorvalue": "5.3%"},


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request addresses a bug introduced with #2096. Until then, it was possible to define an uncertainty range without an Uncertainty value set:

![Captura de 2023-11-16 12-59-53](https://github.com/senaite/senaite.core/assets/832627/0595ff11-7b9a-4b30-9c26-ec92238d9572)

This was handy for when the user wanted the system to not display the uncertainty for certain ranges (e.g when the result is between the detection limit and the quantification limit). With latest version, the system converts empties to 0 automatically:

![Captura de 2023-11-16 13-00-47](https://github.com/senaite/senaite.core/assets/832627/2ee84e28-9d42-4490-bf36-866891ede660)

And even though a `0` is meaningless as uncertainty, it gets displayed in results view and in results report.

This Pull Request makes the system to not render uncertainties if the uncertainty value is not above 0.

## Current behavior before PR

System does render uncertainty of 0 or below 0 in results view and report

![Captura de 2023-11-16 12-37-02](https://github.com/senaite/senaite.core/assets/832627/9978db20-9155-4dde-8ab7-c39b4303c5b2)

## Desired behavior after PR is merged

System does not render uncertainty of 0 or below 0 in results view and report

![Captura de 2023-11-16 12-25-38](https://github.com/senaite/senaite.core/assets/832627/6b819f02-f18d-4b1e-b273-721777f5dc13)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
