### PR TITLE
Add control for select/deselect all attachments when send report

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2615 Add control for select/deselect all attachments when send report
 - #2613 Fix AttributeError for transitions created with core's workflow api
 - #2612 Remove isSampleReceived index from analysis catalog
 - #2611 Add readonly support for non-mutable html elements via AjaxEditForm

--- a/src/bika/lims/browser/publish/static/coffee/email.coffee
+++ b/src/bika/lims/browser/publish/static/coffee/email.coffee
@@ -55,8 +55,10 @@ class EmailController
     $("body").on "click", "#add-attachments", @on_add_attachments_click
 
     # Select/deselect additional attachments
-    $("body").on "change", ".attachments input[type='checkbox']", @on_attachments_select
+    $("body").on "change", ".attachment input[type='checkbox']", @on_attachments_select
 
+    # Select/deselect all additional attachments
+    $("body").on "change", "#select-all-attachments", @on_change_select_all_attachments
 
   get_base_url: ->
     ###
@@ -162,8 +164,22 @@ class EmailController
     # form_data = form.serialize()
     form_data = new FormData(form[0])
 
+    count_attachments = $("input[name='attachment_uids:list']").length
+    select_attachments = form_data.getAll("attachment_uids:list").length
+    select_all_checked = count_attachments == select_attachments;
+    $("#select-all-attachments").prop "checked", select_all_checked
+
     init =
       body: form_data
     @ajax_fetch "recalculate_size", init
     .then (data) =>
       @update_size_info data
+
+
+  on_change_select_all_attachments: (event) =>
+    console.debug "°°° Email::on_change_select_all_attachments"
+
+    checked = event.target.checked
+    $("input[name='attachment_uids:list']").each (index, element) ->
+      $(element).prop "checked", checked
+    @on_attachments_select()

--- a/src/bika/lims/browser/publish/templates/email.pt
+++ b/src/bika/lims/browser/publish/templates/email.pt
@@ -164,6 +164,10 @@
             <div id="additional-attachments-container"
                  class="attachments row"
                  tal:condition="python:any(attachments)">
+              <div>
+                <label i18n:translate="" for="select_all_attachments">Select all:</label>
+                <input type="checkbox" name="select_all_attachments" id="select-all-attachments" />
+              </div>
               <!-- Additional Attachments -->
               <tal:reports repeat="report view/reports_data">
                 <tal:attachments repeat="attachment report/attachments">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Micro improvement for selecting all attachments for sending report

## Current behavior before PR

No control

## Desired behavior after PR is merged

Сan select all attachments with one click

![Screenshot 2024-09-06 at 13 54 14](https://github.com/user-attachments/assets/649b18c6-c4e8-4a08-88d1-109d27ac3681)

_NOTE: used CoffeeScript v2.7.0 for compile to js-script_

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
