### PR TITLE
Fix no available profiles in add form after sample type and/or client change

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2560 Fix no profiles in add form on sample type and/or client change
 - #2559 Fix line breaks are not displayed for text-like results
 - #2558 Fix ValueError when upgrading from <=2614 to >=2617
 - #2550 Migrate StorageLocations to Dexterity


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the Profiles field from add sample form is filtered properly when the value of sample type and/or client fields are updated.

Problem is that when a value of a field changes (e.g. Sample Type or Client), the browser applies the filter queries to the fields that have to be applied in accordance with the object that was selected in the current field, without taking into account values from other fields. This Pull Request resolves this issue by always taking into account the rest of records when building the `filter_queries` dict.

## Current behavior before PR

No profiles are displayed in sample add form after client and/or sample_type changes

## Desired behavior after PR is merged

Profiles are displayed in sample add form after client and/or sample_type changes

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
