### PR TITLE
Fix services widget not found when creating new profiles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2498 Fix services widget not found when creating new profiles
 - #2496 Fix non existing department ID is rendered as link in listing
 - #2495 Fix dynamic analysisspecs are not linked to keywords containing only numbers
 - #2494 Cleanup UID catalog and remove orphan temporary objects

--- a/src/senaite/core/browser/widgets/analysisprofileswidget.py
+++ b/src/senaite/core/browser/widgets/analysisprofileswidget.py
@@ -120,30 +120,31 @@ class AnalysisProfilesWidget(DefaultListingWidget):
     def show_categories_enabled(self):
         """Check in the setup if categories are enabled
         """
-        return self.context.bika_setup.getCategoriseAnalysisServices()
+        bika_setup = api.get_bika_setup()
+        return bika_setup.getCategoriseAnalysisServices()
 
     @view.memoize
     def show_prices(self):
         """Checks if prices should be shown or not
         """
-        setup = api.get_setup()
-        return setup.getShowPrices()
+        bika_setup = api.get_setup()
+        return bika_setup.getShowPrices()
 
     @view.memoize
     def get_currency_symbol(self):
         """Get the currency Symbol
         """
         locale = locales.getLocale("en")
-        setup = api.get_setup()
-        currency = setup.getCurrency()
+        bika_setup = api.get_bika_setup()
+        currency = bika_setup.getCurrency()
         return locale.numbers.currencies[currency].symbol
 
     @view.memoize
     def get_decimal_mark(self):
         """Returns the decimal mark
         """
-        setup = api.get_setup()
-        return setup.getDecimalMark()
+        bika_setup = api.get_bika_setup()
+        return bika_setup.getDecimalMark()
 
     @view.memoize
     def format_price(self, price):

--- a/src/senaite/core/schema/traversal.py
+++ b/src/senaite/core/schema/traversal.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from bika.lims import api
+from plone.dexterity.utils import resolveDottedName
 from zope.component import adapter
 from zope.interface import Interface
 from zope.interface import implementer
@@ -19,8 +20,14 @@ class FieldTraversal(object):
         self.request = request
 
     def traverse(self, name, ignored):
-        fields = api.get_fields(self.context)
-        field = fields.get(name)
+        if "." in name:
+            # we expect the dotted schema interface + the fieldname
+            iface, fieldname = name.rsplit(".", 1)
+            schema = resolveDottedName(iface)
+            field = schema.get(fieldname)
+        else:
+            fields = api.get_fields(self.context)
+            field = fields.get(name)
         if not field:
             raise TraversalError(name)
         field = field.bind(self.context)

--- a/src/senaite/core/z3cform/widgets/listing.txt
+++ b/src/senaite/core/z3cform/widgets/listing.txt
@@ -96,6 +96,7 @@ Create the new content:
 Set a value with the field setter:
 
     >>> field = IMyContentSchema["records"]
+    >>> field.interface.__identifier__ = "mycontent.IMyContentSchema"
     >>> field = field.bind(context)
     >>> field.set(context, [{"uid": 1, "title": "Test"}])
     >>> field.get(context)
@@ -137,7 +138,7 @@ Please note the `data-api-url`, that traverses over the field, so that the listi
       <div class="col-sm-12">
         <div class="small">
           <!-- ReactJS managed component -->
-          <div class="ajax-contents-table w-100" data-form_id="list" data-listing_identifier="default_listing_widget_view" data-enable_ajax_transitions="true" data-active_ajax_transitions="[&quot;activate&quot;, &quot;cancel&quot;, &quot;deactivate&quot;, &quot;receive&quot;, &quot;reinstate&quot;, &quot;submit&quot;, &quot;verify&quot;]" data-pagesize="50" data-api_url="http://nohost/plone/my-content/++field++records/default_listing_widget_view" data-columns="{&quot;Title&quot;: {&quot;index&quot;: &quot;sortable_title&quot;, &quot;title&quot;: &quot;Title&quot;}, &quot;Description&quot;: {&quot;index&quot;: &quot;Description&quot;, &quot;title&quot;: &quot;Description&quot;}}" data-show_column_toggles="false" data-default_review_state="default" data-review_states="[{&quot;contentFilter&quot;: {}, &quot;title&quot;: &quot;All&quot;, &quot;custom_transitions&quot;: [], &quot;transitions&quot;: [], &quot;id&quot;: &quot;default&quot;, &quot;columns&quot;: []}]">
+          <div class="ajax-contents-table w-100" data-form_id="list" data-listing_identifier="default_listing_widget_view" data-enable_ajax_transitions="true" data-active_ajax_transitions="[&quot;activate&quot;, &quot;cancel&quot;, &quot;deactivate&quot;, &quot;receive&quot;, &quot;reinstate&quot;, &quot;submit&quot;, &quot;verify&quot;]" data-pagesize="50" data-api_url="http://nohost/plone/my-content/++field++mycontent.IMyContentSchema.records/default_listing_widget_view" data-columns="{&quot;Title&quot;: {&quot;index&quot;: &quot;sortable_title&quot;, &quot;title&quot;: &quot;Title&quot;}, &quot;Description&quot;: {&quot;index&quot;: &quot;Description&quot;, &quot;title&quot;: &quot;Description&quot;}}" data-show_column_toggles="false" data-default_review_state="default" data-review_states="[{&quot;contentFilter&quot;: {}, &quot;title&quot;: &quot;All&quot;, &quot;custom_transitions&quot;: [], &quot;transitions&quot;: [], &quot;id&quot;: &quot;default&quot;, &quot;columns&quot;: []}]">
           </div>
         </div>
       </div>

--- a/src/senaite/core/z3cform/widgets/listing/view.py
+++ b/src/senaite/core/z3cform/widgets/listing/view.py
@@ -45,7 +45,11 @@ class DefaultListingWidget(ListingView):
     def get_value(self):
         """Return the current value of the field
         """
-        return self.field.get(self.context)
+        try:
+            # we might be in ++add++ view
+            return self.field.get(self.context)
+        except AttributeError:
+            return self.field.default
 
     def extract(self):
         """Extract the selected valued from the request

--- a/src/senaite/core/z3cform/widgets/listing/widget.py
+++ b/src/senaite/core/z3cform/widgets/listing/widget.py
@@ -75,7 +75,8 @@ class ListingWidget(widget.HTMLInputWidget, BaseWidget):
         """
         viewname = self.get_widget_view_name()
         fieldname = self.field.getName()
-        return "++field++{}/{}".format(fieldname, viewname)
+        iface = self.field.interface.__identifier__
+        return "++field++{}.{}/{}".format(iface, fieldname, viewname)
 
     def get_listing_view(self):
         """Lookup the listing view by name


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue that was introduced in https://github.com/senaite/senaite.core/pull/2492 by using the `++add++` traverser to create new Analysis Profiles.

## Current behavior before PR

Listing view for the services widget not found when creating a new profiles

<img width="1440" alt="Analysis Profiles — SENAITE LIMS 2024-02-20 10 PM-40-13" src="https://github.com/senaite/senaite.core/assets/713193/bce6a8a7-b9fa-49c6-823a-14e86c3a4e1c">

## Desired behavior after PR is merged

Listing view found and correctly rendered when creating new profiles

<img width="1440" alt="Analysis Profiles — SENAITE LIMS 2024-02-20 10 PM-39-11" src="https://github.com/senaite/senaite.core/assets/713193/3b1012c4-7bbd-40ec-881b-83aa3285841d">

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
