### PR TITLE
Always display remarks for QC tests listed under Levey-Jennings chart

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2714 Always display remarks for QC tests listed under Levey-Jennings chart
 - #2708 Fix QR code has no embedded ID
 - #2705 Fix instruments not filtered by method in WS template edit view
 - #2707 Fix analyst permission for auto results import

--- a/src/bika/lims/browser/instrument.py
+++ b/src/bika/lims/browser/instrument.py
@@ -561,6 +561,13 @@ class InstrumentReferenceAnalysesView(AnalysesView):
             "sortable": False
         }
 
+        self.columns["Remarks"] = {
+            "title": "Remarks",
+            "toggle": False,
+            "sortable": False,
+            "type": "remarks",
+        }
+
         self.review_states[0]["columns"] = [
             "Service",
             "getReferenceAnalysesGroupID",
@@ -587,6 +594,10 @@ class InstrumentReferenceAnalysesView(AnalysesView):
         sample = analysis.getSample()
         item["replace"]["Partition"] = get_link(api.get_url(sample),
                                                 api.get_id(sample))
+
+        # Display remarks for supervisor QC officer when checking QC results
+        remarks = analysis.getRemarks()
+        item["Remarks"] = api.text_to_html(remarks, wrap=None)
 
         # Get retractions field
         item["Retractions"] = ""


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that previously entered remarks for QC tests are displayed under Levey-Jennnings chart listings even after disabling the option "Add a remarks field to all analyses" from setup. This enhancement allows QC officers to review all QC results for a specified reference sample, along with the recorded QC actions, without navigating to the worksheet where the QC test is assigned.

## Current behavior before PR

Previously entered remarks for QC tests are not displayed under LJ chart after disabling the option "Add a remarks field to all analyses" from setup.

## Desired behavior after PR is merged

Previously entered remarks for QC tests are displayed under LJ chart after disabling the option "Add a remarks field to all analyses" from setup.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
