### PR TITLE
Fix worksheets are not uncatalogued when deleted

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2453 Fix worksheets are not uncatalogued when deleted
 - #2452 Fix reference definition range validation
 - #2450 Fix search bar from worksheet listing does not work
 - #2449 Fix Mine button from worksheets listing does not filter by current user

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -322,6 +322,7 @@ def uncatalog_object(obj):
 
 def catalog_object(obj):
     """Re-catalog the object
+
     :param obj: object to un-catalog
     :type obj: ATContentType/DexterityContentType
     """
@@ -338,6 +339,11 @@ def catalog_object(obj):
 
 def delete(obj, check_permissions=True, suppress_events=False):
     """Deletes the given object
+
+    :param obj: object to un-catalog
+    :param check_permissions: whether delete permission must be checked
+    :param suppress_events: whether ondelete events have to be fired
+    :type obj: ATContentType/DexterityContentType
     """
     from security import check_permission
     if check_permissions and not check_permission(DeleteObjects, obj):

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -55,6 +55,7 @@ from Products.Archetypes.event import ObjectInitializedEvent
 from Products.Archetypes.utils import mapply
 from Products.CMFCore.interfaces import IFolderish
 from Products.CMFCore.interfaces import ISiteRoot
+from Products.CMFCore.permissions import DeleteObjects
 from Products.CMFCore.permissions import ModifyPortalContent
 from Products.CMFCore.permissions import View
 from Products.CMFCore.utils import getToolByName
@@ -301,6 +302,52 @@ def edit(obj, check_permissions=True, **kwargs):
             mapply(mutator, value)
         else:
             field.set(obj, value)
+
+
+def uncatalog_object(obj):
+    """Un-catalog the object from all catalogs
+
+    :param obj: object to un-catalog
+    :type obj: ATContentType/DexterityContentType
+    """
+    # un-catalog from registered catalogs
+    obj.unindexObject()
+    # explicitly un-catalog from uid_catalog
+    uid_catalog = get_tool("uid_catalog")
+    # the uids of uid_catalog are relative paths to portal root
+    # see Products.Archetypes.UIDCatalog.UIDResolver.catalog_object
+    url = "/".join(obj.getPhysicalPath()[2:])
+    uid_catalog.uncatalog_object(url)
+
+
+def catalog_object(obj):
+    """Re-catalog the object
+    :param obj: object to un-catalog
+    :type obj: ATContentType/DexterityContentType
+    """
+    if is_at_content(obj):
+        # explicitly re-catalog AT types at uid_catalog (DX types are
+        # automatically reindexed in UID catalog on reindexObject)
+        uc = get_tool("uid_catalog")
+        # the uids of uid_catalog are relative paths to portal root
+        # see Products.Archetypes.UIDCatalog.UIDResolver.catalog_object
+        url = "/".join(obj.getPhysicalPath()[2:])
+        uc.catalog_object(obj, url)
+    obj.reindexObject()
+
+
+def delete(obj, check_permissions=True, suppress_events=False):
+    """Deletes the given object
+    """
+    from security import check_permission
+    if check_permissions and not check_permission(DeleteObjects, obj):
+        raise Unauthorized("Do not have permissions to remove this object")
+
+    # un-catalog the object from all catalogs (uid_catalog included)
+    uncatalog_object(obj)
+    # delete the object
+    parent = get_parent(obj)
+    parent._delObject(obj.getId(), suppress_events=suppress_events)
 
 
 def get_tool(name, context=None, default=_marker):

--- a/src/bika/lims/workflow/worksheet/events.py
+++ b/src/bika/lims/workflow/worksheet/events.py
@@ -18,6 +18,7 @@
 # Copyright 2018-2021 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from bika.lims import api
 from bika.lims import workflow as wf
 
 
@@ -31,11 +32,9 @@ def after_retract(worksheet):
 def after_remove(worksheet):
     """Removes the worksheet from the system
     """
-    container = worksheet.aq_parent
-
     # bypass security checks on object removal. The removal of worksheet
     # objects is governed by "Transition: Remove Worksheet" permission at
     # worksheet level, along with a specific guard to ensure that only empty
     # worksheets can be removed. Therefore, better keep the "Delete objects"
     # permission at Worksheets folder level as false, because is less specific
-    container._delObject(worksheet.getId())
+    api.delete(worksheet, check_permissions=False)

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2523</version>
+  <version>2524</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -2212,7 +2212,7 @@ Create a copy of an object created earlier:
     >>> uid = api.get_uid(new_client)
     >>> path = api.get_path(new_client)
 
-Trying to delete an object with enough permissions is not possible:
+Trying to delete an object without enough permissions is not possible:
 
     >>> api.delete(new_client)
     Traceback (most recent call last):

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -2163,3 +2163,70 @@ Convert to list
 
     >>> api.to_list('["[1, 2, 3]", "b", "c"]')
     [u'[1, 2, 3]', u'b', u'c']
