### PR TITLE
Fixed improper permission check for editing analysis remarks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2733 Fixed improper permission check for editing analysis remarks
 - #2731 Fix ReactJS complains about duplicate keys
 - #2730 Update D3js 3 -> 7
 - #2728 Update ReactJS 18 -> 19

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -350,7 +350,7 @@ class AnalysesView(ListingView):
             return False
         if obj is None:
             return check_permission(permission, self.context)
-        return check_permission(permission, api.get_object(obj))
+        return check_permission(permission, self.get_object(obj))
 
     @viewcache.memoize
     def is_analysis_edition_allowed(self, analysis_brain):

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -61,6 +61,7 @@ from senaite.core.permissions import EditFieldResults
 from senaite.core.permissions import EditResults
 from senaite.core.permissions import FieldEditAnalysisConditions
 from senaite.core.permissions import FieldEditAnalysisHidden
+from senaite.core.permissions import FieldEditAnalysisRemarks
 from senaite.core.permissions import FieldEditAnalysisResult
 from senaite.core.permissions import TransitionVerify
 from senaite.core.permissions import ViewResults
@@ -349,7 +350,9 @@ class AnalysesView(ListingView):
             return False
         if obj is None:
             return check_permission(permission, self.context)
-        return check_permission(permission, self.get_object(obj))
+        elif api.is_brain(obj):
+            obj = self.get_object(obj)
+        return check_permission(permission, obj)
 
     @viewcache.memoize
     def is_analysis_edition_allowed(self, analysis_brain):
@@ -451,6 +454,12 @@ class AnalysesView(ListingView):
             return False
 
         return True
+
+    def can_edit_remarks(self, analysis_brain):
+        """Returns whether current user can edit the Remarks of the analysis
+        """
+        obj = self.get_object(analysis_brain)
+        return self.has_permission(FieldEditAnalysisRemarks, obj)
 
     @viewcache.memoize
     def is_manual_result_capture_date_allowed(self):
@@ -1668,8 +1677,7 @@ class AnalysesView(ListingView):
 
         if self.analysis_remarks_enabled():
             item["Remarks"] = analysis_brain.getRemarks
-
-        if self.is_analysis_edition_allowed(analysis_brain):
+        if self.can_edit_remarks(analysis_brain):
             item["allow_edit"].extend(["Remarks"])
         else:
             # render HTMLified text in readonly mode

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -350,9 +350,7 @@ class AnalysesView(ListingView):
             return False
         if obj is None:
             return check_permission(permission, self.context)
-        elif api.is_brain(obj):
-            obj = self.get_object(obj)
-        return check_permission(permission, obj)
+        return check_permission(permission, api.get_object(obj))
 
     @viewcache.memoize
     def is_analysis_edition_allowed(self, analysis_brain):

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -1675,6 +1675,7 @@ class AnalysesView(ListingView):
 
         if self.analysis_remarks_enabled():
             item["Remarks"] = analysis_brain.getRemarks
+
         if self.can_edit_remarks(analysis_brain):
             item["allow_edit"].extend(["Remarks"])
         else:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request enforces the correct permission (`senaite.core: Field: Edit Analysis Remarks`) for verifying if the current user can edit the Remarks field in the analyses listing.

## Current behavior before PR

The system relies on the `senaite.core: Field: Edit Analysis Result` permission to determine if the current user can edit the Remarks field in the analyses listing."

## Desired behavior after PR is merged

The system relies on the `senaite.core: Field: Edit Analysis Remarks` permission to determine if the current user can edit the Remarks field in the analyses listing."

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
