### PR TITLE
Support multi-line text on result entry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2537 Support multi-line text on result entry
 - #2536 Fix counts from control-panel includes client-specific items
 - #2535 Fix client-specific analysis profiles are displayed under setup
 - #2534 Fix client-specific sample templates are displayed under setup

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -998,8 +998,7 @@ class AnalysesView(ListingView):
 
             choices = self.get_result_options(obj)
             if choices:
-                choices_type = obj.getResultType()
-                if choices_type == "select":
+                if result_type == "select":
                     # By default set empty as the default selected choice
                     choices.insert(0, dict(ResultValue="", ResultText=""))
                 item["choices"]["Result"] = choices

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -993,6 +993,9 @@ class AnalysesView(ListingView):
                 item["Result"] = "{} {}".format(operand, result).strip()
 
             # Prepare result options
+            result_type = obj.getResultType()
+            item["result_type"] = result_type
+
             choices = self.get_result_options(obj)
             if choices:
                 choices_type = obj.getResultOptionsType()
@@ -1000,13 +1003,8 @@ class AnalysesView(ListingView):
                     # By default set empty as the default selected choice
                     choices.insert(0, dict(ResultValue="", ResultText=""))
                 item["choices"]["Result"] = choices
-                item["result_type"] = choices_type
 
-            elif obj.getStringResult():
-                item["result_type"] = "string"
-
-            else:
-                item["result_type"] = "numeric"
+            if result_type == "numeric":
                 item["help"]["Result"] = _(
                     "Enter the result either in decimal or scientific "
                     "notation, e.g. 0.00005 or 1e-5, 10000 or 1e5")

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -998,7 +998,7 @@ class AnalysesView(ListingView):
 
             choices = self.get_result_options(obj)
             if choices:
