### PR TITLE
Un-catalog orphan brains on uid_catalog's clean-up (upgrade step 2610)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2502 Un-catalog orphan brains on uid_catalog's clean-up (upgrade step 2610)
 - #2476 Fix format type to include strings in calculation formulas
 - #2498 Fix services widget not found when creating new profiles
 - #2496 Fix non existing department ID is rendered as link in listing

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -513,6 +513,7 @@ def cleanup_uid_catalog(tool):
         obj = api.get_object(brain, default=None)
         if not obj:
             orphans.append(brain)
+            continue
 
         # flush obj from memory
         obj._p_deactivate()  # noqa

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -509,7 +509,7 @@ def cleanup_uid_catalog(tool):
             logger.info("Checking catalog brain %s/%s"
                         % (num+1, total))
 
-        # chek for orphan brains
+        # check for orphan brains
         obj = api.get_object(brain, default=None)
         if not obj:
             orphans.append(brain)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request uncatalogs orphan brains to upgrade step 2610

## Current behavior before PR

```
Traceback (innermost last):                                                                                                                                                                                        
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents                                                                                                                                              
  Module ZPublisher.WSGIPublisher, line 385, in publish_module                                                                                                                                                     
  Module ZPublisher.WSGIPublisher, line 288, in publish                                                                                                                                                            
  Module ZPublisher.mapply, line 85, in mapply                                                                                                                                                                     
  Module ZPublisher.WSGIPublisher, line 63, in call_object                                                                                                                                                         
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 666, in __call__                                                                                                                              
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 399, in upgrade_product                                                                                                                       
  Module Products.GenericSetup.tool, line 1202, in upgradeProfile                                                                                                                                                  
  Module Products.GenericSetup.upgrade, line 185, in doStep                                                                                                                                                        
  Module senaite.core.upgrade.v02_06_000, line 545, in cleanup_uid_catalog                                                                                                                                         
AttributeError: 'NoneType' object has no attribute 'getPhysicalPath'
```

## Desired behavior after PR is merged

System checks and uncatalog orphan brains before removal of duplicates and temporaries

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
