### PR TITLE
Fix event subscribers are not triggered on analysis initialization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2649 Fix event subscribers are not triggered on analysis initialization
 - #2648 Increase the default width for field labels to min 150px
 - #2647 Fix analysis instrument is not auto-assigned on change in worksheet
 - #2643 Improve performance of analysis verification

--- a/src/bika/lims/utils/__init__.py
+++ b/src/bika/lims/utils/__init__.py
@@ -23,7 +23,6 @@ import os
 import re
 import tempfile
 from email import Encoders
-
 from email.MIMEBase import MIMEBase
 from time import time
 
@@ -48,6 +47,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFCore.WorkflowCore import WorkflowException
 from Products.CMFPlone.utils import safe_unicode
 from Products.DCWorkflow.events import AfterTransitionEvent
+from Products.DCWorkflow.events import BeforeTransitionEvent
 from senaite.core.p3compat import cmp
 from six.moves.urllib.request import urlopen
 from weasyprint import CSS
@@ -275,9 +275,11 @@ def sortable_title(portal, title):
             break
     return sortabletitle
 
+
 # TODO Remove this function
 def logged_in_client(context, member=None):
     return api.get_current_client()
+
 
 def changeWorkflowState(content, wf_id, state_id, **kw):
     """Change the workflow state of an object
@@ -292,12 +294,16 @@ def changeWorkflowState(content, wf_id, state_id, **kw):
         logger.error("%s: Cannot find workflow id %s" % (content, wf_id))
         return False
 
+    action = kw.get("action")
+    actor = kw.get("actor", api.user.get_user_id())
+    now = DateTime()
+
     wf_state = {
-        'action': kw.get("action", None),
-        'actor': kw.get("actor", api.get_current_user().id),
-        'comments': "Setting state to %s" % state_id,
-        'review_state': state_id,
-        'time': DateTime()
+        "action": action,
+        "actor": actor,
+        "comments": "Setting state to %s" % state_id,
+        "review_state": state_id,
+        "time": now,
     }
 
     # Get old and new state info
@@ -307,17 +313,22 @@ def changeWorkflowState(content, wf_id, state_id, **kw):
         raise WorkflowException("Destination state undefined: {}"
                                 .format(state_id))
 
+    # Notify the *before* transition event
+    notify(BeforeTransitionEvent(
+        content, workflow, old_state, new_state, None, wf_state, None))
+
     # Change status and update permissions
     portal_workflow.setStatusOf(wf_id, content, wf_state)
     workflow.updateRoleMappingsFor(content)
 
-    # Notify the object has been transitioned
-    notify(AfterTransitionEvent(content, workflow, old_state, new_state, None,
-                                wf_state, None))
-
     # Map changes to catalog
     indexes = ["allowedRolesAndUsers", "review_state", "is_active"]
     content.reindexObject(idxs=indexes)
+
+    # Notify the *after* transition event
+    notify(AfterTransitionEvent(
+        content, workflow, old_state, new_state, None, wf_state, None))
+
     return True
 
 

--- a/src/bika/lims/utils/__init__.py
+++ b/src/bika/lims/utils/__init__.py
@@ -314,6 +314,8 @@ def changeWorkflowState(content, wf_id, state_id, **kw):
                                 .format(state_id))
 
     # Notify the *before* transition event
+    # NOTE: We pass `None` for the transition object, which causes no further
+    # workflow event handling! (see bika.lims.workflow.call_workflow_event)
     notify(BeforeTransitionEvent(
         content, workflow, old_state, new_state, None, wf_state, None))
 
@@ -326,6 +328,8 @@ def changeWorkflowState(content, wf_id, state_id, **kw):
     content.reindexObject(idxs=indexes)
 
     # Notify the *after* transition event
+    # NOTE: We pass `None` for the transition object, which causes no further
+    # workflow event handling! (see bika.lims.workflow.call_workflow_event)
     notify(AfterTransitionEvent(
         content, workflow, old_state, new_state, None, wf_state, None))
 

--- a/src/bika/lims/utils/__init__.py
+++ b/src/bika/lims/utils/__init__.py
@@ -281,7 +281,7 @@ def logged_in_client(context, member=None):
     return api.get_current_client()
 
 
-def changeWorkflowState(content, wf_id, state_id, **kw):
+def changeWorkflowState(content, wf_id, state_id, trigger_events=False, **kw):
     """Change the workflow state of an object
     @param content: Content obj which state will be changed
     @param state_id: name of the state to put on content
