### PR TITLE
Fix for sending attachment if filename contain spaces

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2631 Fix for sending email attachment if filename contain spaces 
 - #2629 Fix default sticker template based on sample type is not rendered
 - #2627 Skip workflow transition for temporary analyses
 - #2626 Change to new instrument imports that were introduced with #2555

--- a/src/bika/lims/api/mail.py
+++ b/src/bika/lims/api/mail.py
@@ -169,7 +169,7 @@ def to_email_attachment(filedata, filename="", **kw):
     attachment.set_payload(data)
     encoders.encode_base64(attachment)
     attachment.add_header("Content-Disposition",
-                          "attachment; filename=%s" % filename)
+                          "attachment; filename=\"%s\"" % filename)
     return attachment
 
 

--- a/src/senaite/core/tests/doctests/API_mail.rst
+++ b/src/senaite/core/tests/doctests/API_mail.rst
@@ -115,7 +115,7 @@ This function converts a filename with given filedata to a MIME attachment:
     Content-Type: image/png
     MIME-Version: 1.0
     Content-Transfer-Encoding: base64
-    Content-Disposition: attachment; filename=logo.png
+    Content-Disposition: attachment; filename="logo.png"
     <BLANKLINE>
     iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAACBjSFJN
     ...
@@ -133,7 +133,7 @@ It is also possible to provide the full path to a file:
     Content-Type: image/png
     MIME-Version: 1.0
     Content-Transfer-Encoding: base64
-    Content-Disposition: attachment; filename=logo.png
+    Content-Disposition: attachment; filename="logo.png"
     <BLANKLINE>
     iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAACBjSFJN
     ...
@@ -225,7 +225,7 @@ This function composes a new MIME message:
     Content-Type: image/png
     MIME-Version: 1.0
     Content-Transfer-Encoding: base64
-    Content-Disposition: attachment; filename=logo.png
+    Content-Disposition: attachment; filename="logo.png"
     <BLANKLINE>
     iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAACBjSFJN
     ...


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR

After email being sent and its attachment filename contain spaces - some email services cut off the filename where first space occurs. That disables preview features and etc.

## Desired behavior after PR is merged

files with spaces in filename live better life.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
