### PR TITLE
Fix items count in setupview for lab contacts tile

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2441 Fix items count in setupview for lab contacts tile
 - #2437 Fix DX types imported from tarball do not have valid ids
 - #2431 Fix AttributeError when creating AnalysisSpec with results range via JSONAPI
 - #2436 Fix instrument locations not displayed in listing

--- a/src/senaite/core/browser/controlpanel/setupview.py
+++ b/src/senaite/core/browser/controlpanel/setupview.py
@@ -82,7 +82,8 @@ class SetupView(BrowserView):
         allowed_types = fti.allowed_content_types
         if len(allowed_types) != 1:
             return None
-        return allowed_types[0]
+        # convert from unicode -> str for api.search catalog lookup
+        return list(map(str, allowed_types))
 
     def get_count(self, obj):
         """Retrieve the count of contained items
@@ -97,7 +98,7 @@ class SetupView(BrowserView):
             "portal_type": contained_types,
             "is_active": True,
         }
-        brains = api.search(query, SETUP_CATALOG)
+        brains = api.search(query)
         return len(brains)
 
     def setupitems(self):

--- a/src/senaite/core/browser/controlpanel/setupview.py
+++ b/src/senaite/core/browser/controlpanel/setupview.py
@@ -24,7 +24,6 @@ from plone.memoize.instance import memoize
 from plone.memoize.view import memoize_contextless
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from senaite.core.catalog import SETUP_CATALOG
 from senaite.core.p3compat import cmp
 from zope.component import getMultiAdapter
 

--- a/src/senaite/core/browser/controlpanel/templates/setupview.pt
+++ b/src/senaite/core/browser/controlpanel/templates/setupview.pt
@@ -75,8 +75,12 @@
                 <span class="text-secondary">
                   <span tal:content="count"></span>
                 </span>
-                <span tal:condition="python:count == 1" class="text-secondary">Item</span>
-                <span tal:condition="python:count > 1" class="text-secondary">Items</span>
+                <span i18n:translate="label_setupview_item"
+                      tal:condition="python:count == 1"
+                      class="text-secondary">Item</span>
+                <span i18n:translate="label_setupview_items"
+                      tal:condition="python:count > 1"
+                      class="text-secondary">Items</span>
               </div>
             </a>
           </div>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the setupview items count information

## Current behavior before PR

No items count is displayed for lab contacts tile

<img width="1311" alt="" src="https://github.com/senaite/senaite.core/assets/713193/8377f27e-7323-46ed-8474-87c7e9e93c97">

## Desired behavior after PR is merged

Items count is displayed for lab contacts tile

<img width="1322" alt="" src="https://github.com/senaite/senaite.core/assets/713193/8012ab16-a23f-47ef-ad95-6ec1d2f57227">


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
