### PR TITLE
Allow to delete SENAITE site in ZMI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2666 Allow to delete SENAITE site in ZMI
 - #2665 Do not show "Receive Sample Statusmessage" if sample is already received
 - #2662 Custom catalogs support for default portal types via registry
 - #2652 Fix Subgroups sort by Sort Key

--- a/src/bika/lims/workflow/__init__.py
+++ b/src/bika/lims/workflow/__init__.py
@@ -29,6 +29,7 @@ from bika.lims.browser import ulocalized_time
 from bika.lims.interfaces import IGuardAdapter
 from bika.lims.interfaces import IJSONReadExtender
 from bika.lims.jsonapi import get_include_fields
+from plone.api.exc import CannotGetPortalError
 from Products.CMFCore.utils import getToolByName
 from Products.CMFCore.WorkflowCore import WorkflowException
 from senaite.core.i18n import translate as t
@@ -94,7 +95,11 @@ def doActionFor(instance, action_id):
 
     succeed = False
     message = ""
-    workflow = api.get_tool("portal_workflow")
+    try:
+        workflow = api.get_tool("portal_workflow")
+    except CannotGetPortalError as e:
+        # handle complete site removal gracefully
+        return False, str(e)
     try:
         workflow.doActionFor(instance, action_id)
         succeed = True

--- a/src/senaite/core/patches/archetypes/catalog_multiplex.py
+++ b/src/senaite/core/patches/archetypes/catalog_multiplex.py
@@ -19,9 +19,11 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims import api
+from plone.api.exc import CannotGetPortalError
 from Products.Archetypes.Referenceable import Referenceable
 from Products.Archetypes.utils import shasattr
 from senaite.core.catalog import AUDITLOG_CATALOG
+from zope.interface.interfaces import ComponentLookupError
 
 
 def is_auditlog_enabled():
@@ -57,7 +59,10 @@ def unindexObject(self):
         return
 
     # get all registered catalogs
-    catalogs = api.get_catalogs_for(self)
+    try:
+        catalogs = api.get_catalogs_for(self)
+    except (CannotGetPortalError, ComponentLookupError):
+        return
 
     for catalog in catalogs:
         # skip auditlog_catalog if global auditlogging is deactivated

--- a/src/senaite/core/patches/archetypes/referenceable.py
+++ b/src/senaite/core/patches/archetypes/referenceable.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims import api
+from plone.api.exc import CannotGetPortalError
 from Products.Archetypes.config import UID_CATALOG
 
 
@@ -37,7 +38,12 @@ def _uncatalogUID(self, aq, uc=None):
     if api.is_temporary(self):
         return
     if not uc:
-        uc = api.get_tool(UID_CATALOG)
+        try:
+            uc = api.get_tool(UID_CATALOG)
+        except CannotGetPortalError:
+            # handle site deletion gracefully
+            return
+
     url = self._getURL()
     # XXX This is an ugly workaround. This method shouldn't be called
     # twice for an object in the first place, so we don't have to check


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the traceback that avoids deleting the complete SENAITE site via the ZMI.
 
## Current behavior before PR

SENAITE site could not be entirely deleted in ZMI

## Desired behavior after PR is merged

SENAITE site can be entirely deleted in ZMI

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
