### PR TITLE
Fix traceback when applying referencebehavior to non DX types

### DIFF
--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -1846,6 +1846,9 @@ def set_referenceable_behavior(tool):
     setup = api.get_senaite_setup()
     to_fix = [setup] + list(setup.objectValues())
     for obj in to_fix:
+        if not api.is_dexterity_content(obj):
+            logger.warn("Not a DX folder: %r [SKIP]" % obj)
+            continue
         portal_type = api.get_portal_type(obj)
         fti = pt.get(portal_type)
         if behavior not in fti.behaviors:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a Traceback that occurs when running the upgrade step `2636` (#2578) with an add-on installed that contains non-dexterity types inside `setup` folder.

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 666, in __call__
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 399, in upgrade_product
  Module Products.GenericSetup.tool, line 1202, in upgradeProfile
  Module Products.GenericSetup.upgrade, line 185, in doStep
  Module senaite.core.upgrade.v02_06_000, line 1851, in set_referenceable_behavior
AttributeError: 'RequestContainer' object has no attribute 'behaviors'
```

## Desired behavior after PR is merged

Upgrade step finishes without complains

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
