### PR TITLE
Fix type error for admitted sticker templates widget

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2608 Fix type error for admitted sticker templates widget
 - #2604 Fix allowable and default output type for Html field in the ARReport
 - #2584 Migrate SampleTypes to Dexterity
 - #2602 Fix getAnalyses returns a LazyMap instead of a list

--- a/src/senaite/core/content/sampletype.py
+++ b/src/senaite/core/content/sampletype.py
@@ -44,8 +44,12 @@ from zope.interface import Interface
 from zope.interface import Invalid
 from zope.interface import implementer
 
-
-STICKERS_VOCABULARY = 'senaite.core.vocabularies.stickertemplates'
+STICKERS_VOCABULARY = "senaite.core.vocabularies.stickertemplates"
+DEFAULT_ADMITTED_STICKER_TEMPLATES = [{
+    "admitted": set(),
+    "small_default": None,
+    "large_default": None
+}]
 
 
 def default_retention_period():
@@ -58,10 +62,10 @@ def default_retention_period():
 def prefix_whitespaces_constraint(value):
     """Check that the prefix does not contain whitespaces
     """
-    if ' ' in value:
+    if " " in value:
         raise Invalid(_(
             u"sampletype_prefix_whitespace_validator_message",
-            default=u'No whitespaces in prefix allowed'
+            default=u"No whitespaces in prefix allowed"
         ))
     return True
 
@@ -73,7 +77,7 @@ class IStickersRecordSchema(Interface):
     admitted = schema.Set(
         title=_(
             u"label_sampletype_admitted",
-            default=u'Admitted stickers for the sample type'
+            default=u"Admitted stickers for the sample type"
         ),
         value_type=schema.Choice(
             vocabulary=STICKERS_VOCABULARY,
@@ -84,7 +88,7 @@ class IStickersRecordSchema(Interface):
     small_default = schema.Choice(
         title=_(
             u"label_sampletype_small_default",
-            default=u'Default small sticker'
+            default=u"Default small sticker"
         ),
         vocabulary=STICKERS_VOCABULARY,
         required=False,
@@ -93,7 +97,7 @@ class IStickersRecordSchema(Interface):
     large_default = schema.Choice(
         title=_(
             u"label_sampletype_large_default",
-            default=u'Default large sticker'
+            default=u"Default large sticker"
         ),
         vocabulary=STICKERS_VOCABULARY,
         required=False,
@@ -238,11 +242,7 @@ class ISampleTypeSchema(model.Schema):
                               u"this sample type."),
         value_type=DataGridRow(schema=IStickersRecordSchema),
         required=True,
-        default=[{
-            'admitted': set(),
-            'small_default': None,
-            'large_default': None
-        }]
+        default=DEFAULT_ADMITTED_STICKER_TEMPLATES,
     )
 
 
@@ -260,16 +260,16 @@ class StickersFieldValidator(validator.SimpleFieldValidator):
         if len(value) == 1:
             valid = True
             errors = []
-            if not len(value[0]['admitted']):
+            if not len(value[0]["admitted"]):
                 valid = False
                 errors.append(
-                    _(u'at least one admitted sticker must be chosen'))
-            if not value[0]['small_default']:
+                    _(u"at least one admitted sticker must be chosen"))
+            if not value[0]["small_default"]:
                 valid = False
-                errors.append(_(u'select small default sticker'))
-            if not value[0]['large_default']:
+                errors.append(_(u"select small default sticker"))
+            if not value[0]["large_default"]:
                 valid = False
-                errors.append(_(u'select large default sticker'))
+                errors.append(_(u"select large default sticker"))
             msg = _(u"ERRORS: ") + ", ".join(errors)
 
         if not valid:
@@ -394,6 +394,10 @@ class SampleType(Container):
     @security.protected(permissions.ModifyPortalContent)
     def setAdmittedStickerTemplates(self, value):
         mutator = self.mutator("admitted_sticker_templates")
+        # ensure list and filter out empty dictionaries
+        value = filter(None, api.to_list(value))
+        if not value:
+            value = DEFAULT_ADMITTED_STICKER_TEMPLATES
         mutator(self, value)
 
     # BBB: AT schema field property
@@ -406,7 +410,7 @@ class SampleType(Container):
 
         :return: An array of sticker IDs
         """
-        admitted = self.getAdmittedStickerTemplates()[0].get('admitted')
+        admitted = self.getAdmittedStickerTemplates()[0].get("admitted")
         if admitted:
             return admitted
         return []
@@ -417,7 +421,7 @@ class SampleType(Container):
 
         :return: A string as an sticker ID
         """
-        return self.getAdmittedStickerTemplates()[0].get('small_default')
+        return self.getAdmittedStickerTemplates()[0].get("small_default")
 
     def getDefaultLargeSticker(self):
         """
@@ -425,4 +429,4 @@ class SampleType(Container):
 
         :return: A string as an sticker ID
         """
-        return self.getAdmittedStickerTemplates()[0].get('large_default')
+        return self.getAdmittedStickerTemplates()[0].get("large_default")

--- a/src/senaite/core/content/sampletype.py
+++ b/src/senaite/core/content/sampletype.py
@@ -18,11 +18,12 @@
 # Copyright 2018-2024 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from datetime import timedelta
+
 from AccessControl import ClassSecurityInfo
 from bika.lims import api
 from bika.lims import senaiteMessageFactory as _
 from bika.lims.interfaces import IDeactivable
-from datetime import timedelta
 from plone.autoform import directives
 from plone.supermodel import model
 from Products.CMFCore import permissions
@@ -37,11 +38,11 @@ from senaite.core.schema.fields import DataGridRow
 from senaite.core.z3cform.widgets.datagrid import DataGridWidgetFactory
 from senaite.core.z3cform.widgets.duration.widget import DurationWidgetFactory
 from senaite.core.z3cform.widgets.uidreference import UIDReferenceWidgetFactory
-from zope import schema
 from z3c.form import validator
-from zope.interface import implementer
+from zope import schema
 from zope.interface import Interface
 from zope.interface import Invalid
+from zope.interface import implementer
 
 
 STICKERS_VOCABULARY = 'senaite.core.vocabularies.stickertemplates'

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2647</version>
+  <version>2648</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -2454,7 +2454,7 @@ def ensure_valid_sticker_templates(tool):
     total = len(brains)
     for num, brain in enumerate(brains):
         logger.info("Ensure sample types have valid sticker templates {0}/{1}"
-                    .format(num, total))
+                    .format(num+1, total))
         obj = api.get_object(brain)
         obj.setAdmittedStickerTemplates(obj.getAdmittedStickerTemplates())
     logger.info("Ensure sample types have valid sticker templates [DONE]")

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -2445,3 +2445,16 @@ def del_raw_analyses(tool):
         sample._p_deactivate()
 
     logger.info("Remove Analyses raw attribute from samples [DONE]")
