### PR TITLE
Fix users/groups overview batch navigation styling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2455 Fix users/groups overview batch navigation styling
 - #2454 Fix analyses not filtered by selected WST services
 - #2453 Fix worksheets are not uncatalogued when deleted
 - #2452 Fix reference definition range validation

--- a/src/senaite/core/browser/batching/configure.zcml
+++ b/src/senaite/core/browser/batching/configure.zcml
@@ -1,0 +1,14 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser">
+
+  <browser:page
+      name="batchnavigation"
+      for="*"
+      class="plone.batching.browser.PloneBatchView"
+      template="templates/batchnavigation.pt"
+      permission="zope.Public"
+      layer="senaite.core.interfaces.ISenaiteCore"
+      />
+
+</configure>

--- a/src/senaite/core/browser/batching/templates/batchnavigation.pt
+++ b/src/senaite/core/browser/batching/templates/batchnavigation.pt
@@ -1,0 +1,95 @@
+<!-- Navigation -->
+<tal:batchnavigation
+  define="batch view/batch|nothing"
+  condition="batch"
+  metal:define-macro="navigation">
+
+  <nav i18n:domain="plone"
+       tal:condition="batch/multiple_pages">
+
+    <ul class="pagination pagination-sm p-0 m-0">
+
+      <tal:comment replace="nothing">
+        <!-- Previous page -->
+      </tal:comment>
+      <li class="page-item previous" tal:condition="batch/has_previous">
+        <a class="page-link" tal:attributes="href python:view.make_link(batch.previouspage)">
+          <span class="arrow"></span>
+          <span class="label" i18n:translate="batch_previous_x_items">
+            Previous <span i18n:name="number" tal:content="batch/pagesize" tal:omit-tag="">n</span> items
+          </span>
+        </a>
+      </li>
+
+      <tal:comment replace="nothing">
+        <!-- First page -->
+      </tal:comment>
+      <li class="page-item first" tal:condition="batch/show_link_to_first">
+        <a class="page-link" tal:attributes="href python:view.make_link(1)">1</a>
+      </li>
+
+      <tal:comment replace="nothing">
+        <!-- Ellipsis after first item -->
+      </tal:comment>
+      <li class="page-item disabled" tal:condition="batch/second_page_not_in_navlist">
+        <span class="page-link">...</span>
+      </li>
+
+      <tal:comment replace="nothing">
+        <!-- Pagelist with links to previous pages for quick navigation -->
+      </tal:comment>
+      <li class="page-item" tal:repeat="pagenumber batch/previous_pages">
+        <a class="page-link" tal:content="pagenumber"
+           tal:attributes="href python:view.make_link(pagenumber)" />
+      </li>
+
+      <tal:comment replace="nothing">
+        <!-- Active page -->
+      </tal:comment>
+      <li class="page-item active" tal:condition="batch/navlist">
+        <span class="page-link" tal:content="batch/pagenumber" />
+      </li>
+
+      <tal:comment replace="nothing">
+        <!-- Pagelist with links to next pages for quick navigation -->
+      </tal:comment>
+      <li class="page-item" tal:repeat="pagenumber batch/next_pages">
+        <a class="page-link"
+           tal:content="pagenumber"
+           tal:attributes="href python:view.make_link(pagenumber)" />
+      </li>
+
+      <tal:comment replace="nothing">
+        <!-- Ellipsis before last item -->
+      </tal:comment>
+      <li class="page-item disabled" tal:condition="batch/before_last_page_not_in_navlist">
+        <span class="page-link">...</span>
+      </li>
+
+      <tal:comment replace="nothing">
+        <!-- Last page -->
+      </tal:comment>
+      <li class="page-item last" tal:condition="batch/show_link_to_last">
+        <a class="page-link"
+           tal:attributes="href python:view.make_link(batch.lastpage)"
+           tal:content="batch/lastpage" />
+      </li>
+
+      <tal:comment replace="nothing">
+        <!-- Next page -->
+      </tal:comment>
+      <li class="page-item next" tal:condition="batch/has_next">
+        <a class="page-link" tal:attributes="href python:view.make_link(batch.nextpage)">
+          <span class="label" i18n:translate="batch_next_x_items">
+            Next
+            <span i18n:name="number" tal:omit-tag="" tal:content="batch/next_item_count">n</span>
+            items
+          </span>
+          <span class="arrow"></span>
+        </a>
+      </li>
+    </ul>
+
+  </nav>
+
+</tal:batchnavigation>

--- a/src/senaite/core/browser/configure.zcml
+++ b/src/senaite/core/browser/configure.zcml
@@ -14,6 +14,7 @@
 
   <!-- Package includes -->
   <include package=".attachment"/>
+  <include package=".batching"/>
   <include package=".bootstrap"/>
   <include package=".contentmenu"/>
   <include package=".contentrules"/>

--- a/src/senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt
+++ b/src/senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt
@@ -319,14 +319,14 @@
                               keys batchformkeys|nothing;
                               linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
                               url batch_base_url | string:${context/absolute_url}/${template_id}">
-                    <a class="btn btn-sm btn-outline-secondary mr-2"
+                    <a class="btn btn-sm btn-outline-secondary ml-1"
                        tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
                        i18n:translate="description_pas_show_all_search_results">
                       Show all search results
                     </a>
                   </div>
 
-                  <input class="context btn btn-sm btn-primary"
+                  <input class="btn btn-sm btn-primary ml-1"
                          type="submit"
                          name="form.button.Add"
                          value="Add selected groups and users to this group"

--- a/src/senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt
+++ b/src/senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt
@@ -93,18 +93,21 @@
                 <table class="table table-bordered table-hover table-sm"
                        summary="Group Members Listing"
                        tal:condition="view/groupMembers">
+                  <colgroup>
+                    <col style="width:36px;"/>
+                  </colgroup>
 
                   <tr>
                     <th>
-                      <input class="noborder"
-                             type="checkbox"
-                             src="select_all_icon.png"
-                             name="selectButton"
-                             title="Select all items"
-                             onClick="toggleSelect(this, 'delete:list');"
-                             tal:attributes="src string:$portal_url/select_all_icon.png"
-                             alt="Select all items"
-                             i18n:attributes="title label_select_all_items; alt label_select_all_items;"/>
+                      <!-- <input class="noborder"
+                           type="checkbox"
+                           src="select_all_icon.png"
+                           name="selectButton"
+                           title="Select all items"
+                           onClick="toggleSelect(this, 'delete:list');"
+                           tal:attributes="src string:$portal_url/select_all_icon.png"
+                           alt="Select all items"
+                           i18n:attributes="title label_select_all_items; alt label_select_all_items;"/> -->
                       <!--Remove user from this group-->
                     </th>
                     <th i18n:translate="listingheader_user_name">User name</th>
@@ -126,24 +129,28 @@
 
                       <tal:block tal:condition="python: view.isGroup(this_user)">
                         <td>
-                          <img src="group.png" alt="" />
+                          <i class="fas fa-users text-primary mr-1"></i>
                           <a href="" tal:attributes="href python:'@@usergroup-groupdetails?' + view.makeQuery(groupname=this_user.getGroupName())" >
                             <span tal:replace="this_user/getGroupTitleOrName | default" />
-                            (<span tal:replace="this_user/id" />)
                           </a>
+                          <div class="small text-secondary">(<span tal:replace="this_user/id" />)</div>
                         </td>
                       </tal:block>
 
                       <tal:block tal:condition="python: not view.isGroup(this_user)">
                         <td>
