### PR TITLE
Fix getting ResultsRange field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2523 Fix getting ResultsRange field exception
 - #2515 Worksheet print templates sorting feature
 - #2475 Add field Lab Account Number on a Supplier
 - #2522 Fix user who retest is not considered a verifier

--- a/src/bika/lims/adapters/dynamicresultsrange.py
+++ b/src/bika/lims/adapters/dynamicresultsrange.py
@@ -48,7 +48,8 @@ class DynamicResultsRange(object):
         self.analysis = analysis
         self.analysisrequest = analysis.getRequest()
         self.specification = None
-        if self.analysisrequest and hasattr(self.analysisrequest, "getSpecification"):
+        has_specification = hasattr(self.analysisrequest, "getSpecification")
+        if self.analysisrequest and has_specification:
             self.specification = self.analysisrequest.getSpecification()
         self.dynamicspec = None
         if self.specification:

--- a/src/bika/lims/adapters/dynamicresultsrange.py
+++ b/src/bika/lims/adapters/dynamicresultsrange.py
@@ -48,7 +48,7 @@ class DynamicResultsRange(object):
         self.analysis = analysis
         self.analysisrequest = analysis.getRequest()
         self.specification = None
-        if self.analysisrequest:
+        if self.analysisrequest and hasattr(self.analysisrequest, "getSpecification"):
             self.specification = self.analysisrequest.getSpecification()
         self.dynamicspec = None
         if self.specification:

--- a/src/bika/lims/adapters/dynamicresultsrange.py
+++ b/src/bika/lims/adapters/dynamicresultsrange.py
@@ -19,7 +19,6 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims import api
-from bika.lims import logger
 from bika.lims.interfaces import IDynamicResultsRange
 from plone.memoize.instance import memoize
 from senaite.core.p3compat import cmp

--- a/src/bika/lims/adapters/dynamicresultsrange.py
+++ b/src/bika/lims/adapters/dynamicresultsrange.py
@@ -54,7 +54,7 @@ class DynamicResultsRange(object):
         spec = None
         try:
             spec = self.analysisrequest.getSpecification()
-        except AttributeError as e:
+        except AttributeError:
             # specification is only possible for AnalysisRequest's
             pass
         return spec

--- a/src/bika/lims/adapters/dynamicresultsrange.py
+++ b/src/bika/lims/adapters/dynamicresultsrange.py
@@ -55,8 +55,9 @@ class DynamicResultsRange(object):
         try:
             spec = self.analysisrequest.getSpecification()
         except AttributeError as e:
-            logger.error("Object '{}' has no attribute 'getSpecification': "
-                         "{}".format(self.analysisrequest, str(e)))
+            ex = str(e)
+            logger.error("Failed to get specification value for '{}': "
+                         "{}".format(self.analysisrequest.getId(), ex))
         return spec
 
     @property

--- a/src/bika/lims/adapters/dynamicresultsrange.py
+++ b/src/bika/lims/adapters/dynamicresultsrange.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims import api
+from bika.lims import logger
 from bika.lims.interfaces import IDynamicResultsRange
 from plone.memoize.instance import memoize
 from senaite.core.p3compat import cmp
@@ -47,13 +48,23 @@ class DynamicResultsRange(object):
     def __init__(self, analysis):
         self.analysis = analysis
         self.analysisrequest = analysis.getRequest()
-        self.specification = None
-        has_specification = hasattr(self.analysisrequest, "getSpecification")
-        if self.analysisrequest and has_specification:
-            self.specification = self.analysisrequest.getSpecification()
-        self.dynamicspec = None
+
+    @property
+    def specification(self):
+        spec = None
+        try:
+            spec = self.analysisrequest.getSpecification()
+        except AttributeError as e:
+            logger.error("Object '{}' has no attribute 'getSpecification': "
+                         "{}".format(self.analysisrequest, str(e)))
+        return spec
+
+    @property
+    def dynamicspec(self):
+        dspec = None
         if self.specification:
-            self.dynamicspec = self.specification.getDynamicAnalysisSpec()
+            dspec = self.specification.getDynamicAnalysisSpec()
+        return dspec
 
     @property
     def keyword(self):

--- a/src/bika/lims/adapters/dynamicresultsrange.py
+++ b/src/bika/lims/adapters/dynamicresultsrange.py
@@ -55,9 +55,8 @@ class DynamicResultsRange(object):
         try:
             spec = self.analysisrequest.getSpecification()
         except AttributeError as e:
-            ex = str(e)
-            logger.error("Failed to get specification value for '{}': "
-                         "{}".format(self.analysisrequest.getId(), ex))
+            # specification is only possible for AnalysisRequest's
+            pass
         return spec
 
     @property

--- a/src/bika/lims/browser/fields/resultrangefield.py
+++ b/src/bika/lims/browser/fields/resultrangefield.py
@@ -114,7 +114,7 @@ class DefaultResultsRangeProvider(object):
     def get_results_range(self, sample):
         results_range = None
         try:
-            results_range = sample.ResultsRange()
+            results_range = sample.ResultsRange
         except AttributeError as e:
             logger.error("Object '{}' has no attribute 'ResultsRange': "
                          "{}".format(sample, str(e)))

--- a/src/bika/lims/browser/fields/resultrangefield.py
+++ b/src/bika/lims/browser/fields/resultrangefield.py
@@ -96,7 +96,7 @@ class DefaultResultsRangeProvider(object):
         # Get the AnalysisRequest to look at
         analysis = self.context
         sample = analysis.getRequest()
-        if not sample:
+        if not sample or not hasattr(sample, "ResultsRange"):
             return {}
 
         # Search by keyword


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

_by @toropok description_

With DataBox report based on Analysis query we noticed that when `DefaultResultsRangeProvider` being called following exception raised immediately:

```shell
ERROR Archetypes None
Traceback (most recent call last):
  File "/home/senaite/buildout-cache/eggs/cp27mu/Products.Archetypes-1.16.6-py2.7.egg/Products/Archetypes/BaseObject.py", line 146, in initializeArchetype
    self.setDefaults()
  File "/home/senaite/buildout-cache/eggs/cp27mu/Products.Archetypes-1.16.6-py2.7.egg/Products/Archetypes/BaseObject.py", line 445, in setDefaults
    self.Schema().setDefaults(self)
  File "/home/senaite/buildout-cache/eggs/cp27mu/Products.Archetypes-1.16.6-py2.7.egg/Products/Archetypes/Schema/__init__.py", line 504, in setDefaults
    default = field.getDefault(instance)
  File "/home/senaite/buildout-cache/eggs/cp27mu/Products.Archetypes-1.16.6-py2.7.egg/Products/Archetypes/Field.py", line 693, in getDefault
    return default_adapter()
  File "/home/senaite/senaitelims/src/senaite.core/src/bika/lims/browser/fields/resultrangefield.py", line 104, in __call__
    field = sample.getField("ResultsRange")
AttributeError: 'RequestContainer' object has no attribute 'getField'
```

Investigation shown that it comes from [resultrangefield.py line 103: field = sample.getField("ResultsRange")](https://github.com/senaite/senaite.core/blob/946bce046dcd083300a397c826eedde85513c861/src/bika/lims/browser/fields/resultrangefield.py#L103)

The DefaultResultsRangeProvider docstring states that it follows backward compatibility solution for PR: #1506

I've added couple `hasattr` checks to exclude exceptions riot in logs. 

## Current behavior before PR

Exception thrown

## Desired behavior after PR is merged

tomb silence in logs 🙂 everything goes nice and easy

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
