### PR TITLE
Fix min/max shifted on negative result and % error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2470 Fix min/max shifted on negative result and % error
 - #2467 Support for prioritized specs when using dynamic specifications
 - #2465 Fix traceback when re-installing senaite.core via quick installer
 - #2464 Fix contact assigned to multiple clients cannot see samples from others

--- a/src/bika/lims/browser/widgets/referenceresultswidget.py
+++ b/src/bika/lims/browser/widgets/referenceresultswidget.py
@@ -239,8 +239,8 @@ class ReferenceResultsWidget(TypesWidget):
                 "keyword": service.getKeyword(),
                 "uid": uid,
                 "result": result,
-                "min": s_min,
-                "max": s_max,
+                "min": min([s_min, s_max]),
+                "max": max([s_min, s_max]),
                 "error": str(s_err),
             }
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes min and max values on ReferenceWidget submit when the expected result is a negative value and a % error is used to calculate the shoulders.

Linked issue: #2466

## Current behavior before PR

Minimum value is above maximum value

## Desired behavior after PR is merged

Minimum value is below maximum value

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