-                          <img src="user.png" alt="" />
-                          <a href="" tal:attributes="href python:'@@user-information?' + view.makeQuery(userid=this_user.getId());
-                                   title this_user/getId">
-                            <span tal:replace="python:this_user.getProperty('fullname')">Full Name</span>
+                          <div class="text-nowrap">
+                            <i class="fas fa-user text-primary mr-1"></i>
+                            <a href="" tal:attributes="href python:'@@user-information?' + view.makeQuery(userid=this_user.getId());
+                                     title this_user/getId">
+                              <span tal:replace="python:this_user.getProperty('fullname')">Full Name</span>
+                            </a>
+                          </div>
+                          <div class="small text-secondary">
                             <tal:userid tal:condition="not:view/email_as_username">
                               (<span tal:replace="this_user/getUserName | default" />)
                             </tal:userid>
-                          </a>
+                          </div>
                         </td>
                       </tal:block>
 
@@ -182,6 +189,9 @@
 
                   <table class="table table-bordered table-hover table-sm"
                          summary="Groups">
+                    <colgroup>
+                      <col style="width:36px;">
+                    </colgroup>
                     <tr>
                       <th colspan="3">
                         <div class="input-group input-group-sm">
@@ -218,15 +228,15 @@
                     </tr>
                     <tr tal:condition="batch">
                       <th>
-                        <input class="noborder"
-                               type="checkbox"
-                               src="select_all_icon.png"
-                               name="selectButton"
-                               title="Select all items"
-                               onClick="toggleSelect(this, 'add:list');"
-                               tal:attributes="src string:$portal_url/select_all_icon.png"
-                               alt="Select all items"
-                               i18n:attributes="title label_select_all_items; alt label_select_all_items;"/>
+                        <!-- <input class="noborder"
+                             type="checkbox"
+                             src="select_all_icon.png"
+                             name="selectButton"
+                             title="Select all items"
+                             onClick="toggleSelect(this, 'add:list');"
+                             tal:attributes="src string:$portal_url/select_all_icon.png"
+                             alt="Select all items"
+                             i18n:attributes="title label_select_all_items; alt label_select_all_items;"/> -->
                       </th>
 
                       <th i18n:translate="listingheader_group_user_name">Group/User name</th>
@@ -249,21 +259,25 @@
 
                         <td>
                           <tal:block tal:condition="python:not view.isGroup(this_user)">
-                            <img src="user.png" alt="" />
+                            <i class="fas fa-user text-primary mr-1"></i>
                             <a href="" tal:attributes="href python:'@@user-information?' + view.makeQuery(userid=this_user.getId());
                                      title this_user/getId">
                               <span tal:replace="python:this_user.getProperty('fullname')">Full Name</span>
+                            </a>
+                            <div class="small text-secondary">
                               <tal:userid tal:condition="not:view/email_as_username">
                                 (<span tal:replace="this_user/getUserName | default" />)
                               </tal:userid>
-                            </a>
+                            </div>
                           </tal:block>
                           <tal:block tal:condition="python: view.isGroup(this_user)">
-                            <img src="group.png" alt="" />
+                            <i class="fas fa-users text-primary mr-1"></i>
                             <a href="" tal:attributes="href python:'@@usergroup-groupdetails?' + view.makeQuery(groupname=this_user.getGroupName())">
                               <span tal:replace="this_user/getGroupTitleOrName | default" />
-                              (<span tal:replace="this_user/id | default" />)
                             </a>
+                            <div class="small text-secondary">
+                              (<span tal:replace="this_user/id | default" />)
+                            </div>
                           </tal:block>
                         </td>
                         <td tal:define="email python: this_user.getProperty('email')">
@@ -298,9 +312,7 @@
                           Enter a group or user name to search for or click 'Show All'.
                         </td>
                       </tal:block>
-
                     </tr>
-
                   </table>
 
                   <input type="hidden" value="b_start" name="b_start"
@@ -309,29 +321,29 @@
                   <input type="hidden" value="" name="showAll"
                          tal:attributes="value showAll"/>
 
-                  <div class="d-flex">
+                  <div class="form-inline form-group pb-3">
                     <div metal:use-macro="context/batch_macros/macros/navigation" />
-                  </div>
+                    <div class="showAllSearchResults ml-1"
+                         tal:condition="python:batch.next or batch.previous"
+                         tal:define="mq python:modules['ZTUtils'].make_query;
+                                keys batchformkeys|nothing;
+                                linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
+                                url batch_base_url | string:${context/absolute_url}/${template_id}">
+                      <a class="btn btn-sm btn-outline-secondary"
+                         tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
+                         i18n:translate="description_pas_show_all_search_results">
+                        Show all search results
+                      </a>
+                    </div>
 
-                  <div class="showAllSearchResults"
-                       tal:condition="python:batch.next or batch.previous"
-                       tal:define="mq python:modules['ZTUtils'].make_query;
-                              keys batchformkeys|nothing;
-                              linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
-                              url batch_base_url | string:${context/absolute_url}/${template_id}">
-                    <a class="btn btn-sm btn-outline-secondary ml-1"
-                       tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
-                       i18n:translate="description_pas_show_all_search_results">
-                      Show all search results
-                    </a>
-                  </div>
+                    <input class="btn btn-sm btn-primary ml-1"
+                           type="submit"
+                           name="form.button.Add"
+                           value="Add selected groups and users to this group"
+                           tal:condition="batch"
+                           i18n:attributes="value label_add_users_to_group;" />
 
-                  <input class="btn btn-sm btn-primary ml-1"
-                         type="submit"
-                         name="form.button.Add"
-                         value="Add selected groups and users to this group"
-                         tal:condition="batch"
-                         i18n:attributes="value label_add_users_to_group;" />
+                  </div>
 
                 </tal:addusers>
 

--- a/src/senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt
+++ b/src/senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt
@@ -179,10 +179,10 @@
                                      title group_info/description|string:''">
 
                               <tal:group tal:replace="group_info/title" />
-                              <div class="small text-secondary">
-                                (<tal:id tal:replace="group_info/groupid" />)
-                              </div>
                             </a>
+                            <div class="small text-secondary">
+                              (<tal:id tal:replace="group_info/groupid" />)
+                            </div>
                           </div>
                         </td>
 

--- a/src/senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt
+++ b/src/senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt
@@ -6,264 +6,263 @@
       metal:use-macro="context/prefs_main_template/macros/master"
       i18n:domain="plone">
 
-<body>
+  <body>
 
-<metal:main fill-slot="prefs_configlet_content"
-     tal:define="template_id string:@@usergroup-groupprefs;
-                 errors python:request.get('errors', {});
-                 showAll python:request.get('showAll', '') and not view.newSearch and 'y';
-                 Batch python:modules['Products.CMFPlone'].Batch;
-                 b_start python:0 if showAll or view.newSearch else request.get('b_start',0);
-                 portal_roles view/portal_roles;
-                 search_results view/searchResults;
-                 b_size python:showAll and len(search_results) or 20;
-                 batch python:search_results and Batch(search_results, b_size, int(b_start), orphan=1) or None;
-                 batchformkeys python:['searchstring','_authenticator'];
-                 portal_url context/portal_url;">
+    <metal:main fill-slot="prefs_configlet_content"
+                tal:define="template_id string:@@usergroup-groupprefs;
+                           errors python:request.get('errors', {});
+                           showAll python:request.get('showAll', '') and not view.newSearch and 'y';
+                           Batch python:modules['Products.CMFPlone'].Batch;
+                           b_start python:0 if showAll or view.newSearch else request.get('b_start',0);
+                           portal_roles view/portal_roles;
+                           search_results view/searchResults;
+                           b_size python:showAll and len(search_results) or 20;
+                           batch python:search_results and Batch(search_results, b_size, int(b_start), orphan=1) or None;
+                           batchformkeys python:['searchstring','_authenticator'];
+                           portal_url context/portal_url;">
 
