### PR TITLE
Fix receive guard on sample creation is skipped if auto-receive enabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2764 Fix receive guard on sample creation is skipped if auto-receive enabled
 - #2761 Fix AT decimal widget allows commas
 - #2760 Fix UnicodeDecodeError in instrument importer when processing field values
 - #2759 Fix UnicodeDecodeError on Specification Validation

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -135,7 +135,6 @@ def create_analysisrequest(client, request, values, analyses=None,
     if not IReceived.providedBy(ar):
         setup = api.get_setup()
         auto_receive = setup.getAutoreceiveSamples()
-        import pdb;pdb.set_trace()
         if ar.getSamplingRequired():
             # sample has not been collected yet
             changeWorkflowState(ar, SAMPLE_WORKFLOW, "to_be_sampled",

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -43,6 +43,7 @@ from bika.lims.workflow import doActionFor
 from DateTime import DateTime
 from Products.Archetypes.event import ObjectInitializedEvent
 from Products.CMFPlone.utils import _createObjectByType
+from senaite.core.api.workflow import check_guard
 from senaite.core.catalog import SETUP_CATALOG
 from senaite.core.idserver import renameAfterCreation
 from senaite.core.permissions.sample import can_receive
@@ -134,13 +135,13 @@ def create_analysisrequest(client, request, values, analyses=None,
     if not IReceived.providedBy(ar):
         setup = api.get_setup()
         auto_receive = setup.getAutoreceiveSamples()
-
+        import pdb;pdb.set_trace()
         if ar.getSamplingRequired():
             # sample has not been collected yet
             changeWorkflowState(ar, SAMPLE_WORKFLOW, "to_be_sampled",
                                 action="to_be_sampled")
 
-        elif auto_receive and ar.getDateSampled() and can_receive(ar):
+        elif auto_receive and can_receive(ar) and check_guard(ar, "receive"):
             # auto-receive the sample, but only if the user (that might be
             # a client) has enough privileges and the sample has a value set
             # for DateSampled. Otherwise, sample_due

--- a/src/senaite/core/api/workflow.py
+++ b/src/senaite/core/api/workflow.py
@@ -17,13 +17,14 @@
 #
 # Copyright 2018-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
-
-from bika.lims import api
-from bika.lims.api import _marker
 from Products.DCWorkflow.DCWorkflow import DCWorkflowDefinition
+from Products.DCWorkflow.Expression import StateChangeInfo
+from Products.DCWorkflow.Expression import createExprContext
 from Products.DCWorkflow.Guard import Guard
 from Products.DCWorkflow.States import StateDefinition
 from Products.DCWorkflow.Transitions import TransitionDefinition
+from bika.lims import api
+from bika.lims.api import _marker
 from senaite.core import logger
 
 
@@ -424,3 +425,26 @@ def is_transition_allowed(obj, transition_id):
     if wf.isActionSupported(obj, transition_id):
         return True
     return False
+
+
+def check_guard(obj, transition_id):
+    """Returns whether the guards ass"""
+    obj = api.get_object(obj)
+    wf = get_workflow(obj)
+
+    # get the transition for the given object and workflow
+    transition = get_transition(wf, transition_id)
+    guard = transition.guard
+    if not guard:
+        return True
+
+    # get the guard's TALES expression
+    expr = guard.expr
+    if not expr:
+        return True
+
+    # create the expression context to provide names for TALES expressions
+    context = createExprContext(StateChangeInfo(obj, wf))
+
+    # evaluate the expression
+    return True if expr(context) else False

--- a/src/senaite/core/api/workflow.py
+++ b/src/senaite/core/api/workflow.py
@@ -428,7 +428,16 @@ def is_transition_allowed(obj, transition_id):
 
 
 def check_guard(obj, transition_id):
-    """Returns whether the guards ass"""
+    """Returns whether the guard's expression for the given object and
+    transition evaluates to True
+
+    :param obj: object to evaluate the guard against
+    :type obj: ATContentType/DexterityContentType/CatalogBrain/UID
+    :param transition_id: Workflow transition id
+    :type transition_id: string
+    :returns: True if the guard expression evaluates to True
+    :rtype: bool
+    """
     obj = api.get_object(obj)
     wf = get_workflow(obj)
 

--- a/src/senaite/core/tests/doctests/API_workflow.rst
+++ b/src/senaite/core/tests/doctests/API_workflow.rst
@@ -477,3 +477,44 @@ Non-existing transitions are not possible neither:
 
     >>> wapi.is_transition_allowed(client, "receive")
     False
+
+
+Check the transition guard (expression)
+.......................................
+
+It is possible to directly check if the guard expression of a transition
+evaluates to `True` or `False`, regardless of roles and permissions.
+
+Create an analysis category:
+
+    >>> categories = portal.setup.analysiscategories
+    >>> cat = api.create(categories, "AnalysisCategory", title="Microbiology")
+
+This category can be deactivated:
+
+    >>> wapi.is_transition_allowed(cat, "deactivate")
+    True
+    >>> wapi.check_guard(cat, "deactivate")
+    True
+
+Create an analysis service assigned to this category:
+
+    >>> services = portal.bika_setup.bika_analysisservices
+    >>> cu = api.create(services, "AnalysisService", title="Copper",
+    ...                 Keyword="Cu", Category=cat)
+
+Since there is a service assigned to the category we've created, the guard
+blocks the transition 'deactivate':
+
+    >>> wapi.is_transition_allowed(cat, "deactivate")
+    False
+    >>> wapi.check_guard(cat, "deactivate")
+    False
+
+If we remove the service we created, the guard no longer blocks the transition:
+
+    >>> api.delete(cu, check_permissions=False)
+    >>> wapi.is_transition_allowed(cat, "deactivate")
+    True
+    >>> wapi.check_guard(cat, "deactivate")
+    True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that the guard(s) for the receive transition are evaluated during sample creation when the "Auto-receive samples" option is enabled in the Setup.

## Current behavior before PR

The guard(s) for the receive transition are not evaluated on sample creation

## Desired behavior after PR is merged

The guard(s) for the receive transition are not evaluated on sample creation

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
