### PR TITLE
Rename the permission "Reject" to "senaite.core: Transition: Reject Analysis"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2469 Rename permission "Reject" to "senaite.core: Transition: Reject Analysis"
 - #2467 Support for prioritized specs when using dynamic specifications
 - #2465 Fix traceback when re-installing senaite.core via quick installer
 - #2464 Fix contact assigned to multiple clients cannot see samples from others

--- a/src/senaite/core/permissions/__init__.py
+++ b/src/senaite/core/permissions/__init__.py
@@ -77,6 +77,8 @@ from .worksheet.permissions import ManageWorksheets
 from .worksheet.permissions import TransitionRejectWorksheet
 from .worksheet.permissions import TransitionRemoveWorksheet
 from .worksheet.permissions import WorksheetAddAttachment
+# Analysis permissions
+from .analysis.permissions import TransitionRejectAnalysis
 
 
 # Add Permissions

--- a/src/senaite/core/permissions/analysis/configure.zcml
+++ b/src/senaite/core/permissions/analysis/configure.zcml
@@ -1,0 +1,6 @@
+<configure xmlns="http://namespaces.zope.org/zope">
+
+  <!-- Workflow permissions -->
+  <permission id="senaite.core.permissions.TransitionRejectAnalysis" title="senaite.core: Transition: Reject Analysis"/>
+
+</configure>

--- a/src/senaite/core/permissions/analysis/permissions.py
+++ b/src/senaite/core/permissions/analysis/permissions.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2024 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+# Workflow permissions
+TransitionRejectAnalysis = "senaite.core: Transition: Reject Analysis"

--- a/src/senaite/core/permissions/configure.zcml
+++ b/src/senaite/core/permissions/configure.zcml
@@ -12,6 +12,7 @@
   <utility name="Manager" factory=".localroles.ManagerRole" />
 
   <!-- package includes -->
+  <include package=".analysis" />
   <include package=".sample" />
   <include package=".worksheet" />
 

--- a/src/senaite/core/profiles/default/rolemap.xml
+++ b/src/senaite/core/profiles/default/rolemap.xml
@@ -58,6 +58,13 @@
     </permission>
     <!-- /WORKSHEET -->
 
+    <!-- ANALYSIS -->
+    <permission name="senaite.core: Transition: Reject Analysis" acquire="False">
+      <role name="LabManager"/>
+      <role name="Manager"/>
+    </permission>
+    <!-- /ANALYSIS -->
+
   </permissions>
 
 </rolemap>

--- a/src/senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+++ b/src/senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
@@ -10,11 +10,11 @@
 
   <permission>senaite.core: Transition: Assign Analysis</permission>
   <permission>senaite.core: Transition: Unassign Analysis</permission>
+  <permission>senaite.core: Transition: Reject Analysis</permission>
   <permission>senaite.core: Transition: Retest</permission>
   <permission>senaite.core: Transition: Retract</permission>
   <permission>senaite.core: Transition: Verify</permission>
   <permission>senaite.core: View Results</permission>
-  <permission>Reject</permission>
   <permission>Modify portal content</permission>
 
   <!-- TODO: We need different Analysis objects for Field- and Lab- Analyses,
@@ -147,10 +147,7 @@
       <permission-role>LabClerk</permission-role>
     </permission-map>
 
-    <permission-map name="Reject" acquired="False">
-      <permission-role>LabManager</permission-role>
-      <permission-role>Manager</permission-role>
-    </permission-map>
+    <permission-map name="senaite.core: Transition: Reject Analysis" acquired="True"/>
 
     <!-- FIELD PERMISSIONS (unsassigned) -->
     <permission-map name="senaite.core: Field: Edit Analysis Result" acquired="False">
@@ -228,10 +225,7 @@
       <permission-role>LabClerk</permission-role>
     </permission-map>
 
-    <permission-map name="Reject" acquired="False">
-      <permission-role>LabManager</permission-role>
-      <permission-role>Manager</permission-role>
-    </permission-map>
+    <permission-map name="senaite.core: Transition: Reject Analysis" acquired="True"/>
 
     <!-- FIELD PERMISSIONS (assigned) -->
     <permission-map name="senaite.core: Field: Edit Analysis Result" acquired="False">
@@ -294,10 +288,6 @@
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>RegulatoryInspector</permission-role>
-    </permission-map>
-
-    <!-- Analysis cannot be rejected once cancelled -->
-    <permission-map name="Reject" acquired="False">
     </permission-map>
 
     <!-- FIELD PERMISSIONS (cancelled) -->
