### PR TITLE
Fix APIError on upgrade step 2659 (init_loq)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2691 Fix APIError on upgrade step 2659 (init_loq)
 - #2688 Fix JS events from legacy controllers are bound multiple times
 - #2682 Added Limit of Quantification (LOQ) for services and analyses
 - #2687 Remove legacy and obsolete rejection.js

--- a/src/senaite/core/upgrade/v02_06_000.py
+++ b/src/senaite/core/upgrade/v02_06_000.py
@@ -2771,10 +2771,10 @@ def init_loq(tool):
         ulod = obj.getField("UpperDetectionLimit").getRaw(obj)
 
         # convert values to float
-        fllod = api.to_float(llod)
-        flloq = api.to_float(lloq)
-        fuloq = api.to_float(uloq)
-        fulod = api.to_float(ulod)
+        fllod = api.to_float(llod, 0.0)
+        flloq = api.to_float(lloq, 0.0)
+        fuloq = api.to_float(uloq, 1000000000.0)
+        fulod = api.to_float(ulod, 1000000000.0)
 
         # ·······|-------|=======|-------|·······
         #       LLOD    LLOQ    ULOQ    ULOD


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes the error that may arise when updating to version 2659

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.GenericSetup.tool, line 1135, in manage_doUpgrades
  Module Products.GenericSetup.upgrade, line 185, in doStep
  Module senaite.core.upgrade.v02_06_000, line 2774, in init_loq
  Module bika.lims.api, line 1810, in to_float
  Module bika.lims.api, line 492, in fail
APIError: Value '' is not floatable
```

## Desired behavior after PR is merged

Upgrade 2659 finishes without complains

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
