### PR TITLE
Support for analysis conditions in results reports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2740 Support for analysis conditions in results reports
 - #2739 Fix snapshot versioning
 - #2737 Fix form values omitted on initial load for UID reference fields in sample add form
 - #2735 Fix API field validation for DX contents

--- a/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -267,6 +267,9 @@
                      name="ServiceConditions-{{../arnum}}.required:records"
                      value="{{required}}"/>
               <input type="hidden"
+                     name="ServiceConditions-{{../arnum}}.report:records"
+                     value="{{report}}"/>
+              <input type="hidden"
                      name="ServiceConditions-{{../arnum}}.choices:records"
                      value="{{choices}}"/>
               <input type="hidden"

--- a/src/bika/lims/content/abstractroutineanalysis.py
+++ b/src/bika/lims/content/abstractroutineanalysis.py
@@ -539,6 +539,7 @@ class AbstractRoutineAnalysis(AbstractAnalysis, ClientAwareMixin):
                 "choices": "",
                 "default": "",
                 "required": "",
+                "report": "",
                 "value": "",
             }
             condition = dict(condition)

--- a/src/bika/lims/content/analysisservice.py
+++ b/src/bika/lims/content/analysisservice.py
@@ -210,6 +210,7 @@ Conditions = RecordsField(
         "choices",
         "default",
         "required",
+        "report",
     ),
     required_subfields=(
         "title",
@@ -222,6 +223,7 @@ Conditions = RecordsField(
         "choices": _("Choices"),
         "default": _("Default value"),
         "required": _("Required"),
+        "report": _("Report"),
     },
     subfield_descriptions={
         "choices": _("Please use the following format for select options: "
@@ -234,6 +236,7 @@ Conditions = RecordsField(
         "default": "string",
         "choices": "string",
         "required": "boolean",
+        "report": "boolean",
     },
     subfield_sizes={
         "title": 20,

--- a/src/senaite/core/browser/modals/templates/set_analysis_conditions.pt
+++ b/src/senaite/core/browser/modals/templates/set_analysis_conditions.pt
@@ -27,7 +27,16 @@
             <table class="table table-sm small">
               <colgroup>
                 <col style="width:20%"/>
+                <col style="width:60%"/>
+                <col style="width:20%"/>
               </colgroup>
+              <thead>
+                <tr>
+                  <th i18n:translate="set_analysis_conditions_colname_condition">Condition</th>
+                  <th i18n:translate="set_analysis_conditions_colname_value">Value</th>
+                  <th i18n:translate="set_analysis_conditions_colname_report">Show in report</th>
+                </tr>
+              </thead>
               <tal:condition repeat="condition conditions">
                 <tr tal:define="required python:condition.get('required') == 'on';
                                 is_checkbox python:condition.get('type') == 'checkbox';
@@ -94,6 +103,12 @@
                          tal:attributes="href attachment/download_url"/>
                     </div>
 
+                  </td>
+                  <td>
+                    <!-- Toggle to display/hide in results report -->
+                    <input type="checkbox"
+                           name="conditions.report:records"
+                           tal:attributes="checked python:condition.get('report', 'off') == 'on' or None"/>
                   </td>
                 </tr>
               </tal:condition>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request introduces a new 'Report' option to the Analysis/Service conditions, enabling its use as a discriminator for specifying reporting conditions in results reports.

![20250604114534](https://github.com/user-attachments/assets/9d88fa12-c032-4d25-912f-abc4adb03292)

![20250604114511](https://github.com/user-attachments/assets/9b27872b-db74-49d5-979d-1a3f9fa4406b)

## Current behavior before PR

There is no support for analysis conditions in results report

## Desired behavior after PR is merged

Support for analysis conditions in results report

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
