### PR TITLE
Fix global auditlog error for objects without snapshots

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2758 Fix global auditlog error for objects without snapshots
 - #2752 Add modified index to catalog
 - #2756 Fix reindex behavior in setup_core_catalogs
 - #2755 Remove dependency handling from sample add form

--- a/src/bika/lims/controlpanel/auditlog.py
+++ b/src/bika/lims/controlpanel/auditlog.py
@@ -113,6 +113,12 @@ class AuditLogView(BikaListingView):
             }
         ]
 
+    def isItemAllowed(self, obj):
+        """Skip items without snapshots
+        """
+        obj = api.get_object(obj)
+        return get_last_snapshot(obj) is not None
+
     def folderitem(self, obj, item, index):
         """Service triggered each time an item is iterated in folderitems.
         The use of this service prevents the extra-loops in child objects.


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an `AttributeError` that is raised when the global Auditlog is activated and sorted by `modified` date.

## Current behavior before PR

Traceback occurs for objects w/o snapshots, e.g. the Worksheets folder in that case:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.app.listing.view, line 246, in __call__
  Module senaite.app.listing.ajax, line 112, in handle_subpath
  Module senaite.core.decorators, line 40, in decorator
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 379, in ajax_folderitems
  Module senaite.app.listing.decorators, line 88, in wrapper
  Module senaite.app.listing.ajax, line 258, in get_folderitems
  Module senaite.app.listing.view, line 982, in folderitems
  Module bika.lims.controlpanel.auditlog, line 132, in folderitem
  Module bika.lims.api.snapshot, line 188, in get_snapshot_metadata
AttributeError: 'NoneType' object has no attribute 'get'
```

## Desired behavior after PR is merged

Object w/o snapshots are skipped

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
