### PR TITLE
Update GitHub Action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,27 +35,20 @@ jobs:
             curl https://pyenv.run | bash
           fi
 
-      - name: Set up pyenv environment variables
-        run: |
-          echo "PYENV_ROOT=$HOME/.pyenv" >> $GITHUB_ENV
-          echo "$PYENV_ROOT/bin" >> $GITHUB_PATH
-
       - name: Install Python 2.7 with pyenv (if not cached)
         run: |
-          eval "$(pyenv init - bash)"  # Correctly initializes pyenv
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init --path)"
           pyenv install 2.7.18 || true  # Avoid reinstalling if already cached
           pyenv global 2.7.18
 
       - name: Verify Python Version
         run: |
-          eval "$(pyenv init - bash)"
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init --path)"
           python --version  # Should output Python 2.7.18
-
-      - name: Install pip for Python 2.7
-        run: |
-          eval "$(pyenv init - bash)"
-          wget https://bootstrap.pypa.io/pip/2.7/get-pip.py
-          python get-pip.py
 
       - name: Cache eggs
         uses: actions/cache@v4
@@ -66,7 +59,9 @@ jobs:
 
       - name: Install dependencies and setup virtualenv
         run: |
-          eval "$(pyenv init - bash)"
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init --path)"
           pip install virtualenv
           virtualenv -p `which python` .
           ./bin/pip install --upgrade pip
@@ -76,12 +71,10 @@ jobs:
 
       - name: Lint
         run: |
-          eval "$(pyenv init - bash)"
           ./bin/pip install flake8
           ./bin/flake8 --config ci_flake8.cfg src/bika/
           ./bin/flake8 --config ci_flake8.cfg src/senaite/
 
       - name: Run tests
         run: |
-          eval "$(pyenv init - bash)"
           ./bin/test -s senaite.core.tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,17 +6,53 @@ env:
   PLONE_VERSION: "5.2"
 jobs:
   build-and-test:
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-latest'
     container:
       image: python:2.7.18-buster
     steps:
-      - uses: actions/checkout@v3
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y make build-essential libssl-dev \
+              zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
+              wget curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev \
+              libxmlsec1-dev libffi-dev liblzma-dev
+
+      - name: Install pyenv
+        run: |
+          curl https://pyenv.run | bash
+          echo 'export PYENV_ROOT="$HOME/.pyenv"' >> $HOME/.bashrc
+          echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> $HOME/.bashrc
+          echo 'eval "$(pyenv init --path)"' >> $HOME/.bashrc
+          source $HOME/.bashrc
+
+      - name: Install Python 2.7 with pyenv
+        run: |
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init --path)"
+          pyenv install 2.7.18
+          pyenv global 2.7.18
+
+      - name: Verify Python Version
+        run: python --version  # Should output Python 2.7.18
+
+      - name: Install pip for Python 2.7
+        run: |
+          wget https://bootstrap.pypa.io/pip/2.7/get-pip.py
+          python get-pip.py
+
       - name: cache eggs
         uses: actions/cache@v3
         with:
           key: eggs-cache-${{ hashFiles('buildout.cfg', 'requirements.txt') }}
           path: |
             eggs/
+
       - name: install
         run: |
           pip install virtualenv
@@ -25,11 +61,13 @@ jobs:
           bin/pip install -r requirements.txt
           bin/buildout -N -t 3 annotate
           bin/buildout -N -t 3
+
       - name: lint
         run: |
           bin/pip install flake8
           bin/flake8 --config ci_flake8.cfg src/bika/
           bin/flake8 --config ci_flake8.cfg src/senaite/
+
       - name: test
         run: |
           bin/test -s senaite.core.tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,22 +29,31 @@ jobs:
               wget curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev \
               libxmlsec1-dev libffi-dev liblzma-dev
 
+      - name: Install pyenv
+        run: |
+          if [ ! -d "$HOME/.pyenv" ]; then
+            curl https://pyenv.run | bash
+          fi
+
       - name: Set up pyenv environment variables
         run: |
-          echo 'export PYENV_ROOT="$HOME/.pyenv"' >> $GITHUB_ENV
-          echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> $GITHUB_ENV
-          echo 'eval "$(pyenv init --path)"' >> $GITHUB_ENV
+          echo "PYENV_ROOT=$HOME/.pyenv" >> $GITHUB_ENV
+          echo "$PYENV_ROOT/bin" >> $GITHUB_PATH
 
       - name: Install Python 2.7 with pyenv (if not cached)
         run: |