-  <article id="content">
+      <article id="content">
 
-    <a id="setup-link" class="link-parent"
-       tal:attributes="href string:$portal_url/@@overview-controlpanel"
-       i18n:translate="">
-        Site Setup
-    </a>
+        <a id="setup-link" class="link-parent"
+           tal:attributes="href string:$portal_url/@@overview-controlpanel"
+           i18n:translate="">
+          Site Setup
+        </a>
 
-    <h1 class="documentFirstHeading"
-        i18n:translate="">Users and Groups</h1>
+        <h1 class="documentFirstHeading"
+            i18n:translate="">Users and Groups</h1>
 
-    <div metal:use-macro="context/global_statusmessage/macros/portal_message">
-        Portal status message
-    </div>
-
-    <div id="content-core">
-
-      <div class="autotabs">
-        <div class="autotoc-nav">
-          <a href="${portal_url}/@@usergroup-userprefs"
-             i18n:translate="label_users">Users</a>
-          <a class="active"
-             href="${portal_url}/@@usergroup-groupprefs"
-             i18n:translate="label_groups">Groups</a>
-          <!-- <a href="${portal_url}/@@usergroup-controlpanel"
-               i18n:translate="label_usergroup_settings">Settings</a>
-               <a href="${portal_url}/@@member-fields"
-               i18n:translate="label_member_fields">Member fields</a> -->
+        <div metal:use-macro="context/global_statusmessage/macros/portal_message">
+          Portal status message
         </div>
 
-        <p class="discreet">
-          <span tal:omit-tag=""
-                i18n:translate="description_groups_management">
-            Groups are logical collections of users, such as
-            departments and business units. Groups are not directly
-            related to permissions on a global level, you normally
-            use Roles for that - and let certain Groups have a
-            particular role.
-          </span>
-          <span tal:omit-tag=""
-                i18n:translate="description_groups_management2">
-            The symbol
-            <img i18n:name="image_link_icon"
-                 tal:replace="structure context/site_icon.png" />
-            indicates a role inherited from membership in another group.
-          </span>
-        </p>
+        <div id="content-core">
 
-        <p i18n:translate="description_pas_group_listing"
-           tal:condition="view/show_group_listing_warning">
-            Note: Some or all of your PAS groups
-            source plugins do not allow listing of groups, so you
-            may not see the groups defined by those plugins unless
-            doing a specific search.
-        </p>
-
-        <p>
-          <a class="pat-plone-modal" id="add-group"
-             tal:attributes="href string:${portal_url}/@@usergroup-groupdetails">
-            <button class="btn btn-sm btn-primary context"  i18n:translate="label_add_new_group">
-              Add New Group
-            </button>
-          </a>
-        </p>
-
-        <form action=""
-              class="form-inline"
-              name="groups_search"
-              method="post"
-              tal:attributes="action string:$template_id">
-
-            <input type="hidden" name="form.submitted" value="1" />
-
-            <input type="hidden" value="b_start" name="b_start"
-                   tal:attributes="value b_start"/>
-
-            <input type="hidden" value="" name="showAll"
-                   tal:attributes="value showAll"/>
-
-            <div class="input-group input-group-sm mb-3">
-
-              <div class="input-group-prepend">
-                <div class="input-group-text"
-                     i18n:translate="label_group_search">
-                  Group Search
-                </div>
-              </div>
-
-              <input class="quickSearch form-control"
-                     type="text"
-                     name="searchstring"
-                     value=""
-                     tal:attributes="value view/searchString;"
-              />
-
-              <div class="input-group-append">
-                <input type="submit"
-                       class="searchButton context btn btn-outline-secondary"
-                       name="form.button.Search"
-                       value="Search"
-                       i18n:attributes="value label_search;"
-                />
-
-                <input type="submit"
-                       class="searchButton btn btn-outline-secondary"
-                       name="form.button.FindAll"
-                       value="Show all"
-                       i18n:attributes="value label_showall;"
-                       tal:condition="not:view/many_groups"
-                />
-              </div>
-
+          <div class="autotabs">
+            <div class="autotoc-nav">
+              <a href="${portal_url}/@@usergroup-userprefs"
+                 i18n:translate="label_users">Users</a>
+              <a class="active"
+                 href="${portal_url}/@@usergroup-groupprefs"
+                 i18n:translate="label_groups">Groups</a>
+              <!-- <a href="${portal_url}/@@usergroup-controlpanel"
+                   i18n:translate="label_usergroup_settings">Settings</a>
+                   <a href="${portal_url}/@@member-fields"
+                   i18n:translate="label_member_fields">Member fields</a> -->
             </div>
 
+            <p class="discreet">
+              <span tal:omit-tag=""
+                    i18n:translate="description_groups_management">
+                Groups are logical collections of users, such as
+                departments and business units. Groups are not directly
+                related to permissions on a global level, you normally
+                use Roles for that - and let certain Groups have a
+                particular role.
+              </span>
+              <span tal:omit-tag=""
+                    i18n:translate="description_groups_management2">
+                The symbol
+                <img i18n:name="image_link_icon"
+                     tal:replace="structure context/site_icon.png" />
+                indicates a role inherited from membership in another group.
+              </span>
+            </p>
 
-            <table class="table table-bordered table-hover table-sm"
-                   summary="Select roles for each group"
-                   i18n:attributes="summary summary_roles_for_groups;">
-              <tbody>
+            <p i18n:translate="description_pas_group_listing"
+               tal:condition="view/show_group_listing_warning">
+              Note: Some or all of your PAS groups
+              source plugins do not allow listing of groups, so you
+              may not see the groups defined by those plugins unless
+              doing a specific search.
+            </p>
 
-                <tal:block tal:condition="search_results">
-                  <tr class="odd">
-                    <th rowspan=""
-                        i18n:translate="listingheader_group_name">
-                      Group Name
-                    </th>
+            <p>
+              <a class="pat-plone-modal" id="add-group"
+                 tal:attributes="href string:${portal_url}/@@usergroup-groupdetails">
+                <button class="btn btn-sm btn-success"  i18n:translate="label_add_new_group">
+                  Add New Group
+                </button>
+              </a>
+            </p>
 
-                    <tal:header repeat="portal_role portal_roles">
-                      <th tal:content="portal_role"
-                          i18n:translate="">
-                        Role
+            <form action=""
+                  class="form-inline"
+                  name="groups_search"
+                  method="post"
+                  tal:attributes="action string:$template_id">
+
+              <input type="hidden" name="form.submitted" value="1" />
+
+              <input type="hidden" value="b_start" name="b_start"
+                     tal:attributes="value b_start"/>
+
+              <input type="hidden" value="" name="showAll"
+                     tal:attributes="value showAll"/>
+
+              <div class="input-group input-group-sm mb-3">
+
+                <div class="input-group-prepend">
+                  <div class="input-group-text"
+                       i18n:translate="label_group_search">
+                    Group Search
+                  </div>
+                </div>
+
+                <input class="quickSearch form-control"
+                       type="text"
+                       name="searchstring"
+                       value=""
+                       tal:attributes="value view/searchString;"
+                />
+
+                <div class="input-group-append">
+                  <input type="submit"
+                         class="searchButton context btn btn-outline-secondary"
+                         name="form.button.Search"
+                         value="Search"
+                         i18n:attributes="value label_search;"
+                  />
+
+                  <input type="submit"
+                         class="searchButton btn btn-outline-secondary"
+                         name="form.button.FindAll"
+                         value="Show all"
+                         i18n:attributes="value label_showall;"
+                         tal:condition="not:view/many_groups"
+                  />
+                </div>
+
+              </div>
+
+
+              <table class="table table-bordered table-hover table-sm"
+                     summary="Select roles for each group"
+                     i18n:attributes="summary summary_roles_for_groups;">
+                <tbody>
+
+                  <tal:block tal:condition="search_results">
+                    <tr class="odd">
+                      <th rowspan=""
+                          i18n:translate="listingheader_group_name">
+                        Group Name
                       </th>
