### PR TITLE
Fix temporary batch title

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2683 Fix temporary batch title
 - #2681 Add function to make the assignment of custom catalogs easier
 - #2676 Allow to set the uncertainty to 0
 - #2678 Add validate function in API

--- a/src/bika/lims/content/batch.py
+++ b/src/bika/lims/content/batch.py
@@ -163,6 +163,8 @@ class Batch(ATFolder, ClientAwareMixin):
     def Title(self):
         """Returns the Title or ID
         """
+        if self.isTemporary():
+            return ""
         title = self.getField("title").get(self)
         return title or self.getId()
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes to store the temporary ID as the final title

<img width="487" alt="Add Batch" src="https://github.com/user-attachments/assets/f272c089-a0df-4bd1-a14b-104e9c04ba8b" />


## Current behavior before PR

Temporary ID is stored as the Batch title

## Desired behavior after PR is merged

Title is left empty if the batch on batch creation

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
