### PR TITLE
Tabbed content view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2645 Tabbed content view
 - #2637 Do not remove inactive services from profiles and templates
 - #2642 Fix Attribute Error in Upgrade Step 2619
 - #2641 Fix AttributeError on rejection of samples without a contact set

--- a/src/senaite/core/browser/dexterity/templates/container.pt
+++ b/src/senaite/core/browser/dexterity/templates/container.pt
@@ -10,27 +10,8 @@
     <metal:main fill-slot="content-core">
       <metal:content-core define-macro="content-core">
 
-        <tal:block repeat="widget view/widgets/values|nothing">
-          <tal:block tal:condition="python:widget.__name__ not in ('IBasic.title', 'IBasic.description', 'title', 'description',)">
-            <tal:widget tal:replace="structure widget/@@ploneform-render-widget"/>
-          </tal:block>
-        </tal:block>
-
-        <fieldset tal:repeat="group view/groups|nothing"
-                  tal:attributes="id python:''.join((group.prefix, 'groups.', group.__name__)).replace('.', '-')">
-          <legend tal:content="group/label" />
-          <tal:block tal:repeat="widget group/widgets/values">
-            <tal:widget tal:replace="structure widget/@@ploneform-render-widget"/>
-          </tal:block>
-        </fieldset>
-
-        <!-- hide contents listing -->
-        <fieldset id="folder-listing" tal:condition="python:False">
-          <legend i18n:translate="" i18n:domain="plone">Contents</legend>
-          <tal:block define="view nocall:context/folder_listing; listing_macro view/macros/listing|view/index/macros/listing">
-            <metal:use_macro use-macro="listing_macro" />
-          </tal:block>
-        </fieldset>
+        <!-- Render widgets in tabs -->
+        <tal:tabs tal:replace="structure view/render_widget_tabs"/>
 
       </metal:content-core>
     </metal:main>

--- a/src/senaite/core/browser/dexterity/templates/item.pt
+++ b/src/senaite/core/browser/dexterity/templates/item.pt
@@ -10,19 +10,8 @@
     <metal:main fill-slot="content-core">
       <metal:content-core define-macro="content-core">
 
-        <tal:block repeat="widget view/widgets/values|nothing">
-          <tal:block tal:condition="python:widget.__name__ not in ('IBasic.title', 'IBasic.description', 'title', 'description',)">
-            <tal:widget tal:replace="structure widget/@@ploneform-render-widget"/>
-          </tal:block>
-        </tal:block>
-
-        <div tal:repeat="group view/groups|nothing"
-             tal:attributes="id python:''.join((group.prefix, 'groups.', group.__name__)).replace('.', '-')">
-          <legend class="mt-2 border-top border-bottom" tal:content="group/label" />
-          <tal:block tal:repeat="widget group/widgets/values|nothing">
-            <tal:widget tal:replace="structure widget/@@ploneform-render-widget"/>
-          </tal:block>
-        </div>
+        <!-- Render widgets in tabs -->
+        <tal:tabs tal:replace="structure view/render_widget_tabs"/>
 
       </metal:content-core>
     </metal:main>

