### PR TITLE
Fix duplicate filter buttons in WS add-analyses listing

### DIFF
--- a/src/bika/lims/browser/worksheet/views/add_analyses.py
+++ b/src/bika/lims/browser/worksheet/views/add_analyses.py
@@ -198,9 +198,10 @@ class AddAnalysesView(BikaListingView):
                 })
                 self.default_review_state = "restrict_to_method"
 
-        for state in sorted(new_states, key=lambda s: s.get("id")):
-            if state not in self.review_states:
-                self.review_states.append(state)
+        existing_state_ids = [rs.get("id") for rs in self.review_states]
+        for new_state in new_states:
+            if new_state.get("id") not in existing_state_ids:
+                self.review_states.append(new_state)
 
     def handle_submit(self):
         """Handle form submission


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a side-effect from https://github.com/senaite/senaite.core/pull/2454 when a translated language is used.

## Current behavior before PR

Filter buttons appear multiple times when changing to another language:

<img width="918" alt="" src="https://github.com/senaite/senaite.core/assets/713193/7bf73a0e-2ef8-4daa-a9d8-518dae1aa0d1">

## Desired behavior after PR is merged

Filter buttons appear only once when another language is displayed:

<img width="942" alt="" src="https://github.com/senaite/senaite.core/assets/713193/cf195a73-1724-49c7-bc94-ae2e7d186f51">

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
