### PR TITLE
Fix unicode error if non-latin email template used

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2621 Fix UnicodeDecodeError when render non-latin email template
 - #2620 Support IAddSampleObjectInfo adapter for sample's Template field
 - #2619 Fix analysis categories are not sorted by sort key
 - #2618 Fix UnicodeDecodeError when user linked to a contact with special chars

--- a/src/bika/lims/browser/publish/emailview.py
+++ b/src/bika/lims/browser/publish/emailview.py
@@ -511,14 +511,14 @@ class EmailView(BrowserView):
         """
 
         # allow to add translation for initial template
-        template = self.context.translate(_(template))
+        template = self.context.translate(_(safe_unicode(template)))
         recipients = self.email_recipients_and_responsibles
         if template_context is None:
             template_context = {
-                "recipients": "<br/>".join(recipients),
+                "recipients": "<br/>".join(map(safe_unicode, recipients)),
             }
 
-        email_template = Template(safe_unicode(template)).safe_substitute(
+        email_template = Template(template).safe_substitute(
             **template_context)
 
         return email_template

--- a/src/bika/lims/browser/publish/emailview.py
+++ b/src/bika/lims/browser/publish/emailview.py
@@ -515,7 +515,7 @@ class EmailView(BrowserView):
         recipients = self.email_recipients_and_responsibles
         if template_context is None:
             template_context = {
-                "recipients": "<br/>".join(map(safe_unicode, recipients)),
+                "recipients": u"<br/>".join(map(safe_unicode, recipients)),
             }
 
         email_template = Template(template).safe_substitute(


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

If email template contains non latin chars - `emailview.py` fails on the line 514 when tries to get translation of the particular template.

## Current behavior before PR

fails to get translation of the email template

## Desired behavior after PR is merged

do not fail

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
