### PR TITLE
Fix clashing upgrade step number

### DIFF
--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2646</version>
+  <version>2647</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/v02_06_000.zcml
+++ b/src/senaite/core/upgrade/v02_06_000.zcml
@@ -6,8 +6,8 @@
    <genericsetup:upgradeStep
       title="SENAITE.CORE 2.6.0: Move SampleType to Senaite setup"
       description="Migrate Sample Types to Senaite setup"
-      source="2645"
-      destination="2646"
+      source="2646"
+      destination="2647"
       handler=".v02_06_000.migrate_sampletypes_to_dx"
       profile="senaite.core:default"/>
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is complementary to https://github.com/senaite/senaite.core/pull/2584

## Current behavior before PR

Upgrade step `2646` was already taken by https://github.com/senaite/senaite.core/pull/2603

## Desired behavior after PR is merged

Use upgrade step `2647` instaed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
