### PR TITLE
Refactor sample title + decsription into viewlets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2659 Refactor sample title + decsription into viewlets
 - #2657 Methods from analyses are not updated on instrument change in worksheet
 - #2656 Fix AnalysisProfile keyword validator fail with non-ascii value 
 - #2646 Add SelectOtherField and SelectOtherWidget

--- a/src/bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt
+++ b/src/bika/lims/browser/analysisrequest/templates/analysisrequest_view.pt
@@ -11,29 +11,14 @@
   <body>
 
     <metal:content-title fill-slot="content-title">
-      <h1>
-        <!-- Sample icon -->
-        <i class="sample-icon" title="Sample" i18n:attributes="title">
-          <svg tal:replace="structure senaite_theme/icon_data/sample" />
-        </i>
-        <!-- Title -->
-        <span class="documentFirstHeading" tal:content="context/id"></span>
-        <!-- Hazardous icon -->
-        <i class="hazardous-icon" title="Hazardous" i18n:attributes="title"
-           tal:condition="python:view.is_hazardous()">
-          <svg tal:replace="structure senaite_theme/icon_data/hazardous" />
-        </i>
-        <!-- Exclude Invoice Icon -->
-        <i class="exclude-from-invoice-icon" title="Exclude from invoice" i18n:attributes="title"
-           tal:condition="python:view.exclude_invoice()">
-          <svg tal:replace="structure senaite_theme/icon_data/invoice_exclude" />
-        </i>
-        <!-- Retest Icon -->
-        <i class="retest-icon" title="Results have been withdrawn" i18n:attributes="title"
-           tal:condition="python:view.is_retest()">
-          <svg tal:replace="structure senaite_theme/icon_data/retest" />
-        </i>
-      </h1>
+      <div class="row">
+        <div class="col-sm-12">
+          <!-- Viewlet manager: sample title -->
+          <div tal:replace="structure provider:senaite.sampletitle"></div>
+          <!-- Viewlet manager: sample description -->
+          <div tal:replace="structure provider:senaite.sampledescription"></div>
+        </div>
+      </div>
     </metal:content-title>
 
     <metal:content-description fill-slot="content-description">

--- a/src/senaite/core/browser/viewlets/configure.zcml
+++ b/src/senaite/core/browser/viewlets/configure.zcml
@@ -248,6 +248,24 @@
       layer="senaite.core.interfaces.ISenaiteCore"
       />
 
+  <!-- Viewlet manager in sample view inside the title macro -->
+  <browser:viewletManager
+      name="senaite.sampletitle"
+      provides=".interfaces.ISampleTitle"
+      class="plone.app.viewletmanager.manager.OrderedViewletManager"
+      permission="zope2.View"
+      layer="senaite.core.interfaces.ISenaiteCore"
+      />
+
+  <!-- Viewlet manager in sample view inside the title macro below the title -->
+  <browser:viewletManager
+      name="senaite.sampledescription"
+      provides=".interfaces.ISampleDescription"
+      class="plone.app.viewletmanager.manager.OrderedViewletManager"
+      permission="zope2.View"
+      layer="senaite.core.interfaces.ISenaiteCore"
+      />
+
   <!-- Viewlet manager in sample view above all sections -->
   <browser:viewletManager
       name="senaite.sampleheader"
@@ -292,6 +310,24 @@
       permission="zope2.View"
       layer="senaite.core.interfaces.ISenaiteCore"
       />
+
+  <!-- Sample title viewlet -->
+  <browser:viewlet
+      for="bika.lims.interfaces.IAnalysisRequest"
+      name="senaite.core.sampletitle"
+      manager=".interfaces.ISampleTitle"
+      class=".sampletitle.SampleTitleViewlet"
+      layer="senaite.core.interfaces.ISenaiteCore"
+      permission="zope2.View" />
+
+  <!-- Sample description viewlet -->
+  <browser:viewlet
+      for="bika.lims.interfaces.IAnalysisRequest"
+      name="senaite.core.sampledescription"
+      manager=".interfaces.ISampleDescription"
+      class=".sampledescription.SampleDescriptionViewlet"
+      layer="senaite.core.interfaces.ISenaiteCore"
+      permission="zope2.View" />
 
   <!-- Sample header viewlet -->
   <browser:viewlet

