### PR TITLE
Buildouts redux

### DIFF
--- a/buildout.base.cfg
+++ b/buildout.base.cfg
@@ -1,0 +1,92 @@
+[buildout]
+index = https://pypi.org/simple/
+extends = https://dist.plone.org/release/5.2-latest/versions.cfg
+find-links =
+    https://dist.plone.org/release/5.2-latest/
+    https://dist.plone.org/thirdparty/
+
+parts =
+    instance
+    test
+    omelette
+    i18ndude
+    zopepy
+    write_code_headers
+
+eggs =
+    senaite.core
+    senaite.app.listing
+    senaite.app.spotlight
+    senaite.app.supermodel
+    senaite.impress
+    senaite.jsonapi
+    senaite.lims
+
+    plone.reload
+    Products.PrintingMailHost
+
+extensions = mr.developer
+
+versions = versions
+show-picked-versions = true
+
+plone-user = admin:admin
+
+develop = .
+sources = sources
+auto-checkout = *
+
+[sources]
+senaite.app.listing = git https://github.com/senaite/senaite.app.listing.git pushurl=git@github.com:senaite/senaite.app.listing.git branch=2.x
+senaite.app.spotlight = git https://github.com/senaite/senaite.app.spotlight.git pushurl=git@github.com:senaite/senaite.app.spotlight.git branch=2.x
+senaite.app.supermodel = git https://github.com/senaite/senaite.app.supermodel.git pushurl=git@github.com:senaite/senaite.app.supermodel.git branch=2.x
+senaite.impress = git https://github.com/senaite/senaite.impress.git pushurl=git@github.com:senaite/senaite.impress.git branch=2.x
+senaite.jsonapi = git https://github.com/senaite/senaite.jsonapi.git pushurl=git@github.com:senaite/senaite.jsonapi.git branch=2.x
+senaite.lims = git https://github.com/senaite/senaite.lims.git pushurl=git@github.com:senaite/senaite.lims.git branch=2.x
+
+[instance]
+recipe = plone.recipe.zope2instance
+http-address = 127.0.0.1:8080
+user = ${buildout:plone-user}
+wsgi = off
+eggs =
+    Plone
+    plone.app.upgrade
+    ${buildout:package-name}
+    ${buildout:eggs}
+deprecation-warnings = on
+environment-vars =
+    zope_i18n_compile_mo_files true
+zcml =
+
+[i18ndude]
+unzip = true
+recipe = zc.recipe.egg
+eggs = i18ndude
+
+[write_code_headers]
+recipe = collective.recipe.template
+output = ${buildout:directory}/bin/write_code_headers
+input = ${buildout:directory}/templates/write_code_headers.py.in
+mode = 755
+
+[test]
+recipe = zc.recipe.testrunner
+defaults = ['--auto-color', '--auto-progress']
+eggs =
+    ${buildout:package-name} [test]
+
+[omelette]
+recipe = collective.recipe.omelette
+eggs = ${buildout:eggs}
+
+[zopepy]
+recipe = zc.recipe.egg
+eggs = ${instance:eggs}
+interpreter = zopepy
+scripts = zopepy
+
+[versions]
+# versions taken from requirements.txt
+setuptools =
+zc.buildout =

--- a/buildout.base.cfg
+++ b/buildout.base.cfg
@@ -37,12 +37,13 @@ sources = sources
 auto-checkout = *
 
 [sources]
