### PR TITLE
Fix AttributeError on analysis update with interim values via jsonapi

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2650 Fix AttributeError on analysis update with interim values via jsonapi
 - #2648 Increase the default width for field labels to min 150px
 - #2647 Fix analysis instrument is not auto-assigned on change in worksheet
 - #2643 Improve performance of analysis verification

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -295,7 +295,8 @@ class InterimFieldsValidator:
     def __call__(self, value, *args, **kwargs):
         instance = kwargs['instance']
         fieldname = kwargs['field'].getName()
-        request = kwargs.get('REQUEST', {})
+        # do not rely on kwargs's REQUEST, cause it might be None!
+        request = instance.REQUEST
         form = request.form
         interim_fields = form.get(fieldname, [])
 
@@ -306,7 +307,7 @@ class InterimFieldsValidator:
         # values
         # this value in request prevents running once per subfield value.
         key = instance.id + fieldname
-        if instance.REQUEST.get(key, False):
+        if request.get(key, False):
             return True
 
         for x in range(len(interim_fields)):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes an `AttributeError: 'NoneType' object has no attribute 'form'` error when updating an analysis with interim fields via the `senaite.jsonapi`.

After updating the fields, `senaite.jsonapi` calls `validate_object`: https://github.com/senaite/senaite.jsonapi/blob/a97139a6b85ba33c5811eb72e66e929a9c2d5543/src/senaite/jsonapi/api.py#L1493 

The `validate_object` relies on AT `BaseObject`'s `validate` function: https://github.com/senaite/senaite.jsonapi/blob/a97139a6b85ba33c5811eb72e66e929a9c2d5543/src/senaite/jsonapi/api.py#L1522

AT `BaseObject`'s `validate` functio accepts a `REQUEST` as an argument, but is optional. `senaite.jsonapi` does not assign value to the argument and as a result, an error arises. Also, if a transition was also requested via POST, it is not executed.

For instance:

**`   POST`** http://localhost/senaite/@@API/senaite/v1/update/1dd8d7afc0d34d4da73b06360dbbc789
**`PAYLOAD`** `json/application`
```json
{
  "transition": "submit",
  "Result": "< 20",
  "InterimFields": [
    {
      "value": "< 20",
      "keyword": "ResultValue",
      "unit": "Copies/ml",
      "title": "NValue"
    },
    {
      "wide": "on",
      "keyword": "CF",
      "value": "1.0",
      "title": "CF"
    },
    {
      "value": "< 20",
      "keyword": "NValue",
      "title": "Result Value"
    }
  ]
}
```

we get the following:



**`🟥 RESPONSE [401]`** `json/application`
```json
{
  "_runtime": 1.7443671226501465,
  "message": "'NoneType' object has no attribute 'form'",
  "success": false
}
```

Looking at the traceback from the server:

```
2024-11-29 13:59:16,743 WARNING [senaite.jsonapi:1487][waitress-1] update_object_with_data::skipping key=u'transition'
/home/senaite/buildout-cache/eggs/Products.PlonePAS-6.0.8-py2.7.egg/Products/PlonePAS/tools/membership.py:561: DeprecationWarning: Inefficient GRUF wrapper, use IUserIntrospection instead.
  return self.acl_users.getUserIds()
Traceback (most recent call last):
  File "/home/senaite/buildout-cache/eggs/plone.jsonapi.core-0.7.0-py2.7.egg/plone/jsonapi/core/browser/decorators.py", line 23, in decorator
    return f(*args, **kwargs)
  File "/home/senaite/buildout-cache/eggs/plone.jsonapi.core-0.7.0-py2.7.egg/plone/jsonapi/core/browser/api.py", line 57, in to_json
    return self.dispatch()
  File "/home/senaite/buildout-cache/eggs/plone.jsonapi.core-0.7.0-py2.7.egg/plone/jsonapi/core/browser/api.py", line 51, in dispatch
    return router(self.context, self.request, path)
  File "/home/senaite/buildout-cache/eggs/plone.jsonapi.core-0.7.0-py2.7.egg/plone/jsonapi/core/browser/router.py", line 150, in __call__
    return self.view_functions[endpoint](context, request, **values)
  File "/home/senaite/senaite/src/senaite.jsonapi/src/senaite/jsonapi/v1/routes/content.py", line 88, in action
    items = action_func(portal_type=portal_type, uid=uid)
  File "/home/senaite/senaite/src/senaite.jsonapi/src/senaite/jsonapi/api.py", line 206, in update_items
    obj = update_object_with_data(obj, record)
  File "/home/senaite/senaite/src/senaite.jsonapi/src/senaite/jsonapi/api.py", line 1493, in update_object_with_data
    invalid = validate_object(content, record)
  File "/home/senaite/senaite/src/senaite.jsonapi/src/senaite/jsonapi/api.py", line 1522, in validate_object
    return obj.validate(data=data)
  File "/home/senaite/buildout-cache/eggs/Products.Archetypes-1.16.6-py2.7.egg/Products/Archetypes/BaseObject.py", line 517, in validate
    errors=errors, data=data, metadata=metadata)
  File "/home/senaite/buildout-cache/eggs/Products.Archetypes-1.16.6-py2.7.egg/Products/Archetypes/Schema/__init__.py", line 629, in validate
    REQUEST=REQUEST)
  File "/home/senaite/senaite/src/senaite.core/src/senaite/core/browser/fields/records.py", line 173, in validate
    ), None)
  File "/home/senaite/senaite/src/senaite.core/src/senaite/core/browser/fields/records.py", line 169, in <genexpr>
    result
  File "/home/senaite/senaite/src/senaite.core/src/senaite/core/browser/fields/records.py", line 165, in <genexpr>
    for record
  File "/home/senaite/senaite/src/senaite.core/src/senaite/core/browser/fields/record.py", line 395, in validate
    res = self.validate_validators(value, instance, errors, **kwargs)
  File "/home/senaite/senaite/src/senaite.core/src/senaite/core/browser/fields/record.py", line 412, in validate_validators
    **kwargs
  File "/home/senaite/buildout-cache/eggs/Products.validation-2.1.3-py2.7.egg/Products/validation/chain.py", line 137, in __call__
    result = validator(value, *args, **kwargs)
  File "/home/senaite/senaite/src/senaite.core/src/bika/lims/validators.py", line 299, in __call__
    form = request.form
AttributeError: 'NoneType' object has no attribute 'form'
```

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
