### PR TITLE
Support for prioritized specs when using dynamic specifications

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2467 Support for prioritized specs when using dynamic specifications
 - #2465 Fix traceback when re-installing senaite.core via quick installer
 - #2464 Fix contact assigned to multiple clients cannot see samples from others
 - #2458 Allow portal_type as a parameter for api.get_icon function


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request improves the logic of finding matches when dynamic specifications are used, so when multiple matches are found in the dynamic specs for a given test, the system established a set of priorities so the closest dynamic spec is used. 

For instance, if a column `Method` is defined in the excel file, but a row does not have a value set, the system assumes the min and max values set for that row apply to all tests with that given keyword, regardless of method. Unless there is a more specific record. In such case, the more specific row is used instead.

## Current behavior before PR

Rows from the dynamic specs are not prioritized when looking for matches

## Desired behavior after PR is merged

Rows from the dynamic specs are prioritized when looking for matches

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
