### PR TITLE
Flush calculated result if dependency is flushed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2670 Flush calculated result if dependency is flushed
 - #2667 Specifications support for multi-result analyses
 - #2668 Paste support for select components in sample add form
 - #2658 Batched sample registration form with Paste capabilities

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -581,14 +581,13 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             # check if the dependency is a string result
             str_result = dependency.getStringResult()
             keyword = dependency.getKeyword()
-            if not result:
-                # Dependency without results found
-                if cascade:
-                    # Try to calculate the dependency result
-                    dependency.calculateResult(override, cascade)
-                    result = dependency.getResult()
-                else:
-                    return False
+
+            # Dependency without results found
+            if not result and cascade:
+                # Try to calculate the dependency result
+                dependency.calculateResult(override, cascade)
+                result = dependency.getResult()
+
             if result:
                 try:
                     # we need to quote a string result because of the `eval` below
@@ -611,6 +610,13 @@ class AbstractAnalysis(AbstractBaseAnalysis):
                 # https://docs.python.org/2.7/library/stdtypes.html?highlight=built#string-formatting-operations
                 converter = "s" if str_result else "f"
                 formula = formula.replace("[" + keyword + "]", "%(" + keyword + ")" + converter)
+            else:
+                # flush eventual previously set result
+                if self.getResult():
+                    self.setResult("")
+                    return True
+
+                return False
 
         # convert any remaining placeholders, e.g. from interims etc.
         # NOTE: we assume remaining values are all floatable!


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR flushes any previously calculated result if one of the dependencies was flushed, i.e. no value was saved.


## Current behavior before PR

Previously calculated result is retained

<img width="625" alt="H2O-0001 — SENAITE LIMS 2025-02-11 2 PM-32-34" src="https://github.com/user-attachments/assets/ebbf23ce-180f-4c58-901c-6a27aa960b86" />

## Desired behavior after PR is merged

Previously calculated result is flushed

<img width="620" alt="H2O-0001 — SENAITE LIMS 2025-02-11 2 PM-34-11" src="https://github.com/user-attachments/assets/335119a3-1747-4921-932b-69fafd5570bd" />

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
