### PR TITLE
Fix disappear of the hidden mark for retested analyses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2532 Fix hidden mark disapper analyses created for retest
 - #2530 Fix no selected services when adding a reference sample in a Worksheet
 - #2521 Migrate Sample Templates to Dexterity
 - #2524 Allow to edit the result capture date

--- a/src/bika/lims/utils/analysis.py
+++ b/src/bika/lims/utils/analysis.py
@@ -65,7 +65,6 @@ def create_analysis(context, source, **kwargs):
 
     # do not copy these fields from source
     skip_fields = [
-        "Hidden",
         "Attachment",
         "Result",
         "ResultCaptureDate",
@@ -364,11 +363,6 @@ def create_retest(analysis, **kwargs):
     })
     retest = create_analysis(parent, analysis, **kwargs)
 
-    # Add Hidden mark if it was enabled on the source analysis
-    hidden = analysis.getHidden()
-    if hidden:
-        retest.setHidden(True)
-        
     # Add the retest to the same worksheet, if any
     worksheet = analysis.getWorksheet()
     if worksheet:

--- a/src/bika/lims/utils/analysis.py
+++ b/src/bika/lims/utils/analysis.py
@@ -364,6 +364,11 @@ def create_retest(analysis, **kwargs):
     })
     retest = create_analysis(parent, analysis, **kwargs)
 
+    # Add Hidden mark if it was enabled on the source analysis
+    hidden = analysis.getHidden()
+    if hidden:
+        retest.setHidden(True)
+        
     # Add the retest to the same worksheet, if any
     worksheet = analysis.getWorksheet()
     if worksheet:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

If one marked analysis as hidden or it was initially hidden by AnalysisService settings and service being retested - the hidden mark goes away from retest analysis. 

## Current behavior before PR

hidden mark goes away. #2529 

## Desired behavior after PR is merged

hidden mark sticks to retest item

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
