### PR TITLE
Highlight edit tabs with errors in red

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2526 Highlight edit tabs with errors in red
 - #2525 Fix UnicodeDecodeError during Department DX Migration
 - #2515 Worksheet print templates sorting feature
 - #2475 Add field Lab Account Number on a Supplier

--- a/src/senaite/core/skins/senaite_templates/edit_macros.pt
+++ b/src/senaite/core/skins/senaite_templates/edit_macros.pt
@@ -97,7 +97,9 @@
         <div tal:replace="structure provider:archetypes.edit.beforefieldsets" />
 
         <metal:block define-slot="widgets">
-          <tal:tabbed tal:condition="allow_tabbing | nothing">
+          <tal:tabbed tal:condition="allow_tabbing | nothing"
+                      tal:define="errors options/state/getErrors;
+                                  error_fieldsets python:[context.getField(field).schemata for field in errors.keys()]">
             <!-- Bootstrapped schema tabs -->
             <ul class="nav nav-tabs" role="tablist">
               <tal:fieldsets repeat="fieldset fieldsets">
@@ -106,11 +108,13 @@
                      data-toggle="tab"
                      class="nav-link"
                      role="tab"
-                     tal:define="id python:view.normalizeString(fieldset)"
+                     tal:define="id python:view.normalizeString(fieldset);
+                                 css_class python:repeat['fieldset'].start and 'nav-link active' or 'nav-link';
+                                 error_css_class python:'text-danger' if  fieldset in error_fieldsets else ''"
                      tal:content="python:view.getTranslatedSchemaLabel(fieldset)"
                      tal:attributes="id string:${id}-tab;
                                      href string:#${id};
-                                     class python:repeat['fieldset'].start and 'nav-link active' or 'nav-link'"
+                                     class string:${css_class} ${error_css_class}"
                      i18n:translate="">
                   </a>
                 </li>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR highlights schemata tabs of AT content types that have errors.

<img width="1168" alt="schema tabs with errors" src="https://github.com/senaite/senaite.core/assets/713193/c164a30a-9cb6-4273-91e2-c95e7b26aeee">


## Current behavior before PR

Tabs are not highlighted if they have erroneous fields

## Desired behavior after PR is merged

Tabs are highlighted in red if they have erroneous fields

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
