### PR TITLE
Improve performance of analysis verification

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2643 Improve performance of analysis verification
 - #2642 Fix Attribute Error in Upgrade Step 2619
 - #2641 Fix AttributeError on rejection of samples without a contact set
 - #2640 Fix missing custom transitions via adapter in Worksheet's analyses

--- a/src/bika/lims/workflow/analysis/events.py
+++ b/src/bika/lims/workflow/analysis/events.py
@@ -27,6 +27,8 @@ from bika.lims.interfaces import IVerified
 from bika.lims.interfaces.analysis import IRequestAnalysis
 from bika.lims.utils.analysis import create_retest
 from bika.lims.workflow import doActionFor
+from bika.lims.workflow.analysis import STATE_REJECTED
+from bika.lims.workflow.analysis import STATE_RETRACTED
 from DateTime import DateTime
 from zope.interface import alsoProvides
 
@@ -241,21 +243,27 @@ def after_verify(analysis):
 def check_all_verified(analysis):
     """Checks if all analyses are verified
     """
+    parent = api.get_parent(analysis)
     sample = analysis.getRequest()
     uid = api.get_uid(analysis)
 
-    # get all analyses of the sample
-    analyses = sample.getAnalyses()
-    # get all verified analyses of the sample
+    def is_valid(an):
+        state = api.get_review_status(an)
+        return state not in [STATE_REJECTED, STATE_RETRACTED]
+
+    # get all *valid* analyses of the sample
+    analyses = filter(is_valid, sample.getAnalyses())
+    # get all *verified* analyses of the sample
     verified = sample.getAnalyses(object_provides=IVerified.__identifier__)
 
-    # NOTE: We remove the current processed analysis from the calculation,
-    #       because it is either not yet verified or processed in multi-verify
-    #       scenarios
-    analysis_count = len(filter(lambda x: api.get_uid(x) != uid, analyses))
-    verified_count = len(filter(lambda x: api.get_uid(x) != uid, verified))
+    # NOTE: We remove the current processed routine analysis (if not a WS
+    #       duplicate/reference analysis), because it is either not yet
+    #       verified or processed already in multi-verify scenarios.
+    if sample == parent:
+        analyses = filter(lambda x: api.get_uid(x) != uid, analyses)
+        verified = filter(lambda x: api.get_uid(x) != uid, verified)
 
-    return analysis_count == verified_count
+    return len(analyses) == len(verified)
 
 
 def after_publish(analysis):

--- a/src/bika/lims/workflow/analysis/events.py
+++ b/src/bika/lims/workflow/analysis/events.py
@@ -30,16 +30,7 @@ from bika.lims.workflow import doActionFor
 from bika.lims.workflow.analysis import STATE_REJECTED
 from bika.lims.workflow.analysis import STATE_RETRACTED
 from DateTime import DateTime
-from zope.annotation.interfaces import IAnnotations
-from zope.interface import Interface
 from zope.interface import alsoProvides
-
-try:
-    # https://github.com/senaite/senaite.app.listing/pull/146
-    from senaite.app.listing.interfaces import ITransitionChain
-except ImportError:
-    class ITransitionChain(Interface):
-        pass
 
 
 def after_assign(analysis):
@@ -262,15 +253,6 @@ def check_all_verified(analysis):
     :param analysis: The current verified analysis
     :returns: True if all other routine analyses of the sample are verified
     """
-
-    request = api.get_request()
-    if ITransitionChain.providedBy(request):
-        transition_chain = IAnnotations(request).get("transition_chain")
-        if api.is_list(transition_chain) and len(transition_chain) > 0:
-            # check if the current processed UID is the last
-            uid = api.get_uid(analysis)
-            # skip further processing if the current UID is not the last
-            return uid == transition_chain[-1]
 
     parent = api.get_parent(analysis)
     sample = analysis.getRequest()

--- a/src/bika/lims/workflow/analysis/events.py
+++ b/src/bika/lims/workflow/analysis/events.py
@@ -30,7 +30,16 @@ from bika.lims.workflow import doActionFor
 from bika.lims.workflow.analysis import STATE_REJECTED
 from bika.lims.workflow.analysis import STATE_RETRACTED
 from DateTime import DateTime
+from zope.annotation.interfaces import IAnnotations
+from zope.interface import Interface
 from zope.interface import alsoProvides
+
+try:
+    # https://github.com/senaite/senaite.app.listing/pull/146
+    from senaite.app.listing.interfaces import ITransitionChain
+except ImportError:
+    class ITransitionChain(Interface):
+        pass
 
 
 def after_assign(analysis):
@@ -253,6 +262,16 @@ def check_all_verified(analysis):
     :param analysis: The current verified analysis
     :returns: True if all other routine analyses of the sample are verified
     """
