### PR TITLE
Fix autofill for simple fields when create Sample in the add form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2614 Fix autofill for simple fields when create Sample in the add form
 - #2613 Fix AttributeError for transitions created with core's workflow api
 - #2612 Remove isSampleReceived index from analysis catalog
 - #2611 Add readonly support for non-mutable html elements via AjaxEditForm

--- a/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
@@ -614,10 +614,6 @@
       me = this;
       values_json = JSON.stringify(values);
       field = $("#" + field_name + ("-" + arnum));
-      controller = this.get_widget_controller(field);
-      if (!controller) {
-        return;
-      }
       console.debug("apply_dependent_value: field_name=" + field_name + " field_values=" + values_json);
       if (this.is_reference_field(field)) {
         manually_deselected = this.deselected_uids[field_name] || [];

--- a/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -583,11 +583,6 @@ class window.AnalysisRequestAdd
     values_json = JSON.stringify values
     field = $("#" + field_name + "-#{arnum}")
 
-    controller = @get_widget_controller(field)
-    # No controller found, return immediately
-    # -> happens when the field is hidden or absent
-    return unless controller
-
     console.debug "apply_dependent_value: field_name=#{field_name} field_values=#{values_json}"
 
     # (multi-) reference fields, e.g. CC Contacts of selected Contact


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When filling `add` form for new AnalysisRequest running `recalculate_records` request and received data for filling other fields. Meanwhile received data for fields where not have frontend controller such as `CCEmails`(simple fields)

## Current behavior before PR

Method `apply_dependent_value` in the `bika.lims.analysisrequest.add.coffee` does not continue execution if not found controller for such fields. 

## Desired behavior after PR is merged

Simple fields that do not have frontend-controllers are filled in anyway

_but if fields hidden(in the manager form fields) that they do not have `id` attribute and will not affect the filling in any way._ 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
