### PR TITLE
Fix wrong labels for attachment "Render in Report" checkboxes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2745 Fix wrong labels for attachment "Render in Report" checkboxes
 - #2729 Fix rejected analyses reassigned from profile
 - #2732 Added a sample invalidation form with support for entering a reason
 - #2740 Support for analysis conditions in results reports

--- a/src/senaite/core/browser/viewlets/templates/attachments.pt
+++ b/src/senaite/core/browser/viewlets/templates/attachments.pt
@@ -130,15 +130,18 @@
 
                 <td class="attachment-render-in-report text-center"
                     tal:define="render_in_report python:attachment.get('render_in_report', False)">
-                  <input type="checkbox"
-                         tal:attributes="name string:attachments.RenderInReport:records:boolean;
-                                         checked python:render_in_report;"/>
-                  <input type="hidden"
-                         tal:attributes="name string:attachments.RenderInReport:records:boolean:default;
-                                         value python:False;"/>
+                  <!-- Render in Report -->
+                  <tal:block tal:condition="can_edit">
+                    <input type="checkbox"
+                          tal:attributes="name string:attachments.RenderInReport:records:boolean;
+                                          checked python:render_in_report;"/>
+                    <input type="hidden"
+                          tal:attributes="name string:attachments.RenderInReport:records:boolean:default;
+                                          value python:False;"/>
+                  </tal:block>
                   <span i18n:translate=""
                         tal:condition="not:can_edit"
-                        tal:content="python:'Yes' if attachment.get('can_edit') else 'No'"/>
+                        tal:content="python:'Yes' if attachment.get('render_in_report') else 'No'"/>
                 </td>
 
                 <td class="attachment-delete" tal:condition="can_delete">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the display and label of the `Render in Report` attachment checkboxes when rendered for non-editable samples, e.g. samples in `rejected` state.

<img width="1843" alt="SCR-20250605-sewj" src="https://github.com/user-attachments/assets/7b5a2427-38dd-48e5-b893-dbd1de04c5bd" />

 
## Current behavior before PR

- Checkbox "Render in Report" is displayed
- Label shows always "No"

## Desired behavior after PR is merged

- Checkbox "Render in Report" is not rendered
- Label shows always "Yes" if the "Render in Report" option was turned on, otherwise "No"

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
