### PR TITLE
Trigger recalculation of dependants if uncertainty changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2673 Trigger recalculation of dependants if uncertainty changes
 - #2672 Fix rejected sample analyses are re-added on profile removal
 - #2670 Flush calculated result if dependency is flushed
 - #2667 Specifications support for multi-result analyses

--- a/src/senaite/core/datamanagers/content/analysis.py
+++ b/src/senaite/core/datamanagers/content/analysis.py
@@ -28,6 +28,10 @@ from senaite.core.datamanagers.base import DataManager
 from zope.component import adapter
 
 
+# Fields that cause a recalculation of dependants
+TRIGGER_RECALCULATE_FIELDS = ["Result", "Uncertainty"]
+
+
 @adapter(IRoutineAnalysis)
 class RoutineAnalysisDataManager(DataManager):
     """Data Manager for Routine Analyses
@@ -107,7 +111,7 @@ class RoutineAnalysisDataManager(DataManager):
             self.context.setInterimValue(name, value)
 
         # recalculate dependent results for result and interim fields
-        if name == "Result" or name in interim_keys:
+        if name in TRIGGER_RECALCULATE_FIELDS or name in interim_keys:
             updated_objects.add(self.context)
             updated_objects.update(self.recalculate_results(self.context))
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the behavior of analyses to trigger a recalculation of dependant calculations if the uncertainty changes.

## Current behavior before PR

Recalculation of dependant calculations not triggered if uncertainty changes

## Desired behavior after PR is merged

Recalculation of dependant calculations are triggered if uncertainty changes

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
