### PR TITLE
Fix precision is not calculated from the rounded uncertainty

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2427 Fix precision is not calculated from the rounded uncertainty
 - #2426 Fix ±0 is displayed for results within a range without uncertainty set
 - #2424 Fix sample in "registered" after creation when user cannot receive
 - #2422 Fix Maximum number of Iterations Exceeded when no catalogs set for AT type

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -953,7 +953,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
           in accordance with the manual uncertainty set.
 
         - If Calculate Precision from Uncertainty is set in Analysis Service,
-          calculates the precision in accordance with the uncertainty infered
+          calculates the precision in accordance with the uncertainty inferred
           from uncertainties ranges.
 
         - If neither Manual Uncertainty nor Calculate Precision from
@@ -980,7 +980,23 @@ class AbstractAnalysis(AbstractBaseAnalysis):
                 strres = str(result)
                 numdecimals = strres[::-1].find('.')
                 return numdecimals
+
+            uncertainty = api.to_float(uncertainty)
+            # Get the 'raw' significant digits from uncertainty
+            sig_digits = get_significant_digits(uncertainty)
+            # Round the uncertainty to its significant digit.
+            # Needed because the precision for the result has to be based on
+            # the *rounded* uncertainty. Note the following for a given
+            # uncertainty value:
+            #   >>> round(0.09404, 2)
+            #   0.09
+            #   >>> round(0.09504, 2)
+            #   0.1
+            # The precision when the uncertainty is 0.09504 is not 2, but 1
+            uncertainty = abs(round(uncertainty, sig_digits))
+            # Return the significant digit to apply
             return get_significant_digits(uncertainty)
+
         return self.getField('Precision').get(self)
 
     @security.public

--- a/src/senaite/core/tests/doctests/Uncertainties.rst
+++ b/src/senaite/core/tests/doctests/Uncertainties.rst
@@ -246,6 +246,24 @@ Check the precision of the range 10-20 (0.4):
     >>> fe.getFormattedResult()
     '10.3'
 
+Check the precision is calculated based on the rounded uncertainty:
+
+    >>> uncertainties_2 = [
+    ...    {"intercept_min":  0, "intercept_max":  10, "errorvalue": 0.95404}
+    ... ]
+    >>> fe.setUncertainties(uncertainties_2)
+    >>> fe.setResult("9.6")
+    >>> fe.getResult()
+    '9.6'
+
+    >>> fe.getUncertainty()
+    '0.95404'
+
+    >>> fe.getPrecision()
+    0
+
+    >>> fe.getFormattedResult()
+    '10'
 
 Test uncertainty for results above/below detection limits
 .........................................................

--- a/src/senaite/core/tests/doctests/Uncertainties.rst
+++ b/src/senaite/core/tests/doctests/Uncertainties.rst
@@ -249,7 +249,8 @@ Check the precision of the range 10-20 (0.4):
 Check the precision is calculated based on the rounded uncertainty:
 
     >>> uncertainties_2 = [
-    ...    {"intercept_min":  0, "intercept_max":  10, "errorvalue": 0.95404}
+    ...    {'intercept_min': '1.0', 'intercept_max': '100000', 'errorvalue': '9.9%'},
+    ...    {'intercept_min': '0.5', 'intercept_max': '0.9', 'errorvalue': '0'}
     ... ]
     >>> fe.setUncertainties(uncertainties_2)
     >>> fe.setResult("9.6")
@@ -257,7 +258,7 @@ Check the precision is calculated based on the rounded uncertainty:
     '9.6'
 
     >>> fe.getUncertainty()
-    '0.95404'
+    '0.9504'
 
     >>> fe.getPrecision()
     0


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes ensures that when the precision is inferred from uncertainties, it is calculated from the rounded uncertainty. This is necessary for those cases when the rounding of the uncertainty leads to a change of precision (e.g. values above 0.095):

## Current behavior before PR

![Captura de 2023-11-18 09-57-24](https://github.com/senaite/senaite.core/assets/832627/b53f1fb5-597c-4229-a741-8ef8193d617b)

```python
>>> analysis.getUncertainties()
[{'intercept_min': '1.0', 'intercept_max': '100000', 'errorvalue': '9.9%'}, {'intercept_min': '0.5', 'intercept_max': '0.9', 'errorvalue': '0'}]
>>> # The result of the analysis
>>> analysis.getResult()
'9.6'
>>> # The uncertainty calculated from the result
>>> analysis.getUncertainty()
'0.9504'
>>> # Uncertainty value displayed
>>> format_uncertainty(analysis)
'1'
>>> # Precision as decimal numbers calculated from the uncertainty
>>> analysis.getPrecision()
1
>>> # Formatted result in accordance with precision
>>> analysis.getFormattedResult()
'9.6'
```

## Desired behavior after PR is merged

![Captura de 2023-11-18 10-15-21](https://github.com/senaite/senaite.core/assets/832627/fc3740a5-4c3d-46b1-965a-f50f4e789d3a)


```python
>>> analysis.getUncertainties()
[{'intercept_min': '1.0', 'intercept_max': '100000', 'errorvalue': '9.9%'}, {'intercept_min': '0.5', 'intercept_max': '0.9', 'errorvalue': '0'}]
>>> # The result of the analysis
>>> analysis.getResult()
'9.6'
>>> # The uncertainty calculated from the result
>>> analysis.getUncertainty()
'0.9504'
>>> # Uncertainty value displayed
>>> format_uncertainty(analysis)
'1'
>>> # Precision as decimal numbers calculated from the uncertainty
>>> analysis.getPrecision()
0
>>> # Formatted result in accordance with precision
>>> analysis.getFormattedResult()
'10'
```


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
