### PR TITLE
Added DurationField and DurationWidget for Dexterity types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2482 Added DurationField and DurationWidget for Dexterity types
 - #2478 Migrate Sample Conditions to Dexterity
 - #2471 Migrate Lab Departments to Dexterity
 - #2469 Rename permission "Reject" to "senaite.core: Transition: Reject Analysis"

--- a/src/senaite/core/schema/__init__.py
+++ b/src/senaite/core/schema/__init__.py
@@ -23,8 +23,10 @@ from zope.interface import classImplementsFirst
 from .addressfield import AddressField
 from .addressfield import IAddressField
 from .datetimefield import DatetimeField
+from .durationfield import DurationField
 from .fields import IntField
 from .interfaces import IDatetimeField
+from .interfaces import IDurationField
 from .interfaces import IIntField
 from .interfaces import IRichTextField
 from .phonefield import IPhoneField
@@ -35,6 +37,7 @@ from .uidreferencefield import UIDReferenceField
 
 classImplementsFirst(AddressField, IAddressField)
 classImplementsFirst(DatetimeField, IDatetimeField)
+classImplementsFirst(DurationField, IDurationField)
 classImplementsFirst(IntField, IIntField)
 classImplementsFirst(PhoneField, IPhoneField)
 classImplementsFirst(RichTextField, IRichTextField)

--- a/src/senaite/core/schema/durationfield.py
+++ b/src/senaite/core/schema/durationfield.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2024 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from senaite.core.schema.fields import BaseField
+from senaite.core.schema.interfaces import IDurationField
+from zope.interface import implementer
+from zope.schema import Timedelta
+
+
+@implementer(IDurationField)
+class DurationField(Timedelta, BaseField):
+    """A field that handles days, hours, minutes and seconds
+    """
+    pass

--- a/src/senaite/core/schema/durationfield.py
+++ b/src/senaite/core/schema/durationfield.py
@@ -28,4 +28,3 @@ from zope.schema import Timedelta
 class DurationField(Timedelta, BaseField):
     """A field that handles days, hours, minutes and seconds
     """
-    pass

--- a/src/senaite/core/schema/durationfield.txt
+++ b/src/senaite/core/schema/durationfield.txt
@@ -1,0 +1,54 @@
+Duration field
+==============
+
+The phone field stores timedeltas
+
+Running this test from the buildout directory:
+
+bin/test test_schema_fields -t durationfield
+
+
+Test preparation
+----------------
+
+    >>> import sys
+    >>> from bika.lims import api
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_NAME
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+
+
+Using the field
+---------------
+
+Create a content schema that uses the field:
+
+    >>> from zope.interface import Interface, implementer
+    >>> from senaite.core.schema import DurationField
+
+    >>> class IContent(Interface):
+    ...     duration = DurationField(title=u"Duration")
+
+
+Get the field from the schema interface:
+
+    >>> field = IContent["duration"]
+    >>> field
+    <senaite.core.schema.durationfield.DurationField object at ...>
+
+
+Construct the field:
+
+    >>> from datetime import timedelta
+    >>> from persistent import Persistent
+
+    >>> duration = timedelta(days=2, hours=48, minutes=70, seconds=70)
+    >>> @implementer(IContent)
+    ... class Content(Persistent):
+    ...     def __init__(self, duration=duration):
+    ...         self.duration = duration
+
+    >>> content = Content()
+    >>> content.duration
+    datetime.timedelta(4, 4270)

--- a/src/senaite/core/schema/durationfield.txt
+++ b/src/senaite/core/schema/durationfield.txt
@@ -1,7 +1,7 @@
 Duration field
 ==============
 
-The phone field stores timedeltas
+The duration field stores timedeltas
 
 Running this test from the buildout directory:
 

--- a/src/senaite/core/schema/interfaces.py
+++ b/src/senaite/core/schema/interfaces.py
@@ -25,6 +25,7 @@ from zope.schema.interfaces import IField
 from zope.schema.interfaces import IInt
 from zope.schema.interfaces import IList
 from zope.schema.interfaces import INativeString
+from zope.schema.interfaces import ITimedelta
 
 
 class IBaseField(IField):
@@ -69,4 +70,9 @@ class IRichTextField(IRichText):
 
 class IPhoneField(INativeString):
     """Input type "phone" widget
+    """
+
+
+class IDurationField(ITimedelta):
+    """Senaite Duration field
     """

--- a/src/senaite/core/z3cform/interfaces.py
+++ b/src/senaite/core/z3cform/interfaces.py
@@ -61,3 +61,8 @@ class IPhoneWidget(IWidget):
 class IQuerySelectWidget(IWidget):
     """Allows to search and select a value
     """
+
+
+class IDurationWidget(IWidget):
+    """Allows to set a duration period in days, hours and minutes
+    """

--- a/src/senaite/core/z3cform/widgets/configure.zcml
+++ b/src/senaite/core/z3cform/widgets/configure.zcml
@@ -3,6 +3,7 @@
     i18n_domain="senaite.core">
 
   <!-- package includes -->
+  <include package=".duration" />
   <include package=".uidreference" />
   <include package=".queryselect" />
 

