### PR TITLE
Skip rendering of empty record fiels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2512 Skip rendering of empty record fiels
 - #2510 Fix Add action of the Client located Analysis Profiles Listing
 - #2508 Fix specification values for hide min/max not stored on save
 - #2509 Allow analysis profiles to be filtered by sample type

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/recordswidget.pt
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/recordswidget.pt
@@ -28,7 +28,7 @@
           <ul class="list-inline m-0">
             <tal:loop tal:repeat="subfield subfields">
               <li tal:define="value python:field.getViewFor(context, idx, subfield, innerJoin)"
-                  tal:condition="python:hidden.get(subfield, False) is False"
+                  tal:condition="python:value and hidden.get(subfield, False) is False"
                   class="list-inline-item mr-0 mb-2">
                 <span class="p-1 bg-light border rounded">
                   <span tal:content="structure value"/>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the AT records widget view, so that it does not show empty values.

## Current behavior before PR

Empty values are rendered:

<img width="532" alt="Volume — SENAITE LIMS 2024-03-01 2 PM-50-52" src="https://github.com/senaite/senaite.core/assets/713193/b117af2a-cfd3-4634-b6f6-3a924f1caa87">

## Desired behavior after PR is merged

Empty record values are not rendered:

<img width="532" alt="Volume — SENAITE LIMS 2024-03-01 2 PM-51-27" src="https://github.com/senaite/senaite.core/assets/713193/c1ea9cf6-d4b5-444a-b97b-b5722cf4888e">


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
