### PR TITLE
Fix analysis instrument is not auto-assigned on change in worksheet

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2647 Fix analysis instrument is not auto-assigned on change in worksheet
 - #2643 Improve performance of analysis verification
 - #2645 Tabbed content view
 - #2624 Added "Maximum holding time" setting to services and analyses

--- a/src/bika/lims/browser/worksheet/ajax.py
+++ b/src/bika/lims/browser/worksheet/ajax.py
@@ -20,7 +20,8 @@
 
 import plone
 import plone.protect
-from Products.Archetypes.config import REFERENCE_CATALOG
+
+from bika.lims import api
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
 
@@ -54,13 +55,15 @@ class SetInstrument(BrowserView):
         self.request = request
 
     def __call__(self):
-        rc = getToolByName(self.context, REFERENCE_CATALOG)
         plone.protect.CheckAuthenticator(self.request)
         plone.protect.PostOnly(self.request)
         value = self.request.get('value', '')
         if not value:
             raise Exception("Invalid instrument")
-        instrument = rc.lookupObject(value)
+
+        instrument = api.get_object_by_uid(value, None)
         if not instrument:
             raise Exception("Unable to lookup instrument")
-        self.context.setInstrument(instrument)
+
+        # set the instrument to the worksheet and analyses
+        self.context.setInstrument(instrument, override_analyses=True)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the system to automatically assign the instrument to the analyses (if supported) when the user changes the instrument from the worksheet.

![Captura de 2024-11-26 18-19-02](https://github.com/user-attachments/assets/8bf27107-ba3c-4c97-97d4-6220ce832ebc)


## Current behavior before PR

The instrument of analyses is not updated when changed in worksheet context

## Desired behavior after PR is merged

The instrument of analyses is not updated when changed in worksheet context

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
