### PR TITLE
Fix analysis template view shows hidden subfields for sample partitions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2439 Fix analysis template view shows hidden subfields for sample partitions
 - #2437 Fix DX types imported from tarball do not have valid ids
 - #2431 Fix AttributeError when creating AnalysisSpec with results range via JSONAPI
 - #2436 Fix instrument locations not displayed in listing

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/recordswidget.pt
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/recordswidget.pt
@@ -21,14 +21,21 @@
                         id string:parent-fieldname-$fieldName">
         <tal:block metal:define-slot="inside"
                    tal:repeat="idx python:range(field.getSize(here))"
-                   tal:define="outerJoin field/outerJoin;
-                                      innerJoin field/innerJoin;">
-          <span
-            tal:define="subfieldValues python:[field.getViewFor(here,idx,key,innerJoin) for key in field.getSubfields()];"
-            tal:replace="structure python:innerJoin.join(subfieldValues)" />
-          <span
-            tal:replace="structure outerJoin"
-            tal:condition="not: repeat/idx/end" />
+                   tal:define="subfields python:field.getSubfields();
+                               hidden python:getattr(field, 'subfield_hidden', {});
+                               outerJoin field/outerJoin;
+                               innerJoin field/innerJoin;">
+          <ul class="list-inline m-0">
+            <tal:loop tal:repeat="subfield subfields">
+              <li tal:define="value python:field.getViewFor(context, idx, subfield, innerJoin)"
+                  tal:condition="python:hidden.get(subfield, False) is False"
+                  class="list-inline-item mr-0 mb-2">
+                <span class="p-1 bg-light border rounded">
+                  <span tal:content="structure value"/>
+                </span>
+              </li>
+            </tal:loop>
+          </ul>
         </tal:block>
       </span>
     </metal:view_macro>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue where hidden subfields are displayed for analysis template view

## Current behavior before PR

Hidden UID fields are rendered in view:

<img width="1826" alt="ARTemplate View" src="https://github.com/senaite/senaite.core/assets/713193/b50ba1b9-fe17-4b7c-b094-e5606e851338">

## Desired behavior after PR is merged

Hidden fields are not rendered and improved subfield rendering:

<img width="1832" alt="ARTemplate view improved" src="https://github.com/senaite/senaite.core/assets/713193/3dee9c7b-acfe-417b-a378-dc2c3202e44f">


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
