### PR TITLE
Fix submit form on confirmation dialog "Yes" button click

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2716 Fix submit form on confirmation dialog "Yes" button click
 - #2715 Allow the edition of QC results from inside Instrument
 - #2712 Fix non-consecutive same-day data points in Levey-Jennings chart
 - #2708 Fix QR code has no embedded ID

--- a/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
@@ -2377,7 +2377,7 @@
             // Re-submit
             $("input[name=confirmed]").val("1");
             me.form_submission_flag = false;
-            $("input[name=save_button]").trigger("click");
+            return $("input[name=save_button]").trigger("click");
           });
           return dialog.on("no", function() {
             var destination;

--- a/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/bika.lims.analysisrequest.add.js
@@ -2376,7 +2376,8 @@
           dialog.on("yes", function() {
             // Re-submit
             $("input[name=confirmed]").val("1");
-            return $("input[name=save_button]").trigger("click");
+            me.form_submission_flag = false;
+            $("input[name=save_button]").trigger("click");
           });
           return dialog.on("no", function() {
             var destination;

--- a/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -2151,6 +2151,7 @@ class window.AnalysisRequestAdd
         dialog.on "yes", ->
             # Re-submit
             $("input[name=confirmed]").val "1"
+            @form_submission_flag = no
             $("input[name=save_button]").trigger "click"
 
         dialog.on "no", ->

--- a/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -2151,7 +2151,7 @@ class window.AnalysisRequestAdd
         dialog.on "yes", ->
             # Re-submit
             $("input[name=confirmed]").val "1"
-            @form_submission_flag = no
+            me.form_submission_flag = no
             $("input[name=save_button]").trigger "click"
 
         dialog.on "no", ->


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
This Pull Request addresses an issue with the confirmation dialog in the sample creation workflow


## Current behavior before PR
- Clicking "Yes" in the confirmation dialog closes the dialog but takes no action
- Form stays open and is not submitted
- No additional sample is created despite user confirmation

## Desired behavior after PR is merged
- Clicking "Yes" in the confirmation dialog properly resubmits the form
- Form submission proceeds with `confirmed=1` parameter set

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
