### PR TITLE
Allow to set custom IDs to reference samples

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2720 Allow to set custom IDs to reference samples
 - #2716 Fix submit form on confirmation dialog "Yes" button click
 - #2718 Fix AttributeError in Worksheet Print View
 - #2717 Allow the edition of QC results from inside Reference Sample

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -2110,3 +2110,55 @@ def validate(obj, invariants=True):
             errors[behavior_id] = translate(ex.message)
 
     return errors
+
+
+def get_portal_types():
+    """Returns a list with the registered portal types
+
+    :returns: List of portal type names
+    :rtype: list
+    """
+    types_tool = get_tool("portal_types")
+    return types_tool.listContentTypes()
+
+
+def is_valid_id(thing, container=None):
+    """Checks if is a valid ID candidate based on the following conditions:
+
+      - Contains only letters, numbers, hyphens ('-'), or underscores ('_').
+      - Starts with a letter or a number.
+      - Ends with a letter or a number.
+      - Has a minimum length of 3 characters.
+      - Does not match reserved words (e.g., 'REQUEST') or portal type names.
+
+    If a container is provided, it also verifies the container does not have
+    any attribute or function with same id.
+
+    :param id: the id to validate
+    :type id: str
+    :returns: True if the id meets all the conditions, False otherwise.
+    """
+    id_rx = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_\-]+[a-zA-Z0-9]$")
+    illegal = re.compile(r"^(aq_|manage|request).*")
+
+    if not is_string(thing):
+        return False
+
+    # check length and characters
+    if not id_rx.match(thing):
+        return False
+
+    # check for reserved/illegal word
+    if illegal.match(thing):
+        return False
+
+    # check for portal type names
+    portal_types = get_portal_types()
+    if thing in portal_types:
+        return False
+
+    # check for container attributes and functions
+    if container and hasattr(container, thing):
+        return False
+
+    return True

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -2138,18 +2138,21 @@ def is_valid_id(thing, container=None):
     :type id: str
     :returns: True if the id meets all the conditions, False otherwise.
     """
-    id_rx = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_\-]+[a-zA-Z0-9]$")
+    id_rx = re.compile(r"^[a-z0-9][a-z0-9_\-]+[a-z0-9]$")
     illegal = re.compile(r"^(aq_|manage|request).*")
 
     if not is_string(thing):
         return False
 
+    # convert to lower to simplify regex
+    lower = thing.lower()
+
     # check length and characters
-    if not id_rx.match(thing):
+    if not id_rx.match(lower):
         return False
 
     # check for reserved/illegal word
-    if illegal.match(thing):
+    if illegal.match(lower):
         return False
 
     # check for portal type names

--- a/src/bika/lims/content/referencesample.py
+++ b/src/bika/lims/content/referencesample.py
@@ -216,14 +216,18 @@ class ReferenceSample(BaseFolder):
 
     def _renameAfterCreation(self, check_auto_id=False):
         ref_id = self.getManualId()
-        parent = api.get_parent(self)
-        if not api.is_valid_id(ref_id, container=parent):
-            # empty or non-valid id. Rely on idserver
+        if not ref_id:
+            # empty id. Rely on idserver
             from senaite.core.idserver import renameAfterCreation
             renameAfterCreation(self)
             return
 
-        # Assign the manually entered id
+        parent = api.get_parent(self)
+        if not api.is_valid_id(ref_id, container=parent):
+            # the id is not valid
+            raise ValueError("The ManualID is not valid: %s" % ref_id)
+
+        # assign the manually entered id
         self.setId(ref_id)
 
     security.declarePublic('current_date')

--- a/src/bika/lims/content/referencesample.py
+++ b/src/bika/lims/content/referencesample.py
@@ -44,11 +44,28 @@ from Products.Archetypes.Widget import ComputedWidget
 from Products.Archetypes.Widget import StringWidget
 from Products.Archetypes.Widget import TextAreaWidget
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import check_id
 from senaite.core.browser.widgets.referencewidget import ReferenceWidget
 from senaite.core.catalog import SETUP_CATALOG
 from zope.interface import implements
 
 schema = BikaSchema.copy() + Schema((
+    StringField(
+        "ManualId",
+        schemata="Description",
+        searchable=True,
+        validators=("unique_referencesample_id_validator",),
+        widget=StringWidget(
+            label=_("Reference ID"),
+            description=_(
+                "The unique identifier for this reference sample. If "
+                "specified, the system will use this value as the sample's ID "
+                "instead of automatically generating one based on the "
+                "formatting rules defined in the setup's ID server."
+            ),
+        )
+    ),
+
     UIDReferenceField(
         "ReferenceDefinition",
         schemata="Description",
@@ -199,8 +216,16 @@ class ReferenceSample(BaseFolder):
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
-        from senaite.core.idserver import renameAfterCreation
-        renameAfterCreation(self)
+        ref_id = self.getManualId()
+        parent = api.get_parent(self)
+        if not api.is_valid_id(ref_id, container=parent):
+            # empty or non-valid id. Rely on idserver
+            from senaite.core.idserver import renameAfterCreation
+            renameAfterCreation(self)
+            return
+
+        # Assign the manually entered id
+        self.setId(ref_id)
 
     security.declarePublic('current_date')
     def current_date(self):

--- a/src/bika/lims/content/referencesample.py
+++ b/src/bika/lims/content/referencesample.py
@@ -44,7 +44,6 @@ from Products.Archetypes.Widget import ComputedWidget
 from Products.Archetypes.Widget import StringWidget
 from Products.Archetypes.Widget import TextAreaWidget
 from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.utils import check_id
 from senaite.core.browser.widgets.referencewidget import ReferenceWidget
 from senaite.core.catalog import SETUP_CATALOG
 from zope.interface import implements

--- a/src/bika/lims/subscribers/configure.zcml
+++ b/src/bika/lims/subscribers/configure.zcml
@@ -120,4 +120,10 @@
          zope.lifecycleevent.interfaces.IObjectModifiedEvent"
     handler="bika.lims.subscribers.batch.ObjectModifiedEventHandler" />
 
+  <!-- Reference sample events -->
+  <subscriber
+      for="bika.lims.interfaces.IReferenceSample
+           Products.Archetypes.interfaces.IObjectEditedEvent"
+      handler=".referencesample.ObjectEditedEventHandler" />
+
 </configure>

--- a/src/bika/lims/subscribers/referencesample.py
+++ b/src/bika/lims/subscribers/referencesample.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+from bika.lims import api
+
+
+def ObjectEditedEventHandler(obj, event):
+    """Event called after modifying a ReferenceSample, that is not in the
+    creation stage any more. It updates the ID of the reference sample with the
+    value of field ManualID if valid and different from current id
+    """
+    # compare with current id
+    obj_id = obj.getId()
+    manual_id = obj.getManualId()
+    if obj_id == manual_id:
+        return
+
+    # check if this new id is valid
+    parent = api.get_parent(obj)
+    if not api.is_valid_id(manual_id, container=parent):
+        return
+
+    # re-assign id and reindex
+    obj.setId(manual_id)
+    obj.reindexObject()

--- a/src/bika/lims/subscribers/referencesample.py
+++ b/src/bika/lims/subscribers/referencesample.py
@@ -19,6 +19,10 @@ def ObjectEditedEventHandler(obj, event):
     if not api.is_valid_id(manual_id, container=parent):
         return
 
+    # do not modify the id if it has objects inside
+    if obj.objectIds():
+        return
+
     # re-assign id and reindex
     parent.manage_renameObject(obj_id, manual_id)
     obj.reindexObject()

--- a/src/bika/lims/subscribers/referencesample.py
+++ b/src/bika/lims/subscribers/referencesample.py
@@ -20,5 +20,5 @@ def ObjectEditedEventHandler(obj, event):
         return
 
     # re-assign id and reindex
-    obj.setId(manual_id)
+    parent.manage_renameObject(obj_id, manual_id)
     obj.reindexObject()

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -1584,11 +1584,8 @@ class UniqueReferenceSampleIDValidator(object):
         # check if a reference sample with this id exists already
         uid = api.get_uid(instance)
         cat = api.get_tool(SENAITE_CATALOG)
-        brains = cat(portal_type="ReferenceSample")
+        brains = cat(portal_type="ReferenceSample", getId=value)
         for brain in brains:
-            obj_id = api.get_id(brain)
-            if obj_id != value:
-                continue
             if api.get_uid(brain) == uid:
                 continue
 

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -1566,7 +1566,11 @@ class UniqueReferenceSampleIDValidator(object):
         if not value:
             return
 
-        import pdb;pdb.set_trace()
+        # skip if the value matches with object's current id
+        if instance.getId() == value:
+            return
+
+        # check if the id is valid
         parent = api.get_parent(instance)
         if not api.is_valid_id(value, container=parent):
             return _t(_(

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -1581,6 +1581,15 @@ class UniqueReferenceSampleIDValidator(object):
                         u"Reference Sample with the same ID already exists.",
             ))
 
+        # do not modify the id if it has objects inside
+        if instance.objectIds():
+            return _t(_(
+                u"validator_referencesample_id_children",
+                default=u"The Reference Sample ID cannot be changed because "
+                        u"it is already associated with other objects, such "
+                        u"as QC analyses.",
+            ))
+
         # check if a reference sample with this id exists already
         uid = api.get_uid(instance)
         cat = api.get_tool(SENAITE_CATALOG)

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -35,6 +35,7 @@ from Products.validation import validation
 from Products.validation.interfaces.IValidator import IValidator
 from Products.ZCTextIndex.ParseTree import ParseError
 from senaite.core.api import dtime
+from senaite.core.catalog import SENAITE_CATALOG
 from senaite.core.i18n import translate as _t
 from zope.interface import implements
 
@@ -1550,6 +1551,51 @@ class UpperLimitOfQuantificationValidator(object):
             ))
 
 
+class UniqueReferenceSampleIDValidator(object):
+    """
+    Ensures that no existing object in the system has an ID matching the value
+    of the field to which this validator is applied.
+    """
+    implements(IValidator)
+    name = "unique_referencesample_id_validator"
+
+    def __call__(self, value, **kwargs):
+        instance = kwargs["instance"]
+
+        # skip if no value provided
+        if not value:
+            return
+
+        import pdb;pdb.set_trace()
+        parent = api.get_parent(instance)
+        if not api.is_valid_id(value, container=parent):
+            return _t(_(
+                u"validator_referencesample_id_invalid",
+                default=u"The Reference Sample ID is invalid. Ensure it "
+                        u"contains only letters, numbers, underscores ('_'), "
+                        u"or hyphens ('-'), and verify that no other "
+                        u"Reference Sample with the same ID already exists.",
+            ))
+
+        # check if a reference sample with this id exists already
+        uid = api.get_uid(instance)
+        cat = api.get_tool(SENAITE_CATALOG)
+        brains = cat(portal_type="ReferenceSample")
+        for brain in brains:
+            obj_id = api.get_id(brain)
+            if obj_id != value:
+                continue
+            if api.get_uid(brain) == uid:
+                continue
+
+            return _t(_(
+                u"validator_referencesample_id_exists",
+                default=u"A Reference Sample with the ID '%s' already "
+                        u"exists." % value
+            ))
+
+
 validation.register(LowerLimitOfDetectionValidator())
 validation.register(LowerLimitOfQuantificationValidator())
 validation.register(UpperLimitOfQuantificationValidator())
+validation.register(UniqueReferenceSampleIDValidator())

--- a/src/senaite/core/browser/form/adapters/configure.zcml
+++ b/src/senaite/core/browser/form/adapters/configure.zcml
@@ -83,4 +83,10 @@
            zope.publisher.interfaces.browser.IBrowserRequest"
       factory=".data_import.EditForm"/>
 
+  <!-- Edit Form: Reference Sample -->
+  <adapter
+      for="bika.lims.interfaces.IReferenceSample
+           zope.publisher.interfaces.browser.IBrowserRequest"
+      factory=".referencesample.EditForm"/>
+
 </configure>

--- a/src/senaite/core/browser/form/adapters/referencesample.py
+++ b/src/senaite/core/browser/form/adapters/referencesample.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.lims import _
+from senaite.core.browser.form.adapters import EditFormAdapterBase
+
+
+class EditForm(EditFormAdapterBase):
+    """Edit form adapter for ReferenceSample
+    """
+
+    def initialized(self, data):
+        # disable ManualID if necessary
+        if self.context.objectIds():
+            self.add_readonly_field(
+                "ManualId", _(
+                    "The Reference Sample ID cannot be changed because it is "
+                    "already associated with other objects, such as QC "
+                    "analyses.",
+                )
+            )
+
+        return self.data

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -2569,7 +2569,7 @@ The candidate must contain only letters, numbers, hyphens or underscores:
     False
     >>> api.is_valid_id("12345%")
     False
-    >>> api.is_valid_id("12 345")
+    >>> api.is_valid_id("1234 5")
     False
 
 However, '_' and '-' are not admitted at the start or at the end:
@@ -2582,6 +2582,21 @@ However, '_' and '-' are not admitted at the start or at the end:
     False
     >>> api.is_valid_id("my-own-ID_")
     False
+
+And minimum length of 3 is required:
+
+    >>> api.is_valid_id("1")
+    False
+    >>> api.is_valid_id("12")
+    False
+    >>> api.is_valid_id("123")
+    True
+    >>> api.is_valid_id("a")
+    False
+    >>> api.is_valid_id("ab")
+    False
+    >>> api.is_valid_id("abc")
+    True
 
 Reserved words like `REQUEST`, `aq_parent` or `manage_main` are not supported:
 

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -2521,3 +2521,116 @@ It also takes invariants into consideration:
     >>> category.setSortKey(10.0)
     >>> api.validate(category)
     {}
+
+
+Get the registered portal types
+...............................
+
+We can easily get the list with the names of the portal types registered in
+the system:
+
+    >>> portal_types = api.get_portal_types()
+    >>> sorted(portal_types)
+    ['ARReport', 'ARTemplate', 'ARTemplates', ..., 'WorksheetTemplates']
+
+
+Check if an id is valid
+.......................
+
+`is_valid_id` checks whether a given value is a valid ID candidate.
+
+The candidate must contain only letters, numbers, hyphens or underscores:
+
+    >>> api.is_valid_id("abcABC")
+    True
+    >>> api.is_valid_id("123456")
+    True
+    >>> api.is_valid_id("ab123AB")
+    True
+    >>> api.is_valid_id("a-1-2_3_B")
+    True
+    >>> api.is_valid_id("my-own-ID")
+    True
+    >>> api.is_valid_id("ábcABC")
+    False
+    >>> api.is_valid_id("àbcABC")
+    False
+    >>> api.is_valid_id("a/cABC")
+    False
+    >>> api.is_valid_id("a!cABC")
+    False
+    >>> api.is_valid_id("a#cABC")
+    False
+    >>> api.is_valid_id("a$cABC")
+    False
+    >>> api.is_valid_id("a=cABC")
+    False
+    >>> api.is_valid_id("a$cABC")
+    False
+    >>> api.is_valid_id("12345%")
+    False
+    >>> api.is_valid_id("12 345")
+    False
+
+However, '_' and '-' are not admitted at the start or at the end:
+
+    >>> api.is_valid_id("-my-own-ID")
+    False
+    >>> api.is_valid_id("_my-own-ID")
+    False
+    >>> api.is_valid_id("my-own-ID-")
+    False
+    >>> api.is_valid_id("my-own-ID_")
+    False
+
+Reserved words like `REQUEST`, `aq_parent` or `manage_main` are not supported:
+
+    >>> api.is_valid_id("REQUEST")
+    False
+    >>> api.is_valid_id("request")
+    False
+    >>> api.is_valid_id("aq_inner")
+    False
+    >>> api.is_valid_id("aq_parent")
+    False
+    >>> api.is_valid_id("manage_main")
+    False
+    >>> api.is_valid_id("manage")
+    False
+
+Words that match registered portal types are not supported:
+
+    >>> api.is_valid_id("AnalysisRequest")
+    False
+    >>> api.is_valid_id("analysisRequest")
+    True
+    >>> api.is_valid_id("WorksheetTemplate")
+    False
+    >>> api.is_valid_id("AnalysisService")
+    False
+
+We can even pass the container where the object with the candidate ID would be
+stored. If so, the value cannot match with attributes or functions from the
+container:
+
+    >>> api.is_valid_id("sort_key", container=category)
+    False
+    >>> api.is_valid_id("department", container=category)
+    False
+    >>> api.is_valid_id("getSortKey", container=category)
+    False
+    >>> api.is_valid_id("getDepartment", container=category)
+    False
+
+It also checks for IDs from objects in the container:
+
+    >>> api.is_valid_id("analysiscategory-1")
+    True
+    >>> api.is_valid_id("analysiscategory-1", container=categories)
+    False
+    >>> api.is_valid_id("analysiscategory-2", container=categories)
+    False
+    >>> api.is_valid_id("analysiscategory-5", container=categories)
+    True
+    >>> api.is_valid_id("analysiscategory-1", container=departments)
+    True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes possible to manually assign IDs to objects from `ReferenceSample` while keeping the functionality of auto-generation of IDs when no manual value is set.

Main reason of this change is that some suppliers provide their own QC sample barcodes which are used to run these samples on their instruments.

![Captura de 2025-05-05 15-21-36](https://github.com/user-attachments/assets/15b02cd0-60b7-4f0d-b887-a0c35dc8ca76)


## Current behavior before PR

Is not possible to use a custom ID for objects from `ReferenceSample` type

## Desired behavior after PR is merged

Is possible to use a custom ID for objects from `ReferenceSample` type

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
