### PR TITLE
Fix permissions are not checked on auto-reception of samples

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2709 Fix permissions are not checked on auto-reception of samples
 - #2705 Fix instruments not filtered by method in WS template edit view
 - #2707 Fix analyst permission for auto results import
 

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -144,7 +144,7 @@ def create_analysisrequest(client, request, values, analyses=None,
             # auto-receive the sample, but only if the user (that might be
             # a client) has enough privileges and the sample has a value set
             # for DateSampled. Otherwise, sample_due
-            receive_sample(ar)
+            receive_sample(ar, check_permission=True)
 
         else:
             # sample_due is the default initial status of the sample


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This pull request ensures that only users with `senaite.core: Transition: Receive Sample` permission granted can receive samples when auto-receive setting is enabled.

## Current behavior before PR

Sample does not check if user has `senaite.core: Transition: Receive Sample` permission granted on auto-reception

## Desired behavior after PR is merged

Sample does check if user has `senaite.core: Transition: Receive Sample` permission granted on auto-reception


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
