### PR TITLE
Fix relative paths of section icons in sample view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2528 Fix relative paths of section icons in sample view
 - #2525 Fix UnicodeDecodeError during Department DX Migration
 - #2515 Worksheet print templates sorting feature
 - #2475 Add field Lab Account Number on a Supplier

--- a/src/senaite/core/browser/viewlets/templates/remarks.pt
+++ b/src/senaite/core/browser/viewlets/templates/remarks.pt
@@ -4,9 +4,11 @@
 
   <!-- title and icon -->
   <h3 tal:define="icon view/icon_name|nothing;
-                  title view/title|nothing"
+                  title view/title|nothing;
+                  portal context/@@plone_portal_state/portal"
       tal:condition="title">
-    <img tal:condition="icon|nothing" tal:attributes="src string:senaite_theme/icon/${icon}"/>
+    <img tal:condition="icon|nothing"
+         tal:attributes="src string:${portal/absolute_url}/senaite_theme/icon/${icon}"/>
     <span i18n:translate="" tal:content="title"/>
   </h3>
 

--- a/src/senaite/core/browser/viewlets/templates/resultsinterpretation.pt
+++ b/src/senaite/core/browser/viewlets/templates/resultsinterpretation.pt
@@ -5,9 +5,10 @@
 
   <!-- title and icon -->
   <h3 tal:define="icon view/icon_name|nothing;
-                  title view/title|nothing"
+                  title view/title|nothing;
+                  portal context/@@plone_portal_state/portal"
       tal:condition="title">
-    <img tal:condition="icon|nothing" tal:attributes="src string:senaite_theme/icon/${icon}"/>
+    <img tal:condition="icon|nothing" tal:attributes="src string:${portal/absolute_url}/senaite_theme/icon/${icon}"/>
     <span i18n:translate="" tal:content="title"/>
   </h3>
 

--- a/src/senaite/core/browser/viewlets/templates/sampleanalyses.pt
+++ b/src/senaite/core/browser/viewlets/templates/sampleanalyses.pt
@@ -1,7 +1,8 @@
 <div class="analysis-listing-table"
      tal:condition="python:view.available()"
      tal:define="id string:table-${view/capture|other}-analyses;
-                 collapsed python:view.is_collapsed()"
+                 collapsed python:view.is_collapsed();
+                 portal context/@@plone_portal_state/portal"
      i18n:domain="senaite.core">
   <div class="row mb-4">
     <div class="col-sm-12">
@@ -11,7 +12,8 @@
                       title view/title|nothing"
           class="d-inline-block"
           tal:condition="title">
-        <img tal:condition="icon|nothing" tal:attributes="src string:senaite_theme/icon/${icon}"/>
+        <img tal:condition="icon|nothing"
+             tal:attributes="src string:${portal/absolute_url}/senaite_theme/icon/${icon}"/>
         <span class="align-middle" i18n:translate="" tal:content="title"/>
       </h3>
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the icons from the sections inside sample to not be relative to the sample's client context, and therefore are cached by webservers like nginx only once, regardless of client.

## Current behavior before PR

Urls of icons from sample sections are relative to client context

## Desired behavior after PR is merged

Urls of icons from sample sections are not relative

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
