### PR TITLE
Fix sampletype-related indexes for AnalysisSpec type are not indexed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2639 Fix sampletype-related indexes for AnalysisSpec type are not indexed
 - #2569 Fix samples are indicated as late when Turnaround Time is zero
 - #2636 Fix JS Error in WS Template edit form
 - #2635 Remove reindexing of Analyses and Analysis Services on Category change

--- a/src/senaite/core/catalog/indexer/analysisspec.py
+++ b/src/senaite/core/catalog/indexer/analysisspec.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2024 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.lims import api
+from bika.lims.interfaces import IAnalysisSpec
+from plone.indexer import indexer
+from senaite.core.interfaces import ISetupCatalog
+
+
+@indexer(IAnalysisSpec, ISetupCatalog)
+def sampletype_title(instance):
+    """Returns a list of titles from SampleType the instance is assigned to
+    If the instance has no sample type assigned, it returns a tuple with an
+    empty value. This allows searches for `MissingValue` entries too.
+    """
+    sample_type = instance.getSampleType()
+    sample_type = api.get_title(sample_type)
+    return [sample_type] if sample_type else [""]
+
+
+@indexer(IAnalysisSpec, ISetupCatalog)
+def sampletype_uid(instance):
+    """Returns a list of uids from SampleType the instance is assigned to
+    If the instance has no SampleType assigned, it returns a tuple with an
+    empty value. This allows searches for `MissingValue` entries too.
+    """
+    return instance.getRawSampleType() or [""]

--- a/src/senaite/core/catalog/indexer/analysisspec.py
+++ b/src/senaite/core/catalog/indexer/analysisspec.py
@@ -26,19 +26,25 @@ from senaite.core.interfaces import ISetupCatalog
 
 @indexer(IAnalysisSpec, ISetupCatalog)
 def sampletype_title(instance):
-    """Returns a list of titles from SampleType the instance is assigned to
-    If the instance has no sample type assigned, it returns a tuple with an
-    empty value. This allows searches for `MissingValue` entries too.
+    """Returns a list containing the title of the sample type assigned to this
+    instance, as defined by the AnalysisSpec type. The function returns a list
+    because the index used is a KeywordIndex, which supports searching for
+    missing values in cases where the sample type is not a mandatory field.
     """
     sample_type = instance.getSampleType()
-    sample_type = api.get_title(sample_type)
-    return [sample_type] if sample_type else [""]
+    if not sample_type:
+        return [""]
+    return [api.get_title(sample_type)]
 
 
 @indexer(IAnalysisSpec, ISetupCatalog)
 def sampletype_uid(instance):
-    """Returns a list of uids from SampleType the instance is assigned to
-    If the instance has no SampleType assigned, it returns a tuple with an
-    empty value. This allows searches for `MissingValue` entries too.
+    """Returns a list containing the UID of the sample type assigned to this
+    instance, as defined by the AnalysisSpec type. The function returns a list
+    because the index used is a KeywordIndex, which supports searching for
+    missing values in cases where the sample type is not a mandatory field.
     """
-    return instance.getRawSampleType() or [""]
+    uid = instance.getRawSampleType()
+    if not uid:
+        return [""]
+    return [uid]

--- a/src/senaite/core/catalog/indexer/configure.zcml
+++ b/src/senaite/core/catalog/indexer/configure.zcml
@@ -79,4 +79,8 @@
   <adapter name="sampletype_title" factory=".sampletype.sampletype_title"/>
   <adapter name="sampletype_uid" factory=".sampletype.sampletype_uid"/>
 
+  <!-- AnalysisSpec Indexer -->
+  <adapter name="sampletype_title" factory=".analysisspec.sampletype_title"/>
+  <adapter name="sampletype_uid" factory=".analysisspec.sampletype_uid"/>
+
 </configure>

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2654</version>
+  <version>2655</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -2523,7 +2523,6 @@ def fix_corrupted_transitions(tool):
     logger.info("Fixing corrupted transitions [DONE]")
 
 
-
 def reindex_analysis_categories(tool):
     logger.info("Reindexing analysis categories ...")
     cat = api.get_tool(SETUP_CATALOG)

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -2523,6 +2523,7 @@ def fix_corrupted_transitions(tool):
     logger.info("Fixing corrupted transitions [DONE]")
 
 
+
 def reindex_analysis_categories(tool):
     logger.info("Reindexing analysis categories ...")
     cat = api.get_tool(SETUP_CATALOG)
@@ -2699,3 +2700,16 @@ def migrate_worksheettemplates_to_dx(tool):
             logger.warn("Cannot remove {}. Is not empty".format(origin))
 
     logger.info("Convert Worksheet Templates to Dexterity [DONE]")
+
+
+def reindex_specs(tool):
+    """Reindex the sampletype_uid and sampletype_title indexes from setup
+    catalog for AnalysisSpecs types
+    """
+    logger.info("Reindexing analysis specifications ...")
+    cat = api.get_tool(SETUP_CATALOG)
+    for brain in cat(portal_type="AnalysisSpec"):
+        obj = brain.getObject()
+        logger.info("Reindex analysis spec: %r" % obj)
+        obj.reindexObject(idxs=["sampletype_uid", "sampletype_title"])
+    logger.info("Reindexing analysis specifications [DONE]")

--- a/src/senaite/core/upgrade/v02_06_000.zcml
+++ b/src/senaite/core/upgrade/v02_06_000.zcml
@@ -3,7 +3,15 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     i18n_domain="senaite.core">
 
-   <genericsetup:upgradeStep
+  <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.6.0: Fix sampletype-related indexes for specs"
+      description="SampleType-specific indexes Analysis Specs are not indexed"
+      source="2654"
+      destination="2655"
+      handler=".v02_06_000.reindex_specs"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.6.0: Reindex getDueDate"
       description="Reindex getDueDate from analyses and sample catalogs"
       source="2653"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes an issue introduced with #2584 so the indexes `sampletype_uid` and `sampletype_title` from `setup_catalog` and for portal type `AnalysisSpec` are no longer indexed. Reason is that AnalysisSpec's AT inherits from `SampleTypeAwareMixin` and the indexes for this interface were removed when `SampleType` was ported to DX.

## Current behavior before PR

`sampletype_uid` and `sampletype_title` indexes for `AnalysisSpec` type are not indexed

## Desired behavior after PR is merged

`sampletype_uid` and `sampletype_title` indexes for `AnalysisSpec` type are indexed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