+
+
+def ensure_valid_sticker_templates(tool):
+    logger.info("Ensure sample types have valid sticker templates ...")
+    query = {"portal_type": "SampleType"}
+    brains = api.search(query, SETUP_CATALOG)
+    total = len(brains)
+    for num, brain in enumerate(brains):
+        logger.info("Ensure sample types have valid sticker templates {0}/{1}"
+                    .format(num, total))
+        obj = api.get_object(brain)
+        obj.setAdmittedStickerTemplates(obj.getAdmittedStickerTemplates())
+    logger.info("Ensure sample types have valid sticker templates [DONE]")

--- a/src/senaite/core/upgrade/v02_06_000.zcml
+++ b/src/senaite/core/upgrade/v02_06_000.zcml
@@ -4,6 +4,14 @@
     i18n_domain="senaite.core">
 
    <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.6.0: Ensure valid sticker templates"
+      description="Ensure migrated sample types have valid sticker templates set"
+      source="2647"
+      destination="2648"
+      handler=".v02_06_000.ensure_valid_sticker_templates"
+      profile="senaite.core:default"/>
+
+   <genericsetup:upgradeStep
       title="SENAITE.CORE 2.6.0: Move SampleType to Senaite setup"
       description="Migrate Sample Types to Senaite setup"
       source="2646"

--- a/src/senaite/core/vocabularies/stickertemplates.py
+++ b/src/senaite/core/vocabularies/stickertemplates.py
@@ -29,7 +29,7 @@ class StickerTemplatesVocabulary(object):
 
     def __call__(self, context, filter_by_type=False):
         templates = getStickerTemplates(filter_by_type=filter_by_type)
-        return to_simple_vocabulary([(t['id'], t['title']) for t in templates])
+        return to_simple_vocabulary([(t["id"], t["title"]) for t in templates])
 
 
 StickerTemplatesVocabularyFactory = StickerTemplatesVocabulary()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is complementary to https://github.com/senaite/senaite.core/pull/2584 

