### PR TITLE
Increase the default width for field labels to min 150px

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2648 Increase the default width for field labels to min 150px
 - #2647 Fix analysis instrument is not auto-assigned on change in worksheet
 - #2643 Improve performance of analysis verification
 - #2645 Tabbed content view

--- a/src/senaite/core/browser/dexterity/templates/widget.pt
+++ b/src/senaite/core/browser/dexterity/templates/widget.pt
@@ -63,7 +63,7 @@
 
     <table class="table table-borderless table-hover table-sm">
       <colgroup>
-        <col style="min-width:100px;max-width:200px;">
+        <col style="min-width:150px;max-width:200px;">
         <col style="width:100%">
       </colgroup>
       <tr>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request increases the min-width for field labels in view mode from 100px to 150px. This makes it more eye-candy and also improves the readability.

## Current behavior before PR

![Captura de 2024-11-28 10-55-07](https://github.com/user-attachments/assets/6577faae-ab36-4b71-b4d4-ffcdb5efd20e)

## Desired behavior after PR is merged

![Captura de 2024-11-28 10-55-27](https://github.com/user-attachments/assets/c7b12028-fdb0-445d-b2a3-09241dc1071b)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
