### PR TITLE
Fix error when removing a Worksheet from inside its view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2696 Fix error when removing a Worksheet from inside its view
 - #2690 Support date and datetime on result entry
 - #2691 Fix APIError on upgrade step 2659 (init_loq)
 - #2689 Fix 2-Dimensional CSV import interface

--- a/src/bika/lims/setuphandlers.py
+++ b/src/bika/lims/setuphandlers.py
@@ -108,9 +108,6 @@ def setup_handler(context):
     # XXX P5: Fix HTML filtering
     # setup_html_filter(portal)
 
-    # Set CMF Form actions
-    setup_form_controller_actions(portal)
-
     logger.info("SENAITE setup handler [DONE]")
 
 
@@ -171,24 +168,6 @@ def setup_groups(portal):
                 roles=gdata["roles"],)
             logger.info("+++ Granted group {title} ({id}) the roles {roles}"
                         .format(**gdata))
-
-
-def setup_form_controller_actions(portal):
-    """Setup custom CMF Form actions
-    """
-    logger.info("*** Setup Form Controller custom actions ***")
-    fc_tool = api.get_tool("portal_form_controller")
-
-    # Redirect the user to Worksheets listing view after the "remove" action
-    # from inside Worksheet context is pressed
-    # https://github.com/senaite/senaite.core/pull/1480
-    fc_tool.addFormAction(
-        object_id="content_status_modify",
-        status="success",
-        context_type="Worksheet",
-        button=None,
-        action_type="redirect_to",
-        action_arg="python:object.aq_inner.aq_parent.absolute_url()")
 
 
 def setup_html_filter(portal):

--- a/src/senaite/core/browser/configure.zcml
+++ b/src/senaite/core/browser/configure.zcml
@@ -42,5 +42,6 @@
   <include package=".user"/>
   <include package=".viewlets"/>
   <include package=".widgets"/>
+  <include package=".workflow"/>
 
 </configure>

--- a/src/senaite/core/browser/workflow/__init__.py
+++ b/src/senaite/core/browser/workflow/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.

--- a/src/senaite/core/browser/workflow/configure.zcml
+++ b/src/senaite/core/browser/workflow/configure.zcml
@@ -1,0 +1,15 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
+    i18n_domain="senaite.core">
+
+  <!-- Worksheet: remove -->
+  <adapter
+    name="workflow_action_remove"
+    for="bika.lims.interfaces.IWorksheet
+         zope.publisher.interfaces.browser.IBrowserRequest"
+    factory=".worksheet.WorkflowActionRemoveAdapter"
+    provides="bika.lims.interfaces.IWorkflowActionAdapter"
+    permission="zope.Public" />
+
+</configure>

--- a/src/senaite/core/browser/workflow/worksheet.py
+++ b/src/senaite/core/browser/workflow/worksheet.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.lims import api
+from bika.lims.browser.workflow import WorkflowActionGenericAdapter
+from bika.lims.workflow import doActionFor
+
+
+class WorkflowActionRemoveAdapter(WorkflowActionGenericAdapter):
+    """Adapter in charge of remove a worksheet
+    """
+
+    def __call__(self, action, objects):
+        worksheet = self.context
+
+        # Call the remove action
+        doActionFor(worksheet, "remove")
+
+        parent = api.get_parent(worksheet)
+        url = api.get_url(parent)
+        return self.redirect(redirect_url=url)

--- a/src/senaite/core/setuphandlers.py
+++ b/src/senaite/core/setuphandlers.py
@@ -21,7 +21,6 @@
 from Acquisition import aq_base
 from bika.lims import api
 from bika.lims.setuphandlers import reindex_content_structure
-from bika.lims.setuphandlers import setup_form_controller_actions
 from bika.lims.setuphandlers import setup_groups
 from plone.dexterity.fti import DexterityFTI
 from plone.registry.interfaces import IRegistry
@@ -189,7 +188,6 @@ def install(context):
     add_dexterity_portal_items(portal)
 
     # Set CMF Form actions
-    setup_form_controller_actions(portal)
     setup_form_controller_more_action(portal)
 
     # Setup markup default and allowed schemas


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
This Pull Request resolves a user experience issue that occurs when deleting a worksheet from within its view

## Current behavior before PR
When clicking "Remove" the worksheet is successfully removed. However, the system still redirects to the worksheet's path, which no longer exists, causing an error

## Desired behavior after PR is merged
After clicking "Remove," the worksheet is deleted, and the system redirects the user to the worksheet's parent folder instead of the non-existent worksheet path

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
