### PR TITLE
Fix adding Instrument into Manufacturer view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 2.6.0 (unreleased)
 ------------------
-
+- #2556 Fix adding Instrument into Manufacturer view
 - #2549 Fix contact fullname is not updated in samples listing after edition
 - #2541 Allow to change the "From" address for sample report outgoing emails
 - #2548 Remove SamplerFullName from sample and metadata

--- a/src/senaite/core/browser/controlpanel/manufacturers/instruments.py
+++ b/src/senaite/core/browser/controlpanel/manufacturers/instruments.py
@@ -24,6 +24,10 @@ from bika.lims.controlpanel.bika_instruments import InstrumentsView
 
 class ManufacturerInstrumentsView(InstrumentsView):
 
+    def __init__(self, context, request):
+        super(ManufacturerInstrumentsView, self).__init__(context, request)
+        self.context_actions = {}
+
     def isItemAllowed(self, obj):
         obj = api.get_object(obj)
         uid = obj.getRawManufacturer()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

See: https://github.com/senaite/senaite.core/pull/2542#issuecomment-2119129497

Action "Add" wants create new Instrument into manufacturer folder.

## Current behavior before PR

This action  which leads to the error.

## Desired behavior after PR is merged

Delete action button "Add" for impossibility created Instrument into Manufacturer folder.

_p.s. I tried to solve the issue by changing the request address for action "Add" by adding Manufacturer=UID to it, but when "createObject" method a redirect occurs_

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
