### PR TITLE
Do not show "Receive Sample Statusmessage" if sample is already received

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2665 Do not show "Receive Sample Statusmessage" if sample is already received
 - #2662 Custom catalogs support for default portal types via registry
 - #2652 Fix Subgroups sort by Sort Key
 - #2663 CSS for some add-on based forms

--- a/src/senaite/core/browser/viewlets/sample/not_sampled.py
+++ b/src/senaite/core/browser/viewlets/sample/not_sampled.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 
+from bika.lims.interfaces import IReceived
 from plone.app.layout.viewlets import ViewletBase
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
 
 class NotSampledViewlet(ViewletBase):
-    """ Print a viewlet to display a message stating the Sample cannot
-    transition due to an unset DateSampled 
+    """Print a viewlet to display a message stating the Sample cannot
+    transition due to an unset DateSampled
     """
     index = ViewPageTemplateFile("templates/not_sampled.pt")
 
@@ -14,4 +15,7 @@ class NotSampledViewlet(ViewletBase):
         """Returns whether this viewlet must be visible or not
         """
         sample = self.context
+        if IReceived.providedBy(sample):
+            # sample already received
+            return False
         return not sample.getDateSampled()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR skips the rendering of the status message if the date sampled field is empty and the sample is in received state.

<img width="1274" alt="Sample statusmessage" src="https://github.com/user-attachments/assets/2e722028-597f-47a2-89eb-b363f30eff8e" />

 
## Current behavior before PR

Statusmessage is displayed although the sample is received already

## Desired behavior after PR is merged

Statusmessage is not displayed if the sample is in received state

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
