### PR TITLE
Fix keyword missing in AnalysisSpecificationView

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2460 Fix keyword missing in AnalysisSpecificationView
 
 2.5.0 (2024-01-03)
 ------------------

--- a/src/bika/lims/browser/widgets/analysisspecificationwidget.py
+++ b/src/bika/lims/browser/widgets/analysisspecificationwidget.py
@@ -226,6 +226,7 @@ class AnalysisSpecificationView(BikaListingView):
             item["category"] = category
 
         item["Title"] = title
+        item["Keyword"] = keyword
         item["replace"]["Title"] = get_link(url, value=title)
         item["choices"]["min_operator"] = self.min_operator_choices
         item["choices"]["max_operator"] = self.max_operator_choices


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

AnalysisService keyword column at AnalysisSpecificationView list is empty.

## Desired behavior after PR is merged

fixed 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
