### PR TITLE
Do not remove inactive services from profiles and templates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2637 Do not remove inactive services from profiles and templates
 - #2569 Fix samples are indicated as late when Turnaround Time is zero
 - #2636 Fix JS Error in WS Template edit form
 - #2635 Remove reindexing of Analyses and Analysis Services on Category change

--- a/src/bika/lims/content/analysisservice.py
+++ b/src/bika/lims/content/analysisservice.py
@@ -558,19 +558,6 @@ class AnalysisService(AbstractBaseAnalysis):
         dlist.add("", _("None"))
         return dlist
 
-    def after_deactivate_transition_event(self):
-        """Method triggered after a 'deactivate' transition
-
-        Removes this service from all assigned Profiles and Templates.
-        """
-        catalog = api.get_tool(SETUP_CATALOG)
-
-        # Remove the service from templates to which is assigned
-        templates = catalog(portal_type="SampleTemplate")
-        for template in templates:
-            template = api.get_object(template)
-            template.remove_service(self)
-
     # XXX DECIDE IF NEEDED
     # --------------------
 

--- a/src/bika/lims/content/analysisservice.py
+++ b/src/bika/lims/content/analysisservice.py
@@ -565,12 +565,6 @@ class AnalysisService(AbstractBaseAnalysis):
         """
         catalog = api.get_tool(SETUP_CATALOG)
 
-        # Remove the service from profiles to which is assigned
-        profiles = catalog(portal_type="AnalysisProfile")
-        for profile in profiles:
-            profile = api.get_object(profile)
-            profile.remove_service(self)
-
         # Remove the service from templates to which is assigned
         templates = catalog(portal_type="SampleTemplate")
         for template in templates:

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -41,7 +41,6 @@ from bika.lims.utils import get_link
 from bika.lims.utils import tmpID
 from bika.lims.workflow import doActionFor
 from DateTime import DateTime
-from Products.Archetypes.config import UID_CATALOG
 from Products.Archetypes.event import ObjectInitializedEvent
 from Products.CMFPlone.utils import _createObjectByType
 from senaite.core.catalog import SETUP_CATALOG
@@ -266,14 +265,6 @@ def to_services_uids(services=None, values=None):
 
     # Convert them to a list of service uids
     uids = filter(None, map(to_service_uid, uids))
-
-    # Extend with service uids from profiles
-    profiles = to_list(values.get("Profiles"))
-    if profiles:
-        uid_catalog = api.get_tool(UID_CATALOG)
-        for brain in uid_catalog(UID=profiles):
-            profile = api.get_object(brain)
-            uids.extend(profile.getServiceUIDs() or [])
 
     # Get the service uids without duplicates, but preserving the order
     return list(OrderedDict.fromkeys(uids).keys())

--- a/src/senaite/core/content/analysisprofile.py
+++ b/src/senaite/core/content/analysisprofile.py
@@ -260,7 +260,7 @@ class AnalysisProfile(Container, ClientAwareMixin):
 
         :returns: List of analysis service objects
         """
-        services = map(api.get_object, self.getServicesUIDs())
+        services = map(api.get_object, self.getServiceUIDs())
         if active_only:
             # filter out inactive services
             services = filter(api.is_active, services)
@@ -316,7 +316,7 @@ class AnalysisProfile(Container, ClientAwareMixin):
     Service = Services = property(getServices, setServices)
 
     @security.protected(permissions.View)
-    def getServicesUIDs(self):
+    def getServiceUIDs(self):
         """Returns a list of the selected service UIDs
         """
         services = self.getRawServices()

--- a/src/senaite/core/content/analysisprofile.py
+++ b/src/senaite/core/content/analysisprofile.py
@@ -267,7 +267,7 @@ class AnalysisProfile(Container, ClientAwareMixin):
         return list(services)
 
     @security.protected(permissions.ModifyPortalContent)
-    def setServices(self, value):
+    def setServices(self, value, keep_inactive=True):
         """Set services for the profile
 
         This method accepts either a list of analysis service objects, a list
@@ -298,15 +298,16 @@ class AnalysisProfile(Container, ClientAwareMixin):
                     "Expected object, uid or record, got %r" % type(v))
             records.append({"uid": uid, "hidden": hidden})
 
-        # always keep inactive services so they come up again when reactivated
-        uids = [record.get("uid") for record in records]
-        for record in self.getRawServices():
-            uid = record.get("uid")
-            if uid in uids:
-                continue
-            obj = api.get_object_by_uid(uid)
-            if not api.is_active(obj):
-                records.append(record)
+        if keep_inactive:
+            # keep inactive services so they come up again when reactivated
+            uids = [record.get("uid") for record in records]
+            for record in self.getRawServices():
+                uid = record.get("uid")
+                if uid in uids:
+                    continue
+                obj = api.get_object(uid)
+                if not api.is_active(obj):
+                    records.append(record)
 
         mutator = self.mutator("services")
         mutator(self, records)

--- a/src/senaite/core/content/analysisprofile.py
+++ b/src/senaite/core/content/analysisprofile.py
@@ -260,7 +260,7 @@ class AnalysisProfile(Container, ClientAwareMixin):
 
         :returns: List of analysis service objects
         """
