### PR TITLE
Fix services are not deselected on template removal in sample add form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2675 Fix services are not deselected on template removal in sample add form
 - #2673 Trigger recalculation of dependants if uncertainty changes
 - #2674 Fix partitions not displayed correctly in batch samples listing
 - #2672 Fix rejected sample analyses are re-added on profile removal

--- a/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
@@ -1697,7 +1697,6 @@
         return services.push(record.service_metadata[uid]);
       });
       this.applied_templates[arnum] = null;
-      me = this;
       dialog = this.template_dialog("template-remove-template", context);
       dialog.on("yes", function() {
         // deselect the services

--- a/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
@@ -1678,14 +1678,39 @@
     }
 
     on_analysis_template_removed(event) {
-      var $el, arnum, el;
+      var $el, arnum, context, dialog, el, me, metadata, record, services, template_uid;
       console.debug("°°° on_analysis_template_removed °°°");
+      me = this;
       el = event.currentTarget;
       $el = $(el);
       arnum = $el.closest("[arnum]").attr("arnum");
+      // Get the template UID that has been deselected
+      template_uid = event.detail.value;
+      record = this.records_snapshot[arnum];
+      metadata = record.template_metadata[template_uid];
+      services = [];
+      context = {};
+      context["template"] = metadata;
+      context["services"] = services;
+      // get the list of services assigned to the template
+      $.each(record.template_to_services[template_uid], function(index, uid) {
+        return services.push(record.service_metadata[uid]);
+      });
       this.applied_templates[arnum] = null;
-      // trigger form:changed event
-      return $(this).trigger("form:changed");
+      me = this;
+      dialog = this.template_dialog("template-remove-template", context);
+      dialog.on("yes", function() {
+        // deselect the services
+        $.each(services, function(index, service) {
+          return me.set_service(arnum, service.uid, false);
+        });
+        // trigger form:changed event
+        return $(me).trigger("form:changed");
+      });
+      return dialog.on("no", function() {
+        // trigger form:changed event
+        return $(me).trigger("form:changed");
+      });
     }
 
     on_analysis_profile_selected(event) {

--- a/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -1471,13 +1471,39 @@ class window.AnalysisRequestAdd
   on_analysis_template_removed: (event) =>
     console.debug "°°° on_analysis_template_removed °°°"
 
+    me = this
     el = event.currentTarget
     $el = $(el)
     arnum = $el.closest("[arnum]").attr "arnum"
+
+    # Get the template UID that has been deselected
+    template_uid = event.detail.value
+
+    record = @records_snapshot[arnum]
+    metadata = record.template_metadata[template_uid]
+    services = []
+
+    context = {}
+    context["template"] = metadata
+    context["services"] = services
+
+    # get the list of services assigned to the template
+    $.each record.template_to_services[template_uid], (index, uid) ->
+      services.push record.service_metadata[uid]
+
     @applied_templates[arnum] = null
 
-    # trigger form:changed event
-    $(this).trigger "form:changed"
+    me = this
+    dialog = @template_dialog "template-remove-template", context
+    dialog.on "yes", ->
+      # deselect the services
+      $.each services, (index, service) ->
+        me.set_service arnum, service.uid, no
+      # trigger form:changed event
+      $(me).trigger "form:changed"
+    dialog.on "no", ->
+      # trigger form:changed event
+      $(me).trigger "form:changed"
 
 
   ###*

--- a/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -1493,7 +1493,6 @@ class window.AnalysisRequestAdd
 
     @applied_templates[arnum] = null
 
-    me = this
     dialog = @template_dialog "template-remove-template", context
     dialog.on "yes", ->
       # deselect the services


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the system asks for services clearance when user unselect a sample template in sample add form, like it already does for profile.

![Captura de 2025-02-13 16-08-54](https://github.com/user-attachments/assets/befed532-ca28-4abd-a474-4c60fab2f95c)


## Current behavior before PR

When the sample template in add form is unselected, services remain selected

## Desired behavior after PR is merged

When the sample template in add form is removed, user is asked about the removal of services

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
