### PR TITLE
Add logging if external calculation module import failed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2660 Add logging if external calculation module import failed
 - #2654 Show Batch title or ID in Sample reference field
 - #2657 Methods from analyses are not updated on instrument change in worksheet
 - #2656 Fix AnalysisProfile keyword validator fail with non-ascii value 

--- a/src/bika/lims/content/calculation.py
+++ b/src/bika/lims/content/calculation.py
@@ -45,6 +45,7 @@ from Products.ATContentTypes.lib.historyaware import HistoryAwareMixin
 from Products.CMFCore.utils import getToolByName
 from Products.CMFCore.WorkflowCore import WorkflowException
 from Products.CMFPlone.utils import safe_unicode
+from senaite.core import logger
 from senaite.core.browser.fields.records import RecordsField
 from senaite.core.browser.widgets.referencewidget import ReferenceWidget
 from senaite.core.catalog import SETUP_CATALOG
@@ -439,7 +440,8 @@ class Calculation(BaseFolder, HistoryAwareMixin):
         """
         try:
             mod = importlib.import_module(dotted_name)
-        except ImportError:
+        except ImportError as e:
+            logger.error("Cannot import module %s: %s" % (dotted_name, str(e)))
             return None
 
         members = dict(inspect.getmembers(mod))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds a log message when an external calculation module failed to import

## Current behavior before PR

Unspecific message was logged when a formula could not be evaluated

## Desired behavior after PR is merged

Better error message is logged if the formula could not be evaluated due to import failures of external calculation modules. 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
