### PR TITLE
Fix contact assigned to multiple clients cannot see samples from other clients

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2464 Fix contact assigned to multiple clients cannot see samples from others
 - #2442 Show partitions initially collapsed in partition preview mode
 - #2434 Add string support for interim fields
 - #2417 Use dtime.to_DT instead of api.to_date

--- a/src/senaite/core/browser/samples/view.py
+++ b/src/senaite/core/browser/samples/view.py
@@ -452,14 +452,9 @@ class SamplesView(ListingView):
     def before_render(self):
         """Before template render hook
         """
-        # If the current user is a client contact, display those analysis
-        # requests that belong to same client only
         super(SamplesView, self).before_render()
         client = api.get_current_client()
         if client:
-            self.contentFilter['path'] = {
-                "query": "/".join(client.getPhysicalPath()),
-                "level": 0}
             # No need to display the Client column
             self.remove_column('Client')
 

--- a/src/senaite/core/browser/samples/view.py
+++ b/src/senaite/core/browser/samples/view.py
@@ -453,11 +453,6 @@ class SamplesView(ListingView):
         """Before template render hook
         """
         super(SamplesView, self).before_render()
-        client = api.get_current_client()
-        if client:
-            # No need to display the Client column
-            self.remove_column('Client')
-
         # remove query filter for root samples when listing is flat
         if self.flat_listing:
             self.contentFilter.pop("isRootAncestor", None)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

With https://github.com/senaite/senaite.core/pull/2301 , a Client-specific user group is created. This removes the need of assigning the `Owner` role recursively to the new user for all contents belonging to the same Client.  Thus, the access to samples and other elements from contents inside the Client becomes governed by the group membership of the current user.

However, when adding a user (linked to a client contact) to other client groups, this user was only able to see the samples that were belonging to the "primary" client the contact belongs to.

This Pull Request ensures the visibility of samples in listings relies on the groups the current user belongs to, regardless of Client.

## Current behavior before PR

A client user assigned to client groups other than primary cannot see samples from other clients

## Desired behavior after PR is merged

A client user assigned to client groups other than primary can see samples from other clients

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
