### PR TITLE
Fix user who retest is not considered a verifier

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2522 Fix user who retest is not considered a verifier
 - #2517 Add sorting to the Supported Services list of RefernceSample Multichoice field
 - #2516 Allow to configure the types to be skipped on content structure export
 - #2514 Added functions for easy update of workflows

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -215,11 +215,9 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         """Returns the user ids of the users that verified this analysis
         """
         verifiers = list()
-        actions = ["verify", "multi_verify"]
-        for event in api.get_review_history(self):
-            if event['action'] in actions:
+        for event in api.get_review_history(self, rev=False):
+            if event.get("review_state") == "verified":
                 verifiers.append(event['actor'])
-        sorted(verifiers, reverse=True)
         return verifiers
 
     @security.public

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -217,8 +217,12 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         verifiers = list()
         actions = ["retest", "verify", "multi_verify"]
         for event in api.get_review_history(self, rev=False):
-            if event['action'] in actions:
-                verifiers.append(event['actor'])
+            if event.get("review_state") == "verified":
+                # include all transitions their end state is 'verified'
+                verifiers.append(event["actor"])
+            elif event.get("action") in actions:
+                # include some transitions their end state is not 'verified'
+                verifiers.append(event["actor"])
         return verifiers
 
     @security.public

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -215,8 +215,9 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         """Returns the user ids of the users that verified this analysis
         """
         verifiers = list()
+        actions = ["retest", "verify", "multi_verify"]
         for event in api.get_review_history(self, rev=False):
-            if event.get("review_state") == "verified":
+            if event['action'] in actions:
                 verifiers.append(event['actor'])
         return verifiers
 

--- a/src/senaite/core/tests/doctests/WorkflowAnalysisRetest.rst
+++ b/src/senaite/core/tests/doctests/WorkflowAnalysisRetest.rst
@@ -108,6 +108,11 @@ created (the "retest") and the original analysis is transitioned to `verified`:
     >>> sorted(map(api.get_workflow_status_of, analyses))
     ['to_be_verified', 'to_be_verified', 'unassigned', 'verified']
 
+And the user who triggered the transition is considered a verifier:
+
+    >>> analysis.getVerificators() == [TEST_USER_ID]
+    True
+
 Since there is one new analysis (the "retest") in `unassigned` status, the
 Analysis Request is transitioned to `sample_received`:
 
@@ -133,6 +138,11 @@ And Result capture date is None:
 
     >>> not retest.getResultCaptureDate()
     True
+
+And has not been verified by anybody:
+
+    >>> retest.getVerificators()
+    []
 
 If I submit a result for the "retest":
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request addresses a bug introduced with https://github.com/senaite/senaite.core/pull/1582 so users that performed a 'retest' transition were not considered verifiers.

The problem was that when retrieving the verifiers from a given analysis, the transition `retest` was not being considered at https://github.com/senaite/senaite.core/blob/1.3.x/bika/lims/content/abstractanalysis.py#L218

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR

User that retests an analysis is not considered a verifier of the analysis

## Desired behavior after PR is merged

User that retests an analysis is considered a verifier of the analysis

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
