### PR TITLE
Fix multi-valued interim fields are not displayed correctly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2433 Fix multi-valued interim fields are not displayed correctly
 - #2432 Fix results import files are always rendered for each analysis in report
 - #2427 Fix precision is not calculated from the rounded uncertainty
 - #2426 Fix ±0 is displayed for results within a range without uncertainty set

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -1071,8 +1071,12 @@ class AnalysesView(ListingView):
             interim_value = interim_field.get("value", "")
             interim_allow_empty = interim_field.get("allow_empty") == "on"
             interim_unit = interim_field.get("unit", "")
-            interim_formatted = formatDecimalMark(interim_value, self.dmk)
+
+            # Get the interim's formatted value
+            interim_formatted = self.get_formatted_interim(interim_field)
             interim_field["formatted_value"] = interim_formatted
+
+            # Update the item with the interim
             item[interim_keyword] = interim_field
             item["class"][interim_keyword] = "interim"
 
@@ -1104,7 +1108,6 @@ class AnalysesView(ListingView):
                 # Ensure empty option is available if no default value is set
                 if not interim_value and not multi:
                     # allow empty selection and flush default value
-                    interim_value = ""
                     interim_allow_empty = True
 
                 # Generate the display list
@@ -1119,19 +1122,40 @@ class AnalysesView(ListingView):
 
                 item.setdefault("choices", {})[interim_keyword] = dl
 
-                # Set the text as the formatted value
-                texts = [choices.get(v, "") for v in api.to_list(interim_value)]
-                text = "<br/>".join(filter(None, texts))
-                interim_field["formatted_value"] = text
+            if not is_editable:
+                # Display the text instead of the value
+                interim_field["value"] = interim_formatted
 
-                if not is_editable:
-                    # Display the text instead of the value
-                    interim_field["value"] = text
-
-                item[interim_keyword] = interim_field
+            item[interim_keyword] = interim_field
 
         item["interimfields"] = interim_fields
         self.interim_fields[analysis_brain.UID] = interim_fields
+
+    def get_formatted_interim(self, interim):
+        """Returns the formatted value of the interim
+        """
+        # get the 'raw' value stored for this interim
+        raw_value = interim.get("value")
+
+        if self.is_multi_interim(interim):
+            # value is a jsonified list of values
+            values = api.to_list(raw_value)
+        else:
+            values = [raw_value]
+
+        # remove empties
+        values = filter(None, values)
+
+        choices = self.get_interim_choices(interim)
+        if choices:
+            # values are predefined options for selection
+            values = [choices.get(v) for v in values]
+        else:
+            # values are captured directly by the user
+            values = [formatDecimalMark(value, self.dmk) for value in values]
+
+        # return the values as a single string
+        return "<br/>".join(values)
 
     def _folder_item_unit(self, analysis_brain, item):
         """Fills the analysis' unit to the item passed in.


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that multi-result interim fields are displayed correctly in analyses listing when the item is rendered read-only mode

## Current behavior before PR

The system displays the *representation* of the list of values instead of being properly formatted:

![Captura de 2023-11-22 16-29-52](https://github.com/senaite/senaite.core/assets/832627/07d681b6-d4cd-4d96-9da1-03bb62cb659f)

![Captura de 2023-11-22 16-31-50](https://github.com/senaite/senaite.core/assets/832627/96fd201b-75a2-4aa2-bc1a-067031f0aa7e)


## Desired behavior after PR is merged

The system displays the values of multi-result interim fields properly formatted:

![Captura de 2023-11-22 16-30-19](https://github.com/senaite/senaite.core/assets/832627/e0778f48-1259-4e3d-bee4-9fb9c1da7085)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