-senaite.app.listing = git https://github.com/senaite/senaite.app.listing.git pushurl=git@github.com:senaite/senaite.app.listing.git branch=2.x
-senaite.app.spotlight = git https://github.com/senaite/senaite.app.spotlight.git pushurl=git@github.com:senaite/senaite.app.spotlight.git branch=2.x
-senaite.app.supermodel = git https://github.com/senaite/senaite.app.supermodel.git pushurl=git@github.com:senaite/senaite.app.supermodel.git branch=2.x
-senaite.impress = git https://github.com/senaite/senaite.impress.git pushurl=git@github.com:senaite/senaite.impress.git branch=2.x
-senaite.jsonapi = git https://github.com/senaite/senaite.jsonapi.git pushurl=git@github.com:senaite/senaite.jsonapi.git branch=2.x
-senaite.lims = git https://github.com/senaite/senaite.lims.git pushurl=git@github.com:senaite/senaite.lims.git branch=2.x
+senaite.core = git https://github.com/senaite/senaite.core.git branch=2.x
+senaite.app.listing = git https://github.com/senaite/senaite.app.listing.git branch=2.x
+senaite.app.spotlight = git https://github.com/senaite/senaite.app.spotlight.git branch=2.x
+senaite.app.supermodel = git https://github.com/senaite/senaite.app.supermodel.git branch=2.x
+senaite.impress = git https://github.com/senaite/senaite.impress.git branch=2.x
+senaite.jsonapi = git https://github.com/senaite/senaite.jsonapi.git branch=2.x
+senaite.lims = git https://github.com/senaite/senaite.lims.git branch=2.x
 
 [instance]
 recipe = plone.recipe.zope2instance

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -9,6 +9,16 @@ parts +=
     update_sources
     write_contributors
 
+sources = sources_wo_core
+
+[sources_wo_core]
+senaite.app.listing = git https://github.com/senaite/senaite.app.listing.git branch=2.x
+senaite.app.spotlight = git https://github.com/senaite/senaite.app.spotlight.git branch=2.x
+senaite.app.supermodel = git https://github.com/senaite/senaite.app.supermodel.git branch=2.x
+senaite.impress = git https://github.com/senaite/senaite.impress.git branch=2.x
+senaite.jsonapi = git https://github.com/senaite/senaite.jsonapi.git branch=2.x
+senaite.lims = git https://github.com/senaite/senaite.lims.git branch=2.x
+
 [console_scripts]
 recipe = zc.recipe.egg:scripts
 eggs = senaite.core

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -9,16 +9,6 @@ parts +=
     update_sources
     write_contributors
 
-sources = sources_wo_core
-
-[sources_wo_core]
-senaite.app.listing = git https://github.com/senaite/senaite.app.listing.git branch=2.x
-senaite.app.spotlight = git https://github.com/senaite/senaite.app.spotlight.git branch=2.x
-senaite.app.supermodel = git https://github.com/senaite/senaite.app.supermodel.git branch=2.x
-senaite.impress = git https://github.com/senaite/senaite.impress.git branch=2.x
-senaite.jsonapi = git https://github.com/senaite/senaite.jsonapi.git branch=2.x
-senaite.lims = git https://github.com/senaite/senaite.lims.git branch=2.x
-
 [console_scripts]
 recipe = zc.recipe.egg:scripts
 eggs = senaite.core

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,78 +1,17 @@
 [buildout]
-index = https://pypi.org/simple/
-extends = https://dist.plone.org/release/5.2-latest/versions.cfg
-find-links =
-    https://dist.plone.org/release/5.2-latest/
-    https://dist.plone.org/thirdparty/
-
-parts =
-    instance
-    console_scripts
-    test
-    omelette
-    i18ndude
-    zopepy
-    update_translations
-    update_sources
-    write_code_headers
-    write_contributors
-
-eggs =
-    senaite.core
-    senaite.app.listing
-    senaite.app.spotlight
-    senaite.app.supermodel
-    senaite.impress
-    senaite.jsonapi
-    senaite.lims
-
-    plone.reload
-    Products.PrintingMailHost
-
-extensions = mr.developer
+extends = buildout.base.cfg
 
 package-name = senaite.core
 
