### PR TITLE
Add extra check to make sure a result is a true string before cgi.replace call

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2748 Add extra check to make sure a result is a true string before cgi.replace call
 - #2745 Fix wrong labels for attachment "Render in Report" checkboxes
 - #2743 Added client_sampleid to worksheet printview
 - #2729 Fix rejected analyses reassigned from profile

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -937,7 +937,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         # If string-like result, return without any formatting
         if result_type in ["string", "text"]:
             if html:
-                result = result if isinstance(result, basestring) else str(result)
+                result = result if api.is_string(result) else str(result)
                 result = cgi.escape(result)
                 result = result.replace("\n", "<br/>")
             return result

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -937,6 +937,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         # If string-like result, return without any formatting
         if result_type in ["string", "text"]:
             if html:
+                result = result if isinstance(result, basestring) else str(result)
                 result = cgi.escape(result)
                 result = result.replace("\n", "<br/>")
             return result


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
When passing a non-string result to cgi.escape(), an AttributeError is thrown. This occurs because cgi.escape() expects a string input, but the result being passed is of a different type (e.g., float).

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR
When publishing result/auto-publishing results - an Attribute error is thrown on some float results being handled as strings

## Desired behavior after PR is merged
An extra check will be performed on the result and converted to string when necessary before calling cgi.replace

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
