### PR TITLE
Fix DateTimeError when using API's to_DT and to_dt functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2633 Fix DateTimeError when using API's to_DT and to_dt functions
 - #2629 Fix default sticker template based on sample type is not rendered
 - #2627 Skip workflow transition for temporary analyses
 - #2626 Change to new instrument imports that were introduced with #2555

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -146,7 +146,7 @@ def to_DT(dt):
             kwargs["datefmt"] = "international"
         try:
             return DateTime(dt, **kwargs)
-        except (DateError, TimeError):
+        except (DateError, DateTimeError, TimeError):
             try:
                 dt = ansi_to_dt(dt)
                 return to_DT(dt)

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -208,6 +208,26 @@ Old dates with obsolete timezones (e.g. LMT) are converted as well
     >>> old_DT.tzoffset()
     35340
 
+The function returns `None` when the conversion cannot be done:
+
+    >>> dtime.to_DT(None) is None
+    True
+
+    >>> dtime.to_DT(object) is None
+    True
+
+    >>> dtime.to_DT("Not a date") is None
+    True
+
+    >>> dtime.to_DT("2025-13-01") is None
+    True
+
+    >>> dtime.to_DT("2024-02-25 12:00 POP+2") is None
+    True
+
+    >>> dtime.to_DT("0007-02-27T00:00:00-04:24") is None
+    True
+
 Convert to datetime
 ...................
 
@@ -239,6 +259,25 @@ Timezone aware `DateTime` is converted with timezone.
     >>> dtime.to_dt(dt)
     datetime.datetime(2021, 8, 1, 13, 0, tzinfo=<StaticTzInfo 'Etc/GMT-1'>)
 
+The function returns `None` when the conversion cannot be done:
+
+    >>> dtime.to_dt(None) is None
+    True
+
+    >>> dtime.to_dt(object) is None
+    True
+
+    >>> dtime.to_dt("Not a date") is None
+    True
+
+    >>> dtime.to_dt("2025-13-01") is None
+    True
+
+    >>> dtime.to_dt("2024-02-25 12:00 POP+2") is None
+    True
+
+    >>> dtime.to_dt("0007-02-27T00:00:00-04:24") is None
+    True
 
 Get the timezone
 ................


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When a DateError or TimeError is raised when trying to convert something to a DateTime (Zope) with `dtime.to_DT`, the system return `None`. However, it does not happen the same when the error raised is a `DateTimeError`:

```python
>>> from senaite.core.api import dtime
>>> dtime.to_DT("0007-02-27T00:00:00-04:24")
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/home/senaite/zinstance/src/senaite.core/src/senaite/core/api/dtime.py", line 148, in to_DT
    return DateTime(dt, **kwargs)
  File "/home/senaite/buildout-cache/eggs/DateTime-4.9-py2.7.egg/DateTime/DateTime.py", line 447, in __init__
    return self._parse_args(*args, **kw)
  File "/home/senaite/buildout-cache/eggs/DateTime-4.9-py2.7.egg/DateTime/DateTime.py", line 775, in _parse_args
    'Unknown time zone in date: %s' % arg)
DateTimeError: Unknown time zone in date: 0007-02-27T00:00:00-04:24
```

This Pull Request ensures the function is consistent by returning `None` on a `DateTimeError`


## Current behavior before PR

`DateTimeError` arises when doing `to_DT("0007-02-27T00:00:00-04:24")`

## Desired behavior after PR is merged

`None` is returned when doing `to_DT("0007-02-27T00:00:00-04:24")`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