--- a/src/senaite/core/z3cform/widgets/duration/__init__.py
+++ b/src/senaite/core/z3cform/widgets/duration/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2024 by it's authors.
+# Some rights reserved, see README and LICENSE.

--- a/src/senaite/core/z3cform/widgets/duration/configure.zcml
+++ b/src/senaite/core/z3cform/widgets/duration/configure.zcml
@@ -1,0 +1,33 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:z3c="http://namespaces.zope.org/z3c"
+    i18n_domain="z3c.form">
+
+  <!-- Duration Widget -->
+  <adapter factory=".widget.DurationWidgetFactory" />
+
+  <!-- Duration data converter -->
+  <adapter factory=".widget.DurationDataConverter" />
+
+  <!-- Duration input widget template -->
+  <z3c:widgetTemplate
+      mode="input"
+      widget=".widget.DurationWidget"
+      template="input.pt"
+      layer="senaite.core.interfaces.ISenaiteFormLayer" />
+
+  <!-- Duration display widget template -->
+  <z3c:widgetTemplate
+      mode="display"
+      widget=".widget.DurationWidget"
+      template="display.pt"
+      layer="senaite.core.interfaces.ISenaiteFormLayer" />
+
+  <!-- Duration hidden widget template -->
+  <z3c:widgetTemplate
+      mode="hidden"
+      widget=".widget.DurationWidget"
+      template="hidden.pt"
+      layer="senaite.core.interfaces.ISenaiteFormLayer" />
+
+</configure>

--- a/src/senaite/core/z3cform/widgets/duration/display.pt
+++ b/src/senaite/core/z3cform/widgets/duration/display.pt
@@ -13,36 +13,27 @@
                    klass      python:' '.join([klass, mode_klass]);"
      tal:attributes="class klass">
 
-    <div class="form-row align-items-center">
-      <div class="col-auto"
-           tal:condition="python: view.show_days and days > 0">
-        <span i18n:translate="duration_widget_days_number">
-          <span i18n:name="days" tal:replace="days"/>
-          days
-        </span>
-      </div>
-      <div class="col-auto"
-           tal:condition="python: view.show_days and hours > 0">
-        <span i18n:translate="duration_widget_hours_number">
-          <span i18n:name="hours" tal:replace="hours"/>
-          hours
-        </span>
-      </div>
-      <div class="col-auto"
-           tal:condition="python: view.show_minutes and minutes > 0">
-        <span i18n:translate="duration_widget_minutes_number">
-          <span i18n:name="minutes" tal:replace="minutes"/>
-          minutes
-        </span>
-      </div>
-      <div class="col-auto"
-           tal:condition="python: view.show_seconds and seconds > 0">
-        <span i18n:translate="duration_widget_seconds_number">
-          <span i18n:name="seconds" tal:replace="seconds"/>
-          seconds
-        </span>
-      </div>
-    </div>
+    <span i18n:translate="duration_widget_days_number"
+          tal:condition="python: view.show_days and days > 0">
+      <span i18n:name="days" tal:replace="days"/>
+      days
+    </span>
+    <span i18n:translate="duration_widget_hours_number"
+          tal:condition="python: view.show_hours and hours > 0">
+      <span i18n:name="hours" tal:replace="hours"/>
+      hours
+    </span>
+    <span i18n:translate="duration_widget_minutes_number"
+          tal:condition="python: view.show_minutes and minutes > 0">
+      <span i18n:name="minutes" tal:replace="minutes"/>
+      minutes
+    </span>
+    <span i18n:translate="duration_widget_seconds_number"
+          tal:condition="python: view.show_seconds and seconds > 0">
+      <span i18n:name="seconds" tal:replace="seconds"/>
+      seconds
+    </span>
+
   </div>
 
 </html>

--- a/src/senaite/core/z3cform/widgets/duration/display.pt
+++ b/src/senaite/core/z3cform/widgets/duration/display.pt
@@ -1,0 +1,48 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      tal:omit-tag="">
+
+  <div tal:define="name       python:view.name;
+                   value      python:view.value;
+                   days       python:value.get('days', 0);
+                   hours      python:value.get('hours', 0);
+                   minutes    python:value.get('minutes', 0);
+                   seconds    python:value.get('seconds', 0);
+                   klass      python:view.klass;
+                   mode_klass python:'{}-display'.format(klass);
+                   klass      python:' '.join([klass, mode_klass]);"
+     tal:attributes="class klass">
+
+    <div class="form-row align-items-center">
+      <div class="col-auto"
+           tal:condition="python: view.show_days and days > 0">
+        <span i18n:translate="duration_widget_days_number">
+          <span i18n:name="days" tal:replace="days"/>
+          days
+        </span>
+      </div>
+      <div class="col-auto"
+           tal:condition="python: view.show_days and hours > 0">
+        <span i18n:translate="duration_widget_hours_number">
+          <span i18n:name="hours" tal:replace="hours"/>
+          hours
+        </span>
+      </div>
+      <div class="col-auto"
+           tal:condition="python: view.show_minutes and minutes > 0">
+        <span i18n:translate="duration_widget_minutes_number">
+          <span i18n:name="minutes" tal:replace="minutes"/>
+          minutes
+        </span>
+      </div>
+      <div class="col-auto"
+           tal:condition="python: view.show_seconds and seconds > 0">
+        <span i18n:translate="duration_widget_seconds_number">
+          <span i18n:name="seconds" tal:replace="seconds"/>
+          seconds
+        </span>
+      </div>
+    </div>
+  </div>
+
+</html>

