### PR TITLE
Add search filter by term for services in add sample form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2699 Add search filter by term for services in add sample form
 - #2692 Refactor Sticker Functionality
 - #2696 Fix error when removing a Worksheet from inside its view
 - #2690 Support date and datetime on result entry

--- a/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -518,8 +518,8 @@
                 </td>
                 <td tal:attributes="colspan python:1 + ar_count">
                   <div class="input-group">
-                    <input type="text" class="form-control"
-                           name="poc-services-filter-box"
+                    <input type="text" class="form-control services-filter"
+                           data-poc="poc"
                            i18n:attributes="placeholder"
                            placeholder="Filter analyses by name..."/>
                     <div class="input-group-append">
@@ -564,6 +564,7 @@
                         tal:attributes="id python:service_id;
                                         class python:'{} {} service'.format(category_id, poc);
                                         poc python:poc;
+                                        data-category python:category_id;
                                         fieldname python:'Analyses';">
                       <td class="service-header">
                         <div class="service-title small"

--- a/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -564,6 +564,7 @@
                         tal:attributes="id python:service_id;
                                         class python:'{} {} service'.format(category_id, poc);
                                         poc python:poc;
+                                        data-uid python:service_uid;
                                         data-category python:category_id;
                                         fieldname python:'Analyses';">
                       <td class="service-header">

--- a/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -433,7 +433,7 @@
                           tal:attributes="id string:${fieldName}_help">Help</span>
                   </label>
                 </td>
-                <td>
+                <td class="pl-3 pr-3">
                   <div class="text-center" tal:condition="python:view.show_copy_button_for(field)">
                     <!-- Copy Button -->
                     <a class="copy d-block"
@@ -504,7 +504,7 @@
               <tr tal:attributes="poc poc;
                                   data-poc poc;
                                   class string:${poc} service-listing-header field-services-header">
-                <td tal:attributes="colspan python:2 + ar_count">
+                <td colspan="2">
                   <div class="poc-service-title">
                     <span tal:condition="python:poc=='field'"
                           i18n:translate="">
@@ -514,6 +514,19 @@
                           i18n:translate="">
                       Lab Analyses
                     </span>
+                  </div>
+                </td>
+                <td tal:attributes="colspan python:1 + ar_count">
+                  <div class="input-group">
+                    <input type="text" class="form-control"
+                           name="poc-services-filter-box"
+                           i18n:attributes="placeholder"
+                           placeholder="Filter analyses by name..."/>
+                    <div class="input-group-append">
+                      <div class="input-group-text">
+                        <i class="fas fa-filter"></i>
+                      </div>
+                    </div>
                   </div>
                 </td>
               </tr>

--- a/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
@@ -273,6 +273,10 @@
        * Highlight a line number in the paste panel
        */
       this.highlight_paster_line = this.highlight_paster_line.bind(this);
+      /**
+       * Restores the visibility of services and categories
+       */
+      this.reset_category_visibility = this.reset_category_visibility.bind(this);
       //#####################
       /* EVENT HANDLERS */
       //#####################
@@ -338,6 +342,17 @@
        * @param event {Object} The event object
        */
       this.on_service_listing_header_click = this.on_service_listing_header_click.bind(this);
