### PR TITLE
Fix recipients column in report listing to show those recipients to whom the report was also sent to

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2429 Fix recipients column in report listing to show those recipients to whom the report was also sent to
 - #2427 Fix precision is not calculated from the rounded uncertainty
 - #2426 Fix ±0 is displayed for results within a range without uncertainty set
 - #2424 Fix sample in "registered" after creation when user cannot receive


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR corrects the recipients column in the report listing to show only the recipients to whom the report was actually sent to.

## Current behavior before PR

All possible recipients are listed in the column, no matter if the report was sent or not


## Desired behavior after PR is merged

Only recipients to whom the report was also sent to are listed in the column

<img width="1038" src="https://github.com/senaite/senaite.core/assets/713193/6a8d3342-5e1b-478d-af0f-d6c80f778a13">


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
