### PR TITLE
Fix results import files are always rendered for each analysis in report

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2432 Fix results import files are always rendered for each analysis in report
 - #2427 Fix precision is not calculated from the rounded uncertainty
 - #2426 Fix ±0 is displayed for results within a range without uncertainty set
 - #2424 Fix sample in "registered" after creation when user cannot receive

--- a/src/senaite/core/exportimport/instruments/resultsimport.py
+++ b/src/senaite/core/exportimport/instruments/resultsimport.py
@@ -677,7 +677,9 @@ class AnalysisResultsImporter(Logger):
                 title=filename,
                 AttachmentFile=infile,
                 AttachmentType=attuid,
-                AttachmentKeys='Results, Automatic import')
+                AttachmentKeys='Results, Automatic import',
+                RenderInReport=False,
+            )
             attachment.reindexObject()
         return attachment
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the automatic rendering of results import files in the report.

![280065209-7df1b7cd-db93-403a-98f8-8b53357b42df](https://github.com/senaite/senaite.core/assets/713193/6ff100e0-f207-46e1-bb0c-aa90b40d18d5)

## Current behavior before PR

When instrument results are importer, the importer creates automatically an attachment for each analysis if the analysis is assigned to a Worksheet.

These attachments are all rendered in the report.

## Desired behavior after PR is merged

Analysis Attachments created by the importer are not rendered in report per default.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
