### PR TITLE
Fix multi Code_128_1x48mm sticker renders only 1 PDF

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2440 Fix multi Code_128_1x48mm sticker renders only 1 PDF
 - #2437 Fix DX types imported from tarball do not have valid ids
 - #2431 Fix AttributeError when creating AnalysisSpec with results range via JSONAPI
 - #2436 Fix instrument locations not displayed in listing

--- a/src/bika/lims/browser/templates/stickers/Code_128_1x72mm.pt
+++ b/src/bika/lims/browser/templates/stickers/Code_128_1x72mm.pt
@@ -17,65 +17,63 @@
 
 
   <table cellpadding="0" cellspacing="0" class="info-container">
-    <thead>
+    <tr>
+      <th i18n:translate="">Sample ID</th>
+      <td><strong tal:content="string:${sample_id}"/></td>
+      <th i18n:translate="">Hazardous</th>
+      <td tal:content="hazardous"/>
+    </tr>
+    <tr>
+      <th i18n:translate="">Date Sampled</th>
+      <td tal:content="date_sampled"/>
+      <th i18n:translate="">Sampler</th>
+      <td tal:content="sampler"/>
+    </tr>
+    <tr>
+      <th i18n:translate="">CSID</th>
+      <td tal:content="client_sample_id"/>
+      <th i18n:translate="">Order</th>
+      <td tal:content="client_order_num"/>
+    </tr>
+    <tr>
+      <th i18n:translate="">Deviation</th>
+      <td tal:content="deviation"/>
+      <th i18n:translate="">Composite</th>
+      <td class="left" tal:content="composite"/>
+    </tr>
+    <tr>
+      <th i18n:translate="">Container</th>
+      <td tal:content="container"/>
+      <th i18n:translate="">Preservation</th>
+      <td tal:content="preservation"/>
+    </tr>
+    <tr>
+      <th i18n:translate="">Sample Type</th>
+      <td colspan='3' tal:content="sample_type"/>
+    </tr>
+    <tr>
+      <th i18n:translate="">Sample Point</th>
+      <td colspan='3' tal:content="sample_point"/>
+    </tr>
+    <tr tal:condition="python:field_analyses">
+      <th colspan="4" i18n:translate="">Field Analyses</th>
+    </tr>
+    <tal:block repeat="analysis python:field_analyses">
       <tr>
-        <th i18n:translate="">Sample ID</th>
-        <td><strong tal:content="string:${sample_id}"/></td>
-        <th i18n:translate="">Hazardous</th>
-        <td tal:content="hazardous"/>
+        <td colspan="4" tal:content="python:analysis.Title()"/>
       </tr>
-      <tr>
-        <th i18n:translate="">Date Sampled</th>
-        <td tal:content="date_sampled"/>
-        <th i18n:translate="">Sampler</th>
-        <td tal:content="sampler"/>
-      </tr>
-      <tr>
-        <th i18n:translate="">CSID</th>
-        <td tal:content="client_sample_id"/>
-        <th i18n:translate="">Order</th>
-        <td tal:content="client_order_num"/>
-      </tr>
-      <tr>
-        <th i18n:translate="">Deviation</th>
-        <td tal:content="deviation"/>
-        <th i18n:translate="">Composite</th>
-        <td class="left" tal:content="composite"/>
-      </tr>
-      <tr>
-        <th i18n:translate="">Container</th>
-        <td tal:content="container"/>
-        <th i18n:translate="">Preservation</th>
-        <td tal:content="preservation"/>
-      </tr>
-      <tr>
-        <th i18n:translate="">Sample Type</th>
-        <td colspan='3' tal:content="sample_type"/>
-      </tr>
-      <tr>
-        <th i18n:translate="">Sample Point</th>
-        <td colspan='3' tal:content="sample_point"/>
-      </tr>
-      <tr tal:condition="python:field_analyses">
-        <th colspan="4" i18n:translate="">Field Analyses</th>
-      </tr>
-      <tal:block repeat="analysis python:field_analyses">
-        <tr>
-          <td colspan="4" tal:content="python:analysis.Title()"/>
-        </tr>
-      </tal:block>
-      <tr>
-        <td colspan="4" class="barcode-container">
-          <!-- Barcode -->
-          <div class="barcode"
-               tal:attributes="data-id sample_id;"
-               data-barHeight="12"
-               data-code="code128"
-               data-addQuietZone="true"
-               data-showHRI="false">
-          </div>
-        </td>
-      </tr>
-    </thead>
+    </tal:block>
+    <tr>
+      <td colspan="4" class="barcode-container">
+        <!-- Barcode -->
+        <div class="barcode"
+             tal:attributes="data-id sample_id;"
+             data-barHeight="12"
+             data-code="code128"
+             data-addQuietZone="true"
+             data-showHRI="false">
+        </div>
+      </td>
+    </tr>
   </table>
 </tal:sticker>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the Code_128_1x48mm sticker rendering

## Current behavior before PR

Only first sticker is generated as PDF

## Desired behavior after PR is merged

All stickers are generated as PDF

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
