### PR TITLE
Support date and datetime on result entry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2690 Support date and datetime on result entry
 - #2688 Fix JS events from legacy controllers are bound multiple times
 - #2682 Added Limit of Quantification (LOQ) for services and analyses
 - #2687 Remove legacy and obsolete rejection.js

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -54,6 +54,7 @@ from Products.CMFCore.permissions import View
 from senaite.core.api import dtime
 from senaite.core.browser.fields.datetime import DateTimeField
 from senaite.core.i18n import translate as t
+from senaite.core.i18n import get_dt_format
 from senaite.core.permissions import FieldEditAnalysisResult
 from senaite.core.permissions import ViewResults
 from six import string_types
@@ -533,8 +534,12 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         # Check if a date/time result
         result_type = self.getResultType()
         if result_type in ["date", "datetime"]:
-            # store as ISO YYYY-MM-DD HH:MM:SS
-            val = dtime.to_iso_format(val) or ""
+            # convert to datetime
+            dt = dtime.to_dt(val)
+            # make it TZ-naive to prevent undesired shifts
+            dt = dt.replace(tzinfo=None) if dt else None
+            # store as ISO format for easy handling
+            val = dtime.date_to_string(dt, fmt="%Y-%m-%d %H:%M:%S")
             self.getField("Result").set(self, val)
             return
 
@@ -916,13 +921,16 @@ class AbstractAnalysis(AbstractBaseAnalysis):
 
         result_type = self.getResultType()
 
-        # If date result, return the localized date
-        if result_type == "date":
-            return dtime.to_localized_time(result, long_format=False)
-
-        # If date result, return the localized date
-        if result_type == "datetime":
-            return dtime.to_localized_time(result, long_format=True)
+        # If date result, apply the format for current locale, without TZ
+        if result_type in ["date", "datetime"]:
+            # convert to datetime
+            dt = dtime.to_dt(result)
+            # make TZ-naive to prevent undesired shifts
+            dt = dt.replace(tzinfo=None) if dt else None
+            # apply format set for current locale, but without localizing
+            fmt = get_dt_format(result_type)
+            result = dtime.date_to_string(dt, fmt)
+            return cgi.escape(result) if html else result
 
         # If string-like result, return without any formatting
         if result_type in ["string", "text"]:

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -539,7 +539,9 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             # make it TZ-naive to prevent undesired shifts
             dt = dt.replace(tzinfo=None) if dt else None
             # store as ISO format for easy handling
-            val = dtime.date_to_string(dt, fmt="%Y-%m-%d %H:%M:%S")
+            with_time = result_type == "datetime"
+            fmt = "%Y-%m-%d %H:%M:%S" if with_time else "%Y-%m-%d"
+            val = dtime.date_to_string(dt, fmt=fmt)
             self.getField("Result").set(self, val)
             return
 

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -51,6 +51,7 @@ from Products.Archetypes.Field import StringField
 from Products.Archetypes.references import HoldingReference
 from Products.Archetypes.Schema import Schema
 from Products.CMFCore.permissions import View
+from senaite.core.api import dtime
 from senaite.core.browser.fields.datetime import DateTimeField
 from senaite.core.i18n import translate as t
 from senaite.core.permissions import FieldEditAnalysisResult
@@ -529,6 +530,14 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         # Ensure result integrity regards to None, empty and 0 values
         val = str("" if not value and value != 0 else value).strip()
 
+        # Check if a date/time result
+        result_type = self.getResultType()
+        if result_type in ["date", "datetime"]:
+            # store as ISO YYYY-MM-DD HH:MM:SS
+            val = dtime.to_iso_format(val) or ""
+            self.getField("Result").set(self, val)
+            return
+
         # Check if an string result is expected
         string_result = self.getStringResult()
 
@@ -905,8 +914,18 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             except (ValueError, TypeError):
                 pass
 
