### PR TITLE
Fix inactive services are added via profile on sample creation or edition

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2623 Fix inactive services are added via profile on sample creation/edition
 - #2620 Support IAddSampleObjectInfo adapter for sample's Template field
 - #2619 Fix analysis categories are not sorted by sort key
 - #2618 Fix UnicodeDecodeError when user linked to a contact with special chars

--- a/src/bika/lims/content/analysisservice.py
+++ b/src/bika/lims/content/analysisservice.py
@@ -27,7 +27,6 @@ from bika.lims.browser.fields import InterimFieldsField
 from bika.lims.browser.fields import PartitionSetupField
 from bika.lims.browser.fields import UIDReferenceField
 from bika.lims.browser.fields.partitionsetupfield import getContainers
-from bika.lims.browser.fields.uidreferencefield import get_backreferences
 from bika.lims.browser.widgets.partitionsetupwidget import PartitionSetupWidget
 from bika.lims.browser.widgets.recordswidget import RecordsWidget
 from senaite.core.browser.widgets.referencewidget import ReferenceWidget

--- a/src/bika/lims/content/analysisservice.py
+++ b/src/bika/lims/content/analysisservice.py
@@ -564,15 +564,15 @@ class AnalysisService(AbstractBaseAnalysis):
 
         Removes this service from all assigned Profiles and Templates.
         """
+        catalog = api.get_tool(SETUP_CATALOG)
+
         # Remove the service from profiles to which is assigned
-        uc = api.get_tool("uid_catalog")
-        uids = get_backreferences(self, "AnalysisProfileAnalysisService")
-        for brain in uc(UID=uids):
-            profile = api.get_object(brain)
+        profiles = catalog(portal_type="AnalysisProfile")
+        for profile in profiles:
+            profile = api.get_object(profile)
             profile.remove_service(self)
 
         # Remove the service from templates to which is assigned
-        catalog = api.get_tool(SETUP_CATALOG)
         templates = catalog(portal_type="SampleTemplate")
         for template in templates:
             template = api.get_object(template)

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2651</version>
+  <version>2652</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/tests/doctests/AnalysisServiceInactivation.rst
+++ b/src/senaite/core/tests/doctests/AnalysisServiceInactivation.rst
@@ -140,3 +140,36 @@ But if we activate `Ca` again:
     >>> performed = doActionFor(hardness, 'activate')
     >>> api.is_active(hardness)
     True
+
+
+Deactivated service is removed automatically from profiles
+..........................................................
+
+Create a profile:
+
+    >>> profile = api.create(setup.analysisprofiles, "AnalysisProfile")
+    >>> profile.setServices([Ca, Mg, Au])
+    >>> [service.getKeyword() for service in profile.getServices()]
+    ['Ca', 'Mg', 'Au']
+    >>> len(profile.getRawServices())
+    3
+
+If we deactivate `Au`:
+
+    >>> performed = doActionFor(Au, 'deactivate')
+    >>> api.is_active(Au)
+    False
+
+Profile does no longer contain this service:
+
+    >>> [service.getKeyword() for service in profile.getServices()]
+    ['Ca', 'Mg']
+
+    >>> len(profile.getRawServices())
+    2
+
+Re-activate `Au`:
+
+    >>> performed = doActionFor(Au, 'activate')
+    >>> api.is_active(Au)
+    True

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -2490,3 +2490,20 @@ def reindex_analysis_categories(tool):
         logger.info("Reindex analysis category: %r" % obj)
         obj.reindexObject(idxs=["sortable_title"], update_metadata=False)
     logger.info("Reindexing analysis categories [DONE]")
+
+
+def remove_inactive_services_from_profiles(tool):
+    logger.info("Removing inactive services from profiles ...")
+    cat = api.get_tool(SETUP_CATALOG)
+
+    # build a list of deactivated services
+    services = cat(portal_type="AnalysisService", is_active=False)
+    inactive = [api.get_object(service) for service in services]
+
+    # remove inactive services from profiles
+    for brain in cat(portal_type="AnalysisProfile"):
+        obj = api.get_object(brain)
+        for service in inactive:
+            obj.remove_service(service)
+
+    logger.info("Removing inactive services from profiles [DONE]")

--- a/src/senaite/core/upgrade/v02_06_000.zcml
+++ b/src/senaite/core/upgrade/v02_06_000.zcml
@@ -4,6 +4,14 @@
     i18n_domain="senaite.core">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.6.0: Remove deactivated services from profiles"
+      description="Removes deactivated analysis services from Profiles"
+      source="2651"
+      destination="2652"
+      handler=".v02_06_000.remove_inactive_services_from_profiles"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.6.0: Fix categories not sorted by sort key"
       description="Reindex sortable_title for all analysis categories"
       source="2650"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a side-effect of https://github.com/senaite/senaite.core/pull/2492 , so that inactivated services were no longer removed from existing panels on inactivation. Amongst other undesired effects, this was causing user was able to add inactive services on sample creation through the selection of analysis profiles with those services assigned.

## Current behavior before PR

Inactive services are added on sample creation/edition when a profile with inactive services is selected

## Desired behavior after PR is merged

Inactive services are added on sample creation/edition when a profile with inactive services is selected

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
