### PR TITLE
Widget text extensions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2588 Widget text extensions
 - #2586 Support multiple files for datagrid fields
 - #2581 Migrate Suppliers to Dexterity
 - #2587 Fix InvalidOperation: Invalid literal for Decimal: ''

--- a/src/senaite/core/browser/dexterity/templates/widget.pt
+++ b/src/senaite/core/browser/dexterity/templates/widget.pt
@@ -6,9 +6,8 @@
                  error_class python:error and ' error' or '';
                  empty_values python: (None, '', [], ('', '', '', '00', '00', ''), ('', '', ''));
                  empty_class python: (widget.value in empty_values) and ' empty' or '';
-	               wrapper_css_class  widget/wrapper_css_class|nothing;
+                 wrapper_css_class  widget/wrapper_css_class|nothing;
                  fieldname_class string:kssattr-fieldname-${widget/name};"
-     data-pat-inlinevalidation='{"type":"z3c.form"}'
      tal:attributes="class string:field pat-inlinevalidation ${fieldname_class}${error_class}${empty_class} ${wrapper_css_class};
                      data-fieldname widget/name;
                      id string:formfield-${widget/id};">

--- a/src/senaite/core/browser/dexterity/templates/widget.pt
+++ b/src/senaite/core/browser/dexterity/templates/widget.pt
@@ -36,7 +36,34 @@
     field description
   </span>
 
-  <input type="text"
-         tal:replace="structure widget/render"
-         metal:define-slot="widget" />
+  <!-- widget insert mode -->
+  <div class="input-group input-group-sm d-flex"
+       style="width:auto"
+       tal:define="prefix python:view.get_prepend_text();
+                   appendix python:view.get_append_text()"
+       tal:condition="python:view.is_input_mode()">
+    <div tal:condition="python:prefix" class="input-group-prepend">
+      <span class="input-group-text" tal:content="structure python:prefix"/>
+    </div>
+    <input type="text"
+           tal:replace="structure widget/render"
+           metal:define-slot="widget" />
+    <div tal:condition="python:appendix" class="input-group-append">
+      <span class="input-group-text" tal:content="structure python:appendix"/>
+    </div>
+  </div>
+
+  <!-- widget view mode -->
+  <div tal:define="prefix python:view.get_prepend_text();
+                   appendix python:view.get_append_text()"
+       tal:condition="python:view.is_view_mode()">
+    <!-- field prefix -->
+    <span tal:content="structure python:prefix" class="field-prefix"></span>
+    <input type="text"
+           tal:replace="structure widget/render"
+           metal:define-slot="widget" />
+    <!-- field appendix -->
+    <span tal:content="structure python:appendix" class="field-prefix"></span>
+  </div>
+
 </div>

--- a/src/senaite/core/browser/dexterity/views.py
+++ b/src/senaite/core/browser/dexterity/views.py
@@ -77,11 +77,17 @@ class SenaiteRenderWidget(RenderWidget):
         return not self.is_input_mode()
 
     def get_prepend_text(self):
+        omit_mode = getattr(self.context, "before_text_omit_mode", "")
+        if omit_mode and self.context.mode in omit_mode.split():
+            return
         before_text = getattr(self.context, "before_text", None)
         before_css_class = getattr(self.context, "before_css_class", None)
         return self.format_text(before_text, css_class=before_css_class)
 
     def get_append_text(self):
+        omit_mode = getattr(self.context, "after_text_omit_mode", "")
+        if omit_mode and self.context.mode in omit_mode.split():
+            return
         after_text = getattr(self.context, "after_text", None)
         after_css_class = getattr(self.context, "after_css_class", None)
         return self.format_text(after_text, css_class=after_css_class)

--- a/src/senaite/core/browser/dexterity/views.py
+++ b/src/senaite/core/browser/dexterity/views.py
@@ -67,12 +67,12 @@ class SenaiteRenderWidget(RenderWidget):
         self.request = request
 
     def is_input_mode(self):
-        """Check if we are in INPUT mode currently
+        """Check if we are in INPUT mode
         """
         return self.context.mode == INPUT_MODE
 
     def is_view_mode(self):
-        """Check if we are in view mode currently
+        """Checks if we are in view (DISPLAY/HIDDEN) mode
         """
         return not self.is_input_mode()
 

