### PR TITLE
Fix traceback on upgrade step 2610 while cleaning up uid_catalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2503 Fix traceback on upgrade step 2610 while cleaning up uid_catalog
 - #2476 Fix format type to include strings in calculation formulas
 - #2498 Fix services widget not found when creating new profiles
 - #2496 Fix non existing department ID is rendered as link in listing

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -521,6 +521,13 @@ def cleanup_uid_catalog(tool):
         if duplicate is None:
             mapping[uid] = path
         else:
+            obj = api.get_object(brain)
+            dup_obj = api.get_object(duplicate)
+            if obj != dup_obj:
+                # different objects with same UID!
+                logger.error("Different objects with same UID: {}".format(uid))
+                continue
+
             # duplicate detected!
             duplicates.append(brain)
             if duplicate not in duplicates:

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -515,11 +515,10 @@ def cleanup_uid_catalog(tool):
 
         # check if we found a duplicate
         uid = brain.UID
-        path = brain.getPath()
         duplicate = mapping.get(uid)
 
         if duplicate is None:
-            mapping[uid] = path
+            mapping[uid] = brain
         else:
             obj = api.get_object(brain)
             dup_obj = api.get_object(duplicate)

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -533,6 +533,7 @@ def cleanup_uid_catalog(tool):
     for brain in duplicates:
         oid = api.get_id(brain)
         path = api.get_path(brain)
+        obj = api.get_object(brain)
         # uncatalog the object for the current path
         logger.info("Uncatalog brain '%s' at '%s'" % (oid, path))
         catalog.uncatalog_object(path)
@@ -541,13 +542,11 @@ def cleanup_uid_catalog(tool):
         fti = type_info.get(brain.portal_type)
         if fti.product:
             # catalog the object on the relative path
-            obj = api.get_object(brain)
             rel_url = getRelURL(catalog, obj.getPhysicalPath())
             logger.info("Catalog brain '%s' at '%s'" % (oid, rel_url))
             catalog.catalog_object(obj, rel_url)
         else:
             # catalog the object on the absolute path
-            obj = api.get_object(brain)
             abs_url = "/".join(obj.getPhysicalPath())
             logger.info("Catalog brain '%s' at '%s'" % (oid, abs_url))
             catalog.catalog_object(obj, abs_url)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a tracbeack that arises when cleaning up the `uid_catalog` because of trying to get the object after being uncatalogued. This PR also takes corrupt brains (with same UID, but different object) into account.

## Current behavior before PR

```
Traceback (innermost last):                                                                                                                                                                                        
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents                                                                                                                                              
  Module ZPublisher.WSGIPublisher, line 385, in publish_module                                                                                                                                                     
  Module ZPublisher.WSGIPublisher, line 288, in publish                                                                                                                                                            
  Module ZPublisher.mapply, line 85, in mapply                                                                                                                                                                     
  Module ZPublisher.WSGIPublisher, line 63, in call_object                                                                                                                                                         
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 666, in __call__                                                                                                                              
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 399, in upgrade_product                                                                                                                       
  Module Products.GenericSetup.tool, line 1202, in upgradeProfile                                                                                                                                                  
  Module Products.GenericSetup.upgrade, line 185, in doStep                                                                                                                                                        
  Module senaite.core.upgrade.v02_06_000, line 545, in cleanup_uid_catalog                                                                                                                                         
AttributeError: 'NoneType' object has no attribute 'getPhysicalPath'
```

## Desired behavior after PR is merged

Upgrade step completes successfully

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
