### PR TITLE
Fix AttributeError on upgrade step 2654 (reindex_getDueDate)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2638 Fix AttributeError on upgrade step 2654 (reindex_getDueDate)
 - #2569 Fix samples are indicated as late when Turnaround Time is zero
 - #2636 Fix JS Error in WS Template edit form
 - #2635 Remove reindexing of Analyses and Analysis Services on Category change

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -53,6 +53,7 @@ from senaite.core.upgrade.utils import copy_snapshots
 from senaite.core.upgrade.utils import del_metadata
 from senaite.core.upgrade.utils import delete_object
 from senaite.core.upgrade.utils import permanently_allow_type_for
+from senaite.core.upgrade.utils import uncatalog_brain
 from senaite.core.upgrade.utils import uncatalog_object
 from senaite.core.upgrade.utils import UpgradeUtils
 from senaite.core.workflow import ANALYSIS_WORKFLOW
@@ -2079,7 +2080,13 @@ def reindex_getDueDate(tool):
     total = len(brains)
     sample_uids = set()
     for num, brain in enumerate(brains):
-        obj = api.get_object(brain)
+        try:
+            obj = api.get_object(brain, default=None)
+        except AttributeError:
+            obj = None
+        if obj is None:
+            uncatalog_brain(brain)
+            continue
         if not IRequestAnalysis.providedBy(obj):
             continue
         if num and num % 100 == 0:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request bypass `AttributeError` when running upgrade step 2654 and removes stale brains, if any.

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 666, in __call__
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 399, in upgrade_product
  Module Products.GenericSetup.tool, line 1202, in upgradeProfile
  Module Products.GenericSetup.upgrade, line 185, in doStep
  Module senaite.core.upgrade.v02_06_000, line 2082, in reindex_getDueDate
  Module bika.lims.api, line 527, in get_object
  Module Products.ZCatalog.CatalogBrains, line 89, in getObject
  Module OFS.Traversable, line 328, in unrestrictedTraverse
   - __traceback_info__: ([], 'BSE24A002')
AttributeError: BSE24A002
```

## Desired behavior after PR is merged

Upgrade step finishes successfully and the stale brains that have been uncatalogued are displayed in the log

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
