### PR TITLE
Fix partitions not displayed correctly in batch samples listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2674 Fix partitions not displayed correctly in batch samples listing
 - #2672 Fix rejected sample analyses are re-added on profile removal
 - #2670 Flush calculated result if dependency is flushed
 - #2667 Specifications support for multi-result analyses

--- a/src/bika/lims/browser/batch/analysisrequests.py
+++ b/src/bika/lims/browser/batch/analysisrequests.py
@@ -18,15 +18,10 @@
 # Copyright 2018-2024 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from bika.lims import api
-from bika.lims.browser.analysisrequest import AnalysisRequestsView as BaseView
+# flake8: noqa
 
+from senaite.core.browser.batches.samples import \
+    SamplesView as AnalysisRequestsView
+from zope import deprecation
 
-class AnalysisRequestsView(BaseView):
-
-    def __init__(self, context, request):
-        super(AnalysisRequestsView, self).__init__(context, request)
-        self.contentFilter = {"portal_type": "AnalysisRequest",
-                              "getBatchUID": api.get_uid(self.context),
-                              "sort_on": "created",
-                              "sort_order": "reverse"}
+deprecation.deprecated("AnalysisRequestsView", "Moved to senaite.core.browser.batches.samples.SamplesView")

--- a/src/bika/lims/browser/batch/configure.zcml
+++ b/src/bika/lims/browser/batch/configure.zcml
@@ -6,14 +6,6 @@
 
     <browser:page
       for="bika.lims.interfaces.IBatch"
-      name="analysisrequests"
-      class="bika.lims.browser.batch.analysisrequests.AnalysisRequestsView"
-      permission="zope2.View"
-      layer="bika.lims.interfaces.IBikaLIMS"
-    />
-
-    <browser:page
-      for="bika.lims.interfaces.IBatch"
       name="batchbook"
       class="bika.lims.browser.batch.batchbook.BatchBookView"
       permission="zope2.View"

--- a/src/senaite/core/browser/batches/configure.zcml
+++ b/src/senaite/core/browser/batches/configure.zcml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser">
+
+    <browser:page
+      for="bika.lims.interfaces.IBatch"
+      name="analysisrequests"
+      class=".samples.SamplesView"
+      permission="zope2.View"
+      layer="senaite.core.interfaces.ISenaiteCore"
+    />
+
+</configure>

--- a/src/senaite/core/browser/batches/samples.py
+++ b/src/senaite/core/browser/batches/samples.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+from bika.lims import api
+from senaite.core.browser.samples.view import SamplesView as BaseView
+
+
+class SamplesView(BaseView):
+    """Samples listing inside Batches
+    """
+
+    def __init__(self, context, request):
+        super(SamplesView, self).__init__(context, request)
+        self.contentFilter = {
+            "portal_type": "AnalysisRequest",
+            "getBatchUID": api.get_uid(self.context),
+            "sort_on": "created",
+            "sort_order": "reverse",
+            "isRootAncestor": True,  # only root ancestors
+        }

--- a/src/senaite/core/browser/configure.zcml
+++ b/src/senaite/core/browser/configure.zcml
@@ -13,6 +13,7 @@
 
   <!-- Package includes -->
   <include package=".attachment"/>
+  <include package=".batches"/>
   <include package=".batching"/>
   <include package=".bootstrap"/>
   <include package=".clients"/>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue in the samples listing view of a batch.

## Current behavior before PR

Partitions are displayed as root sample and below the actual root sample:

<img width="1855" alt="B-001 — SENAITE LIMS 2025-02-12 2 PM-12-44" src="https://github.com/user-attachments/assets/d96a4467-7f4e-445f-970a-cbef184c18d6" />

## Desired behavior after PR is merged

Partitions in batch based samples listing are only shown below the root sample:

<img width="1856" alt="B-001 — SENAITE LIMS 2025-02-12 2 PM-14-00" src="https://github.com/user-attachments/assets/fdf7130b-8814-4e49-810e-58d33373b9a2" />


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