--- a/src/senaite/core/z3cform/widgets/duration/hidden.pt
+++ b/src/senaite/core/z3cform/widgets/duration/hidden.pt
@@ -1,0 +1,27 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      tal:omit-tag="">
+
+  <div tal:define="name       python:view.name;
+                   value      python:view.value;
+                   days       python:value.get('days', 0);
+                   hours      python:value.get('hours', 0);
+                   minutes    python:value.get('minutes', 0);
+                   seconds    python:value.get('seconds', 0);">
+
+    <input type="hidden"
+           tal:attributes="name string:${name}:days;
+                           value days;"/>
+    <input type="hidden"
+           tal:attributes="name string:${name}:hours;
+                         value hours;"/>
+    <input type="hidden"
+           tal:attributes="name string:${name}:minutes;
+                         value minutes;"/>
+    <input type="hidden"
+           tal:attributes="name string:${name}:seconds;
+                         value seconds;"/>
+
+  </div>
+
+</html>

--- a/src/senaite/core/z3cform/widgets/duration/hidden.pt
+++ b/src/senaite/core/z3cform/widgets/duration/hidden.pt
@@ -2,26 +2,26 @@
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
 
-  <div tal:define="name       python:view.name;
-                   value      python:view.value;
-                   days       python:value.get('days', 0);
-                   hours      python:value.get('hours', 0);
-                   minutes    python:value.get('minutes', 0);
-                   seconds    python:value.get('seconds', 0);">
+  <tal:widget define="name     python:view.name;
+                      value    python:view.value;
+                      days     python:value.get('days', 0);
+                      hours    python:value.get('hours', 0);
+                      minutes  python:value.get('minutes', 0);
+                      seconds  python:value.get('seconds', 0);">
 
     <input type="hidden"
-           tal:attributes="name string:${name}:days;
+           tal:attributes="name string:${name}.days:record:int;
                            value days;"/>
     <input type="hidden"
-           tal:attributes="name string:${name}:hours;
-                         value hours;"/>
+           tal:attributes="name string:${name}.hours:record:int;
+                           value hours;"/>
     <input type="hidden"
-           tal:attributes="name string:${name}:minutes;
-                         value minutes;"/>
+           tal:attributes="name string:${name}.minutes:record:int;
+                           value minutes;"/>
     <input type="hidden"
-           tal:attributes="name string:${name}:seconds;
-                         value seconds;"/>
+           tal:attributes="name string:${name}.seconds:record:int;
+                           value seconds;"/>
 
-  </div>
+  </tal:widget>
 
 </html>

--- a/src/senaite/core/z3cform/widgets/duration/input.pt
+++ b/src/senaite/core/z3cform/widgets/duration/input.pt
@@ -13,7 +13,7 @@
                    klass      python:' '.join([klass, mode_klass]);"
        tal:attributes="class klass">
 
-    <div class="form-row align-items-center">
+    <div class="form-row">
       <div tal:define="name  string:${name}:days;"
            tal:attributes="class python:'col-auto' if view.show_days else 'd-none'">
         <label i18n:translate="duration_widget_label_days"

--- a/src/senaite/core/z3cform/widgets/duration/input.pt
+++ b/src/senaite/core/z3cform/widgets/duration/input.pt
@@ -1,0 +1,57 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      tal:omit-tag="">
+
+  <div tal:define="name       python:view.name;
+                   value      python:view.value;
+                   days       python:value.get('days', 0);
+                   hours      python:value.get('hours', 0);
+                   minutes    python:value.get('minutes', 0);
+                   seconds    python:value.get('seconds', 0);
+                   klass      python:view.klass;
+                   mode_klass python:'{}-input'.format(klass);
+                   klass      python:' '.join([klass, mode_klass]);"
+       tal:attributes="class klass">
+
+    <div class="form-row align-items-center">
+      <div tal:define="name  string:${name}:days;"
+           tal:attributes="class python:'col-auto' if view.show_days else 'd-none'">
+        <label i18n:translate="duration_widget_label_days"
+               tal:attributes="for name">Days</label>
+        <input type="number" size="6"
+               tal:attributes="name name;
+                               value days;"/>
+      </div>
+      <div class="col-auto"
+           tal:define="name string:${name}:hours"
+           tal:attributes="class python:'col-auto' if view.show_hours else 'd-none'">
+        <label i18n:translate="duration_widget_label_hours"
+               tal:attributes="for name">Hours</label>
+        <input type="number" size="6"
+               tal:attributes="name name;
+                               value hours"/>
+      </div>
+      <div class="col-auto"
+           tal:define="name string:${name}:minutes"
+           tal:attributes="class python:'col-auto' if view.show_minutes else 'd-none'">
+        <label i18n:translate="duration_widget_label_minutes"
+               tal:attributes="for name">Minutes</label>
+        <input type="number" size="6"
+               i18n:attributes="placeholder"
+               tal:attributes="name name;
+                               value minutes"/>
+      </div>
+      <div class="col-auto"
+           tal:define="name string:${name}:seconds"
+           tal:attributes="class python:'col-auto' if view.show_seconds else 'd-none'">
+        <label i18n:translate="duration_widget_label_seconds"
+               tal:attributes="for name">Seconds</label>
+        <input type="number" size="6"
+               tal:attributes="name name;
+                               value seconds"/>
+      </div>
+
+    </div>
+  </div>
+
+</html>

