### PR TITLE
Fix Traceback in referencesample analyses listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2590 Fix Traceback in referencesample analyses listing
 - #2589 Fix reject report to fully conform with the ISO standard
 - #2588 Widget text extensions
 - #2586 Support multiple files for datagrid fields

--- a/src/bika/lims/browser/referencesample.py
+++ b/src/bika/lims/browser/referencesample.py
@@ -221,9 +221,9 @@ class ReferenceAnalysesView(AnalysesView):
 
         if not item:
             return None
-        ref_analysis = api.get_object(obj)
+        obj = api.get_object(obj)
         item["Category"] = obj.getCategoryTitle()
-        ws = ref_analysis.getWorksheet()
+        ws = obj.getWorksheet()
         if not ws:
             logger.warn(
                 "No Worksheet found for ReferenceAnalysis {}"


### PR DESCRIPTION


## Description of the issue/feature this PR addresses

This PR fixes a traceback that occurs when accessing referencesample analyses view, e.g. `http://localhost:8080/senaite/setup/suppliers/supplier-1/QC-001/analyses`

## Current behavior before PR

Traceback occurs:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module bika.lims.browser.referencesample, line 88, in __call__
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 215, in render
  Module chameleon.template, line 192, in render
  Module c0e4e4f05befc990cbc845319789a886, line 462, in render
  Module fba1ad8cf97631ac9ceec57f9cd95334, line 1428, in render_master
  Module fba1ad8cf97631ac9ceec57f9cd95334, line 407, in render_content
  Module c0e4e4f05befc990cbc845319789a886, line 386, in __fill_content_core
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module bika.lims.browser.referencesample, line 115, in get_analyses_table_view
  Module senaite.app.listing.decorators, line 88, in wrapper
  Module senaite.app.listing.ajax, line 259, in get_folderitems
  Module bika.lims.browser.analyses.view, line 803, in folderitems
  Module senaite.app.listing.view, line 982, in folderitems
  Module bika.lims.browser.referencesample, line 227, in folderitem
AttributeError: 'RequestContainer' object has no attribute 'getCategoryTitle'

 - Expression: "provider:plone.abovecontentbody"
 - Filename:   ... te/core/browser/main_template/templates/main_template.pt
 - Location:   (line 132: col 84)
 - Source:     ...
                                     ^
 - Expression: "here/main_template/macros/master"
 - Filename:   ... /bika/lims/browser/templates/referencesample_analyses.pt
 - Location:   (line 5: col 23)
 - Source:     metal:use-macro="here/main_template/macros/master"
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  repeat: <Products.PageTemplates.engine.RepeatDictWrapper object at 0x12a8675a0>
               template: <Products.Five.browser.pagetemplatefile.ViewPageTemplateFile object at 0x12b7f6bd0>
               views: <Products.Five.browser.pagetemplatefile.ViewMapper object at 0x12b1c3e50>
               request: <WSGIRequest, URL=http://localhost:8080/senaite/setup/suppliers/supplier-10/QC-003/analyses>
               args: ()
               here: <ReferenceSample at /senaite/setup/suppliers/supplier-10/QC-003>
               user: <PropertiedUser 'admin'>
               nothing: None
               root: <Application at >
               translate: <function translate at 0x1283b52d0>
               container: <ReferenceSample at /senaite/setup/suppliers/supplier-10/QC-003>
               macroname: u'master'
               modules: <Products.PageTemplates.ZRPythonExpr._SecureModuleImporter object at 0x10d2acb10>
               traverse_subpath: []
               default: <DEFAULT>
               loop: {}
               context: <ReferenceSample at /senaite/setup/suppliers/supplier-10/QC-003>
               view: <Products.Five.browser.metaconfigure.ReferenceAnalysesViewView object at 0x12b0b7490>
               target_language: None
               attrs: {}
               options: {}
```

## Desired behavior after PR is merged

No traceback occurs

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
