### PR TITLE
Fix DX types imported from tarball do not have valid ids

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2437 Fix DX types imported from tarball do not have valid ids
 - #2431 Fix AttributeError when creating AnalysisSpec with results range via JSONAPI
 - #2436 Fix instrument locations not displayed in listing
 - #2433 Fix multi-valued interim fields are not displayed correctly

--- a/src/senaite/core/exportimport/genericsetup/structure.py
+++ b/src/senaite/core/exportimport/genericsetup/structure.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 import json
+from plone.dexterity.utils import addContentToContainer
 from xml.dom.minidom import parseString
 
 from bika.lims import api
@@ -477,9 +478,8 @@ def create_or_get(parent, id, uid, portal_type):
             obj._setPortalTypeName(fti.getId())
         # set the old UID to maintain references
         setattr(obj, "_plone.uuid", uid)
-        notify(ObjectCreatedEvent(obj))
-        parent._setObject(tmp_id, obj)
-        obj = parent._getOb(api.get_id(obj))
+        # IMPORTANT: this will generate a new ID by the ID Server config
+        obj = addContentToContainer(parent, obj, checkConstraints=False)
 
     return obj
 

--- a/src/senaite/core/exportimport/genericsetup/structure.py
+++ b/src/senaite/core/exportimport/genericsetup/structure.py
@@ -19,9 +19,6 @@
 # Some rights reserved, see README and LICENSE.
 
 import json
-from plone.dexterity.utils import addContentToContainer
-from xml.dom.minidom import parseString
-
 from bika.lims import api
 from bika.lims import logger
 from bika.lims.interfaces import IAuditable
@@ -30,6 +27,7 @@ from DateTime import DateTime
 from OFS.interfaces import IOrderedContainer
 from plone.dexterity.interfaces import IDexterityContainer
 from plone.dexterity.interfaces import IDexterityItem
+from plone.dexterity.utils import addContentToContainer
 from Products.Archetypes.interfaces import IBaseObject
 from Products.CMFPlone.utils import _createObjectByType
 from Products.CMFPlone.utils import safe_unicode
@@ -40,13 +38,12 @@ from Products.GenericSetup.utils import I18NURI
 from Products.GenericSetup.utils import ObjectManagerHelpers
 from Products.GenericSetup.utils import XMLAdapterBase
 from senaite.core.p3compat import cmp
+from xml.dom.minidom import parseString
 from zope.component import adapts
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
 from zope.component.interfaces import IFactory
-from zope.event import notify
 from zope.interface import alsoProvides
-from zope.lifecycleevent import ObjectCreatedEvent
 
 from .config import SITE_ID
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that DX content types imported from tarball have a valid id.

The id for DX content types imported from tarball is not generated automatically, but keep the original UID as the id. No valid id is generated and therefore not properly catalog, cause the `api.is_temporary(obj)` returns False

## Current behavior before PR

DX content types imported from tarball do not have a valid id, but keep original UID as the id

## Desired behavior after PR is merged

DX content types imported from tarball have a valid id and they are properly catalogued

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
