### PR TITLE
Fix reference field flush in add sample form when sort_limit is used

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2616 Fix reference field flush in add sample form when sort_limit is used
 - #2613 Fix AttributeError for transitions created with core's workflow api
 - #2612 Remove isSampleReceived index from analysis catalog
 - #2611 Add readonly support for non-mutable html elements via AjaxEditForm

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1127,6 +1127,9 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         label = payload.get("label", "")
         field = label or name
 
+        # Remove sort_limit to prevent false negatives
+        query.pop("sort_limit", None)
+
         # Skip the catalog search if we can assume to be allowed
         white_keys = ["portal_type", "sort_on", "sort_order", "is_active"]
         if set(query.keys()).issubset(white_keys):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request prevents the system to flush reference fields in sample add form when `sort_limit` is used in the field's default query and the selected item is not within the first `n` elements of the search results.

The JSON call `is_reference_value_allowed` relies on the field's default query, `sort_limit` criteria included, to check if a given UID is supported. 

![Captura de 2024-09-06 21-00-02](https://github.com/user-attachments/assets/dc00b1fd-be43-49c7-b50c-f91acd92d1d7)

## Current behavior before PR

The value of a field with `sort_limit` set in the default query is flushed when the UID is not present within the first `n` elements

## Desired behavior after PR is merged

`sort_limit` is not considered when checking if the reference value is allowed and therefore, the field is not flushed.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
