### PR TITLE
Custom contact widget in user profile

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2698 Custom contact widget in user profile
 - #2692 Refactor Sticker Functionality
 - #2696 Fix error when removing a Worksheet from inside its view
 - #2690 Support date and datetime on result entry

--- a/src/senaite/core/browser/user/userdatapanel.py
+++ b/src/senaite/core/browser/user/userdatapanel.py
@@ -22,6 +22,7 @@ from bika.lims import api
 from bika.lims import senaiteMessageFactory as _
 from bika.lims.interfaces import IContact
 from bika.lims.interfaces import ILabContact
+from bika.lims.utils import get_link_for
 from plone.app.users.browser.account import getSchema
 from plone.app.users.browser.userdatapanel import UserDataPanel as Base
 from plone.app.users.browser.userdatapanel import UserDataPanelAdapter
@@ -31,11 +32,27 @@ from plone.app.users.schema import checkEmailAddress
 from plone.autoform import directives
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from senaite.core.catalog import CONTACT_CATALOG
-from senaite.core.z3cform.widgets.uidreference.widget import \
-    UIDReferenceWidgetFactory
+from z3c.form.browser.text import TextWidget
 from z3c.form.interfaces import DISPLAY_MODE
+from z3c.form.interfaces import IFieldWidget
+from z3c.form.widget import FieldWidget
 from zope.interface import Interface
+from zope.interface import implementer
 from zope.schema import TextLine
+
+
+class ContactLinkWidget(TextWidget):
+    """Widget to render contact UID as a clickable link
+    """
+    def render(self):
+        if not self.value:
+            return None
+        return get_link_for(self.value)
+
+
+@implementer(IFieldWidget)
+def ContactLinkWidgetFactory(field, request):
+    return FieldWidget(field, ContactLinkWidget(request))
 
 
 class IUserDataSchema(Interface):
@@ -58,7 +75,7 @@ class IUserDataSchema(Interface):
 
     # Field behaves like a readonly field
     directives.mode(contact=DISPLAY_MODE)
-    directives.widget("contact", UIDReferenceWidgetFactory)
+    directives.widget("contact", ContactLinkWidgetFactory)
     contact = TextLine(
         title=_(u"label_user_contact", default=u"Contact"),
         description=_(u"description_user_contact",


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR introduces a custom contact link widget in the user profile panel.

Hopefully this fixes this inglorious traceback that only occurs occasionally:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
    * [ ] Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.core.browser.user.userdatapanel, line 97, in __call__
  Module plone.app.users.browser.userdatapanel, line 95, in __call__
  Module z3c.form.form, line 233, in __call__
  Module plone.z3cform.fieldsets.extensible, line 65, in update
  Module plone.z3cform.patch, line 30, in GroupForm_update
  Module z3c.form.group, line 132, in update
  Module senaite.core.browser.user.userdatapanel, line 127, in updateWidgets
  Module z3c.form.form, line 136, in updateWidgets
  Module z3c.form.field, line 277, in update
  Module senaite.core.z3cform.widgets.queryselect.widget, line 86, in update
  Module z3c.form.browser.widget, line 171, in update
  Module Products.CMFPlone.patches.z3c_form, line 47, in _wrapped
  Module z3c.form.widget, line 106, in update
  Module z3c.form.datamanager, line 76, in query
  Module z3c.form.datamanager, line 71, in get
  Module z3c.form.datamanager, line 66, in adapted_context
TypeError: ('Could not adapt', <PloneSite at /senaite>, <InterfaceClass senaite.core.browser.user.userdatapanel.IUserDataSchema>)
```

Also see here:
https://community.senaite.org/t/error-when-i-click-on-user-contact/1519


## Current behavior before PR

UIDReference Widget is used for the linked user contact field

## Desired behavior after PR is merged

Custom contact link widget is used to render a plain link for a linked user contact

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
