### PR TITLE
Fix Traceback on "Manage analyses" when dynamic specs assigned

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2486 Fix Traceback on "Manage analyses" when dynamic specs assigned
 - #2484 Disable CSRF protection in SENAITE
 - #2482 Added DurationField and DurationWidget for Dexterity types
 - #2481 Disable snapshots for container on content add

--- a/src/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/src/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -146,11 +146,14 @@ class AnalysisRequestAnalysesView(BikaListingView):
         result ranges set in analyses. This guarantees that result ranges for
         already present analyses are not overriden after form submission
         """
-        # Extract the result ranges from Sample analyses
-        analyses = self.analyses.values()
-        analyses_rrs = map(lambda an: an.getResultsRange(), analyses)
-        analyses_rrs = filter(None, analyses_rrs)
-        rrs = dicts_to_dict(analyses_rrs, "keyword")
+        # Extract the result ranges from Sample analyses grouped by keyword
+        rrs = {}
+        for analysis in self.analyses.values():
+            results_range = analysis.getResultsRange()
+            if not results_range:
+                continue
+            keyword = analysis.getKeyword()
+            rrs[keyword] = results_range
 
         # Bail out ranges from Sample that are already present in analyses
         sample_rrs = self.context.getResultsRange()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a traceback that occurs when accessing to "Manage analyses" from inside sample when dynamic specification assigned

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.app.listing.view, line 246, in __call__
  Module senaite.app.listing.ajax, line 113, in handle_subpath
  Module senaite.core.decorators, line 40, in decorator
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 383, in ajax_folderitems
  Module senaite.app.listing.decorators, line 88, in wrapper
  Module senaite.app.listing.ajax, line 259, in get_folderitems
  Module bika.lims.browser.analysisrequest.manage_analyses, line 188, in folderitems
  Module senaite.app.listing.view, line 982, in folderitems
  Module bika.lims.browser.analysisrequest.manage_analyses, line 234, in folderitem
  Module plone.memoize.view, line 59, in memogetter
  Module bika.lims.browser.analysisrequest.manage_analyses, line 153, in get_results_range
  Module bika.lims.utils, line 500, in dicts_to_dict
KeyError: 'keyword'
```

## Desired behavior after PR is merged

No traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
