### PR TITLE
Fix default landing page is not considered in clients listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2459 Fix default landing page is not considered in clients listing
 - #2456 Remove groups from user add form
 - #2455 Fix users/groups overview batch navigation styling
 - #2454 Fix analyses not filtered by selected WST services

--- a/src/bika/lims/browser/clientfolder.py
+++ b/src/bika/lims/browser/clientfolder.py
@@ -44,9 +44,6 @@ class ClientFolderContentsView(ListingView):
         self.description = ""
         self.form_id = "list_clientsfolder"
         self.sort_on = "sortable_title"
-        # Landing page to be added to the link of each client from the list
-        self.landing_page = get_registry_record("client_landing_page",
-                                                default="analysisrequests")
 
         self.catalog = CLIENT_CATALOG
         self.contentFilter = {
@@ -123,6 +120,10 @@ class ClientFolderContentsView(ListingView):
         """
         # Call `before_render` from the base class
         super(ClientFolderContentsView, self).before_render()
+
+        # Landing page to be added to the link of each client from the list
+        self.landing_page = get_registry_record("client_landing_page",
+                                                default="analysisrequests")
 
         # Render the Add button if the user has the AddClient permission
         if check_permission(AddClient, self.context):

--- a/src/bika/lims/browser/clientfolder.py
+++ b/src/bika/lims/browser/clientfolder.py
@@ -28,6 +28,7 @@ from bika.lims.utils import get_link
 from Products.CMFCore.permissions import ModifyPortalContent
 from senaite.app.listing import ListingView
 from senaite.core.catalog import CLIENT_CATALOG
+from senaite.core.config.registry import CLIENT_LANDING_PAGE
 from senaite.core.permissions import AddClient
 from senaite.core.permissions import ManageAnalysisRequests
 from senaite.core.registry import get_registry_record
@@ -122,8 +123,7 @@ class ClientFolderContentsView(ListingView):
         super(ClientFolderContentsView, self).before_render()
 
         # Landing page to be added to the link of each client from the list
-        self.landing_page = get_registry_record("client_landing_page",
-                                                default="analysisrequests")
+        self.landing_page = get_registry_record(CLIENT_LANDING_PAGE)
 
         # Render the Add button if the user has the AddClient permission
         if check_permission(AddClient, self.context):

--- a/src/bika/lims/browser/clientfolder.py
+++ b/src/bika/lims/browser/clientfolder.py
@@ -25,20 +25,17 @@ from bika.lims import bikaMessageFactory as _
 from bika.lims.utils import check_permission
 from bika.lims.utils import get_email_link
 from bika.lims.utils import get_link
-from bika.lims.utils import get_registry_value
 from Products.CMFCore.permissions import ModifyPortalContent
 from senaite.app.listing import ListingView
 from senaite.core.catalog import CLIENT_CATALOG
 from senaite.core.permissions import AddClient
 from senaite.core.permissions import ManageAnalysisRequests
+from senaite.core.registry import get_registry_record
 
 
 class ClientFolderContentsView(ListingView):
     """Listing view for all Clients
     """
-
-    _LANDING_PAGE_REGISTRY_KEY = "bika.lims.client.default_landing_page"
-    _DEFAULT_LANDING_PAGE = "analysisrequests"
 
     def __init__(self, context, request):
         super(ClientFolderContentsView, self).__init__(context, request)
@@ -48,8 +45,8 @@ class ClientFolderContentsView(ListingView):
         self.form_id = "list_clientsfolder"
         self.sort_on = "sortable_title"
         # Landing page to be added to the link of each client from the list
-        self.landing_page = get_registry_value(
-            self._LANDING_PAGE_REGISTRY_KEY, self._DEFAULT_LANDING_PAGE)
+        self.landing_page = get_registry_record("client_landing_page",
+                                                default="analysisrequests")
 
         self.catalog = CLIENT_CATALOG
         self.contentFilter = {

--- a/src/bika/lims/browser/myorganization.py
+++ b/src/bika/lims/browser/myorganization.py
@@ -20,6 +20,7 @@
 
 from bika.lims import api
 from bika.lims.browser import BrowserView
+from senaite.core.registry import get_registry_record
 
 
 class MyOrganizationView(BrowserView):
@@ -28,11 +29,22 @@ class MyOrganizationView(BrowserView):
     """
 
     def __call__(self):
-        url = api.get_url(api.get_portal())
+
+        client = api.get_current_client()
+        if client:
+            # User belongs to a client, redirect to client's default view
+            view = get_registry_record("client_landing_page")
+            url = "{}/{}".format(api.get_url(client), view)
+            return self.request.response.redirect(url)
+
         current_user = api.get_current_user()
         contact = api.get_user_contact(current_user)
         if contact:
+            # Redirect to the contact's container
             parent = api.get_parent(contact)
             url = api.get_url(parent)
+            return self.request.response.redirect(url)
 
+        # Not a contact, redirect to portal
+        url = api.get_url(api.get_portal())
         return self.request.response.redirect(url)

--- a/src/bika/lims/browser/myorganization.py
+++ b/src/bika/lims/browser/myorganization.py
@@ -20,6 +20,7 @@
 
 from bika.lims import api
 from bika.lims.browser import BrowserView
+from senaite.core.config.registry import CLIENT_LANDING_PAGE
 from senaite.core.registry import get_registry_record
 
 
@@ -33,7 +34,7 @@ class MyOrganizationView(BrowserView):
         client = api.get_current_client()
         if client:
             # User belongs to a client, redirect to client's default view
-            view = get_registry_record("client_landing_page")
+            view = get_registry_record(CLIENT_LANDING_PAGE)
             url = "{}/{}".format(api.get_url(client), view)
             return self.request.response.redirect(url)
 

--- a/src/bika/lims/profiles/default/registry.xml
+++ b/src/bika/lims/profiles/default/registry.xml
@@ -3,6 +3,7 @@
 <!-- Operation Definitions -->
 <registry xmlns:i18n="http://xml.zope.org/namespaces/i18n" i18n:domain="senaite.core">
 
+    <!-- Ported to 2.x: https://github.com/senaite/senaite.core/pull/2459 -->
     <record name="bika.lims.client.default_landing_page">
       <field type="plone.registry.field.Choice">
         <default>analysisrequests</default>

--- a/src/bika/lims/utils/__init__.py
+++ b/src/bika/lims/utils/__init__.py
@@ -754,8 +754,13 @@ def get_registry_value(key, default=None):
     :param default: default value if the key is not registered
     :return: value in the registry for the key passed in
     """
-    registry = queryUtility(IRegistry)
-    return registry.get(key, default)
+    # cannot use bika.lims.deprecated (circular dependencies)
+    import warnings
+    warnings.simplefilter("always", DeprecationWarning)
+    warn = "Deprecated: use senaite.core.api.get_registry_record instead"
+    warnings.warn(warn, category=DeprecationWarning, stacklevel=2)
+    warnings.simplefilter("default", DeprecationWarning)
+    return api.get_registry_record(key, default=default)
 
 
 def check_permission(permission, obj):

--- a/src/senaite/core/browser/frontpage/frontpage.py
+++ b/src/senaite/core/browser/frontpage/frontpage.py
@@ -24,6 +24,7 @@ from bika.lims.interfaces import IFrontPageAdapter
 from plone import api as ploneapi
 from plone.protect.utils import addTokenToUrl
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from senaite.core.config.registry import CLIENT_LANDING_PAGE
 from senaite.core.registry import get_registry_record
 from zope.component import getAdapters
 
@@ -93,7 +94,7 @@ class FrontPageView(BrowserView):
         # Fourth precedence: Default landing page in client view
         client = api.get_current_client()
         if client:
-            view = get_registry_record("client_landing_page")
+            view = get_registry_record(CLIENT_LANDING_PAGE)
             url = "{}/{}".format(api.get_url(client), view)
             return self.request.response.redirect(url)
 

--- a/src/senaite/core/browser/frontpage/frontpage.py
+++ b/src/senaite/core/browser/frontpage/frontpage.py
@@ -24,6 +24,7 @@ from bika.lims.interfaces import IFrontPageAdapter
 from plone import api as ploneapi
 from plone.protect.utils import addTokenToUrl
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from senaite.core.registry import get_registry_record
 from zope.component import getAdapters
 
 
@@ -88,6 +89,13 @@ class FrontPageView(BrowserView):
         # Third precedence: Custom Landing Page
         if landingpage:
             return self.request.response.redirect(landingpage.absolute_url())
+
+        # Fourth precedence: Default landing page in client view
+        client = api.get_current_client()
+        if client:
+            view = get_registry_record("client_landing_page")
+            url = "{}/{}".format(api.get_url(client), view)
+            return self.request.response.redirect(url)
 
         # Last precedence: Front Page
         return self.template()

--- a/src/senaite/core/config/registry.py
+++ b/src/senaite/core/config/registry.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2023 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+CLIENT_LANDING_PAGE = "client_landing_page"

--- a/src/senaite/core/configure.zcml
+++ b/src/senaite/core/configure.zcml
@@ -31,6 +31,7 @@
   <include package=".subscribers" />
   <include package=".upgrade" />
   <include package=".utilities" />
+  <include package=".vocabularies" />
   <include package=".z3cform" />
 
   <!-- portal skins -->

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2524</version>
+  <version>2525</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/registry/schema.py
+++ b/src/senaite/core/registry/schema.py
@@ -40,6 +40,7 @@ class IClientRegistry(ISenaiteRegistry):
         description=_("Settings for Clients"),
         fields=[
             "auto_create_client_group",
+            "client_landing_page",
         ],
     )
 
@@ -55,6 +56,22 @@ class IClientRegistry(ISenaiteRegistry):
                       ),
         default=True,
         required=False,
+    )
+
+    client_landing_page = schema.Choice(
+        title=_(
+            u"label_registry_client_landing_page",
+            default=u"Client landing page"
+        ),
+        description=_(
+            u"description_registry_client_landing_page",
+            default=u"Select the default landing page. This is used when a "
+                    u"Client user logs into the system, or when a client is "
+                    u"selected from the client folder listing"
+        ),
+        vocabulary="senaite.core.vocabularies.registry.client_landing_pages",
+        default="analysisrequests",
+        required=True,
     )
 
 

--- a/src/senaite/core/upgrade/v02_05_000.py
+++ b/src/senaite/core/upgrade/v02_05_000.py
@@ -666,16 +666,15 @@ def setup_client_landing_page(tool):
     import_registry(tool)
 
     # look for the legacy registry record
-    import pdb;pdb.set_trace()
-    legacy_key = "bika.lims.client.default_landing_page"
-    legacy_value = get_registry_record(legacy_key, default="analysisrequests")
+    key = "bika.lims.client.default_landing_page"
+    value = api.get_registry_record(key, default="")
 
     # set the value to the new registry record
     vocab_key = "senaite.core.vocabularies.registry.client_landing_pages"
     vocab_factory = getUtility(IVocabularyFactory, vocab_key)
     vocabulary = vocab_factory(api.get_portal())
     values = [item.value for item in vocabulary]
-    if legacy_value in values:
-        set_registry_record("client_landing_page", legacy_value)
+    if value in values:
+        set_registry_record("client_landing_page", value)
 
     logger.info("Setup client's default landing page [DONE]")

--- a/src/senaite/core/upgrade/v02_05_000.py
+++ b/src/senaite/core/upgrade/v02_05_000.py
@@ -266,6 +266,7 @@ def update_report_catalog(tool):
     logger.info("Update report catalog [DONE]")
 
 
+@upgradestep(product, version)
 def import_registry(tool):
     """Import registry step from profiles
     """

--- a/src/senaite/core/upgrade/v02_05_000.py
+++ b/src/senaite/core/upgrade/v02_05_000.py
@@ -51,8 +51,6 @@ from senaite.core.setuphandlers import setup_portal_catalog
 from senaite.core.upgrade import upgradestep
 from senaite.core.upgrade.utils import uncatalog_brain
 from senaite.core.upgrade.utils import UpgradeUtils
-from senaite.core.vocabularies.registry import \
-    ClientLandingPagesVocabularyFactory
 from senaite.core.workflow import ANALYSIS_WORKFLOW
 from senaite.core.workflow import SAMPLE_WORKFLOW
 from zope.interface import alsoProvides

--- a/src/senaite/core/upgrade/v02_05_000.py
+++ b/src/senaite/core/upgrade/v02_05_000.py
@@ -37,6 +37,7 @@ from senaite.core.catalog import SAMPLE_CATALOG
 from senaite.core.catalog import SETUP_CATALOG
 from senaite.core.catalog import WORKSHEET_CATALOG
 from senaite.core.config import PROJECTNAME as product
+from senaite.core.config.registry import CLIENT_LANDING_PAGE
 from senaite.core.permissions import ManageBika
 from senaite.core.permissions import TransitionReceiveSample
 from senaite.core.registry import get_registry_record
@@ -673,6 +674,6 @@ def setup_client_landing_page(tool):
     vocabulary = vocab_factory(api.get_portal())
     values = [item.value for item in vocabulary]
     if value in values:
-        set_registry_record("client_landing_page", value)
+        set_registry_record(CLIENT_LANDING_PAGE, value)
 
     logger.info("Setup client's default landing page [DONE]")

--- a/src/senaite/core/upgrade/v02_05_000.zcml
+++ b/src/senaite/core/upgrade/v02_05_000.zcml
@@ -4,6 +4,14 @@
     i18n_domain="senaite.core">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.5.0: Setup client landing page"
+      description="Setup client landing page configuration"
+      source="2524"
+      destination="2525"
+      handler=".v02_05_000.setup_client_landing_page"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.5.0: Un-catalog orphan worksheets"
       description="Un-catalog worksheets that were once removed"
       source="2523"

--- a/src/senaite/core/vocabularies/__init__.py
+++ b/src/senaite/core/vocabularies/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2023 by it's authors.
+# Some rights reserved, see README and LICENSE.

--- a/src/senaite/core/vocabularies/configure.zcml
+++ b/src/senaite/core/vocabularies/configure.zcml
@@ -1,0 +1,9 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    i18n_domain="senaite.core">
+
+  <utility
+      component=".registry.ClientLandingPagesVocabularyFactory"
+      name="senaite.core.vocabularies.registry.client_landing_pages" />
+
+</configure>

--- a/src/senaite/core/vocabularies/registry.py
+++ b/src/senaite/core/vocabularies/registry.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2023 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from zope.interface import implementer
+from zope.schema.interfaces import IVocabularyFactory
+from zope.schema.vocabulary import SimpleTerm
+from zope.schema.vocabulary import SimpleVocabulary
+from bika.lims import api
+
+
+@implementer(IVocabularyFactory)
+class ClientLandingPagesVocabulary(object):
+    """Vocabulary factory for Client landing pages
+    """
+
+    skip = ["edit", "manage_access", "auditlog", ]
+
+    def __call__(self, context):
+        pt = api.get_tool("portal_types")
+        type_info = pt.getTypeInfo("Client")
+        terms = []
+        for action in type_info.listActionInfos():
+            if not action.get("visible", True):
+                continue
+            if action.get("id") in self.skip:
+                continue
+            url = action.get("url")
+            if not url:
+                continue
+
+            # remove leading/trailing slashes
+            url = url.strip("/")
+
+            # create the vocab term
+            title = action.get("title")
+            term = SimpleTerm(url, url, title)
+            terms.append(term)
+
+        return SimpleVocabulary(terms)
+
+
+ClientLandingPagesVocabularyFactory = ClientLandingPagesVocabulary()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes the default landing page when a client from the folder listing is selected as well as when a client login the system and no default wide landing page is set in classic setup.

This functionality was once provided by means of the registry record with key `bika.lims.client.default_landing_page`, that is no longer available in 2.x instances, but in those upgraded from 1.x

The setting is now available under SENAITE Registry:

![Captura de 2023-12-28 19-16-32](https://github.com/senaite/senaite.core/assets/832627/38676fe1-6caf-4d35-823c-e79bd16114f3)


## Current behavior before PR

The legacy setting for the default landing page is no longer used

## Desired behavior after PR is merged

The legacy setting for the default landing page is ported to SENAITE registry

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