+      /**
+       * Event handler for the services filter box
+       *
+       * Searches services their name match with the given term and make them
+       * visible. Categories without matches and without any pre-selected service
+       * are hidden. If no term, the visibility of categories and services is
+       * restored.
+       *
+       * @param event {Object} The event object
+       */
+      this.on_services_filter_change = this.on_services_filter_change.bind(this);
       /**
        * Event handler for analysis service category rows.
        *
@@ -593,6 +608,8 @@
       console.debug("AnalysisRequestAdd::bind_eventhandler");
       // Categories header clicked
       $("body").on("click", ".service-listing-header", this.on_service_listing_header_click);
+      // Categories filter search input changed
+      $("body").on("keyup", "input.services-filter", this.on_services_filter_change);
       // Category toggle button clicked
       $("body").on("click", "tr.category", this.on_service_category_click);
       // Composite Checkbox clicked
@@ -1505,6 +1522,31 @@
       }
     }
 
+    reset_category_visibility(category) {
+      var $btn, $category, category_id, checked, poc, services, unchecked;
+      $category = $(category);
+      poc = $category.attr("poc");
+      category_id = $category.data("category");
+      // hide services with non-ticked checkboxes
+      services = $(`tr.${poc}.${category_id}.service`);
+      unchecked = $("input[type=checkbox]:not(checked)", services);
+      unchecked.closest("tr").removeClass("visible");
+      // display services with ticked checkboxes
+      checked = $("input[type=checkbox]:checked", services);
+      checked.closest("tr").addClass("visible");
+      // toggle the visibility of the category
+      $btn = $(".service-category-toggle", $category);
+      if (checked.length > 0) {
+        $category.addClass("visible");
+        $category.addClass("expanded");
+        return $btn.text("-");
+      } else {
+        $category.addClass("visible");
+        $category.removeClass("expanded");
+        return $btn.text("+");
+      }
+    }
+
     on_sample_nav(event) {
       var $el, el, idx, primary, target;
       el = event.currentTarget;
@@ -1776,6 +1818,70 @@
       visible = $el.hasClass("visible");
       toggle = !visible;
       return this.toggle_poc_categories(poc, toggle);
+    }
+
+    on_services_filter_change(event) {
+      var $el, categories, me, poc, services, term, visible_categories;
+      me = this;
+      $el = $(event.currentTarget);
+      poc = $el.closest("tr").data("poc");
+      // display the categories that belong to this poc
+      this.toggle_poc_categories(poc, true);
+      // get the term to search by and strip leading and trailing whitespaces
+      term = $el.val();
+      term = term = term.replace(/^\s+|\s+$/g, "");
+      term = term.toLowerCase();
+      if (!term) {
+        // reset the visibility of categories
+        categories = $(`tr.${poc}.category`);
+        $.each(categories, function(num, category) {
+          return me.reset_category_visibility(category);
+        });
+        return;
+      }
+      // keep track of the categories to make visible
+      visible_categories = new Set([]);
+      // iterate through all registered services to find matches
+      services = $(`tr.${poc}.service`);
+      $.each(services, function(num, service) {
+        var $service, category_id, checked, name, name_el;
+        // get the name of the service
+        $service = $(service);
+        category_id = $service.data("category");
+        name_el = $("div.service-title", $service);
+        name = name_el.html().toLowerCase();
+        // hide service if no match found and not checked for any sample
+        if (name.indexOf(term) === -1) {
+          checked = $("input[type=checkbox]:checked", service);
+          if (checked.length === 0) {
+            $service.removeClass("visible");
+          }
+        } else {
+          $service.addClass("visible");
+        }
+        // add to the categories to make visible
+        if ($service.hasClass("visible")) {
+          return visible_categories.add(category_id);
+        }
+      });
+      // iterate through categories and update their visibility
+      categories = $(`tr.${poc}.category`);
+      return $.each(categories, function(num, category) {
+        var $btn, $category, category_id;
+        // toggle the visibility of the category
+        $category = $(category);
+        $btn = $(".service-category-toggle", $category);
+        category_id = $category.data("category");
+        if (visible_categories.has(category_id)) {
+          $category.addClass("visible");
+          $category.addClass("expanded");
+          return $btn.text("-");
+        } else {
+          $category.removeClass("visible");
+          $category.removeClass("expanded");
+          return $btn.text("+");
+        }
+      });
     }
 
     on_service_category_click(event) {

--- a/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
@@ -273,6 +273,10 @@
        * Highlight a line number in the paste panel
        */
       this.highlight_paster_line = this.highlight_paster_line.bind(this);
