### PR TITLE
Allow to recalculate an analysis result

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2661 Allow to recalculate an analysis result
 - #2654 Show Batch title or ID in Sample reference field
 - #2657 Methods from analyses are not updated on instrument change in worksheet
 - #2656 Fix AnalysisProfile keyword validator fail with non-ascii value 

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -1089,6 +1089,14 @@ class AnalysesView(ListingView):
         item["Calculation"] = calculation_title
         item["replace"]["Calculation"] = calculation_link or _("Manual")
 
+        if is_editable and calculation:
+            url = analysis_brain.getURL()
+            item["after"]["Result"] = item["after"].get("Result") or ""
+            item["after"]["Result"] += get_link(
+                "{}/action/recalculate".format(url),
+                value="<i class='small text-secondary fas fa-sync'></i>",
+                title=t(_("Recalculate")), css_class="listing-ajax-action")
+
         # Set interim fields. Note we add the key 'formatted_value' to the list
         # of interims the analysis has already assigned.
         analysis_obj = self.get_object(analysis_brain)

--- a/src/senaite/core/browser/listing/actions/README.md
+++ b/src/senaite/core/browser/listing/actions/README.md
@@ -1,0 +1,6 @@
+# Listing actions
+
+A listing action is basically a browser view that get asynchornously executed
+from a listing view.
+
+Therefore, it returns just a plain message that can be displayed to the user after execution.

--- a/src/senaite/core/browser/listing/actions/README.md
+++ b/src/senaite/core/browser/listing/actions/README.md
@@ -3,4 +3,12 @@
 A listing action is basically a browser view that get asynchornously executed
 from a listing view.
 
-Therefore, it returns just a plain message that can be displayed to the user after execution.
+Therefore, it must return a JSON message with the following contents:
+
+``` json
+{
+  "message": "Return message of the action",
+  "success": true/false
+}
+```
+

