### PR TITLE
Added client sampleid to worksheet printview 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2743 Added client_sampleid to worksheet printview
 - #2732 Added a sample invalidation form with support for entering a reason
 - #2740 Support for analysis conditions in results reports
 - #2738 Fix the behavior of the 'Save' button when errors occur during submission

--- a/src/bika/lims/browser/worksheet/views/printview.py
+++ b/src/bika/lims/browser/worksheet/views/printview.py
@@ -482,7 +482,6 @@ class PrintView(BrowserView):
                         sample.getDateSampled(), long_format=True),
                     'date_received': self.ulocalized_time(
                         sample.getDateReceived(), long_format=0),
-                    'client_sampleid': sample.getClientSampleID(),
                     }
 
             if sample.portal_type == "ReferenceSample":
@@ -491,6 +490,7 @@ class PrintView(BrowserView):
             else:
                 data['sample_type'] = self._sample_type(sample)
                 data['sample_point'] = self._sample_point(sample)
+                data['client_sampleid'] = sample.getClientSampleID()
         return data
 
     def _sample_type(self, sample=None):

--- a/src/bika/lims/browser/worksheet/views/printview.py
+++ b/src/bika/lims/browser/worksheet/views/printview.py
@@ -482,6 +482,7 @@ class PrintView(BrowserView):
                         sample.getDateSampled(), long_format=True),
                     'date_received': self.ulocalized_time(
                         sample.getDateReceived(), long_format=0),
+                    'client_sampleid': sample.getClientSampleID(),
                     }
 
             if sample.portal_type == "ReferenceSample":


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
The fields client_sampleid is missing senaite.core 2.x. This causes the system to fail to print worksheet.

Linked issue: https://github.com/senaite/senaite.core/issues/2742

## Current behavior before PR
Printing a worksheet if producing an error during render on `tal:content="ar/sample/client_sampleid"`

## Desired behavior after PR is merged
Must be able to print custom worksheets templates with ability to access the client_sampleid

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