+      /**
+       * Flush services search filters
+       */
+      this.flush_search_terms = this.flush_search_terms.bind(this);
       //#####################
       /* EVENT HANDLERS */
       //#####################
@@ -424,6 +428,8 @@
       this.deselected_uids = {};
       // Remove the '.blurrable' class to avoid inline field validation
       $(".blurrable").removeClass("blurrable");
+      // manually flush service search terms
+      this.flush_search_terms();
       // bind the event handler to the elements
       this.bind_eventhandler();
       // N.B.: The new AR Add form handles File fields like this:
@@ -1516,6 +1522,12 @@
       if (lines[idx]) {
         return $(lines[idx]).addClass(cls);
       }
+    }
+
+    flush_search_terms() {
+      var el;
+      el = $("tr.service-listing-header input.services-filter");
+      return $(el).val("");
     }
 
     /**

--- a/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
@@ -273,10 +273,6 @@
        * Highlight a line number in the paste panel
        */
       this.highlight_paster_line = this.highlight_paster_line.bind(this);
-      /**
-       * Restores the visibility of services and categories
-       */
-      this.reset_category_visibility = this.reset_category_visibility.bind(this);
       //#####################
       /* EVENT HANDLERS */
       //#####################
@@ -1522,29 +1518,56 @@
       }
     }
 
