### PR TITLE
Fix return base URL for AJAX requests in the AR add form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2757 Fix return base URL for AJAX requests in the AR added form
 - #2752 Add modified index to catalog
 - #2756 Fix reindex behavior in setup_core_catalogs
 - #2755 Remove dependency handling from sample add form

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- #2757 Fix return base URL for AJAX requests in the AR added form
+- #2757 Fix return base URL for AJAX requests in the AR add form
 - #2752 Add modified index to catalog
 - #2756 Fix reindex behavior in setup_core_catalogs
 - #2755 Remove dependency handling from sample add form

--- a/src/senaite/core/browser/static/js/senaite.core.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/senaite.core.analysisrequest.add.coffee
@@ -458,7 +458,11 @@ class window.AnalysisRequestAdd
     base_url = window.location.href
     if base_url.search("/portal_factory") >= 0
       return base_url.split("/portal_factory")[0]
-    return base_url.split("/ar_add")[0]
+    url = window.location.origin + window.location.pathname
+    paths = url.split("/")
+    # delete current page path for getting current context
+    paths.pop()
+    return paths.join("/")
 
 
   ###*

--- a/src/senaite/core/browser/static/js/senaite.core.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/senaite.core.analysisrequest.add.coffee
@@ -455,9 +455,6 @@ class window.AnalysisRequestAdd
    * @returns {String} Base URL for Ajax Request
   ###
   get_base_url: =>
-    base_url = window.location.href
-    if base_url.search("/portal_factory") >= 0
-      return base_url.split("/portal_factory")[0]
     return document.body.dataset.baseUrl
 
 

--- a/src/senaite/core/browser/static/js/senaite.core.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/senaite.core.analysisrequest.add.coffee
@@ -458,11 +458,7 @@ class window.AnalysisRequestAdd
     base_url = window.location.href
     if base_url.search("/portal_factory") >= 0
       return base_url.split("/portal_factory")[0]
-    url = window.location.origin + window.location.pathname
-    paths = url.split("/")
-    # delete current page path for getting current context
-    paths.pop()
-    return paths.join("/")
+    return document.body.dataset.baseUrl
 
 
   ###*

--- a/src/senaite/core/browser/static/js/senaite.core.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/senaite.core.analysisrequest.add.js
@@ -789,12 +789,16 @@ window.AnalysisRequestAdd = class AnalysisRequestAdd {
   }
 
   get_base_url() {
-    var base_url;
+    var base_url, paths, url;
     base_url = window.location.href;
     if (base_url.search("/portal_factory") >= 0) {
       return base_url.split("/portal_factory")[0];
     }
-    return base_url.split("/ar_add")[0];
+    url = window.location.origin + window.location.pathname;
+    paths = url.split("/");
+    // delete current page path for getting current context
+    paths.pop();
+    return paths.join("/");
   }
 
   /**

--- a/src/senaite/core/browser/static/js/senaite.core.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/senaite.core.analysisrequest.add.js
@@ -789,16 +789,12 @@ window.AnalysisRequestAdd = class AnalysisRequestAdd {
   }
 
   get_base_url() {
-    var base_url, paths, url;
+    var base_url;
     base_url = window.location.href;
     if (base_url.search("/portal_factory") >= 0) {
       return base_url.split("/portal_factory")[0];
     }
-    url = window.location.origin + window.location.pathname;
-    paths = url.split("/");
-    // delete current page path for getting current context
-    paths.pop();
-    return paths.join("/");
+    return document.body.dataset.baseUrl;
   }
 
   /**

--- a/src/senaite/core/browser/static/js/senaite.core.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/senaite.core.analysisrequest.add.js
@@ -789,11 +789,6 @@ window.AnalysisRequestAdd = class AnalysisRequestAdd {
   }
 
   get_base_url() {
-    var base_url;
-    base_url = window.location.href;
-    if (base_url.search("/portal_factory") >= 0) {
-      return base_url.split("/portal_factory")[0];
-    }
     return document.body.dataset.baseUrl;
   }
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When we need override `ar_add` with custom page path and inherited from parent class `AnalysisRequestAddView` then ajax requests is failed after form loaded.

## Current behavior before PR

Method `get_base_url` cut last part from current url - `ar_add` and after that added `/ajax_ar_add` for ajax post requests. That not working for custom overrided add's forms.

## Desired behavior after PR is merged

Ajax post request working for different views.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
