### PR TITLE
Fix reindex behavior in setup_core_catalogs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2756 Fix reindex behavior in setup_core_catalogs
 - #2755 Remove dependency handling from sample add form
 - #2754 Fix template service partition selector update
 - #2753 Enable full view reload for specific item transitions in listings

--- a/src/senaite/core/setuphandlers.py
+++ b/src/senaite/core/setuphandlers.py
@@ -347,10 +347,6 @@ def setup_core_catalogs(portal, catalog_classes=None, reindex=True):
         for column in catalog_columns:
             add_catalog_column(catalog, column)
 
-        if not reindex:
-            logger.info("*** Skipping reindex of new indexes")
-            return
-
         # map allowed types to this catalog in archetype_tool
         for portal_type in catalog_types:
             # check existing catalogs
@@ -361,6 +357,10 @@ def setup_core_catalogs(portal, catalog_classes=None, reindex=True):
                 at.setCatalogsByType(portal_type, new_catalogs)
                 logger.info("*** Mapped catalog '%s' for type '%s'"
                             % (catalog_id, portal_type))
+
+    if not reindex:
+        logger.info("*** Skipping reindex of new indexes")
+        return
 
     # reindex new indexes
     for catalog, idx_id in to_reindex:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the behavior for `setup_core_catalogs` if `reindex=False`.
Also see: https://github.com/senaite/senaite.core/pull/2752/files#r2161076220

## Current behavior before PR

Function returns for first catalog

## Desired behavior after PR is merged

Catalog indexes are added for all catalogs, but not reindexed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
