### PR TITLE
Fix TypeError when applying format to interim field result

### DIFF
--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -1155,6 +1155,7 @@ class AnalysesView(ListingView):
             values = [formatDecimalMark(value, self.dmk) for value in values]
 
         # return the values as a single string
+        values = filter(None, values)
         return "<br/>".join(values)
 
     def _folder_item_unit(self, analysis_brain, item):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a bug introduced with #2433 so when the value of an interim does not match with any of the options (choices) available, a `TypeError` arises.

## Current behavior before PR

```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module senaite.app.listing.view, line 248, in __call__
  Module senaite.app.listing.ajax, line 113, in handle_subpath
  Module senaite.core.decorators, line 40, in decorator
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 383, in ajax_folderitems
  Module senaite.app.listing.decorators, line 88, in wrapper
  Module senaite.app.listing.ajax, line 259, in get_folderitems
  Module my.lims.browser.views.astresults, line 65, in folderitems
  Module senaite.ast.browser.results, line 179, in folderitems
  Module senaite.app.listing.view, line 981, in folderitems
  Module my.lims.browser.views.astresults, line 52, in folderitem
  Module senaite.ast.browser.results, line 138, in folderitem
  Module bika.lims.browser.analyses.view, line 1076, in _folder_item_calculation
  Module bika.lims.browser.analyses.view, line 1158, in get_formatted_interim
TypeError: sequence item 0: expected string, NoneType found
```

## Desired behavior after PR is merged

No traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