-        # If string result, return without any formatting
-        if self.getStringResult():
+        result_type = self.getResultType()
+
+        # If date result, return the localized date
+        if result_type == "date":
+            return dtime.to_localized_time(result, long_format=False)
+
+        # If date result, return the localized date
+        if result_type == "datetime":
+            return dtime.to_localized_time(result, long_format=True)
+
+        # If string-like result, return without any formatting
+        if result_type in ["string", "text"]:
             if html:
                 result = cgi.escape(result)
                 result = result.replace("\n", "<br/>")

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -678,6 +678,8 @@ RESULT_TYPES = (
     ("multiselect", _("Multiple selection")),
     ("multiselect_duplicates", _("Multiple selection (with duplicates)")),
     ("multichoice", _("Multiple choices")),
+    ("date", _("Date")),
+    ("datetime", _("Datetime")),
 )
 
 # Type of control to be rendered on results entry

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -34,6 +34,7 @@ from Products.CMFPlone.utils import safe_unicode
 from Products.validation import validation
 from Products.validation.interfaces.IValidator import IValidator
 from Products.ZCTextIndex.ParseTree import ParseError
+from senaite.core.api import dtime
 from senaite.core.i18n import translate as _t
 from zope.interface import implements
 
@@ -1371,6 +1372,10 @@ class DefaultResultValidator(object):
         result_type = request.get("ResultType")
         if result_type in ["string", "text"]:
             return True
+
+        elif result_type in ["date", "datetime"]:
+            if not dtime.is_date(default_result):
+                return _t(_("Default result is not a valid date"))
 
         elif result_type == "numeric":
             if not api.is_floatable(default_result):

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -39,6 +39,12 @@ from DateTime.DateTime import DateError
 from DateTime.DateTime import DateTimeError
 from DateTime.DateTime import SyntaxError
 from DateTime.DateTime import TimeError
+from Products.CMFPlone.i18nl10n import monthname_msgid
+from Products.CMFPlone.i18nl10n import monthname_msgid_abbr
+from Products.CMFPlone.i18nl10n import weekdayname_msgid
+from Products.CMFPlone.i18nl10n import weekdayname_msgid_abbr
+from senaite.core.i18n import get_month_name
+from senaite.core.i18n import get_weekday_name
 from zope.i18n import translate
 
 
@@ -481,7 +487,21 @@ def date_to_string(dt, fmt="%Y-%m-%d", default=""):
             "M": "{:0>2}".format(dt.minute()),
             "p": dt.ampm().upper(),
             "S": "{:0>2}".format(dt.second()),
+            "Z": get_timezone(dt),
+            "b": get_month_name(dt.month(), abbr=True),
+            "B": get_month_name(dt.month()),
         }
+
+        if "${w}" in new_fmt:
+            data["w"] = int(dt.strftime("%w"))
+
+        if "${a}" in new_fmt.lower():
+            # Weekday name ${A} or abbreviation (${a})
+            weekday = int(dt.strftime("%w"))
+            data.update({
+                "a": get_weekday_name(weekday, abbr=True),
+                "A": get_weekday_name(weekday),
+            })
 
         return Template(new_fmt).safe_substitute(data) or default
 

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -39,10 +39,6 @@ from DateTime.DateTime import DateError
 from DateTime.DateTime import DateTimeError
 from DateTime.DateTime import SyntaxError
 from DateTime.DateTime import TimeError
-from Products.CMFPlone.i18nl10n import monthname_msgid
-from Products.CMFPlone.i18nl10n import monthname_msgid_abbr
-from Products.CMFPlone.i18nl10n import weekdayname_msgid
-from Products.CMFPlone.i18nl10n import weekdayname_msgid_abbr
 from senaite.core.i18n import get_month_name
 from senaite.core.i18n import get_weekday_name
 from zope.i18n import translate

--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -428,6 +428,25 @@ def to_iso_format(dt):
     return None
 
 