--- a/src/senaite/core/browser/dexterity/views.py
+++ b/src/senaite/core/browser/dexterity/views.py
@@ -35,7 +35,7 @@ from senaite.core.interfaces import ISenaiteFormLayer
 from z3c.form.interfaces import INPUT_MODE
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 
-FORMAT_TPL = Template("""<span class="$css_class">
+FORMAT_TPL = Template("""<span class="$css">
   $text
 </span>
 """)
@@ -65,16 +65,52 @@ class SenaiteRenderWidget(RenderWidget):
         super(SenaiteRenderWidget, self).__init__(context, request)
         self.context = context
         self.request = request
+        # allow per mode styling
+        if context:
+            context.klass = self.get_widget_mode_css(context)
+
+    def get_mode(self):
+        """Get the current widget mode
+
+        returns either input, display or hidden
+        """
+        return self.context.mode
 
     def is_input_mode(self):
         """Check if we are in INPUT mode
         """
-        return self.context.mode == INPUT_MODE
+        return self.get_mode() == INPUT_MODE
 
     def is_view_mode(self):
         """Checks if we are in view (DISPLAY/HIDDEN) mode
         """
         return not self.is_input_mode()
+
+    def get_widget_mode_css(self, widget):
+        """Allows mode specific css styling for the widget itself
+
+        Example:
+
+            directives.widget("department_id",
+                              widget_css_display="text-danger text-monospace",
+                              widget_css_input="text-primary")
+            department_id = schema.TextLine(...)
+        """
+        mode = self.get_mode()
+
+        widget_css = getattr(widget, "widget_css_%s" % mode, None)
+        if not widget_css:
+            widget_css = getattr(widget, "widget_css", None)
+
+        if not widget_css:
+            return widget.klass
+
+        # append the mode specific widget css classes
+        current_css = widget.klass.split()
+        for cls in widget_css.split():
+            if cls not in current_css:
+                current_css.append(cls)
+        return " ".join(current_css)
 
     def get_prepend_text(self):
         """Get the text/style to prepend to the input field
@@ -83,13 +119,13 @@ class SenaiteRenderWidget(RenderWidget):
         Example:
 
             directives.widget("department_id",
-                            before_text_edit="ID",
-                            before_css_class_edit="text-secondary",
-                            before_text_display="ID:",
-                            before_css_class_display="font-weight-bold")
+                              before_text_input="ID",
+                              before_css_input="text-secondary",
+                              before_text_display="ID:",
+                              before_css_display="font-weight-bold")
             department_id = schema.TextLine(...)
         """
-        mode = self.context.mode
+        mode = self.get_mode()
         widget = self.context
 
         # omit the text in the current mode
@@ -103,11 +139,11 @@ class SenaiteRenderWidget(RenderWidget):
             before_text = getattr(widget, "before_text", None)
 
         # get the CSS classes for the append text
-        before_css_class = getattr(widget, "before_css_class_%s" % mode, None)
-        if not before_css_class:
-            before_css_class = getattr(widget, "before_css_class", None)
+        before_css = getattr(widget, "before_css_%s" % mode, None)
+        if not before_css:
+            before_css = getattr(widget, "before_css", None)
 
-        return self.format_text(before_text, css_class=before_css_class)
+        return self.format_text(before_text, css=before_css)
 
     def get_append_text(self):
         """Get the text/style to append to the input field
