### PR TITLE
Fix specification values for hide min/max not stored on save

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2508 Fix specification values for hide min/max not stored on save
 - #2501 Migrate Sample Matrices to Dexterity
 - #2505 Fix UnicodeDecodeError when migrating Analysis Profiles
 - #2504 Fix subfield_sizes have no effect when rendering RecordField

--- a/src/bika/lims/browser/widgets/analysisspecificationwidget.py
+++ b/src/bika/lims/browser/widgets/analysisspecificationwidget.py
@@ -348,8 +348,10 @@ class AnalysisSpecificationWidget(TypesWidget):
                 "max": s_max,
                 "warn_min": self._get_spec_value(form, uid, "warn_min"),
                 "warn_max": self._get_spec_value(form, uid, "warn_max"),
-                "hidemin": self._get_spec_value(form, uid, "hidemin"),
-                "hidemax": self._get_spec_value(form, uid, "hidemax"),
+                "hidemin": self._get_spec_value(
+                    form, uid, "hidemin", check_floatable=False),
+                "hidemax": self._get_spec_value(
+                    form, uid, "hidemax", check_floatable=False),
                 "rangecomment": self._get_spec_value(form, uid, "rangecomment",
                                                      check_floatable=False)
             }

--- a/src/bika/lims/browser/widgets/analysisspecificationwidget.py
+++ b/src/bika/lims/browser/widgets/analysisspecificationwidget.py
@@ -91,18 +91,13 @@ class AnalysisSpecificationView(BikaListingView):
                 "sortable": False,
                 "type": "numeric",
             }),
-            ("min_operator", {
-                "title": _("Min operator"),
-                "type": "choices",
-                "sortable": False,
-            }),
             ("min", {
                 "title": _("Min"),
                 "sortable": False,
                 "type": "numeric",
             }),
-            ("max_operator", {
-                "title": _("Max operator"),
+            ("min_operator", {
+                "title": _("Min operator"),
                 "type": "choices",
                 "sortable": False,
             }),
@@ -115,6 +110,11 @@ class AnalysisSpecificationView(BikaListingView):
                 "title": _("Max warn"),
                 "sortable": False,
                 "type": "numeric",
+            }),
+            ("max_operator", {
+                "title": _("Max operator"),
+                "type": "choices",
+                "sortable": False,
             }),
             ("hidemin", {
                 "title": _("< Min"),

--- a/src/bika/lims/browser/widgets/analysisspecificationwidget.py
+++ b/src/bika/lims/browser/widgets/analysisspecificationwidget.py
@@ -348,10 +348,8 @@ class AnalysisSpecificationWidget(TypesWidget):
                 "max": s_max,
                 "warn_min": self._get_spec_value(form, uid, "warn_min"),
                 "warn_max": self._get_spec_value(form, uid, "warn_max"),
-                "hidemin": self._get_spec_value(
-                    form, uid, "hidemin", check_floatable=False),
-                "hidemax": self._get_spec_value(
-                    form, uid, "hidemax", check_floatable=False),
+                "hidemin": self._get_spec_value(form, uid, "hidemin"),
+                "hidemax": self._get_spec_value(form, uid, "hidemax"),
                 "rangecomment": self._get_spec_value(form, uid, "rangecomment",
                                                      check_floatable=False)
             }
@@ -391,6 +389,14 @@ class AnalysisSpecificationWidget(TypesWidget):
         value = values[0].get(uid, default)
         if not check_floatable:
             return value
+
+        value = value.strip()
+        for operator in ["<", ">"]:
+            if value.startswith(operator):
+                # also remove any additional spaces between the operator
+                # and the value
+                value = value.lstrip(operator + " ")
+
         return api.is_floatable(value) and value or default
 
     security.declarePublic("AnalysisSpecificationResults")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue for specification objects if the values for `<Min` and `>Max` are set.
 
## Current behavior before PR

Values are not stored after save.

## Desired behavior after PR is merged

Values are stored after safe

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