-                    </tal:header>
 
-                    <th rowspan=""
-                        i18n:translate="listingheader_remove">
-                      Remove
-                    </th>
-                  </tr>
+                      <tal:header repeat="portal_role portal_roles">
+                        <th tal:content="portal_role"
+                            i18n:translate="">
+                          Role
+                        </th>
+                      </tal:header>
 
-                  <tal:block repeat="group_info batch">
-                    <tr tal:define="oddrow repeat/group_info/odd;"
-                        tal:attributes="class python:oddrow and 'odd' or 'even'">
+                      <th rowspan=""
+                          i18n:translate="listingheader_remove">
+                        Remove
+                      </th>
+                    </tr>
 
-                      <td>
-                        <input type="hidden"
-                               name=""
-                               tal:attributes="name string:group_${group_info/groupid}:list"
-                               value=""
-                        />
+                    <tal:block repeat="group_info batch">
+                      <tr tal:define="oddrow repeat/group_info/odd;"
+                          tal:attributes="class python:oddrow and 'odd' or 'even'">
 
-                        <a href="#"
-                           tal:attributes="href python:portal_url+'/@@usergroup-groupmembership?'+view.makeQuery(groupname=group_info['groupid']);
-                                 title group_info/description|string:''">
-                          <tal:block replace="structure context/portal_url/group.png" />&nbsp;
-                          <tal:group tal:replace="group_info/title" /> <tal:groupid tal:condition="python:group_info['groupid'] != group_info['title']">(<tal:id tal:replace="group_info/groupid" />)</tal:groupid>
-                        </a>
-                      </td>
-
-                      <td class="listingCheckbox text-center align-middle"
-                          tal:repeat="portal_role portal_roles">
-                        <tal:block tal:define="inherited python:group_info['roles'][portal_role]['inherited'];
-                                               explicit python:group_info['roles'][portal_role]['explicit'];
-                                               enabled python:group_info['roles'][portal_role]['canAssign']">
-                          <input type="checkbox"
-                                 class="noborder"
-                                 name="name"
-                                 value="Manager"
-                                 tal:condition="not:inherited"
-                                 tal:attributes="name string:group_${group_info/groupid}:list;
-                                       value portal_role;
-                                       checked python:'checked' if explicit else nothing;
-                                       disabled python:default if enabled else 'disabled'"
-                          />
+                        <td>
                           <input type="hidden"
-                                 name="name"
-                                 value="Manager"
-                                 tal:condition="python:explicit and not enabled and not inherited"
-                                 tal:attributes="name string:group_${group_info/groupid}:list;
-                                       value portal_role" />
-                          <img tal:condition="inherited" tal:replace="structure context/site_icon.png" />
-                        </tal:block>
-                      </td>
+                                 name=""
+                                 tal:attributes="name string:group_${group_info/groupid}:list"
+                                 value=""
+                          />
 
-                      <td class="listingCheckbox text-center align-middle">
-                        <input type="checkbox"
-                               class="noborder notify"
-                               name="delete:list"
-                               value="value"
-                               tal:attributes="value group_info/groupid;
-                                     disabled python:default if group_info['can_delete'] else 'disabled'"
-                        />
+                        <i class="fas fa-users text-primary mr-1"></i>
+                          <a href="#"
+                             tal:attributes="href python:portal_url+'/@@usergroup-groupmembership?'+view.makeQuery(groupname=group_info['groupid']);
+                                   title group_info/description|string:''">
+                            <tal:group tal:replace="group_info/title" /> <tal:groupid tal:condition="python:group_info['groupid'] != group_info['title']">(<tal:id tal:replace="group_info/groupid" />)</tal:groupid>
+                          </a>
+                        </td>
+
+                        <td class="listingCheckbox text-center align-middle"
+                            tal:repeat="portal_role portal_roles">
+                          <tal:block tal:define="inherited python:group_info['roles'][portal_role]['inherited'];
+                                                 explicit python:group_info['roles'][portal_role]['explicit'];
+                                                 enabled python:group_info['roles'][portal_role]['canAssign']">
+                            <input type="checkbox"
+                                   class="noborder"
+                                   name="name"
+                                   value="Manager"
+                                   tal:condition="not:inherited"
+                                   tal:attributes="name string:group_${group_info/groupid}:list;
+                                         value portal_role;
+                                         checked python:'checked' if explicit else nothing;
+                                         disabled python:default if enabled else 'disabled'"
+                            />
+                            <input type="hidden"
+                                   name="name"
+                                   value="Manager"
+                                   tal:condition="python:explicit and not enabled and not inherited"
+                                   tal:attributes="name string:group_${group_info/groupid}:list;
+                                         value portal_role" />
+                            <img tal:condition="inherited" tal:replace="structure context/site_icon.png" />
+                          </tal:block>
+                        </td>
+
+                        <td class="listingCheckbox text-center align-middle">
+                          <input type="checkbox"
+                                 class="noborder notify"
+                                 name="delete:list"
+                                 value="value"
+                                 tal:attributes="value group_info/groupid;
+                                       disabled python:default if group_info['can_delete'] else 'disabled'"
+                          />
+                        </td>
+                      </tr>
+                    </tal:block>
+
+                  </tal:block>
+
+                  <tal:block tal:condition="python:(view.searchString and not search_results)">
+                    <tr>
+                      <td i18n:translate="text_nomatches"
+                          style="text-align:center;">
+                        No matches
                       </td>
                     </tr>
                   </tal:block>
+                </tbody>
+              </table>
 
-                </tal:block>
+              <tal:block tal:condition="python:(search_results)">
+                <div class="form-group pb-3">
+                  <div metal:use-macro="context/batch_macros/macros/navigation" />
 
-                <tal:block tal:condition="python:(view.searchString and not search_results)">
-                  <tr>
-                    <td i18n:translate="text_nomatches"
-                        style="text-align:center;">
-                      No matches
-                    </td>
-                  </tr>
-                </tal:block>
-              </tbody>
-            </table>
-
-            <tal:block tal:condition="python:(search_results)">
-
-                <div metal:use-macro="context/batch_macros/macros/navigation" />
-
-                <div class="showAllSearchResults"
-                     tal:condition="python:batch.next or batch.previous"
-                     tal:define="mq python:modules['ZTUtils'].make_query;
-                                 keys batchformkeys|nothing;
-                                 linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
-                                 url batch_base_url | string:${context/absolute_url}/${template_id}">
-                    <a tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
+                  <div class="showAllSearchResults ml-1"
+                       tal:condition="python:batch.next or batch.previous"
+                       tal:define="mq python:modules['ZTUtils'].make_query;
+                              keys batchformkeys|nothing;
+                              linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
+                              url batch_base_url | string:${context/absolute_url}/${template_id}">
+                    <a class="btn btn-sm btn-outline-secondary"
+                       tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
                        i18n:translate="description_pas_show_all_search_results">
