### PR TITLE
Fix default sticker template based on sample type is not rendered

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2629 Fix default sticker template based on sample type is not rendered
 - #2626 Change to new instrument imports that were introduced with #2555
 - #2625 Fix sizing of listing widgets
 - #2621 Fix UnicodeDecodeError when render non-latin email template

--- a/src/bika/lims/browser/stickers.py
+++ b/src/bika/lims/browser/stickers.py
@@ -29,7 +29,6 @@ from bika.lims import logger
 from bika.lims.browser import BrowserView
 from bika.lims.interfaces import IAnalysisRequest
 from bika.lims.interfaces import IGetStickerTemplates
-from bika.lims.interfaces import ISampleType
 from bika.lims.utils import createPdf
 from bika.lims.utils import to_int
 from bika.lims.vocabularies import getStickerTemplates
@@ -38,6 +37,7 @@ from plone.resource.utils import queryResourceDirectory
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from senaite.app.supermodel import SuperModel
+from senaite.core.interfaces import ISampleType
 from zope.component import getAdapters
 from zope.component.interfaces import ComponentLookupError
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a wrong import that was causing the system to not render the default sticker template for a sample based on the assigned sample type.

## Current behavior before PR

The sample-type based default sticker template is not rendered by default

## Desired behavior after PR is merged

The sample-type based default sticker template is rendered by default

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