--- a/src/senaite/core/browser/dexterity/templates/tabs.pt
+++ b/src/senaite/core/browser/dexterity/templates/tabs.pt
@@ -1,0 +1,70 @@
+<div tal:define="groups view/groups | nothing;
+                 enable_form_tabbing view/enable_form_tabbing | python:True;
+                 default_fieldset_label view/default_fieldset_label | string:Default;
+                 has_groups python:bool(groups);">
+
+  <!-- navigation tabs -->
+  <ul class="nav nav-tabs" role="tablist"
+      tal:condition="python: has_groups and enable_form_tabbing">
+
+    <!-- primary tab -->
+    <li class="nav-item" role="presentation">
+      <a tal:content="default_fieldset_label"
+         tal:attributes="class python:'nav-link active'"
+         id="default-tab"
+         href="#default"
+         data-toggle="tab"
+         role="tab">
+        Label
+      </a>
+    </li>
+    <!-- secondary tabs -->
+    <li tal:repeat="group groups" class="nav-item" role="presentation">
+      <a tal:define="normalizeString nocall:context/@@plone/normalizeString;
+                     fieldset_label group/label;
+                     fieldset_name python:getattr(group, '__name__', False) or getattr(group.label, 'default', False) or fieldset_label;
+                     fieldset_name python:normalizeString(fieldset_name);
+                     has_errors group/widgets/errors|nothing"
+         tal:attributes="id string:${fieldset_name}-tab;
+                         href string:#${fieldset_name};
+                         class python:has_errors and 'nav-link text-danger' or 'nav-link'"
+         tal:content="fieldset_label"
+         data-toggle="tab"
+         role="tab">
+        Label
+      </a>
+    </li>
+  </ul>
+
+  <!-- tab content -->
+  <div class="tab-content">
+    <!-- Primary fieldsets -->
+    <div class="tab-pane active" id="default" role="tabpanel">
+      <tal:block repeat="widget view/widgets/values|nothing">
+        <tal:block tal:condition="python:widget.__name__ not in ('IBasic.title', 'IBasic.description', 'title', 'description',)">
+          <tal:widget tal:replace="structure widget/@@ploneform-render-widget"/>
+        </tal:block>
+      </tal:block>
+    </div>
+    <!-- Secondary fieldsets -->
+    <tal:block tal:repeat="group groups" condition="has_groups">
+      <div class="tab-pane"
+           tal:define="normalizeString nocall:context/@@plone/normalizeString;
+                       fieldset_label group/label;
+                       fieldset_name python:getattr(group, '__name__', False) or getattr(group.label, 'default', False) or fieldset_label;
+                       fieldset_name python:normalizeString(fieldset_name);"
+           tal:attributes="id string:${fieldset_name};
+                           class python:'tab-pane' if enable_form_tabbing else 'd-block';
+                           data-fieldset fieldset_name;">
+
+        <fieldset tal:repeat="group view/groups|nothing"
+                  tal:attributes="id python:''.join((group.prefix, 'groups.', group.__name__)).replace('.', '-')">
+          <tal:block tal:repeat="widget group/widgets/values">
+            <tal:widget tal:replace="structure widget/@@ploneform-render-widget"/>
+          </tal:block>
+        </fieldset>
+
+      </div>
+    </tal:block>
+  </div>
+</div>

--- a/src/senaite/core/browser/dexterity/templates/tabs.pt
+++ b/src/senaite/core/browser/dexterity/templates/tabs.pt
@@ -4,7 +4,8 @@
                  has_groups python:bool(groups);">
 
   <!-- Tab view toggle -->
-  <div class="d-flex flex-row-reverse">
+  <div class="d-flex flex-row-reverse"
+       tal:condition="has_groups">
     <!-- shows all contents on one page -->
     <a href="#"
        tal:condition="python:enable_form_tabbing"

--- a/src/senaite/core/browser/dexterity/templates/tabs.pt
+++ b/src/senaite/core/browser/dexterity/templates/tabs.pt
@@ -3,13 +3,16 @@
                  default_fieldset_label view/default_fieldset_label | string:'General';
                  has_groups python:bool(groups);">
 
+  <!-- Tab view toggle -->
   <div class="d-flex flex-row-reverse">
+    <!-- shows all contents on one page -->
     <a href="#"
        tal:condition="python:enable_form_tabbing"
        tal:attributes="href string:${context/absolute_url}?enable_form_tabbing=0;"
        title="">
       <i class="fas fa-expand"></i>
     </a>
+    <!-- shows contents in tabs -->
     <a href="#"
        tal:condition="python:not enable_form_tabbing"
        tal:attributes="href string:${context/absolute_url}?enable_form_tabbing=1;"

--- a/src/senaite/core/browser/dexterity/templates/tabs.pt
+++ b/src/senaite/core/browser/dexterity/templates/tabs.pt
@@ -1,6 +1,6 @@
 <div tal:define="groups view/groups | nothing;
                  enable_form_tabbing view/enable_form_tabbing | python:True;
-                 default_fieldset_label view/default_fieldset_label | string:Default;
+                 default_fieldset_label view/default_fieldset_label | string:'General';
                  has_groups python:bool(groups);">
 
   <!-- navigation tabs -->

