### PR TITLE
Disable CSRF protection in SENAITE

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2484 Disable CSRF protection in SENAITE
 - #2482 Added DurationField and DurationWidget for Dexterity types
 - #2481 Disable snapshots for container on content add
 - #2478 Migrate Sample Conditions to Dexterity

--- a/src/senaite/core/interfaces/__init__.py
+++ b/src/senaite/core/interfaces/__init__.py
@@ -19,14 +19,17 @@
 # Some rights reserved, see README and LICENSE.
 
 from plone.app.z3cform.interfaces import IPloneFormLayer
-from senaite.core.interfaces.catalog import *
-from senaite.core.interfaces.datamanager import IDataManager
-from senaite.core.interfaces.widget import *
+from plone.protect.interfaces import IDisableCSRFProtection
+from senaite.core.interfaces.catalog import *  # noqa:F401,F403
+from senaite.core.interfaces.datamanager import IDataManager  # noqa:F401
+from senaite.core.interfaces.widget import *  # noqa:F401,F403
 from zope.interface import Interface
 
 
-class ISenaiteCore(Interface):
+class ISenaiteCore(IDisableCSRFProtection):
     """Marker interface that defines a Zope 3 browser layer.
+
+    NOTE: We disable CSRF protection site-wide.
     """
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR disables CSRF protection in SENAITE.

## Current behavior before PR

Confirm action dialog is displayed when e.g. accessing the SENAITE Impress configuration

## Desired behavior after PR is merged

No confirmation dialogs are displayed in SENAITE.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
