### PR TITLE
Fix instrument locations not displayed in listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2436 Fix instrument locations not displayed in listing
 - #2433 Fix multi-valued interim fields are not displayed correctly
 - #2429 Fix recipients column in report listing to show those recipients to whom the report was also sent to
 - #2432 Fix results import files are always rendered for each analysis in report

--- a/src/senaite/core/browser/controlpanel/instrumentlocations.py
+++ b/src/senaite/core/browser/controlpanel/instrumentlocations.py
@@ -22,9 +22,10 @@ import collections
 
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
-from senaite.core.permissions import AddInstrumentLocation
 from bika.lims.utils import get_link_for
 from senaite.app.listing import ListingView
+from senaite.core.catalog import SETUP_CATALOG
+from senaite.core.permissions import AddInstrumentLocation
 
 
 class InstrumentLocationsView(ListingView):
@@ -33,6 +34,8 @@ class InstrumentLocationsView(ListingView):
 
     def __init__(self, context, request):
         super(InstrumentLocationsView, self).__init__(context, request)
+
+        self.catalog = SETUP_CATALOG
 
         self.contentFilter = {
             "portal_type": "InstrumentLocation",


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the instrument locations listing view in the setup.

## Current behavior before PR

No instrument locations are displayed

## Desired behavior after PR is merged

Instrument locations are displayed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