+def to_msgstr(fmt):
+    """Converts to the format used by the TranslationServiceTool, that supports
+    the following directives, each used as a variable in msgstr:
+       ${A} ${a} ${B} ${b} ${H} ${I} ${m} ${d} ${M} ${p} ${S} ${Y} ${y} ${Z}
+
+    For example: "${d}-${m}-${Y} ${H}:${M}"
+
+    Note the following directives from C standard are NOT supported:
+        %w %f %z %j %U %W %c %x %X
+    """
+    return re.sub(r"%([aAdbBmyYHIpMSZ])", r"${\1}", fmt)
+
+
+def to_C1989(fmt):
+    """Converts to a format code that adheres to the C standard (1989 version)
+    """
+    return re.sub(r"\${([aAwdbBmyYHIpMSfzZjUWcxX])}", r"%\1", fmt)
+
+
 def date_to_string(dt, fmt="%Y-%m-%d", default=""):
     """Format the date to string
     """
@@ -440,31 +459,15 @@ def date_to_string(dt, fmt="%Y-%m-%d", default=""):
     if isinstance(dt, six.string_types):
         dt = to_DT(dt)
 
+    # convert the format to C Standard (1989 version) just in case
+    fmt_c1989 = to_C1989(fmt)
+
     try:
-        return dt.strftime(fmt)
+        return dt.strftime(fmt_c1989) or default
     except ValueError:
-        #  Fix ValueError: year=1111 is before 1900;
-        #  the datetime strftime() methods require year >= 1900
-
-        # convert format string to be something like "${Y}-${m}-${d}"
-        new_fmt = ""
-        var = False
-        for x in fmt:
-            if x == "%":
-                var = True
-                new_fmt += "${"
-                continue
-            if var:
-                new_fmt += x
-                new_fmt += "}"
-                var = False
-            else:
-                new_fmt += x
-
-        def pad(val):
-            """Add a zero if val is a single digit
-            """
-            return "{:0>2}".format(val)
+        # The datetime strftime() function requires year >= 1900
+        # Use safe_substitute instead
+        new_fmt = to_msgstr(fmt)
 
         # Manually extract relevant date and time parts
         dt = to_DT(dt)
@@ -473,14 +476,14 @@ def date_to_string(dt, fmt="%Y-%m-%d", default=""):
             "y": dt.yy(),
             "m": dt.mm(),
             "d": dt.dd(),
-            "H": pad(dt.h_24()),
-            "I": pad(dt.h_12()),
-            "M": pad(dt.minute()),
+            "H": "{:0>2}".format(dt.h_24()),
+            "I": "{:0>2}".format(dt.h_12()),
+            "M": "{:0>2}".format(dt.minute()),
             "p": dt.ampm().upper(),
-            "S": dt.second(),
+            "S": "{:0>2}".format(dt.second()),
         }
 
-        return Template(new_fmt).safe_substitute(data)
+        return Template(new_fmt).safe_substitute(data) or default
 
 
 def to_localized_time(dt, long_format=None, time_only=None,

--- a/src/senaite/core/browser/form/adapters/analysisservice.py
+++ b/src/senaite/core/browser/form/adapters/analysisservice.py
@@ -199,7 +199,7 @@ class EditForm(EditFormAdapterBase):
         if result_type and api.is_list(result_type):
             return self.toggle_result_type(result_type[0])
 
-        if result_type in ["numeric", "string", "text"]:
+        if result_type in ["numeric", "string", "text", "date", "datetime"]:
             self.add_hide_field("ResultOptions")
             self.add_hide_field("ResultOptionsSorting")
         else:

--- a/src/senaite/core/i18n.py
+++ b/src/senaite/core/i18n.py
@@ -20,6 +20,9 @@
 
 from bika.lims import api
 from zope.i18n import translate as ztranslate
+from zope.i18nmessageid import MessageFactory
+
+_pl = MessageFactory("plonelocales")
 
 
 def translate(msgid, to_utf8=True, **kwargs):
@@ -69,3 +72,23 @@ def get_dt_format(msgid):
     if not fmt or fmt == msgid:
         return defaults.get(msgid)
     return fmt
+
+
+def get_weekday_name(day, abbr=False, to_utf8=True):
+    """Returns the name of the day of the week for the current locale, starting
+    with Sunday == 0
+    """
+    ids = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"]
+    msgid = "weekday_%s_abbr" if abbr else "weekday_%s"
+    msgid = msgid % ids[day]
+    return translate(_pl(msgid), to_utf8=to_utf8)
+
+
+def get_month_name(month, abbr=False, to_utf8=True):
+    """Returns the name of the month for the current locale, starting with
+    """
+    ids = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep",
+           "oct", "nov", "dec"]
+    msgid = "month_%s_abbr" if abbr else "month_%s"
+    msgid = msgid % ids[month-1]
+    return translate(_pl(msgid), to_utf8=to_utf8)