-                        Show all search results
+                      Show all search results
                     </a>
-                </div>
+                  </div>
 
-                <div class="formControls">
-                  <input class="context"
+                  <input class="btn btn-sm btn-primary ml-1"
                          type="submit"
                          name="form.button.Modify"
                          value="Save"
                          i18n:attributes="value label_save;"
-                         />
+                  />
                 </div>
+              </tal:block>
 
-            </tal:block>
+              <input tal:replace="structure context/@@authenticator/authenticator" />
 
-            <input tal:replace="structure context/@@authenticator/authenticator" />
+            </form>
+          </div>
+        </div>
+      </article>
 
-        </form>
-      </div>
-    </div>
-  </article>
-
-</metal:main>
-</body>
+    </metal:main>
+  </body>
 </html>

--- a/src/senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt
+++ b/src/senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt
@@ -172,12 +172,18 @@
                                  value=""
                           />
 
-                        <i class="fas fa-users text-primary mr-1"></i>
-                          <a href="#"
-                             tal:attributes="href python:portal_url+'/@@usergroup-groupmembership?'+view.makeQuery(groupname=group_info['groupid']);
-                                   title group_info/description|string:''">
-                            <tal:group tal:replace="group_info/title" /> <tal:groupid tal:condition="python:group_info['groupid'] != group_info['title']">(<tal:id tal:replace="group_info/groupid" />)</tal:groupid>
-                          </a>
+                          <div class="text-nowrap">
+                            <i class="fas fa-users text-primary mr-1"></i>
+                            <a href="#"
+                               tal:attributes="href python:portal_url+'/@@usergroup-groupmembership?'+view.makeQuery(groupname=group_info['groupid']);
+                                     title group_info/description|string:''">
+
+                              <tal:group tal:replace="group_info/title" />
+                              <div class="small text-secondary">
+                                (<tal:id tal:replace="group_info/groupid" />)
+                              </div>
+                            </a>
+                          </div>
                         </td>
 
                         <td class="listingCheckbox text-center align-middle"

--- a/src/senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt
+++ b/src/senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt
@@ -149,13 +149,14 @@
                       </th>
 
                       <tal:header repeat="portal_role portal_roles">
-                        <th tal:content="portal_role"
+                        <th class="text-center"
+                            tal:content="portal_role"
                             i18n:translate="">
                           Role
                         </th>
                       </tal:header>
 
-                      <th rowspan=""
+                      <th rowspan="" class="text-center"
                           i18n:translate="listingheader_remove">
                         Remove
                       </th>

--- a/src/senaite/core/browser/usergroup/templates/usergroups_usermembership.pt
+++ b/src/senaite/core/browser/usergroup/templates/usergroups_usermembership.pt
@@ -80,10 +80,10 @@
                                   groupId group/getId;"
                       tal:attributes="class python:'odd' if oddrow else 'even'">
                     <td>
+                      <i class="fas fa-users text-primary mr-1"></i>
                       <a href="@@usergroup-groupdetails"
                          tal:attributes="href string:@@usergroup-groupdetails?groupname=${groupId}">
-                        <tal:block replace="structure portal/group.png"/>&nbsp;<span
-                                                                                 tal:replace="group/getGroupTitleOrName">group name</span>
+                        <span tal:replace="group/getGroupTitleOrName">group name</span>
                       </a>
                     </td>
 
@@ -160,7 +160,7 @@
                       </td>
 
                       <td>
-                        <img src="group.png" alt="" />
+                        <i class="fas fa-users text-primary mr-1"></i>
                         <a href="" tal:attributes="href python:'@@usergroup-groupdetails?'+mq(groupname=obj.getGroupName())"
                            tal:content="obj/getGroupTitleOrName | default">
                           <span i18n:translate="link_groupname_not_available">

--- a/src/senaite/core/browser/usergroup/templates/usergroups_usermembership.pt
+++ b/src/senaite/core/browser/usergroup/templates/usergroups_usermembership.pt
@@ -173,34 +173,38 @@
                 </tal:block>
               </table>
 
-              <div metal:use-macro="context/batch_macros/macros/navigation" />
+              <div class="form-inline form-group pb-3">
+                <div metal:use-macro="context/batch_macros/macros/navigation" />
 
-              <div class="showAllSearchResults"
-                   tal:condition="python:batch.next or batch.previous"
-                   tal:define="mq python:modules['ZTUtils'].make_query;
-                          keys batchformkeys|nothing;
-                          linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
-                          url batch_base_url | string:${context/absolute_url}/${template_id}">
-                <a tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
-                   i18n:translate="description_pas_show_all_search_results">
-                  Show all search results
-                </a>
+                <div class="showAllSearchResults ml-1"
+                     tal:condition="python:batch.next or batch.previous"
+                     tal:define="mq python:modules['ZTUtils'].make_query;
+                            keys batchformkeys|nothing;
+                            linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
+                            url batch_base_url | string:${context/absolute_url}/${template_id}">
+                  <a class="btn btn-sm btn-outline-secondary"
+                     tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
+                     i18n:translate="description_pas_show_all_search_results">
+                    Show all search results
+                  </a>
+                </div>
+
+                <input type="hidden" value="b_start" name="b_start"
+                       tal:attributes="value b_start"/>
+
+                <input type="hidden" value="" name="showAll"
+                       tal:attributes="value showAll"/>
+
+                <input type="hidden" name="form.submitted" value="1" />
+
+                <input class="btn btn-sm btn-primary ml-1"
+                       type="submit"
+                       name="form.button.Add"
+                       value="Add user to selected groups"
+                       tal:condition="batch"
+                       i18n:attributes="value label_add_user_to_group;" />
               </div>
 
-              <input type="hidden" value="b_start" name="b_start"
-                     tal:attributes="value b_start"/>
-
-              <input type="hidden" value="" name="showAll"
-                     tal:attributes="value showAll"/>
-
-              <input type="hidden" name="form.submitted" value="1" />
-
-              <input class="context btn btn-sm btn-primary"
-                     type="submit"
-                     name="form.button.Add"
-                     value="Add user to selected groups"
-                     tal:condition="batch"
-                     i18n:attributes="value label_add_user_to_group;" />
               <input tal:replace="structure context/@@authenticator/authenticator" />
 
             </form>

--- a/src/senaite/core/browser/usergroup/templates/usergroups_usermembership.pt
+++ b/src/senaite/core/browser/usergroup/templates/usergroups_usermembership.pt
@@ -71,29 +71,30 @@
                 <table class="table table-bordered table-hover table-sm"
                        summary="Group Memberships Listing"
                        tal:condition="groups">
+                <colgroup>
+                  <col style="width:36px;"/>
+                </colgroup>
                 <tr>
+                  <th i18n:translate="listingheader_group_remove"></th>
                   <th i18n:translate="listingheader_group_name">Group Name</th>
-                  <th i18n:translate="listingheader_group_remove">Remove</th>
                 </tr>
                 <tal:block repeat="group groups">
                   <tr tal:define="oddrow repeat/group/odd;
                                   groupId group/getId;"
                       tal:attributes="class python:'odd' if oddrow else 'even'">