-        services = map(api.get_object, self.getServiceUIDs())
+        services = map(api.get_object, self.getRawServiceUIDs())
         if active_only:
             # filter out inactive services
             services = filter(api.is_active, services)
@@ -316,8 +316,22 @@ class AnalysisProfile(Container, ClientAwareMixin):
     Service = Services = property(getServices, setServices)
 
     @security.protected(permissions.View)
-    def getServiceUIDs(self):
-        """Returns a list of the selected service UIDs
+    def getServiceUIDs(self, active_only=True):
+        """Returns a list of UIDs for the referenced AnalysisService objects
+
+        :param active_only: If True, only UIDs of active services are returned
+        :returns: A list of unique identifiers (UIDs)
+        """
+        if active_only:
+            services = self.getServices(active_only=active_only)
+            return list(map(api.get_uid, services))
+        return self.getRawServiceUIDs()
+
+    @security.protected(permissions.View)
+    def getRawServiceUIDs(self):
+        """Returns the list of UIDs stored as raw data in the 'Services' field
+
+        :returns: A list of UIDs extracted from the raw 'Services' data.
         """
         services = self.getRawServices()
         return list(map(lambda record: record.get("uid"), services))

--- a/src/senaite/core/content/analysisprofile.py
+++ b/src/senaite/core/content/analysisprofile.py
@@ -260,7 +260,7 @@ class AnalysisProfile(Container, ClientAwareMixin):
 
         :returns: List of analysis service objects
         """
-        services = map(api.get_object, self.getServiceUIDs())
+        services = map(api.get_object, self.getServicesUIDs())
         if active_only:
             # filter out inactive services
             services = filter(api.is_active, services)
@@ -316,7 +316,7 @@ class AnalysisProfile(Container, ClientAwareMixin):
     Service = Services = property(getServices, setServices)
 
     @security.protected(permissions.View)
-    def getServiceUIDs(self):
+    def getServicesUIDs(self):
         """Returns a list of the selected service UIDs
         """
         services = self.getRawServices()

--- a/src/senaite/core/content/analysisprofile.py
+++ b/src/senaite/core/content/analysisprofile.py
@@ -260,12 +260,11 @@ class AnalysisProfile(Container, ClientAwareMixin):
 
         :returns: List of analysis service objects
         """
-        services = []
-        for uid in self.getServiceUIDs():
-            obj = api.get_object(uid)
-            if not active_only or api.is_active(obj):
-                services.append(obj)
-        return services
+        services = map(api.get_object, self.getServiceUIDs())
+        if active_only:
+            # filter out inactive services
+            services = filter(api.is_active, services)
+        return list(services)
 
     @security.protected(permissions.ModifyPortalContent)
     def setServices(self, value):

--- a/src/senaite/core/content/analysisprofile.py
+++ b/src/senaite/core/content/analysisprofile.py
@@ -252,7 +252,7 @@ class AnalysisProfile(Container, ClientAwareMixin):
         return accessor(self) or []
 
     @security.protected(permissions.View)
-    def getServices(self):
+    def getServices(self, active_only=True):
         """Returns a list of service objects
 
         >>> self.getServices()
@@ -260,9 +260,12 @@ class AnalysisProfile(Container, ClientAwareMixin):
 
         :returns: List of analysis service objects
         """
-        records = self.getRawServices()
-        service_uids = map(lambda r: r.get("uid"), records)
-        return list(map(api.get_object, service_uids))
+        services = []
+        for uid in self.getServiceUIDs():
+            obj = api.get_object(uid)
+            if not active_only or api.is_active(obj):
+                services.append(obj)
+        return services
 
     @security.protected(permissions.ModifyPortalContent)
     def setServices(self, value):
@@ -295,6 +298,17 @@ class AnalysisProfile(Container, ClientAwareMixin):
                 raise TypeError(
                     "Expected object, uid or record, got %r" % type(v))
             records.append({"uid": uid, "hidden": hidden})
+
+        # always keep inactive services so they come up again when reactivated
+        uids = [record.get("uid") for record in records]
+        for record in self.getRawServices():
+            uid = record.get("uid")
+            if uid in uids:
+                continue
+            obj = api.get_object_by_uid(uid)
+            if not api.is_active(obj):
+                records.append(record)
+
         mutator = self.mutator("services")
         mutator(self, records)
 

--- a/src/senaite/core/content/sampletemplate.py
+++ b/src/senaite/core/content/sampletemplate.py
@@ -461,12 +461,11 @@ class SampleTemplate(Container, ClientAwareMixin):
 
         :returns: List of analysis service objects
         """
-        services = []
-        for uid in self.getServiceUIDs():
-            obj = api.get_object(uid)
-            if not active_only or api.is_active(obj):
-                services.append(obj)
-        return services
+        services = map(api.get_object, self.getServiceUIDs())
+        if active_only:
+            # filter out inactive services
+            services = filter(api.is_active, services)
+        return list(services)
 
     @security.protected(permissions.ModifyPortalContent)
     def setServices(self, value):

