### PR TITLE
Fix references from sample templates are not kept when partitioning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2630 Fix references from sample templates are not kept when partitioning
 - #2627 Skip workflow transition for temporary analyses
 - #2626 Change to new instrument imports that were introduced with #2555
 - #2625 Fix sizing of listing widgets

--- a/src/senaite/core/browser/samples/partition_magic.py
+++ b/src/senaite/core/browser/samples/partition_magic.py
@@ -228,32 +228,6 @@ class PartitionMagicView(BrowserView):
             out.append(info)
         return out
 
-    def get_partitions_info(self, template):
-        """Return a list with the partitions information of the template
-        """
-        if not template:
-            return {}
-
-        def first(records, default=""):
-            if not records:
-                return default
-            if api.is_uid(records):
-                return records
-            return records[0]
-
-        # UIDReference sub-fields are stored as a list!
-        partitions = []
-        for part in template.getPartitions():
-            partition = part.copy()
-            partition.update({
-                "sampletype": first(part.get("sampletype")),
-                "container": first(part.get("container")),
-                "preservation": first(part.get("preservation")),
-            })
-            partitions.append(partition)
-
-        return partitions
-
     def get_template_data_for(self, ar):
         """Return the Template data for this AR
         """
@@ -284,7 +258,7 @@ class PartitionMagicView(BrowserView):
             internal_use_by_partition = defaultdict(list)
 
             partitions = []
-            for part in self.get_partitions_info(template):
+            for part in template.getPartitions():
                 partition = part.get("part_id")
                 partitions.append(partition)
                 sampletype_uid = part.get('sampletype', ar_sampletype_uid)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that sample types, containers and preservations from each partition of a sample template are automatically assigned later on partition magic view.

When partitions are set in a template like follows:

![Captura de 2024-10-21 15-28-38](https://github.com/user-attachments/assets/e33cc627-25d1-41bc-b8b1-efe6a0ff5e28)

Partition magic must select the correct values from the selection lists accordingly:

![Captura de 2024-10-21 15-30-08](https://github.com/user-attachments/assets/c7bb5835-23f0-419b-b0ab-3e0c3b9f3516)



## Current behavior before PR

Referenced fields (sample type, container, preservations) from sample template are not automatically filled on partition magic

## Desired behavior after PR is merged

Referenced fields (sample type, container, preservations) from sample template are automatically filled on partition magic


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
