### PR TITLE
Fix clients groups are displayed on labcontact's user creation form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2527 Fix clients groups are displayed on labcontact's user creation form
 - #2525 Fix UnicodeDecodeError during Department DX Migration
 - #2515 Worksheet print templates sorting feature
 - #2475 Add field Lab Account Number on a Supplier

--- a/src/bika/lims/browser/contact.py
+++ b/src/bika/lims/browser/contact.py
@@ -36,6 +36,7 @@ from Products.CMFPlone.controlpanel.browser.usergroups_usersoverview import \
     UsersOverviewControlPanel
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from senaite.core.catalog import CLIENT_CATALOG
 from senaite.core.config.groups import HIDDEN_GROUPS
 from senaite.core.p3compat import cmp
 
@@ -82,12 +83,10 @@ class ContactLoginDetailsView(BrowserView):
     def get_clients_groups(self):
         """Returns the client-specific groups
         """
-        groups = []
-        uc = api.get_tool("uid_catalog")
-        for brain in uc(portal_type="Client"):
-            client = api.get_object(brain)
-            groups.append(client.group_id)
-        return groups
+        cat = api.get_tool(CLIENT_CATALOG)
+        brains = cat(portal_type="Client")
+        groups = map(lambda brain: brain.group_id, brains)
+        return filter(None, groups)
 
     def get_laboratory_groups(self):
         """Return the groups available for laboratory users

--- a/src/bika/lims/browser/contact.py
+++ b/src/bika/lims/browser/contact.py
@@ -83,10 +83,12 @@ class ContactLoginDetailsView(BrowserView):
     def get_clients_groups(self):
         """Returns the client-specific groups
         """
+        groups = []
         cat = api.get_tool(CLIENT_CATALOG)
-        brains = cat(portal_type="Client")
-        groups = map(lambda brain: brain.getGroupId, brains)
-        return filter(None, groups)
+        for brain in cat(portal_type="Client"):
+            if brain.getGroupId:
+                groups.append(brain.getGroupId)
+        return groups
 
     def get_laboratory_groups(self):
         """Return the groups available for laboratory users

--- a/src/bika/lims/browser/contact.py
+++ b/src/bika/lims/browser/contact.py
@@ -95,13 +95,9 @@ class ContactLoginDetailsView(BrowserView):
         gtool = api.get_tool("portal_groups")
         groups = gtool.listGroupIds()
 
-        # exclude hidden groups (Administrators, etc.)
-        groups = filter(lambda group: group not in HIDDEN_GROUPS, groups)
-
-        # exclude client-specific groups
-        c_groups = self.get_clients_groups()
-        c_groups = dict.fromkeys(c_groups, True)
-        groups = filter(lambda group: not c_groups.get(group, False), groups)
+        # exclude hidden (Administrators, etc.) and client-specific groups
+        to_skip = HIDDEN_GROUPS + self.get_clients_groups()
+        groups = filter(lambda group: group not in to_skip, groups)
 
         # sort them
         return sorted(groups)

