### PR TITLE
Fix Slot Header titile of QC samples in Worksheet view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2520 Fix Slot Header titile of QC samples in Worksheet view
 - #2517 Add sorting to the Supported Services list of RefernceSample Multichoice field
 - #2516 Allow to configure the types to be skipped on content structure export
 - #2514 Added functions for easy update of workflows

--- a/src/bika/lims/browser/worksheet/views/analyses.py
+++ b/src/bika/lims/browser/worksheet/views/analyses.py
@@ -566,9 +566,9 @@ class AnalysesView(BaseView):
             # item
             sample = obj.getSample()
             item_obj = sample
-            obj_id = api.get_id(obj)
             sample_id = api.get_id(sample)
-            item_title = "%s (%s)" % (obj_id, sample_id)
+            sample_title = api.get_title(sample)
+            item_title = "%s (%s)" % (sample_title, sample_id)
             item_url = api.get_url(sample)
             item_img_url = api.get_url(sample)
             item_img = "control.png"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fix of QC title issue

Linked issue: https://github.com/senaite/senaite.core/issues/2518

## Current behavior before PR

QC title displays as AnalysisService Keyword

## Desired behavior after PR is merged

QC title dispalys with its title