### PR TITLE
Fix reference definition range validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2452 Fix reference definition range validation
 - #2450 Fix search bar from worksheet listing does not work
 - #2449 Fix Mine button from worksheets listing does not filter by current user
 - #2448 Fix open filter is not visible to analysts in worksheets listing

--- a/src/bika/lims/browser/widgets/referenceresultswidget.py
+++ b/src/bika/lims/browser/widgets/referenceresultswidget.py
@@ -220,6 +220,12 @@ class ReferenceResultsWidget(TypesWidget):
             s_min = self._get_spec_value(form, uid, "min", result)
             s_max = self._get_spec_value(form, uid, "max", result)
 
+            # shift min/max values according to the result
+            if s_max < result:
+                s_max = result
+            if s_min > result:
+                s_min = result
+
             # If an error percentage was given, calculate the min/max from the
             # error percentage
             if s_err:

--- a/src/bika/lims/browser/widgets/referenceresultswidget.py
+++ b/src/bika/lims/browser/widgets/referenceresultswidget.py
@@ -229,6 +229,8 @@ class ReferenceResultsWidget(TypesWidget):
             # If an error percentage was given, calculate the min/max from the
             # error percentage
             if s_err:
+                # Negative percentage not permitted to prevent min above max
+                s_err = abs(float(s_err))
                 s_min = float(result) * (1 - float(s_err)/100)
                 s_max = float(result) * (1 + float(s_err)/100)
 
@@ -239,7 +241,7 @@ class ReferenceResultsWidget(TypesWidget):
                 "result": result,
                 "min": s_min,
                 "max": s_max,
-                "error": s_err
+                "error": str(s_err),
             }
 
         return values.values(), {}

