### PR TITLE
Fix missing custom transitions via adapter in Worksheet's analyses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2640 Fix missing custom transitions via adapter in Worksheet's analyses
 - #2639 Fix sampletype-related indexes for AnalysisSpec type are not indexed
 - #2638 Fix AttributeError on upgrade step 2654 (reindex_getDueDate)
 - #2569 Fix samples are indicated as late when Turnaround Time is zero

--- a/src/bika/lims/browser/worksheet/views/analyses.py
+++ b/src/bika/lims/browser/worksheet/views/analyses.py
@@ -162,15 +162,16 @@ class AnalysesView(BaseView):
 
         # Inject custom transition for remarks
         if self.show_analysis_remarks_transition():
+            set_remarks = {
+                "id": "modal_set_analysis_remarks",
+                "title": _("Set remarks"),
+                "url": "{}/set_analysis_remarks_modal".format(
+                    api.get_url(self.context)),
+                "css_class": "btn btn-outline-secondary",
+                "help": _("Set remarks for selected analyses")
+            }
             for state in self.review_states:
-                state["custom_transitions"] = [{
-                    "id": "modal_set_analysis_remarks",
-                    "title": _("Set remarks"),
-                    "url": "{}/set_analysis_remarks_modal".format(
-                        api.get_url(self.context)),
-                    "css_class": "btn btn-outline-secondary",
-                    "help": _("Set remarks for selected analyses")
-                }]
+                state.setdefault("custom_transitions", []).append(set_remarks)
 
     @view.memoize
     def get_default_columns_order(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request allows custom transitions to be added to the worksheet's analysis listing via subscriber adapters when the remarks transition setting is enabled. The underlying issue was that custom transitions for each review state were being overwritten in the main listing after the call to `before_render` from the base class, which is responsible for invoking the subscriber adapters.

For instance, with a subscriber adapter like this:

```xml
<!-- Analyses listing from inside a Worksheet -->
<subscriber
    for="bika.lims.browser.worksheet.views.AnalysesView
         bika.lims.interfaces.IWorksheet"
    provides="senaite.app.listing.interfaces.IListingViewAdapter"
    factory=".analyses.WorksheetAnalysesListingAdapter"/>
```

```python
@adapter(IListingView)
@implementer(IListingViewAdapter)
class WorksheetAnalysesListingAdapter(object):

    ...

    def before_render(self):
        # Additional custom transitions
        url = api.get_url(self.context)
        print_stickers = {
            "id": "print_sample_stickers",
            "title": _("Print stickers"),
            "url": "%s/workflow_action?action=print_sample_stickers" % url,
            "css_class": "btn btn-outline-secondary",
        }

        for rs in self.listing.review_states:
            rs.setdefault("custom_transitions", []).append(print_stickers)

```

The listing should display a custom transition (*Print stickers*), along with those added by the listing itself (*Set remarks*):

![Captura de 2024-11-05 23-41-35](https://github.com/user-attachments/assets/a346f024-59d2-42d4-8dc9-f26e41c4f110)


## Current behavior before PR

Custom transitions added via subscriber adapters are not visible in worksheet analyses listing

## Desired behavior after PR is merged

Custom transitions added via subscriber adapters are visible in worksheet analyses listing

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
