### PR TITLE
Fix no selected services when adding a reference sample in a Worksheet

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2530 Fix ReferenceSample Listing Table Multi choice field
 - #2521 Migrate Sample Templates to Dexterity
 - #2524 Allow to edit the result capture date
 - #2527 Fix clients groups are displayed on labcontact's user creation form

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
-- #2530 Fix ReferenceSample Listing Table Multi choice field
+- #2530 Fix no selected services when adding a reference sample in a Worksheet
 - #2521 Migrate Sample Templates to Dexterity
 - #2524 Allow to edit the result capture date
 - #2527 Fix clients groups are displayed on labcontact's user creation form

--- a/src/bika/lims/browser/worksheet/views/referencesamples.py
+++ b/src/bika/lims/browser/worksheet/views/referencesamples.py
@@ -248,16 +248,16 @@ class ReferenceSamplesView(BikaListingView):
         item["allow_edit"] = self.get_editable_columns()
 
         # Supported Services
-        supported_services_choices = self.make_supported_services_choices(obj)
-        item["choices"]["SupportedServices"] = supported_services_choices
-        selected = []
-        for choice in supported_services_choices:
-            if choice.get("selected", False):
-                selected.append(choice)
-        item["SupportedServices"] = selected
+        supported_services = self.make_supported_services_choices(obj)
+        item["choices"]["SupportedServices"] = supported_services
+        item["SupportedServices"] = self.get_selected_items(supported_services)
 
         # Position
         item["Position"] = "new"
         item["choices"]["Position"] = self.make_position_choices()
 
         return item
+
+    def get_selected_items(self, supported_services_choices):
+        return [item.get("ResultValue") for item in supported_services_choices
+                if item.get("selected", False)]

--- a/src/bika/lims/browser/worksheet/views/referencesamples.py
+++ b/src/bika/lims/browser/worksheet/views/referencesamples.py
@@ -250,6 +250,11 @@ class ReferenceSamplesView(BikaListingView):
         # Supported Services
         supported_services_choices = self.make_supported_services_choices(obj)
         item["choices"]["SupportedServices"] = supported_services_choices
+        selected = []
+        for choice in supported_services_choices:
+            if choice.get("selected", False):
+                selected.append(choice)
+        item["SupportedServices"] = selected
 
         # Position
         item["Position"] = "new"

--- a/src/bika/lims/browser/worksheet/views/referencesamples.py
+++ b/src/bika/lims/browser/worksheet/views/referencesamples.py
@@ -250,7 +250,7 @@ class ReferenceSamplesView(BikaListingView):
         # Supported Services
         supported_services = self.make_supported_services_choices(obj)
         item["choices"]["SupportedServices"] = supported_services
-        item["SupportedServices"] = self.get_selected_items(supported_services)
+        item["SupportedServices"] = self.get_selected_values(supported_services)
 
         # Position
         item["Position"] = "new"
@@ -258,6 +258,6 @@ class ReferenceSamplesView(BikaListingView):
 
         return item
 
-    def get_selected_items(self, supported_services_choices):
-        return [item.get("ResultValue") for item in supported_services_choices
+    def get_selected_items(self, choices):
+        return [item.get("ResultValue") for item in choices
                 if item.get("selected", False)]

--- a/src/bika/lims/browser/worksheet/views/referencesamples.py
+++ b/src/bika/lims/browser/worksheet/views/referencesamples.py
@@ -248,9 +248,10 @@ class ReferenceSamplesView(BikaListingView):
         item["allow_edit"] = self.get_editable_columns()
 
         # Supported Services
-        supported_services = self.make_supported_services_choices(obj)
-        item["choices"]["SupportedServices"] = supported_services
-        item["SupportedServices"] = self.get_selected_values(supported_services)
+        supported_services_choices = self.make_supported_services_choices(obj)
+        item["choices"]["SupportedServices"] = supported_services_choices
+        item["SupportedServices"] = \
+            self.get_selected_values(supported_services_choices)
 
         # Position
         item["Position"] = "new"

--- a/src/bika/lims/browser/worksheet/views/referencesamples.py
+++ b/src/bika/lims/browser/worksheet/views/referencesamples.py
@@ -258,6 +258,6 @@ class ReferenceSamplesView(BikaListingView):
 
         return item
 
-    def get_selected_items(self, choices):
+    def get_selected_values(self, choices):
         return [item.get("ResultValue") for item in choices
                 if item.get("selected", False)]


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

References samples app.listing multi choice field doesn’t display checkboxes properly.

When user adds Reference sample to the worksheet using AddControlView or AddBlankView - the system offers the choice of particular ReferenceSamples.

But checkboxes of Multichoice field aren’t selected, the object which comes to the browser contains information that the AnalysesService should be in selected state via selected field for each item.

see: https://github.com/senaite/senaite.app.listing/pull/142

## Current behavior before PR

not selected

## Desired behavior after PR is merged

selected

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
