### PR TITLE
Fix: Imported Worksheet Templates not editable after Load Setup Data …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 2.7.0 (unreleased)
 ------------------
-
+- #2776 Fix Imported Worksheet Templates not editable after Load Setup Data
 - #2781 Fix formatted specification interval for result options
 - #2780 Fix result options text not displayed if it contains character entities
 - #2778 Allow manual submission for imported results

--- a/src/senaite/core/exportimport/setupdata/__init__.py
+++ b/src/senaite/core/exportimport/setupdata/__init__.py
@@ -2023,7 +2023,7 @@ class Worksheet_Templates(WorksheetImporter):
                     "pos": int(row["pos"]),
                     "type": analysis_type[0].lower(), # if 'type' is full word
                     "blank_ref": [blank_uid] if blank_uid else [],
-                    "control_ref": [control_uid] if blank_uid else [],
+                    "control_ref": [control_uid] if control_uid else [],
                     "reference_proxy": ref_proxy,
                     "dup": dup,
                     "dup_proxy": dup,


### PR DESCRIPTION
…import (#2776)

## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/2776

## Current behavior before PR

Imported worksheet templates from load setup data, can not be view/edited from listing view

## Desired behavior after PR is merged
Imported worksheet templates from load setup data, can be view/edited from listing view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
