### PR TITLE
Fix incompatible sort key type for subgroup

### DIFF
--- a/src/senaite/core/content/subgroup.py
+++ b/src/senaite/core/content/subgroup.py
@@ -95,7 +95,19 @@ class SubGroup(Container):
     @security.protected(permissions.View)
     def getSortKey(self):
         accessor = self.accessor("sort_key")
-        return accessor(self)
+        # XXX: Temporary, remove after 2.6.0
+        # sort_key moved from string to float and might cause the traceback:
+        #   ValueError: Unknown format code 'f' for object of type 'unicode'
+        # if a previous upgrade step reindexes this value.
+        #
+        # https://github.com/senaite/senaite.core/pull/2652
+        # https://github.com/senaite/senaite.core/pull/2664
+        sort_key = accessor(self)
+        try:
+            sort_key = float(sort_key)
+        except (ValueError, TypeError):
+            sort_key = None
+        return sort_key
 
     @security.protected(permissions.ModifyPortalContent)
     def setSortKey(self, value):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is another fixture for the type change of the subgroup sort key from string -> float that was introduced in https://github.com/senaite/senaite.core/pull/2652

## Current behavior before PR

If a previous upgrade step reindexes this value *before* upgrade step 2656 was run, the following traceback occurs:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 182, in transaction_pubevents
  Module transaction._manager, line 257, in commit
  Module transaction._manager, line 134, in commit
  Module transaction._transaction, line 267, in commit
  Module transaction._transaction, line 333, in _callBeforeCommitHooks
  Module transaction._transaction, line 372, in _call_hooks
  Module Products.CMFCore.indexing, line 317, in before_commit
  Module Products.CMFCore.indexing, line 227, in process
  Module senaite.core.catalog.catalog_multiplex_processor, line 105, in reindex
  Module Products.CMFCore.CatalogTool, line 368, in _reindexObject
  Module Products.CMFPlone.CatalogTool, line 362, in catalog_object
  Module Products.ZCatalog.ZCatalog, line 508, in catalog_object
  Module Products.ZCatalog.Catalog, line 372, in catalogObject
  Module Products.PluginIndexes.unindex, line 237, in index_object
  Module Products.PluginIndexes.unindex, line 249, in _index_object
  Module Products.PluginIndexes.unindex, line 294, in _get_object_datum
  Module plone.indexer.wrapper, line 65, in __getattr__
  Module plone.indexer.delegate, line 20, in __call__
  Module senaite.core.catalog.indexer.subgroup, line 29, in sortable_title
  Module senaite.core.catalog.utils, line 137, in sortable_sortkey_title
ValueError: Unknown format code 'f' for object of type 'unicode'
```

## Desired behavior after PR is merged

Incompatible subgroupd sort key types are handled gracefully during reindexing

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
