### PR TITLE
Apply worksheet template only to analyses of selected samples

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2751 Apply worksheet template only to analyses of selected samples
 - #2745 Fix wrong labels for attachment "Render in Report" checkboxes
 - #2743 Added client_sampleid to worksheet printview
 - #2729 Fix rejected analyses reassigned from profile

--- a/src/bika/lims/content/worksheet.py
+++ b/src/bika/lims/content/worksheet.py
@@ -818,7 +818,7 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         layout = self.getLayout()
         return map(lambda l: (l["container_uid"], int(l["position"])), layout)
 
-    def _apply_worksheet_template_routine_analyses(self, wst):
+    def _apply_worksheet_template_routine_analyses(self, wst, analyses=None):
         """Add routine analyses to worksheet according to the worksheet template
         layout passed in w/o overwriting slots that are already filled.
 
@@ -829,6 +829,7 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         analyses that allows the method will be added
 
         :param wst: worksheet template used as the layout
+        :param analyses: list of analyses
         :returns: None
         """
         # Get the services from the Worksheet Template
@@ -839,19 +840,34 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
                         .format(api.get_path(wst)))
             return
 
-        # Search for unassigned analyses
-        query = {
-            "portal_type": "Analysis",
-            "getServiceUID": service_uids,
-            "review_state": "unassigned",
-            "sort_on": "getPrioritySortkey"
-        }
-        analyses = api.search(query, ANALYSIS_CATALOG)
-        if not analyses:
-            return
+        if analyses is None:
+            # Search for unassigned analyses
+            query = {
+                "portal_type": "Analysis",
+                "getServiceUID": service_uids,
+                "review_state": "unassigned",
+                "sort_on": "getPrioritySortkey"
+            }
+            analyses = api.search(query, ANALYSIS_CATALOG)
+            if not analyses:
+                return
+        else:
+            assignable_analyses = []
+            # filter assigned analyses and those that do not belong to the WST
+            for analysis in analyses:
+                analysis = api.get_object(analysis)
+                # analysis must be unassigned
+                if analysis.getWorksheetUID():
+                    continue
+                service_uid = analysis.getRawAnalysisService()
+                # analysis must belong to the services of the WST
+                if service_uid not in service_uids:
+                    continue
+                assignable_analyses.append(analysis)
+            analyses = assignable_analyses
 
         # Available slots for routine analyses
-        available_slots = self.resolve_available_slots(wst, 'a')
+        available_slots = self.resolve_available_slots(wst, "a")
         available_slots.sort(reverse=True)
 
         # If there is an instrument assigned to this Worksheet Template, take
@@ -1053,22 +1069,26 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
             services = reference['supported_services']
             self.addReferenceAnalyses(sample, services, slot)
 
-    def applyWorksheetTemplate(self, wst):
+    def applyWorksheetTemplate(self, wst, analyses=None):
         """ Add analyses to worksheet according to wst's layout.
             Will not overwrite slots which are filled already.
             If the selected template has an instrument assigned, it will
             only be applied to those analyses for which the instrument
             is allowed, the same happens with methods.
+
+        :param wst: worksheet template used as the layout
         """
+        wst = api.get_object(wst, default=None)
+
         # Store the Worksheet Template field and reindex it
-        self.getField('WorksheetTemplate').set(self, wst)
+        self.getField("WorksheetTemplate").set(self, wst)
         self.reindexObject(idxs=["getWorksheetTemplateTitle"])
-        
+
         if not wst:
             return
 
         # Apply the template for routine analyses
-        self._apply_worksheet_template_routine_analyses(wst)
+        self._apply_worksheet_template_routine_analyses(wst, analyses=analyses)
 
         # Apply the template for duplicate analyses
         self._apply_worksheet_template_duplicate_analyses(wst)

--- a/src/senaite/core/browser/modals/sample.py
+++ b/src/senaite/core/browser/modals/sample.py
@@ -83,9 +83,15 @@ class CreateWorksheetModal(Modal):
         :returns: new created Workshett
         """
         categories = map(api.get_object, categories)
+
         analyses = []
+        unassigned_analyses = []
         for sample in samples:
             for analysis in sample.getAnalyses(full_objects=True):
+                # collect all unassigned analyses
+                if analysis.getWorksheetUID() is None:
+                    unassigned_analyses.append(analysis)
+                # skip analyses that do not belong to the selsected categories
                 if analysis.getCategory() not in categories:
                     continue
                 analyses.append(analysis)
@@ -94,8 +100,13 @@ class CreateWorksheetModal(Modal):
         ws = api.create(self.worksheet_folder, "Worksheet")
         ws.setAnalyst(analyst)
         ws.addAnalyses(analyses)
-        ws.applyWorksheetTemplate(api.get_object(template, None))
         ws.setResultsLayout(self.worksheet_layout)
+
+        # apply the worksheet template to all unassigned analyses
+        wst = api.get_object(template, None)
+        if wst:
+            ws.applyWorksheetTemplate(wst, analyses=unassigned_analyses)
+
         return ws
 
     @property

--- a/src/senaite/core/browser/modals/templates/create_worksheet.pt
+++ b/src/senaite/core/browser/modals/templates/create_worksheet.pt
@@ -83,7 +83,7 @@
           <small id="analyst-help"
                  i18n:translate=""
                  class="form-text text-muted">
-            The template that will be immediately assigned to the worksheet
+            The worksheet template to apply to unassigned analyses of the selected samples.
           </small>
         </div>
 

--- a/src/senaite/core/browser/modals/templates/create_worksheet.pt
+++ b/src/senaite/core/browser/modals/templates/create_worksheet.pt
@@ -34,8 +34,8 @@
           </select>
           <small id="analyst-help"
                  i18n:translate=""
-                 class="form-text text-muted">
-            The worksheet will be assigned to this analyst
+                 class="form-text text-muted small">
+            The analyst responsible for completing the analyses in this worksheet
           </small>
         </div>
 
@@ -58,7 +58,7 @@
           <small id="analysis-categories-help"
                  i18n:translate=""
                  class="form-text text-muted">
-            Only analyses of the selected category will be added to the worksheet
+            Categories used to filter which analyses from the selected samples will be included in the worksheet
           </small>
         </div>
 
@@ -83,7 +83,9 @@
           <small id="analyst-help"
                  i18n:translate=""
                  class="form-text text-muted">
-            The worksheet template to apply to unassigned analyses of the selected samples.
+            The worksheet includes all unassigned analyses specified in the chosen template
+            <br/>
+            <i class="fa-solid fa-circle-info"></i> Analyses from the selected categories will also be added.
           </small>
         </div>
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is an improvement for https://github.com/senaite/senaite.core/pull/2724.

## Current behavior before PR

If a worksheet template is selected in the popup, it pulls in also analyses of samples that were not initially  selected

## Desired behavior after PR is merged

If a worksheet template is selected in the popup, it assignes only those analyses that belong to the selected samples and are unassigned and belong to the template services.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