--- a/src/senaite/core/content/sampletemplate.py
+++ b/src/senaite/core/content/sampletemplate.py
@@ -461,7 +461,7 @@ class SampleTemplate(Container, ClientAwareMixin):
 
         :returns: List of analysis service objects
         """
-        services = map(api.get_object, self.getServicesUIDs())
+        services = map(api.get_object, self.getServiceUIDs())
         if active_only:
             # filter out inactive services
             services = filter(api.is_active, services)
@@ -528,7 +528,7 @@ class SampleTemplate(Container, ClientAwareMixin):
     Services = property(getServices, setServices)
 
     @security.protected(permissions.View)
-    def getServicesUIDs(self):
+    def getServiceUIDs(self):
         """Returns a list of the selected service UIDs
         """
         services = self.getRawServices()
@@ -622,12 +622,12 @@ class SampleTemplate(Container, ClientAwareMixin):
             return ""
         return record.get("part_id", "")
 
-    @deprecate("deprecated since SENAITE 2.6: Use getServicesUIDs() instead")
     @security.protected(permissions.View)
     def getAnalysisServiceUIDs(self):
         """Returns a list of all assigned service UIDs
         """
-        return self.getServicesUIDs()
+        services = self.getRawServices()
+        return list(map(lambda record: record.get("uid"), services))
 
     @security.protected(permissions.View)
     def get_services_by_uid(self):

--- a/src/senaite/core/content/sampletemplate.py
+++ b/src/senaite/core/content/sampletemplate.py
@@ -461,7 +461,7 @@ class SampleTemplate(Container, ClientAwareMixin):
 
         :returns: List of analysis service objects
         """
-        services = map(api.get_object, self.getServiceUIDs())
+        services = map(api.get_object, self.getRawServiceUIDs())
         if active_only:
             # filter out inactive services
             services = filter(api.is_active, services)
@@ -528,8 +528,22 @@ class SampleTemplate(Container, ClientAwareMixin):
     Services = property(getServices, setServices)
 
     @security.protected(permissions.View)
-    def getServiceUIDs(self):
-        """Returns a list of the selected service UIDs
+    def getServiceUIDs(self, active_only=True):
+        """Returns a list of UIDs for the referenced AnalysisService objects
+
+        :param active_only: If True, only UIDs of active services are returned
+        :returns: A list of unique identifiers (UIDs)
+        """
+        if active_only:
+            services = self.getServices(active_only=active_only)
+            return list(map(api.get_uid, services))
+        return self.getRawServiceUIDs()
+
+    @security.protected(permissions.View)
+    def getRawServiceUIDs(self):
+        """Returns the list of UIDs stored as raw data in the 'Services' field
+
+        :returns: A list of UIDs extracted from the raw 'Services' data.
         """
         services = self.getRawServices()
         return list(map(lambda record: record.get("uid"), services))

--- a/src/senaite/core/content/sampletemplate.py
+++ b/src/senaite/core/content/sampletemplate.py
@@ -461,7 +461,7 @@ class SampleTemplate(Container, ClientAwareMixin):
 
         :returns: List of analysis service objects
         """
-        services = map(api.get_object, self.getServiceUIDs())
+        services = map(api.get_object, self.getServicesUIDs())
         if active_only:
             # filter out inactive services
             services = filter(api.is_active, services)
@@ -528,7 +528,7 @@ class SampleTemplate(Container, ClientAwareMixin):
     Services = property(getServices, setServices)
 
     @security.protected(permissions.View)
-    def getServiceUIDs(self):
+    def getServicesUIDs(self):
         """Returns a list of the selected service UIDs
         """
         services = self.getRawServices()
@@ -622,12 +622,12 @@ class SampleTemplate(Container, ClientAwareMixin):
             return ""
         return record.get("part_id", "")
 
+    @deprecate("deprecated since SENAITE 2.6: Use getServicesUIDs() instead")
     @security.protected(permissions.View)
     def getAnalysisServiceUIDs(self):
         """Returns a list of all assigned service UIDs
         """
-        services = self.getRawServices()
-        return list(map(lambda record: record.get("uid"), services))
+        return self.getServicesUIDs()
 
     @security.protected(permissions.View)
     def get_services_by_uid(self):

--- a/src/senaite/core/content/sampletemplate.py
+++ b/src/senaite/core/content/sampletemplate.py
@@ -622,12 +622,12 @@ class SampleTemplate(Container, ClientAwareMixin):
             return ""
         return record.get("part_id", "")
 
+    @deprecate("deprecated since SENAITE 2.6: Use getServiceUIDs() instead")
     @security.protected(permissions.View)
     def getAnalysisServiceUIDs(self):
         """Returns a list of all assigned service UIDs
         """
-        services = self.getRawServices()
-        return list(map(lambda record: record.get("uid"), services))
+        return self.getServiceUIDs()
 
     @security.protected(permissions.View)
     def get_services_by_uid(self):

--- a/src/senaite/core/content/sampletemplate.py
+++ b/src/senaite/core/content/sampletemplate.py
@@ -468,7 +468,7 @@ class SampleTemplate(Container, ClientAwareMixin):
         return list(services)
 
     @security.protected(permissions.ModifyPortalContent)
