### PR TITLE
Show "Save" button in sample header if at least one field is editable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2767 Show "Save" button in sample header if at least one field is editable
 - #2766 Allow negative numbers in numeric fields
 - #2765 DX address widget improvements and fixtures
 - #2763 Updated intl-tel-input 17.0.19 -> 25.3.1

--- a/src/senaite/core/browser/viewlets/sampleheader.py
+++ b/src/senaite/core/browser/viewlets/sampleheader.py
@@ -34,7 +34,6 @@ from Products.Archetypes.event import ObjectEditedEvent
 from Products.Archetypes.interfaces import IField as IATField
 from Products.CMFCore.permissions import ModifyPortalContent
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from senaite.core import logger
 from senaite.core.interfaces import IDataManager
 from zope import event
 from zope.component import queryAdapter
@@ -47,6 +46,11 @@ class SampleHeaderViewlet(ViewletBase):
     """Header table with editable sample fields
     """
     template = ViewPageTemplateFile("templates/sampleheader.pt")
+
+    def __init__(self, context, request, view, manager=None):
+        super(SampleHeaderViewlet, self).__init__(
+            context, request, view, manager=manager)
+        self.show_save = False
 
     def render(self):
         """Renders the viewlet and handles form submission
@@ -239,10 +243,7 @@ class SampleHeaderViewlet(ViewletBase):
         mode = "view"
         if field.checkPermission("edit", self.context):
             mode = "edit"
-            if not self.is_edit_allowed():
-                logger.warn("Permission '{}' granted for the edition of '{}', "
-                            "but 'Modify portal content' not granted"
-                            .format(field.write_permission, field.getName()))
+            self.show_save = True
         elif field.checkPermission("view", self.context):
             mode = "view"
 

--- a/src/senaite/core/browser/viewlets/templates/sampleheader.pt
+++ b/src/senaite/core/browser/viewlets/templates/sampleheader.pt
@@ -167,7 +167,7 @@
 
         <tal:controls condition="python:render_prominent_fields and render_standard_fields">
           <!-- Save Button -->
-          <input tal:condition="python:view.is_edit_allowed()"
+          <input tal:condition="python:view.show_save"
                  class="btn btn-sm btn-primary mt-2"
                  type="submit"
                  name="sampleheader_form_save"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the display condition of the "Save" button in the sample header form, so that it get displayed if at least one field is editable by the current user.

## Current behavior before PR

Save button display is controlled by the permission `Modify portal content`.
Therefore, it is not diplayed for Analyst users who can modify one or more fields.

## Desired behavior after PR is merged

Save button is displayed if at least one field is editable.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