-                choices_type = obj.getResultOptionsType()
+                choices_type = obj.getResultType()
                 if choices_type == "select":
                     # By default set empty as the default selected choice
                     choices.insert(0, dict(ResultValue="", ResultText=""))

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -464,7 +464,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         :param value: is expected to be a string.
         """
         # Convert to list ff the analysis has result options set with multi
-        if self.getResultOptions() and "multi" in self.getResultOptionsType():
+        if self.getResultOptions() and "multi" in self.getResultType():
             if not isinstance(value, (list, tuple)):
                 value = filter(None, [value])
 

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -70,9 +70,7 @@ Attachment = UIDReferenceField(
     relationship='AnalysisAttachment'
 )
 
-# The final result of the analysis is stored here.  The field contains a
-# String value, but the result itself is required to be numeric.  If
-# a non-numeric result is needed, ResultOptions can be used.
+# The final result of the analysis is stored here
 Result = StringField(
     'Result',
     read_permission=ViewResults,

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -636,8 +636,7 @@ ResultOptions = RecordsField(
 # TODO Remove ResultOptionsType field. It was Replaced by ResultType
 ResultOptionsType = StringField(
     "ResultOptionsType",
-    schemata="Result Options",
-    default="select",
+    readonly=True,
     widget=StringWidget(
         visible=False,
     )
@@ -676,8 +675,7 @@ ResultOptionsSorting = StringField(
 # TODO Remove StringResult field. It was Replaced by ResultType
 StringResult = BooleanField(
     "StringResult",
-    schemata="Analysis",
-    default=False,
+    readonly=True,
     widget=BooleanWidget(
         visible=False,
     )

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -1081,6 +1081,8 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
 
     # TODO Remove. ResultOptionsType field was replaced by ResulType field
     def getResultOptionsType(self):
+        if self.getStringResult():
+            return "select"
         return self.getResultType()
 
     # TODO Remove. ResultOptionsType field was replaced by ResulType field
@@ -1090,8 +1092,10 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
     # TODO Remove. StringResults field was replaced by ResulType field
     def getStringResult(self):
         result_type = self.getResultType()
-        return result_type == "string"
+        return result_type in ["string", "text"]
 
     # TODO Remove. StringResults field was replaced by ResulType field
     def setStringResult(self, value):
-        self.setResultType("string")
+        if bool(value):
+            self.setResultType("string")
+        self.setResultType("numeric")

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -20,7 +20,6 @@
 
 from AccessControl import ClassSecurityInfo
 from bika.lims import bikaMessageFactory as _
-from bika.lims import deprecated
 from bika.lims.browser.fields import DurationField
 from bika.lims.browser.fields import UIDReferenceField
 from bika.lims.browser.widgets.durationwidget import DurationWidget
@@ -634,19 +633,12 @@ ResultOptions = RecordsField(
     )
 )
 
-# XXX: HIDDEN -> TO BE REMOVED
-# Replaced by ResultType
+# TODO Remove ResultOptionsType field. It was Replaced by ResultType
 ResultOptionsType = StringField(
     "ResultOptionsType",
     schemata="Result Options",
-    vocabulary=DisplayList(RESULT_TYPES),
-    widget=SelectionWidget(
-        label=_("Control type"),
-        description=_(
-            "Type of control to be displayed on result entry when predefined "
-            "results are set"
-        ),
-        format="select",
+    default="select",
+    widget=StringWidget(
         visible=False,
     )
 )
@@ -681,18 +673,13 @@ ResultOptionsSorting = StringField(
 )
 
 # Allow/disallow the capture of text as the result of the analysis
-# XXX: HIDDEN -> TO BE REMOVED
-# Replaced by ResultType
+# TODO Remove StringResult field. It was Replaced by ResultType
 StringResult = BooleanField(
     "StringResult",
     schemata="Analysis",
     default=False,
     widget=BooleanWidget(
         visible=False,
-        label=_("String result"),
-        description=_(
-            "Enable this option to allow the capture of text as result"
-        )
     )
 )
 
@@ -1094,19 +1081,19 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
         tat = self.Schema().getField("MaxTimeAllowed").get(self)
         return tat or self.bika_setup.getDefaultTurnaroundTime()
 
-    @deprecated("Use self.getResultType() instead")
+    # TODO Remove. ResultOptionsType field was replaced by ResulType field
     def getResultOptionsType(self):
         return self.getResultType()
 
-    @deprecated("Use self.getResultType() instead")
+    # TODO Remove. ResultOptionsType field was replaced by ResulType field
     def setResultOptionsType(self, value):
-        self.setResultOptionsType(self, value)
+        self.setResultType(value)
 
-    @deprecated("Use self.getResultType() == 'string' instead")
+    # TODO Remove. StringResults field was replaced by ResulType field
     def getStringResult(self):
         result_type = self.getResultType()
         return result_type == "string"
 
-    @deprecated("Use self.setResultType('string') instead")
+    # TODO Remove. StringResults field was replaced by ResulType field
     def setStringResult(self, value):
         self.setResultType("string")

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -1096,6 +1096,5 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
 
     # TODO Remove. StringResults field was replaced by ResulType field
     def setStringResult(self, value):
-        if bool(value):
-            self.setResultType("string")
-        self.setResultType("numeric")
+        result_type = "string" if bool(value) else "numeric"
+        self.setResultType(result_type)

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -639,7 +639,6 @@ ResultOptions = RecordsField(
 ResultOptionsType = StringField(
     "ResultOptionsType",
     schemata="Result Options",
-    default="select",
     vocabulary=DisplayList(RESULT_TYPES),
     widget=SelectionWidget(
         label=_("Control type"),

--- a/src/bika/lims/content/analysisservice.py
+++ b/src/bika/lims/content/analysisservice.py
@@ -190,7 +190,7 @@ PartitionSetup = PartitionSetupField(
 # Allow/disallow the capture of text as the result of the analysis
 DefaultResult = StringField(
     "DefaultResult",
-    schemata="Analysis",
+    schemata="Result Options",
     validators=('service_defaultresult_validator',),
     widget=StringWidget(
         label=_("Default result"),
@@ -292,8 +292,8 @@ schema = schema.copy() + Schema((
 schema.moveField("Method", after="Methods")
 # Move default instrument field after available instruments field
 schema.moveField("Instrument", after="Instruments")
-# Move default result field after String result
-schema.moveField("DefaultResult", after="StringResult")
+# Move default result field after Result Type
+schema.moveField("DefaultResult", after="ResultType")
 
 
 class AnalysisService(AbstractBaseAnalysis):

--- a/src/bika/lims/content/analysisservice.py
+++ b/src/bika/lims/content/analysisservice.py
@@ -292,8 +292,8 @@ schema = schema.copy() + Schema((
 schema.moveField("Method", after="Methods")
 # Move default instrument field after available instruments field
 schema.moveField("Instrument", after="Instruments")
-# Move default result field after Result Type
-schema.moveField("DefaultResult", after="ResultType")
+# Move default result field after Result Options
+schema.moveField("DefaultResult", after="ResultOptions")
 
 
 class AnalysisService(AbstractBaseAnalysis):

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -1355,27 +1355,27 @@ class DefaultResultValidator(object):
     name = "service_defaultresult_validator"
 
     def __call__(self, value, **kwargs):
-        instance = kwargs['instance']
         request = kwargs.get('REQUEST', {})
         field_name = kwargs['field'].getName()
-        translate = getToolByName(instance, 'translation_service').translate
 
         default_result = request.get(field_name, None)
-        if default_result:
-            # Default result must be one of the available result options
-            options = request.get("ResultOptions", None)
-            if options:
-                values = map(lambda ro: ro.get("ResultValue"), options)
-                if default_result not in values:
-                    msg = _("Default result must be one of the following "
-                            "result options: {}").format(", ".join(values))
-                    return to_utf8(translate(msg))
+        if not default_result:
+            return True
 
-            elif not request.get("StringResult"):
-                # Default result must be numeric
-                if not api.is_floatable(default_result):
-                    msg = _("Default result is not numeric")
-                    return to_utf8(translate(msg))
+        result_type = request.get("ResultType")
+        if result_type in ["string", "text"]:
+            return True
+
+        elif result_type == "numeric":
+            if not api.is_floatable(default_result):
+                return _t(_("Default result is not numeric"))
+
+        else:
+            options = request.get("ResultOptions", [])
+            values = map(lambda ro: ro.get("ResultValue"), options)
+            if default_result not in values:
+                return _t(_("Default result must be one of the following "
+                            "result options: {}").format(", ".join(values)))
 
         return True
 

--- a/src/senaite/core/browser/form/adapters/analysisservice.py
+++ b/src/senaite/core/browser/form/adapters/analysisservice.py
@@ -50,6 +50,9 @@ class EditForm(EditFormAdapterBase):
                 self.add_readonly_field(
                     "Keyword", _("Keyword is used in active analyses "
                                  "and can not be changed anymore"))
+        # Show/hide predefined options
+        result_type = form.get("ResultType")
+        self.toggle_result_type(result_type)
 
         return self.data
 
@@ -114,6 +117,10 @@ class EditForm(EditFormAdapterBase):
                 title=api.get_title(o), value=api.get_uid(o)), instruments)
             self.add_update_field("Instrument", {
                 "options": empty + i_opts})
+
+        # Show/hide predefined options
+        elif name == "ResultType":
+            self.toggle_result_type(value)
 
         return self.data
 
@@ -185,3 +192,18 @@ class EditForm(EditFormAdapterBase):
         if isinstance(check, string_types):
             return _(check)
         return None
+
+    def toggle_result_type(self, result_type):
+        """Hides/Show result options depending on the resulty type
+        """
+        if result_type and api.is_list(result_type):
+            return self.toggle_result_type(result_type[0])
+
+        if result_type in ["numeric", "string", "text"]:
+            self.add_hide_field("ResultOptions")
+            self.add_hide_field("ResultOptionsSorting")
+            self.add_show_field("DefaultResult")
+        else:
+            self.add_show_field("ResultOptions")
+            self.add_show_field("ResultOptionsSorting")
+            self.add_hide_field("DefaultResult")

--- a/src/senaite/core/browser/form/adapters/analysisservice.py
+++ b/src/senaite/core/browser/form/adapters/analysisservice.py
@@ -202,8 +202,6 @@ class EditForm(EditFormAdapterBase):
         if result_type in ["numeric", "string", "text"]:
             self.add_hide_field("ResultOptions")
             self.add_hide_field("ResultOptionsSorting")
-            self.add_show_field("DefaultResult")
         else:
             self.add_show_field("ResultOptions")
             self.add_show_field("ResultOptionsSorting")
-            self.add_hide_field("DefaultResult")

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2618</version>
+  <version>2619</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/tests/doctests/ResultOptions.rst
+++ b/src/senaite/core/tests/doctests/ResultOptions.rst
@@ -91,10 +91,10 @@ Apply result options to the services:
 
 And a different control type for each service
 
-    >>> Cu.setResultOptionsType("select")
-    >>> Fe.setResultOptionsType("multiselect")
-    >>> Au.setResultOptionsType("multiselect_duplicates")
-    >>> Zn.setResultOptionsType("multichoice")
+    >>> Cu.setResultType("select")
+    >>> Fe.setResultType("multiselect")
+    >>> Au.setResultType("multiselect_duplicates")
+    >>> Zn.setResultType("multichoice")
 
 Test formatted result
 .....................

--- a/src/senaite/core/tests/doctests/TextResult.rst
+++ b/src/senaite/core/tests/doctests/TextResult.rst
@@ -1,0 +1,121 @@
+Text Result
+-----------
+
+An analysis can be configured so the captured value is treated as text.
+
+Running this test from the buildout directory::
+
+    bin/test test_textual_doctests -t TextResult
+
+
+Test Setup
+..........
+
+Needed Imports:
+
+    >>> from bika.lims import api
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+    >>> from DateTime import DateTime
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+
+Functional Helpers:
+
+    >>> def start_server():
+    ...     from Testing.ZopeTestCase.utils import startZServer
+    ...     ip, port = startZServer()
+    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
+
+    >>> def timestamp(format="%Y-%m-%d"):
+    ...     return DateTime().strftime(format)
+
+    >>> def new_sample(services):
+    ...     values = {
+    ...         'Client': client.UID(),
+    ...         'Contact': contact.UID(),
+    ...         'DateSampled': date_now,
+    ...         'SampleType': sampletype.UID()}
+    ...     service_uids = map(api.get_uid, services)
+    ...     ar = create_analysisrequest(client, request, values, service_uids)
+    ...     transitioned = do_action_for(ar, "receive")
+    ...     return ar
+
+    >>> def get_analysis(sample, service):
+    ...     service_uid = api.get_uid(service)
+    ...     for analysis in sample.getAnalyses(full_objects=True):
+    ...         if analysis.getServiceUID() == service_uid:
+    ...             return analysis
+    ...     return None
+
+    >>> def submit_analyses(ar, result="13"):
+    ...     for analysis in ar.getAnalyses(full_objects=True):
+    ...         analysis.setResult(result)
+    ...         do_action_for(analysis, "submit")
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = portal.setup
+    >>> bikasetup = api.get_bika_setup()
+    >>> date_now = DateTime().strftime("%Y-%m-%d")
+
+We need to create some basic objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
+    >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH", MemberDiscountApplies=True)
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(bikasetup.bika_sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> labcontact = api.create(bikasetup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = api.create(bikasetup.bika_analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> Cu = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID())
+    >>> Cu.setResultType("text")
+
+Test text result
+................
+
+When a result is captured and the analysis has the value 'text' as ResultType,
+the system returns the string value "as-is" without any processing:
+
+    >>> sample = new_sample([Cu])
+
+    >>> cu = get_analysis(sample, Cu)
+    >>> cu.setResult(1.23456789)
+    >>> cu.getResult()
+    '1.23456789'
+    >>> cu.getFormattedResult()
+    '1.23456789'
+    >>> cu.setResult('0')
+    >>> cu.getResult()
+    '0'
+    >>> cu.getFormattedResult()
+    '0'
+
+    >>> cu.setResult('This is a text result')
+    >>> cu.getResult()
+    'This is a text result'
+    >>> cu.getFormattedResult()
+    'This is a text result'
+
+The result supports multiple lines as well:
+
+    >>> cu.setResult("This is a text result with\r\nof multiple\nlines")
+    >>> cu.getResult()
+    'This is a text result with\r\nof multiple\nlines'
+
+If the result contains html characters, `getFormattedResult` escape them
+by default:
+
+    >>> cu.setResult('< Detection Limit')
+    >>> cu.getResult()
+    '< Detection Limit'
+    >>> cu.getFormattedResult()
+    '&lt; Detection Limit'
+
+Unless the parameter `html` is set to False:
+
+    >>> cu.getFormattedResult(html=False)
+    '< Detection Limit'

--- a/src/senaite/core/upgrade/v02_06_000.zcml
+++ b/src/senaite/core/upgrade/v02_06_000.zcml
@@ -4,6 +4,14 @@
     i18n_domain="senaite.core">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.6.0: Text (multi-lines) support for results"
+      description="Updates the value for ResultType from all analyses"
+      source="2618"
+      destination="2619"
+      handler=".v02_06_000.setup_result_types"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.6.0: Fix sample points not filtered by sample type"
       description="Sample points are not filtered by sample type in add sample"
       source="2617"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

> [!CAUTION]
> Merge https://github.com/senaite/senaite.app.listing/pull/144 first!

This Pull Request provides support for "Text" result in results entry:


![Captura de 2024-04-26 12-55-00](https://github.com/senaite/senaite.app.listing/assets/832627/fde79107-80f7-4f8f-b5a2-611f9d8b13dc)

For this to work, the field `String Result` and `Control type` have been removed in favour of `Result type` in Analysis Service edit view:

![Captura de 2024-04-26 15-09-03](https://github.com/senaite/senaite.core/assets/832627/132d9721-acb9-4e2c-954d-b67ebe798cf4)

When an option other than "Numeric", "String" or "Text" is selected, the field for the introduction of results option is displayed:

![Captura de 2024-04-26 15-10-19](https://github.com/senaite/senaite.core/assets/832627/ededbedc-4cdd-41a8-afec-e6a6f1078004)


## Current behavior before PR

Multi-line text is not supported on result entry

## Desired behavior after PR is merged

Multi-line text is supported on result entry

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
