### PR TITLE
Fix UnicodeDecodeError on Specification Validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2759 Fix UnicodeDecodeError on Specification Validation
 - #2752 Add modified index to catalog
 - #2756 Fix reindex behavior in setup_core_catalogs
 - #2755 Remove dependency handling from sample add form

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -852,7 +852,7 @@ class AnalysisSpecificationsValidator:
 
             err_msg = "{}: {}".format(title, _(err_msg))
             translate = api.get_tool("translation_service").translate
-            instance.REQUEST[key] = to_utf8(translate(safe_unicode(err_msg)))
+            instance.REQUEST[key] = translate(safe_unicode(err_msg))
             return instance.REQUEST[key]
 
         instance.REQUEST[key] = True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an `UnicodeDecodeError` that occurs on specification validation if the service name contains unicode characters, e.g. `SiO₂`:

<img width="1485" alt="SCR-20250627-tjtn" src="https://github.com/user-attachments/assets/7c74a5f0-8750-4323-8c0e-a02d9eb12f1f" />


## Current behavior before PR

Traceback occurs:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.CMFFormController.FSControllerPageTemplate, line 92, in __call__
  Module Products.CMFFormController.BaseControllerPageTemplate, line 27, in _call
  Module Products.CMFFormController.FormController, line 385, in validate
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.CMFFormController.FSControllerValidator, line 57, in __call__
  Module Products.CMFFormController.Script, line 145, in __call__
  Module Products.CMFCore.FSPythonScript, line 134, in __call__
  Module Shared.DC.Scripts.Bindings, line 335, in __call__
  Module Shared.DC.Scripts.Bindings, line 372, in _bindAndExec
  Module Products.PythonScripts.PythonScript, line 349, in _exec
  Module script, line 6, in validate_base
   - <FSControllerValidator at /senaite/validate_base used for /senaite/bika_setup/bika_analysisspecs/analysisspec-1>
   - Line 6
  Module Products.Archetypes.BaseObject, line 517, in validate
  Module Products.Archetypes.Schema, line 629, in validate
  Module senaite.core.browser.fields.records, line 173, in validate
  Module senaite.core.browser.fields.records, line 169, in <genexpr>
  Module senaite.core.browser.fields.records, line 165, in <genexpr>
  Module senaite.core.browser.fields.record, line 396, in validate
  Module senaite.core.browser.fields.record, line 413, in validate_validators
  Module Products.validation.chain, line 164, in __call__
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 19: ordinal not in range(128)
```


## Desired behavior after PR is merged

Service title is correctly displayed in the error message

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