+                    <td class="listingCheckbox text-center">
+                      <input type="checkbox"
+                             class="noborder notify"
+                             name="delete:list"
+                             tal:attributes="value groupId;
+                                             disabled python:member.canRemoveFromGroup(groupId) and default or 'disabled'" />
+                    </td>
                     <td>
                       <i class="fas fa-users text-primary mr-1"></i>
                       <a href="@@usergroup-groupdetails"
                          tal:attributes="href string:@@usergroup-groupdetails?groupname=${groupId}">
                         <span tal:replace="group/getGroupTitleOrName">group name</span>
                       </a>
-                    </td>
-
-
-                    <td class="listingCheckbox">
-                      <input type="checkbox"
-                             class="noborder notify"
-                             name="delete:list"
-                             tal:attributes="value groupId;
-                                   disabled python:member.canRemoveFromGroup(groupId) and default or 'disabled'" />
                     </td>
                   </tr>
                 </tal:block>
@@ -111,6 +112,9 @@
 
                 <table class="table table-bordered table-hover table-sm"
                        summary="Groups">
+                <colgroup>
+                  <col style="width:36px;"/>
+                </colgroup>
                 <tr>
                   <th colspan="2" tal:condition="many_groups">
                     <span tal:omit-tag="" i18n:translate="label_quick_search">Quick search</span>:
@@ -132,15 +136,15 @@
                 <tal:block condition="python:results">
                   <tr>
                     <th>
-                      <input class="noborder"
-                             type="checkbox"
-                             src="select_all_icon.png"
-                             name="selectButton"
-                             title="Select all items"
-                             onClick="toggleSelect(this, 'add:list');"
-                             tal:attributes="src string:${context/portal_url}/select_all_icon.png"
-                             alt="Select all items"
-                             i18n:attributes="title label_select_all_items; alt label_select_all_items;"/>
+                      <!-- <input class="noborder"
+                           type="checkbox"
+                           src="select_all_icon.png"
+                           name="selectButton"
+                           title="Select all items"
+                           onClick="toggleSelect(this, 'add:list');"
+                           tal:attributes="src string:${context/portal_url}/select_all_icon.png"
+                           alt="Select all items"
+                           i18n:attributes="title label_select_all_items; alt label_select_all_items;"/> -->
                     </th>
                     <th i18n:translate="listingheader_group_name">Group Name</th>
                   </tr>
@@ -148,7 +152,7 @@
                     <tr tal:define="oddrow repeat/obj/odd"
                         tal:attributes="class python:'odd' if oddrow else 'even'">
 
-                      <td class="listingCheckbox">
+                      <td class="listingCheckbox text-center">
                         <input type="checkbox"
                                class="noborder"
                                name="add:list"

--- a/src/senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt
+++ b/src/senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt
@@ -2,251 +2,254 @@
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-    lang="en"
-    metal:use-macro="context/prefs_main_template/macros/master"
-    i18n:domain="plone">
+      lang="en"
+      metal:use-macro="context/prefs_main_template/macros/master"
+      i18n:domain="plone">
 
-<body>
+  <body>
 
-<metal:main fill-slot="prefs_configlet_content"
-    tal:define="template_id string:@@usergroup-userprefs;
-                showAll python:request.get('showAll', '') and not view.newSearch and 'y';
-                Batch python:modules['Products.CMFPlone'].Batch;
-                b_start python:0 if showAll or view.newSearch else request.get('b_start',0);
-                b_size python:showAll and len(view.searchResults) or 20;
-                portal_roles view/portal_roles;
-                portal_url context/portal_url;">
+    <metal:main fill-slot="prefs_configlet_content"
+                tal:define="template_id string:@@usergroup-userprefs;
+                           showAll python:request.get('showAll', '') and not view.newSearch and 'y';
+                           Batch python:modules['Products.CMFPlone'].Batch;
+                           b_start python:0 if showAll or view.newSearch else request.get('b_start',0);
+                           b_size python:showAll and len(view.searchResults) or 20;
+                           portal_roles view/portal_roles;
+                           portal_url context/portal_url;">
 
-  <article id="content">
+      <article id="content">
 
-    <a id="setup-link" class="link-parent"
-       tal:attributes="href string:$portal_url/@@overview-controlpanel"
-       i18n:translate="">
-        Site Setup
-    </a>
+        <a id="setup-link" class="link-parent"
+           tal:attributes="href string:$portal_url/@@overview-controlpanel"
+           i18n:translate="">
+          Site Setup
+        </a>
 
-    <h1 class="documentFirstHeading"
-        i18n:translate="">Users and Groups</h1>
+        <h1 class="documentFirstHeading"
+            i18n:translate="">Users and Groups</h1>
 
-    <div metal:use-macro="context/global_statusmessage/macros/portal_message">
-      Portal status message
-    </div>
-
-    <div id="content-core">
-
-      <div class="autotabs">
-        <div class="autotoc-nav">
-          <a class="active"
-             href="${portal_url}/@@usergroup-userprefs"
-             i18n:translate="label_users">Users</a>
-          <a href="${portal_url}/@@usergroup-groupprefs"
-             i18n:translate="label_groups">Groups</a>
-          <!-- <a href="${portal_url}/@@usergroup-controlpanel"
-               i18n:translate="label_usergroup_settings">Settings</a>
-               <a href="${portal_url}/@@member-fields"
-               i18n:translate="label_member_fields">Member fields</a> -->
+        <div metal:use-macro="context/global_statusmessage/macros/portal_message">
+          Portal status message
         </div>
 
-        <p i18n:translate="user_roles_note" class="discreet">
-          Note that roles set here apply directly to a user.
-          The symbol <img i18n:name="image_link_icon" tal:replace="structure context/site_icon.png" />
-          indicates a role inherited from membership in a group.
-        </p>
-        <p tal:condition="view/show_users_listing_warning" class="portalMessage warning" role="status">
-          <strong i18n:translate="">Note</strong>
-          <span i18n:translate="description_pas_users_listing">Some or all of your PAS user source
-          plugins do not allow listing of users, so you may not see
-          the users defined by those plugins unless doing a specific
-          search.</span>
-        </p>
-        <p>
-          <a class="pat-plone-modal" id="add-user"
-             data-pat-plone-modal="{&quot;actionOptions&quot;: {&quot;displayInModal&quot;: false}}"
-             tal:attributes="href string:${portal_url}/@@new-user">
-            <button class="btn btn-sm btn-primary context" i18n:translate="label_add_new_user" id="add-new-user">
-              Add New User
-            </button>
-          </a>
-        </p>
-        <form action=""
-              class="pat-formautofocus form-inline"
-              name="users_search"
-              method="post"
-              tal:attributes="action string:$portal_url/$template_id"
-              tal:define="findAll python:'form.button.FindAll' in request.keys();
+        <div id="content-core">
+
+          <div class="autotabs">
+            <div class="autotoc-nav">
+              <a class="active"
+                 href="${portal_url}/@@usergroup-userprefs"
+                 i18n:translate="label_users">Users</a>
+              <a href="${portal_url}/@@usergroup-groupprefs"
+                 i18n:translate="label_groups">Groups</a>
+              <!-- <a href="${portal_url}/@@usergroup-controlpanel"
+                   i18n:translate="label_usergroup_settings">Settings</a>
+                   <a href="${portal_url}/@@member-fields"
+                   i18n:translate="label_member_fields">Member fields</a> -->
+            </div>
+
+            <p i18n:translate="user_roles_note" class="discreet">
+              Note that roles set here apply directly to a user.
+              The symbol <img i18n:name="image_link_icon" tal:replace="structure context/site_icon.png" />
+              indicates a role inherited from membership in a group.
+            </p>
+            <p tal:condition="view/show_users_listing_warning" class="portalMessage warning" role="status">
+              <strong i18n:translate="">Note</strong>
+              <span i18n:translate="description_pas_users_listing">Some or all of your PAS user source
+                plugins do not allow listing of users, so you may not see
+                the users defined by those plugins unless doing a specific
+                search.</span>
+            </p>
+            <p>
+              <a class="pat-plone-modal" id="add-user"
+                 data-pat-plone-modal="{&quot;actionOptions&quot;: {&quot;displayInModal&quot;: false}}"
+                 tal:attributes="href string:${portal_url}/@@new-user">
+                <button class="btn btn-sm btn-success" i18n:translate="label_add_new_user" id="add-new-user">
+                  Add New User
+                </button>
+              </a>
+            </p>
+            <form action=""
+                  class="pat-formautofocus form-inline"
+                  name="users_search"
+                  method="post"
+                  tal:attributes="action string:$portal_url/$template_id"
+                  tal:define="findAll python:'form.button.FindAll' in request.keys();
                           portal_users view/searchResults;
                           batch python:Batch(portal_users, b_size, int(b_start), orphan=1);
                           batchformkeys python:['searchstring','_authenticator'];
                           many_users view/many_users">