@@ -295,6 +295,7 @@ def changeWorkflowState(content, wf_id, state_id, **kw):
         return False
 
     action = kw.get("action")
+    tdef = workflow.transitions.get(action)
     actor = kw.get("actor", api.user.get_user_id())
     now = DateTime()
 
@@ -313,11 +314,10 @@ def changeWorkflowState(content, wf_id, state_id, **kw):
         raise WorkflowException("Destination state undefined: {}"
                                 .format(state_id))
 
-    # Notify the *before* transition event
-    # NOTE: We pass `None` for the transition object, which causes no further
-    # workflow event handling! (see bika.lims.workflow.call_workflow_event)
-    notify(BeforeTransitionEvent(
-        content, workflow, old_state, new_state, None, wf_state, None))
+    if trigger_events:
+        # Notify the *before* transition event
+        notify(BeforeTransitionEvent(
+            content, workflow, old_state, new_state, tdef, wf_state, None))
 
     # Change status and update permissions
     portal_workflow.setStatusOf(wf_id, content, wf_state)
@@ -327,11 +327,10 @@ def changeWorkflowState(content, wf_id, state_id, **kw):
     indexes = ["allowedRolesAndUsers", "review_state", "is_active"]
     content.reindexObject(idxs=indexes)
 
-    # Notify the *after* transition event
-    # NOTE: We pass `None` for the transition object, which causes no further
-    # workflow event handling! (see bika.lims.workflow.call_workflow_event)
-    notify(AfterTransitionEvent(
-        content, workflow, old_state, new_state, None, wf_state, None))
+    if trigger_events:
+        # Notify the *after* transition event
+        notify(AfterTransitionEvent(
+            content, workflow, old_state, new_state, tdef, wf_state, None))
 
     return True
 

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -194,6 +194,9 @@ def receive_sample(sample, check_permission=False, date_received=None):
     for obj in sample.objectValues():
         if obj.portal_type != "Analysis":
             continue
+        # NOTE: we use `doActionFor` instead of `changeWorkflowState` to keep
+        # the behavior consistent with the manual "receive" transition,
+        # especially for our WF event handlers.
         doActionFor(obj, "initialize")
 
     return True

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -194,10 +194,11 @@ def receive_sample(sample, check_permission=False, date_received=None):
     for obj in sample.objectValues():
         if obj.portal_type != "Analysis":
             continue
-        # NOTE: we use `doActionFor` instead of `changeWorkflowState` to keep
-        # the behavior consistent with the manual "receive" transition,
-        # especially for our WF event handlers.
-        doActionFor(obj, "initialize")
+        # https://github.com/senaite/senaite.core/pull/2650
+        # NOTE: We trigger event handlers for analyses to keep it consistent
+        # with the behavior when manually received.
+        changeWorkflowState(obj, ANALYSIS_WORKFLOW, "unassigned",
+                            action="initialize", trigger_events=True)
 
     return True
 

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -194,8 +194,7 @@ def receive_sample(sample, check_permission=False, date_received=None):
     for obj in sample.objectValues():
         if obj.portal_type != "Analysis":
             continue
-        changeWorkflowState(obj, ANALYSIS_WORKFLOW, "unassigned",
-                            action="initialize")
+        doActionFor(obj, "initialize")
 
     return True
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that when the "Auto-receive" setting is enabled, event subscribers are properly called on analyses initialization transition.

## Current behavior before PR

Event subscribers are not called when the analyses are initialized on sample creation if "auto-receive" is enabled

## Desired behavior after PR is merged

Event subscribers are not called when the analyses are initialized on sample creation if "auto-receive" is enabled

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
