### PR TITLE
Fix add sort to Supported Services List of ReferenceSample Multichoice field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2517 Add sorting to the Supported Services list of RefernceSample Multichoice field
 - #2516 Allow to configure the types to be skipped on content structure export
 - #2514 Added functions for easy update of workflows
 - #2512 Skip rendering of empty record fiels

--- a/src/bika/lims/browser/worksheet/views/referencesamples.py
+++ b/src/bika/lims/browser/worksheet/views/referencesamples.py
@@ -249,7 +249,7 @@ class ReferenceSamplesView(BikaListingView):
 
         # Supported Services
         supported_services_choices = self.make_supported_services_choices(obj)
-        item["choices"]["SupportedServices"] = supported_services_choices
+        item["choices"]["SupportedServices"] = sorted(supported_services_choices, key=lambda d: d['ResultText'])
 
         # Position
         item["Position"] = "new"

--- a/src/bika/lims/browser/worksheet/views/referencesamples.py
+++ b/src/bika/lims/browser/worksheet/views/referencesamples.py
@@ -198,7 +198,7 @@ class ReferenceSamplesView(BikaListingView):
                 "ResultText": title,
                 "selected": selected,
             })
-        return choices
+        return sorted(choices, key=lambda d: d['ResultText'])
 
     @view.memoize
     def make_position_choices(self):
@@ -249,7 +249,7 @@ class ReferenceSamplesView(BikaListingView):
 
         # Supported Services
         supported_services_choices = self.make_supported_services_choices(obj)
-        item["choices"]["SupportedServices"] = sorted(supported_services_choices, key=lambda d: d['ResultText'])
+        item["choices"]["SupportedServices"] = supported_services_choices
 
         # Position
         item["Position"] = "new"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The list of supported services in referenceSample Table List is unsorted

<img width="1306" alt="image" src="https://github.com/senaite/senaite.core/assets/14867014/ce25ee40-2a9b-4047-985a-035a77b11d95">

## Current behavior before PR

unsorted

## Desired behavior after PR is merged

sorted by service Title

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
