### PR TITLE
Fix Attribute Error in Upgrade Step 2619

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2642 Fix Attribute Error in Upgrade Step 2619
 - #2641 Fix AttributeError on rejection of samples without a contact set
 - #2640 Fix missing custom transitions via adapter in Worksheet's analyses
 - #2639 Fix sampletype-related indexes for AnalysisSpec type are not indexed

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -2189,7 +2189,12 @@ def setup_result_types(tool):
             continue
 
         # check if it was set as a string result
-        string_result = obj.getField("StringResult").get(obj)
+        field = obj.getField("StringResult")
+        if not field:
+            logger.error("Field 'StringResult' not found on object %s (%s)"
+                         % (api.get_path(obj), api.get_uid(obj)))
+            continue
+        string_result = field.get(obj)
 
         # get the results options type
         options_field = obj.getField("ResultOptionsType")

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -2191,6 +2191,7 @@ def setup_result_types(tool):
         # check if it was set as a string result
         field = obj.getField("StringResult")
         if not field:
+            # https://github.com/senaite/senaite.core/pull/2642
             logger.error("Field 'StringResult' not found on object %s (%s)"
                          % (api.get_path(obj), api.get_uid(obj)))
             continue


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR handles the following error in Upgrade Step 2619 that was introduced in [#2537](https://github.com/senaite/senaite.core/pull/2537):

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.GenericSetup.tool, line 1135, in manage_doUpgrades
  Module Products.GenericSetup.upgrade, line 185, in doStep
  Module senaite.core.upgrade.v02_06_000, line 2192, in setup_result_types
AttributeError: 'NoneType' object has no attribute 'get'
```

## Current behavior before PR

Traceback occurs due to a false indexed object in the UID catalog

## Desired behavior after PR is merged

Error is handled gracefully and an error log is printed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