-    reset_category_visibility(category) {
-      var $btn, $category, category_id, checked, poc, services, unchecked;
-      $category = $(category);
-      poc = $category.attr("poc");
-      category_id = $category.data("category");
-      // hide services with non-ticked checkboxes
-      services = $(`tr.${poc}.${category_id}.service`);
-      unchecked = $("input[type=checkbox]:not(checked)", services);
-      unchecked.closest("tr").removeClass("visible");
-      // display services with ticked checkboxes
-      checked = $("input[type=checkbox]:checked", services);
-      checked.closest("tr").addClass("visible");
-      // toggle the visibility of the category
-      $btn = $(".service-category-toggle", $category);
-      if (checked.length > 0) {
-        $category.addClass("visible");
-        $category.addClass("expanded");
-        return $btn.text("-");
-      } else {
-        $category.addClass("visible");
-        $category.removeClass("expanded");
-        return $btn.text("+");
+    /**
+     * Returns the term to search through services from categories that belong
+     * to the given point of capture (poc)
+     *
+     * @param poc {String} The point of capture
+     * @returns {String} The search term
+     */
+    get_search_term(poc) {
+      var el, term;
+      el = $(`tr.${poc}.service-listing-header input.services-filter`);
+      // strip leading and trailing whitespaces
+      term = $(el).val();
+      return term.replace(/^\s+|\s+$/g, "");
+    }
+
+    /**
+     * Returns the list of service uids from categories that belong to the given
+     * point of capture and their human name match with the term passed-in.
+     * Returns an empty list if empty term
+     *
+     * @param poc {String} The point of capture
+     * @param term {String} The search term
+     * @returns {List} The list of service uids
+     */
+    search_services(poc, term) {
+      var matches, services;
+      matches = [];
+      // assume no matches if term is empty
+      if (!term) {
+        return matches;
       }
+      // transform the term to lower case
+      term = term.toLowerCase();
+      // iterate through all registered services to find matches
+      services = $(`tr.${poc}.service`);
+      $.each(services, function(num, service) {
+        var $service, category_id, name, name_el, service_uid;
+        // get the service basic info
+        $service = $(service);
+        category_id = $service.data("category");
+        service_uid = $service.data("uid");
+        // get the service human name
+        name_el = $("div.service-title", $service);
+        name = name_el.html().toLowerCase();
+        // hide service if no match found and not checked for any sample
+        if (name.indexOf(term) !== -1) {
+          return matches.push(service_uid);
+        }
+      });
+      return matches;
     }
 
     on_sample_nav(event) {
@@ -1812,74 +1835,81 @@
     }
 
     on_service_listing_header_click(event) {
-      var $el, poc, toggle, visible;
+      var $el, poc, services, term, toggle, visible;
       $el = $(event.currentTarget);
       poc = $el.data("poc");
+      // keep categories with selected services visible if search term set
+      term = this.get_search_term(poc);
+      if (term) {
+        services = $(`tr.${poc}.service.visible`);
+        $.each(services, function(num, service) {
+          var $service, category;
+          $service = $(service);
+          category = $service.data("category");
+          return $(`tr.${poc}.${category}.category`).addClass("visible");
+        });
+        return;
+      }
+      // toggle visibility
       visible = $el.hasClass("visible");
       toggle = !visible;
       return this.toggle_poc_categories(poc, toggle);
     }
 
     on_services_filter_change(event) {
-      var $el, categories, me, poc, services, term, visible_categories;
-      me = this;
+      var $el, categories, expanded_categories, poc, services, term, uids;
       $el = $(event.currentTarget);
       poc = $el.closest("tr").data("poc");
-      // display the categories that belong to this poc
-      this.toggle_poc_categories(poc, true);
-      // get the term to search by and strip leading and trailing whitespaces
-      term = $el.val();
-      term = term = term.replace(/^\s+|\s+$/g, "");
-      term = term.toLowerCase();
-      if (!term) {
-        // reset the visibility of categories
-        categories = $(`tr.${poc}.category`);
-        $.each(categories, function(num, category) {
-          return me.reset_category_visibility(category);
-        });
-        return;
-      }
-      // keep track of the categories to make visible
-      visible_categories = new Set([]);
-      // iterate through all registered services to find matches
+      // keep track of the categories to expand and keep visible
+      expanded_categories = new Set([]);
+      // get the term so search by
+      term = this.get_search_term(poc);
+      // do the search
+      uids = this.search_services(poc, term);
+      // show services that match or with ticked checkboxes
       services = $(`tr.${poc}.service`);
       $.each(services, function(num, service) {
-        var $service, category_id, checked, name, name_el;
-        // get the name of the service
+        var $service, category, checked, uid;
         $service = $(service);
-        category_id = $service.data("category");
-        name_el = $("div.service-title", $service);
-        name = name_el.html().toLowerCase();
-        // hide service if no match found and not checked for any sample
-        if (name.indexOf(term) === -1) {
-          checked = $("input[type=checkbox]:checked", service);
-          if (checked.length === 0) {
-            $service.removeClass("visible");
-          }
-        } else {
+        category = $service.data("category");
+        uid = $service.data("uid");
+        if (indexOf.call(uids, uid) >= 0) {
           $service.addClass("visible");
+          expanded_categories.add(category);
+          return;
         }
-        // add to the categories to make visible
-        if ($service.hasClass("visible")) {
-          return visible_categories.add(category_id);
+        // show if ticked checkboxes
+        checked = $("input[type=checkbox]:checked", $service);
+        if (checked.length > 0) {
+          $service.addClass("visible");
+          expanded_categories.add(category);
+          return;
         }
+        // hide the service
+        return $service.removeClass("visible");
       });
-      // iterate through categories and update their visibility
+      // expand categories with visible services
       categories = $(`tr.${poc}.category`);
       return $.each(categories, function(num, category) {
-        var $btn, $category, category_id;
+        var $btn, $category, category_id, expanded;
         // toggle the visibility of the category
         $category = $(category);
         $btn = $(".service-category-toggle", $category);
         category_id = $category.data("category");
-        if (visible_categories.has(category_id)) {
-          $category.addClass("visible");
+        // expand the category if at least on service visible
+        expanded = expanded_categories.has(category_id);
+        if (expanded) {
           $category.addClass("expanded");
-          return $btn.text("-");
+          $btn.text("-");
         } else {
-          $category.removeClass("visible");
           $category.removeClass("expanded");
-          return $btn.text("+");
+          $btn.text("+");
+        }
+        // make category visible if expanded or empty search term
+        if (expanded || !term) {
+          return $category.addClass("visible");
+        } else {
+          return $category.removeClass("visible");
         }
       });
     }

--- a/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
@@ -356,7 +356,8 @@
       /**
        * Event handler for analysis service category rows.
        *
-       * Toggles the visibility of all services within this category.
+       * Toggles the visibility of all services within this category, but only if
+       * the search filter mode for this category is not enabled.
        * NOTE: Selected services always stay visible.
        *
        * @param event {Object} The event object
@@ -1546,6 +1547,22 @@
     }
 
     /**
+     * Returns whether the search of services by term for the given point of
+     * capture is active
+     *
+     * @param poc {String} The point of capture
+     * @returns {Boolean} Whether the search by term is active or not
+     */
+    is_search_active(poc) {
+      var term;
+      term = this.get_search_term(poc);
+      if (term) {
+        return true;
+      }
+      return false;
+    }
+
+    /**
      * Returns the list of service uids from categories that belong to the given
      * point of capture and their human name match with the term passed-in.
      * Returns an empty list if empty term
@@ -1847,12 +1864,11 @@
     }
 
     on_service_listing_header_click(event) {
-      var $el, poc, services, term, toggle, visible;
+      var $el, poc, services, toggle, visible;
       $el = $(event.currentTarget);
       poc = $el.data("poc");
-      // keep categories with selected services visible if search term set
-      term = this.get_search_term(poc);
-      if (term) {
+      // keep categories with selected services visible if search by term active
+      if (this.is_search_active(poc)) {
         services = $(`tr.${poc}.service.visible`);
         $.each(services, function(num, service) {
           var $service, category;
@@ -1931,6 +1947,10 @@
       event.preventDefault();
       $el = $(event.currentTarget);
       poc = $el.attr("poc");
+      // do nothing if search by term is active
+      if (this.is_search_active(poc)) {
+        return;
+      }
       $btn = $(".service-category-toggle", $el);
       expanded = $el.hasClass("expanded");
       category = $el.data("category");

--- a/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -243,6 +243,8 @@ class window.AnalysisRequestAdd
 
     # Categories header clicked
     $("body").on "click", ".service-listing-header", @on_service_listing_header_click
+    # Categories filter search input changed
+    $("body").on "keyup", "input.services-filter", @on_services_filter_change
     # Category toggle button clicked
     $("body").on "click", "tr.category", @on_service_category_click
     # Composite Checkbox clicked
@@ -1265,6 +1267,34 @@ class window.AnalysisRequestAdd
     lines.removeClass(cls)
     if lines[idx] then $(lines[idx]).addClass(cls)
 
+  ###*
+   * Restores the visibility of services and categories
+  ###
+  reset_category_visibility: (category) =>
+    $category = $(category)
+    poc = $category.attr "poc"
+    category_id = $category.data "category"
+
+    # hide services with non-ticked checkboxes
+    services = $("tr.#{poc}.#{category_id}.service")
+    unchecked = $("input[type=checkbox]:not(checked)", services)
+    unchecked.closest("tr").removeClass "visible"
+
+    # display services with ticked checkboxes
+    checked = $("input[type=checkbox]:checked", services)
+    checked.closest("tr").addClass "visible"
+
+    # toggle the visibility of the category
+    $btn = $(".service-category-toggle", $category)
+    if checked.length > 0
+      $category.addClass "visible"
+      $category.addClass "expanded"
+      $btn.text "-"
+    else
+      $category.addClass "visible"
+      $category.removeClass "expanded"
+      $btn.text "+"
+
 
   ######################
   ### EVENT HANDLERS ###
@@ -1592,6 +1622,79 @@ class window.AnalysisRequestAdd
     visible = $el.hasClass("visible")
     toggle = not visible
     @toggle_poc_categories poc, toggle
+
+
+  ###*
+   * Event handler for the services filter box
+   *
+   * Searches services their name match with the given term and make them
+   * visible. Categories without matches and without any pre-selected service
+   * are hidden. If no term, the visibility of categories and services is
+   * restored.
+   *
+   * @param event {Object} The event object
+  ###
+  on_services_filter_change: (event) =>
+    me = this
+    $el = $(event.currentTarget)
+    poc = $el.closest("tr").data("poc")
+
+    # display the categories that belong to this poc
+    @toggle_poc_categories poc, true
+
+    # get the term to search by and strip leading and trailing whitespaces
+    term = $el.val()
+    term = term = term.replace /^\s+|\s+$/g, ""
+    term = term.toLowerCase()
+
+    if not term
+      # reset the visibility of categories
+      categories = $("tr.#{poc}.category")
+      $.each categories, (num, category) ->
+        me.reset_category_visibility category
+      return
+
+    # keep track of the categories to make visible
+    visible_categories = new Set([])
+
+    # iterate through all registered services to find matches
+    services = $("tr.#{poc}.service")
+    $.each services, (num, service) ->
+
+      # get the name of the service
+      $service = $(service)
+      category_id = $service.data "category"
+      name_el = $("div.service-title", $service)
+      name = name_el.html().toLowerCase()
+
+      # hide service if no match found and not checked for any sample
+      if name.indexOf(term) is -1
+        checked = $("input[type=checkbox]:checked", service)
+        if checked.length == 0
+          $service.removeClass "visible"
+      else
+        $service.addClass "visible"
+
+      # add to the categories to make visible
+      if $service.hasClass "visible"
+        visible_categories.add category_id
+
+    # iterate through categories and update their visibility
+    categories = $("tr.#{poc}.category")
+    $.each categories, (num, category) ->
+
+      # toggle the visibility of the category
+      $category = $(category)
+      $btn = $(".service-category-toggle", $category)
+      category_id = $category.data "category"
+      if visible_categories.has category_id
+        $category.addClass "visible"
+        $category.addClass "expanded"
+        $btn.text "-"
+      else
+        $category.removeClass "visible"
+        $category.removeClass "expanded"
+        $btn.text "+"
 
 
   ###*

--- a/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -33,6 +33,9 @@ class window.AnalysisRequestAdd
     # Remove the '.blurrable' class to avoid inline field validation
     $(".blurrable").removeClass("blurrable")
 
+    # manually flush service search terms
+    @flush_search_terms()
+
     # bind the event handler to the elements
     @bind_eventhandler()
 
@@ -1267,6 +1270,13 @@ class window.AnalysisRequestAdd
     lines.removeClass(cls)
     if lines[idx] then $(lines[idx]).addClass(cls)
 
+
+  ###*
+   * Flush services search filters
+  ###
+  flush_search_terms: =>
+    el = $("tr.service-listing-header input.services-filter")
+    $(el).val("")
 
   ###*
    * Returns the term to search through services from categories that belong

--- a/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -1291,6 +1291,18 @@ class window.AnalysisRequestAdd
     term = $(el).val()
     return term.replace /^\s+|\s+$/g, ""
 
+  ###*
+   * Returns whether the search of services by term for the given point of
+   * capture is active
+   *
+   * @param poc {String} The point of capture
+   * @returns {Boolean} Whether the search by term is active or not
+  ###
+  is_search_active: (poc) ->
+    term = @get_search_term poc
+    if term
+      return true
+    return false
 
   ###*
    * Returns the list of service uids from categories that belong to the given
@@ -1653,16 +1665,15 @@ class window.AnalysisRequestAdd
   ###
   on_service_listing_header_click: (event) =>
     $el = $(event.currentTarget)
-    poc = $el.data("poc")
+    poc = $el.data "poc"
 
-    # keep categories with selected services visible if search term set
-    term = @get_search_term(poc)
-    if term
+    # keep categories with selected services visible if search by term active
+    if @is_search_active poc
       services = $("tr.#{poc}.service.visible")
       $.each services, (num, service) ->
         $service = $(service)
         category = $service.data "category"
-        $("tr.#{poc}.#{category}.category").addClass("visible")
+        $("tr.#{poc}.#{category}.category").addClass "visible"
       return
 
     # toggle visibility
@@ -1742,7 +1753,8 @@ class window.AnalysisRequestAdd
   ###*
    * Event handler for analysis service category rows.
    *
-   * Toggles the visibility of all services within this category.
+   * Toggles the visibility of all services within this category, but only if
+   * the search filter mode for this category is not enabled.
    * NOTE: Selected services always stay visible.
    *
    * @param event {Object} The event object
@@ -1751,6 +1763,11 @@ class window.AnalysisRequestAdd
     event.preventDefault()
     $el = $(event.currentTarget)
     poc = $el.attr("poc")
+
+    # do nothing if search by term is active
+    if @is_search_active poc
+      return
+
     $btn = $(".service-category-toggle", $el)
 
     expanded = $el.hasClass("expanded")

--- a/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -1267,33 +1267,58 @@ class window.AnalysisRequestAdd
     lines.removeClass(cls)
     if lines[idx] then $(lines[idx]).addClass(cls)
 
+
   ###*
-   * Restores the visibility of services and categories
+   * Returns the term to search through services from categories that belong
+   * to the given point of capture (poc)
+   *
+   * @param poc {String} The point of capture
+   * @returns {String} The search term
   ###
-  reset_category_visibility: (category) =>
-    $category = $(category)
-    poc = $category.attr "poc"
-    category_id = $category.data "category"
+  get_search_term: (poc) ->
+    el = $("tr.#{poc}.service-listing-header input.services-filter")
+    # strip leading and trailing whitespaces
+    term = $(el).val()
+    return term.replace /^\s+|\s+$/g, ""
 
-    # hide services with non-ticked checkboxes
-    services = $("tr.#{poc}.#{category_id}.service")
-    unchecked = $("input[type=checkbox]:not(checked)", services)
-    unchecked.closest("tr").removeClass "visible"
 
-    # display services with ticked checkboxes
-    checked = $("input[type=checkbox]:checked", services)
-    checked.closest("tr").addClass "visible"
+  ###*
+   * Returns the list of service uids from categories that belong to the given
+   * point of capture and their human name match with the term passed-in.
+   * Returns an empty list if empty term
+   *
+   * @param poc {String} The point of capture
+   * @param term {String} The search term
+   * @returns {List} The list of service uids
+  ###
+  search_services: (poc, term) ->
+    matches = []
 
-    # toggle the visibility of the category
-    $btn = $(".service-category-toggle", $category)
-    if checked.length > 0
-      $category.addClass "visible"
-      $category.addClass "expanded"
-      $btn.text "-"
-    else
-      $category.addClass "visible"
-      $category.removeClass "expanded"
-      $btn.text "+"
+    # assume no matches if term is empty
+    if not term
+      return matches
+
+    # transform the term to lower case
+    term = term.toLowerCase()
+
+    # iterate through all registered services to find matches
+    services = $("tr.#{poc}.service")
+    $.each services, (num, service) ->
+
+      # get the service basic info
+      $service = $(service)
+      category_id = $service.data "category"
+      service_uid = $service.data "uid"
+
+      # get the service human name
+      name_el = $("div.service-title", $service)
+      name = name_el.html().toLowerCase()
+
+      # hide service if no match found and not checked for any sample
+      if name.indexOf(term) isnt -1
+        matches.push service_uid
+
+    return matches
 
 
   ######################
@@ -1619,6 +1644,18 @@ class window.AnalysisRequestAdd
   on_service_listing_header_click: (event) =>
     $el = $(event.currentTarget)
     poc = $el.data("poc")
+
+    # keep categories with selected services visible if search term set
+    term = @get_search_term(poc)
+    if term
+      services = $("tr.#{poc}.service.visible")
+      $.each services, (num, service) ->
+        $service = $(service)
+        category = $service.data "category"
+        $("tr.#{poc}.#{category}.category").addClass("visible")
+      return
+
+    # toggle visibility
     visible = $el.hasClass("visible")
     toggle = not visible
     @toggle_poc_categories poc, toggle
@@ -1635,66 +1672,61 @@ class window.AnalysisRequestAdd
    * @param event {Object} The event object
   ###
   on_services_filter_change: (event) =>
-    me = this
     $el = $(event.currentTarget)
     poc = $el.closest("tr").data("poc")
 
-    # display the categories that belong to this poc
-    @toggle_poc_categories poc, true
+    # keep track of the categories to expand and keep visible
+    expanded_categories = new Set([])
 
-    # get the term to search by and strip leading and trailing whitespaces
-    term = $el.val()
-    term = term = term.replace /^\s+|\s+$/g, ""
-    term = term.toLowerCase()
+    # get the term so search by
+    term = @get_search_term poc
 
-    if not term
-      # reset the visibility of categories
-      categories = $("tr.#{poc}.category")
-      $.each categories, (num, category) ->
-        me.reset_category_visibility category
-      return
+    # do the search
+    uids = @search_services poc, term
 
-    # keep track of the categories to make visible
-    visible_categories = new Set([])
-
-    # iterate through all registered services to find matches
+    # show services that match or with ticked checkboxes
     services = $("tr.#{poc}.service")
     $.each services, (num, service) ->
-
-      # get the name of the service
       $service = $(service)
-      category_id = $service.data "category"
-      name_el = $("div.service-title", $service)
-      name = name_el.html().toLowerCase()
-
-      # hide service if no match found and not checked for any sample
-      if name.indexOf(term) is -1
-        checked = $("input[type=checkbox]:checked", service)
-        if checked.length == 0
-          $service.removeClass "visible"
-      else
+      category = $service.data "category"
+      uid = $service.data "uid"
+      if uid in uids
         $service.addClass "visible"
+        expanded_categories.add category
+        return
 
-      # add to the categories to make visible
-      if $service.hasClass "visible"
-        visible_categories.add category_id
+      # show if ticked checkboxes
+      checked = $("input[type=checkbox]:checked", $service)
+      if checked.length > 0
+        $service.addClass "visible"
+        expanded_categories.add category
+        return
 
-    # iterate through categories and update their visibility
+      # hide the service
+      $service.removeClass "visible"
+
+    # expand categories with visible services
     categories = $("tr.#{poc}.category")
     $.each categories, (num, category) ->
-
       # toggle the visibility of the category
       $category = $(category)
       $btn = $(".service-category-toggle", $category)
       category_id = $category.data "category"
-      if visible_categories.has category_id
-        $category.addClass "visible"
+
+      # expand the category if at least on service visible
+      expanded = expanded_categories.has category_id
+      if expanded
         $category.addClass "expanded"
         $btn.text "-"
       else
-        $category.removeClass "visible"
         $category.removeClass "expanded"
         $btn.text "+"
+
+      # make category visible if expanded or empty search term
+      if expanded or not term
+        $category.addClass "visible"
+      else
+        $category.removeClass "visible"
 
 
   ###*


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds a search box to filter services in sample add form. 

- The search by term filter is specific of point of testing.
- Services checked previously are kept visible when filter by term is active.
- Services are dynamically filtered by term while typing.
- The button for toggling categories have no effect when filter by term is active.

![Captura de 2025-03-29 11-02-59](https://github.com/user-attachments/assets/6560a832-fe3d-48ba-86e4-ce23c81707a1)


## Current behavior before PR

Is not possible to filter services by term

## Desired behavior after PR is merged

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
