### PR TITLE
Allow to select an analyst and template in the create worksheet modal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2724 Allow to select an analyst in the create worksheet modal
 - #2720 Allow to set custom IDs to reference samples
 - #2721 Retain result for analysis retest
 - #2716 Fix submit form on confirmation dialog "Yes" button click

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- #2724 Allow to select an analyst in the create worksheet modal
+- #2724 Allow to select an analyst and template in the create worksheet modal
 - #2723 Add registry to control import file attachment to Worksheet assigned analyses
 - #2722 Fix instrument import loggings
 - #2720 Allow to set custom IDs to reference samples

--- a/src/senaite/core/browser/modals/sample.py
+++ b/src/senaite/core/browser/modals/sample.py
@@ -159,4 +159,5 @@ class CreateWorksheetModal(Modal):
                 "username": username,
                 "fullname": fullname or username,
             })
-        return analysts
+        # sort by fulname
+        return sorted(analysts, key=lambda x: x.get("fullname").lower())

--- a/src/senaite/core/browser/modals/sample.py
+++ b/src/senaite/core/browser/modals/sample.py
@@ -54,18 +54,21 @@ class CreateWorksheetModal(Modal):
     def handle_submit(self, REQUEST=None):
         """Extract categories from request and create worksheet
         """
+        analyst = self.request.form.get("analyst")
         categories = self.request.form.get("categories")
+
         if isinstance(categories, string_types):
             categories = [categories]
         # filter out non-UIDs
         categories = filter(api.is_uid, categories)
-        worksheet = self.create_worksheet_for(self.uids, categories)
+
+        worksheet = self.create_worksheet_for(self.uids, analyst, categories)
         self.add_status_message(
             _("Created worksheet %s" % api.get_id(worksheet)), level="info")
         # redirect to the new worksheet
         return api.get_url(worksheet)
 
-    def create_worksheet_for(self, samples, categories):
+    def create_worksheet_for(self, samples, analyst, categories):
         """Create a new worksheet
 
         The new worksheet contains the analyses of all samples which match the
@@ -87,6 +90,7 @@ class CreateWorksheetModal(Modal):
         # create the new worksheet
         ws = api.create(self.worksheet_folder, "Worksheet")
         ws.setResultsLayout(self.worksheet_layout)
+        ws.setAnalyst(analyst)
         ws.addAnalyses(analyses)
         return ws
 
@@ -135,3 +139,24 @@ class CreateWorksheetModal(Modal):
             "uid": api.get_uid(category),
             "obj": category,
         }
+
+    def get_analysts(self):
+        """Returns all analyst users
+
+        This function searches for users which have at least the Analyst role,
+        and prepares a list of dictionaries for each user containing the
+        username and fullname.
+
+        :returns: List of analyst data dictionaries
+        """
+        #
+        users = api.get_users_by_roles(["Manager", "LabManager", "Analyst"])
+        analysts = []
+        for user in users:
+            username = user.getUserName()
+            fullname = api.get_user_fullname(username)
+            analysts.append({
+                "username": username,
+                "fullname": fullname or username,
+            })
+        return analysts

--- a/src/senaite/core/browser/modals/sample.py
+++ b/src/senaite/core/browser/modals/sample.py
@@ -18,12 +18,12 @@
 # Copyright 2018-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from six import string_types
-
 from bika.lims import api
 from bika.lims import senaiteMessageFactory as _
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from senaite.core.browser.modals import Modal
+from senaite.core.catalog import SETUP_CATALOG
+from six import string_types
 
 
 class CreateWorksheetModal(Modal):
@@ -55,30 +55,33 @@ class CreateWorksheetModal(Modal):
         """Extract categories from request and create worksheet
         """
         analyst = self.request.form.get("analyst")
-        categories = self.request.form.get("categories")
+        categories = self.request.form.get("categories", [])
+        template = self.request.form.get("template")
+        samples = list(map(api.get_object, self.uids))
 
         if isinstance(categories, string_types):
             categories = [categories]
         # filter out non-UIDs
         categories = filter(api.is_uid, categories)
 
-        worksheet = self.create_worksheet_for(self.uids, analyst, categories)
+        worksheet = self.create_worksheet_for(
+            samples, analyst, categories, template)
         self.add_status_message(
             _("Created worksheet %s" % api.get_id(worksheet)), level="info")
         # redirect to the new worksheet
         return api.get_url(worksheet)
 
-    def create_worksheet_for(self, samples, analyst, categories):
+    def create_worksheet_for(self, samples, analyst, categories, template):
         """Create a new worksheet
 
         The new worksheet contains the analyses of all samples which match the
