### PR TITLE
Fix `AttributeError` on rejection of samples without a contact set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2641 Fix AttributeError on rejection of samples without a contact set
 - #2639 Fix sampletype-related indexes for AnalysisSpec type are not indexed
 - #2638 Fix AttributeError on upgrade step 2654 (reindex_getDueDate)
 - #2569 Fix samples are indicated as late when Turnaround Time is zero

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -574,6 +574,7 @@ def get_rejection_email_recipients(sample):
     """
     # extract the emails from contacts
     contacts = [sample.getContact()] + sample.getCCContact()
+    contacts = filter(None, contacts)
     emails = map(lambda contact: contact.getEmailAddress(), contacts)
 
     # extend with the CC emails


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a Traceback that arises when rejecting a sample if no contact is set (maybe a custom add-on temporarily disables the contact field requirement).

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.core.browser.samples.rejection.reject_samples, line 123, in __call__
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 215, in render
  Module chameleon.template, line 192, in render
  Module a2a06353c5baaaab68b659e8bc0d647d, line 1030, in render
  Module 1d2b42742cb8a09dce2a38d8b894621c, line 1428, in render_master
  Module 1d2b42742cb8a09dce2a38d8b894621c, line 407, in render_content
  Module a2a06353c5baaaab68b659e8bc0d647d, line 317, in __fill_content_core
  Module Products.PageTemplates.engine, line 78, in __call__
  Module senaite.core.browser.samples.rejection.reject_samples, line 157, in get_samples_data
  Module bika.lims.utils.analysisrequest, line 589, in get_rejection_email_recipients
  Module bika.lims.utils.analysisrequest, line 589, in <lambda>
AttributeError: 'NoneType' object has no attribute 'getEmailAddress'
```

## Desired behavior after PR is merged

Rejection report is generated without errors

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
