### PR TITLE
Fix AttributeError for Instrument Adapters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2543 Fix AttributeError for Instrument Adapters
 - #2533 Migrate Sample Points to Dexterity
 - #2537 Support multi-line text on result entry
 - #2536 Fix counts from control-panel includes client-specific items

--- a/src/senaite/core/browser/form/adapters/data_import.py
+++ b/src/senaite/core/browser/form/adapters/data_import.py
@@ -18,6 +18,7 @@
 # Copyright 2018-2024 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import inspect
 import json
 import os
 import traceback
@@ -184,8 +185,17 @@ class EditForm(EditFormAdapterBase):
     def get_instrument_import_template(self, exim):
         """Returns the import template path
         """
-        exim_path = os.path.dirname(exim.__file__)
-        exim_file = os.path.basename(exim.__file__)
+        try:
+            fpath = exim.__file__
+        except AttributeError:
+            # There is no `__file__` for dynamically created objects, e.g.
+            # like instrument adapters.
+            klass = getattr(exim, "__class__", None)
+            fpath = inspect.getfile(klass) if klass else None
+        if fpath is None:
+            return
+        exim_path = os.path.dirname(fpath)
+        exim_file = os.path.basename(fpath)
         exim_name = os.path.splitext(exim_file)[0]
         template = "{}_import.pt".format(exim_name)
         return os.path.join(exim_path, template)

--- a/src/senaite/core/browser/form/adapters/data_import.py
+++ b/src/senaite/core/browser/form/adapters/data_import.py
@@ -193,7 +193,7 @@ class EditForm(EditFormAdapterBase):
             klass = getattr(exim, "__class__", None)
             fpath = inspect.getfile(klass) if klass else None
         if fpath is None:
-            return
+            return None
         exim_path = os.path.dirname(fpath)
         exim_file = os.path.basename(fpath)
         exim_name = os.path.splitext(exim_file)[0]


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an `AttributeError` that happens in the Instrument Import Form for external Instrument Adapters.


## Current behavior before PR

`AttributeError` is raised, because dynamically created objects do not provide the `__file__` attribute

## Desired behavior after PR is merged

Instrument Import Template is correctly looked up in the adapted Instrument parser folder

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
