### PR TITLE
Fix Traceback in run upgrade for improve system performance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2596 Fix attribute getter after improve system performance upgrade
 - #2593 Always do a full reindex of the object after transition
 - #2593 Retrieve and store object's raw data on snapshot creation
 - #2593 Skip permissions update after transition when InternalUse is unchanged

--- a/src/bika/lims/browser/fields/aranalysesfield.py
+++ b/src/bika/lims/browser/fields/aranalysesfield.py
@@ -65,7 +65,9 @@ class ARAnalysesField(ObjectField):
 
     @security.public
     def getRaw(self, instance, **kw):
-        return getattr(instance, self.getName())
+        if hasattr(instance, self.getName()):
+            return getattr(instance, self.getName())
+        return []
 
     @security.private
     def setRaw(self, instance, uids):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Received traceback when running upgrade step ['Store analyses UIDs as raw data in samples'](https://github.com/senaite/senaite.core/pull/2593)

## Current behavior before PR

```shell
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.GenericSetup.tool, line 1135, in manage_doUpgrades
  Module Products.GenericSetup.upgrade, line 185, in doStep
  Module senaite.core.upgrade.v02_06_000, line 2286, in store_raw_analyses
  Module Products.Archetypes.ClassGen, line 67, in generatedEditAccessor
  Module bika.lims.browser.fields.aranalysesfield, line 68, in getRaw
AttributeError: 'RequestContainer' object has no attribute 'Analyses'
```

## Desired behavior after PR is merged

Without traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
