### PR TITLE
Fix open filter is not visible to analysts in worksheets listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2448 Fix open filter is not visible to analysts in worksheets listing
 - #2444 Fix reference widget search uses JSON encoded query
 - #2443 Fix missing required marker in edit forms
 - #2441 Fix items count in setupview for lab contacts tile

--- a/src/bika/lims/browser/worksheet/views/folder.py
+++ b/src/bika/lims/browser/worksheet/views/folder.py
@@ -223,11 +223,20 @@ class FolderView(BikaListingView):
 
         if self.show_only_mine():
             # Remove 'Mine' button and hide 'Analyst' column
-            del self.review_states[-1]  # Mine
+            self.remove_review_state("mine")
             self.columns["Analyst"]["toggle"] = False
             self.contentFilter["getAnalyst"] = self.member.id
             for rvw in self.review_states:
                 rvw["contentFilter"]["getAnalyst"] = self.member.id
+
+    def remove_review_state(self, id):
+        """Removes the review status button with the given id
+        """
+        ids = [review_state["id"] for review_state in self.review_states]
+        if id not in ids:
+            return
+        index = ids.index(id)
+        del self.review_states[index]
 
     def is_privileged_user(self):
         """Returns whether the current user is a privileged member

--- a/src/bika/lims/browser/worksheet/views/folder.py
+++ b/src/bika/lims/browser/worksheet/views/folder.py
@@ -223,7 +223,7 @@ class FolderView(BikaListingView):
 
         if self.show_only_mine():
             # Remove 'Mine' button and hide 'Analyst' column
-            del self.review_states[1]  # Mine
+            del self.review_states[-1]  # Mine
             self.columns["Analyst"]["toggle"] = False
             self.contentFilter["getAnalyst"] = self.member.id
             for rvw in self.review_states:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the filter button "Mine" (aka review_state) is hidden instead of "Open" when the logged in user is an analyst and the access to worksheets is restricted in accordance with the setup setting.

## Current behavior before PR

When logged in as analyst, the "Open" filter button in worksheets listing is hidden, but "Mine" is visible

## Desired behavior after PR is merged

When logged in as analyst, the "Mine" filter button in worksheets listing is hidden, but "Open" is visible

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
