### PR TITLE
Fix getAnalyses returns a LazyMap instead of a list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2602 Fix getAnalyses returns a LazyMap instead of a list
 - #2593 Always do a full reindex of the object after transition
 - #2593 Store Analyses UIDs as raw data in a Sample's attr (Analyses)
 - #2593 Skip permissions update after transition when InternalUse is unchanged

--- a/src/senaite/core/datamanagers/field/sample_analyses.py
+++ b/src/senaite/core/datamanagers/field/sample_analyses.py
@@ -50,7 +50,7 @@ class SampleAnalysesFieldDataManager(FieldDataManager):
         brains = catalog(query)
         if kw.get("full_objects", False):
             return map(api.get_object, brains)
-        return brains
+        return list(brains)
 
     def set(self, items, prices, specs, hidden, **kw):
         """Set/Assign Analyses to this AR

--- a/src/senaite/core/tests/doctests/ARAnalysesField.rst
+++ b/src/senaite/core/tests/doctests/ARAnalysesField.rst
@@ -209,7 +209,7 @@ This field maintains `Analyses` within `AnalysesRequests`:
 Getting Analyses
 ~~~~~~~~~~~~~~~~
 
-The `get` method returns a list of assined analyses brains:
+The `get` method returns a list of assigned analyses brains:
 
     >>> field.get(ar)
     [<Products.ZCatalog.Catalog.mybrains object at ...>]
@@ -223,6 +223,11 @@ The analysis `PH` is now contained in the AR:
 
     >>> ar.objectValues("Analysis")
     [<Analysis at /plone/clients/client-1/water-0001/PH>]
+
+The `get` method does not return a `ZTUtils.Lazy.LazyMap`, but a list:
+
+    >>> type(field.get(ar))
+    <type 'list'>
 
 
 Setting Analyses


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes `ARAnalyses.get` to return a `list` when `full_objects=False` via DataManager (see https://github.com/senaite/senaite.core/pull/2595)

## Current behavior before PR

```python
(Pdb++) type(sample.getAnalyses())
<class 'ZTUtils.Lazy.LazyMap'>
```

## Desired behavior after PR is merged


```python
(Pdb++) type(sample.getAnalyses())
<type 'list'>

```

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