-    def setServices(self, value):
+    def setServices(self, value, keep_inactive=True):
         """Set services for the template
 
         This method accepts either a list of analysis service objects, a list
@@ -510,15 +510,16 @@ class SampleTemplate(Container, ClientAwareMixin):
                 "part_id": part_id,
             })
 
-        # always keep inactive services so they come up again when reactivated
-        uids = [record.get("uid") for record in records]
-        for record in self.getRawServices():
-            uid = record.get("uid")
-            if uid in uids:
-                continue
-            obj = api.get_object_by_uid(uid)
-            if not api.is_active(obj):
-                records.append(record)
+        if keep_inactive:
+            # keep inactive services so they come up again when reactivated
+            uids = [record.get("uid") for record in records]
+            for record in self.getRawServices():
+                uid = record.get("uid")
+                if uid in uids:
+                    continue
+                obj = api.get_object(uid)
+                if not api.is_active(obj):
+                    records.append(record)
 
         mutator = self.mutator("services")
         mutator(self, records)

--- a/src/senaite/core/content/sampletemplate.py
+++ b/src/senaite/core/content/sampletemplate.py
@@ -453,7 +453,7 @@ class SampleTemplate(Container, ClientAwareMixin):
         return accessor(self) or []
 
     @security.protected(permissions.View)
-    def getServices(self):
+    def getServices(self, active_only=True):
         """Returns a list of service objects
 
         >>> self.getServices()
