### PR TITLE
Fix Mine button from worksheets listing does not filter by current user

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2449 Fix Mine button from worksheets listing does not filter by current user
 - #2444 Fix reference widget search uses JSON encoded query
 - #2443 Fix missing required marker in edit forms
 - #2441 Fix items count in setupview for lab contacts tile

--- a/src/bika/lims/browser/worksheet/views/folder.py
+++ b/src/bika/lims/browser/worksheet/views/folder.py
@@ -221,6 +221,10 @@ class FolderView(BikaListingView):
             # Remove the add button
             self.context_actions = {}
 
+        # Update the "Mine" review status with current user id
+        mine = self.get_review_state("mine")
+        mine["contentFilter"]["getAnalyst"] = self.member.id
+
         if self.show_only_mine():
             # Remove 'Mine' button and hide 'Analyst' column
             del self.review_states[1]  # Mine


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the "Mine" filter button (aka "review_state") from worksheets listing to only display the worksheets that are assigned to the current user

## Current behavior before PR

"Mine" button from worksheets listing does not work

## Desired behavior after PR is merged

"Mine" button from worksheets listing does work

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
