### PR TITLE
Fix client indexer typeerror

### DIFF
--- a/src/senaite/core/catalog/indexer/client.py
+++ b/src/senaite/core/catalog/indexer/client.py
@@ -47,3 +47,4 @@ def client_searchable_text(instance):
     # return a single unicode string with all the concatenated tokens
     return u" ".join(map(lambda x: api.safe_unicode(str(x)), tokens))
 
+

--- a/src/senaite/core/catalog/indexer/client.py
+++ b/src/senaite/core/catalog/indexer/client.py
@@ -45,4 +45,5 @@ def client_searchable_text(instance):
     tokens = filter(None, set(tokens))
 
     # return a single unicode string with all the concatenated tokens
-    return u" ".join(map(api.safe_unicode, tokens))
+    return u" ".join(map(lambda x: api.safe_unicode(str(x)), tokens))
+


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fixes a `TypeError` in the `client_searchable_text` indexer when one or more fields (e.g., phone, fax, tax number) return a non-string value, such as an integer.

Linked issue: N/A (issue discovered during portal_setup import)

## Current behavior before PR

Importing a configuration tarball via `portal_setup` fails with:

TypeError: sequence item 4: expected string or Unicode, int found

## Desired behavior after PR is merged

The indexer uses `str()` on all values before calling `safe_unicode()`, ensuring robustness during indexing and imports.
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
