### PR TITLE
Display previously entered remarks for QC tests even if not currently enabled in setup

### DIFF
--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -205,15 +205,13 @@ class AnalysesView(ListingView):
                 "type": "boolean"}),
         ))
 
-        # Inject Remarks column for listing
-        if self.analysis_remarks_enabled():
-            self.columns["Remarks"] = {
-                "title": "Remarks",
-                "toggle": False,
-                "sortable": False,
-                "type": "remarks",
-                "ajax": True,
-            }
+        self.columns["Remarks"] = {
+            "title": "Remarks",
+            "toggle": False,
+            "sortable": False,
+            "type": "remarks",
+            "ajax": True,
+        }
 
         self.review_states = [
             {
@@ -1666,15 +1664,18 @@ class AnalysesView(ListingView):
         :param item: analysis' dictionary counterpart that represents a row
         """
 
-        if self.analysis_remarks_enabled():
-            item["Remarks"] = analysis_brain.getRemarks
+        remarks = analysis_brain.getRemarks
 
-        if self.is_analysis_edition_allowed(analysis_brain):
+        # do allow edition only if remarks enabled in setup
+        enabled = self.analysis_remarks_enabled()
+        can_edit = self.is_analysis_edition_allowed(analysis_brain)
+        if enabled and can_edit:
+            item["Remarks"] = remarks
             item["allow_edit"].extend(["Remarks"])
-        else:
-            # render HTMLified text in readonly mode
-            item["Remarks"] = api.text_to_html(
-                analysis_brain.getRemarks, wrap=None)
+
+        elif not can_edit:
+            # render HTMLified text in readonly mode, even if not enabled
+            item["Remarks"] = api.text_to_html(remarks, wrap=None)
 
     def _append_html_element(self, item, element, html, glue="&nbsp;",
                              after=True):

--- a/src/bika/lims/browser/instrument.py
+++ b/src/bika/lims/browser/instrument.py
@@ -561,13 +561,6 @@ class InstrumentReferenceAnalysesView(AnalysesView):
             "sortable": False
         }
 
-        self.columns["Remarks"] = {
-            "title": "Remarks",
-            "toggle": False,
-            "sortable": False,
-            "type": "remarks",
-        }
-
         self.review_states[0]["columns"] = [
             "Service",
             "getReferenceAnalysesGroupID",

--- a/src/bika/lims/browser/instrument.py
+++ b/src/bika/lims/browser/instrument.py
@@ -561,6 +561,13 @@ class InstrumentReferenceAnalysesView(AnalysesView):
             "sortable": False
         }
 
+        self.columns["Remarks"] = {
+            "title": "Remarks",
+            "toggle": False,
+            "sortable": False,
+            "type": "remarks",
+        }
+
         self.review_states[0]["columns"] = [
             "Service",
             "getReferenceAnalysesGroupID",
@@ -587,6 +594,10 @@ class InstrumentReferenceAnalysesView(AnalysesView):
         sample = analysis.getSample()
         item["replace"]["Partition"] = get_link(api.get_url(sample),
                                                 api.get_id(sample))
+
+        # Display remarks for supervisor QC officer when checking QC results
+        remarks = analysis.getRemarks()
+        item["Remarks"] = api.text_to_html(remarks, wrap=None)
 
         # Get retractions field
         item["Retractions"] = ""

--- a/src/bika/lims/browser/instrument.py
+++ b/src/bika/lims/browser/instrument.py
@@ -588,10 +588,6 @@ class InstrumentReferenceAnalysesView(AnalysesView):
         item["replace"]["Partition"] = get_link(api.get_url(sample),
                                                 api.get_id(sample))
 
-        # Display remarks for supervisor QC officer when checking QC results
-        remarks = analysis.getRemarks()
-        item["Remarks"] = api.text_to_html(remarks, wrap=None)
-
         # Get retractions field
         item["Retractions"] = ""
         report = analysis.getRetractedAnalysesPdfReport()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that previously entered remarks for tests are displayed in analyses (and QC) listings even after disabling the option "Add a remarks field to all analyses" from setup.

## Current behavior before PR

Previously entered remarks for tests are not displayed after disabling "Add a remarks field to all analyses" from setup

## Desired behavior after PR is merged

Previously entered remarks for tests are displayed after disabling "Add a remarks field to all analyses" from setup

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
