### PR TITLE
Fix AttributeError when creating AnalysisSpec with results range via JSONAPI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 2.5.0 (unreleased)
 ------------------
-
+- #2428 Fix error raise when create analysisspec with resultsrange by JSONAPI
 - #2427 Fix precision is not calculated from the rounded uncertainty
 - #2426 Fix ±0 is displayed for results within a range without uncertainty set
 - #2424 Fix sample in "registered" after creation when user cannot receive

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -815,9 +815,7 @@ class AnalysisSpecificationsValidator:
 
     def __call__(self, value, *args, **kwargs):
         instance = kwargs["instance"]
-        request = kwargs.get("REQUEST", {})
-        if request is None:
-            request = {}
+        request = kwargs.get("REQUEST") or {}
         fieldname = kwargs["field"].getName()
 
         # This value in request prevents running once per subfield value.

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -816,6 +816,8 @@ class AnalysisSpecificationsValidator:
     def __call__(self, value, *args, **kwargs):
         instance = kwargs["instance"]
         request = kwargs.get("REQUEST", {})
+        if request is None:
+            request = {}
         fieldname = kwargs["field"].getName()
 
         # This value in request prevents running once per subfield value.


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR
in src/bika/lims/validators.py, line 818
          request = kwargs.get("REQUEST", {})
request is None, when create analysisspec by JSONAPI.
then, in src/bika/lims/validators.py, line 829
          service_uids = request.get("uids", [])
raise an error, 'NoneType' object has no attribute 'get'

## Desired behavior after PR is merged
fix the bug when "request" is None.
the analysisspec with "ResultsRange" by JSONAPI created work fine.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
