### PR TITLE
Fix "Other reasons" for rejection are not saved on sample registration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2610 Fix sample is not auto-rejected when only other reasons is submitted
 - #2608 Fix type error for admitted sticker templates widget
 - #2604 Fix allowable and default output type for Html field in the ARReport
 - #2584 Migrate SampleTypes to Dexterity

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
-- #2610 Fix sample is not auto-rejected when only other reasons is submitted
+- #2610 Fix "Other reasons" for rejection are not saved on sample registration
 - #2608 Fix type error for admitted sticker templates widget
 - #2604 Fix allowable and default output type for Html field in the ARReport
 - #2584 Migrate SampleTypes to Dexterity

--- a/src/bika/lims/skins/bika/bika_widgets/rejectionwidget.pt
+++ b/src/bika/lims/skins/bika/bika_widgets/rejectionwidget.pt
@@ -64,8 +64,8 @@
                     <div class="other-text">
                         <input type="text"
                             tal:attributes="
-                                name string:${fieldName}.textfield.other:records;
-                                id string:${fieldName}.textfield.other;"
+                              name string:${fieldName}.other:records;
+                              id string:${fieldName}.other;"
                             size="20"
                             tabindex="#"
                             class="rejectionwidget-input-other rejectionwidget-field"/>

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -508,30 +508,27 @@ def resolve_rejection_reasons(values):
     """Resolves the rejection reasons from the submitted values to the format
     supported by Sample's Rejection Reason field
     """
-    rejection_reasons = values.get("RejectionReasons")
-    if not rejection_reasons:
+    reasons = values.get("RejectionReasons")
+    if not reasons:
+        return []
+
+    # XXX RejectionReasons returns a list with a single dict
+    reasons = reasons[0] or {}
+    if reasons.get("checkbox") != "on":
+        # reasons entry is toggled off
         return []
 
     # Predefined reasons selected?
-    selected = rejection_reasons[0] or {}
-    if selected.get("checkbox") == "on":
-        selected = selected.get("multiselection") or []
-    else:
-        selected = []
+    selected = reasons.get("multiselection") or []
 
     # Other reasons set?
-    other = values.get("RejectionReasons.textfield")
-    if other:
-        other = other[0] or {}
-        other = other.get("other", "")
-    else:
-        other = ""
+    other = reasons.get("other") or ""
 
     # If neither selected nor other reasons are set, return empty
-    if any([selected, other]):
-        return [{"selected": selected, "other": other}]
+    if not any([selected, other]):
+        return []
 
-    return []
+    return [{"selected": selected, "other": other}]
 
 
 def do_rejection(sample, notify=None):

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -525,10 +525,10 @@ def resolve_rejection_reasons(values):
     other = reasons.get("other") or ""
 
     # If neither selected nor other reasons are set, return empty
-    if not any([selected, other]):
-        return []
+    if any([selected, other]):
+        return [{"selected": selected, "other": other}]
 
-    return [{"selected": selected, "other": other}]
+    return []
 
 
 def do_rejection(sample, notify=None):

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -508,12 +508,12 @@ def resolve_rejection_reasons(values):
     """Resolves the rejection reasons from the submitted values to the format
     supported by Sample's Rejection Reason field
     """
-    reasons = values.get("RejectionReasons")
-    if not reasons:
+    rejection_reasons = values.get("RejectionReasons")
+    if not rejection_reasons:
         return []
 
     # XXX RejectionReasons returns a list with a single dict
-    reasons = reasons[0] or {}
+    reasons = rejection_reasons[0] or {}
     if reasons.get("checkbox") != "on":
         # reasons entry is toggled off
         return []


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes that the sample is not automatically rejected when using "Other reasons" only without selecting predefined reasons in sample add form:

![Captura de 2024-08-22 17-20-46](https://github.com/user-attachments/assets/7a7c7b9a-5ded-4bc9-bfc3-5494e9ba4e5b)

The sample is created and transitioned as usual (to sample_due or received) instead.

## Current behavior before PR

Sample is not automatically rejected when using "Other reasons" only in sample add form

## Desired behavior after PR is merged

Sample is automatically rejected when using "Other reasons" only in sample add form

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
