### PR TITLE
Fix `is_ymd('1h')` rises error

### DIFF
--- a/src/senaite/core/api/dtime.py
+++ b/src/senaite/core/api/dtime.py
@@ -51,7 +51,7 @@ YMD_REGEX = (
     r"((?P<y>(\d+))y){0,1}\s*"  # years
     r"((?P<m>(\d+))m){0,1}\s*"  # months
     r"((?P<d>(\d+))d){0,1}\s*"  # days
-    r"((?P<h>(\d+))d){0,1}\s*"  # hours
+    r"((?P<h>(\d+))h){0,1}\s*"  # hours
 )
 
 _marker = object()

--- a/src/senaite/core/tests/doctests/API_datetime.rst
+++ b/src/senaite/core/tests/doctests/API_datetime.rst
@@ -1296,6 +1296,9 @@ Returns true for ymd-like strings:
     >>> dtime.is_ymd("0d")
     True
 
+    >>> dtime.is_ymd("1h")
+    True
+
 But returns false if the format or type is not valid:
 
     >>> dtime.is_ymd("y3d")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request resolves the silent issue detected in https://github.com/senaite/senaite.jsonapi/pull/67#issuecomment-2773571530

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
