### PR TITLE
Remove groups from user add form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2456 Remove groups from user add form
 - #2455 Fix users/groups overview batch navigation styling
 - #2454 Fix analyses not filtered by selected WST services
 - #2453 Fix worksheets are not uncatalogued when deleted

--- a/src/senaite/core/browser/configure.zcml
+++ b/src/senaite/core/browser/configure.zcml
@@ -38,6 +38,7 @@
   <include package=".setup"/>
   <include package=".sharing"/>
   <include package=".usergroup"/>
+  <include package=".users"/>
   <include package=".viewlets"/>
   <include package=".widgets"/>
 

--- a/src/senaite/core/browser/users/configure.zcml
+++ b/src/senaite/core/browser/users/configure.zcml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser">
+
+  <browser:page
+      name="new-user"
+      for="plone.app.layout.navigation.interfaces.INavigationRoot"
+      class=".register.AddUserForm"
+      permission="plone.app.controlpanel.UsersAndGroups"
+      layer="senaite.core.interfaces.ISenaiteCore"
+      />
+
+</configure>

--- a/src/senaite/core/browser/users/register.py
+++ b/src/senaite/core/browser/users/register.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+from plone.app.users.browser.register import AddUserForm as BaseAddUserForm
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
+
+class AddUserForm(BaseAddUserForm):
+    template = ViewPageTemplateFile("templates/newuser_form.pt")
+
+    def updateFields(self):
+        super(AddUserForm, self).updateFields()
+
+        # remove groups field from registration
+        if "groups" in self.fields:
+            del self.fields["groups"]
+
+    def updateWidgets(self):
+        super(AddUserForm, self).updateWidgets()
+
+    def updateActions(self):
+        super(AddUserForm, self).updateActions()
+        self.actions["register"].klass = "btn btn-sm btn-success"

--- a/src/senaite/core/browser/users/templates/newuser_form.pt
+++ b/src/senaite/core/browser/users/templates/newuser_form.pt
@@ -1,0 +1,32 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      metal:use-macro="context/main_template/macros/master"
+      i18n:domain="plone">
+  <body>
+    <metal:body fill-slot="body">
+
+      <article id="content">
+        <h1 class="documentFirstHeading"
+            tal:content="view/label | nothing" />
+        <div id="content-core">
+          <metal:block use-macro="context/@@ploneform-macros/titlelessform">
+          <metal:actions-slot fill-slot="actions">
+            <!-- override the actions slot in
+                 plone/app/z3cform/templates/marcros.pt to apply custom styles -->
+            <metal:define define-macro="actions">
+              <div class="form-group" tal:condition="view/actions/values|nothing">
+                <tal:block repeat="action view/actions/values">
+                  <input type="submit" tal:replace="structure action/render" />
+                </tal:block>
+              </div>
+            </metal:define>
+          </metal:actions-slot>
+          </metal:block>
+        </div>
+      </article>
+
+    </metal:body>
+  </body>
+</html>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the groups checkbox listing in the user add form.

## Current behavior before PR

With https://github.com/senaite/senaite.core/pull/2301 we create a group for every Client that is created in the system.

In a site with many clients / groups, the user add form becomes confusing and not usable anymore.

## Desired behavior after PR is merged

Groups are not displayed in the user add form.

<img width="1159" alt="" src="https://github.com/senaite/senaite.core/assets/713193/47a03398-ccb6-4ae2-9e8b-21b7b6ab9f6c">


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
