### PR TITLE
Fix sample points are not filtered by type on sample creation or edition

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2531 Fix sample points are not filtered by type on sample creation or edition
 - #2521 Migrate Sample Templates to Dexterity
 - #2524 Allow to edit the result capture date
 - #2527 Fix clients groups are displayed on labcontact's user creation form

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1018,7 +1018,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             # Display Sample Points that have this sample type assigned plus
             # those that do not have a sample type assigned
             "SamplePoint": {
-                "sampletype_uid": [sample_type_uid, None],
+                "sampletype_uid": [sample_type_uid, ""],
                 "getClientUID": [client_uid, ""],
             },
             # Display Analysis Profiles that have this sample type assigned

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -761,11 +761,7 @@ schema = BikaSchema.copy() + Schema((
                 "secondary": "disabled",
             },
             catalog_name=SETUP_CATALOG,
-            query={
-                "is_active": True,
-                "sort_on": "sortable_title",
-                "sort_order": "ascending"
-            },
+            query="get_sample_points_query",
         )
     ),
 
@@ -2620,6 +2616,21 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
             "sampletype_uid": [sample_type_uid, ""],
             "is_active": True,
             "sort_on": "title",
+            "sort_order": "ascending",
+        }
+        return query
+
+    def get_sample_points_query(self):
+        """Returns the query for the Sample Point field, so only active sample
+        points without any sample type set and those that support the sample's
+        sample type are returned
+        """
+        sample_type_uid = self.getRawSampleType()
+        query = {
+            "portal_type": "SamplePoint",
+            "sampletype_uid": [sample_type_uid, ""],
+            "is_active": True,
+            "sort_on": "sortable_title",
             "sort_order": "ascending",
         }
         return query

--- a/src/bika/lims/content/samplepoint.py
+++ b/src/bika/lims/content/samplepoint.py
@@ -98,8 +98,13 @@ schema = BikaSchema.copy() + Schema((
             description=_(
                 "description_samplepoint_sampletypes",
                 default="The list of sample types that can be collected "
-                "at this sample point.  If no sample types are "
-                "selected, then all sample types are available."),
+                        "at this sample point. The field for the selection of "
+                        "a sample point in sample creation and edit forms "
+                        "will be filtered in accordance. Still, sample points "
+                        "that do not have any sample type assigned will "
+                        "always be available for selection, regardless of the "
+                        "type."
+            ),
             catalog=SETUP_CATALOG,
             query={
                 "is_active": True,

--- a/src/senaite/core/catalog/indexer/configure.zcml
+++ b/src/senaite/core/catalog/indexer/configure.zcml
@@ -74,4 +74,7 @@
   <!-- SampleTemplate Indexer -->
   <adapter name="sampletype_uid" factory=".sampletemplate.sampletype_uid"/>
 
+  <!-- SamplePoint Indexer -->
+  <adapter name="sampletype_uid" factory=".samplepoint.sampletype_uid"/>
+
 </configure>

--- a/src/senaite/core/catalog/indexer/samplepoint.py
+++ b/src/senaite/core/catalog/indexer/samplepoint.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2024 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from plone.indexer import indexer
+from bika.lims.interfaces import ISamplePoint
+from senaite.core.interfaces import ISetupCatalog
+
+
+@indexer(ISamplePoint, ISetupCatalog)
+def sampletype_uid(instance):
+    """Returns a list of uids from SampleType the instance is assigned to
+    If the instance has no SampleType assigned, it returns a tuple with an
+    empty value. This allows searches for `MissingValue` entries too.
+    """
+    return instance.getRawSampleTypes() or [""]

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2617</version>
+  <version>2618</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/v02_06_000.zcml
+++ b/src/senaite/core/upgrade/v02_06_000.zcml
@@ -4,6 +4,14 @@
     i18n_domain="senaite.core">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.6.0: Fix sample points not filtered by sample type"
+      description="Sample points are not filtered by sample type in add sample"
+      source="2617"
+      destination="2618"
+      handler=".v02_06_000.reindex_sampletype_uid"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.6.0: Migrate Sample Templates to DX"
       description="Migrate Sample Templates to Dexterity"
       source="2616"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the SamplePoint field is filtered by SampleType in sample add form and sample edit view. Sample points without sample type assigned are always available for selection.

## Current behavior before PR

Sample Points are not filtered by Sample type

## Desired behavior after PR is merged

Sample Points are filtered by Sample type

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
