### PR TITLE
Fix UnicodeDecodeError during Department DX Migration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2525 Fix UnicodeDecodeError during Department DX Migration
 - #2515 Worksheet print templates sorting feature
 - #2475 Add field Lab Account Number on a Supplier
 - #2522 Fix user who retest is not considered a verifier

--- a/src/senaite/core/content/department.py
+++ b/src/senaite/core/content/department.py
@@ -22,6 +22,7 @@ from AccessControl import ClassSecurityInfo
 from bika.lims import api
 from bika.lims import senaiteMessageFactory as _
 from bika.lims.interfaces import IDeactivable
+from bika.lims.interfaces import IHaveDepartment
 from plone.autoform import directives
 from plone.supermodel import model
 from Products.CMFCore import permissions
@@ -122,7 +123,7 @@ class IDepartmentSchema(model.Schema):
             raise Invalid(_("Department ID must be unique"))
 
 
-@implementer(IDepartment, IDepartmentSchema, IDeactivable)
+@implementer(IDepartment, IDepartmentSchema, IHaveDepartment, IDeactivable)
 class Department(Container):
     """Department
     """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the following traceback when running the Department DX migration step:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.GenericSetup.tool, line 1135, in manage_doUpgrades
  Module Products.GenericSetup.upgrade, line 185, in doStep
  Module senaite.core.upgrade, line 39, in wrap_func_args
  Module senaite.core.upgrade.v02_06_000, line 331, in migrate_departments_to_dx
  Module senaite.core.upgrade.v02_06_000, line 130, in migrate_to_dx
  Module Products.BTreeFolder2.BTreeFolder2, line 469, in _setObject
  Module zope.event, line 33, in notify
  Module zope.component.event, line 27, in dispatch
  Module zope.component._api, line 134, in subscribers
  Module zope.interface.registry, line 448, in subscribers
  Module zope.interface.adapter, line 899, in subscribers
  Module zope.component.event, line 36, in objectEventNotify
  Module zope.component._api, line 134, in subscribers
  Module zope.interface.registry, line 448, in subscribers
  Module zope.interface.adapter, line 899, in subscribers
  Module Products.CMFCore.CMFCatalogAware, line 274, in handleContentishEvent
  Module Products.CMFCore.CMFCatalogAware, line 197, in notifyWorkflowCreated
  Module Products.CMFCore.WorkflowTool, line 300, in notifyCreated
  Module Products.CMFCore.WorkflowTool, line 610, in _reindexWorkflowVariables
  Module Products.CMFCore.CMFCatalogAware, line 110, in reindexObjectSecurity
  Module Products.CMFCore.CatalogTool, line 272, in unrestrictedSearchResults
  Module Products.CMFCore.indexing, line 97, in processQueue
  Module Products.CMFCore.indexing, line 227, in process
  Module senaite.core.catalog.catalog_multiplex_processor, line 100, in reindex
  Module Products.CMFCore.CatalogTool, line 368, in _reindexObject
  Module senaite.core.patches.catalog, line 66, in catalog_object
  Module Products.ZCatalog.ZCatalog, line 508, in catalog_object
  Module Products.ZCatalog.Catalog, line 372, in catalogObject
  Module Products.PluginIndexes.unindex, line 237, in index_object
  Module Products.PluginIndexes.KeywordIndex.KeywordIndex, line 69, in _index_object
  Module Products.PluginIndexes.unindex, line 213, in insertForwardIndexEntry
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 18: ordinal not in range(128)
```

The reason for this was, that the schema field was directly used instead of the custom catalog indexer due to a missing `IHaveDepartment` interface:

https://github.com/senaite/senaite.core/blob/2.x/src/senaite/core/catalog/indexer/senaitesetup.py#L124-L129


## Current behavior before PR

`UnicodeDecodeError` occurs during the migration if a department ID contains a unicode character.

## Desired behavior after PR is merged

The Department DX migration succeeds.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
