### PR TITLE
Fix analyses not filtered by selected WST services

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2454 Fix analyses not filtered by selected WST services
 - #2453 Fix worksheets are not uncatalogued when deleted
 - #2452 Fix reference definition range validation
 - #2450 Fix search bar from worksheet listing does not work

--- a/src/bika/lims/browser/worksheet/templates/add_analyses.pt
+++ b/src/bika/lims/browser/worksheet/templates/add_analyses.pt
@@ -23,7 +23,7 @@
         <div class="col-sm-12">
           <!-- WS Template Select Form -->
           <form id="applytemplate_form"
-                class="form form-inline"
+                class="form form-inline mb-3"
                 method="POST">
             <input type="hidden" name="submitted" value="1"/>
             <input tal:replace="structure context/@@authenticator/authenticator"/>

--- a/src/bika/lims/browser/worksheet/views/add_analyses.py
+++ b/src/bika/lims/browser/worksheet/views/add_analyses.py
@@ -166,11 +166,38 @@ class AddAnalysesView(BikaListingView):
         """
         super(AddAnalysesView, self).update()
         wst = self.context.getWorksheetTemplate()
+        new_states = []
         if wst:
-            method = wst.getRawRestrictToMethod()
             # restrict the available analysis services by method
+            method = wst.getRawRestrictToMethod()
             if method:
-                self.contentFilter["getServiceUID"] = getServiceUidsByMethod(method)
+                service_uids = getServiceUidsByMethod(method)
+                new_states.append({
+                    "id": "restrict_to_method",
+                    "title": _("Filter by template method"),
+                    "contentFilter": {
+                        "getServiceUID": service_uids
+                    },
+                    "transitions": [{"id": "assign"}, ],
+                    "columns": self.columns.keys(),
+                })
+
+            wst_service_uids = wst.getRawService()
+            # restrict to the selected template services
+            if wst_service_uids:
+                new_states.append({
+                    "id": "restrict_to_services",
+                    "title": _("Filter by template services"),
+                    "contentFilter": {
+                        "getServiceUID": wst_service_uids,
+                    },
+                    "transitions": [{"id": "assign"}, ],
+                    "columns": self.columns.keys(),
+                })
+
+        for state in sorted(new_states, key=lambda s: s.get("id")):
+            if state not in self.review_states:
+                self.review_states.append(state)
 
     def handle_submit(self):
         """Handle form submission

--- a/src/bika/lims/browser/worksheet/views/add_analyses.py
+++ b/src/bika/lims/browser/worksheet/views/add_analyses.py
@@ -168,19 +168,6 @@ class AddAnalysesView(BikaListingView):
         wst = self.context.getWorksheetTemplate()
         new_states = []
         if wst:
-            # restrict the available analysis services by method
-            method = wst.getRawRestrictToMethod()
-            if method:
-                service_uids = getServiceUidsByMethod(method)
-                new_states.append({
-                    "id": "restrict_to_method",
-                    "title": _("Filter by template method"),
-                    "contentFilter": {
-                        "getServiceUID": service_uids
-                    },
-                    "transitions": [{"id": "assign"}, ],
-                    "columns": self.columns.keys(),
-                })
 
             wst_service_uids = wst.getRawService()
             # restrict to the selected template services
@@ -194,6 +181,22 @@ class AddAnalysesView(BikaListingView):
                     "transitions": [{"id": "assign"}, ],
                     "columns": self.columns.keys(),
                 })
+                self.default_review_state = "restrict_to_services"
+
+            # restrict the available analysis services by method
+            method = wst.getRawRestrictToMethod()
+            if method:
+                service_uids = getServiceUidsByMethod(method)
+                new_states.append({
+                    "id": "restrict_to_method",
+                    "title": _("Filter by template method"),
+                    "contentFilter": {
+                        "getServiceUID": service_uids
+                    },
+                    "transitions": [{"id": "assign"}, ],
+                    "columns": self.columns.keys(),
+                })
+                self.default_review_state = "restrict_to_method"
 
         for state in sorted(new_states, key=lambda s: s.get("id")):
             if state not in self.review_states:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the "Add analyses" filter for Worksheets when a template was assigned.

## Current behavior before PR

All analyses are shown, even if the worksheet template has restricted services

## Desired behavior after PR is merged

Only analyses are shown in the listing that match the selected services of the worksheet template.

<img width="1833" alt="WST Filter" src="https://github.com/senaite/senaite.core/assets/713193/9b51afb7-a216-4655-bc3e-912b116b8293">

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
