### PR TITLE
Fix profile services are not applied when creating samples programmatically

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2736 Fix profile services are not applied when creating samples programmatically
 - #2733 Fixed improper permission check for editing analysis remarks
 - #2731 Fix ReactJS complains about duplicate keys
 - #2730 Update D3js 3 -> 7

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -1515,7 +1515,8 @@ class AnalysisRequest(BaseFolder, ClientAwareMixin):
             return
 
         # Don't add analyses from profiles during sample creation.
-        # In this case the required analyses are added afterwards explicitly.
+        # In this case the required analyses are already extracted from all
+        # profiles.
         #
         # Also only add analyses if a profile (value) is selected:
         # https://github.com/senaite/senaite.core/pull/2672

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -270,8 +270,8 @@ def to_service_uids(services=None, values=None):
     uids = filter(None, map(to_service_uid, uids))
 
     # Extract and append the service UIDs from the profiles
-    for profile in values.get("Profiles", []):
-        profile = api.get_object(profile)
+    for profile in to_list(values.get("Profiles", [])):
+        profile = api.get_object(profile, None)
         if not profile:
             continue
         uids.extend(profile.getServiceUIDs())

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -76,7 +76,7 @@ def create_analysisrequest(client, request, values, analyses=None,
     # Resolve the Service uids of analyses to be added in the Sample. Values
     # passed-in might contain Profiles and also values that are not uids. Also,
     # additional analyses can be passed-in through either values or services
-    service_uids = to_services_uids(values=values, services=analyses)
+    service_uids = to_service_uids(services=analyses, values=values)
 
     # Remove the Analyses from values. We will add them manually
     values.update({"Analyses": []})
@@ -243,7 +243,7 @@ def get_hidden_service_uids(profile_or_template):
     return map(lambda setting: setting["uid"], hidden)
 
 
-def to_services_uids(services=None, values=None):
+def to_service_uids(services=None, values=None):
     """Returns a list of Analysis Services UIDS
 
     :param services: A list of service items (uid, keyword, brain, obj, title)
@@ -268,6 +268,13 @@ def to_services_uids(services=None, values=None):
 
     # Convert them to a list of service uids
     uids = filter(None, map(to_service_uid, uids))
+
+    # Extract and append the service UIDs from the profiles
+    for profile in values.get("Profiles", []):
+        profile = api.get_object(profile)
+        if not profile:
+            continue
+        uids.extend(profile.getServiceUIDs())
 
     # Get the service uids without duplicates, but preserving the order
     return list(OrderedDict.fromkeys(uids).keys())


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a side effect that was introduced in https://github.com/senaite/senaite.core/pull/2672

The problem arises if samples are created programmatically via the `bika.lims.utils.analysisrequest.create_analysisrequest` helper and not via the sample add form (where we already have these profile services extracted).

## Current behavior before PR

Profile services are not added during sample creation if created programmatically.

## Desired behavior after PR is merged

Profile services are added during sample creation if created programmatically.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