-versions = versions
-show-picked-versions = true
-
-plone-user = admin:admin
-
-develop = .
-sources = sources
-auto-checkout = *
-
-[sources]
-senaite.app.listing = git https://github.com/senaite/senaite.app.listing.git pushurl=git@github.com:senaite/senaite.app.listing.git branch=2.x
-senaite.app.spotlight = git https://github.com/senaite/senaite.app.spotlight.git pushurl=git@github.com:senaite/senaite.app.spotlight.git branch=2.x
-senaite.app.supermodel = git https://github.com/senaite/senaite.app.supermodel.git pushurl=git@github.com:senaite/senaite.app.supermodel.git branch=2.x
-senaite.impress = git https://github.com/senaite/senaite.impress.git pushurl=git@github.com:senaite/senaite.impress.git branch=2.x
-senaite.jsonapi = git https://github.com/senaite/senaite.jsonapi.git pushurl=git@github.com:senaite/senaite.jsonapi.git branch=2.x
-senaite.lims = git https://github.com/senaite/senaite.lims.git pushurl=git@github.com:senaite/senaite.lims.git branch=2.x
-
-[instance]
-recipe = plone.recipe.zope2instance
-http-address = 127.0.0.1:8080
-user = ${buildout:plone-user}
-wsgi = off
-eggs =
-    Plone
-    plone.app.upgrade
-    ${buildout:package-name}
-    ${buildout:eggs}
-deprecation-warnings = on
-environment-vars =
-    zope_i18n_compile_mo_files true
-zcml =
+parts +=
+    console_scripts
+    update_translations
+    update_sources
+    write_contributors
 
 [console_scripts]
 recipe = zc.recipe.egg:scripts
 eggs = senaite.core
-
-[i18ndude]
-unzip = true
-recipe = zc.recipe.egg
-eggs = i18ndude
 
 [update_translations]
 recipe = collective.recipe.template
@@ -86,35 +25,8 @@ output = ${buildout:directory}/bin/update_sources
 input = ${buildout:directory}/templates/update_sources.in
 mode = 755
 
-[write_code_headers]
-recipe = collective.recipe.template
-output = ${buildout:directory}/bin/write_code_headers
-input = ${buildout:directory}/templates/write_code_headers.py.in
-mode = 755
-
 [write_contributors]
 recipe = collective.recipe.template
 output = ${buildout:directory}/bin/write_contributors
 input = ${buildout:directory}/templates/write_contributors.py.in
 mode = 755
-
-[test]
-recipe = zc.recipe.testrunner
-defaults = ['--auto-color', '--auto-progress']
-eggs =
-    senaite.core [test]
-
-[omelette]
-recipe = collective.recipe.omelette
-eggs = ${buildout:eggs}
-
-[zopepy]
-recipe = zc.recipe.egg
-eggs = ${instance:eggs}
-interpreter = zopepy
-scripts = zopepy
-
-[versions]
-# versions taken from requirements.txt
-setuptools =
-zc.buildout =

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -9,15 +9,14 @@ parts +=
     update_sources
     write_contributors
 
-sources = sources_wo_core
-
-[sources_wo_core]
-senaite.app.listing = git https://github.com/senaite/senaite.app.listing.git branch=2.x
-senaite.app.spotlight = git https://github.com/senaite/senaite.app.spotlight.git branch=2.x
-senaite.app.supermodel = git https://github.com/senaite/senaite.app.supermodel.git branch=2.x
-senaite.impress = git https://github.com/senaite/senaite.impress.git branch=2.x
-senaite.jsonapi = git https://github.com/senaite/senaite.jsonapi.git branch=2.x
-senaite.lims = git https://github.com/senaite/senaite.lims.git branch=2.x
+# Auto-checkout all sources but senaite.core
+auto-checkout =
+    senaite.app.listing
+    senaite.app.spotlight
+    senaite.app.supermodel
+    senaite.impress
+    senaite.jsonapi
+    senaite.lims
 
 [console_scripts]
 recipe = zc.recipe.egg:scripts


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request does a buildout redux so depending add-ons can rely directly on this one as simple as follows:

```ini
[buildout]
extends = https://raw.githubusercontent.com/senaite/senaite.core/2.x/buildout.base.cfg
package-name = something.cool

[sources]
# sources of dependencies here
senaite.dependency = git https://github.com/senaite/senaite.dependency.git
```

## Current behavior before PR

`buildout` files spread here and there

## Desired behavior after PR is merged

centralized `buildout` file

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
