### PR TITLE
Fix client-specific sample templates are displayed under setup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2534 Fix client-specific sample templates are displayed under setup
 - #2532 Fix hidden mark is not kept in retests
 - #2531 Fix sample points are not filtered by type on sample creation or edition
 - #2530 Fix no selected services when adding a reference sample in a Worksheet

--- a/src/senaite/core/browser/clients/client/sampletemplates/view.py
+++ b/src/senaite/core/browser/clients/client/sampletemplates/view.py
@@ -18,7 +18,6 @@
 # Copyright 2018-2024 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from bika.lims import api
 from senaite.core.browser.controlpanel.sampletemplates.view import \
     SampleTemplatesView
 
@@ -26,11 +25,3 @@ from senaite.core.browser.controlpanel.sampletemplates.view import \
 class ClientSampleTemplatesView(SampleTemplatesView):
     """Client based sample templates view
     """
-    def __init__(self, context, request):
-        super(ClientSampleTemplatesView, self).__init__(context, request)
-
-        # restrict the search to the current folder only
-        self.contentFilter["path"] = {
-            "query": api.get_path(context),
-            "level": 0,
-        }

--- a/src/senaite/core/browser/controlpanel/sampletemplates/view.py
+++ b/src/senaite/core/browser/controlpanel/sampletemplates/view.py
@@ -41,6 +41,11 @@ class SampleTemplatesView(ListingView):
             "portal_type": "SampleTemplate",
             "sort_on": "sortable_title",
             "sort_order": "ascending",
+            # restrict the search to the current folder only
+            "path": {
+                "query": api.get_path(context),
+                "level": 0,
+            }
         }
 
         self.context_actions = {


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR ensures that only sample templates that are not client-specific are displayed under setup

## Current behavior before PR

Client-specific sample templates are displayed under setup

## Desired behavior after PR is merged

Client-specific sample templates are not displayed under setup

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
