### PR TITLE
Fix AttributeError for transitions created with core's workflow api

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2613 Fix AttributeError for transitions created with core's workflow api
 - #2612 Remove isSampleReceived index from analysis catalog
 - #2611 Add readonly support for non-mutable html elements via AjaxEditForm
 - #2609 Added Date Sample required (Y/N) setting in Setup

--- a/src/senaite/core/api/workflow.py
+++ b/src/senaite/core/api/workflow.py
@@ -338,7 +338,7 @@ def update_transition(transition, **kwargs):
     }
     properties = {}
     for key, property_id in mapping.items():
-        default = getattr(transition, property_id)
+        default = getattr(transition, property_id) or ""
         value = kwargs.get(key, None)
         if value is None:
             value = default

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2649</version>
+  <version>2650</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -31,6 +31,7 @@ from plone.namedfile import NamedBlobFile
 from Products.Archetypes.utils import getRelURL
 from Products.CMFCore.permissions import View
 from senaite.core import logger
+from senaite.core.api import workflow as wapi
 from senaite.core.api.catalog import del_index
 from senaite.core.api.catalog import reindex_index
 from senaite.core.catalog import ANALYSIS_CATALOG
@@ -2465,3 +2466,17 @@ def remove_is_sample_received_index(tool):
     cat = api.get_tool(ANALYSIS_CATALOG)
     del_index(cat, "isSampleReceived")
     logger.info("Removing isSampleReceived index from catalogs [DONE]")
+
+
+def fix_corrupted_transitions(tool):
+    logger.info("Fixing corrupted transitions ...")
+    wf_tool = api.get_tool("portal_workflow")
+    for wf_id in wf_tool.getWorkflowIds():
+        wf = wf_tool.getWorkflowById(wf_id)
+        for transition_id, transition in wf.transitions.items():
+            after_script = getattr(transition, "after_script_name")
+            if after_script in ["None", None]:
+                logger.info("Fixing %s.%s" % (wf_id, transition_id))
+                wapi.update_transition(transition, after_script="")
+
+    logger.info("Fixing corrupted transitions [DONE]")

--- a/src/senaite/core/upgrade/v02_06_000.zcml
+++ b/src/senaite/core/upgrade/v02_06_000.zcml
@@ -4,6 +4,15 @@
     i18n_domain="senaite.core">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.6.0: Fix corrupted transitions"
+      description="Restores the value of the property `after_script_name` from
+        transitions that were created or updated with the core's workflow api"
+      source="2649"
+      destination="2650"
+      handler=".v02_06_000.fix_corrupted_transitions"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.6.0: Remove isSampleReceived index"
       description="Remove isSampleReceived index"
       source="2648"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes an `AttributeError` that arises when triggering transitions that were created or updated by using `senaite.core.api.workflow` because the transition property `script_after_name` (*Script (after)*) was wrongly set to `'None'`:

![Captura de 2024-08-28 17-30-13](https://github.com/user-attachments/assets/c0dc9466-9ba2-45d3-ac33-3d8b02d9389d)

The value of `script_after_name` for `Transition` instances is initialized as `None` by default, although the rest of attributes (except `guard`) are initialized with empty string `''`: https://github.com/zopefoundation/Products.DCWorkflow/blob/master/src/Products/DCWorkflow/Transitions.py#L45-L56

However, on `setProperties`, the system stringifies the values and therefore, the value of the attribute becomes `'None'` instead:

```python
>>> from senaite.core.api import workflow as wapi
>>> wf = wapi.get_workflow(SAMPLE_WORKFLOW)
>>> # Add a new 'dumb' transition using DCWorkflow
>>> wf.transitions.addTransition("dumb")
>>> dumb = wf.transitions.get("dumb")
>>> getattr(dumb, "after_script_name") is None
True
>>> dumb.setProperties("Dumb", "", after_script_name=None)
>>> getattr(dumb, "after_script_name") is None
False
>>> getattr(dumb, "after_script_name")
'None'
```

This Pull Request makes `senaite.core.api.workflow` to be aware of this inconsistent behavior when updating/creating transitions.

## Current behavior before PR

The value for attribute `after_script_name` of transitions updated or created with core's workflow API have a `'None'` value (as string)

```python
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module bika.lims.browser.workflow, line 153, in __call__
  Module bika.lims.browser.workflow, line 164, in __call__
  Module bika.lims.browser.workflow, line 182, in do_action
  Module bika.lims.workflow, line 99, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 252, in doActionFor
  Module Products.CMFCore.WorkflowTool, line 537, in _invokeWithNotification
AttributeError: 'exceptions.KeyError' object has no attribute 'with_traceback'
```

## Desired behavior after PR is merged

The value for attribute `after_script_name` of transitions updated or created with core's workflow API have a `None` value

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
