### PR TITLE
Fix AttributeError in Worksheet Print View

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2718 Fix AttributeError in Worksheet Print View
 - #2717 Allow the edition of QC results from inside Reference Sample
 - #2715 Allow the edition of QC results from inside Instrument
 - #2712 Fix non-consecutive same-day data points in Levey-Jennings chart

--- a/src/bika/lims/browser/worksheet/views/printview.py
+++ b/src/bika/lims/browser/worksheet/views/printview.py
@@ -33,15 +33,17 @@ from bika.lims.interfaces import IReferenceAnalysis
 from bika.lims.interfaces import IReferenceSample
 from bika.lims.utils import format_supsub
 from bika.lims.utils import formatDecimalMark
+from bika.lims.utils import get_client
 from bika.lims.utils import to_utf8
 from bika.lims.utils.analysis import format_uncertainty
 from DateTime import DateTime
+from plone.memoize import view
 from plone.resource.utils import queryResourceDirectory
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from senaite.core.config.registry import WS_PRINT_TMPL_RECORD
 from senaite.core.p3compat import cmp
 from senaite.core.registry import get_registry_record
-from senaite.core.config.registry import WS_PRINT_TMPL_RECORD
 
 
 class PrintView(BrowserView):
@@ -96,6 +98,13 @@ class PrintView(BrowserView):
             return self._flush_pdf()
         else:
             return self.template()
+
+    @view.memoize
+    def get_default_decimal_mark(self):
+        """Returns the default decimal mark from the setup
+        """
+        setup = api.get_setup()
+        return setup.getDecimalMark()
 
     def get_analyses_data_by_title(self, ar_data, title):
         """A template helper to pick an Analysis identified by the name of the
@@ -398,7 +407,12 @@ class PrintView(BrowserView):
     def _analysis_data(self, analysis):
         """ Returns a dict that represents the analysis
         """
-        decimalmark = analysis.aq_parent.aq_parent.getDecimalMark()
+        client = get_client(analysis)
+        if client:
+            decimalmark = client.getDecimalMark()
+        else:
+            # no client found – this happens for QC analyses
+            decimalmark = self.get_default_decimal_mark()
         keyword = analysis.getKeyword()
         andict = {
             'obj': analysis,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue that happens if a WS contains QC analyses and wants to be printed.

## Current behavior before PR

Attribute Error raises:

```
Traceback (most recent call last):
  File "/Users/rbartl/develop/buildout/src/senaite.core/src/bika/lims/browser/worksheet/views/printview.py", line 138, in renderWSTemplate
    reptemplate = embed(self)
  File "/Users/rbartl/develop/buildout/eggs/Zope-4.8.10-py2.7.egg/Products/Five/browser/pagetemplatefile.py", line 61, in __call__
    sourceAnnotations=getattr(debug_flags, 'sourceAnnotations', 0),
  File "/Users/rbartl/develop/buildout/eggs/zope.pagetemplate-4.6.0-py2.7.egg/zope/pagetemplate/pagetemplate.py", line 135, in pt_render
    strictinsert=0, sourceAnnotations=sourceAnnotations
  File "/Users/rbartl/develop/buildout/eggs/Zope-4.8.10-py2.7.egg/Products/PageTemplates/engine.py", line 378, in __call__
    return template.render(**kwargs)
  File "/Users/rbartl/develop/buildout/eggs/z3c.pt-3.3.1-py2.7.egg/z3c/pt/pagetemplate.py", line 176, in render
    return base_renderer(**context)
  File "/Users/rbartl/develop/buildout/eggs/Chameleon-3.9.1-py2.7.egg/chameleon/zpt/template.py", line 302, in render
    return super(PageTemplate, self).render(**_kw)
  File "/Users/rbartl/develop/buildout/eggs/Chameleon-3.9.1-py2.7.egg/chameleon/template.py", line 215, in render
    raise_with_traceback(exc, tb)
  File "/Users/rbartl/develop/buildout/eggs/Chameleon-3.9.1-py2.7.egg/chameleon/template.py", line 192, in render
    self._render(stream, econtext, rcontext)
  File "/Users/rbartl/develop/buildout/db/wasserbw.lims/cache/5b163f94a2b33fa54afcb73a7d9984e6.py", line 131, in render
    __value = _static_4567548048('python', u'view.getWorksheet()', econtext=econtext)(_static_4567548496(econtext, __zt_tmp))
  File "/Users/rbartl/develop/buildout/eggs/zope.tales-5.2-py2.7.egg/zope/tales/pythonexpr.py", line 73, in __call__
    return eval(self._code, vars)
  File "", line 1, in 
  File "/Users/rbartl/develop/buildout/src/senaite.core/src/bika/lims/browser/worksheet/views/printview.py", line 185, in getWorksheet
    ws = self._ws_data(self._worksheets[self._current_ws_index])
  File "/Users/rbartl/develop/buildout/src/senaite.core/src/bika/lims/browser/worksheet/views/printview.py", line 248, in _ws_data
    data['ars'] = self._analyses_data(ws)
  File "/Users/rbartl/develop/buildout/src/senaite.core/src/bika/lims/browser/worksheet/views/printview.py", line 335, in _analyses_data
    andict = self._analysis_data(an)
  File "/Users/rbartl/develop/buildout/src/senaite.core/src/bika/lims/browser/worksheet/views/printview.py", line 403, in _analysis_data
    andict = {
AttributeError: 'RequestContainer' object has no attribute 'getDecimalMark'
```

## Desired behavior after PR is merged

WS Print View works with QC Analyses

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
