### PR TITLE
Make expected sampling date optional

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.6.0 (unreleased)
 ------------------
 
+- #2701 Make expected sampling date optional
 - #2697 Allow to remove users
 - #2698 Custom contact widget in user profile
 - #2699 Add search filter by term for services in add sample form

--- a/src/bika/lims/adapters/widgetvisibility.py
+++ b/src/bika/lims/adapters/widgetvisibility.py
@@ -175,7 +175,6 @@ class SamplingFieldsVisibility(SenaiteATWidgetVisibility):
                 return "invisible"
 
         elif field_name == "SamplingDate":
-            field.required = sampling
             if not sampling:
                 # sampling deactivated, do not display this field
                 return "invisible"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR makes the "Expected Sampling Date" optional if the Sampling Workflow is enabled.

<img width="1281" alt="" src="https://github.com/user-attachments/assets/9e8c6572-9f48-45ca-99ce-fbde5dc95ee6" />

## Current behavior before PR

Expected sampling date becomes required if the Sampling Workflow is enabled

<img width="625" alt="" src="https://github.com/user-attachments/assets/47e97ce2-5da2-4425-a811-1d4ecd88e37c" />

## Desired behavior after PR is merged

Expected sampling date does not become required if the Sampling Workflow is enabled

<img width="683" alt="" src="https://github.com/user-attachments/assets/25d0a14a-a553-4a38-bd72-1a69007ebace" />

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