The following traceback occurs, because the migrated sticker templates are set to `[{}]`:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module plone.autoform.view, line 42, in __call__
  Module plone.autoform.view, line 33, in render
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module f278745d4236cfe7df532e8a8d574e0e, line 517, in render
  Module 82b23ba6dc88305900870d9ad3b88696, line 1428, in render_master
  Module 82b23ba6dc88305900870d9ad3b88696, line 407, in render_content
  Module f278745d4236cfe7df532e8a8d574e0e, line 502, in __fill_content_core
  Module f278745d4236cfe7df532e8a8d574e0e, line 151, in render_content_core
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module zope.browserpage.simpleviewclass, line 41, in __call__
  Module zope.browserpage.viewpagetemplatefile, line 81, in __call__
  Module zope.browserpage.viewpagetemplatefile, line 49, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module dd38b593084195e8308561b531913cf3, line 898, in render
  Module dd38b593084195e8308561b531913cf3, line 725, in render_widget_wrapper
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module z3c.form.widget, line 156, in render
  Module zope.browserpage.viewpagetemplatefile, line 49, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module d32d361afd5650641dad4b6efc33a606, line 488, in render
  Module d32d361afd5650641dad4b6efc33a606, line 122, in render_widget_row
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module collective.z3cform.datagridfield.datagridfield, line 324, in render
  Module z3c.form.object, line 310, in render
  Module z3c.form.widget, line 156, in render
  Module zope.browserpage.viewpagetemplatefile, line 49, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module 4339159092d213fd06e7e144be3053fc, line 197, in render
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module z3c.form.widget, line 156, in render
  Module zope.browserpage.viewpagetemplatefile, line 49, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 215, in render
  Module chameleon.template, line 192, in render
  Module 788929a44b54c1d75e3e54ac3f6a0da7, line 348, in render
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 217, in _eval
  Module zope.tales.expressions, line 153, in _eval
  Module Products.PageTemplates.Expressions, line 134, in trustedBoboAwareZopeTraverse
  Module zope.traversing.adapters, line 156, in traversePathElement
   - __traceback_info__: (<SelectWidget 'form.widgets.admitted_sticker_templates.0.widgets.admitted'>, 'displayValue')
  Module zope.traversing.adapters, line 47, in traverse
   - __traceback_info__: (<SelectWidget 'form.widgets.admitted_sticker_templates.0.widgets.admitted'>, 'displayValue', [])
  Module z3c.form.widget, line 208, in displayValue
TypeError: 'NO_VALUE' object is not iterable

 - Expression: "view/displayValue"
 - Filename:   ... .form-3.7.1-py2.7.egg/z3c/form/browser/select_display.pt
 - Location:   (line 20: col 18)
 - Source:     repeat="value view/displayValue"
                             ^^^^^^^^^^^^^^^^^
 - Expression: "widget/render"
 - Filename:   ... ite/core/z3cform/widgets/datagrid/datagridrow_display.pt
 - Location:   (line 7: col 32)
 - Source:     ... div tal:replace="structure widget/render"></div>
                                              ^^^^^^^^^^^^^
 - Expression: "widget/render"
 - Filename:   ... enaite/core/z3cform/widgets/datagrid/datagrid_display.pt
 - Location:   (line 36: col 42)
 - Source:     ... div tal:replace="structure widget/render"></div>
                                              ^^^^^^^^^^^^^
 - Expression: "widget/render"
 - Filename:   ... e/src/senaite/core/browser/dexterity/templates/widget.pt
 - Location:   (line 63: col 34)
 - Source:     tal:replace="structure widget/render"
                                      ^^^^^^^^^^^^^
 - Expression: "widget/@@ploneform-render-widget"
 - Filename:   ... rc/senaite/core/browser/dexterity/templates/container.pt
 - Location:   (line 15: col 47)
 - Source:     ... place="structure widget/@@ploneform-render-widget"/>
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Expression: "provider:plone.abovecontentbody"
 - Filename:   ... te/core/browser/main_template/templates/main_template.pt
 - Location:   (line 132: col 84)
 - Source:     ... 
                                     ^
 - Expression: "context/@@main_template/macros/master"
 - Filename:   ... rc/senaite/core/browser/dexterity/templates/container.pt
 - Location:   (line 6: col 23)
 - Source:     ... tal:use-macro="context/@@main_template/macros/master"
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  repeat: <Products.PageTemplates.engine.RepeatDictWrapper object at 0x130d57f50>
               context: {}
               views: <zope.browserpage.viewpagetemplatefile.ViewMapper object at 0x12d222810>
               modules: <zope.pagetemplate.engine.TraversableModuleImporter object at 0x102704410>
               args: ()
               attrs: {}
               nothing: None
               target_language: None
               default: <DEFAULT>
               request: <WSGIRequest, URL=http://localhost:8080/bikalims/setup/sampletypes/sampletype-9/view>
               loop: {}
               template: <zope.browserpage.viewpagetemplatefile.ViewPageTemplateFile object at 0x10a3a20d0>
               translate: <function translate at 0x122df95d0>
               options: {}
               view: <SelectWidget 'form.widgets.admitted_sticker_templates.0.widgets.admitted'>
```


## Current behavior before PR

Some migrated instances raise a `TypeError` after migration, because the admitted sticker templates are set to `[{}]`

## Desired behavior after PR is merged

Valid admitted sticker templates are set and the edit view is working properly.
 
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
