### PR TITLE
Fix permission for Uncertainty field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2677 Fix permission for Uncertainty field
 - #2672 Fix rejected sample analyses are re-added on profile removal
 - #2670 Flush calculated result if dependency is flushed
 - #2667 Specifications support for multi-result analyses

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -23,7 +23,6 @@ import copy
 import json
 import math
 from decimal import Decimal
-from six import string_types
 
 from AccessControl import ClassSecurityInfo
 from bika.lims import api
@@ -41,20 +40,21 @@ from bika.lims.config import UDL
 from bika.lims.content.abstractbaseanalysis import AbstractBaseAnalysis
 from bika.lims.content.abstractbaseanalysis import schema
 from bika.lims.interfaces import IDuplicateAnalysis
-from senaite.core.permissions import FieldEditAnalysisResult
-from senaite.core.permissions import ViewResults
 from bika.lims.utils import formatDecimalMark
 from bika.lims.utils.analysis import format_numeric_result
 from bika.lims.utils.analysis import get_significant_digits
 from bika.lims.workflow import getTransitionActor
 from bika.lims.workflow import getTransitionDate
 from DateTime import DateTime
-from senaite.core.browser.fields.datetime import DateTimeField
 from Products.Archetypes.Field import IntegerField
 from Products.Archetypes.Field import StringField
 from Products.Archetypes.references import HoldingReference
 from Products.Archetypes.Schema import Schema
 from Products.CMFCore.permissions import View
+from senaite.core.browser.fields.datetime import DateTimeField
+from senaite.core.permissions import FieldEditAnalysisResult
+from senaite.core.permissions import ViewResults
+from six import string_types
 
 # A link directly to the AnalysisService object used to create the analysis
 AnalysisService = UIDReferenceField(
@@ -111,9 +111,9 @@ Analyst = StringField(
 # The actual uncertainty for this analysis' result, populated from the ranges
 # specified in the analysis service when the result is submitted.
 Uncertainty = StringField(
-    'Uncertainty',
+    "Uncertainty",
     read_permission=View,
-    write_permission="senaite.core: Field: Edit Analysis Result",
+    write_permission=FieldEditAnalysisResult,
     precision=10,
 )
 

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -113,7 +113,7 @@ Analyst = StringField(
 Uncertainty = StringField(
     'Uncertainty',
     read_permission=View,
-    write_permission="Field: Edit Result",
+    write_permission="senaite.core: Field: Edit Analysis Result",
     precision=10,
 )
 

--- a/src/bika/lims/content/abstractroutineanalysis.py
+++ b/src/bika/lims/content/abstractroutineanalysis.py
@@ -53,7 +53,7 @@ from zope.interface import noLongerProvides
 Uncertainty = StringField(
     'Uncertainty',
     read_permission=View,
-    write_permission="Field: Edit Result",
+    write_permission="senaite.core: Field: Edit Analysis Result",
     precision=10,
     widget=DecimalWidget(
         label=_("Uncertainty")

--- a/src/bika/lims/content/abstractroutineanalysis.py
+++ b/src/bika/lims/content/abstractroutineanalysis.py
@@ -44,6 +44,7 @@ from Products.ATContentTypes.utils import DT2dt
 from Products.ATContentTypes.utils import dt2DT
 from Products.CMFCore.permissions import View
 from senaite.core.catalog.indexer.baseanalysis import sortable_title
+from senaite.core.permissions import FieldEditAnalysisResult
 from zope.interface import alsoProvides
 from zope.interface import implements
 from zope.interface import noLongerProvides
@@ -51,9 +52,9 @@ from zope.interface import noLongerProvides
 # The actual uncertainty for this analysis' result, populated when the result
 # is submitted.
 Uncertainty = StringField(
-    'Uncertainty',
+    "Uncertainty",
     read_permission=View,
-    write_permission="senaite.core: Field: Edit Analysis Result",
+    write_permission=FieldEditAnalysisResult,
     precision=10,
     widget=DecimalWidget(
         label=_("Uncertainty")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR replaces the orphane field permission `Field: Edit Result` with `senaite.core: Field: Edit Analysis Result`

## Current behavior before PR

An Error is displayed if an Analyst enters a value into the Uncertainty field:

2025-02-20 14:50:24,376 ERROR   [senaite.core:93][waitress-2] Field 'Uncertainty' not writeable!

## Desired behavior after PR is merged

No Error is displayed if an Analyst enters a value into the Uncertainty field

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
