### PR TITLE
Make the prepublish guard to rely on interfaces instead of statuses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2468 Make the prepublish guard to rely on interfaces instead of statuses
 - #2467 Support for prioritized specs when using dynamic specifications
 - #2465 Fix traceback when re-installing senaite.core via quick installer
 - #2464 Fix contact assigned to multiple clients cannot see samples from others

--- a/src/bika/lims/workflow/analysisrequest/guards.py
+++ b/src/bika/lims/workflow/analysisrequest/guards.py
@@ -22,6 +22,7 @@ from bika.lims import api
 from bika.lims.interfaces import IInternalUse
 from bika.lims.interfaces import IRejected
 from bika.lims.interfaces import IRetracted
+from bika.lims.interfaces import ISubmitted
 from bika.lims.interfaces import IVerified
 from bika.lims.workflow import isTransitionAllowed
 
@@ -118,9 +119,9 @@ def guard_verify(analysis_request):
 
 
 def guard_prepublish(analysis_request):
-    """Returns whether 'prepublish' transition can be perform or not. Returns
-    True if the at least one of the analyses of the sample has been verified
-    and has not been retracted or rejected. Otherwise, return False
+    """Returns whether 'prepublish' transition can be performed or not. Returns
+    True if the at least one of the analyses of the sample has been submitted
+    and has not been retracted or rejected. Otherwise, returns False
     """
     if IInternalUse.providedBy(analysis_request):
         return False
@@ -131,8 +132,9 @@ def guard_prepublish(analysis_request):
             continue
         if IRejected.providedBy(analysis):
             continue
-        if IVerified.providedBy(analysis):
+        if ISubmitted.providedBy(analysis):
             return True
+
     return False
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the guard `pre-publish` relies on interfaces instead of statuses. Relying on interfaces is better, especially when there are other add-ons that extend the analyses workflow with other statuses and transitions.

For instance, one might have a custom transition that moves the analysis to the status `out_of_stock`, but we do want the system to behave as if it was a submitted (`to_be_verified`) and verified (`verified`) analysis. With the current implementation we don't have a choice other than overwriting the guards to allow the user to pre-publish and publish samples with one single analysis (in `out_of_stock` status).

With this PR, one can simply mark the object with the proper interface `ISubmitted` (`alsoProvides(ISubmitted, analysis)` in an `AfterTransitionEvent` and the system will behave as expected without the need of monkey patching the guards from core.

## Current behavior before PR

Need to monkey patch `guard_prepublish` when new transitions/statuses are added

## Desired behavior after PR is merged

No need to monkey patch `guard_prepublish` when new transitions/statuses are added

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