--- a/src/senaite/core/browser/dexterity/templates/tabs.pt
+++ b/src/senaite/core/browser/dexterity/templates/tabs.pt
@@ -4,7 +4,7 @@
                  has_groups python:bool(groups);">
 
   <!-- navigation tabs -->
-  <ul class="nav nav-tabs" role="tablist"
+  <ul class="nav nav-tabs mb-2" role="tablist"
       tal:condition="python: has_groups and enable_form_tabbing">
 
     <!-- primary tab -->
@@ -48,7 +48,7 @@
     </div>
     <!-- Secondary fieldsets -->
     <tal:block tal:repeat="group groups" condition="has_groups">
-      <div class="tab-pane"
+      <div class="tab-pane" role="tabpanel"
            tal:define="normalizeString nocall:context/@@plone/normalizeString;
                        fieldset_label group/label;
                        fieldset_name python:getattr(group, '__name__', False) or getattr(group.label, 'default', False) or fieldset_label;
@@ -56,14 +56,9 @@
            tal:attributes="id string:${fieldset_name};
                            class python:'tab-pane' if enable_form_tabbing else 'd-block';
                            data-fieldset fieldset_name;">
-
-        <fieldset tal:repeat="group view/groups|nothing"
-                  tal:attributes="id python:''.join((group.prefix, 'groups.', group.__name__)).replace('.', '-')">
-          <tal:block tal:repeat="widget group/widgets/values">
-            <tal:widget tal:replace="structure widget/@@ploneform-render-widget"/>
-          </tal:block>
-        </fieldset>
-
+        <tal:block tal:repeat="widget group/widgets/values">
+          <tal:widget tal:replace="structure widget/@@ploneform-render-widget"/>
+        </tal:block>
       </div>
     </tal:block>
   </div>

--- a/src/senaite/core/browser/dexterity/templates/tabs.pt
+++ b/src/senaite/core/browser/dexterity/templates/tabs.pt
@@ -3,6 +3,21 @@
                  default_fieldset_label view/default_fieldset_label | string:'General';
                  has_groups python:bool(groups);">
 
+  <div class="d-flex flex-row-reverse">
+    <a href="#"
+       tal:condition="python:enable_form_tabbing"
+       tal:attributes="href string:${context/absolute_url}?enable_form_tabbing=0;"
+       title="">
+      <i class="fas fa-expand"></i>
+    </a>
+    <a href="#"
+       tal:condition="python:not enable_form_tabbing"
+       tal:attributes="href string:${context/absolute_url}?enable_form_tabbing=1;"
+       title="">
+      <i class="fas fa-compress"></i>
+    </a>
+  </div>
+
   <!-- navigation tabs -->
   <ul class="nav nav-tabs mb-2" role="tablist"
       tal:condition="python: has_groups and enable_form_tabbing">

--- a/src/senaite/core/browser/dexterity/templates/widget.pt
+++ b/src/senaite/core/browser/dexterity/templates/widget.pt
@@ -14,59 +14,83 @@
                      data-fieldname widget/name;
                      id string:formfield-${widget/id};">
 
-  <div for=""
+  <!-- EDIT MODE -->
+  <tal:edit_mode condition="python:view.is_input_mode()">
+    <div for=""
          class="horizontal font-weight-bold"
          tal:attributes="for widget/id"
          tal:condition="python: not hidden and widget.label">
-    <span i18n:translate="" tal:replace="widget/label">label</span>
+      <span i18n:translate="" tal:replace="widget/label">label</span>
 
-    <span class="required horizontal" title="Required"
-          tal:condition="python:widget.required and widget.mode == 'input'"
-          i18n:attributes="title title_required;">&nbsp;</span>
-  </div>
-
-  <div class="fieldErrorBox"
-       tal:content="structure error/render|nothing">
-    Error
-  </div>
-
-  <span class="formHelp text-secondary text-muted"
-        tal:define="description python: getattr(widget, 'description', widget.field.description)"
-        i18n:translate=""
-        tal:content="structure description"
-        tal:condition="python:description and not hidden">
-    field description
-  </span>
-
-  <!-- widget insert mode -->
-  <div class="input-group input-group-sm d-flex"
-       style="width:auto"
-       tal:attributes="class python:widget_css_class"
-       tal:define="prefix python:view.get_prepend_text();
-                   appendix python:view.get_append_text()"
-       tal:condition="python:view.is_input_mode()">
-    <div tal:condition="python:prefix" class="input-group-prepend">
-      <span class="input-group-text" tal:content="structure python:prefix"/>
+      <span class="required horizontal" title="Required"
+            tal:condition="python:widget.required and widget.mode == 'input'"
+            i18n:attributes="title title_required;">&nbsp;</span>
     </div>
