### PR TITLE
Fix missing default instrument import template

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2685 Fix missing default instrument import template
 - #2681 Add function to make the assignment of custom catalogs easier
 - #2676 Allow to set the uncertainty to 0
 - #2678 Add validate function in API

--- a/src/senaite/core/browser/form/adapters/data_import.py
+++ b/src/senaite/core/browser/form/adapters/data_import.py
@@ -205,8 +205,7 @@ class EditForm(EditFormAdapterBase):
         """
         import senaite.core.exportimport.instruments
         path = os.path.dirname(senaite.core.exportimport.instruments.__file__)
-        template = "instrument.pt"
-        return os.path.join(path, template)
+        return os.path.join(path, "templates", "default.pt")
 
     def get_default_import_results_template(self):
         """Returns the path of the default import template

--- a/src/senaite/core/exportimport/instruments/templates/default.pt
+++ b/src/senaite/core/exportimport/instruments/templates/default.pt
@@ -1,0 +1,30 @@
+<div class="my-2">
+  <label for="instrument_results_file">File</label>
+  <input type="file" name="instrument_results_file" id="instrument_results_file"/>
+  <p></p>
+
+  <h3>Advanced options</h3>
+  <table cellpadding="0" cellspacing="0">
+    <tr>
+      <td><label for="artoapply">Samples state</label></td>
+      <td>
+        <select name="artoapply" id="artoapply">
+          <option value="received">Received</option>
+          <option value="received_tobeverified">Received and to be verified</option>
+        </select>
+      </td>
+    </tr>
+    <tr>
+      <td><label for="results_override">Results override</label></td>
+      <td>
+        <select name="results_override" id="results_override">
+          <option value="nooverride">Don't override results</option>
+          <option value="override">Override non-empty results</option>
+          <option value="overrideempty">Override non-empty results (also with empty)</option>
+        </select>
+      </td>
+    </tr>
+  </table>
+  <p></p>
+  <input name="firstsubmit" type="submit" value="Submit" i18n:attributes="value"/>
+</div>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds a default instrument import template that is rendered if now specific template was found in the instrument folder.

## Current behavior before PR

If an instrument is configured using the "2-Dimensional CSV" import interface, nothing was rendered on selection.

## Desired behavior after PR is merged

If an instrument is configured using the "2-Dimensional CSV" import interface, the default import template rendered on selection.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
