### PR TITLE
Fix dynamic analysisspecs are not linked to keywords containing only numbers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2495 Fix dynamic analysisspecs are not linked to keywords containing only numbers
 - #2494 Cleanup UID catalog and remove orphan temporary objects
 - #2493 Add listing widget for Dexterity records field
 - #2492 Migrate Analysis Profiles to Dexterity

--- a/src/bika/lims/content/dynamic_analysisspec.py
+++ b/src/bika/lims/content/dynamic_analysisspec.py
@@ -19,15 +19,16 @@
 # Some rights reserved, see README and LICENSE.
 
 from collections import defaultdict
-from six import StringIO
 
 from bika.lims import _
+from bika.lims import api
 from bika.lims.catalog import SETUP_CATALOG
 from openpyxl.reader.excel import load_workbook
 from openpyxl.utils.exceptions import InvalidFileException
 from plone.dexterity.content import Item
 from plone.namedfile import field as namedfile
 from plone.supermodel import model
+from six import StringIO
 from z3c.form.interfaces import NOT_CHANGED
 from zope.interface import Invalid
 from zope.interface import implementer
@@ -118,11 +119,20 @@ class DynamicAnalysisSpec(Item):
             return []
         keys = self.get_header()
         specs = []
+
+        def get_cell_string_value(cell):
+            value = cell.value
+            if api.is_string(value):
+                return value
+            elif value is None:
+                return None
+            return str(value)
+
         for num, row in enumerate(ps.rows):
             # skip the header
             if num == 0:
                 continue
-            values = map(lambda cell: cell.value, row)
+            values = map(get_cell_string_value, row)
             data = dict(zip(keys, values))
             specs.append(data)
         return specs


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue where a linked dynamic analysis specification does not hook to analysis service keywords if they consist only of numbers, e.g. `413`.

## Current behavior before PR

<img width="803" alt="Cannot add Analysis Specifications based on Dynamic Analysis Specification sheet for certain analyses · Issue #96 · ridingbytes… 2024-02-19 11 AM-11-16" src="https://github.com/senaite/senaite.core/assets/713193/102f03c8-46d4-4099-9b81-329196504c81">

<img width="817" alt="Cannot add Analysis Specifications based on Dynamic Analysis Specification sheet for certain analyses · Issue #96 · ridingbytes… 2024-02-19 11 AM-11-42" src="https://github.com/senaite/senaite.core/assets/713193/a2d105f7-e456-4e10-8b95-372a9b7aa4bd">

## Desired behavior after PR is merged

Dynamic analysisspecs also hook services with number keywords

<img width="1168" alt="Dynamic spes" src="https://github.com/senaite/senaite.core/assets/713193/85216cd1-0288-427b-994d-5c67d7c469b4">



--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