--- a/src/senaite/core/i18n.py
+++ b/src/senaite/core/i18n.py
@@ -46,3 +46,26 @@ def translate(msgid, to_utf8=True, **kwargs):
 
     message = ztranslate(msgid, **params)
     return api.to_utf8(message) if to_utf8 else message
+
+
+def get_dt_format(msgid):
+    """Returns the date/time msgstr format for the current locale
+    :param id: locale msgid or "date"/"time"/"datetime"
+    """
+    mapping = {
+        "date": "date_format_short",
+        "datetime": "date_format_long",
+        "time": "time_format",
+    }
+    defaults = {
+        "time_format": "${H}:${M}",
+        "date_format_short": "${Y}-${m}-${d}",
+        "date_format_long": "${Y}-${m}-${d} ${H}:${M}",
+    }
+
+    # extract the current locale for the given msgid from TranslationService
+    msgid = mapping.get(msgid, msgid)
+    fmt = translate(msgid, to_utf8=False)
+    if not fmt or fmt == msgid:
+        return defaults.get(msgid)
+    return fmt

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -1027,7 +1027,7 @@ We can compare dates without time as well:
 
 
 Convert timedelta to Dict Object and Back
-................................
+.........................................
 
 Let's try to initialize a timedelta object and convert it first:
 

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -1088,3 +1088,30 @@ Wrong values are ignored and replaced with 0:
 
     >>> dtime.to_timedelta({'days': 'wrong value'})
     datetime.timedelta(0)
+
+
+Date and time format conversions
+................................
+
+We can easily convert formats expressed in C standard (1989 version) to msgids
+used by the TranslationServiceTool:
+
+    >>> dtime.to_msgstr("%Y-%m-%d %I:%M %p")
+    '${Y}-${m}-${d} ${I}:${M} ${p}'
+
+    >>> dtime.to_msgstr("%Y-%m-%d %H:%M")
+    '${Y}-${m}-${d} ${H}:${M}'
+
+    >>> dtime.to_msgstr("%A %d. %B %Y, %H:%M %Z")
+    '${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}'
+
+And the other way round:
+
+    >>> dtime.to_C1989("${Y}-${m}-${d} ${I}:${M} ${p}")
+    '%Y-%m-%d %I:%M %p'
+
+    >>> dtime.to_C1989("${Y}-${m}-${d} ${H}:${M}")
+    '%Y-%m-%d %H:%M'
+
+    >>> dtime.to_C1989("${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}")
+    '%A %d. %B %Y, %H:%M %Z'

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -630,6 +630,87 @@ Check 24h vs 12h format:
     >>> dtime.date_to_string(dt, fmt="%Y-%m-%d %I:%M %p")
     '1755-08-01 11:01 PM'
 
