### PR TITLE
Fix UnicodeDecodeError when migrating Analysis Profiles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2505 Fix UnicodeDecodeError when migrating Analysis Profiles
 - #2504 Fix subfield_sizes have no effect when rendering RecordField
 - #2503 Fix traceback on upgrade step 2610 while cleaning up uid_catalog
 - #2476 Fix format type to include strings in calculation formulas

--- a/src/senaite/core/content/analysisprofile.py
+++ b/src/senaite/core/content/analysisprofile.py
@@ -192,7 +192,7 @@ class AnalysisProfile(Container, ClientAwareMixin):
     def getProfileKey(self):
         accessor = self.accessor("profile_key")
         value = accessor(self) or ""
-        return value.encode("utf-8")
+        return api.to_utf8(value)
 
     @security.protected(permissions.ModifyPortalContent)
     def setProfileKey(self, value):
@@ -275,7 +275,7 @@ class AnalysisProfile(Container, ClientAwareMixin):
     def getCommercialID(self):
         accessor = self.accessor("commercial_id")
         value = accessor(self) or ""
-        return value.encode("utf-8")
+        return api.to_utf8(value)
 
     @security.protected(permissions.ModifyPortalContent)
     def setCommercialID(self, value):

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -333,9 +333,10 @@ def migrate_analysisprofiles_to_dx(tool):
             target = destination._getOb(src_id)
 
         # Manually set the fields
-        target.title = src.Title()
-        target.description = src.Description()
-        target.profile_key = src.getProfileKey()
+        # NOTE: always convert string values to unicode for dexterity fields!
+        target.title = api.safe_unicode(src.Title() or "")
+        target.description = api.safe_unicode(src.Description() or "")
+        target.profile_key = api.safe_unicode(src.getProfileKey() or "")
 
         # services is now a records field containing the selected service and
         # the hidden settings


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an error that occurs during the migration of [Analysis Profiles](https://github.com/senaite/senaite.core/pull/2492) but probably happens as well if unicode characters are entered for the profile key or commercial ID.

## Current behavior before PR

Traceback occurs during migration:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.GenericSetup.tool, line 1135, in manage_doUpgrades
  Module Products.GenericSetup.upgrade, line 185, in doStep
  Module senaite.core.upgrade, line 39, in wrap_func_args
  Module senaite.core.upgrade.v02_06_000, line 332, in migrate_analysisprofiles_to_dx
  Module Products.BTreeFolder2.BTreeFolder2, line 469, in _setObject
  Module zope.event, line 33, in notify
  Module zope.component.event, line 27, in dispatch
  Module zope.component._api, line 134, in subscribers
  Module zope.interface.registry, line 448, in subscribers
  Module zope.interface.adapter, line 899, in subscribers
  Module zope.component.event, line 36, in objectEventNotify
  Module zope.component._api, line 134, in subscribers
  Module zope.interface.registry, line 448, in subscribers
  Module zope.interface.adapter, line 899, in subscribers
  Module Products.CMFCore.CMFCatalogAware, line 274, in handleContentishEvent
  Module Products.CMFCore.CMFCatalogAware, line 197, in notifyWorkflowCreated
  Module Products.CMFCore.WorkflowTool, line 300, in notifyCreated
  Module Products.CMFCore.WorkflowTool, line 610, in _reindexWorkflowVariables
  Module Products.CMFCore.CMFCatalogAware, line 110, in reindexObjectSecurity
  Module Products.CMFCore.CatalogTool, line 272, in unrestrictedSearchResults
  Module Products.CMFCore.indexing, line 97, in processQueue
  Module Products.CMFCore.indexing, line 227, in process
  Module senaite.core.catalog.catalog_multiplex_processor, line 100, in reindex
  Module Products.CMFCore.CatalogTool, line 368, in _reindexObject
  Module senaite.core.patches.catalog, line 66, in catalog_object
  Module Products.ZCatalog.ZCatalog, line 508, in catalog_object
  Module Products.ZCatalog.Catalog, line 347, in catalogObject
  Module Products.ZCatalog.Catalog, line 292, in updateMetadata
  Module Products.ZCatalog.Catalog, line 427, in recordify
  Module senaite.core.content.analysisprofile, line 195, in getProfileKey
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 4: ordinal not in range(128)
```
## Desired behavior after PR is merged

No traceback occurs.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
