### PR TITLE
Allow to configure the types to be skipped on content structure export

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2516 Allow to configure the types to be skipped on content structure export
 - #2514 Added functions for easy update of workflows
 - #2512 Skip rendering of empty record fiels
 - #2510 Fix Add action of the Client located Analysis Profiles Listing

--- a/src/senaite/core/exportimport/genericsetup/structure.py
+++ b/src/senaite/core/exportimport/genericsetup/structure.py
@@ -41,7 +41,6 @@ from Products.GenericSetup.utils import XMLAdapterBase
 from senaite.core.p3compat import cmp
 from senaite.core.registry import get_registry_record
 from xml.dom.minidom import parseString
-from zope.annotation.interfaces import IAnnotations
 from zope.component import adapts
 from zope.component import getUtility
 from zope.component import queryMultiAdapter

--- a/src/senaite/core/exportimport/genericsetup/structure.py
+++ b/src/senaite/core/exportimport/genericsetup/structure.py
@@ -473,11 +473,7 @@ def create_or_get(parent, id, uid, portal_type):
     return obj
 
 
-def get_cache_key(fun, portal_type, request):
-    return "%s-%s" % (fun.__name__, portal_type)
-
-
-@cache(get_key=get_cache_key)
+@cache(get_key=lambda *args: 'can-export-%s' % args[1])
 def can_export_type(portal_type, request):
     """Returns whether objects from this type can be exported
     """

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2613</version>
+  <version>2614</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/profiles/default/registry.xml
+++ b/src/senaite/core/profiles/default/registry.xml
@@ -19,6 +19,9 @@
   <!-- Registry for sample header configuration -->
   <records interface="senaite.core.registry.schema.ISampleHeaderRegistry" />
 
+  <!-- Registry for generic setup configuration -->
+  <records interface="senaite.core.registry.schema.IGenericSetupRegistry" />
+
   <!-- Site Title -->
   <record name="plone.site_title" interface="Products.CMFPlone.interfaces.controlpanel.ISiteSchema" field="site_title">
     <field type="plone.registry.field.TextLine">

--- a/src/senaite/core/registry/schema.py
+++ b/src/senaite/core/registry/schema.py
@@ -269,3 +269,42 @@ class ISampleHeaderRegistry(ISenaiteRegistry):
         value_type=schema.Bool(title=_("Field visibility"), default=True),
         required=False,
     )
+
+
+class IGenericSetupRegistry(ISenaiteRegistry):
+    """Registry settings for Generic Setup
+    """
+
+    model.fieldset(
+        "generic_setup",
+        label=_(u"Generic Setup"),
+        description=_("Configuration for Generic Setup"),
+        fields=[
+            "generic_setup_skip_export_types",
+        ],
+    )
+
+    generic_setup_skip_export_types = schema.List(
+        title=_(
+            u"label_registry_generic_setup_skip_export_types",
+            default=u"Portal types to skip on content structure export"
+        ),
+        description=_(
+            u"description_registry_generic_setup_skip_export_types",
+            default=u"List of portal types to be skipped when exporting the "
+                    u"content structure of the site via Generic Setup"
+        ),
+        value_type=schema.ASCIILine(),
+        required=False,
+        default=[
+            "AnalysisRequest",
+            "ARReport",
+            "Attachment",
+            "AutoImportLog",
+            "Batch",
+            "Invoice",
+            "ReferenceSample",
+            "Report",
+            "Worksheet",
+        ]
+    )

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -694,3 +694,12 @@ def reindex_sampletype_uid(tool):
     logger.info("Reindexing sampletype_uid index from setup ...")
     reindex_index(SETUP_CATALOG, "sampletype_uid")
     logger.info("Reindexing sampletype_uid index from setup [DONE]")
+
+
+@upgradestep(product, version)
+def import_registry(tool):
+    """Import registry step from profiles
+    """
+    portal = tool.aq_inner.aq_parent
+    setup = portal.portal_setup
+    setup.runImportStepFromProfile(profile, "plone.app.registry")

--- a/src/senaite/core/upgrade/v02_06_000.zcml
+++ b/src/senaite/core/upgrade/v02_06_000.zcml
@@ -4,6 +4,14 @@
     i18n_domain="senaite.core">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.6.0: Import registry settings"
+      description="Import generic setup settings to SENAITE registry"
+      source="2613"
+      destination="2614"
+      handler=".v02_06_000.import_registry"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.6.0: Re-index sampletype_uid index"
       description="Re-index sampletype_uid index"
       source="2612"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds a new section "Generic Setup" in registry that allows to configure the types to be skipped when exporting the content structure of the site via GenericSetup

## Current behavior before PR

The portal types to be skipped on content structure export are not configurable

## Desired behavior after PR is merged

The portal types to be skipped on content structure export are configurable


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
