### PR TITLE
Add setting to show/hide the laboratory name in login  page

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2491 Add setting to show/hidde the laboratory name in login page
 - #2485 More informative progress of the sample analyses states
 - #2487 Fix ValueError when creating new Dexterity contents
 - #2486 Fix Traceback on "Manage analyses" when dynamic specs assigned

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
-- #2491 Add setting to show/hidde the laboratory name in login page
+- #2491 Add setting to show/hide the laboratory name in login page
 - #2485 More informative progress of the sample analyses states
 - #2487 Fix ValueError when creating new Dexterity contents
 - #2486 Fix Traceback on "Manage analyses" when dynamic specs assigned

--- a/src/bika/lims/content/bikasetup.py
+++ b/src/bika/lims/content/bikasetup.py
@@ -976,6 +976,22 @@ schema = BikaFolderSchema.copy() + Schema((
             ),
         )
     ),
+    # NOTE: This is a Proxy Field which delegates to senaite_setup DX
+    BooleanField(
+        "ShowLabNameInLogin",
+        schemata="Appearance",
+        default=False,
+        widget=BooleanWidget(
+            label=_(
+                u"title_senaitesetup_show_lab_name_in_login",
+                default=u"Display laboratory name in the login page"),
+            description=_(
+                u"description_senaitesetup_show_lab_name_in_login",
+                default=u"When selected, the laboratory name will be displayed"
+                        u"in the login page, above the access credentials."
+            ),
+        )
+    ),
 ))
 
 schema['title'].validators = ()
@@ -1205,6 +1221,23 @@ class BikaSetup(folder.ATFolder):
             # we get a string value here!
             value = api.to_int(value, default=10)
             setup.setMaxNumberOfSamplesAdd(value)
+
+    def getShowLabNameInLogin(self):
+        """Get the value from the senaite setup
+        """
+        setup = api.get_senaite_setup()
+        # setup is `None` during initial site content structure installation
+        if setup:
+            return setup.getShowLabNameInLogin()
+        return False
+
+    def setShowLabNameInLogin(self, value):
+        """Set the value in the senaite setup
+        """
+        setup = api.get_senaite_setup()
+        # setup is `None` during initial site content structure installation
+        if setup:
+            setup.setShowLabNameInLogin(value)
 
 
 registerType(BikaSetup, PROJECTNAME)

--- a/src/senaite/core/browser/login/login.py
+++ b/src/senaite/core/browser/login/login.py
@@ -18,6 +18,7 @@
 # Copyright 2018-2024 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from bika.lims import api
 from Products.CMFPlone.browser.login.login import LoginForm as BaseLoginForm
 
 
@@ -37,3 +38,13 @@ class LoginForm(BaseLoginForm):
     def updateActions(self):
         super(LoginForm, self).updateActions()
         self.actions["login"].addClass("btn btn-primary btn-sm")
+
+    @property
+    def show_lab_name(self):
+        setup = api.get_senaite_setup()
+        return setup.getShowLabNameInLogin()
+
+    @property
+    def lab_name(self):
+        lab = api.get_setup().laboratory
+        return api.get_title(lab)

--- a/src/senaite/core/browser/login/templates/login.pt
+++ b/src/senaite/core/browser/login/templates/login.pt
@@ -24,6 +24,12 @@
             </div>
 
             <div class="card-body">
+
+              <tal:card-header tal:condition="python:view.show_lab_name">
+                <h5 class="card-title" tal:content="python:view.lab_name"/>
+                <hr class="dashed"/>
+              </tal:card-header>
+
               <form action="."
                     method="post"
                     class="loginform"

--- a/src/senaite/core/content/senaitesetup.py
+++ b/src/senaite/core/content/senaitesetup.py
@@ -156,6 +156,17 @@ class ISetupSchema(model.Schema):
         ),
         default=10
     )
+    show_lab_name_in_login = schema.Bool(
+        title=_(
+            u"title_senaitesetup_show_lab_name_in_login",
+            default=u"Display laboratory name in the login page"),
+        description=_(
+            u"description_senaitesetup_show_lab_name_in_login",
+            default=u"When selected, the laboratory name will be displayed"
+                    u"in the login page, above the access credentials."
+        ),
+        default=False,
+    )
 
     ###
     # Fieldsets
@@ -192,6 +203,7 @@ class ISetupSchema(model.Schema):
         fields=[
             "site_logo",
             "site_logo_css",
+            "show_lab_name_in_login",
         ]
     )
 
@@ -341,4 +353,18 @@ class Setup(Container):
         field 'Number of samples'
         """
         mutator = self.mutator("max_number_of_samples_add")
+        return mutator(self, value)
+
+    @security.protected(permissions.View)
+    def getShowLabNameInLogin(self):
+        """Returns if the laboratory name has to be displayed in login page
+        """
+        accessor = self.accessor("show_lab_name_in_login")
+        return accessor(self)
+
+    @security.protected(permissions.ModifyPortalContent)
+    def setShowLabNameInLogin(self, value):
+        """Show/hide the laboratory name in the login page
+        """
+        mutator = self.mutator("show_lab_name_in_login")
         return mutator(self, value)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Adds a setting that allows the show/hie the laboratory name in the login page

## Current behavior before PR

Is not possible to display the laboratory name in the login page

## Desired behavior after PR is merged

It i possible to display the laboratory name in the login page

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