+
+    request = api.get_request()
+    if ITransitionChain.providedBy(request):
+        transition_chain = IAnnotations(request).get("transition_chain")
+        if api.is_list(transition_chain) and len(transition_chain) > 0:
+            # check if the current processed UID is the last
+            uid = api.get_uid(analysis)
+            # skip further processing if the current UID is not the last
+            return uid == transition_chain[-1]
+
     parent = api.get_parent(analysis)
     sample = analysis.getRequest()
     uid = api.get_uid(analysis)

--- a/src/bika/lims/workflow/analysis/events.py
+++ b/src/bika/lims/workflow/analysis/events.py
@@ -242,10 +242,20 @@ def check_all_verified(analysis):
     """Checks if all analyses are verified
     """
     sample = analysis.getRequest()
+    analysis_uid = api.get_uid(analysis)
+
+    # get all analyses of the sample
     analyses = sample.getAnalyses()
+    # get all verified analyses of the sample
     verified = sample.getAnalyses(object_provides=IVerified.__identifier__)
-    # NOTE: We count the current processed analysis as verified!
-    return len(analyses) == len(verified) + 1
+
+    # NOTE: We remove the current processed analysis from the calculation,
+    #       because it is either not yet verified or processed in multi-verify
+    #       scenarios
+    analysis_count = filter(lambda x: api.get_uid(x) != analysis_uid, analyses)
+    verified_count = filter(lambda x: api.get_uid(x) != analysis_uid, verified)
+
+    return analysis_count == verified_count
 
 
 def after_publish(analysis):

--- a/src/bika/lims/workflow/analysis/events.py
+++ b/src/bika/lims/workflow/analysis/events.py
@@ -229,13 +229,23 @@ def after_verify(analysis):
         ws.reindexObject()
 
     # Promote transition to Analysis Request if Sample auto-verify is enabled
-    if IRequestAnalysis.providedBy(analysis):
+    if IRequestAnalysis.providedBy(analysis) and check_all_verified(analysis):
         setup = api.get_setup()
         if setup.getAutoVerifySamples():
             doActionFor(analysis.getRequest(), "verify")
 
         # Reindex the sample (and ancestors) this analysis belongs to
         reindex_request(analysis)
+
+
+def check_all_verified(analysis):
+    """Checks if all analyses are verified
+    """
+    sample = analysis.getRequest()
+    analyses = sample.getAnalyses()
+    verified = sample.getAnalyses(object_provides=IVerified.__identifier__)
+    # NOTE: We count the current processed analysis as verified!
+    return len(analyses) == len(verified) + 1
 
 
 def after_publish(analysis):

--- a/src/bika/lims/workflow/analysis/events.py
+++ b/src/bika/lims/workflow/analysis/events.py
@@ -242,6 +242,16 @@ def after_verify(analysis):
 
 def check_all_verified(analysis):
     """Checks if all analyses are verified
+
+    NOTE: This check is provided solely for performance reasons of the `verify`
+    transition, because it is a less expensive calculation than executing the
+    `doActionFor` method on the sample for each verified analysis.
+
+    The worst case that can happen is that the sample does not get
+    automatically verified and needs to be transitioned manually.
+
+    :param analysis: The current verified analysis
+    :returns: True if all other routine analyses of the sample are verified
     """
     parent = api.get_parent(analysis)
     sample = analysis.getRequest()

--- a/src/bika/lims/workflow/analysis/events.py
+++ b/src/bika/lims/workflow/analysis/events.py
@@ -242,7 +242,7 @@ def check_all_verified(analysis):
     """Checks if all analyses are verified
     """
     sample = analysis.getRequest()
-    analysis_uid = api.get_uid(analysis)
+    uid = api.get_uid(analysis)
 
     # get all analyses of the sample
     analyses = sample.getAnalyses()
@@ -252,8 +252,8 @@ def check_all_verified(analysis):
     # NOTE: We remove the current processed analysis from the calculation,
     #       because it is either not yet verified or processed in multi-verify
     #       scenarios
-    analysis_count = filter(lambda x: api.get_uid(x) != analysis_uid, analyses)
-    verified_count = filter(lambda x: api.get_uid(x) != analysis_uid, verified)
+    analysis_count = len(filter(lambda x: api.get_uid(x) != uid, analyses))
+    verified_count = len(filter(lambda x: api.get_uid(x) != uid, verified))
 
     return analysis_count == verified_count
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR speeds up the verification process from ~2-3 seconds to 0.5 seconds~ ~200ms to ~125ms per Analysis.

## Current behavior before PR

The `after_verify` WF event handler tries to transition the parent sample after each analysis verification to `verified`.

## Desired behavior after PR is merged

The `after_verify` WF event handler checks first if all Analyses are in the state `verified` before trying to transition the parent to `verified`


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
