### PR TITLE
Fix Traceback for unicode titled instruments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2684 Fix Traceback for unicode titled instruments
 - #2681 Add function to make the assignment of custom catalogs easier
 - #2676 Allow to set the uncertainty to 0
 - #2678 Add validate function in API

--- a/src/senaite/core/exportimport/dataimport.py
+++ b/src/senaite/core/exportimport/dataimport.py
@@ -22,6 +22,7 @@ import json
 
 from bika.lims import api
 from bika.lims import senaiteMessageFactory as _
+from bika.lims.api import safe_unicode as u
 from bika.lims.browser import BrowserView
 from bika.lims.interfaces import ISetupDataSetList
 from pkg_resources import resource_listdir
@@ -132,6 +133,7 @@ class ImportView(BrowserView):
             if not len(interfaces) > 0:
                 # skip instruments w/o import interface
                 continue
-            items.append((instrument.UID(), instrument.Title()))
+            items.append((instrument.UID(), u(instrument.Title())))
+
         items.sort(lambda x, y: cmp(x[1].lower(), y[1].lower()))
         return DisplayList(list(items))


### PR DESCRIPTION

## Description of the issue/feature this PR addresses

This PR fixes an error that occurs on the instrument import page if there are instruments configured in the system that contain unicode characters in the title.

## Current behavior before PR

Traceback occurs:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.core.exportimport.dataimport, line 119, in __call__
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 215, in render
  Module chameleon.template, line 192, in render
  Module 0c877b892465347b4a0c701d9d823666, line 1064, in render
  Module b16d8944110ee46da85a221c8445f4d4, line 1428, in render_master
  Module b16d8944110ee46da85a221c8445f4d4, line 407, in render_content
  Module 0c877b892465347b4a0c701d9d823666, line 469, in __fill_content_core
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module senaite.core.exportimport.dataimport, line 138, in getInstruments
  Module senaite.core.exportimport.dataimport, line 138, in <lambda>
  Module senaite.core.p3compat, line 32, in cmp
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 10: ordinal not in range(128)
```

## Desired behavior after PR is merged

No Traceback occurs

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
