### PR TITLE
Do not create snapshots of parent DX folder on content creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2480 Do not create snapshots of parent DX folder on content creation
 - #2478 Migrate Sample Conditions to Dexterity
 - #2471 Migrate Lab Departments to Dexterity
 - #2469 Rename permission "Reject" to "senaite.core: Transition: Reject Analysis"

--- a/src/bika/lims/subscribers/auditlog.py
+++ b/src/bika/lims/subscribers/auditlog.py
@@ -65,6 +65,13 @@ def unindex_object(obj):
     auditlog_catalog.unindexObject(obj)
 
 
+def get_request():
+    """Returns the current request
+    """
+    # Fixture for tests that do not have a regular request!!!
+    return api.get_request() or api.get_test_request()
+
+
 def set_added(object):
     """Keeps track of this object as being initialized/added within the
     current request life-cycle
@@ -76,7 +83,7 @@ def set_added(object):
 
     # add the path and store in the request
     paths.append(path)
-    request = api.get_request()
+    request = get_request()
     request.set(ADDED_PATHS, paths)
 
 
@@ -84,7 +91,7 @@ def get_added_paths():
     """Returns the paths that have been initialized (added) within the
     current request life-cycle
     """
-    request = api.get_request()
+    request = get_request()
     paths = request.get(ADDED_PATHS) or []
     return list(paths)
 

--- a/src/bika/lims/subscribers/auditlog.py
+++ b/src/bika/lims/subscribers/auditlog.py
@@ -95,9 +95,7 @@ def get_added_paths():
     """
     request = get_request()
     annotations = IAnnotations(request)
-    paths = annotations.get(ADDED_PATHS)
-    if not paths:
-        paths = []
+    paths = annotations.get(ADDED_PATHS) or []
     return list(paths)
 
 

--- a/src/bika/lims/subscribers/auditlog.py
+++ b/src/bika/lims/subscribers/auditlog.py
@@ -26,6 +26,7 @@ from bika.lims.api.snapshot import take_snapshot
 from bika.lims.interfaces import IDoNotSupportSnapshots
 from DateTime import DateTime
 from senaite.core.catalog import AUDITLOG_CATALOG
+from zope.annotation.interfaces import IAnnotations
 from zope.interface import alsoProvides
 
 
@@ -84,7 +85,8 @@ def set_added(object):
     # add the path and store in the request
     paths.append(path)
     request = get_request()
-    request.set(ADDED_PATHS, paths)
+    annotations = IAnnotations(request)
+    annotations[ADDED_PATHS] = tuple(paths)
 
 
 def get_added_paths():
@@ -92,7 +94,10 @@ def get_added_paths():
     current request life-cycle
     """
     request = get_request()
-    paths = request.get(ADDED_PATHS) or []
+    annotations = IAnnotations(request)
+    paths = annotations.get(ADDED_PATHS)
+    if not paths:
+        paths = []
     return list(paths)
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that no snapshot of parent (DX) folder is taken when a content is added, but only when the folder is edited.

This was not required for AT types because `Products.Archetypes.interfaces.IObjectEditedEvent` was only triggered when the object was edited, but not when a content was added. We use `zope.lifecycleevent.interfaces.IObjectModifiedEvent` with DX types, which is also triggered when a content is added.

## Current behavior before PR

Snapshots of a DX container are when the object is modified and when contents added

## Desired behavior after PR is merged

Snapshots of a DX container are taken only when the object is modified, not when contents added

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