+          eval "$(pyenv init - bash)"  # Correctly initializes pyenv
           pyenv install 2.7.18 || true  # Avoid reinstalling if already cached
           pyenv global 2.7.18
 
       - name: Verify Python Version
-        run: python --version  # Should output Python 2.7.18
+        run: |
+          eval "$(pyenv init - bash)"
+          python --version  # Should output Python 2.7.18
 
       - name: Install pip for Python 2.7
         run: |
+          eval "$(pyenv init - bash)"
           wget https://bootstrap.pypa.io/pip/2.7/get-pip.py
           python get-pip.py
 
@@ -57,6 +66,7 @@ jobs:
 
       - name: Install dependencies and setup virtualenv
         run: |
+          eval "$(pyenv init - bash)"
           pip install virtualenv
           virtualenv -p `which python` .
           ./bin/pip install --upgrade pip
@@ -66,10 +76,12 @@ jobs:
 
       - name: Lint
         run: |
+          eval "$(pyenv init - bash)"
           ./bin/pip install flake8
           ./bin/flake8 --config ci_flake8.cfg src/bika/
           ./bin/flake8 --config ci_flake8.cfg src/senaite/
 
       - name: Run tests
         run: |
+          eval "$(pyenv init - bash)"
           ./bin/test -s senaite.core.tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,8 +7,6 @@ env:
 jobs:
   build-and-test:
     runs-on: 'ubuntu-latest'
-    container:
-      image: python:2.7.18-buster
     steps:
 
       - name: Checkout code
@@ -16,8 +14,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt update
-          sudo apt install -y make build-essential libssl-dev \
+          apt update
+          apt install -y make build-essential libssl-dev \
               zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
               wget curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev \
               libxmlsec1-dev libffi-dev liblzma-dev
@@ -47,7 +45,7 @@ jobs:
           python get-pip.py
 
       - name: cache eggs
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: eggs-cache-${{ hashFiles('buildout.cfg', 'requirements.txt') }}
           path: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,9 +4,10 @@ on:
   - pull_request
 env:
   PLONE_VERSION: "5.2"
+
 jobs:
   build-and-test:
-    runs-on: 'ubuntu-latest'
+    runs-on: ubuntu-latest
     steps:
 
       - name: Checkout code
@@ -14,8 +15,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt update
-          apt install -y make build-essential libssl-dev \
+          sudo apt update
+          sudo apt install -y make build-essential libssl-dev \
               zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
               wget curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev \
               libxmlsec1-dev libffi-dev liblzma-dev
@@ -26,7 +27,6 @@ jobs:
           echo 'export PYENV_ROOT="$HOME/.pyenv"' >> $HOME/.bashrc
           echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> $HOME/.bashrc
           echo 'eval "$(pyenv init --path)"' >> $HOME/.bashrc
-          source $HOME/.bashrc
 
       - name: Install Python 2.7 with pyenv
         run: |
@@ -37,35 +37,45 @@ jobs:
           pyenv global 2.7.18
 
       - name: Verify Python Version
-        run: python --version  # Should output Python 2.7.18
+        run: |
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init --path)"
+          python --version  # Should output Python 2.7.18
 
       - name: Install pip for Python 2.7
         run: |
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init --path)"
           wget https://bootstrap.pypa.io/pip/2.7/get-pip.py
           python get-pip.py
 
-      - name: cache eggs
+      - name: Cache eggs
         uses: actions/cache@v4
         with:
           key: eggs-cache-${{ hashFiles('buildout.cfg', 'requirements.txt') }}
           path: |
             eggs/
 
-      - name: install
+      - name: Install dependencies and setup virtualenv
         run: |
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init --path)"
           pip install virtualenv
           virtualenv -p `which python` .
-          bin/pip install --upgrade pip
-          bin/pip install -r requirements.txt
-          bin/buildout -N -t 3 annotate
-          bin/buildout -N -t 3
+          ./bin/pip install --upgrade pip
+          ./bin/pip install -r requirements.txt
+          ./bin/buildout -N -t 3 annotate
+          ./bin/buildout -N -t 3
 
-      - name: lint
+      - name: Lint
         run: |
-          bin/pip install flake8
-          bin/flake8 --config ci_flake8.cfg src/bika/
-          bin/flake8 --config ci_flake8.cfg src/senaite/
+          ./bin/pip install flake8
+          ./bin/flake8 --config ci_flake8.cfg src/bika/
+          ./bin/flake8 --config ci_flake8.cfg src/senaite/
 
-      - name: test
+      - name: Run tests
         run: |
