### PR TITLE
Fix API field validation for DX contents

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2735 Fix API field validation for DX contents
 - #2733 Fixed improper permission check for editing analysis remarks
 - #2731 Fix ReactJS complains about duplicate keys
 - #2730 Update D3js 3 -> 7

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -55,6 +55,7 @@ from plone.memoize.volatile import DontCache
 from Products.Archetypes.atapi import DisplayList
 from Products.Archetypes.BaseObject import BaseObject
 from Products.Archetypes.event import ObjectInitializedEvent
+from Products.Archetypes.public import StringField
 from Products.Archetypes.utils import mapply
 from Products.CMFCore.interfaces import IFolderish
 from Products.CMFCore.interfaces import ISiteRoot
@@ -77,10 +78,10 @@ from zope.component import queryMultiAdapter
 from zope.container.contained import notifyContainerModified
 from zope.event import notify
 from zope.i18n import translate
+from zope.interface import Invalid
 from zope.interface import alsoProvides
 from zope.interface import directlyProvides
 from zope.interface import noLongerProvides
-from zope.interface import Invalid
 from zope.lifecycleevent import ObjectMovedEvent
 from zope.publisher.browser import TestRequest
 from zope.schema import getFieldsInOrder
@@ -118,6 +119,20 @@ UID_RX = re.compile("[a-z0-9]{32}$")
 UID_CATALOG = "uid_catalog"
 PORTAL_CATALOG = "portal_catalog"
 
+# fields that are not validated by the API
+SKIP_VALIDATION_FIELDS = [
+    "allow_discussion",
+    "contributors",
+    "creators",
+    "effective",
+    "exclude_from_nav",
+    "expires",
+    "language",
+    "nextPreviousEnabled",
+    "relatedItems",
+    "rights",
+    "subjects",
+]
 
 class APIError(Exception):
     """Base exception class for bika.lims errors."""
@@ -2078,19 +2093,39 @@ def validate(obj, invariants=True):
     if not is_dexterity_content(obj):
         raise TypeError("%r is not supported" % type(obj))
 
+    def is_string_field(field):
+        """Check if the field is a string field
+        """
+        return isinstance(field, (StringField)) or \
+            getattr(field, "_type", None) in [str]
+
     errors = {}
 
     # iterate through object fields and validate each
     fields = get_fields(obj)
+
     for field_name, field in fields.items():
+        if field_name in SKIP_VALIDATION_FIELDS:
+            continue
+
         value = getattr(obj, field_name, None)
-        value = safe_unicode(value)
+
+        # Handle callable values
+        if callable(value):
+            value = value()
+        if isinstance(value, six.string_types):
+            value = safe_unicode(value)
+        if is_string_field(field):
+            value = to_utf8(value)
+
         try:
             field.validate(value)
         except RequiredMissing:
             errors[field_name] = "required field"
         except WrongType:
-            errors[field_name] = "wrong type"
+            # ignore wrong type errors if the field is not required and unset
+            if value is not None:
+                errors[field_name] = "wrong type"
         except Invalid as ex:
             errors[field_name] = translate(ex.message)
 

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -2110,12 +2110,13 @@ def validate(obj, invariants=True):
 
         value = getattr(obj, field_name, None)
 
-        # Handle callable values
         if callable(value):
+            # Handle callable values, e.g. effective, expired etc.
             value = value()
         if isinstance(value, six.string_types):
             value = safe_unicode(value)
         if is_string_field(field):
+            # provide UTF8 encoded strings for stringfields, e.g. the ID field.
             value = to_utf8(value)
 
         try:

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -2522,6 +2522,22 @@ It also takes invariants into consideration:
     >>> api.validate(category)
     {}
 
+It is also possible to validate standard DX content types:
+
+    >>> client = self.portal.clients["client-1"]
+
+A standard Plone folder:
+
+    >>> dx_folder = api.create(client, "Folder", title="Test Folder")
+    >>> api.validate(dx_folder)
+    {}
+
+A standard Plone document:
+
+    >>> dx_document = api.create(dx_folder, "Document", title="Test Document")
+    >>> api.validate(dx_document)
+    {}
+
 
 Get the registered portal types
 ...............................


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the validation function provided by the API, which is used by `senaite.jsonapi` here:
https://github.com/senaite/senaite.jsonapi/blob/c2ba85d51cfeee2447c01b4616664d39e12519c2/src/senaite/jsonapi/api.py#L1516

## Current behavior before PR

It is not possible to create standard DX contents, e.g. Folder or Document with the JSON API, because the fields are not correctly validated.

## Desired behavior after PR is merged

It is possible to create standard DX contents, e.g. Folder or Document with the JSON API.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
