### PR TITLE
Fix instrument import log message when field value is set

### DIFF
--- a/src/senaite/core/exportimport/instruments/importer.py
+++ b/src/senaite/core/exportimport/instruments/importer.py
@@ -739,7 +739,7 @@ class AnalysisResultsImporter(Logger):
                        mapping={
                            "sid": sid,
                            "field": key,
-                           "value": field_value,
+                           "value": value,
                        }))
 
         return updated


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a bug that was introduced with https://github.com/senaite/senaite.core/pull/2555

## Current behavior before PR

When a field value, e.g. `LowerDetectionLimit` or `Uncertainty` is imported, the old field value was shown in the log message

<img width="559" alt="Instrument Import Log" src="https://github.com/senaite/senaite.core/assets/713193/2fd534bf-8ff8-403d-82df-e9d3dd2f5052">


## Desired behavior after PR is merged

The new field value is shown in the log message

<img width="686" alt="Instrument Import Log" src="https://github.com/senaite/senaite.core/assets/713193/29fa45a4-345f-47c6-8302-94dd27d79392">

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