@@ -363,10 +353,7 @@
       <permission-role>Verifier</permission-role>
     </permission-map>
 
-    <permission-map name="Reject" acquired="False">
-      <permission-role>LabManager</permission-role>
-      <permission-role>Manager</permission-role>
-    </permission-map>
+    <permission-map name="senaite.core: Transition: Reject Analysis" acquired="True"/>
 
     <!-- FIELD PERMISSIONS (to_be_verified) -->
     <permission-map name="senaite.core: Field: Edit Analysis Result" acquired="False">
@@ -414,10 +401,6 @@
       <permission-role>RegulatoryInspector</permission-role>
       <permission-role>Sampler</permission-role>
       <permission-role>Verifier</permission-role>
-    </permission-map>
-
-    <!-- Analysis cannot be rejected once retracted -->
-    <permission-map name="Reject" acquired="False">
     </permission-map>
 
     <!-- FIELD PERMISSIONS (retracted) -->
@@ -472,10 +455,6 @@
     <permission-map name="senaite.core: Transition: Retract" acquired="False">
     </permission-map>
 
-    <!-- Analysis cannot be rejected again -->
-    <permission-map name="Reject" acquired="False">
-    </permission-map>
-
     <!-- FIELD PERMISSIONS (rejected) -->
     <permission-map name="senaite.core: Field: Edit Analysis Result" acquired="False">
     </permission-map>
@@ -519,10 +498,6 @@
       <permission-role>RegulatoryInspector</permission-role>
       <permission-role>Sampler</permission-role>
       <permission-role>Verifier</permission-role>
-    </permission-map>
-
-    <!-- Analysis cannot be rejected once verified -->
-    <permission-map name="Reject" acquired="False">
     </permission-map>
 
     <!-- FIELD PERMISSIONS (verified) -->
@@ -573,10 +548,6 @@
       <permission-role>RegulatoryInspector</permission-role>
       <permission-role>Sampler</permission-role>
       <permission-role>Verifier</permission-role>
-    </permission-map>
-
-    <!-- Analyses cannot be rejected once published -->
-    <permission-map name="Reject" acquired="False">
     </permission-map>
 
     <!-- FIELD PERMISSIONS (published) -->
@@ -719,7 +690,7 @@
               i18n:attributes="title">
     <action url="" category="workflow" icon="">Reject</action>
     <guard>
-      <guard-permission>Reject</guard-permission>
+      <guard-permission>senaite.core: Transition: Reject Analysis</guard-permission>
       <guard-expression>python:here.guard_handler("reject")</guard-expression>
     </guard>
   </transition>

--- a/src/senaite/core/tests/doctests/WorkflowAnalysisReject.rst
+++ b/src/senaite/core/tests/doctests/WorkflowAnalysisReject.rst
@@ -22,6 +22,7 @@ Needed Imports:
     >>> from plone.app.testing import setRoles
     >>> from plone.app.testing import TEST_USER_ID
     >>> from plone.app.testing import TEST_USER_PASSWORD
+    >>> from senaite.core.permissions import TransitionRejectAnalysis
 
 Functional Helpers:
 
@@ -414,7 +415,7 @@ In `unassigned` state, exactly these roles can reject:
 
     >>> api.get_workflow_status_of(analysis)
     'unassigned'
-    >>> get_roles_for_permission("Reject", analysis)
+    >>> get_roles_for_permission(TransitionRejectAnalysis, analysis)
     ['LabManager', 'Manager']
 
 Current user can reject because has the `LabManager` role:
@@ -448,7 +449,7 @@ In `assigned` state, exactly these roles can reject:
     >>> worksheet.addAnalysis(analysis)
     >>> api.get_workflow_status_of(analysis)
     'assigned'
-    >>> get_roles_for_permission("Reject", analysis)
+    >>> get_roles_for_permission(TransitionRejectAnalysis, analysis)
     ['LabManager', 'Manager']
     >>> isTransitionAllowed(analysis, "reject")
     True
@@ -484,7 +485,7 @@ In `to_be_verified` state, exactly these roles can reject:
     >>> success = do_action_for(analysis, "submit")
     >>> api.get_workflow_status_of(analysis)
     'to_be_verified'
-    >>> get_roles_for_permission("Reject", analysis)
+    >>> get_roles_for_permission(TransitionRejectAnalysis, analysis)
     ['LabManager', 'Manager']
     >>> isTransitionAllowed(analysis, "reject")
     True
