### PR TITLE
Add validate function in API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2678 Add validate function in API
 - #2675 Fix services are not deselected on template removal in sample add form
 - #2673 Trigger recalculation of dependants if uncertainty changes
 - #2674 Fix partitions not displayed correctly in batch samples listing

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -77,7 +77,6 @@ from zope.component import queryMultiAdapter
 from zope.container.contained import notifyContainerModified
 from zope.event import notify
 from zope.i18n import translate
-from zope.i18nmessageid import Message
 from zope.interface import alsoProvides
 from zope.interface import directlyProvides
 from zope.interface import noLongerProvides

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -43,6 +43,7 @@ from plone import api as ploneapi
 from plone.api.exc import InvalidParameterError
 from plone.app.layout.viewlets.content import ContentHistoryView
 from plone.behavior.interfaces import IBehaviorAssignable
+from plone.behavior.registration import lookup_behavior_registration
 from plone.dexterity.interfaces import IDexterityContent
 from plone.dexterity.schema import SchemaInvalidatedEvent
 from plone.dexterity.utils import addContentToContainer
@@ -75,12 +76,17 @@ from zope.component import getUtility
 from zope.component import queryMultiAdapter
 from zope.container.contained import notifyContainerModified
 from zope.event import notify
+from zope.i18n import translate
+from zope.i18nmessageid import Message
 from zope.interface import alsoProvides
 from zope.interface import directlyProvides
 from zope.interface import noLongerProvides
+from zope.interface import Invalid
 from zope.lifecycleevent import ObjectMovedEvent
 from zope.publisher.browser import TestRequest
 from zope.schema import getFieldsInOrder
+from zope.schema.interfaces import RequiredMissing
+from zope.schema.interfaces import WrongType
 from zope.security.interfaces import Unauthorized
 
 """SENAITE LIMS Framework API
@@ -2058,3 +2064,50 @@ def to_list(value):
     if not isinstance(value, (list, tuple, set)):
         value = [value]
     return list(value)
+
+
+def validate(obj, invariants=True):
+    """Validates the full object
+
+    :param obj: the object to validate the data against
+    :type obj: ATContentType/DexterityContentType
+    :returns: a dict with field names as keys and errors as values
+    """
+    if is_at_content(obj):
+        return obj.validate(data=True)
+
+    if not is_dexterity_content(obj):
+        raise TypeError("%r is not supported" % type(obj))
+
+    errors = {}
+
+    # iterate through object fields and validate each
+    fields = get_fields(obj)
+    for field_name, field in fields.items():
+        value = getattr(obj, field_name, None)
+        value = safe_unicode(value)
+        try:
+            field.validate(value)
+        except RequiredMissing:
+            errors[field_name] = "required field"
+        except WrongType:
+            errors[field_name] = "wrong type"
+        except Invalid as ex:
+            errors[field_name] = translate(ex.message)
+
+    # validate invariants from schema
+    sch = get_schema(obj)
+    try:
+        sch.validateInvariants(obj)
+    except Invalid as ex:
+        errors[sch.getName()] = translate(ex.message)
+
+    # validate invariants from behaviors
+    for behavior_id in get_behaviors(obj):
+        behavior = lookup_behavior_registration(behavior_id)
+        try:
+            behavior.interface.validateInvariants(obj)
+        except Invalid as ex:
+            errors[behavior_id] = translate(ex.message)
+
+    return errors

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -2449,3 +2449,75 @@ Still, destination container must allow the object's type:
     Traceback (most recent call last):
     [...]
     ValueError: Disallowed subobject type: Contact
+
+
+Validate an object
+..................
+
+This function validates the object.
+
+System complains when validating an object with required, but not set, fields:
+
+    >>> sample_types = self.portal.setup.sampletypes
+    >>> data = {
+    ...     "title": "My Sample Type",
+    ...     "Prefix": "MyPrefix",
+    ... }
+    >>> sample_type = api.create(sample_types, "SampleType", **data)
+    >>> api.validate(sample_type)
+    {'min_volume': 'required field'}
+
+    >>> sample_type.setMinimumVolume("10 mL")
+    >>> api.validate(sample_type)
+    {}
+
+It also reports multiple validation errors at a time:
+
+    >>> departments = self.portal.setup.departments
+    >>> department = api.create(departments, "Department", title="My dept")
+    >>> errors = api.validate(department)
+    >>> [(key, errors[key]) for key in sorted(errors.keys())]
+    [('department_id', 'required field'), ('manager', 'required field')]
+
+The validator assigned to the field is also considered:
+
+    >>> sample_type.setPrefix("My Prefix With Whitespaces")
+    >>> api.validate(sample_type)
+    {'prefix': u'No whitespaces in prefix allowed'}
+
+    >>> sample_type.setPrefix("MyPrefix")
+    >>> api.validate(sample_type)
+    {}
+
+    >>> sample_type.setMinimumVolume("10 mL")
+    >>> api.validate(sample_type)
+    {}
+
+System complains if the value has the wrong type:
+
+    >>> sample_type.admitted_sticker_templates = "dummy"
+    >>> api.validate(sample_type)
+    {'admitted_sticker_templates': 'wrong type'}
+
+It also takes invariants into consideration:
+
+    >>> categories = self.portal.setup.analysiscategories
+    >>> data = {
+    ...     "title": "My cat",
+    ...     "Department": department,
+    ... }
+    >>> category = api.create(categories, "AnalysisCategory", **data)
+    >>> api.validate(category)
+    {}
+
+    >>> category.setSortKey(-1.0)
+    >>> api.validate(category)
+    {'IAnalysisCategorySchema': u'Validation failed: value must be between 0 and 1000'}
+
+    >>> category.setSortKey(10)
+    >>> api.validate(category)
+    {'sort_key': 'wrong type'}
+
+    >>> category.setSortKey(10.0)
+    >>> api.validate(category)
+    {}


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds a `validate` function in the API to validate the values of an object are properly set.

## Current behavior before PR

Not possible to check the validity of data from objects easily

## Desired behavior after PR is merged

Is possible to check the validity of data from objects easily

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