@@ -116,11 +152,11 @@ class SenaiteRenderWidget(RenderWidget):
 
             directives.widget("department_id",
                               after_text="<i class='fas fa-id-card'></i>",
-                              after_css_class="text-primary",
+                              after_css="text-primary",
                               after_text_omit_display=True)
             department_id = schema.TextLine(...)
         """
-        mode = self.context.mode
+        mode = self.get_mode()
         widget = self.context
 
         # omit the text in the current mode
@@ -134,22 +170,22 @@ class SenaiteRenderWidget(RenderWidget):
             after_text = getattr(widget, "after_text", None)
 
         # get the CSS classes for the append text
-        after_css_class = getattr(widget, "after_css_class_%s" % mode, None)
-        if not after_css_class:
-            after_css_class = getattr(widget, "after_css_class", None)
+        after_css = getattr(widget, "after_css_%s" % mode, None)
+        if not after_css:
+            after_css = getattr(widget, "after_css", None)
 
-        return self.format_text(after_text, css_class=after_css_class)
+        return self.format_text(after_text, css=after_css)
 
-    def format_text(self, text, css_class=None):
+    def format_text(self, text, css=None):
         """HTML format the text
         """
         if not text:
             return ""
-        if css_class is None:
-            css_class = ""
+        if css is None:
+            css = ""
         context = {
             "text": text,
-            "css_class": css_class,
+            "css": css,
 
         }
         return FORMAT_TPL.safe_substitute(context)

--- a/src/senaite/core/browser/dexterity/views.py
+++ b/src/senaite/core/browser/dexterity/views.py
@@ -77,19 +77,67 @@ class SenaiteRenderWidget(RenderWidget):
         return not self.is_input_mode()
 
     def get_prepend_text(self):
-        omit_mode = getattr(self.context, "before_text_omit_mode", "")
-        if omit_mode and self.context.mode in omit_mode.split():
+        """Get the text/style to prepend to the input field
+
+
+        Example:
+
+            directives.widget("department_id",
+                            before_text_edit="ID",
+                            before_css_class_edit="text-secondary",
+                            before_text_display="ID:",
+                            before_css_class_display="font-weight-bold")
+            department_id = schema.TextLine(...)
+        """
+        mode = self.context.mode
+        widget = self.context
+
+        # omit the text in the current mode
+        omit = getattr(widget, "before_text_omit_%s" % mode, False)
+        if omit:
             return
-        before_text = getattr(self.context, "before_text", None)
-        before_css_class = getattr(self.context, "before_css_class", None)
+
+        # get the append text
+        before_text = getattr(widget, "before_text_%s" % mode, None)
+        if not before_text:
+            before_text = getattr(widget, "before_text", None)
+
+        # get the CSS classes for the append text
+        before_css_class = getattr(widget, "before_css_class_%s" % mode, None)
+        if not before_css_class:
+            before_css_class = getattr(widget, "before_css_class", None)
+
         return self.format_text(before_text, css_class=before_css_class)
 
     def get_append_text(self):
-        omit_mode = getattr(self.context, "after_text_omit_mode", "")
-        if omit_mode and self.context.mode in omit_mode.split():
+        """Get the text/style to append to the input field
+
+        Example:
+
+            directives.widget("department_id",
+                              after_text="<i class='fas fa-id-card'></i>",
+                              after_css_class="text-primary",
+                              after_text_omit_display=True)
+            department_id = schema.TextLine(...)
+        """
+        mode = self.context.mode
+        widget = self.context
+
+        # omit the text in the current mode
+        omit = getattr(widget, "after_text_omit_%s" % mode, False)
+        if omit:
             return
-        after_text = getattr(self.context, "after_text", None)
-        after_css_class = getattr(self.context, "after_css_class", None)
+
+        # get the append text
+        after_text = getattr(widget, "after_text_%s" % mode, None)
+        if not after_text:
+            after_text = getattr(widget, "after_text", None)
+
+        # get the CSS classes for the append text
+        after_css_class = getattr(widget, "after_css_class_%s" % mode, None)
+        if not after_css_class:
+            after_css_class = getattr(widget, "after_css_class", None)
+
         return self.format_text(after_text, css_class=after_css_class)
 
     def format_text(self, text, css_class=None):

--- a/src/senaite/core/browser/dexterity/views.py
+++ b/src/senaite/core/browser/dexterity/views.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 import os
+from string import Template
 
 import plone.app.z3cform
 import plone.app.z3cform.interfaces
@@ -31,7 +32,13 @@ from plone.app.z3cform.views import RenderWidget
 from plone.dexterity.browser.edit import DefaultEditView
 from plone.dexterity.browser.view import DefaultView
 from senaite.core.interfaces import ISenaiteFormLayer
+from z3c.form.interfaces import INPUT_MODE
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
+
+FORMAT_TPL = Template("""<span class="$css_class">
+  $text
+</span>
+""")
 
 
 def path(filepart):
@@ -58,6 +65,40 @@ class SenaiteRenderWidget(RenderWidget):
         super(SenaiteRenderWidget, self).__init__(context, request)
         self.context = context
         self.request = request
+
+    def is_input_mode(self):
+        """Check if we are in INPUT mode currently
+        """
+        return self.context.mode == INPUT_MODE
+
+    def is_view_mode(self):
+        """Check if we are in view mode currently
+        """
+        return not self.is_input_mode()
+
+    def get_prepend_text(self):
+        before_text = getattr(self.context, "before_text", None)
+        before_css_class = getattr(self.context, "before_css_class", None)
+        return self.format_text(before_text, css_class=before_css_class)
+
+    def get_append_text(self):
+        after_text = getattr(self.context, "after_text", None)
+        after_css_class = getattr(self.context, "after_css_class", None)
+        return self.format_text(after_text, css_class=after_css_class)
+
+    def format_text(self, text, css_class=None):
+        """HTML format the text
+        """
+        if not text:
+            return ""
+        if css_class is None:
+            css_class = ""
+        context = {
+            "text": text,
+            "css_class": css_class,
+
+        }
+        return FORMAT_TPL.safe_substitute(context)
 
 
 class SenaiteDefaultView(DefaultView):

--- a/src/senaite/core/content/department.py
+++ b/src/senaite/core/content/department.py
@@ -33,6 +33,7 @@ from senaite.core.content.base import Container
 from senaite.core.interfaces import IDepartment
 from senaite.core.schema import UIDReferenceField
 from senaite.core.z3cform.widgets.uidreference import UIDReferenceWidgetFactory
+from z3c.form.interfaces import DISPLAY_MODE
 from zope import schema
 from zope.interface import Invalid
 from zope.interface import implementer
@@ -48,6 +49,10 @@ class IDepartmentSchema(model.Schema):
             u"title_department_title",
             default=u"Name"
         ),
+        description=_(
+            u"description_department_title",
+            default=u"Name of the department"
+        ),
         required=True,
     )
 
@@ -60,6 +65,13 @@ class IDepartmentSchema(model.Schema):
     )
 
     # Department ID
+    directives.widget("department_id",
+                      before_text="ID",
+                      before_css_class="text-secondary",
+                      before_text_omit_mode=DISPLAY_MODE,
+                      after_text="<i class='fas fa-id-card'></i>",
+                      after_css_class="text-primary",
+                      after_text_omit_mode=DISPLAY_MODE)
     department_id = schema.TextLine(
         title=_(
             u"title_department_id",
@@ -113,7 +125,6 @@ class IDepartmentSchema(model.Schema):
         if context and context.department_id == dpt_id:
             # nothing changed
             return
-        # TODO: Catalog query for same ID
         query = {
             "portal_type": "Department",
             "department_id": dpt_id,

--- a/src/senaite/core/content/department.py
+++ b/src/senaite/core/content/department.py
@@ -66,12 +66,10 @@ class IDepartmentSchema(model.Schema):
 
     # Department ID
     directives.widget("department_id",
-                      before_text="ID",
-                      before_css_class="text-secondary",
-                      before_text_omit_mode=DISPLAY_MODE,
-                      after_text="<i class='fas fa-id-card'></i>",
-                      after_css_class="text-primary",
-                      after_text_omit_mode=DISPLAY_MODE)
+                      before_text_edit="ID",
+                      before_css_class_edit="text-secondary",
+                      after_text_edit="<i class='fas fa-id-card'></i>",
+                      after_css_class_edit="text-primary")
     department_id = schema.TextLine(
         title=_(
             u"title_department_id",

--- a/src/senaite/core/content/department.py
+++ b/src/senaite/core/content/department.py
@@ -67,9 +67,11 @@ class IDepartmentSchema(model.Schema):
     # Department ID
     directives.widget("department_id",
                       before_text_edit="ID",
-                      before_css_class_edit="text-secondary",
-                      after_text_edit="<i class='fas fa-id-card'></i>",
-                      after_css_class_edit="text-primary")
+                      before_css_input="text-secondary",
+                      widget_css_display="text-primary text-monospace",
+                      widget_css_input="text-primary text-monospace",
+                      after_text_input="<i class='fas fa-id-card'></i>",
+                      after_css_input="text-primary")
     department_id = schema.TextLine(
         title=_(
             u"title_department_id",

--- a/src/senaite/core/content/department.py
+++ b/src/senaite/core/content/department.py
@@ -33,7 +33,6 @@ from senaite.core.content.base import Container
 from senaite.core.interfaces import IDepartment
 from senaite.core.schema import UIDReferenceField
 from senaite.core.z3cform.widgets.uidreference import UIDReferenceWidgetFactory
-from z3c.form.interfaces import DISPLAY_MODE
 from zope import schema
 from zope.interface import Invalid
 from zope.interface import implementer


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds the ability to prepend/append text to common widgets in view/edit modes.

<img width="753" src="https://github.com/user-attachments/assets/52d44dcc-72f7-48a8-8eab-542060c4b224">

Additional text can be added by using `directives.widget`:

```python
class IDepartmentSchema(model.Schema):
    """Schema interface
    """

    directives.widget("title",
                      before_text=">",
                      before_css_class="text-secondary",
                      after_text="<i class='fas fa-building'></i>",
                      after_css_class="text-primary",
                      wrapper_css_class="float-left mr-4")
    title = schema.TextLine(
        title=_(
            u"title_department_title",
            default=u"Name"
        ),
        description=_(
            u"description_department_title",
            default=u"Name of the department"
        ),
        required=True,
    )

    # Department ID
    directives.widget("department_id",
                      before_text_input="ID",
                      before_css_input="text-secondary",
                      widget_css_display="text-primary text-monospace",
                      widget_css_input="text-primary text-monospace",
                      after_text_input="<i class='fas fa-id-card'></i>",
                      after_css_input="text-primary")
    department_id = schema.TextLine(
        title=_(
            u"title_department_id",
            default=u"Department ID"
        ),
        description=_(
            u"description_department_id",
            default=u"Please provide a unique department identifier"
        ),
        required=True,
    )

```



## Current behavior before PR

Only plain widget rendering possible

## Desired behavior after PR is merged

Widgets can render with additional text before and after.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
