### PR TITLE
Fix TypeError when creating a DX object that once was from AT type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2490 Fix TypeError when creating a DX object that once was from AT type
 - #2485 More informative progress of the sample analyses states
 - #2487 Fix ValueError when creating new Dexterity contents
 - #2486 Fix Traceback on "Manage analyses" when dynamic specs assigned

--- a/src/senaite/core/browser/controlpanel/sampleconditions/view.py
+++ b/src/senaite/core/browser/controlpanel/sampleconditions/view.py
@@ -45,7 +45,7 @@ class SampleConditionsView(ListingView):
 
         self.context_actions = {
             _(u"listing_sampleconditions_action_add", default=u"Add"): {
-                "url": "createObject?type_name=SampleCondition",
+                "url": "++add++SampleCondition",
                 "permission": AddSampleCondition,
                 "icon": "++resource++bika.lims.images/add.png"
             }

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2605</version>
+  <version>2606</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -80,6 +80,14 @@ def remove_at_portal_types(tool):
             # Removed already
             continue
         pt.manage_delObjects(fti.getId())
+
+    # remove from AT's factory tool as well. This is necessary for the AT's
+    # factory_tool to not shortcut `createObject?type_name=` on object creation
+    ft = api.get_tool("portal_factory")
+    at_types = ft.getFactoryTypes().keys()
+    at_types = filter(lambda name: name not in REMOVE_AT_TYPES, at_types)
+    ft.manage_setPortalFactoryTypes(listOfTypeIds=at_types)
+
     logger.info("Remove AT types from portal_types tool ... [DONE]")
 
 

--- a/src/senaite/core/upgrade/v02_06_000.zcml
+++ b/src/senaite/core/upgrade/v02_06_000.zcml
@@ -4,6 +4,14 @@
     i18n_domain="senaite.core">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.6.0: Remove old AT from AT's factory tool"
+      description="Remove old AT types from factory tool"
+      source="2605"
+      destination="2606"
+      handler=".v02_06_000.remove_at_portal_types"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.6.0: Remove auditlog and snapshots from setup folders"
       description="Remove auditlog and snapshots from setup folders"
       source="2604"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensure that the creation of objects that once where from AT types takes place without error even when the `createObject` url form is used (e.g. "http://localhost:9090/senaite/setup/sampleconditions/createObject?type_name=SampleCondition")

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 182, in transaction_pubevents
  Module transaction._manager, line 257, in commit
  Module transaction._manager, line 134, in commit
  Module transaction._transaction, line 282, in commit
  Module transaction._transaction, line 273, in commit
  Module transaction._transaction, line 456, in _commitResources
  Module transaction._transaction, line 430, in _commitResources
  Module ZODB.Connection, line 498, in commit
  Module ZODB.Connection, line 545, in _commit
  Module ZODB.Connection, line 576, in _store_objects
  Module ZODB.serialize, line 434, in serialize
TypeError: Can't pickle objects in acquisition wrappers.
```

## Desired behavior after PR is merged

Able to create a Sample Condition without traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