--- a/src/senaite/core/z3cform/widgets/duration/input.pt
+++ b/src/senaite/core/z3cform/widgets/duration/input.pt
@@ -14,39 +14,43 @@
        tal:attributes="class klass">
 
     <div class="form-row">
-      <div tal:define="name  string:${name}:days;"
+      <div tal:define="id string:${name}:days;"
            tal:attributes="class python:'col-auto' if view.show_days else 'd-none'">
         <label i18n:translate="duration_widget_label_days"
-               tal:attributes="for name">Days</label>
+               tal:attributes="for id">Days</label>
         <input type="number" size="5"
-               tal:attributes="name name;
+               tal:attributes="id id;
+                               name id;
                                value days;"/>
       </div>
       <div class="col-auto"
-           tal:define="name string:${name}:hours"
+           tal:define="id string:${name}:hours"
            tal:attributes="class python:'col-auto' if view.show_hours else 'd-none'">
         <label i18n:translate="duration_widget_label_hours"
-               tal:attributes="for name">Hours</label>
+               tal:attributes="for id">Hours</label>
         <input type="number" size="5"
-               tal:attributes="name name;
+               tal:attributes="id id;
+                               name id;
                                value hours"/>
       </div>
       <div class="col-auto"
-           tal:define="name string:${name}:minutes"
+           tal:define="id string:${name}:minutes"
            tal:attributes="class python:'col-auto' if view.show_minutes else 'd-none'">
         <label i18n:translate="duration_widget_label_minutes"
-               tal:attributes="for name">Minutes</label>
+               tal:attributes="for id">Minutes</label>
         <input type="number" size="5"
-               tal:attributes="name name;
+               tal:attributes="id id;
+                               name id;
                                value minutes"/>
       </div>
       <div class="col-auto"
-           tal:define="name string:${name}:seconds"
+           tal:define="id string:${name}:seconds"
            tal:attributes="class python:'col-auto' if view.show_seconds else 'd-none'">
         <label i18n:translate="duration_widget_label_seconds"
-               tal:attributes="for name">Seconds</label>
+               tal:attributes="for id">Seconds</label>
         <input type="number" size="5"
-               tal:attributes="name name;
+               tal:attributes="id id;
+                               name id;
                                value seconds"/>
       </div>
 

--- a/src/senaite/core/z3cform/widgets/duration/input.pt
+++ b/src/senaite/core/z3cform/widgets/duration/input.pt
@@ -14,7 +14,7 @@
        tal:attributes="class klass">
 
     <div class="form-row">
-      <div tal:define="id string:${name}:days;"
+      <div tal:define="id string:${name}.days:record:int"
            tal:attributes="class python:'col-auto' if view.show_days else 'd-none'">
         <label i18n:translate="duration_widget_label_days"
                tal:attributes="for id">Days</label>
@@ -24,7 +24,7 @@
                                value days;"/>
       </div>
       <div class="col-auto"
-           tal:define="id string:${name}:hours"
+           tal:define="id string:${name}.hours:record:int"
            tal:attributes="class python:'col-auto' if view.show_hours else 'd-none'">
         <label i18n:translate="duration_widget_label_hours"
                tal:attributes="for id">Hours</label>
@@ -34,7 +34,7 @@
                                value hours"/>
       </div>
       <div class="col-auto"
-           tal:define="id string:${name}:minutes"
+           tal:define="id string:${name}.minutes:record:int"
            tal:attributes="class python:'col-auto' if view.show_minutes else 'd-none'">
         <label i18n:translate="duration_widget_label_minutes"
                tal:attributes="for id">Minutes</label>
@@ -44,7 +44,7 @@
                                value minutes"/>
       </div>
       <div class="col-auto"
-           tal:define="id string:${name}:seconds"
+           tal:define="id string:${name}.seconds:record:int"
            tal:attributes="class python:'col-auto' if view.show_seconds else 'd-none'">
         <label i18n:translate="duration_widget_label_seconds"
                tal:attributes="for id">Seconds</label>

--- a/src/senaite/core/z3cform/widgets/duration/input.pt
+++ b/src/senaite/core/z3cform/widgets/duration/input.pt
@@ -18,7 +18,7 @@
            tal:attributes="class python:'col-auto' if view.show_days else 'd-none'">
         <label i18n:translate="duration_widget_label_days"
                tal:attributes="for name">Days</label>
-        <input type="number" size="6"
+        <input type="number" size="5"
                tal:attributes="name name;
                                value days;"/>
       </div>
