### PR TITLE
Skip workflow transition for temporary analyses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2627 Skip workflow transition for temporary analyses
 - #2626 Change to new instrument imports that were introduced with #2555
 - #2625 Fix sizing of listing widgets
 - #2621 Fix UnicodeDecodeError when render non-latin email template

--- a/src/bika/lims/subscribers/analysis.py
+++ b/src/bika/lims/subscribers/analysis.py
@@ -18,12 +18,17 @@
 # Copyright 2018-2024 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from bika.lims import api
 from bika.lims import workflow as wf
 
 
 def ObjectInitializedEventHandler(analysis, event):
     """Actions to be done when an analysis is added in an Analysis Request
     """
+    # Skip temporary analyses that are constructed during new sample creation.
+    # This avoids the warning "No workflow provides the '${action_id}' action."
+    if api.is_temporary(analysis):
+        return
 
     # Initialize the analysis if it was e.g. added by Manage Analysis
     wf.doActionFor(analysis, "initialize")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the following warning on new sample creation `No workflow provides the '${action_id}' action.`.

## Current behavior before PR

Temporary Analyses are being transitioned in `ObjectInitializedEventHandler`.

## Desired behavior after PR is merged

Temporary Analyses are skipped.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
