### PR TITLE
Fix upgrade step 2656

### DIFF
--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -2732,6 +2732,16 @@ def reindex_sub_groups(tool):
     cat = api.get_tool(SETUP_CATALOG)
     for brain in cat(portal_type="SubGroup"):
         obj = brain.getObject()
+        # ensure float values (was a string field before)
+        sort_key = obj.getSortKey()
+        if not api.is_floatable(sort_key):
+            # api.to_float does not accept `None` as default
+            try:
+                sort_key = float(sort_key)
+            except (ValueError, TypeError):
+                sort_key = None
+            obj.setSortKey(sort_key)
+
         logger.info("Reindex sub group: %r" % obj)
         if obj.sort_key:
             obj.sort_key = api.to_float(obj.sort_key, 0.0)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a Traceback that was introduced with https://github.com/senaite/senaite.core/pull/2652 where subgroup sort keys were previously created with string values

## Current behavior before PR

Traceback occurs:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 182, in transaction_pubevents
  Module transaction._manager, line 257, in commit
  Module transaction._manager, line 134, in commit
  Module transaction._transaction, line 267, in commit
  Module transaction._transaction, line 333, in _callBeforeCommitHooks
  Module transaction._transaction, line 372, in _call_hooks
  Module Products.CMFCore.indexing, line 317, in before_commit
  Module Products.CMFCore.indexing, line 227, in process
  Module senaite.core.catalog.catalog_multiplex_processor, line 105, in reindex
  Module Products.CMFCore.CatalogTool, line 368, in _reindexObject
  Module Products.CMFPlone.CatalogTool, line 362, in catalog_object
  Module Products.ZCatalog.ZCatalog, line 508, in catalog_object
  Module Products.ZCatalog.Catalog, line 372, in catalogObject
  Module Products.PluginIndexes.unindex, line 237, in index_object
  Module Products.PluginIndexes.unindex, line 249, in _index_object
  Module Products.PluginIndexes.unindex, line 294, in _get_object_datum
  Module plone.indexer.wrapper, line 65, in __getattr__
  Module plone.indexer.delegate, line 20, in __call__
  Module senaite.core.catalog.indexer.subgroup, line 29, in sortable_title
  Module senaite.core.catalog.utils, line 137, in sortable_sortkey_title
ValueError: Unknown format code 'f' for object of type 'unicode'
```

## Desired behavior after PR is merged

Subgroup sort_key values are migrated to floatable values or None. 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