-    <input type="text"
-           tal:replace="structure widget/render"
-           metal:define-slot="widget" />
-    <div tal:condition="python:appendix" class="input-group-append">
-      <span class="input-group-text" tal:content="structure python:appendix"/>
-    </div>
-  </div>
 
-  <!-- widget view mode -->
-  <div tal:define="prefix python:view.get_prepend_text();
-                   appendix python:view.get_append_text()"
-       tal:condition="python:view.is_view_mode()">
-    <!-- field prefix -->
-    <span tal:content="structure python:prefix" class="field-prefix"></span>
-    <input type="text"
-           tal:replace="structure widget/render"
-           metal:define-slot="widget" />
-    <!-- field appendix -->
-    <span tal:content="structure python:appendix" class="field-prefix"></span>
-  </div>
+    <div class="fieldErrorBox"
+         tal:content="structure error/render|nothing">
+      Error
+    </div>
+
+    <span class="formHelp text-secondary text-muted"
+          tal:define="description python: getattr(widget, 'description', widget.field.description)"
+          i18n:translate=""
+          tal:content="structure description"
+          tal:condition="python:description and not hidden">
+      field description
+    </span>
+
+    <div class="input-group input-group-sm d-flex"
+         style="width:auto"
+         tal:attributes="class python:widget_css_class"
+         tal:define="prefix python:view.get_prepend_text();
+                appendix python:view.get_append_text()">
+      <div tal:condition="python:prefix" class="input-group-prepend">
+        <span class="input-group-text" tal:content="structure python:prefix"/>
+      </div>
+      <input type="text"
+             tal:replace="structure widget/render"
+             metal:define-slot="widget" />
+      <div tal:condition="python:appendix" class="input-group-append">
+        <span class="input-group-text" tal:content="structure python:appendix"/>
+      </div>
+    </div>
+  </tal:edit_mode>
+
+
+  <!-- VIEW MODE -->
+  <tal:view_mode condition="python:view.is_view_mode()">
+
+    <table class="table table-borderless table-hover table-sm">
+      <tr>
+        <td class="col-1">
+          <div for=""
+               class="horizontal font-weight-bold"
+               tal:attributes="for widget/id"
+               tal:condition="python: not hidden and widget.label">
+            <span i18n:translate="" tal:replace="widget/label">label</span>
+
+            <span class="required horizontal" title="Required"
+                  tal:condition="python:widget.required and widget.mode == 'input'"
+                  i18n:attributes="title title_required;">&nbsp;</span>
+          </div>
+
+        </td>
+        <td class="text-left">
+          <div tal:define="prefix python:view.get_prepend_text();
+                           appendix python:view.get_append_text()">
+            <!-- field prefix -->
+            <span tal:content="structure python:prefix" class="field-prefix"></span>
+            <input type="text"
+                   tal:replace="structure widget/render"
+                   metal:define-slot="widget" />
+            <!-- field appendix -->
+            <span tal:content="structure python:appendix" class="field-prefix"></span>
+          </div>
+
+        </td>
+      </tr>
+    </table>
+  </tal:view_mode>
 
 </div>

--- a/src/senaite/core/browser/dexterity/templates/widget.pt
+++ b/src/senaite/core/browser/dexterity/templates/widget.pt
@@ -62,13 +62,24 @@
   <tal:view_mode condition="python:view.is_view_mode()">
 
     <table class="table table-borderless table-hover table-sm">
+      <colgroup>
+        <col style="min-width:100px;max-width:200px;">
+        <col style="width:100%">
+      </colgroup>
       <tr>
-        <td class="col-1">
+        <td>
           <div for=""
                class="horizontal font-weight-bold"
                tal:attributes="for widget/id"
                tal:condition="python: not hidden and widget.label">
