### PR TITLE
Fix "Reject" permission from analysis workflow is not updated

### DIFF
--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2600</version>
+  <version>2601</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -49,6 +49,7 @@ def upgrade(tool):
     return True
 
 
+@upgradestep(product, version)
 def fix_analysis_reject_permission(tool):
     """Fixes the analysis reject permission, that was not defined at top-level
     """
@@ -57,6 +58,9 @@ def fix_analysis_reject_permission(tool):
 
     # Reimport rolemap.xml
     setup.runImportStepFromProfile(profile, "rolemap")
+
+    # Reimport workflows
+    setup.runImportStepFromProfile(profile, "workflow")
 
     # Update role mappings of analyses, but only for those analyses that are
     # in a state from which the new permission can apply


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

> [!CAUTION]
> This requires to re-run upgrade step 2601

This Pull Request ensures the the legacy permission `Reject` is successfully renamed as `senaite.core: Transition: Reject Analysis` (introduced with #2469) in `senaite_analysis_workflow`.


## Current behavior before PR

Permission `Reject` from `senaite_analysis_workflow` is not renamed to `senaite.core: Transition: Reject Analysis`

## Desired behavior after PR is merged

Permission `Reject` from `senaite_analysis_workflow` is renamed to `senaite.core: Transition: Reject Analysis`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