@@ -461,9 +461,12 @@ class SampleTemplate(Container, ClientAwareMixin):
 
         :returns: List of analysis service objects
         """
-        records = self.getRawServices()
-        service_uids = map(lambda r: r.get("uid"), records)
-        return list(map(api.get_object, service_uids))
+        services = []
+        for uid in self.getServiceUIDs():
+            obj = api.get_object(uid)
+            if not active_only or api.is_active(obj):
+                services.append(obj)
+        return services
 
     @security.protected(permissions.ModifyPortalContent)
     def setServices(self, value):
@@ -508,11 +511,28 @@ class SampleTemplate(Container, ClientAwareMixin):
                 "part_id": part_id,
             })
 
+        # always keep inactive services so they come up again when reactivated
+        uids = [record.get("uid") for record in records]
+        for record in self.getRawServices():
+            uid = record.get("uid")
+            if uid in uids:
+                continue
+            obj = api.get_object_by_uid(uid)
+            if not api.is_active(obj):
+                records.append(record)
+
         mutator = self.mutator("services")
         mutator(self, records)
 
     # BBB: AT schema field property
     Services = property(getServices, setServices)
+
+    @security.protected(permissions.View)
+    def getServiceUIDs(self):
+        """Returns a list of the selected service UIDs
+        """
+        services = self.getRawServices()
+        return list(map(lambda record: record.get("uid"), services))
 
     @deprecate("deprecated since SENAITE 2.6: Use getRawServices() instead")
     @security.protected(permissions.View)

--- a/src/senaite/core/tests/doctests/AnalysisProfile.rst
+++ b/src/senaite/core/tests/doctests/AnalysisProfile.rst
@@ -213,7 +213,10 @@ Inactive services are not returned by default:
     >>> Fe in profile1.getServices()
     False
 
-But kept just in case we re-activate the service later:
+But kept as raw data, just in case we re-activate the service later:
+
+    >>> Fe in profile1.getServices(active_only=False)
+    True
 
     >>> api.get_uid(Fe) in profile1.getRawServiceUIDs()
     True

--- a/src/senaite/core/tests/doctests/AnalysisProfile.rst
+++ b/src/senaite/core/tests/doctests/AnalysisProfile.rst
@@ -215,7 +215,7 @@ Inactive services are not returned by default:
 
 But kept just in case we re-activate the service later:
 
-    >>> api.get_uid(Fe) in profile1.getServiceUIDs()
+    >>> api.get_uid(Fe) in profile1.getRawServiceUIDs()
     True
 
 By default, inactive services are kept as raw data when the value is set:
@@ -228,6 +228,10 @@ By default, inactive services are kept as raw data when the value is set:
     >>> api.get_uid(Cu) in profile1.getServiceUIDs()
     False
     >>> api.get_uid(Fe) in profile1.getServiceUIDs()
+    False
+    >>> api.get_uid(Cu) in profile1.getRawServiceUIDs()
+    False
+    >>> api.get_uid(Fe) in profile1.getRawServiceUIDs()
     True
 
 Unless we use `keep_inactive=False`:
@@ -240,4 +244,8 @@ Unless we use `keep_inactive=False`:
     >>> api.get_uid(Cu) in profile1.getServiceUIDs()
     False
     >>> api.get_uid(Fe) in profile1.getServiceUIDs()
+    False
+    >>> api.get_uid(Cu) in profile1.getRawServiceUIDs()
+    False
+    >>> api.get_uid(Fe) in profile1.getRawServiceUIDs()
     False

--- a/src/senaite/core/tests/doctests/AnalysisProfile.rst
+++ b/src/senaite/core/tests/doctests/AnalysisProfile.rst
@@ -215,7 +215,7 @@ Inactive services are not returned by default:
 
 But kept just in case we re-activate the service later:
 
-    >>> api.get_uid(Fe) in profile1.getServiceUIDs()
+    >>> api.get_uid(Fe) in profile1.getServicesUIDs()
     True
 
 By default, inactive services are kept as raw data when the value is set:
@@ -225,9 +225,9 @@ By default, inactive services are kept as raw data when the value is set:
     False
     >>> Fe in profile1.getServices()
     False
-    >>> api.get_uid(Cu) in profile1.getServiceUIDs()
+    >>> api.get_uid(Cu) in profile1.getServicesUIDs()
     False
-    >>> api.get_uid(Fe) in profile1.getServiceUIDs()
+    >>> api.get_uid(Fe) in profile1.getServicesUIDs()
     True
 
 Unless we use `keep_inactive=False`:
@@ -237,7 +237,7 @@ Unless we use `keep_inactive=False`:
     False
     >>> Fe in profile1.getServices()
     False
-    >>> api.get_uid(Cu) in profile1.getServiceUIDs()
+    >>> api.get_uid(Cu) in profile1.getServicesUIDs()
     False
-    >>> api.get_uid(Fe) in profile1.getServiceUIDs()
+    >>> api.get_uid(Fe) in profile1.getServicesUIDs()
     False

--- a/src/senaite/core/tests/doctests/AnalysisProfile.rst
+++ b/src/senaite/core/tests/doctests/AnalysisProfile.rst
@@ -215,7 +215,7 @@ Inactive services are not returned by default:
 
 But kept just in case we re-activate the service later:
 
-    >>> api.get_uid(Fe) in profile1.getServicesUIDs()
+    >>> api.get_uid(Fe) in profile1.getServiceUIDs()
     True
 
 By default, inactive services are kept as raw data when the value is set:
@@ -225,9 +225,9 @@ By default, inactive services are kept as raw data when the value is set:
     False
     >>> Fe in profile1.getServices()
     False
-    >>> api.get_uid(Cu) in profile1.getServicesUIDs()
+    >>> api.get_uid(Cu) in profile1.getServiceUIDs()
     False
-    >>> api.get_uid(Fe) in profile1.getServicesUIDs()
+    >>> api.get_uid(Fe) in profile1.getServiceUIDs()
     True
 
 Unless we use `keep_inactive=False`:
@@ -237,7 +237,7 @@ Unless we use `keep_inactive=False`:
     False
     >>> Fe in profile1.getServices()
     False
-    >>> api.get_uid(Cu) in profile1.getServicesUIDs()
+    >>> api.get_uid(Cu) in profile1.getServiceUIDs()
     False
-    >>> api.get_uid(Fe) in profile1.getServicesUIDs()
+    >>> api.get_uid(Fe) in profile1.getServiceUIDs()
     False

--- a/src/senaite/core/tests/doctests/AnalysisProfile.rst
+++ b/src/senaite/core/tests/doctests/AnalysisProfile.rst
@@ -196,3 +196,48 @@ Setting the profile works up to this state:
     >>> services = get_services(ar3)
     >>> set(map(api.get_uid, services)).issuperset(service_uids1 + [Au.UID()])
     True
+
+
+Inactive services
+.................
+
+Inactive services are not returned by default:
+
+    >>> Fe in profile1.getServices()
+    True
+
+    >>> success = do_action_for(Fe, "deactivate")
+    >>> api.get_workflow_status_of(Fe)
+    'inactive'
+
+    >>> Fe in profile1.getServices()
+    False
+
+But kept just in case we re-activate the service later:
+
+    >>> api.get_uid(Fe) in profile1.getServiceUIDs()
+    True
+
+By default, inactive services are kept as raw data when the value is set:
+
+    >>> profile1.setServices([])
+    >>> Cu in profile1.getServices()
+    False
+    >>> Fe in profile1.getServices()
+    False
+    >>> api.get_uid(Cu) in profile1.getServiceUIDs()
+    False
+    >>> api.get_uid(Fe) in profile1.getServiceUIDs()
+    True
+
+Unless we use `keep_inactive=False`:
+
+    >>> profile1.setServices([], keep_inactive=False)
+    >>> Cu in profile1.getServices()
+    False
+    >>> Fe in profile1.getServices()
+    False
+    >>> api.get_uid(Cu) in profile1.getServiceUIDs()
+    False
+    >>> api.get_uid(Fe) in profile1.getServiceUIDs()
+    False

--- a/src/senaite/core/tests/doctests/AnalysisServiceInactivation.rst
+++ b/src/senaite/core/tests/doctests/AnalysisServiceInactivation.rst
@@ -142,8 +142,8 @@ But if we activate `Ca` again:
     True
 
 
-Deactivated service is removed automatically from profiles
-..........................................................
+Deactivated service is kept in profiles, but not returned
+.........................................................
 
 Create a profile:
 
@@ -162,14 +162,29 @@ If we deactivate `Au`:
 
 Profile does no longer contain this service:
 
-    >>> [service.getKeyword() for service in profile.getServices()]
+    >>> services = profile.getServices()
+    >>> [service.getKeyword() for service in services]
     ['Ca', 'Mg']
 
-    >>> len(profile.getRawServices())
-    2
+Unless we explicitly ask to include inactive ones:
 
-Re-activate `Au`:
+    >>> services = profile.getServices(active_only=False)
+    >>> [service.getKeyword() for service in services]
+    ['Ca', 'Mg', 'Au']
+
+So the reference to inactive services is kept as a raw value:
+
+    >>> len(profile.getRawServices())
+    3
+
+And if we re-activate `Au`:
 
     >>> performed = doActionFor(Au, 'activate')
     >>> api.is_active(Au)
     True
+
+The profile returns the service again:
+
+    >>> services = profile.getServices()
+    >>> [service.getKeyword() for service in services]
+    ['Ca', 'Mg', 'Au']

--- a/src/senaite/core/tests/doctests/AnalysisServiceInactivation.rst
+++ b/src/senaite/core/tests/doctests/AnalysisServiceInactivation.rst
@@ -188,3 +188,51 @@ The profile returns the service again:
     >>> services = profile.getServices()
     >>> [service.getKeyword() for service in services]
     ['Ca', 'Mg', 'Au']
+
+
+Deactivated service is kept in templates, but not returned
+..........................................................
+
+Create a sample template:
+
+    >>> template = api.create(setup.sampletemplates, "SampleTemplate")
+    >>> template.setServices([Ca, Mg, Au])
+    >>> [service.getKeyword() for service in template.getServices()]
+    ['Ca', 'Mg', 'Au']
+    >>> len(template.getRawServices())
+    3
+
+If we deactivate `Au`:
+
+    >>> performed = doActionFor(Au, 'deactivate')
+    >>> api.is_active(Au)
+    False
+
+Template does no longer contain this service:
+
+    >>> services = template.getServices()
+    >>> [service.getKeyword() for service in services]
+    ['Ca', 'Mg']
+
+Unless we explicitly ask to include inactive ones:
+
+    >>> services = template.getServices(active_only=False)
+    >>> [service.getKeyword() for service in services]
+    ['Ca', 'Mg', 'Au']
+
+So the reference to inactive services is kept as a raw value:
+
+    >>> len(profile.getRawServices())
+    3
+
+And if we re-activate `Au`:
+
+    >>> performed = doActionFor(Au, 'activate')
+    >>> api.is_active(Au)
+    True
+
+The template returns the service again:
+
+    >>> services = template.getServices()
+    >>> [service.getKeyword() for service in services]
+    ['Ca', 'Mg', 'Au']

--- a/src/senaite/core/tests/doctests/SampleTemplate.rst
+++ b/src/senaite/core/tests/doctests/SampleTemplate.rst
@@ -305,7 +305,7 @@ Get the partition ID for a given service:
 Get the service UIDs for all assigned services:
 
     >>> uids = [api.get_uid(Fe), api.get_uid(Cu), api.get_uid(Au)]
-    >>> all(map(lambda uid: uid in uids, template1.getAnalysisServiceUIDs()))
+    >>> all(map(lambda uid: uid in uids, template1.getServicesUIDs()))
     True
 
 Update the settings for *all* assigned services with `setAnalysisServicesSettings` (plural):
@@ -320,7 +320,7 @@ Unassign a service from the template:
     >>> template1.remove_service(Au)
     True
 
-    >>> api.get_uid(Au) in template1.getAnalysisServiceUIDs()
+    >>> api.get_uid(Au) in template1.getServicesUIDs()
     False
 
     >>> template1.remove_service(Au)
@@ -331,7 +331,7 @@ Unassignment happens automatically if an Analysis Service was deactivated:
     >>> Fe in template1.getServices()
     True
 
-    >>> api.get_uid(Fe) in template1.getAnalysisServiceUIDs()
+    >>> api.get_uid(Fe) in template1.getServicesUIDs()
     True
 
     >>> api.get_workflow_status_of(Fe)
@@ -346,7 +346,7 @@ Unassignment happens automatically if an Analysis Service was deactivated:
 
 But are kept as raw data, just in case we re-activate the service later:
 
-    >>> api.get_uid(Fe) in template1.getAnalysisServiceUIDs()
+    >>> api.get_uid(Fe) in template1.getServicesUIDs()
     True
 
 By default, inactive services are kept as raw data when the value is set:
@@ -356,9 +356,9 @@ By default, inactive services are kept as raw data when the value is set:
     False
     >>> Fe in template1.getServices()
     False
-    >>> api.get_uid(Cu) in template1.getAnalysisServiceUIDs()
+    >>> api.get_uid(Cu) in template1.getServicesUIDs()
     False
-    >>> api.get_uid(Fe) in template1.getAnalysisServiceUIDs()
+    >>> api.get_uid(Fe) in template1.getServicesUIDs()
     True
 
 Unless we use `keep_inactive=False`:
@@ -368,7 +368,7 @@ Unless we use `keep_inactive=False`:
     False
     >>> Fe in template1.getServices()
     False
-    >>> api.get_uid(Cu) in template1.getAnalysisServiceUIDs()
+    >>> api.get_uid(Cu) in template1.getServicesUIDs()
     False
-    >>> api.get_uid(Fe) in template1.getAnalysisServiceUIDs()
+    >>> api.get_uid(Fe) in template1.getServicesUIDs()
     False

--- a/src/senaite/core/tests/doctests/SampleTemplate.rst
+++ b/src/senaite/core/tests/doctests/SampleTemplate.rst
@@ -305,7 +305,7 @@ Get the partition ID for a given service:
 Get the service UIDs for all assigned services:
 
     >>> uids = [api.get_uid(Fe), api.get_uid(Cu), api.get_uid(Au)]
-    >>> all(map(lambda uid: uid in uids, template1.getAnalysisServiceUIDs()))
+    >>> all(map(lambda uid: uid in uids, template1.getServiceUIDs()))
     True
 
 Update the settings for *all* assigned services with `setAnalysisServicesSettings` (plural):
@@ -320,7 +320,7 @@ Unassign a service from the template:
     >>> template1.remove_service(Au)
     True
 
-    >>> api.get_uid(Au) in template1.getAnalysisServiceUIDs()
+    >>> api.get_uid(Au) in template1.getServiceUIDs()
     False
 
     >>> template1.remove_service(Au)
@@ -331,7 +331,7 @@ Unassignment happens automatically if an Analysis Service was deactivated:
     >>> Fe in template1.getServices()
     True
 
-    >>> api.get_uid(Fe) in template1.getAnalysisServiceUIDs()
+    >>> api.get_uid(Fe) in template1.getServiceUIDs()
     True
 
     >>> api.get_workflow_status_of(Fe)
@@ -346,7 +346,7 @@ Unassignment happens automatically if an Analysis Service was deactivated:
 
 But are kept as raw data, just in case we re-activate the service later:
 
-    >>> api.get_uid(Fe) in template1.getAnalysisServiceUIDs()
+    >>> api.get_uid(Fe) in template1.getServiceUIDs()
     True
 
 By default, inactive services are kept as raw data when the value is set:
@@ -356,9 +356,9 @@ By default, inactive services are kept as raw data when the value is set:
     False
     >>> Fe in template1.getServices()
     False
-    >>> api.get_uid(Cu) in template1.getAnalysisServiceUIDs()
+    >>> api.get_uid(Cu) in template1.getServiceUIDs()
     False
-    >>> api.get_uid(Fe) in template1.getAnalysisServiceUIDs()
+    >>> api.get_uid(Fe) in template1.getServiceUIDs()
     True
 
 Unless we use `keep_inactive=False`:
@@ -368,7 +368,7 @@ Unless we use `keep_inactive=False`:
     False
     >>> Fe in template1.getServices()
     False
-    >>> api.get_uid(Cu) in template1.getAnalysisServiceUIDs()
+    >>> api.get_uid(Cu) in template1.getServiceUIDs()
     False
-    >>> api.get_uid(Fe) in template1.getAnalysisServiceUIDs()
+    >>> api.get_uid(Fe) in template1.getServiceUIDs()
     False

--- a/src/senaite/core/tests/doctests/SampleTemplate.rst
+++ b/src/senaite/core/tests/doctests/SampleTemplate.rst
@@ -334,6 +334,9 @@ Unassignment happens automatically if an Analysis Service was deactivated:
     >>> api.get_uid(Fe) in template1.getServiceUIDs()
     True
 
+    >>> api.get_uid(Fe) in template1.getRawServiceUIDs()
+    True
+
     >>> api.get_workflow_status_of(Fe)
     'active'
 
@@ -344,9 +347,12 @@ Unassignment happens automatically if an Analysis Service was deactivated:
     >>> Fe in template1.getServices()
     False
 
+    >>> api.get_uid(Fe) in template1.getServiceUIDs()
+    False
+
 But are kept as raw data, just in case we re-activate the service later:
 
-    >>> api.get_uid(Fe) in template1.getServiceUIDs()
+    >>> api.get_uid(Fe) in template1.getRawServiceUIDs()
     True
 
 By default, inactive services are kept as raw data when the value is set:
@@ -359,6 +365,10 @@ By default, inactive services are kept as raw data when the value is set:
     >>> api.get_uid(Cu) in template1.getServiceUIDs()
     False
     >>> api.get_uid(Fe) in template1.getServiceUIDs()
+    False
+    >>> api.get_uid(Cu) in template1.getRawServiceUIDs()
+    False
+    >>> api.get_uid(Fe) in template1.getRawServiceUIDs()
     True
 
 Unless we use `keep_inactive=False`:
@@ -371,4 +381,8 @@ Unless we use `keep_inactive=False`:
     >>> api.get_uid(Cu) in template1.getServiceUIDs()
     False
     >>> api.get_uid(Fe) in template1.getServiceUIDs()
+    False
+    >>> api.get_uid(Cu) in template1.getRawServiceUIDs()
+    False
+    >>> api.get_uid(Fe) in template1.getRawServiceUIDs()
     False

--- a/src/senaite/core/tests/doctests/SampleTemplate.rst
+++ b/src/senaite/core/tests/doctests/SampleTemplate.rst
@@ -230,7 +230,7 @@ Test get/set methods:
 Services
 ^^^^^^^^
 
-Anbalysis Services can be assigned to the Template, so that they are
+Analysis Services can be assigned to the Template, so that they are
 automatically added when the sample is created.
 
 Each service can be configured for a specific partition and if it should be
@@ -348,3 +348,27 @@ But are kept as raw data, just in case we re-activate the service later:
 
     >>> api.get_uid(Fe) in template1.getAnalysisServiceUIDs()
     True
+
+By default, inactive services are kept as raw data when the value is set:
+
+    >>> template1.setServices([])
+    >>> Cu in template1.getServices()
+    False
+    >>> Fe in template1.getServices()
+    False
+    >>> api.get_uid(Cu) in template1.getAnalysisServiceUIDs()
+    False
+    >>> api.get_uid(Fe) in template1.getAnalysisServiceUIDs()
+    True
+
+Unless we use `keep_inactive=False`:
+
+    >>> template1.setServices([], keep_inactive=False)
+    >>> Cu in template1.getServices()
+    False
+    >>> Fe in template1.getServices()
+    False
+    >>> api.get_uid(Cu) in template1.getAnalysisServiceUIDs()
+    False
+    >>> api.get_uid(Fe) in template1.getAnalysisServiceUIDs()
+    False

--- a/src/senaite/core/tests/doctests/SampleTemplate.rst
+++ b/src/senaite/core/tests/doctests/SampleTemplate.rst
@@ -352,6 +352,9 @@ Unassignment happens automatically if an Analysis Service was deactivated:
 
 But are kept as raw data, just in case we re-activate the service later:
 
+    >>> Fe in template1.getServices(active_only=False)
+    True
+
     >>> api.get_uid(Fe) in template1.getRawServiceUIDs()
     True
 

--- a/src/senaite/core/tests/doctests/SampleTemplate.rst
+++ b/src/senaite/core/tests/doctests/SampleTemplate.rst
@@ -305,7 +305,7 @@ Get the partition ID for a given service:
 Get the service UIDs for all assigned services:
 
     >>> uids = [api.get_uid(Fe), api.get_uid(Cu), api.get_uid(Au)]
-    >>> all(map(lambda uid: uid in uids, template1.getServicesUIDs()))
+    >>> all(map(lambda uid: uid in uids, template1.getAnalysisServiceUIDs()))
     True
 
 Update the settings for *all* assigned services with `setAnalysisServicesSettings` (plural):
@@ -320,7 +320,7 @@ Unassign a service from the template:
     >>> template1.remove_service(Au)
     True
 
-    >>> api.get_uid(Au) in template1.getServicesUIDs()
+    >>> api.get_uid(Au) in template1.getAnalysisServiceUIDs()
     False
 
     >>> template1.remove_service(Au)
@@ -331,7 +331,7 @@ Unassignment happens automatically if an Analysis Service was deactivated:
     >>> Fe in template1.getServices()
     True
 
-    >>> api.get_uid(Fe) in template1.getServicesUIDs()
+    >>> api.get_uid(Fe) in template1.getAnalysisServiceUIDs()
     True
 
     >>> api.get_workflow_status_of(Fe)
@@ -346,7 +346,7 @@ Unassignment happens automatically if an Analysis Service was deactivated:
 
 But are kept as raw data, just in case we re-activate the service later:
 
-    >>> api.get_uid(Fe) in template1.getServicesUIDs()
+    >>> api.get_uid(Fe) in template1.getAnalysisServiceUIDs()
     True
 
 By default, inactive services are kept as raw data when the value is set:
@@ -356,9 +356,9 @@ By default, inactive services are kept as raw data when the value is set:
     False
     >>> Fe in template1.getServices()
     False
-    >>> api.get_uid(Cu) in template1.getServicesUIDs()
+    >>> api.get_uid(Cu) in template1.getAnalysisServiceUIDs()
     False
-    >>> api.get_uid(Fe) in template1.getServicesUIDs()
+    >>> api.get_uid(Fe) in template1.getAnalysisServiceUIDs()
     True
 
 Unless we use `keep_inactive=False`:
@@ -368,7 +368,7 @@ Unless we use `keep_inactive=False`:
     False
     >>> Fe in template1.getServices()
     False
-    >>> api.get_uid(Cu) in template1.getServicesUIDs()
+    >>> api.get_uid(Cu) in template1.getAnalysisServiceUIDs()
     False
-    >>> api.get_uid(Fe) in template1.getServicesUIDs()
+    >>> api.get_uid(Fe) in template1.getAnalysisServiceUIDs()
     False

--- a/src/senaite/core/tests/doctests/SampleTemplate.rst
+++ b/src/senaite/core/tests/doctests/SampleTemplate.rst
@@ -328,6 +328,9 @@ Unassign a service from the template:
 
 Unassignment happens automatically if an Analysis Service was deactivated:
 
+    >>> Fe in template1.getServices()
+    True
+
     >>> api.get_uid(Fe) in template1.getAnalysisServiceUIDs()
     True
 
@@ -335,9 +338,13 @@ Unassignment happens automatically if an Analysis Service was deactivated:
     'active'
 
     >>> success = do_action_for(Fe, "deactivate")
-
     >>> api.get_workflow_status_of(Fe)
     'inactive'
 
-    >>> api.get_uid(Fe) in template1.getAnalysisServiceUIDs()
+    >>> Fe in template1.getServices()
     False
+
+But are kept as raw data, just in case we re-activate the service later:
+
+    >>> api.get_uid(Fe) in template1.getAnalysisServiceUIDs()
+    True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request achieves the functionality suggested at https://github.com/senaite/senaite.core/pull/2623#issuecomment-2396572026 for both `AnalysisProfile` and `SampleTemplate`:

- no need to update/recatalog other objects via subscriber on service deactivation
- service can be deactivated/reactivated and user won't need to manually reassign services to profiles later

## Current behavior before PR

Deactivated services do not come-up automatically on profiles when reactivated

## Desired behavior after PR is merged

Deactivated services come-up automatically on profiles when reactivated

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
