### PR TITLE
Fix ValueError when creating new Dexterity contents

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2487 Fix ValueError when creating new Dexterity contents
 - #2486 Fix Traceback on "Manage analyses" when dynamic specs assigned
 - #2484 Disable CSRF protection in SENAITE
 - #2482 Added DurationField and DurationWidget for Dexterity types

--- a/src/bika/lims/api/snapshot.py
+++ b/src/bika/lims/api/snapshot.py
@@ -331,7 +331,12 @@ def pause_snapshots_for(obj):
 def resume_snapshots_for(obj):
     """Resume snapshots for the given object
     """
-    noLongerProvides(obj, IDoNotSupportSnapshots)
+    try:
+        noLongerProvides(obj, IDoNotSupportSnapshots)
+    except ValueError:
+        # Handle ValueError: Can only remove directly provided interfaces.
+        # when the interface was directly provided on class level
+        pass
 
 
 def compare_snapshots(snapshot_a, snapshot_b, raw=False):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a side-effect that was introduced with https://github.com/senaite/senaite.core/pull/2481 for folders, that have the `IDoNotSupportSnapshots` interface implemented on class level

## Current behavior before PR

Traceback occurs when e.g. a new patient is created:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module plone.z3cform.layout, line 63, in __call__
  Module plone.z3cform.layout, line 47, in update
  Module plone.dexterity.browser.add, line 138, in update
  Module plone.z3cform.fieldsets.extensible, line 65, in update
  Module plone.z3cform.patch, line 30, in GroupForm_update
  Module z3c.form.group, line 145, in update
  Module plone.app.z3cform.csrf, line 22, in execute
  Module z3c.form.action, line 98, in execute
  Module z3c.form.button, line 315, in __call__
  Module z3c.form.button, line 170, in __call__
  Module plone.dexterity.browser.add, line 116, in handleAdd
  Module z3c.form.form, line 265, in createAndAdd
  Module senaite.core.browser.dexterity.add, line 37, in add
  Module bika.lims.api.snapshot, line 334, in resume_snapshots_for
  Module zope.interface.declarations, line 956, in noLongerProvides
ValueError: Can only remove directly provided interfaces.
```

## Desired behavior after PR is merged

Interface removal is performed gracefully.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