@@ -27,7 +27,7 @@
            tal:attributes="class python:'col-auto' if view.show_hours else 'd-none'">
         <label i18n:translate="duration_widget_label_hours"
                tal:attributes="for name">Hours</label>
-        <input type="number" size="6"
+        <input type="number" size="5"
                tal:attributes="name name;
                                value hours"/>
       </div>
@@ -36,8 +36,7 @@
            tal:attributes="class python:'col-auto' if view.show_minutes else 'd-none'">
         <label i18n:translate="duration_widget_label_minutes"
                tal:attributes="for name">Minutes</label>
-        <input type="number" size="6"
-               i18n:attributes="placeholder"
+        <input type="number" size="5"
                tal:attributes="name name;
                                value minutes"/>
       </div>
@@ -46,7 +45,7 @@
            tal:attributes="class python:'col-auto' if view.show_seconds else 'd-none'">
         <label i18n:translate="duration_widget_label_seconds"
                tal:attributes="for name">Seconds</label>
-        <input type="number" size="6"
+        <input type="number" size="5"
                tal:attributes="name name;
                                value seconds"/>
       </div>

--- a/src/senaite/core/z3cform/widgets/duration/widget.py
+++ b/src/senaite/core/z3cform/widgets/duration/widget.py
@@ -20,7 +20,6 @@
 
 from datetime import timedelta
 
-from bika.lims import api
 from senaite.core.interfaces import ISenaiteFormLayer
 from senaite.core.schema.interfaces import IDurationField
 from senaite.core.z3cform.interfaces import IDurationWidget
@@ -56,17 +55,7 @@ class DurationDataConverter(TimedeltaDataConverter):
     def toFieldValue(self, value):
         """Converts from widget to field value
         """
-        # days, hours, minutes, seconds
-        dhms = list(value) + [0]*4
-        seconds = sum((
-            api.to_int(dhms[0], 0)*86400, # days
-            api.to_int(dhms[1], 0)*3600, # hours
-            api.to_int(dhms[2], 0)*60, # minutes
-            api.to_int(dhms[3], 0) # seconds
-        ))
-        if not seconds:
-            return self.field.missing_value
-        return timedelta(seconds=seconds)
+        return timedelta(**value)
 
 
 @implementer(IDurationWidget)

--- a/src/senaite/core/z3cform/widgets/duration/widget.py
+++ b/src/senaite/core/z3cform/widgets/duration/widget.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2024 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from datetime import timedelta
+
+from bika.lims import api
+from senaite.core.interfaces import ISenaiteFormLayer
+from senaite.core.schema.interfaces import IDurationField
+from senaite.core.z3cform.interfaces import IDurationWidget
+from senaite.core.z3cform.widgets.basewidget import BaseWidget
+from z3c.form.browser import widget
+from z3c.form.browser.widget import HTMLInputWidget
+from z3c.form.converter import TimedeltaDataConverter
+from z3c.form.interfaces import IFieldWidget
+from z3c.form.widget import FieldWidget
+from zope.component import adapter
+from zope.interface import implementer
+
+
+@adapter(IDurationField, IDurationWidget)
+class DurationDataConverter(TimedeltaDataConverter):
+    """Converts the value between the field and the widget
+    """
+
+    def toWidgetValue(self, value):
+        """Converts from field value to widget
+        """
+        if not isinstance(value, timedelta):
+            return {}
+
+        # Note timedelta keeps days and seconds a part!
+        return {
+            "days": value.days,
+            "hours": (value.seconds / 3600) % 24, # hours within a day
+            "minutes": (value.seconds / 60) % 60, # minutes within an hour
+            "seconds": value.seconds % 60, # seconds within a minute
+        }
+
+    def toFieldValue(self, value):
+        """Converts from widget to field value
+        """
+        # days, hours, minutes, seconds
+        dhms = list(value) + [0]*4
+        seconds = sum((
+            api.to_int(dhms[0], 0)*86400, # days
+            api.to_int(dhms[1], 0)*3600, # hours
+            api.to_int(dhms[2], 0)*60, # minutes
+            api.to_int(dhms[3], 0) # seconds
+        ))
+        if not seconds:
+            return self.field.missing_value
+        return timedelta(seconds=seconds)
+
+
+@implementer(IDurationWidget)
+class DurationWidget(HTMLInputWidget, BaseWidget):
+    """Widget for duration in days, hours, minutes and seconds
+    """
+    klass = u"senaite-duration-widget"
+
+    # Basic properties
+    show_days = True
+    show_hours = True
+    show_minutes = True
+    show_seconds = False
+
+    def update(self):
+        """Computes self.value for the widget templates
+
+        see z3c.form.widget.Widget
+        """
+        super(DurationWidget, self).update()
+        widget.addFieldClass(self)
+
+
+@adapter(IDurationField, ISenaiteFormLayer)
+@implementer(IFieldWidget)
+def DurationWidgetFactory(field, request):
+    """Widget factory for duration field
+    """
+    return FieldWidget(field, DurationWidget(request))

--- a/src/senaite/core/z3cform/widgets/durationwidget.txt
+++ b/src/senaite/core/z3cform/widgets/durationwidget.txt
@@ -70,24 +70,25 @@ If we render the widget we get the HTML:
           <div class="form-row">
             <div class="col-auto">
               <label for="duration:days">Days</label>
