### PR TITLE
Fix UnicodeDecodeError when user linked to a contact with special chars

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2618 Fix UnicodeDecodeError when user linked to a contact with special chars
 - #2614 Fix autofill for simple fields when create Sample in the add form
 - #2617 Fix cannot set/edit the name/title of InterpretationTemplate objects
 - #2616 Fix reference field flush in add sample form when sort_limit is used

--- a/src/senaite/core/browser/user/userdatapanel.py
+++ b/src/senaite/core/browser/user/userdatapanel.py
@@ -142,13 +142,22 @@ class UserDataPanel(Base):
         """
         contact = self.get_linked_contact()
         if ILabContact.providedBy(contact):
-            self.add_status_message(
-                _("User is linked to lab contact '%s'" %
-                  contact.getFullname()))
+            self.add_status_message(_(
+                "User is linked to lab contact '${fullname}'",
+                mapping={"fullname": api.safe_unicode(contact.getFullname())}
+            ))
+
         elif IContact.providedBy(contact):
-            self.add_status_message(
-                _("User is linked to the client contact '%s' (%s)" %
-                  (contact.getFullname(), contact.aq_parent.getName())))
+            fullname = contact.getFullname()
+            client_name = contact.aq_parent.getName()
+            self.add_status_message(_(
+                "User is linked to the client contact '${fullname}' "
+                "(${client_name})",
+                mapping={
+                    "fullname": api.safe_unicode(fullname),
+                    "client_name": api.safe_unicode(client_name)
+                }
+            ))
 
     def add_status_message(self, message, level="info"):
         """Add a portal status message


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a traceback that occurs in `user-information` view when the user is linked to a contact that contains special characters on its full name.

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.core.browser.user.userdatapanel, line 78, in __call__
  Module senaite.core.browser.user.userdatapanel, line 147, in notify_linked_user
  Module zope.i18nmessageid.message, line 113, in __call__
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 44: ordinal not in range(128)
```

## Desired behavior after PR is merged

No traceback

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