--- a/src/bika/lims/content/referencedefinition.py
+++ b/src/bika/lims/content/referencedefinition.py
@@ -43,9 +43,11 @@ schema = BikaSchema.copy() + Schema((
             "max": "analysisspecs_validator",
         },
         widget=ReferenceResultsWidget(
-            label=_("Reference Values"),
+            label=_("label_referencedefinition_referencevalues",
+                    default=u"Reference Values"),
             description=_(
-                "Click on Analysis Categories (against shaded background"
+                "description_referencedefinition_referencevalues",
+                default=u"Click on Analysis Categories "
                 "to see Analysis Services in each category. Enter minimum "
                 "and maximum values to indicate a valid results range. "
                 "Any result outside this range will raise an alert. "
@@ -53,7 +55,8 @@ schema = BikaSchema.copy() + Schema((
                 "considered when evaluating results against minimum and "
                 "maximum values. A result out of range but still in range "
                 "if the % error is taken into consideration, will raise a "
-                "less severe alert."),
+                "less severe alert."
+            ),
         ),
     ),
 
@@ -62,9 +65,11 @@ schema = BikaSchema.copy() + Schema((
         schemata="Description",
         default=False,
         widget=BooleanWidget(
-            label=_("Blank"),
+            label=_("label_referencedefinition_blank",
+                    default=u"Blank"),
             description=_(
-                "Reference sample values are zero or 'blank'"
+                "description_referencedefinition_blank",
+                default=u"Reference sample values are zero or 'blank'"
             ),
         ),
     ),
@@ -74,9 +79,12 @@ schema = BikaSchema.copy() + Schema((
         schemata="Description",
         default=False,
         widget=BooleanWidget(
-            label=_("Hazardous"),
+            label=_("label_referencedefinition_hazardous",
+                    default=u"Hazardous",
             description=_(
-                "Samples of this type should be treated as hazardous"),
+                "description_referencedefinition_hazardous",
+                default=u"Samples of this type should be treated as hazardous"
+            ),
         ),
     ),
 ))

--- a/src/bika/lims/content/referencedefinition.py
+++ b/src/bika/lims/content/referencedefinition.py
@@ -18,28 +18,33 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-""" Reference Definitions represent standard specifications for
-    reference samples used in quality control
-"""
 from AccessControl import ClassSecurityInfo
-from Products.Archetypes.public import *
-from bika.lims.content.bikaschema import BikaSchema
+from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.fields import ReferenceResultsField
 from bika.lims.browser.widgets import ReferenceResultsWidget
 from bika.lims.config import PROJECTNAME
-from bika.lims import bikaMessageFactory as _
+from bika.lims.content.bikaschema import BikaSchema
 from bika.lims.interfaces import IDeactivable
+from Products.Archetypes.public import BaseContent
+from Products.Archetypes.public import BooleanField
+from Products.Archetypes.public import BooleanWidget
+from Products.Archetypes.public import Schema
+from Products.Archetypes.public import registerType
 from zope.interface import implements
 
 schema = BikaSchema.copy() + Schema((
-    ReferenceResultsField('ReferenceResults',
-        schemata = 'Reference Values',
-        required = 1,
-        subfield_validators = {
-            'result':'referencevalues_validator',},
-        widget = ReferenceResultsWidget(
+    ReferenceResultsField(
+        "ReferenceResults",
+        schemata="Reference Values",
+        required=1,
+        subfield_validators={
+            "result": "analysisspecs_validator",
+            "min": "analysisspecs_validator",
+            "max": "analysisspecs_validator",
+        },
+        widget=ReferenceResultsWidget(
             label=_("Reference Values"),
-            description =_(
+            description=_(
                 "Click on Analysis Categories (against shaded background"
                 "to see Analysis Services in each category. Enter minimum "
                 "and maximum values to indicate a valid results range. "
@@ -51,38 +56,46 @@ schema = BikaSchema.copy() + Schema((
                 "less severe alert."),
         ),
     ),
-    BooleanField('Blank',
-        schemata = 'Description',
-        default = False,
-        widget = BooleanWidget(
+
+    BooleanField(
+        "Blank",
+        schemata="Description",
+        default=False,
+        widget=BooleanWidget(
             label=_("Blank"),
-            description=_("Reference sample values are zero or 'blank'"),
+            description=_(
+                "Reference sample values are zero or 'blank'"
+            ),
         ),
     ),
-    BooleanField('Hazardous',
-        schemata = 'Description',
-        default = False,
-        widget = BooleanWidget(
+
+    BooleanField(
+        "Hazardous",
+        schemata="Description",
+        default=False,
+        widget=BooleanWidget(
             label=_("Hazardous"),
-            description=_("Samples of this type should be treated as hazardous"),
+            description=_(
+                "Samples of this type should be treated as hazardous"),
         ),
     ),
 ))
 
-schema['title'].schemata = 'Description'
-schema['title'].widget.visible = True
-schema['description'].schemata = 'Description'
-schema['description'].widget.visible = True
+schema["title"].schemata = "Description"
+schema["title"].widget.visible = True
+schema["description"].schemata = "Description"
+schema["description"].widget.visible = True
+
 
 class ReferenceDefinition(BaseContent):
     implements(IDeactivable)
     security = ClassSecurityInfo()
-    displayContentsTab = False
     schema = schema
-
     _at_rename_after_creation = True
+
     def _renameAfterCreation(self, check_auto_id=False):
         from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
+
 
 registerType(ReferenceDefinition, PROJECTNAME)

--- a/src/bika/lims/content/referencedefinition.py
+++ b/src/bika/lims/content/referencedefinition.py
@@ -80,7 +80,7 @@ schema = BikaSchema.copy() + Schema((
         default=False,
         widget=BooleanWidget(
             label=_("label_referencedefinition_hazardous",
-                    default=u"Hazardous",
+                    default=u"Hazardous"),
             description=_(
                 "description_referencedefinition_hazardous",
                 default=u"Samples of this type should be treated as hazardous"

--- a/src/bika/lims/content/referencesample.py
+++ b/src/bika/lims/content/referencesample.py
@@ -170,7 +170,7 @@ schema = BikaSchema.copy() + Schema((
         schemata = 'Reference Values',
         required = 1,
         subfield_validators = {
-                    'result':'referencevalues_validator',},
+                    'result':'analysisspecs_validator',},
         widget = ReferenceResultsWidget(
             label=_("Expected Values"),
         ),

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -1004,64 +1004,6 @@ class DurationValidator:
 validation.register(DurationValidator())
 
 
-class ReferenceValuesValidator:
-    """Min value must be below max value
-       Percentage value must be between 0 and 100
-       Values must be numbers
-       Expected values must be between min and max values
-    """
-
-    implements(IValidator)
-    name = "referencevalues_validator"
-
-    def __call__(self, value, *args, **kwargs):
-        request = kwargs.get('REQUEST', {})
-        # Retrieve all AS uids
-        services = request.get('service', [{}])[0]
-        for uid, service_name in services.items():
-            err_msg = self.validate_service(request, uid)
-            if not err_msg:
-                continue
-
-            # Validation failed
-            err_msg = "{}: {}".format(_("Validation for '{}' failed"),
-                                      _(err_msg))
-            err_msg = err_msg.format(service_name)
-            translate = api.get_tool('translation_service').translate
-            return to_utf8(translate(safe_unicode(err_msg)))
-
-        return True
-
-    def validate_service(self, request, uid):
-        """Validates the specs values from request for the service uid. Returns
-        a non-translated message if the validation failed."""
-
-        result = get_record_value(request, uid, 'result')
-        if not result:
-            # No result set for this service, dismiss
-            return None
-
-        if not api.is_floatable(result):
-            return "Expected result value must be numeric"
-
-        spec_min = get_record_value(request, uid, "min", result)
-        spec_max = get_record_value(request, uid, "max", result)
-        error = get_record_value(request, uid, "error", "0")
-        if not api.is_floatable(spec_min):
-            return "'Min' value must be numeric"
-        if not api.is_floatable(spec_max):
-            return "'Max' value must be numeric"
-        if api.to_float(spec_min) > api.to_float(result):
-            return "'Min' value must be below the expected result"
-        if api.to_float(spec_max) < api.to_float(result):
-            return "'Max' value must be above the expected result"
-        if not api.is_floatable(error) or 0.0 < api.to_float(error) > 100:
-            return "% Error must be between 0 and 100"
-        return None
-
-validation.register(ReferenceValuesValidator())
-
-
 class PercentValidator:
     """ Floatable, >=0, <=100. """
 

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2522</version>
+  <version>2523</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/v02_05_000.py
+++ b/src/senaite/core/upgrade/v02_05_000.py
@@ -618,6 +618,20 @@ def fix_range_values_for(brains):
                         new_max=r["max"],
                     ))
                 reindex = True
+
+            # check if error < 0
+            r_err = api.to_float(r.get("error"), 0)
+            if r_err < 0:
+                r_err = abs(r_err)
+                r["error"] = str(r_err)
+                logger.info(
+                    "Fixing negative error % for service '{r_key}: {r_err}"
+                    .format(
+                        r_key=r_key,
+                        r_err=r["error"],
+                    ))
+                reindex = True
+
         if reindex:
             obj.reindexObject()
         obj._p_deactivate()

--- a/src/senaite/core/upgrade/v02_05_000.py
+++ b/src/senaite/core/upgrade/v02_05_000.py
@@ -576,3 +576,48 @@ def fix_searches_worksheets(tool):
         obj._p_deactivate()
 
     logger.info("Reindexing listing_searchable_text from Worksheets [DONE]")
+
+
+def fix_range_values(tool):
+    """Fix possible min > max in reference definition/sample ranges
+    """
+    logger.info("Fix min/max for reference definitions and samples ...")
+    fix_range_values_for(api.search({"portal_type": "ReferenceDefinition"}))
+    # XXX: Reference Samples live in SENAITE CATALOG
+    fix_range_values_for(api.search({"portal_type": "ReferenceSample"}))
+    logger.info("Fix min/max for reference definitions and samples [DONE]")
+
+
+def fix_range_values_for(brains):
+    """Fix range values for the given brains
+    """
+    total = len(brains)
+    for num, brain in enumerate(brains):
+        obj = api.get_object(brain)
+        reindex = False
+        logger.info("Checking range values %d/%d: `%s`" % (
+            num+1, total, api.get_path(obj)))
+        rr = obj.getReferenceResults()
+        for r in rr:
+            r_key = r.get("keyword")
+            r_min = api.to_float(r.get("min"), 0)
+            r_max = api.to_float(r.get("max"), 0)
+
+            # check if max > min
+            if r_min > r_max:
+                # set min value to the same as max value
+                r["min"] = r["max"]
+                logger.info(
+                    "Fixing range values for service '{r_key}': "
+                    "[{r_min},{r_max}] -> [{new_min},{new_max}]"
+                    .format(
+                        r_key=r_key,
+                        r_min=r_min,
+                        r_max=r_max,
+                        new_min=r["min"],
+                        new_max=r["max"],
+                    ))
+                reindex = True
+        if reindex:
+            obj.reindexObject()
+        obj._p_deactivate()

--- a/src/senaite/core/upgrade/v02_05_000.zcml
+++ b/src/senaite/core/upgrade/v02_05_000.zcml
@@ -4,6 +4,14 @@
     i18n_domain="senaite.core">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.5.0: Fix min/max range values"
+      description="Fix possible min > max in range values for reference definitions/samples"
+      source="2522"
+      destination="2523"
+      handler=".v02_05_000.fix_range_values"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.5.0: Fix searches in worksheets not working"
       description="Reindex the listing_searchable_text index for worksheets"
       source="2521"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the field validation for the result, min and max values of the reference definition ranges.

## Current behavior before PR

- min value can be above max value
- min/max values are kept when result changes, e.g. it is possible to change the result above the `max` value or below the `min` value afterwards.

## Desired behavior after PR is merged

- min value is validated to be below max value
- min/max values are shifted when the result changes

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