+Formats used by TranslationService are also supported:
+
+    >>> DATE = "2021-08-01 22:13:05"
+    >>> dt = datetime.strptime(DATE, "%Y-%m-%d %H:%M:%S")
+    >>> dtime.date_to_string(dt, fmt="${Y}-${m}-${d} ${H}:${M}:${S}")
+    '2021-08-01 22:13:05'
+
+    >>> dtime.date_to_string(dt, fmt="${Y}-${m}-${d} ${I}:${M} ${p}")
+    '2021-08-01 10:13 PM'
+
+    >>> dtime.date_to_string(dt, fmt="${Y}-${m}-${d} ${H}:${M}")
+    '2021-08-01 22:13'
+
+    >>> dtime.date_to_string(dt, fmt="${Y}-${m}-${d}")
+    '2021-08-01'
+
+    >>> dtime.date_to_string(dt, fmt="${Y}-${m}-${d}")
+    '2021-08-01'
+
+    >>> dtime.date_to_string(dt, fmt="${I}:${M} ${p}")
+    '10:13 PM'
+
+    >>> dtime.date_to_string(dt, fmt="${A} ${d}. ${B} ${Y}, ${H}:${M}")
+    'Sunday 01. August 2021, 22:13'
+
+    >>> dtime.date_to_string(dt, fmt="${a} ${d} ${b} ${Y}, ${H}:${M}")
+    'Sun 01 Aug 2021, 22:13'
+
+It works with timezones too:
+
+    >>> dt = dtime.to_zone(dt, "Europe/Berlin")
+    >>> dtime.date_to_string(dt, fmt="${A} ${d}. ${B} ${Y}, ${H}:${M} ${Z}")
+    'Sunday 01. August 2021, 22:13 CEST'
+
+It also works when the year is <= 1900:
+
+    >>> DATE = "1010-11-12 22:23:03"
+    >>> dt = datetime.strptime(DATE, "%Y-%m-%d %H:%M:%S")
+    >>> dtime.date_to_string(dt, fmt="${Y}-${m}-${d} ${I}:${M} ${p}")
+    '1010-11-12 10:23 PM'
+
+    >>> dtime.date_to_string(dt, fmt="${H}:${M}")
+    '22:23'
+
+    >>> dtime.date_to_string(dt, fmt="${Y}-${m}-${d}T${H}:${M}")
+    '1010-11-12T22:23'
+
+    >>> dtime.date_to_string(dt, fmt="${Y}-${m}-${d} ${H}:${M}")
+    '1010-11-12 22:23'
+
+    >>> dtime.date_to_string(dt, fmt="${Y}/${m}/${d} ${H}:${M}")
+    '1010/11/12 22:23'
+
+    >>> dtime.date_to_string(dt, fmt="${d} ${b} ${Y}, ${H}:${M}")
+    '12 Nov 1010, 22:23'
+
+    >>> dtime.date_to_string(dt, fmt="${d} ${B} ${Y}, ${H}:${M}")
+    '12 November 1010, 22:23'
+
+As long as we don't ask for the name or abbreviation of weeks:
+
+    >>> dtime.date_to_string(dt, fmt="${A} ${d}. ${B} ${Y}, ${H}:${M}")
+    Traceback (most recent call last):
+    ...
+    ValueError: year=1010 is before 1900; the datetime strftime() methods require year >= 1900
+
+    >>> dtime.date_to_string(dt, fmt="${w}")
+    Traceback (most recent call last):
+    ...
+    ValueError: year=1010 is before 1900; the datetime strftime() methods require year >= 1900
+
+    >>> dtime.date_to_string(dt, fmt="${a}")
+    Traceback (most recent call last):
+    ...
+    ValueError: year=1010 is before 1900; the datetime strftime() methods require year >= 1900
+
+    >>> dtime.date_to_string(dt, fmt="${A}")
+    Traceback (most recent call last):
+    ...
+    ValueError: year=1010 is before 1900; the datetime strftime() methods require year >= 1900
+
 
 Localization
 ............

