### PR TITLE
Fix missing condition fieldname in sample add form statusmessage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2700 Fix missing condition fieldname in sample add form statusmessage
 - #2697 Allow to remove users
 - #2698 Custom contact widget in user profile
 - #2699 Add search filter by term for services in add sample form

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1881,7 +1881,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             # If there are required fields missing, flag an error
             for field in missing:
                 fieldname = "{}-{}".format(field, num)
-                label = self.get_field_label(field)
+                label = self.get_field_label(field) or field
                 msg = self.context.translate(_("Field '{}' is required"))
                 fielderrors[fieldname] = msg.format(label)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an empty Statusmessage if a required field is missing from a condition.

<img width="1833" alt="" src="https://github.com/user-attachments/assets/4b4fd02b-7712-46b4-b956-83cc864942bd" />

## Current behavior before PR

If a service condition was not met, i.e. the field is empty but required, the statusmessage does not show the field name.

<img width="1408" alt="" src="https://github.com/user-attachments/assets/c09d59cd-07ab-4c18-b31a-f324671cc75a" />

## Desired behavior after PR is merged

The required condition fieldname is displayed.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