--- a/src/senaite/core/browser/viewlets/interfaces.py
+++ b/src/senaite/core/browser/viewlets/interfaces.py
@@ -46,6 +46,16 @@ class IBelowListingTable(IViewletManager):
     """
 
 
+class ISampleTitle(IViewletManager):
+    """A viewlet manager in the sample view title section
+    """
+
+
+class ISampleDescription(IViewletManager):
+    """A viewlet manager in the sample view below the title
+    """
+
+
 class ISampleHeader(IViewletManager):
     """A viewlet manager in sample view above the sections
     """

--- a/src/senaite/core/browser/viewlets/sampledescription.py
+++ b/src/senaite/core/browser/viewlets/sampledescription.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2024 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from senaite.core.browser.viewlets.sampletitle import SampleTitleViewlet
+
+
+class SampleDescriptionViewlet(SampleTitleViewlet):
+    index = ViewPageTemplateFile("templates/sampledescription.pt")

--- a/src/senaite/core/browser/viewlets/sampletitle.py
+++ b/src/senaite/core/browser/viewlets/sampletitle.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2024 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from plone.app.layout.viewlets.common import GlobalSectionsViewlet as Base
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from plone.memoize.instance import memoize
+from zope.component import getMultiAdapter
+
+
+class SampleTitleViewlet(Base):
+    index = ViewPageTemplateFile("templates/sampletitle.pt")
+
+    def __init__(self, context, request, view, manager=None):
+        super(SampleTitleViewlet, self).__init__(
+            context, request, view, manager=manager)
+
+    @property
+    @memoize
+    def theme_view(self):
+        return getMultiAdapter(
+            (self.context, self.request),
+            name="senaite_theme")
+
+    def update(self):
+        super(SampleTitleViewlet, self).update()
+
+    def is_hazardous(self):
+        return self.context.getHazardous()
+
+    def exclude_invoice(self):
+        return self.context.getInvoiceExclude()
+
+    def is_retest(self):
+        return self.context.getRetest()

--- a/src/senaite/core/browser/viewlets/templates/sampledescription.pt
+++ b/src/senaite/core/browser/viewlets/templates/sampledescription.pt
@@ -1,2 +1,2 @@
-<div class="sample-description">
-</div>
+<span class="sample-description">
+</span>

--- a/src/senaite/core/browser/viewlets/templates/sampledescription.pt
+++ b/src/senaite/core/browser/viewlets/templates/sampledescription.pt
@@ -1,0 +1,2 @@
+<div class="sample-description">
+</div>

--- a/src/senaite/core/browser/viewlets/templates/sampletitle.pt
+++ b/src/senaite/core/browser/viewlets/templates/sampletitle.pt
@@ -1,0 +1,25 @@
+<div class="sample-title">
+  <h1>
+    <!-- Sample icon -->
+    <i class="sample-icon" title="Sample" i18n:attributes="title">
+      <svg tal:replace="structure view/theme_view/icon_data/sample" />
+    </i>
+    <!-- Title -->
+    <span class="documentFirstHeading" tal:content="context/id"></span>
+    <!-- Hazardous icon -->
+    <i class="hazardous-icon" title="Hazardous" i18n:attributes="title"
+       tal:condition="python:view.is_hazardous()">
+      <svg tal:replace="structure view/theme_view/icon_data/hazardous" />
+    </i>
+    <!-- Exclude Invoice Icon -->
+    <i class="exclude-from-invoice-icon" title="Exclude from invoice" i18n:attributes="title"
+       tal:condition="python:view.exclude_invoice()">
+      <svg tal:replace="structure view/theme_view/icon_data/invoice_exclude" />
+    </i>
+    <!-- Retest Icon -->
+    <i class="retest-icon" title="Results have been withdrawn" i18n:attributes="title"
+       tal:condition="python:view.is_retest()">
+      <svg tal:replace="structure view/theme_view/icon_data/retest" />
+    </i>
+  </h1>
+</div>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR refactors the Sample Title and Description into Viewlets

## Current behavior before PR

Title + Description provided in macros of the sample view

## Desired behavior after PR is merged

Title + Description provided in Viewlets with their own Viewlet managers

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
