### PR TITLE
Fix cannot set/edit the name/title of InterpretationTemplate objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2617 Fix cannot set/edit the name/title of InterpretationTemplate objects
 - #2613 Fix AttributeError for transitions created with core's workflow api
 - #2612 Remove isSampleReceived index from analysis catalog
 - #2611 Add readonly support for non-mutable html elements via AjaxEditForm

--- a/src/senaite/core/content/interpretationtemplate.py
+++ b/src/senaite/core/content/interpretationtemplate.py
@@ -29,6 +29,7 @@ from senaite.core.content.base import Container
 from senaite.core.interfaces import IInterpretationTemplate
 from senaite.core.schema import UIDReferenceField
 from senaite.core.z3cform.widgets.uidreference import UIDReferenceWidgetFactory
+from zope import schema
 from zope.interface import implementer
 
 
@@ -37,6 +38,22 @@ class IInterpretationTemplateSchema(model.Schema):
     """
     # The behavior IRichTextBehavior applies to this content type, so it
     # already provides the "text" field that renders the TinyMCE's Wsiwyg
+
+    title = schema.TextLine(
+        title=_(
+            u"title_interpretationtemplate_title",
+            default=u"Name"
+        ),
+        required=True,
+    )
+
+    description = schema.Text(
+        title=_(
+            u"title_interpretationtemplate_description",
+            default=u"Description"
+        ),
+        required=False,
+    )
 
     analysis_templates = UIDReferenceField(
         title=_(u"Analysis templates"),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds the `title` and `description` schema fields that were no longer available because of the removal of [the behavior `plone.app.dexterity.behaviors.metadata.IBasic` was removed](https://github.com/senaite/senaite.core/pull/2573/files#diff-76e017a0816aa31d85d02889d297035e78c2b2f665ab579b948473e6db3ff781L52) done with https://github.com/senaite/senaite.core/pull/2573 .

## Current behavior before PR

Title and description not available for content type `InterpretationTemplate`

## Desired behavior after PR is merged

Title and description available for content type `InterpretationTemplate`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