-        are in the given categories
+        are in the given categories.
 
         :param samples: Sample obejects or UIDs
         :param categories: Category objects or UIDs
+        :param template: Worksheet template
         :returns: new created Workshett
         """
-        samples = map(api.get_object, samples)
         categories = map(api.get_object, categories)
         analyses = []
         for sample in samples:
@@ -89,9 +92,10 @@ class CreateWorksheetModal(Modal):
 
         # create the new worksheet
         ws = api.create(self.worksheet_folder, "Worksheet")
-        ws.setResultsLayout(self.worksheet_layout)
         ws.setAnalyst(analyst)
         ws.addAnalyses(analyses)
+        ws.applyWorksheetTemplate(api.get_object(template, None))
+        ws.setResultsLayout(self.worksheet_layout)
         return ws
 
     @property
@@ -161,3 +165,25 @@ class CreateWorksheetModal(Modal):
             })
         # sort by fulname
         return sorted(analysts, key=lambda x: x.get("fullname").lower())
+
+    def get_worksheet_templates(self):
+        """Returns all WS templates
+
+        This function searches for worksheet templates and prepares a list of
+        dictionaries for each template containing the UID and the title.
+
+        :returns_ List of worksheet template data dictionaries
+        """
+        templates = [{"uid": "", "title": ""}]
+        query = {
+            "portal_type": "WorksheetTemplate",
+            "is_active": True,
+            "sort_on": "sortable_title",
+        }
+        results = api.search(query, SETUP_CATALOG)
+        for brain in results:
+            templates.append({
+                "uid": api.get_uid(brain),
+                "title": api.get_title(brain)
+            })
+        return templates

--- a/src/senaite/core/browser/modals/templates/create_worksheet.pt
+++ b/src/senaite/core/browser/modals/templates/create_worksheet.pt
@@ -62,12 +62,36 @@
           </small>
         </div>
 
+        <!-- Available Worksheet Templates -->
+        <div class="form-group form-group-sm mb-3">
+          <label i18n:translate=""
+                 class="mr-2"
+                 for="worksheet-templates-select">
+            Select worksheet template
+          </label>
+          <select id="worksheet-template-select"
+                  class="selectpicker show-tick"
+                  name="template"
+                  tal:define="templates view/get_worksheet_templates">
+            <tal:options repeat="template templates">
+              <option tal:define="uid python:template.get('uid');
+                                  title python:template.get('title');"
+                      tal:attributes="value python:uid;"
+                      tal:content="python:title"/>
+            </tal:options>
+          </select>
+          <small id="analyst-help"
+                 i18n:translate=""
+                 class="form-text text-muted">
+            The template that will be immediately assigned to the worksheet
+          </small>
+        </div>
+
         <!-- Submit -->
         <div class="form-group mt-2">
           <input class="btn btn-sm btn-primary"
                  type="submit"
                  name="create_worksheet"
-                 disabled="disabled"
                  i18n:attributes="value"
                  value="Create Worksheet" />
         </div>
@@ -88,24 +112,18 @@
      $("select#analysis-categories-select").selectpicker({
        actionsBox: true,
        liveSearch: true,
-       noneSelectedText: _t("No items selected"),
+       noneSelectedText: _t("Select category"),
        selectAllText: _t("Select all"),
        deselectAllText: _t("Deselect all")
      });
      $("select#analyst-select").selectpicker({
        liveSearch: true,
+       noneSelectedText: _t("Select analyst"),
      });
-     // callback to toggle the submit button on or off
-     $("select#analysis-categories-select").on("changed.bs.select", function (e, clickedIndex, isSelected, previousValue) {
-       let el = e.currentTarget;
-       let submit = $("input[name='create_worksheet']");
-       if (el.value) {
-         submit.attr("disabled", false);
-       } else {
-         submit.attr("disabled", true);
-       }
+     $("select#worksheet-template-select").selectpicker({
+       liveSearch: true,
+       noneSelectedText: _t("Select template"),
      });
-
    });
   </script>
 </div>

--- a/src/senaite/core/browser/modals/templates/create_worksheet.pt
+++ b/src/senaite/core/browser/modals/templates/create_worksheet.pt
@@ -13,13 +13,35 @@
             enctype="multipart/form-data"
             tal:attributes="action string:${here/absolute_url}/create_worksheet_modal">
 
-        <div class="form-group form-group-sm">
+        <!-- Available Analysts -->
+        <div class="form-group form-group-sm mb-3">
+          <label i18n:translate=""
+                 class="mr-2"
+                 for="analysis-categories-select">
+            Select analyst
+          </label>
+          <select id="analyst-select"
+                  name="analyst"
+                  tal:define="analysts view/get_analysts">
+            <tal:options repeat="analyst analysts">
+              <option tal:attributes="value python:analyst.get('username')"
+                      tal:content="python:analyst.get('fullname')"/>
+            </tal:options>
+          </select>
+          <small id="analyst-help"
+                 i18n:translate=""
+                 class="form-text text-muted">
+            The worksheet will be assigned to this analyst
+          </small>
+        </div>
+
+        <!-- Available Categories -->
+        <div class="form-group form-group-sm mb-3">
           <label i18n:translate=""
                  class="mr-2"
                  for="analysis-categories-select">
             Select analysis categories
           </label>
-          <!-- Available Categories -->
           <select multiple
                   id="analysis-categories-select"
                   name="categories"
@@ -36,6 +58,7 @@
           </small>
         </div>
 
+        <!-- Submit -->
         <div class="form-group mt-2">
           <input class="btn btn-sm btn-primary"
                  type="submit"
@@ -64,6 +87,9 @@
        noneSelectedText: _t("No items selected"),
        selectAllText: _t("Select all"),
        deselectAllText: _t("Deselect all")
+     });
+     $("select#analyst-select").selectpicker({
+       liveSearch: true,
      });
      // callback to toggle the submit button on or off
      $("select#analysis-categories-select").on("changed.bs.select", function (e, clickedIndex, isSelected, previousValue) {

--- a/src/senaite/core/browser/modals/templates/create_worksheet.pt
+++ b/src/senaite/core/browser/modals/templates/create_worksheet.pt
@@ -21,11 +21,15 @@
             Select analyst
           </label>
           <select id="analyst-select"
+                  class="selectpicker show-tick"
                   name="analyst"
                   tal:define="analysts view/get_analysts">
             <tal:options repeat="analyst analysts">
-              <option tal:attributes="value python:analyst.get('username')"
-                      tal:content="python:analyst.get('fullname')"/>
+              <option tal:define="username python:analyst.get('username');
+                                  fullname python:analyst.get('fullname');"
+                      tal:attributes="value python:username;
+                                      data-subtext string:(${username})"
+                      tal:content="python:fullname"/>
             </tal:options>
           </select>
           <small id="analyst-help"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR allows to select an analyst **and** a worksheet template in the worksheet create modal, that is triggered from the samples list.

## Current behavior before PR

Only analyses categories can be selected.

<img width="498" alt="SCR-20250515-hcel" src="https://github.com/user-attachments/assets/8ae36795-5f0b-44be-85f6-435c27df4f07" />

## Desired behavior after PR is merged

Analyst + Template and Categories can be selcted to create a new worksheet.
<img width="1029" alt="SCR-20250516-lqnq" src="https://github.com/user-attachments/assets/ef266e52-69df-430e-9667-4a5925050f77" />


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
