### PR TITLE
Fix manually deselected references in sample add form can not be set anymore

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2462 Fix manually deselected references in sample add form can not be set anymore
+
 
 2.5.0 (2024-01-03)
 ------------------

--- a/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
@@ -703,18 +703,26 @@
       /*
        * Generic event handler for when a reference field value changed
        */
-      var $el, after_change, arnum, deselected, el, event_data, field_name, me, value;
+      var $el, after_change, arnum, el, event_data, field_name, manually_deselected, me, select, value;
       me = this;
       el = event.currentTarget;
       $el = $(el);
       field_name = $el.closest("tr[fieldname]").attr("fieldname");
       arnum = $el.closest("[arnum]").attr("arnum");
-      if (event.type === "deselect") {
-        value = event.detail.value;
-        deselected = this.deselected_uids[field_name] || [];
-        if (value && indexOf.call(deselected, value) < 0) {
-          this.deselected_uids[field_name] = deselected.concat(value);
+      value = event.detail.value;
+      if (value) {
+        manually_deselected = this.deselected_uids[field_name] || [];
+        select = event.type === "select" ? true : false;
+        if (select) {
+          manually_deselected = manually_deselected.filter(function(item) {
+            return item !== value;
+          });
+          console.debug("Reference with UID " + value + " was manually selected");
+        } else {
+          manually_deselected = manually_deselected.indexOf(value > -1) ? manually_deselected.concat(value) : void 0;
+          console.debug("Reference with UID " + value + " was manually deselected");
         }
+        this.deselected_uids[field_name] = manually_deselected;
       }
       if (field_name === "Template" || field_name === "Profiles") {
         return;

--- a/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -688,12 +688,20 @@ class window.AnalysisRequestAdd
     field_name = $el.closest("tr[fieldname]").attr "fieldname"
     arnum = $el.closest("[arnum]").attr "arnum"
 
-    # remember deselected UIDs
-    if event.type is "deselect"
-      value = event.detail.value
-      deselected = @deselected_uids[field_name] or []
-      if value and value not in deselected
-        @deselected_uids[field_name] = deselected.concat value
+    # handle manually selected/deselected UIDs
+    value = event.detail.value
+    if value
+      manually_deselected = @deselected_uids[field_name] or []
+      select = if event.type is "select" then yes else no
+      if select
+        # remove UID from the manually deselected list again
+        manually_deselected = manually_deselected.filter (item) -> item isnt value
+        console.debug "Reference with UID #{value} was manually selected"
+      else
+        # remember UID as manually deselected
+        manually_deselected = if manually_deselected.indexOf value > -1 then manually_deselected.concat value
+        console.debug "Reference with UID #{value} was manually deselected"
+      @deselected_uids[field_name] = manually_deselected
 
     if field_name in ["Template", "Profiles"]
       # These fields have it's own event handler


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue where manually deselected references could not be added anymore

## Current behavior before PR

If a reference field is set as a dependency from another field and the user deselects this reference, it is no longer possible to add the same reference again

## Desired behavior after PR is merged

If a reference field is set as a dependency from another field and the user deselects this reference, it is possible to set the same value again.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
