### PR TITLE
Remove reindexing of Analyses and Analysis Services on Category change

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2635 Remove reindexing of Analyses and Analysis Services on Category change
 - #2599 Migrate WorksheetTemplates to Dexterity
 - #2632 Refactor Catalog Indexing
 - #2630 Fix references from sample templates are not kept when partitioning

--- a/src/bika/lims/subscribers/objectmodified.py
+++ b/src/bika/lims/subscribers/objectmodified.py
@@ -20,8 +20,6 @@
 
 from bika.lims import api
 from Products.CMFCore.utils import getToolByName
-from senaite.core.catalog import ANALYSIS_CATALOG
-from senaite.core.catalog import SETUP_CATALOG
 
 
 def ObjectModifiedEventHandler(obj, event):
@@ -46,22 +44,3 @@ def ObjectModifiedEventHandler(obj, event):
                               'email': contact_email,
                               'fullname': contact_fullname}
                 member.setMemberProperties(properties)
-
-    elif portal_type == 'AnalysisCategory':
-        # If the analysis category's Title is modified, we must
-        # re-index all services and analyses that refer to this title.
-        uid = obj.UID()
-
-        # re-index all analysis services
-        query = dict(category_uid=uid, portal_type="AnalysisService")
-        brains = api.search(query, SETUP_CATALOG)
-        for brain in brains:
-            ob = api.get_object(brain)
-            ob.reindexObject()
-
-        # re-index analyses
-        query = dict(getCategoryUID=uid)
-        brains = api.search(query, ANALYSIS_CATALOG)
-        for brain in brains:
-            ob = api.get_object(brain)
-            ob.reindexObject()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes high loads when a category was changed where many analyses are linked to.

As far as I can see, this reindexing is not required because there are no metadata columns or indexes that need to be updated in Analysis- or Setup Catalog

## Current behavior before PR

The whole system becomes inresponsive, especially if an SQL multiplexer is hooked

## Desired behavior after PR is merged

No reindexing is done if an Analysis Category is modified.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
