### PR TITLE
Fix SubGroups migration typo

### DIFF
--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2627</version>
+  <version>2628</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/profiles/default/types/SubGroup.xml
+++ b/src/senaite/core/profiles/default/types/SubGroup.xml
@@ -11,7 +11,7 @@
   <property name="icon_expr">senaite_theme/icon/subgroup</property>
 
   <!-- factory name; usually the same as type name -->
-  <property name="factory">ContainerType</property>
+  <property name="factory">SubGroup</property>
 
   <!-- URL TALES expression to add an item TTW -->
   <property name="add_view_expr">string:${folder_url}/++add++SubGroup</property>

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -1202,6 +1202,15 @@ def migrate_containertypes_to_dx(tool):
 
 
 @upgradestep(product, version)
+def update_typeinfo_subgroups_fix(tool):
+    """Fix sub groups typeinfo
+    """
+
+    # run required import steps
+    tool.runImportStepFromProfile(profile, "typeinfo")
+
+
+@upgradestep(product, version)
 def migrate_subgroups_to_dx(tool):
     """Converts existing sub groups to Dexterity
     """

--- a/src/senaite/core/upgrade/v02_06_000.zcml
+++ b/src/senaite/core/upgrade/v02_06_000.zcml
@@ -4,6 +4,14 @@
     i18n_domain="senaite.core">
 
     <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.6.0: Update SubGroups typeinfo (fix)"
+      description="Update SubGroups typeinfo (fix)"
+      source="2627"
+      destination="2628"
+      handler=".v02_06_000.update_typeinfo_subgroups_fix"
+      profile="senaite.core:default"/>
+
+    <genericsetup:upgradeStep
       title="SENAITE.CORE 2.6.0: Migrate SubGroups to DX"
       description="Migrate SubGroups to Dexterity"
       source="2626"


### PR DESCRIPTION
Fix default factory typo from #2545 

## Description of the issue/feature this PR addresses

typo 

## Current behavior before PR

## Desired behavior after PR is merged

fix 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