-          <input type="hidden" name="form.submitted" value="1" />
+              <input type="hidden" name="form.submitted" value="1" />
 
-          <div class="input-group input-group-sm mb-3">
-            <div class="input-group-prepend">
-              <div class="input-group-text"
-                   i18n:translate="label_user_search">
-                User Search
+              <div class="input-group input-group-sm mb-3">
+                <div class="input-group-prepend">
+                  <div class="input-group-text"
+                       i18n:translate="label_user_search">
+                    User Search
+                  </div>
+                </div>
+                <input class="quickSearch form-control"
+                       id="quickSearch"
+                       type="text"
+                       name="searchstring"
+                       value=""
+                       tal:attributes="value view/searchString;"
+                />
+
+                <div class="input-group-append">
+                  <input type="submit"
+                         class="searchButton context btn btn-outline-secondary"
+                         name="form.button.Search"
+                         value="Search"
+                         i18n:attributes="value label_search;"
+                  />
+
+                  <input type="submit"
+                         class="searchButton standalone btn btn-outline-secondary"
+                         name="form.button.FindAll"
+                         value="Show all"
+                         i18n:attributes="value label_showall;"
+                         tal:condition="not:many_users"
+                  />
+                </div>
               </div>
-            </div>
-            <input class="quickSearch form-control"
-                   id="quickSearch"
-                   type="text"
-                   name="searchstring"
-                   value=""
-                   tal:attributes="value view/searchString;"
-            />
 
-            <div class="input-group-append">
-              <input type="submit"
-                     class="searchButton context btn btn-outline-secondary"
-                     name="form.button.Search"
-                     value="Search"
-                     i18n:attributes="value label_search;"
-              />
+              <table class="table table-bordered table-hover table-sm" summary="User Listing">
+                <tbody>
+                  <tal:block tal:condition="portal_users" >
+                    <tr class="odd">
+                      <th rowspan="" i18n:translate="listingheader_user_name">User name</th>
+                      <th tal:repeat="portal_role portal_roles" tal:content="portal_role" i18n:translate="">Role</th>
+                      <th rowspan="" i18n:translate="listingheader_reset_password">Reset Password</th>
+                      <!-- <th rowspan="" i18n:translate="listingheader_remove">Remove</th> -->
+                    </tr>
+                  </tal:block>
+                  <tal:block repeat="user batch">
+                    <tr tal:define="oddrow repeat/user/odd;
+                                    userid user/userid;
+                                    userquery python:view.makeQuery(userid=userid);"
+                        tal:attributes="class python:oddrow and 'odd' or 'even'">
 
-              <input type="submit"
-                     class="searchButton standalone btn btn-outline-secondary"
-                     name="form.button.FindAll"
-                     value="Show all"
-                     i18n:attributes="value label_showall;"
-                     tal:condition="not:many_users"
-              />
-            </div>
-          </div>
+                      <td>
+                        <div class="text-nowrap">
+                          <i class="fas fa-user text-primary mr-1"></i>
+                          <a href="@@user-information"
+                             tal:attributes="href string:$portal_url/@@user-information?${userquery};
+                                   title userid">
+                            <span tal:content="user/fullname">Full Name</span>
+                          </a>
+                        </div>
+                        <div class="small text-secondary">(<span tal:replace="user/login">login name</span>)</div>
+                        <input type="hidden" name="users.id:records" tal:attributes="value userid" />
+                      </td>
 
-          <table class="table table-bordered table-hover table-sm" summary="User Listing">
-            <tbody>
-              <tal:block tal:condition="portal_users" >
-                <tr class="odd">
-                  <th rowspan="" i18n:translate="listingheader_user_name">User name</th>
-                  <th tal:repeat="portal_role portal_roles" tal:content="portal_role" i18n:translate="">Role</th>
-                  <th rowspan="" i18n:translate="listingheader_reset_password">Reset Password</th>
-                  <!-- <th rowspan="" i18n:translate="listingheader_remove">Remove</th> -->
-                </tr>
-              </tal:block>
-              <tal:block repeat="user batch">
-                <tr tal:define="oddrow repeat/user/odd;
-                                userid user/userid;
-                                userquery python:view.makeQuery(userid=userid);"
-                    tal:attributes="class python:oddrow and 'odd' or 'even'">
+                      <td class="listingCheckbox text-center align-middle"
+                          tal:repeat="portal_role portal_roles">
+                        <tal:block tal:define="inherited python:user['roles'][portal_role]['inherited'];
+                                               explicit python:user['roles'][portal_role]['explicit'];
+                                               enabled python:user['roles'][portal_role]['canAssign']">
+                          <input type="checkbox"
+                                 class="noborder"
+                                 name="users.roles:list:records"
+                                 value="Manager"
+                                 tal:condition="not:inherited"
+                                 tal:attributes="value portal_role;
+                                       checked python:'checked' if explicit else nothing;
+                                       disabled python:default if enabled else 'disabled'" />
+                          <input type="hidden"
+                                 name="users.roles:list:records"
+                                 value="Manager"
+                                 tal:condition="python:inherited"
+                                 tal:attributes="value portal_role" />
+                          <img tal:condition="inherited" tal:replace="structure context/site_icon.png" />
+                        </tal:block>
 
-                  <td>
-                    <a href="@@user-information"
-                       tal:attributes="href string:$portal_url/@@user-information?${userquery};
-                             title userid">
-                      <span tal:replace="user/fullname">Full Name</span>
-                      <em> – <em tal:replace="user/login">login name</em></em>
-                    </a>
-                    <input type="hidden" name="users.id:records" tal:attributes="value userid" />
-                  </td>
+                      </td>
 