--- a/src/senaite/core/browser/listing/actions/README.md
+++ b/src/senaite/core/browser/listing/actions/README.md
@@ -9,6 +9,7 @@ Therefore, it must return a JSON message with the following contents:
 {
   "message": "Return message of the action",
   "success": true/false
+  "title": "Action title"
 }
 ```
 

--- a/src/senaite/core/browser/listing/actions/__init__.py
+++ b/src/senaite/core/browser/listing/actions/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from bika.lims.decorators import returns_json
+from Products.Five.browser import BrowserView
+
+
+class BaseActionView(BrowserView):
+    """Base class for Action Views
+    """
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    @returns_json
+    def message(self, message, success=True, **kw):
+        """Returns a JSON message
+        """
+        msg = {
+            "message": message,
+            "success": success,
+        }
+        msg.update(kw)
+        return msg

--- a/src/senaite/core/browser/listing/actions/analysis.py
+++ b/src/senaite/core/browser/listing/actions/analysis.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from senaite.core.browser.listing.actions import BaseActionView
+
+
+class ActionView(BaseActionView):
+    """Action View for Analyses
+    """
+
+    def recalculate(self):
+        """Recalculate the results
+        """
+        calc = self.context.getCalculation()
+        if not calc:
+            return self.message("No calculation found", False)
+        success = self.context.calculateResult(override=True)
+        if not success:
+            return self.message("Failed to recalculate result", False)
+
+        return self.message("Result recalucated", True)

--- a/src/senaite/core/browser/listing/actions/analysis.py
+++ b/src/senaite/core/browser/listing/actions/analysis.py
@@ -10,11 +10,13 @@ class ActionView(BaseActionView):
     def recalculate(self):
         """Recalculate the results
         """
+        title = self.context.Title()
         calc = self.context.getCalculation()
         if not calc:
-            return self.message("No calculation found", False)
+            return self.message("No calculation found", False, title=title)
         success = self.context.calculateResult(override=True)
         if not success:
-            return self.message("Failed to recalculate result", False)
+            return self.message(
+                "Failed to recalculate result", False, title=title)
 
-        return self.message("Result recalucated", True)
+        return self.message("Result recalucated", True, title=title)

--- a/src/senaite/core/browser/listing/actions/configure.zcml
+++ b/src/senaite/core/browser/listing/actions/configure.zcml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser">
+
+  <browser:page
+      name="action"
+      for="bika.lims.interfaces.IAnalysis"
+      permission="zope2.View"
+      class=".analysis.ActionView"
+      allowed_attributes="recalculate"
+      layer="senaite.core.interfaces.ISenaiteCore"
+      />
+
+</configure>

--- a/src/senaite/core/browser/listing/configure.zcml
+++ b/src/senaite/core/browser/listing/configure.zcml
@@ -1,35 +1,8 @@
 <configure
-    xmlns="http://namespaces.zope.org/zope"
-    xmlns:zcml="http://namespaces.zope.org/zcml">
+  xmlns="http://namespaces.zope.org/zope"
+  xmlns:zcml="http://namespaces.zope.org/zcml">
 
-  <configure zcml:condition="installed senaite.app.listing">
-
-    <!-- Custom listing adapter for sample transition "receive" -->
-    <adapter
-        for="senaite.app.listing.interfaces.IAjaxListingView
-             bika.lims.interfaces.IAnalysisRequest
-             senaite.core.interfaces.ISenaiteCore"
-        factory=".workflow.sample.SampleReceiveWorkflowTransition"
-        name="receive"/>
-
-    <!-- Custom listing adapter for analysis transition "retract" -->
-    <adapter
-        name="retract"
-        for="senaite.app.listing.interfaces.IAjaxListingView
-             bika.lims.interfaces.analysis.IRequestAnalysis
-             senaite.core.interfaces.ISenaiteCore"
-        provides="senaite.app.listing.interfaces.IListingWorkflowTransition"
-        factory=".workflow.analysis.AnalysisRetractAdapter" />
-
-    <!-- Custom listing adapter for analysis transition "retest" -->
-    <adapter
-        name="retest"
-        for="senaite.app.listing.interfaces.IAjaxListingView
-             bika.lims.interfaces.analysis.IRequestAnalysis
-             senaite.core.interfaces.ISenaiteCore"
-        provides="senaite.app.listing.interfaces.IListingWorkflowTransition"
-        factory=".workflow.analysis.AnalysisRetestAdapter" />
-
-  </configure>
+  <include package=".actions" />
+  <include package=".workflow" />
 
 </configure>

--- a/src/senaite/core/browser/listing/workflow/configure.zcml
+++ b/src/senaite/core/browser/listing/workflow/configure.zcml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:zcml="http://namespaces.zope.org/zcml">
+
+  <configure zcml:condition="installed senaite.app.listing">
+
+    <!-- Custom listing adapter for sample transition "receive" -->
+    <adapter
+        for="senaite.app.listing.interfaces.IAjaxListingView
+             bika.lims.interfaces.IAnalysisRequest
+             senaite.core.interfaces.ISenaiteCore"
+        factory=".sample.SampleReceiveWorkflowTransition"
+        name="receive"/>
+
+    <!-- Custom listing adapter for analysis transition "retract" -->
+    <adapter
+        name="retract"
+        for="senaite.app.listing.interfaces.IAjaxListingView
+             bika.lims.interfaces.analysis.IRequestAnalysis
+             senaite.core.interfaces.ISenaiteCore"
+        provides="senaite.app.listing.interfaces.IListingWorkflowTransition"
+        factory=".analysis.AnalysisRetractAdapter" />
+
+    <!-- Custom listing adapter for analysis transition "retest" -->
+    <adapter
+        name="retest"
+        for="senaite.app.listing.interfaces.IAjaxListingView
+             bika.lims.interfaces.analysis.IRequestAnalysis
+             senaite.core.interfaces.ISenaiteCore"
+        provides="senaite.app.listing.interfaces.IListingWorkflowTransition"
+        factory=".analysis.AnalysisRetestAdapter" />
+
+  </configure>
+</configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**☝️ NOTE:** This PR requires https://github.com/senaite/senaite.app.listing/pull/149 to work

This PR adds an action link next to calculated analyses to recalculate the existing result.
This is especially helpful, if the calculation triggers a function of an external calculation module.

<img width="837" alt="H2O-0009 — SENAITE LIMS 2025-01-29 6 PM-47-31" src="https://github.com/user-attachments/assets/4cc1c92f-e92d-4066-8c81-0ba6f18616a2" />

## Current behavior before PR

Recalculation of calculated results is not possible

## Desired behavior after PR is merged

Recalculation of calculated results is possible

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
