### PR TITLE
fix "Progress" missing i18n support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 2.6.0 (unreleased)
 ------------------
-
+- #2585 Fix Progress string missing i18n
 - #2574 Migrate LabProducts to Dexterity
 - #2583 Make SampleContainer DX type inherit from core's DX Container
 - #2582 Do not override dependent values with empties

--- a/src/senaite/core/browser/samples/view.py
+++ b/src/senaite/core/browser/samples/view.py
@@ -110,7 +110,7 @@ class SamplesView(ListingView):
                 "index": "getPrioritySortkey",
                 "sortable": True, }),
             ("Progress", {
-                "title": "Progress",
+                "title": _("Progress"),
                 "index": "getProgress",
                 "sortable": True,
                 "toggle": True}),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR
str "Progress" not support i18n
## Desired behavior after PR is merged
str "Porgress" works in the mechanism of i18n
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