-                  <td class="listingCheckbox text-center align-middle"
-                      tal:repeat="portal_role portal_roles">
-                    <tal:block tal:define="inherited python:user['roles'][portal_role]['inherited'];
-                                           explicit python:user['roles'][portal_role]['explicit'];
-                                           enabled python:user['roles'][portal_role]['canAssign']">
-                      <input type="checkbox"
-                             class="noborder"
-                             name="users.roles:list:records"
-                             value="Manager"
-                             tal:condition="not:inherited"
-                             tal:attributes="value portal_role;
-                                   checked python:'checked' if explicit else nothing;
-                                   disabled python:default if enabled else 'disabled'" />
-                      <input type="hidden"
-                             name="users.roles:list:records"
-                             value="Manager"
-                             tal:condition="python:inherited"
-                             tal:attributes="value portal_role" />
-                      <img tal:condition="inherited" tal:replace="structure context/site_icon.png" />
-                    </tal:block>
+                      <td class="listingCheckbox text-center align-middle">
+                        <input type="checkbox"
+                               class="noborder"
+                               name="users.resetpassword:records"
+                               value=""
+                               tal:attributes="value userid;
+                                     disabled python:user['can_set_password'] and default or 'disabled'" />
+                      </td>
 
-                  </td>
-
-                  <td class="listingCheckbox text-center align-middle">
-                    <input type="checkbox"
-                           class="noborder"
-                           name="users.resetpassword:records"
+                      <!-- N.B.: We disallow to delete users here, because this can bring a large site down when all contents are processed to change the owner.
+                           <td class="listingCheckbox">
+                           <input type="checkbox"
+                           class="noborder notify"
+                           name="delete:list"
                            value=""
                            tal:attributes="value userid;
-                                 disabled python:user['can_set_password'] and default or 'disabled'" />
-                  </td>
+                           disabled python:user['can_delete'] and default or 'disabled'" />
+                           </td>
+                      -->
 
-                  <!-- N.B.: We disallow to delete users here, because this can bring a large site down when all contents are processed to change the owner.
-                       <td class="listingCheckbox">
-                       <input type="checkbox"
-                       class="noborder notify"
-                       name="delete:list"
-                       value=""
-                       tal:attributes="value userid;
-                       disabled python:user['can_delete'] and default or 'disabled'" />
-                       </td>
-                  -->
+                    </tr>
+                  </tal:block>
+                  <tr tal:condition="not:batch">
+                    <td tal:condition="view/searchString"
+                        i18n:translate="text_nomatches"
+                        style="text-align:center;">No matches</td>
+                    <tal:block tal:condition="not:view/searchString">
+                      <td tal:condition="many_users"
+                          class="discreet"
+                          i18n:translate="text_no_user_searchstring"
+                          style="text-align:center; font-size: 100%;">
+                        Enter a username to search for
+                      </td>
+                      <td tal:condition="not:many_users"
+                          class="discreet"
+                          i18n:translate="text_no_user_searchstring_largesite"
+                          style="text-align:center; font-size: 100%;">
+                        Enter a username to search for, or click 'Show All'
+                      </td>
+                    </tal:block>
+                  </tr>
+                </tbody>
+              </table>
 
-                </tr>
-              </tal:block>
-              <tr tal:condition="not:batch">
-                <td tal:condition="view/searchString"
-                    i18n:translate="text_nomatches"
-                    style="text-align:center;">No matches</td>
-                <tal:block tal:condition="not:view/searchString">
-                  <td tal:condition="many_users"
-                      class="discreet"
-                      i18n:translate="text_no_user_searchstring"
-                      style="text-align:center; font-size: 100%;">
-                    Enter a username to search for
-                  </td>
-                  <td tal:condition="not:many_users"
-                      class="discreet"
-                      i18n:translate="text_no_user_searchstring_largesite"
-                      style="text-align:center; font-size: 100%;">
-                    Enter a username to search for, or click 'Show All'
-                  </td>
-                </tal:block>
-              </tr>
-            </tbody>
-          </table>
+              <div class="form-group pb-3">
+                <div metal:use-macro="context/batch_macros/macros/navigation" />
 
-          <div metal:use-macro="context/batch_macros/macros/navigation" />
+                <div class="showAllSearchResults ml-1"
+                     tal:condition="python:batch.next or batch.previous"
+                     tal:define="mq python:modules['ZTUtils'].make_query;
+                            keys batchformkeys|nothing;
+                            linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
+                            url batch_base_url | string:${context/absolute_url}/${template_id}">
+                  <a class="btn btn-sm btn-outline-secondary"
+                     tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
+                     i18n:translate="description_pas_show_all_search_results">
+                    Show all search results
+                  </a>
+                </div>
 
-          <div class="showAllSearchResults"
-               tal:condition="python:batch.next or batch.previous"
-               tal:define="mq python:modules['ZTUtils'].make_query;
-                           keys batchformkeys|nothing;
-                           linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
-                           url batch_base_url | string:${context/absolute_url}/${template_id}">
-              <a tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
-                 i18n:translate="description_pas_show_all_search_results">
-                  Show all search results
-              </a>
+                <input type="hidden" value="b_start" name="b_start"
+                       tal:attributes="value b_start"/>
+
+                <input type="hidden" value="" name="showAll"
+                       tal:attributes="value showAll"/>
+
+                <div tal:condition="batch">
+                  <input class="btn btn-sm btn-primary ml-1"
+                         type="submit"
+                         name="form.button.Modify"
+                         value="Save"
+                         i18n:attributes="value label_save;"
+                  />
+                </div>
+              </div>
+
+              <input tal:replace="structure context/@@authenticator/authenticator" />
+
+            </form>
           </div>
+        </div>
 
-          <input type="hidden" value="b_start" name="b_start"
-                 tal:attributes="value b_start"/>
+      </article>
 
-          <input type="hidden" value="" name="showAll"
-                 tal:attributes="value showAll"/>
+    </metal:main>
 
-          <div tal:condition="batch">
-
-            <div class="formControls">
-              <input class="context"
-                 type="submit"
-                 name="form.button.Modify"
-                 value="Save"
-                 i18n:attributes="value label_save;"
-                 />
-            </div>
-          </div>
-
-          <input tal:replace="structure context/@@authenticator/authenticator" />
-
-        </form>
-      </div>
-    </div>
-
-  </article>
-
-</metal:main>
-
-</body>
+  </body>
 </html>

--- a/src/senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt
+++ b/src/senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt
@@ -118,8 +118,8 @@
                   <tal:block tal:condition="portal_users" >
                     <tr class="odd">
                       <th rowspan="" i18n:translate="listingheader_user_name">User name</th>
-                      <th tal:repeat="portal_role portal_roles" tal:content="portal_role" i18n:translate="">Role</th>
-                      <th rowspan="" i18n:translate="listingheader_reset_password">Reset Password</th>
+                      <th class="text-center" tal:repeat="portal_role portal_roles" tal:content="portal_role" i18n:translate="">Role</th>
+                      <th class="text-center" rowspan="" i18n:translate="listingheader_reset_password">Reset Password</th>
                       <!-- <th rowspan="" i18n:translate="listingheader_remove">Remove</th> -->
                     </tr>
                   </tal:block>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the batch navigation styling of the Users & Groups overviews

## Current behavior before PR

Batch navigations not properly styled:

<img width="418" alt="" src="https://github.com/senaite/senaite.core/assets/713193/cdb6353f-4c70-4a83-abb9-22c84a5f585d">

<img width="417" alt="" src="https://github.com/senaite/senaite.core/assets/713193/ed7f9846-89b6-4314-96a6-8c2966f7e1e1">

## Desired behavior after PR is merged

All batch navigations properly styled in the Users & Groups overviews:

<img width="597" alt="" src="https://github.com/senaite/senaite.core/assets/713193/851503f0-317d-4725-a00c-4a2457e433e5">

<img width="741" alt="" src="https://github.com/senaite/senaite.core/assets/713193/5a20ce3c-1cb2-475b-9cb2-c8cd0e7c4bf0">

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