-              <input name="duration:days" size="5" type="number" value="2">
+              <input id="duration:days" name="duration:days" size="5" type="number" value="2">
             </div>
             <div class="col-auto">
               <label for="duration:hours">Hours</label>
-              <input name="duration:hours" size="5" type="number" value="48">
+              <input id="duration:hours" name="duration:hours" size="5" type="number" value="48">
             </div>
             <div class="col-auto">
               <label for="duration:minutes">Minutes</label>
-              <input name="duration:minutes" size="5" type="number" value="70">
+              <input id="duration:minutes" name="duration:minutes" size="5" type="number" value="70">
             </div>
             <div class="d-none">
               <label for="duration:seconds">Seconds</label>
-              <input name="duration:seconds" size="5" type="number" value="70">
+              <input id="duration:seconds" name="duration:seconds" size="5" type="number" value="70">
             </div>
           </div>
         </div>
       </body>
     </html>
+
 
 Render without the days component:
 
@@ -99,19 +100,19 @@ Render without the days component:
           <div class="form-row">
             <div class="d-none">
               <label for="duration:days">Days</label>
-              <input name="duration:days" size="5" type="number" value="2">
+              <input id="duration:days" name="duration:days" size="5" type="number" value="2">
             </div>
             <div class="col-auto">
               <label for="duration:hours">Hours</label>
-              <input name="duration:hours" size="5" type="number" value="48">
+              <input id="duration:hours" name="duration:hours" size="5" type="number" value="48">
             </div>
             <div class="col-auto">
               <label for="duration:minutes">Minutes</label>
-              <input name="duration:minutes" size="5" type="number" value="70">
+              <input id="duration:minutes" name="duration:minutes" size="5" type="number" value="70">
             </div>
             <div class="d-none">
               <label for="duration:seconds">Seconds</label>
-              <input name="duration:seconds" size="5" type="number" value="70">
+              <input id="duration:seconds" name="duration:seconds" size="5" type="number" value="70">
             </div>
           </div>
         </div>

--- a/src/senaite/core/z3cform/widgets/durationwidget.txt
+++ b/src/senaite/core/z3cform/widgets/durationwidget.txt
@@ -70,19 +70,19 @@ If we render the widget we get the HTML:
           <div class="form-row">
             <div class="col-auto">
               <label for="duration:days">Days</label>
-              <input name="duration:days" size="6" type="number" value="2">
+              <input name="duration:days" size="5" type="number" value="2">
             </div>
             <div class="col-auto">
               <label for="duration:hours">Hours</label>
-              <input name="duration:hours" size="6" type="number" value="48">
+              <input name="duration:hours" size="5" type="number" value="48">
             </div>
             <div class="col-auto">
               <label for="duration:minutes">Minutes</label>
-              <input name="duration:minutes" placeholder="placeholder" size="6" type="number" value="70">
+              <input name="duration:minutes" size="5" type="number" value="70">
             </div>
             <div class="d-none">
               <label for="duration:seconds">Seconds</label>
-              <input name="duration:seconds" size="6" type="number" value="70">
+              <input name="duration:seconds" size="5" type="number" value="70">
             </div>
           </div>
         </div>
@@ -99,19 +99,19 @@ Render without the days component:
           <div class="form-row">
             <div class="d-none">
               <label for="duration:days">Days</label>
-              <input name="duration:days" size="6" type="number" value="2">
+              <input name="duration:days" size="5" type="number" value="2">
             </div>
             <div class="col-auto">
               <label for="duration:hours">Hours</label>
-              <input name="duration:hours" size="6" type="number" value="48">
+              <input name="duration:hours" size="5" type="number" value="48">
             </div>
             <div class="col-auto">
               <label for="duration:minutes">Minutes</label>
-              <input name="duration:minutes" placeholder="placeholder" size="6" type="number" value="70">
+              <input name="duration:minutes" size="5" type="number" value="70">
             </div>
             <div class="d-none">
               <label for="duration:seconds">Seconds</label>
-              <input name="duration:seconds" size="6" type="number" value="70">
+              <input name="duration:seconds" size="5" type="number" value="70">
             </div>
           </div>
         </div>

--- a/src/senaite/core/z3cform/widgets/durationwidget.txt
+++ b/src/senaite/core/z3cform/widgets/durationwidget.txt
@@ -155,11 +155,9 @@ Check HIDDEN_MODE:
     >>> print(widget.render())
     <html>
       <body>
-        <div>
-          <input name="duration:days" type="hidden" value="2">
-          <input name="duration:hours" type="hidden" value="48">
-          <input name="duration:minutes" type="hidden" value="70">
-          <input name="duration:seconds" type="hidden" value="70">
-        </div>
+        <input name="duration.days:record:int" type="hidden" value="2">
+        <input name="duration.hours:record:int" type="hidden" value="48">
+        <input name="duration.minutes:record:int" type="hidden" value="70">
+        <input name="duration.seconds:record:int" type="hidden" value="70">
       </body>
     </html>