-          bin/test -s senaite.core.tests
+          ./bin/test -s senaite.core.tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,6 +13,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Cache pyenv Python builds
+        uses: actions/cache@v4
+        with:
+          path: ~/.pyenv
+          key: pyenv-2.7.18-${{ runner.os }}
+          restore-keys: |
+            pyenv-2.7.18-
+
       - name: Install dependencies
         run: |
           sudo apt update
@@ -21,33 +29,22 @@ jobs:
               wget curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev \
               libxmlsec1-dev libffi-dev liblzma-dev
 
-      - name: Install pyenv
+      - name: Set up pyenv environment variables
         run: |
-          curl https://pyenv.run | bash
-          echo 'export PYENV_ROOT="$HOME/.pyenv"' >> $HOME/.bashrc
-          echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> $HOME/.bashrc
-          echo 'eval "$(pyenv init --path)"' >> $HOME/.bashrc
+          echo 'export PYENV_ROOT="$HOME/.pyenv"' >> $GITHUB_ENV
+          echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> $GITHUB_ENV
+          echo 'eval "$(pyenv init --path)"' >> $GITHUB_ENV
 
-      - name: Install Python 2.7 with pyenv
+      - name: Install Python 2.7 with pyenv (if not cached)
         run: |
-          export PYENV_ROOT="$HOME/.pyenv"
-          export PATH="$PYENV_ROOT/bin:$PATH"
-          eval "$(pyenv init --path)"
-          pyenv install 2.7.18
+          pyenv install 2.7.18 || true  # Avoid reinstalling if already cached
           pyenv global 2.7.18
 
       - name: Verify Python Version
-        run: |
-          export PYENV_ROOT="$HOME/.pyenv"
-          export PATH="$PYENV_ROOT/bin:$PATH"
-          eval "$(pyenv init --path)"
-          python --version  # Should output Python 2.7.18
+        run: python --version  # Should output Python 2.7.18
 
       - name: Install pip for Python 2.7
         run: |
-          export PYENV_ROOT="$HOME/.pyenv"
-          export PATH="$PYENV_ROOT/bin:$PATH"
-          eval "$(pyenv init --path)"
           wget https://bootstrap.pypa.io/pip/2.7/get-pip.py
           python get-pip.py
 
@@ -60,9 +57,6 @@ jobs:
 
       - name: Install dependencies and setup virtualenv
         run: |
-          export PYENV_ROOT="$HOME/.pyenv"
-          export PATH="$PYENV_ROOT/bin:$PATH"
-          eval "$(pyenv init --path)"
           pip install virtualenv
           virtualenv -p `which python` .
           ./bin/pip install --upgrade pip

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,27 +21,27 @@ jobs:
     steps:
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Show workspace
         run: echo ${{ github.workspace }}
 
       - name: Checkout senaite.docker
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: "senaite/senaite.docker"
           path: "senaite.docker"
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: ${{ github.workspace }}/senaite.docker/latest
           file: ${{ github.workspace }}/senaite.docker/latest/Dockerfile


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR updates the GitHub action to use `ubuntu-latest` due to this accouncement:

---

The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:

March 4 14:00 UTC – 22:00 UTC
March 11 13:00 UTC – 21:00 UTC
March 18 13:00 UTC – 21:00 UTC
March 25 13:00 UTC – 21:00 UTC
What you need to do

Jobs using the ubuntu-20.04 YAML workflow label should be updated to ubuntu-22.04, ubuntu-24.04 or ubuntu-latest. You can always get up-to-date information on our tools by reading about the software in the [runner images repository](https://app.github.media/e/er?s=88570519&lid=3455&elqTrackId=1befe7689f3c4a1a9cba67758d7c6fa0&elq=5a935d2f562545389886a76b81bdba2b&elqaid=4309&elqat=1&elqak=8AF512931A9D3060F4A93E1FC36635281ABF09F623AAA206E910BE71975C2C8355F1). Please contact GitHub [Support](https://app.github.media/e/er?s=88570519&lid=3338&elqTrackId=51ced43500f64a46924167a4a536829b&elq=5a935d2f562545389886a76b81bdba2b&elqaid=4309&elqat=1&elqak=8AF5D818E42E3357A6143F29D23F7AD3B3C109F623AAA206E910BE71975C2C8355F1) if you run into any problems or need help.

---


## Current behavior before PR

Ubuntu 20 is used with a Python 2.7 container

## Desired behavior after PR is merged

Ubuntu latest is used that installs Python 2.7 with PyEnv

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
