### PR TITLE
Fix sizing of listing widgets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2625 Fix sizing of listing widgets
 - #2621 Fix UnicodeDecodeError when render non-latin email template
 - #2623 Fix inactive services are added via profile on sample creation/edition
 - #2620 Support IAddSampleObjectInfo adapter for sample's Template field

--- a/src/senaite/core/browser/dexterity/templates/widget.pt
+++ b/src/senaite/core/browser/dexterity/templates/widget.pt
@@ -1,6 +1,8 @@
 <div metal:define-macro="widget-wrapper"
      i18n:domain="plone"
      tal:define="widget nocall:context;
+                 widget_clazz python:widget.__class__.__name__;
+                 widget_css_class python:'input-group input-group-sm d-flex' if widget_clazz != 'ListingWidget' else '';
                  hidden python:widget.mode == 'hidden';
                  error widget/error;
                  error_class python:error and ' error' or '';
@@ -39,6 +41,7 @@
   <!-- widget insert mode -->
   <div class="input-group input-group-sm d-flex"
        style="width:auto"
+       tal:attributes="class python:widget_css_class"
        tal:define="prefix python:view.get_prepend_text();
                    appendix python:view.get_append_text()"
        tal:condition="python:view.is_input_mode()">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a side-effect that was introduced #2588 on listing table widgets, e.g. those used for Analysis selection in Sample Templates.

## Current behavior before PR

Listing widgets are rendered half-width:

<img width="1552" alt="Bruma Metals — SENAITE LIMS 2024-10-16 12 PM-52-43" src="https://github.com/user-attachments/assets/2b873073-26c0-4f02-b070-4bc9a0dceabf">

## Desired behavior after PR is merged

Listing widgets are rendered full width:

<img width="1552" alt="Bruma Metals — SENAITE LIMS 2024-10-16 12 PM-54-18" src="https://github.com/user-attachments/assets/82aa842c-599a-4603-aa04-2116b2e13817">

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