--- a/src/senaite/core/z3cform/widgets/durationwidget.txt
+++ b/src/senaite/core/z3cform/widgets/durationwidget.txt
@@ -69,20 +69,20 @@ If we render the widget we get the HTML:
         <div class="senaite-duration-widget senaite-duration-widget-input">
           <div class="form-row">
             <div class="col-auto">
-              <label for="duration:days">Days</label>
-              <input id="duration:days" name="duration:days" size="5" type="number" value="2">
+              <label for="duration.days:record:int">Days</label>
+              <input id="duration.days:record:int" name="duration.days:record:int" size="5" type="number" value="2">
             </div>
             <div class="col-auto">
-              <label for="duration:hours">Hours</label>
-              <input id="duration:hours" name="duration:hours" size="5" type="number" value="48">
+              <label for="duration.hours:record:int">Hours</label>
+              <input id="duration.hours:record:int" name="duration.hours:record:int" size="5" type="number" value="48">
             </div>
             <div class="col-auto">
-              <label for="duration:minutes">Minutes</label>
-              <input id="duration:minutes" name="duration:minutes" size="5" type="number" value="70">
+              <label for="duration.minutes:record:int">Minutes</label>
+              <input id="duration.minutes:record:int" name="duration.minutes:record:int" size="5" type="number" value="70">
             </div>
             <div class="d-none">
-              <label for="duration:seconds">Seconds</label>
-              <input id="duration:seconds" name="duration:seconds" size="5" type="number" value="70">
+              <label for="duration.seconds:record:int">Seconds</label>
+              <input id="duration.seconds:record:int" name="duration.seconds:record:int" size="5" type="number" value="70">
             </div>
           </div>
         </div>
@@ -99,20 +99,20 @@ Render without the days component:
         <div class="senaite-duration-widget senaite-duration-widget-input">
           <div class="form-row">
             <div class="d-none">
-              <label for="duration:days">Days</label>
-              <input id="duration:days" name="duration:days" size="5" type="number" value="2">
+              <label for="duration.days:record:int">Days</label>
+              <input id="duration.days:record:int" name="duration.days:record:int" size="5" type="number" value="2">
             </div>
             <div class="col-auto">
-              <label for="duration:hours">Hours</label>
-              <input id="duration:hours" name="duration:hours" size="5" type="number" value="48">
+              <label for="duration.hours:record:int">Hours</label>
+              <input id="duration.hours:record:int" name="duration.hours:record:int" size="5" type="number" value="48">
             </div>
             <div class="col-auto">
-              <label for="duration:minutes">Minutes</label>
-              <input id="duration:minutes" name="duration:minutes" size="5" type="number" value="70">
+              <label for="duration.minutes:record:int">Minutes</label>
+              <input id="duration.minutes:record:int" name="duration.minutes:record:int" size="5" type="number" value="70">
             </div>
             <div class="d-none">
-              <label for="duration:seconds">Seconds</label>
-              <input id="duration:seconds" name="duration:seconds" size="5" type="number" value="70">
+              <label for="duration.seconds:record:int">Seconds</label>
+              <input id="duration.seconds:record:int" name="duration.seconds:record:int" size="5" type="number" value="70">
             </div>
           </div>
         </div>

