### PR TITLE
Fix Traceback for repeated migration of Suppliers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2594 Fix Traceback when running migration again for Suppliers
 - #2591 Remove CreationDate index from catalogs in favour of created
 - #2592 Remove Action Handler Pool
 - #2590 Fix Traceback in referencesample analyses listing

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -1752,6 +1752,11 @@ def migrate_suppliers_to_dx(tool):
     tool.runImportStepFromProfile(profile, "workflow")
 
     origin = api.get_setup().get("bika_suppliers")
+    if not origin:
+        # old container is already gone
+        return
+
+    # get the destination container
     destination = get_setup_folder("suppliers")
 
     # un-catalog the old container


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

[Linked issue: https://github.com/senaite/senaite.core/issues/](https://github.com/senaite/senaite.core/pull/2581#issuecomment-2250209871)

## Current behavior before PR

Received traceback when running migration for Suppliers again

## Desired behavior after PR is merged

Silently exit

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
