### PR TITLE
Fix analysis categories are not sorted by sort key

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2619 Fix analysis categories are not sorted by sort key
 - #2614 Fix autofill for simple fields when create Sample in the add form
 - #2617 Fix cannot set/edit the name/title of InterpretationTemplate objects
 - #2616 Fix reference field flush in add sample form when sort_limit is used

--- a/src/senaite/core/catalog/indexer/analysiscategory.py
+++ b/src/senaite/core/catalog/indexer/analysiscategory.py
@@ -18,10 +18,10 @@
 # Copyright 2018-2024 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from bika.lims.interfaces import IAnalysisCategory
 from plone.indexer import indexer
 from Products.CMFPlone.utils import safe_callable
 from senaite.core.catalog.utils import sortable_sortkey_title
+from senaite.core.interfaces import IAnalysisCategory
 
 
 @indexer(IAnalysisCategory)

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2650</version>
+  <version>2651</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -2480,3 +2480,13 @@ def fix_corrupted_transitions(tool):
                 wapi.update_transition(transition, after_script="")
 
     logger.info("Fixing corrupted transitions [DONE]")
+
+
+def reindex_analysis_categories(tool):
+    logger.info("Reindexing analysis categories ...")
+    cat = api.get_tool(SETUP_CATALOG)
+    for brain in cat(portal_type="AnalysisCategory"):
+        obj = brain.getObject()
+        logger.info("Reindex analysis category: %r" % obj)
+        obj.reindexObject(idxs=["sortable_title"], update_metadata=False)
+    logger.info("Reindexing analysis categories [DONE]")

--- a/src/senaite/core/upgrade/v02_06_000.zcml
+++ b/src/senaite/core/upgrade/v02_06_000.zcml
@@ -4,6 +4,14 @@
     i18n_domain="senaite.core">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.6.0: Fix categories not sorted by sort key"
+      description="Reindex sortable_title for all analysis categories"
+      source="2650"
+      destination="2651"
+      handler=".v02_06_000.reindex_analysis_categories"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.6.0: Fix corrupted transitions"
       description="Restores the value of the property `after_script_name` from
         transitions that were created or updated with the core's workflow api"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request addresses an issue introduced with https://github.com/senaite/senaite.core/pull/2567 so that categories are no longer sorted by Sort Key in analyses listings and in sample add form. Reason is that `sortable_title` was declared as an indexer for the old `IAnalysisCategory` marker interface that was used for AT.

## Current behavior before PR

Analysis categories are not sorted in accorance with SortKey in analyses listings

## Desired behavior after PR is merged

Analysis categories are sorted in accorance with SortKey in analyses listings

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
