### PR TITLE
Fixed InvalidOperation: Invalid literal for Decimal: ''

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2587 Fix InvalidOperation: Invalid literal for Decimal: ''
 - #2574 Migrate LabProducts to Dexterity
 - #2583 Make SampleContainer DX type inherit from core's DX Container
 - #2582 Do not override dependent values with empties

--- a/src/senaite/core/content/labproduct.py
+++ b/src/senaite/core/content/labproduct.py
@@ -210,7 +210,7 @@ class LabProduct(Container):
     def getTotalPrice(self):
         """ compute total price """
         price = Decimal(self.getPrice() or '0.00')
-        vat = Decimal(self.getVAT())
+        vat = Decimal(self.getVAT() or "0.00")
         vat = vat and vat / 100 or 0
         price = price + (price * vat)
         return price.quantize(Decimal('0.00'))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR
Geting an error running upgrade script 2642
```InvalidOperation: Invalid literal for Decimal: ''
(39 additional frame(s) were not displayed)
  File ".../src/senaite.core/src/senaite/core/upgrade/v02_06_000.py", line 2025, in migrate_labproduct_to_dx
    destination._setObject(target_id, target)
  File "...src/senaite.core/src/senaite/core/catalog/catalog_multiplex_processor.py", line 100, in reindex
    obj, idxs=indexes, update_metadata=update_metadata)
  File ".../src/senaite.core/src/senaite/core/patches/catalog.py", line 66, in catalog_object
    update_metadata, pghandler=pghandler)
  File "...src/senaite.core/src/senaite/core/catalog/indexer/senaitesetup.py", line 97, in price_total
    return instance.getTotalPrice()
  File "...src/senaite.core/src/senaite/core/content/labproduct.py", line 213, in getTotalPrice
    vat = Decimal(self.getVAT())
```
    
## Desired behavior after PR is merged
Upgrade script to run without the error

--

I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
