### PR TITLE
Add function to make the assignment of custom catalogs easier

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2681 Add function to make the assignment of custom catalogs easier
 - #2678 Add validate function in API
 - #2677 Fix permission for Uncertainty field
 - #2675 Fix services are not deselected on template removal in sample add form

--- a/src/senaite/core/catalog/__init__.py
+++ b/src/senaite/core/catalog/__init__.py
@@ -19,8 +19,11 @@
 # Some rights reserved, see README and LICENSE.
 
 # flake8:noqa:F401
+import copy
+
 from plone.memoize import forever
 
+from senaite.core import logger
 from senaite.core.catalog.analysis_catalog import \
     CATALOG_ID as ANALYSIS_CATALOG
 from senaite.core.catalog.analysis_catalog import AnalysisCatalog
@@ -48,6 +51,9 @@ from senaite.core.catalog.worksheet_catalog import \
     CATALOG_ID as WORKSHEET_CATALOG
 from senaite.core.catalog.worksheet_catalog import WorksheetCatalog
 from senaite.core.registry import get_registry_record
+from senaite.core.registry import set_registry_record
+
+CATALOG_MAPPINGS_REGISTRY_KEY = "catalog_mappings"
 
 CATALOG_MAPPINGS = (
     # portal_type, catalog_ids
@@ -120,7 +126,10 @@ def get_catalogs_by_type(portal_type):
     mapping = dict(CATALOG_MAPPINGS)
     catalogs = mapping.get(portal_type) or []
 
-    registry_mapping = get_registry_record("catalog_mappings")
+    # copy to prevent persistent changes
+    catalogs = copy.deepcopy(catalogs)
+
+    registry_mapping = get_registry_record(CATALOG_MAPPINGS_REGISTRY_KEY)
     if not registry_mapping:
         return catalogs
 
@@ -132,3 +141,58 @@ def get_catalogs_by_type(portal_type):
         catalogs.append(catalog)
 
     return catalogs
+
+
+def set_catalogs(portal_type, catalogs):
+    """Update the catalog mappings for the given portal type
+
+    IMPORTANT: This only takes effect on the current process, so be sure to
+               restart the zeoclients for the changes to take effect.
+
+    :param portal_type: The portal type to update its catalog mappings
+    :param catalogs: list (to extend) or tuple (to replace) of catalog ids
+    """
+    mapping = get_registry_record(CATALOG_MAPPINGS_REGISTRY_KEY) or {}
+    if catalogs is None:
+        catalogs = []
+
+    # list extends, tuple replaces
+    existing = mapping.pop(portal_type, [])
+    if isinstance(catalogs, list):
+        catalogs.extend(existing)
+
+    # remove duplicates
+    catalogs = list(set(catalogs))
+    if catalogs:
+        mapping[portal_type] = catalogs
+
+    # update the registry record
+    set_registry_record(CATALOG_MAPPINGS_REGISTRY_KEY, mapping)
+
+    # flush the catalogs mapping cache, if any
+    flush_catalogs_cache(portal_type)
+
+    # restart the instance for the changes to take effect!
+    logger.warn("*----------------------------------------------------------*")
+    logger.warn("*    Catalogs for %s updated" % portal_type)
+    logger.warn("*    RESTART THE CLIENTS for the changes to take effect")
+    logger.warn("*----------------------------------------------------------*")
+
+
+def flush_catalogs_cache(portal_type):
+    """Flushes the cache storing the catalog mappings for the given portal type
+
+    IMPORTANT: This only takes effect on the current process, so be sure to
+               restart the zeoclients for the changes to take effect.
+
+    :param portal_type: The portal type to update its catalog mappings
+    """
+    # emulate forever.memoize get_key
+    key = ((portal_type, ), frozenset([]))
+    # build the key from volatile.cache
+    fun = get_catalogs_by_type
+    key = "%s.%s:%s" % (fun.__module__, fun.__name__, key)
+    # delete the portal_type from the forever._memos cache
+    cache = forever._memos  # noqa
+    if key in cache:
+        del(cache[key])

--- a/src/senaite/core/tests/doctests/Catalogs.rst
+++ b/src/senaite/core/tests/doctests/Catalogs.rst
@@ -88,17 +88,19 @@ Analyses should be registered in the analysis catalog:
 Get catalogs by type
 ....................
 
-Since `archetype_tool` only gives us the catalogs for `Archetype`-based types,
-one can easily get catalogs from a given type, regardless of its nature.
+The `archetype_tool` only gives us the catalogs for `Archetype`-based types.
+The function `get_catalogs_by_type` allows us to overcome this problem, but
+with the following considerations:
 
-However, `auditlog_catalog` is skipped, cause the cataloguing of objects into
-that catalog is automatically handled by the catalog multiplexer functionality.
+- `auditlog_catalog` is skipped, cause the cataloguing of objects into
+  that catalog is automatically handled by the multiplexer functionality.
 
-Likewise `uid_catalog` is a special catalog where all AT contents, plus those
-DX contents implementing the `Referenceable` behavior are catalogued.
+- Likewise, `uid_catalog` is a special catalog where all AT contents, plus those
+  DX contents implementing the `Referenceable` behavior are catalogued.
 
-As a result, `get_catalogs_by_type` only returns the catalogs that are specific
-for the given portal type. Nothing less, nothing more:
+As a result, `get_catalogs_by_type` returns the catalogs despite the *nature*
+of the type (`Archetype` or `Dexterity`) but only those that are specific for
+the given portal type. Nothing less, nothing more:
 
     >>> get_catalogs_by_type("Analysis")
     ['senaite_catalog_analysis']

--- a/src/senaite/core/tests/doctests/Catalogs.rst
+++ b/src/senaite/core/tests/doctests/Catalogs.rst
@@ -17,9 +17,14 @@ Needed Imports::
 
     >>> from bika.lims import api
 
+    >>> from senaite.core.catalog import flush_catalogs_cache
+    >>> from senaite.core.catalog import get_catalogs_by_type
+    >>> from senaite.core.catalog import set_catalogs
     >>> from senaite.core.catalog import ANALYSIS_CATALOG
     >>> from senaite.core.catalog import AUDITLOG_CATALOG
     >>> from senaite.core.catalog import SAMPLE_CATALOG
+    >>> from senaite.core.registry import get_registry_record
+    >>> from senaite.core.registry import set_registry_record
     >>> from senaite.core.setuphandlers import CATALOG_MAPPINGS
 
 
@@ -78,3 +83,98 @@ Analyses should be registered in the analysis catalog:
 
     >>> AUDITLOG_CATALOG in catmap
     True
+
+
+Get catalogs by type
+....................
+
+Since `archetype_tool` only gives us the catalogs for `Archetype`-based types,
+one can easily get catalogs from a given type, regardless of its nature.
+
+However, `auditlog_catalog` is skipped, cause the cataloguing of objects into
+that catalog is automatically handled by the catalog multiplexer functionality.
+
+Likewise `uid_catalog` is a special catalog where all AT contents, plus those
+DX contents implementing the `Referenceable` behavior are catalogued.
+
+As a result, `get_catalogs_by_type` only returns the catalogs that are specific
+for the given portal type. Nothing less, nothing more:
+
+    >>> get_catalogs_by_type("Analysis")
+    ['senaite_catalog_analysis']
+
+    >>> get_catalogs_by_type("SampleType")
+    ['senaite_catalog_setup']
+
+
+Set catalogs programmatically
+.............................
+
+We can even add catalogs for a given portal type programmatically, with ease.
+
+    >>> set_catalogs("Analysis", ["portal_catalog"])
+    >>> get_catalogs_by_type("Analysis")
+    ['senaite_catalog_analysis', 'portal_catalog']
+
+Again, this works for both AT and DX:
+
+    >>> set_catalogs("SampleType", ["portal_catalog"])
+    >>> get_catalogs_by_type("SampleType")
+    ['senaite_catalog_setup', 'portal_catalog']
+
+We can replace the catalogs if we use a tuple instead of a list:
+
+    >>> set_catalogs("Analysis", tuple(["senaite_catalog_analysis"]))
+    >>> get_catalogs_by_type("Analysis")
+    ['senaite_catalog_analysis']
+
+    >>> set_catalogs("SampleType", tuple(["senaite_catalog_setup"]))
+    >>> get_catalogs_by_type("SampleType")
+    ['senaite_catalog_setup']
+
+If the given type is from `senaite.core` we cannot remove default catalogs
+though:
+
+    >>> set_catalogs("SampleType", tuple(["portal_catalog"]))
+    >>> get_catalogs_by_type("SampleType")
+    ['senaite_catalog_setup', 'portal_catalog']
+
+Even when using an empty tuple:
+
+    >>> set_catalogs("SampleType", tuple())
+    >>> get_catalogs_by_type("SampleType")
+    ['senaite_catalog_setup']
+
+
+Flush catalogs mapping cache
+............................
+
+To speed up the process of retrieval of catalogs, the output of the function
+`get_catalogs_by_type` is forever memoized. This means that if we manually
+update the value of the registry record that stores the catalog mappings,
+changes won't take effect until restart:
+
+    >>> get_catalogs_by_type("SampleType")
+    ['senaite_catalog_setup']
+
+    >>> mappings = get_registry_record("catalog_mappings") or {}
+    >>> mappings["SampleType"] = ["portal_catalog"]
+    >>> set_registry_record("catalog_mappings", mappings)
+
+    >>> get_catalogs_by_type("SampleType")
+    ['senaite_catalog_setup']
+
+To prevent this to happen, we can flush the cache for the given type:
+
+    >>> flush_catalogs_cache("SampleType")
+    >>> get_catalogs_by_type("SampleType")
+    ['senaite_catalog_setup', 'portal_catalog']
+
+    >>> mappings["SampleType"] = []
+    >>> set_registry_record("catalog_mappings", mappings)
+    >>> get_catalogs_by_type("SampleType")
+    ['senaite_catalog_setup', 'portal_catalog']
+
+    >>> flush_catalogs_cache("SampleType")
+    >>> get_catalogs_by_type("SampleType")
+    ['senaite_catalog_setup']


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds a function for the programmatically assignment of custom catalogs to specific portal types easier.

Note user might need to restart instances/zeo clients for the changes take effect, cause  `get_catalogs_by_type` is memoized forever.

## Current behavior before PR

Not easy enough to programmatically edit/add catalogs for non-core types

## Desired behavior after PR is merged

Not easy enough to programmatically edit/add catalogs for non-core types

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
