### PR TITLE
Fix rejected sample analyses are re-added on profile removal 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2672 Fix rejected sample analyses are re-added on profile removal
 - #2667 Specifications support for multi-result analyses
 - #2668 Paste support for select components in sample add form
 - #2658 Batched sample registration form with Paste capabilities

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -1516,7 +1516,7 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
 
         # Don't add analyses from profiles during sample creation.
         # In this case the required analyses are added afterwards explicitly.
-        if not api.is_temporary(self):
+        if value and not api.is_temporary(self):
             # get the profiles
             profiles = map(api.get_object_by_uid, uids)
             # get the current set of analyses/services

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -1516,6 +1516,9 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
 
         # Don't add analyses from profiles during sample creation.
         # In this case the required analyses are added afterwards explicitly.
+        #
+        # Also only add analyses if a profile (value) is selected:
+        # https://github.com/senaite/senaite.core/pull/2672
         if value and not api.is_temporary(self):
             # get the profiles
             profiles = map(api.get_object_by_uid, uids)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the behavior that rejected sample analyses are re-added if the Profile was unlinked *after* the analyses have been rejected.

Example:

1. Add a sample with a profile:

<img width="1831" alt="H2O-0002 — SENAITE LIMS 2025-02-12 9 AM-57-50" src="https://github.com/user-attachments/assets/564dd6b7-dac7-4bb2-8138-6a89644e16a7" />

2. Reject all analyses:

<img width="1830" alt="H2O-0002 — SENAITE LIMS 2025-02-12 9 AM-58-48" src="https://github.com/user-attachments/assets/8851dd2a-08c4-493a-89c0-dd45c602d47f" />

3. Unlink the profile and save:

<img width="1839" alt="H2O-0002 — SENAITE LIMS 2025-02-12 9 AM-59-47" src="https://github.com/user-attachments/assets/2e1c45cd-60f9-49c0-81cc-2e413ab9b0f2" />



## Current behavior before PR

Analyses are added again:

<img width="1830" alt="H2O-0002 — SENAITE LIMS 2025-02-12 10 AM-00-59" src="https://github.com/user-attachments/assets/45915d20-5a93-4ca3-be5a-ef5f4811f9bd" />


## Desired behavior after PR is merged

No additional analyses are added:

<img width="1830" alt="H2O-0002 — SENAITE LIMS 2025-02-12 9 AM-58-48" src="https://github.com/user-attachments/assets/8851dd2a-08c4-493a-89c0-dd45c602d47f" />

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
