### PR TITLE
Fix UnicodeDecodeError in instrument importer when processing field values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2760 Fix UnicodeDecodeError in instrument importer when processing field values
 - #2757 Fix return base URL for AJAX requests in the AR add form
 - #2752 Add modified index to catalog
 - #2756 Fix reindex behavior in setup_core_catalogs

--- a/src/senaite/core/exportimport/instruments/importer.py
+++ b/src/senaite/core/exportimport/instruments/importer.py
@@ -22,6 +22,7 @@ import six
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
+from bika.lims import safe_unicode
 from bika.lims.interfaces import IReferenceAnalysis
 from bika.lims.interfaces import IRoutineAnalysis
 from plone.memoize.view import memoize_contextless
@@ -648,17 +649,16 @@ class AnalysisResultsImporter(Logger):
                        "'{sid}' with calculation '{calculation}'"
                        .format(keyword=keyword,
                                sid=sid,
-                               calculation=api.safe_unicode(
-                                   calculation.Title()))))
+                               calculation=safe_unicode(calculation.Title()))))
             return False
 
         # check if non-empty result can be overwritten
         if not self.can_override_analysis_result(analysis, result):
-            self.log(_("Analysis '{keyword}' of sample '{sid}' has the "
+            self.log(_(u"Analysis '{keyword}' of sample '{sid}' has the "
                        "result '{result}' set, which is kept due to the "
                        "selected override option"
                        .format(sid=sid,
-                               result=analysis.getResult(),
+                               result=safe_unicode(analysis.getResult()),
                                keyword=keyword)))
             return False
 
@@ -679,7 +679,7 @@ class AnalysisResultsImporter(Logger):
 
         self.log(_(u"{sid} result for '{keyword}': '{result}'"
                    .format(sid=sid, keyword=keyword,
-                           result=api.safe_unicode(result))))
+                           result=safe_unicode(result))))
 
         return True
 
@@ -730,7 +730,7 @@ class AnalysisResultsImporter(Logger):
             updated = True
             self.log(_(u"{sid} Updated field '{field}' with '{value}'"
                        .format(sid=sid, field=key,
-                               value=api.safe_unicode(value))))
+                               value=safe_unicode(value))))
         return updated
 
     def save_submit_analysis(self, analysis):

--- a/src/senaite/core/exportimport/instruments/importer.py
+++ b/src/senaite/core/exportimport/instruments/importer.py
@@ -677,8 +677,9 @@ class AnalysisResultsImporter(Logger):
         if date_captured:
             analysis.setResultCaptureDate(date_captured)
 
-        self.log(_("{sid} result for '{keyword}': '{result}'"
-                   .format(sid=sid, keyword=keyword, result=result)))
+        self.log(_(u"{sid} result for '{keyword}': '{result}'"
+                   .format(sid=sid, keyword=keyword,
+                           result=api.safe_unicode(result))))
 
         return True
 
@@ -727,8 +728,9 @@ class AnalysisResultsImporter(Logger):
                 field.set(analysis, value)
 
             updated = True
-            self.log(_("{sid} Updated field '{field}' with '{value}'"
-                       .format(sid=sid, field=key, value=value)))
+            self.log(_(u"{sid} Updated field '{field}' with '{value}'"
+                       .format(sid=sid, field=key,
+                               value=api.safe_unicode(value))))
         return updated
 
     def save_submit_analysis(self, analysis):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue where field values are imported by an instrument, e.g. the Unit:
`UnicodeEncodeError('ascii', u'Bq\xb7g<sup>-1</sup>', 2, 3, 'ordinal not in range(128)')`

## Current behavior before PR

The importer fails if e.g. the Unit contains an unicode encoded string

## Desired behavior after PR is merged

The import works correctly for unicode encoded strings, e.g. `u'Bq\xb7g<sup>-1</sup>'`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