--- a/src/senaite/core/z3cform/widgets/durationwidget.txt
+++ b/src/senaite/core/z3cform/widgets/durationwidget.txt
@@ -1,0 +1,164 @@
+Duration widget
+===============
+
+The duration field widget allows to set a duration in days, hours, minutes and
+seconds and display it.
+
+
+Running this test from the buildout directory:
+
+    bin/test test_z3c_widgets -t durationwidget
+
+Hints:
+
+`plone.app.z3cform.widget.DurationWidget`
+
+
+Some variables we need:
+
+    >>> NAME = "duration"
+    >>> VALUE = {"days": 2, "hours": 48, "minutes": 70, "seconds": 70}
+    >>> INPUT_TPL = "duration/input.pt"
+    >>> HIDDEN_TPL = "duration/hidden.pt"
+    >>> DISPLAY_TPL = "duration/display.pt"
+
+The widget can render a input field for a days, hours, minutes and seconds:
+
+    >>> from zope.interface.verify import verifyClass
+    >>> from z3c.form import interfaces
+    >>> from senaite.core.z3cform.widgets.duration.widget import DurationWidget
+
+Verify widget:
+
+    >>> verifyClass(interfaces.IWidget, DurationWidget)
+    True
+
+The widget can render a input field only by adapting a request:
+
+    >>> from z3c.form.testing import TestRequest
+    >>> request = TestRequest()
+    >>> widget = DurationWidget(request)
+
+Such a field provides IWidget:
+
+    >>> interfaces.IWidget.providedBy(widget)
+    True
+
+We also need to register the template for at least the widget and request:
+
+    >>> import os.path
+    >>> import zope.interface
+    >>> from zope.publisher.interfaces.browser import IDefaultBrowserLayer
+    >>> from zope.pagetemplate.interfaces import IPageTemplate
+    >>> import senaite.core.z3cform.widgets
+    >>> import z3c.form.widget
+    >>> template = os.path.join(os.path.dirname(senaite.core.z3cform.widgets.__file__), INPUT_TPL)
+    >>> factory = z3c.form.widget.WidgetTemplateFactory(template)
+    >>> zope.component.provideAdapter(factory,
+    ...     (zope.interface.Interface, IDefaultBrowserLayer, None, None, None),
+    ...     IPageTemplate, name='input')
+
+If we render the widget we get the HTML:
+
+    >>> widget.name = NAME
+    >>> widget.value = VALUE
+    >>> widget.mode = interfaces.INPUT_MODE
+    >>> print(widget.render().replace('\n', ''))
+    <html>
+      <body>
+        <div class="senaite-duration-widget senaite-duration-widget-input">
+          <div class="form-row">
+            <div class="col-auto">
+              <label for="duration:days">Days</label>
+              <input name="duration:days" size="6" type="number" value="2">
+            </div>
+            <div class="col-auto">
+              <label for="duration:hours">Hours</label>
+              <input name="duration:hours" size="6" type="number" value="48">
+            </div>
+            <div class="col-auto">
+              <label for="duration:minutes">Minutes</label>
+              <input name="duration:minutes" placeholder="placeholder" size="6" type="number" value="70">
+            </div>
+            <div class="d-none">
+              <label for="duration:seconds">Seconds</label>
+              <input name="duration:seconds" size="6" type="number" value="70">
+            </div>
+          </div>
+        </div>
+      </body>
+    </html>
+
+Render without the days component:
+
+    >>> widget.show_days = False
+    >>> print(widget.render().replace('\n', ''))
+    <html>
+      <body>
+        <div class="senaite-duration-widget senaite-duration-widget-input">
+          <div class="form-row">
+            <div class="d-none">
+              <label for="duration:days">Days</label>
+              <input name="duration:days" size="6" type="number" value="2">
+            </div>
+            <div class="col-auto">
+              <label for="duration:hours">Hours</label>
+              <input name="duration:hours" size="6" type="number" value="48">
+            </div>
+            <div class="col-auto">
+              <label for="duration:minutes">Minutes</label>
+              <input name="duration:minutes" placeholder="placeholder" size="6" type="number" value="70">
+            </div>
+            <div class="d-none">
+              <label for="duration:seconds">Seconds</label>
+              <input name="duration:seconds" size="6" type="number" value="70">
+            </div>
+          </div>
+        </div>
+      </body>
+    </html>
+
+Check DISPLAY_MODE:
+
+    >>> template = os.path.join(os.path.dirname(senaite.core.z3cform.widgets.__file__), DISPLAY_TPL)
+    >>> factory = z3c.form.widget.WidgetTemplateFactory(template)
+    >>> zope.component.provideAdapter(factory,
+    ...     (zope.interface.Interface, IDefaultBrowserLayer, None, None, None),
+    ...     IPageTemplate, name='display')
+
+    >>> widget.name = NAME
+    >>> widget.value = VALUE
+    >>> widget.mode = interfaces.DISPLAY_MODE
+    >>> print(widget.render())
+    <html>
+      <body>
+        <div class="senaite-duration-widget senaite-duration-widget-display">
+          <span>48 hours</span>
+          <span>70 minutes</span>
+        </div>
+      </body>
+    </html>
+
+
+Check HIDDEN_MODE:
+
+    >>> template = os.path.join(os.path.dirname(senaite.core.z3cform.widgets.__file__), HIDDEN_TPL)
+    >>> factory = z3c.form.widget.WidgetTemplateFactory(template)
+    >>> zope.component.provideAdapter(factory,
+    ...     (zope.interface.Interface, IDefaultBrowserLayer, None, None, None),
+    ...     IPageTemplate, name='hidden')
+
+    >>> widget.name = NAME
+    >>> widget.value = VALUE
+    >>> widget.mode = interfaces.HIDDEN_MODE
+    >>> print(widget.render())
+    <html>
+      <body>
+        <div>
+          <input name="duration:days" type="hidden" value="2">
+          <input name="duration:hours" type="hidden" value="48">
+          <input name="duration:minutes" type="hidden" value="70">
+          <input name="duration:seconds" type="hidden" value="70">
+        </div>
+      </body>
+    </html>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds a new `DurationField` and `DurationWidget` that can be used in DX types as follows:

```python

from plone.autoform import directives
from senaite.core.schema.durationfield import DurationField
from senaite.core.z3cform.widgets.duration.widget import DurationWidgetFactory

class IMyContentSchema(model.Schema):
    """Schema interface
    """

    directives.widget("duration", DurationWidgetFactory)
    duration = DurationField(
        title=_("Duration"),
        required=False,
    )

```

Widget displayed in edit mode:

![Captura de 2024-02-10 17-32-01](https://github.com/senaite/senaite.core/assets/832627/8460a184-a3e2-43fc-afd8-02a440a5db9b)


Widget displayed in view mode:

![Captura de 2024-02-10 17-32-30](https://github.com/senaite/senaite.core/assets/832627/24c92551-056a-4aa1-9190-83fef1a1338f)


## Current behavior before PR

There is no duration widget for DX types, but for AT types only

## Desired behavior after PR is merged

There is a duration widget for DX types

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
