### PR TITLE
Fix non existing department ID is rendered as link in listing 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2496 Fix non existing department ID is rendered as link in listing
 - #2495 Fix dynamic analysisspecs are not linked to keywords containing only numbers
 - #2494 Cleanup UID catalog and remove orphan temporary objects
 - #2493 Add listing widget for Dexterity records field

--- a/src/senaite/core/browser/controlpanel/departments/view.py
+++ b/src/senaite/core/browser/controlpanel/departments/view.py
@@ -122,7 +122,9 @@ class DepartmentsView(BikaListingView):
         # Department ID
         department_id = obj.getDepartmentID()
         item["DepartmentID"] = department_id
-        item["replace"]["DepartmentID"] = get_link(url, value=department_id)
+        if department_id:
+            item["replace"]["DepartmentID"] = get_link(
+                url, value=department_id)
 
         item["Manager"] = ""
         item["ManagerPhone"] = ""

--- a/src/senaite/core/content/department.py
+++ b/src/senaite/core/content/department.py
@@ -44,7 +44,7 @@ class IDepartmentSchema(model.Schema):
 
     title = schema.TextLine(
         title=u"Title",
-        required=False,
+        required=True,
     )
 
     description = schema.Text(

--- a/src/senaite/core/content/department.py
+++ b/src/senaite/core/content/department.py
@@ -43,12 +43,18 @@ class IDepartmentSchema(model.Schema):
     """
 
     title = schema.TextLine(
-        title=u"Title",
+        title=_(
+            u"title_department_title",
+            default=u"Name"
+        ),
         required=True,
     )
 
     description = schema.Text(
-        title=u"Description",
+        title=_(
+            u"title_department_description",
+            default=u"Description"
+        ),
         required=False,
     )
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the department ID rendering in the listing view, if no department ID is set. E.g. this might be a side effect when importing setup data from an older instance.

## Current behavior before PR

Non existing Department ID is rendered as a link:

<img width="869" alt="Lab Departments — SENAITE LIMS 2024-02-19 1 PM-40-15" src="https://github.com/senaite/senaite.core/assets/713193/6a6fa93f-2cfa-45e1-b27f-413620859875">

## Desired behavior after PR is merged

Non existing Department ID is not rendered in the listing
<img width="725" alt="Lab Departments — SENAITE LIMS 2024-02-19 1 PM-41-15" src="https://github.com/senaite/senaite.core/assets/713193/eba278d4-169c-4ee2-b453-68a7353f06d3">




--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