--- a/src/senaite/core/tests/doctests/DatetimeResult.rst
+++ b/src/senaite/core/tests/doctests/DatetimeResult.rst
@@ -16,6 +16,7 @@ Needed Imports:
     >>> from bika.lims import api
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
+    >>> from datetime import date
     >>> from datetime import datetime
     >>> from DateTime import DateTime
 
@@ -98,6 +99,10 @@ When a result is captured and the analysis has the value 'datetime' as
     >>> inc.getResult()
     '2025-03-14 12:56:04'
 
+    >>> inc.setResult(date(2025, 3, 14))
+    >>> inc.getResult()
+    '2025-03-14 00:00:00'
+
     >>> inc.setResult("20250314125605")
     >>> inc.getResult()
     '2025-03-14 12:56:05'
@@ -165,6 +170,10 @@ When a result is captured and the analysis has the value 'date' as
     '2025-03-14'
 
     >>> inc.setResult(datetime(2025, 3, 14, 12, 56, 4))
+    >>> inc.getResult()
+    '2025-03-14'
+
+    >>> inc.setResult(date(2025, 3, 14))
     >>> inc.getResult()
     '2025-03-14'
 

--- a/src/senaite/core/tests/doctests/DatetimeResult.rst
+++ b/src/senaite/core/tests/doctests/DatetimeResult.rst
@@ -1,0 +1,206 @@
+Datetime Result
+---------------
+
+An analysis can be configured so the captured value is treated as a datetime.
+
+Running this test from the buildout directory::
+
+    bin/test test_textual_doctests -t DatetimeResult
+
+
+Test Setup
+..........
+
+Needed Imports:
+
+    >>> from bika.lims import api
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+    >>> from datetime import datetime
+    >>> from DateTime import DateTime
+
+Test fixture:
+
+    >>> import os
+    >>> os.environ["TZ"] = "CET"
+
+Functional Helpers:
+
+    >>> def new_sample(services):
+    ...     values = {
+    ...         'Client': client.UID(),
+    ...         'Contact': contact.UID(),
+    ...         'DateSampled': date_now,
+    ...         'SampleType': sampletype.UID()}
+    ...     service_uids = map(api.get_uid, services)
+    ...     ar = create_analysisrequest(client, request, values, service_uids)
+    ...     transitioned = do_action_for(ar, "receive")
+    ...     return ar
+
+    >>> def get_analysis(sample, service):
+    ...     service_uid = api.get_uid(service)
+    ...     for analysis in sample.getAnalyses(full_objects=True):
+    ...         if analysis.getServiceUID() == service_uid:
+    ...             return analysis
+    ...     return None
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = portal.setup
+    >>> bikasetup = api.get_bika_setup()
+    >>> date_now = DateTime().strftime("%Y-%m-%d")
+
+Setup the test user
+...................
+
+We need certain permissions to create and access objects used in this test,
+so here we will assume the role of Lab Manager.
+
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import setRoles
+    >>> setRoles(portal, TEST_USER_ID, ['Manager',])
+
+Setup the initial data
+......................
+
+We need to create some basic objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
+    >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH")
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(setup.sampletypes, "SampleType", title="Faeces", Prefix="W")
+    >>> labcontact = api.create(bikasetup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.departments, "Department", title="Microbiology", Manager=labcontact)
+    >>> category = api.create(setup.analysiscategories, "AnalysisCategory", title="Incubations", Department=department)
+    >>> Inc = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Incubation", Keyword="Inc", Category=category.UID())
+    >>> Inc.setResultType("datetime")
+
+Test datetime result
+....................
+
+When a result is captured and the analysis has the value 'datetime' as
+`ResultType`, the system stores the value in ISO format:
+
+    >>> sample = new_sample([Inc])
+
+    >>> inc = get_analysis(sample, Inc)
+    >>> inc.setResult("2025-03-14 12:56:02")
+    >>> inc.getResult()
+    '2025-03-14 12:56:02'
+
+    >>> inc.setResult(DateTime(2025, 3, 14, 12, 56, 3))
+    >>> inc.getResult()
+    '2025-03-14 12:56:03'
+
+    >>> inc.setResult(datetime(2025, 3, 14, 12, 56, 4))
+    >>> inc.getResult()
+    '2025-03-14 12:56:04'
+
+    >>> inc.setResult("20250314125605")
+    >>> inc.getResult()
+    '2025-03-14 12:56:05'
+
+Dates without time are supported as well:
+
+    >>> inc.setResult("20250314")
+    >>> inc.getResult()
+    '2025-03-14 00:00:00'
+
+    >>> inc.setResult(DateTime(2025, 3, 15))
+    >>> inc.getResult()
+    '2025-03-15 00:00:00'
+
+    >>> inc.setResult(datetime(2025, 3, 16))
+    >>> inc.getResult()
+    '2025-03-16 00:00:00'
+
+It does store an empty value if not a valid datetime:
+
+    >>> inc.setResult("uhh")
+    >>> inc.getResult()
+    ''
+
+The function `getFormattedResult` returns the datetime as well, but formatted
+in accordance with current locale:
+
+    >>> from senaite.core.api import dtime
+    >>> from senaite.core.i18n import get_dt_format
+
+    >>> get_dt_format("datetime")
+    '${Y}-${m}-${d} ${H}:${M}'
+
+    >>> inc.setResult("20250314125605")
+    >>> inc.getResult()
+    '2025-03-14 12:56:05'
+
+    >>> inc.getFormattedResult()
+    '2025-03-14 12:56'
+
+    >>> inc.setResult("20250314")
+    >>> inc.getResult()
+    '2025-03-14 00:00:00'
+
+    >>> inc.getFormattedResult()
+    '2025-03-14 00:00'
+
+
+Test date result
+................
+
+When a result is captured and the analysis has the value 'date' as
+`ResultType`, the system stores the date without time in ISO format:
+
+    >>> Inc.setResultType("date")
+    >>> sample = new_sample([Inc])
+
+    >>> inc = get_analysis(sample, Inc)
+    >>> inc.setResult("2025-03-14 12:56:02")
+    >>> inc.getResult()
+    '2025-03-14'
+
+    >>> inc.setResult(DateTime(2025, 3, 14, 12, 56, 3))
+    >>> inc.getResult()
+    '2025-03-14'
+
+    >>> inc.setResult(datetime(2025, 3, 14, 12, 56, 4))
+    >>> inc.getResult()
+    '2025-03-14'
+
+    >>> inc.setResult("20250314125605")
+    >>> inc.getResult()
+    '2025-03-14'
+
+    >>> inc.setResult("20250314")
+    >>> inc.getResult()
+    '2025-03-14'
+
+    >>> inc.setResult(DateTime(2025, 3, 15))
+    >>> inc.getResult()
+    '2025-03-15'
+
+    >>> inc.setResult(datetime(2025, 3, 16))
+    >>> inc.getResult()
+    '2025-03-16'
+
+It does store an empty value if not a valid datetime:
+
+    >>> inc.setResult("uhh")
+    >>> inc.getResult()
+    ''
+
+The function `getFormattedResult` returns the date in current locale:
+
+    >>> from senaite.core.api import dtime
+    >>> from senaite.core.i18n import get_dt_format
+
+    >>> inc.setResult("20250314125605")
+    >>> inc.getResult()
+    '2025-03-14'
+
+    >>> get_dt_format("date")
+    '${Y}-${m}-${d}'
+
+    >>> inc.getFormattedResult()
+    '2025-03-14'


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request provides support for "date" and "datetime" result on results entry:

![Captura de 2025-03-14 12-35-53](https://github.com/user-attachments/assets/12762abb-ca16-401c-ab56-a7953b42945e)

## Current behavior before PR

`date` and `datetime` are not supported on result entry

## Desired behavior after PR is merged

`date` and `datetime` are supported on result entry

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