--- a/src/bika/lims/browser/contact.py
+++ b/src/bika/lims/browser/contact.py
@@ -85,7 +85,7 @@ class ContactLoginDetailsView(BrowserView):
         """
         cat = api.get_tool(CLIENT_CATALOG)
         brains = cat(portal_type="Client")
-        groups = map(lambda brain: brain.group_id, brains)
+        groups = map(lambda brain: brain.getGroupId, brains)
         return filter(None, groups)
 
     def get_laboratory_groups(self):

--- a/src/bika/lims/browser/contact.py
+++ b/src/bika/lims/browser/contact.py
@@ -78,6 +78,17 @@ class ContactLoginDetailsView(BrowserView):
         users_view = UsersOverviewControlPanel(self.context, self.request)
         return users_view.doSearch("")
 
+    @view.memoize
+    def get_clients_groups(self):
+        """Returns the client-specific groups
+        """
+        groups = []
+        uc = api.get_tool("uid_catalog")
+        for brain in uc(portal_type="Client"):
+            client = api.get_object(brain)
+            groups.append(client.group_id)
+        return groups
+
     def get_laboratory_groups(self):
         """Return the groups available for laboratory users
         """
@@ -86,6 +97,11 @@ class ContactLoginDetailsView(BrowserView):
 
         # exclude hidden groups (Administrators, etc.)
         groups = filter(lambda group: group not in HIDDEN_GROUPS, groups)
+
+        # exclude client-specific groups
+        c_groups = self.get_clients_groups()
+        c_groups = dict.fromkeys(c_groups, True)
+        groups = filter(lambda group: not c_groups.get(group, False), groups)
 
         # sort them
         return sorted(groups)

--- a/src/bika/lims/content/client.py
+++ b/src/bika/lims/content/client.py
@@ -315,6 +315,12 @@ class Client(Organisation):
         return api.user.del_group(group, user)
 
     @security.public
+    def getGroupId(self):
+        """Returns the id of the Plone's client-speficic group for this client
+        """
+        return self.group_id
+
+    @security.public
     def getContactFromUsername(self, username):
         for contact in self.objectValues("Contact"):
             if contact.getUsername() == username:

--- a/src/senaite/core/catalog/client_catalog.py
+++ b/src/senaite/core/catalog/client_catalog.py
@@ -42,6 +42,7 @@ COLUMNS = BASE_COLUMNS + [
     "getClientID",
     "getName",
     "getEmailAddress",  # used in reference widget columns
+    "group_id",
 ]
 
 TYPES = [

--- a/src/senaite/core/catalog/client_catalog.py
+++ b/src/senaite/core/catalog/client_catalog.py
@@ -42,7 +42,7 @@ COLUMNS = BASE_COLUMNS + [
     "getClientID",
     "getName",
     "getEmailAddress",  # used in reference widget columns
-    "group_id",
+    "getGroupId",
 ]
 
 TYPES = [

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2615</version>
+  <version>2616</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -28,6 +28,7 @@ from Products.Archetypes.utils import getRelURL
 from senaite.core import logger
 from senaite.core.api.catalog import reindex_index
 from senaite.core.catalog import ANALYSIS_CATALOG
+from senaite.core.catalog import CLIENT_CATALOG
 from senaite.core.catalog import SETUP_CATALOG
 from senaite.core.config import PROJECTNAME as product
 from senaite.core.interfaces import IContentMigrator
@@ -703,3 +704,16 @@ def import_registry(tool):
     portal = tool.aq_inner.aq_parent
     setup = portal.portal_setup
     setup.runImportStepFromProfile(profile, "plone.app.registry")
+
+
+def setup_client_catalog(tool):
+    """Setup client catalog
+    """
+    logger.info("Setup Client Catalog ...")
+    portal = api.get_portal()
+
+    setup_core_catalogs(portal)
+    client_catalog = api.get_tool(CLIENT_CATALOG)
+    client_catalog.clearFindAndRebuild()
+
+    logger.info("Setup Client Catalog [DONE]")

--- a/src/senaite/core/upgrade/v02_06_000.zcml
+++ b/src/senaite/core/upgrade/v02_06_000.zcml
@@ -4,8 +4,8 @@
     i18n_domain="senaite.core">
 
   <genericsetup:upgradeStep
-      title="SENAITE.CORE 2.6.0: Add group_id metadata in client_catalog"
-      description="Add group_id metadata column in client_catalog"
+      title="SENAITE.CORE 2.6.0: Add getGroupId metadata in client_catalog"
+      description="Add getGroupId metadata column in client_catalog"
       source="2615"
       destination="2616"
       handler=".v02_06_000.setup_client_catalog"

--- a/src/senaite/core/upgrade/v02_06_000.zcml
+++ b/src/senaite/core/upgrade/v02_06_000.zcml
@@ -4,6 +4,14 @@
     i18n_domain="senaite.core">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.6.0: Add group_id metadata in client_catalog"
+      description="Add group_id metadata column in client_catalog"
+      source="2615"
+      destination="2616"
+      handler=".v02_06_000.setup_client_catalog"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.6.0: Update registry settings"
       description="Import worksheet printing templates registry"
       source="2614"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that the list of client-specific groups are not displayed for selection in the user edit form associated to a laboratory contact

## Current behavior before PR

All user groups are displayed in labcontact's user form

## Desired behavior after PR is merged

Client-specific groups are not displayed in labcontact's user form

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
