### PR TITLE
Do not override dependent values with empties

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2582 Do not override dependent values with empties
 - #2573 Move Interpretation Templates to Senaite setup folder
 - #2563 Move Dynamic Analysis Specs to Setup folder
 - #2554 Migrate AttachmentTypes to Dexterity

--- a/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
@@ -608,6 +608,9 @@
       if (!this.is_array(values)) {
         values = [values];
       }
+      if (!(values.length > 0)) {
+        return;
+      }
       me = this;
       values_json = JSON.stringify(values);
       field = $("#" + field_name + ("-" + arnum));

--- a/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -576,6 +576,9 @@ class window.AnalysisRequestAdd
     if not @is_array(values)
       values = [values]
 
+    # avoid flushing the field with empty values
+    return unless values.length > 0
+
     me = this
     values_json = JSON.stringify values
     field = $("#" + field_name + "-#{arnum}")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a bug that was introduced in https://github.com/senaite/senaite.core/pull/2570
  
## Current behavior before PR

CCContact field is always flushed

## Desired behavior after PR is merged

CCContact field (and other dependent fields) are not overwritten with empties.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
