### PR TITLE
Disable snapshots for container on content add

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2481 Disable snapshots for container on content add
 - #2478 Migrate Sample Conditions to Dexterity
 - #2471 Migrate Lab Departments to Dexterity
 - #2469 Rename permission "Reject" to "senaite.core: Transition: Reject Analysis"

--- a/src/senaite/core/browser/dexterity/add.py
+++ b/src/senaite/core/browser/dexterity/add.py
@@ -18,6 +18,8 @@
 # Copyright 2018-2024 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from bika.lims.api.snapshot import pause_snapshots_for
+from bika.lims.api.snapshot import resume_snapshots_for
 from plone.dexterity.browser.add import DefaultAddForm as BaseAddForm
 from plone.dexterity.browser.add import DefaultAddView as BaseAddView
 
@@ -25,6 +27,14 @@ from plone.dexterity.browser.add import DefaultAddView as BaseAddView
 class DefaultAddForm(BaseAddForm):
     """Patched Add Form to handle renameAfterCreation of DX objects
     """
+
+    def add(self, object):
+        """Create a new object in a container
+        """
+        # Temporary disable snapshot creation for container
+        pause_snapshots_for(self.container)
+        super(DefaultAddForm, self).add(object)
+        resume_snapshots_for(self.container)
 
 
 class DefaultAddView(BaseAddView):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR avoids snapshot creation for the container when new contents were added.

## Current behavior before PR

Snapshots are created when new DX contents are added in a container

## Desired behavior after PR is merged

No snapshots are created when new DX contents are added in a container

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
