### PR TITLE
Retain result for analysis retest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2721 Retain result for analysis retest
 - #2716 Fix submit form on confirmation dialog "Yes" button click
 - #2718 Fix AttributeError in Worksheet Print View
 - #2717 Allow the edition of QC results from inside Reference Sample

--- a/src/bika/lims/utils/analysis.py
+++ b/src/bika/lims/utils/analysis.py
@@ -29,6 +29,12 @@ from bika.lims.interfaces.analysis import IRequestAnalysis
 from bika.lims.utils import formatDecimalMark
 from bika.lims.utils import format_supsub
 
+DEFAULT_SKIP_FIELDS = [
+    "Attachment",
+    "ResultCaptureDate",
+    "Worksheet"
+]
+
 
 def create_analysis(context, source, **kwargs):
     """Create a new Analysis.  The source can be an Analysis Service or
@@ -64,12 +70,7 @@ def create_analysis(context, source, **kwargs):
     interim_fields = kwargs.pop("InterimFields", service.getInterimFields())
 
     # do not copy these fields from source
-    skip_fields = [
-        "Attachment",
-        "Result",
-        "ResultCaptureDate",
-        "Worksheet"
-    ]
+    skip_fields = kwargs.pop("skip", DEFAULT_SKIP_FIELDS)
 
     kwargs.update({
         "container": context,

--- a/src/senaite/core/tests/doctests/WorkflowAnalysisRetest.rst
+++ b/src/senaite/core/tests/doctests/WorkflowAnalysisRetest.rst
@@ -129,12 +129,12 @@ The "retest" is a copy of original analysis:
     >>> retest.getKeyword() == analysis.getKeyword()
     True
 
-But it does not keep the result:
+It keeps the result:
 
-    >>> not retest.getResult()
+    >>> retest.getResult() == analysis.getResult()
     True
 
-And Result capture date is None:
+But the result capture date is None:
 
     >>> not retest.getResultCaptureDate()
     True

--- a/src/senaite/core/tests/doctests/WorkflowAnalysisRetract.rst
+++ b/src/senaite/core/tests/doctests/WorkflowAnalysisRetract.rst
@@ -132,12 +132,12 @@ The new analysis is a copy of retracted one:
     >>> retest.getKeyword() == analysis.getKeyword()
     True
 
-But it does not keep the result:
+It keeps the result:
 
-    >>> not retest.getResult()
+    >>> retest.getResult() == analysis.getResult()
     True
 
-And Result capture date is None:
+But the result capture date is None:
 
     >>> not retest.getResultCaptureDate()
     True

--- a/src/senaite/core/tests/doctests/WorkflowAnalysisRetract.rst
+++ b/src/senaite/core/tests/doctests/WorkflowAnalysisRetract.rst
@@ -391,7 +391,7 @@ Do the same with Upper Detection Limit (UDL):
     >>> cu.getDetectionLimitOperand()
     '>'
 
-The Detection Limit is not kept on the retest:
+The Detection Limit is kept on the retest:
 
     >>> success = do_action_for(cu, "retract")
     >>> retest = cu.getRetest()

--- a/src/senaite/core/tests/doctests/WorkflowAnalysisRetract.rst
+++ b/src/senaite/core/tests/doctests/WorkflowAnalysisRetract.rst
@@ -357,21 +357,21 @@ Create the sample:
     >>> cu.getDetectionLimitOperand()
     '<'
 
-The Detection Limit is not kept on the retest:
+The Detection Limit is kept on the retest:
 
-    >>> success = do_action_for(analysis, "retract")
-    >>> retest = analysis.getRetest()
+    >>> success = do_action_for(cu, "retract")
+    >>> retest = cu.getRetest()
     >>> retest.getResult()
-    ''
+    '10'
 
     >>> retest.getFormattedResult(html=False)
-    ''
+    '< 10'
 
     >>> retest.isLowerDetectionLimit()
-    False
+    True
 
     >>> retest.getDetectionLimitOperand()
-    ''
+    '<'
 
 Do the same with Upper Detection Limit (UDL):
 
@@ -393,16 +393,16 @@ Do the same with Upper Detection Limit (UDL):
 
 The Detection Limit is not kept on the retest:
 
-    >>> success = do_action_for(analysis, "retract")
-    >>> retest = analysis.getRetest()
+    >>> success = do_action_for(cu, "retract")
+    >>> retest = cu.getRetest()
     >>> retest.getResult()
-    ''
+    '10'
 
     >>> retest.getFormattedResult(html=False)
-    ''
+    '> 10'
 
     >>> retest.isUpperDetectionLimit()
-    False
+    True
 
     >>> retest.getDetectionLimitOperand()
-    ''
+    '>'


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an inconsistent behavior for retracted/retested analyses, so that both, the result and the uncertainty is kept for the new created retest.

## Current behavior before PR

Result field is flushed for retest

## Desired behavior after PR is merged

Result field is retained for retest

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