-            <span i18n:translate="" tal:replace="widget/label">label</span>
+
+            <span tal:define="description python: getattr(widget, 'description', widget.field.description)"
+                  tal:attributes="title python:description"
+                  data-toggle="tooltip"
+                  data-html="true">
+                <span i18n:translate="" tal:replace="widget/label">label</span>
+            </span>
+
 
             <span class="required horizontal" title="Required"
                   tal:condition="python:widget.required and widget.mode == 'input'"
@@ -76,7 +87,7 @@
           </div>
 
         </td>
-        <td class="text-left">
+        <td>
           <div tal:define="prefix python:view.get_prepend_text();
                            appendix python:view.get_append_text()">
             <!-- field prefix -->

--- a/src/senaite/core/browser/dexterity/views.py
+++ b/src/senaite/core/browser/dexterity/views.py
@@ -32,7 +32,6 @@ from plone.app.z3cform.views import RenderWidget
 from plone.dexterity.browser.edit import DefaultEditView
 from plone.dexterity.browser.view import DefaultView
 from senaite.core.interfaces import ISenaiteFormLayer
-from Products.Five.browser import BrowserView
 from z3c.form.interfaces import INPUT_MODE
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 

--- a/src/senaite/core/browser/dexterity/views.py
+++ b/src/senaite/core/browser/dexterity/views.py
@@ -27,6 +27,7 @@ import plone.z3cform.interfaces
 import plone.z3cform.templates
 import senaite.core.browser.dexterity
 import z3c.form.interfaces
+from bika.lims import senaiteMessageFactory as _
 from plone.app.z3cform.views import Macros
 from plone.app.z3cform.views import RenderWidget
 from plone.dexterity.browser.edit import DefaultEditView
@@ -201,9 +202,10 @@ class SenaiteDefaultView(DefaultView):
         super(SenaiteDefaultView, self).__init__(context, request)
         self.context = context
         self.request = request
+        self.enable_form_tabbing = self.get_default_form_tabbing()
+        self.default_fieldset_label = _("General")
 
-    @property
-    def enable_form_tabbing(self):
+    def get_default_form_tabbing(self):
         tabbing = self.request.get("enable_form_tabbing", "1")
         if tabbing.lower() in ["0", "no"]:
             return False

--- a/src/senaite/core/browser/dexterity/views.py
+++ b/src/senaite/core/browser/dexterity/views.py
@@ -32,6 +32,7 @@ from plone.app.z3cform.views import RenderWidget
 from plone.dexterity.browser.edit import DefaultEditView
 from plone.dexterity.browser.view import DefaultView
 from senaite.core.interfaces import ISenaiteFormLayer
+from Products.Five.browser import BrowserView
 from z3c.form.interfaces import INPUT_MODE
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 
@@ -195,11 +196,22 @@ class SenaiteDefaultView(DefaultView):
     """The default view for Dexterity content.
     This uses a WidgetsView and renders all widgets in display mode.
     """
+    tabs_template = ViewPageTemplateFile("templates/tabs.pt")
 
     def __init__(self, context, request):
         super(SenaiteDefaultView, self).__init__(context, request)
         self.context = context
         self.request = request
+
+    @property
+    def enable_form_tabbing(self):
+        tabbing = self.request.get("enable_form_tabbing", "1")
+        if tabbing.lower() in ["0", "no"]:
+            return False
+        return True
+
+    def render_widget_tabs(self):
+        return self.tabs_template()
 
 
 class SenaiteDefaultEditView(DefaultEditView):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR improves the content view to show the contents within tabs like in the edit view and horizontal instead of stacked.

## Current behavior before PR

All values are shown stacked in one page:

<img width="1836" alt="Micro-Bio check — SENAITE LIMS 2024-11-20 3 PM-09-20" src="https://github.com/user-attachments/assets/58952bfc-8c2a-4857-b577-39cdcb2c79fb">

## Desired behavior after PR is merged

Items are shown horizontal in tabs:

<img width="541" alt="Micro-Bio check — SENAITE LIMS 2024-11-20 3 PM-08-29" src="https://github.com/user-attachments/assets/a8ebbe5e-1916-46fa-b11e-87a7752ae860">


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
