### PR TITLE
Temporary deactivation of Workflow Variables Patch from #2593

### DIFF
--- a/src/senaite/core/patches/configure.zcml
+++ b/src/senaite/core/patches/configure.zcml
@@ -69,11 +69,15 @@
       replacement=".catalog.catalog_object"
       />
 
+  <!-- XXX: This patch was temporary deactivated due to a side-effect that
+            catalog multiplexers, e.g. SQL Multiplexer for Analyses, were no
+            longer called!
+  -->
   <!-- Ensure the full object is re-indexed after transition -->
-  <monkey:patch
-    description=""
-    class="Products.CMFCore.WorkflowTool.WorkflowTool"
-    original="_reindexWorkflowVariables"
-    replacement=".workflow._reindexWorkflowVariables"/>
+  <!-- <monkey:patch -->
+  <!--   description="" -->
+  <!--   class="Products.CMFCore.WorkflowTool.WorkflowTool" -->
+  <!--   original="_reindexWorkflowVariables" -->
+  <!--   replacement=".workflow._reindexWorkflowVariables"/> -->
 
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR temporarily deactivates the patch from PR #2593 because of side-effects.

## Current behavior before PR

Hooked in catalog multiplexers, e.g. an SQL multipler, is no longer called on Analysis WF transition.

## Desired behavior after PR is merged

Hooked in catalog multiplexers are called on Analysis WF transition.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