+
+
+Un-catalog an object
+....................
+
+This function un-catalogs an object from **all** catalogs:
+
+    >>> api.uncatalog_object(client)
+    >>> uid = api.get_uid(client)
+    >>> catalogs = api.get_catalogs_for(client)
+    >>> matches = [cat(UID=uid) for cat in catalogs]
+    >>> any(matches)
+    False
+
+Even from `uid_catalog`:
+
+    >>> uc = api.get_tool("uid_catalog")
+    >>> any(uc(UID=uid))
+    False
+
+Catalog an object
+.................
+
+This function (re)catalogs an object in **all** catalogs:
+
+    >>> api.catalog_object(client)
+    >>> uid = api.get_uid(client)
+    >>> catalogs = api.get_catalogs_for(client)
+    >>> matches = [cat(UID=uid) for cat in catalogs]
+    >>> all(matches)
+    True
+
+Even in `uid_catalog`:
+
+    >>> uc = api.get_tool("uid_catalog")
+    >>> len(uc(UID=uid)) == 1
+    True
+
+
+Delete an object
+................
+
+This function deletes an object from the system.
+Create a copy of an object created earlier:
+
+    >>> new_client = api.copy_object(client, title="Client to delete")
+    >>> uid = api.get_uid(new_client)
+    >>> path = api.get_path(new_client)
+
+Trying to delete an object with enough permissions is not possible:
+
+    >>> api.delete(new_client)
+    Traceback (most recent call last):
+    ...
+    Unauthorized: Do not have permissions to remove this object
+
+Unless we explicitly tell the system to bypass security check:
+
+    >>> api.delete(new_client, check_permissions=False)
+    >>> api.get_object_by_uid(uid)
+    Traceback (most recent call last):
+    ...
+    APIError: No object found for UID ...
+
+    >>> obj = api.get_object_by_path(path)
+    >>> api.is_object(obj)
+    False

--- a/src/senaite/core/upgrade/v02_05_000.py
+++ b/src/senaite/core/upgrade/v02_05_000.py
@@ -563,7 +563,6 @@ def fix_searches_worksheets(tool):
     """Reindex listing_searchable_text index from Worksheets
     """
     logger.info("Reindexing listing_searchable_text from Worksheets ...")
-
     request = api.get_request()
     cat = api.get_tool(WORKSHEET_CATALOG)
     brains = cat(portal_type="Worksheet")
@@ -635,3 +634,27 @@ def fix_range_values_for(brains):
         if reindex:
             obj.reindexObject()
         obj._p_deactivate()
+
+
+def purge_orphan_worksheets(tool):
+    """Walks through all records from worksheets catalog and remove orphans
+    """
+    logger.info("Purging orphan Worksheet records from catalog ...")
+    request = api.get_request()
+    cat = api.get_tool(WORKSHEET_CATALOG)
+    paths = cat._catalog.uids.keys()
+    for path in paths:
+        # try to wake-up the object
+        obj = cat.resolve_path(path)
+        if obj is None:
+            obj = cat.resolve_url(path, request)
+
+        if obj is None:
+            # object is missing, remove
+            logger.info("Removing stale record: {}".format(path))
+            cat.uncatalog_object(path)
+            continue
+
+        obj._p_deactivate()
+
+    logger.info("Purging orphan Worksheet records from catalog [DONE]")

--- a/src/senaite/core/upgrade/v02_05_000.py
+++ b/src/senaite/core/upgrade/v02_05_000.py
@@ -565,15 +565,7 @@ def fix_searches_worksheets(tool):
     logger.info("Reindexing listing_searchable_text from Worksheets ...")
     request = api.get_request()
     cat = api.get_tool(WORKSHEET_CATALOG)
-    brains = cat(portal_type="Worksheet")
-    total = len(brains)
-    for num, brain in enumerate(brains):
-        obj = api.get_object(brain)
-        logger.info("Reindexing control analysis %d/%d: `%s`" % (
-            num+1, total, api.get_path(obj)))
-        cat.manage_reindexIndex("listing_searchable_text", REQUEST=request)
-        obj._p_deactivate()
-
+    cat.manage_reindexIndex("listing_searchable_text", REQUEST=request)
     logger.info("Reindexing listing_searchable_text from Worksheets [DONE]")
 
 

--- a/src/senaite/core/upgrade/v02_05_000.zcml
+++ b/src/senaite/core/upgrade/v02_05_000.zcml
@@ -4,6 +4,14 @@
     i18n_domain="senaite.core">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.5.0: Un-catalog orphan worksheets"
+      description="Un-catalog worksheets that were once removed"
+      source="2523"
+      destination="2524"
+      handler=".v02_05_000.purge_orphan_worksheets"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.5.0: Fix min/max range values"
       description="Fix possible min > max in range values for reference definitions/samples"
       source="2522"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Requests ensures that when removing a Worksheet, the object is uncatalogued as well. Besides, this PR adds some functions in the API and an upgrade step to purge stale worksheets

## Current behavior before PR

When deleting a Worksheet (w/o analyses), the system does not uncatalog the worksheet

## Desired behavior after PR is merged

When deleting a Worksheet (w/o analyses), the system does uncatalog the worksheet

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