@@ -519,8 +520,6 @@ In `retracted` state, the analysis cannot be rejected:
     >>> success = do_action_for(analysis, "retract")
     >>> api.get_workflow_status_of(analysis)
     'retracted'
-    >>> get_roles_for_permission("Reject", analysis)
-    []
     >>> isTransitionAllowed(analysis, "reject")
     False
 
@@ -537,8 +536,6 @@ In `verified` state, the analysis cannot be rejected:
     >>> success = do_action_for(analysis, "verify")
     >>> api.get_workflow_status_of(analysis)
     'verified'
-    >>> get_roles_for_permission("Reject", analysis)
-    []
     >>> isTransitionAllowed(analysis, "reject")
     False
 
@@ -552,8 +549,6 @@ In `published` state, the analysis cannot be rejected:
     (True, '')
     >>> api.get_workflow_status_of(analysis)
     'published'
-    >>> get_roles_for_permission("Reject", analysis)
-    []
     >>> isTransitionAllowed(analysis, "reject")
     False
 
@@ -567,8 +562,6 @@ In `cancelled` state, the analysis cannot be rejected:
     >>> success = do_action_for(ar, "cancel")
     >>> api.get_workflow_status_of(analysis)
     'cancelled'
-    >>> get_roles_for_permission("Reject", analysis)
-    []
     >>> isTransitionAllowed(analysis, "reject")
     False
 

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -18,10 +18,13 @@
 # Copyright 2018-2024 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from bika.lims import api
 from senaite.core import logger
+from senaite.core.catalog import ANALYSIS_CATALOG
 from senaite.core.config import PROJECTNAME as product
 from senaite.core.upgrade import upgradestep
 from senaite.core.upgrade.utils import UpgradeUtils
+from senaite.core.workflow import ANALYSIS_WORKFLOW
 
 version = "2.6.0"  # Remember version number in metadata.xml and setup.py
 profile = "profile-{0}:default".format(product)
@@ -44,3 +47,41 @@ def upgrade(tool):
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
+
+
+def fix_analysis_reject_permission(tool):
+    """Fixes the analysis reject permission, that was not defined at top-level
+    """
+    portal = api.get_portal()
+    setup = portal.portal_setup
+
+    # Reimport rolemap.xml
+    setup.runImportStepFromProfile(profile, "rolemap")
+
+    # Update role mappings of analyses, but only for those analyses that are
+    # in a state from which the new permission can apply
+    statuses = ["unassigned", "assigned", "to_be_verified"]
+    logger.info("Updating role mappings: Analysis ({}) ..."
+                .format(", ".join(statuses)))
+    query = {"portal_type": "Analysis", "review_state": statuses}
+    brains = api.search(query, ANALYSIS_CATALOG)
+    update_workflow_role_mappings(ANALYSIS_WORKFLOW, brains)
+    logger.info("Updating role mappings: Analysis ({}) [DONE]"
+                .format(", ".join(statuses)))
+
+
+def update_workflow_role_mappings(wf_id, objs_or_brains):
+    """Update the workflow role mappings for the given objects or brains
+    """
+    wf_tool = api.get_tool("portal_workflow")
+    workflow = wf_tool.getWorkflowById(wf_id)
+    total = len(objs_or_brains)
+
+    for num, obj_brain in enumerate(objs_or_brains):
+        if num and num % 100 == 0:
+            logger.info("Updating role mappings {0}/{1}".format(num, total))
+
+        obj = api.get_object(obj_brain)
+        workflow.updateRoleMappingsFor(obj)
+        obj.reindexObject()
+        obj._p_deactivate()

--- a/src/senaite/core/upgrade/v02_06_000.zcml
+++ b/src/senaite/core/upgrade/v02_06_000.zcml
@@ -4,6 +4,14 @@
     i18n_domain="senaite.core">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.5.0: Fix Reject permission for Analysis"
+      description="Fix Reject permission for Analysis"
+      source="2600"
+      destination="2601"
+      handler=".v02_06_000.fix_analysis_reject_permission"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="Upgrade to SENAITE.CORE 2.6.0"
       source="2525"
       destination="2600"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request renames the permission "Reject" to adhere to the policy we have in place. It also sets the permission at rolemap level to prevent the need to deal with the roles that have the permission granted at workflow status level.

## Current behavior before PR

Legacy permission "Reject" is not defined at rolemap

## Desired behavior after PR is merged

New permission "senaite.core: Transition: Reject Analysis", defined at rolemap

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
