### PR TITLE
Rollback ARAnalysesField's getRaw behavior

### DIFF
--- a/src/bika/lims/browser/fields/aranalysesfield.py
+++ b/src/bika/lims/browser/fields/aranalysesfield.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 from AccessControl import ClassSecurityInfo
+from bika.lims import api
 from bika.lims.interfaces import IARAnalysesField
 from Products.Archetypes.public import Field
 from Products.Archetypes.public import ObjectField
@@ -66,7 +67,7 @@ class ARAnalysesField(ObjectField):
     @security.public
     def getRaw(self, instance, **kw):
         brains = self.get(instance)
-        return [brain.UID for brain in brains]
+        return [api.get_uid(brain) for brain in brains]
 
 
 registerField(ARAnalysesField,

--- a/src/bika/lims/browser/fields/aranalysesfield.py
+++ b/src/bika/lims/browser/fields/aranalysesfield.py
@@ -65,12 +65,12 @@ class ARAnalysesField(ObjectField):
 
     @security.public
     def getRaw(self, instance, **kw):
-        return getattr(instance, self.getName(), [])
+        brains = self.get(instance)
+        return [brain.UID for brain in brains]
 
     @security.private
     def setRaw(self, instance, uids):
-        uids = uids if uids else []
-        setattr(instance, self.getName(), uids)
+        return
 
 
 registerField(ARAnalysesField,

--- a/src/bika/lims/browser/fields/aranalysesfield.py
+++ b/src/bika/lims/browser/fields/aranalysesfield.py
@@ -68,10 +68,6 @@ class ARAnalysesField(ObjectField):
         brains = self.get(instance)
         return [brain.UID for brain in brains]
 
-    @security.private
-    def setRaw(self, instance, uids):
-        return
-
 
 registerField(ARAnalysesField,
               title="Analyses",

--- a/src/senaite/core/datamanagers/field/sample_analyses.py
+++ b/src/senaite/core/datamanagers/field/sample_analyses.py
@@ -114,12 +114,6 @@ class SampleAnalysesFieldDataManager(FieldDataManager):
         # Remove analyses
         map(self.remove_analysis, to_remove)
 
-        # Store the uids in instance's attribute for this field
-        # Note we only store the UIDs of the contained analyses!
-        contained = self.context.objectValues("Analysis")
-        contained_uids = [analysis.UID() for analysis in contained]
-        self.field.setRaw(self.context, contained_uids)
-
     def resolve_specs(self, instance, results_ranges):
         """Returns a dictionary where the key is the service_uid and the value
         is its results range. The dictionary is made by extending the

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2645</version>
+  <version>2646</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/tests/doctests/ARAnalysesFieldWithPartitions.rst
+++ b/src/senaite/core/tests/doctests/ARAnalysesFieldWithPartitions.rst
@@ -112,6 +112,21 @@ Get the field data manager to play with:
     >>> field = sample.getField("Analyses")
     >>> dm = queryMultiAdapter((sample, self.request, field), interface=IDataManager, name="Analyses")
 
+get vs getRaw
+~~~~~~~~~~~~~
+
+`getRaw` returns the UIDs of same analyses returned by default by `get`. This
+is, analyses from partitions included:
+
+    >>> brains = field.get(sample)
+    >>> brain_uids = sorted([brain.UID for brain in brains])
+    >>> len(brain_uids)
+    2
+
+    >>> uids = field.getRaw(sample)
+    >>> brain_uids == sorted(uids)
+    True
+
 get_from_instance
 ~~~~~~~~~~~~~~~~~
 

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -2295,3 +2295,22 @@ def store_raw_analyses(tool):
         sample._p_deactivate()
 
     logger.info("Storing analysis UIDs as raw data in samples [DONE]")
+
+
+def del_raw_analyses(tool):
+    logger.info("Remove Analyses raw attribute from samples ...")
+    query = {"portal_type": "AnalysisRequest"}
+    brains = api.search(query, SAMPLE_CATALOG)
+    total = len(brains)
+    for num, brain in enumerate(brains):
+        if num and num % 100 == 0:
+            logger.info("Removing Analyses raw attribute from samples {0}/{1}"
+                        .format(num, total))
+
+        sample = api.get_object(brain)
+        if hasattr(sample, "Analyses"):
+            delattr(sample, "Analyses")
+
+        sample._p_deactivate()
+
+    logger.info("Remove Analyses raw attribute from samples [DONE]")

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -2274,26 +2274,8 @@ def remove_creation_date_index(tool):
 
 def store_raw_analyses(tool):
     logger.info("Storing analysis UIDs as raw data in samples ...")
-    query = {"portal_type": "AnalysisRequest"}
-    brains = api.search(query, SAMPLE_CATALOG)
-    total = len(brains)
-    for num, brain in enumerate(brains):
-        if num and num % 100 == 0:
-            logger.info("Storing analysis UIDs as raw data in samples {0}/{1}"
-                        .format(num, total))
-
-        sample = api.get_object(brain)
-        if sample.getRawAnalyses():
-            # already set, skip
-            continue
-
-        # Store the UIDs of the analyses from the sample on it's own attr
-        contained = sample.objectValues("Analysis")
-        contained_uids = [analysis.UID() for analysis in contained]
-        field = sample.getField("Analyses")
-        field.setRaw(sample, contained_uids)
-        sample._p_deactivate()
-
+    # Rolled back
+    # see https://github.com/senaite/senaite.core/pull/2603
     logger.info("Storing analysis UIDs as raw data in samples [DONE]")
 
 

--- a/src/senaite/core/upgrade/v02_06_000.zcml
+++ b/src/senaite/core/upgrade/v02_06_000.zcml
@@ -4,6 +4,14 @@
     i18n_domain="senaite.core">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.6.0: Remove Analyses raw attribute from samples"
+      description="Remove Analyses raw attribute from samples"
+      source="2645"
+      destination="2646"
+      handler=".v02_06_000.del_raw_analyses"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.6.0: Store analyses UIDs as raw data in samples"
       description="Store analyses UIDs as raw data in samples"
       source="2644"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`getRaw` function for `ARAnalysesField` was introduced with https://github.com/senaite/senaite.core/pull/2593 , but there are too many side-effects.

Keeping a list of UIDs in-sync in this case is challenging, cause we need to keep that list up-to-date in event subscribers (on creation and on removal). And this might entail issues (e.g. you never know which subscriber is called first). Reason is that, except on sample creation and on manage analyses, we always create analyses programmatically (e.g by using [create_analysis](https://github.com/senaite/senaite.core/blob/2.x/src/bika/lims/utils/analysis.py#L33). For instance, when we create a retest.

Making `getRaw` to rely on `instance.objectValues('Analysis')` instead of relying on an object attribute could be considered as an alternative. However, `objectValues` wakes up all the contained objects. A query against the catalog will be faster, cause we get brains instead. In such scenario, there is no benefit compared to what we had before https://github.com/senaite/senaite.core/pull/2593 . Likewise, having an inconsistency between the values returned by `getRaw` and `get` is also not worth.

Therefore, this Pull Request reverts back the attribute `Analyses` that was handled by `ARAnalysesField` and although it keeps the `getRaw` function, it is now consistent with the brains returned by default by `get`.

## Current behavior before PR

Too many side-effects because of the need of keeping `Analyses` attribute up-to-date

## Desired behavior after PR is merged

Analyses UIDs are no longer kept in an object attribute. `getRaw` is consistent with `getAnalyses`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
