### PR TITLE
Fix line breaks are not displayed for text-like results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2559 Fix line breaks are not displayed for text-like results
 - #2558 Fix ValueError when upgrading from <=2614 to >=2617
 - #2550 Migrate StorageLocations to Dexterity
 - #2545 Migrate Sub Groups to Dexterity

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -895,7 +895,10 @@ class AbstractAnalysis(AbstractBaseAnalysis):
 
         # If string result, return without any formatting
         if self.getStringResult():
-            return cgi.escape(result) if html else result
+            if html:
+                result = cgi.escape(result)
+                result = result.replace("\n", "<br/>")
+            return result
 
         # If a detection limit, return '< LDL' or '> UDL'
         dl = self.getDetectionLimitOperand()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Requests ensures the text-like results are displayed correctly when rendered in read-only mode in results reports and in listing views

## Current behavior before PR

Line breaks are not displayed for text-like results

![Captura de 2024-05-23 11-49-23](https://github.com/senaite/senaite.core/assets/832627/6f696523-0b1d-42ed-b7dc-9aaa1d91a1cf)

![Captura de 2024-05-23 11-48-32](https://github.com/senaite/senaite.core/assets/832627/18c58611-1269-49e1-80c3-c9e327a5a126)


## Desired behavior after PR is merged

Line breaks are displayed for text-like results

![Captura de 2024-05-23 11-44-41](https://github.com/senaite/senaite.core/assets/832627/548d7043-28e6-46ce-8156-c90be3a58f22)

![Captura de 2024-05-23 11-44-55](https://github.com/senaite/senaite.core/assets/832627/8a023d76-fef3-47f7-82f3-89deb5c624cc)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
