### PR TITLE
Fix traceback when re-installing senaite.core via quick installer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2465 Fix traceback when re-installing senaite.core via quick installer
 - #2464 Fix contact assigned to multiple clients cannot see samples from others
 - #2458 Allow portal_type as a parameter for api.get_icon function
 - #2442 Show partitions initially collapsed in partition preview mode

--- a/src/senaite/core/configure.zcml
+++ b/src/senaite/core/configure.zcml
@@ -58,6 +58,7 @@
       title="SENAITE CORE: Run Setup Handler"
       description="Run install handler"
       handler="senaite.core.setuphandlers.install">
+    <depends name="typeinfo"/>
   </genericsetup:importStep>
 
   <!-- Hidden Profiles -->


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a traceback that occurs when trying to re-install `senaite.core` product via ZMI's quick installer. This bug was introduced with #2459 and the traceback is rised [here](https://github.com/senaite/senaite.core/pull/2459/files#diff-a1e5b69a335cc7e088540ad2ca7eaedcc98999ed64e404e2af545006788e50e6R39). Type infos are not initialized when the vocabulary is instantiated and therefore, `type_info` variable is `None`.

With this PR we ensure types are loaded first on re-install.

## Current behavior before PR

```
2024-01-15 11:09:23,811 ERROR   [Zope.SiteErrorLog:252][waitress-1] 1705313363.810.271710711741 http://localhost:9090/senaite/portal_quickinstaller/reinstallProducts
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module <string>, line 6, in reinstallProducts
  Module AccessControl.requestmethod, line 89, in _curried
  Module Products.CMFQuickInstallerTool.QuickInstallerTool, line 812, in reinstallProducts
  Module <string>, line 3, in installProducts
  Module AccessControl.requestmethod, line 89, in _curried
  Module Products.CMFQuickInstallerTool.QuickInstallerTool, line 714, in installProducts
  Module Products.CMFQuickInstallerTool.QuickInstallerTool, line 630, in installProduct
   - __traceback_info__: ('senaite.core',)
  Module Products.GenericSetup.tool, line 405, in runAllImportStepsFromProfile
   - __traceback_info__: profile-senaite.core:default
  Module Products.GenericSetup.tool, line 1511, in _runImportStepsFromContext
  Module Products.GenericSetup.tool, line 1323, in _doRunImportStep
   - __traceback_info__: plone.app.registry
  Module plone.app.registry.exportimport.handler, line 79, in importRegistry
   - __traceback_info__: registry.xml
  Module plone.app.registry.exportimport.handler, line 127, in importDocument
  Module plone.app.registry.exportimport.handler, line 394, in importRecords
   - __traceback_info__: records name: senaite.core.registry.schema.IClientRegistry
  Module plone.registry.registry, line 121, in registerInterface
  Module plone.registry.field, line 297, in bind
  Module Zope2.App.schema, line 32, in get
  Module senaite.core.vocabularies.registry, line 39, in __call__
AttributeError: 'NoneType' object has no attribute 'listActionInfos'
```

## Desired behavior after PR is merged

No traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
