### PR TITLE
Allow manual submission for imported results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2778 Allow manual submission for imported results
 - #2768 Pin magnitude to a Python 2 compatible version
 - #2762 Fix performance of analysis dependency calculations
 - #2767 Show "Save" button in sample header if at least one field is editable

--- a/src/senaite/core/exportimport/instruments/importer.py
+++ b/src/senaite/core/exportimport/instruments/importer.py
@@ -736,6 +736,10 @@ class AnalysisResultsImporter(Logger):
     def save_submit_analysis(self, analysis):
         """Submit analysis and ignore errors
         """
+        # Allow manual submission if this setting is disabled
+        submit = get_registry_record("import_analysis_submit")
+        if submit is False:
+            return
         try:
             api.do_transition_for(analysis, "submit")
         except api.APIError:

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2705</version>
+  <version>2706</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/registry/schema.py
+++ b/src/senaite/core/registry/schema.py
@@ -409,6 +409,7 @@ class IImportRegistry(ISenaiteRegistry):
         ),
         fields=[
             "import_analysis_attach_importfile",
+            "import_analysis_submit",
         ],
     )
 
@@ -422,5 +423,18 @@ class IImportRegistry(ISenaiteRegistry):
             default=u"Attach import file to all Worksheet assigned analyses"
         ),
         default=False,
+        required=False,
+    )
+
+    import_analysis_submit = schema.Bool(
+        title=_(
+            u"label_registry_import_analysis_submit",
+            default=u"Submit Analyses upon import"
+        ),
+        description=_(
+            u"description_registry_import_analysis_submit",
+            default=u"Automatically submit analyses upon import"
+        ),
+        default=True,
         required=False,
     )

--- a/src/senaite/core/tests/doctests/InstrumentResultsImport.rst
+++ b/src/senaite/core/tests/doctests/InstrumentResultsImport.rst
@@ -37,6 +37,8 @@ Imports:
     >>> from bika.lims.utils.analysisrequest import create_partition
     >>> from bika.lims.api.analysis import is_out_of_range
 
+    >>> from senaite.core.registry import set_registry_record
+
     >>> from plone.app.testing import setRoles
     >>> from plone.app.testing import TEST_USER_ID
     >>> from plone.app.testing import TEST_USER_PASSWORD
@@ -237,7 +239,6 @@ Allow the instrument for our services and controls:
 
 Attach import file to each analysis that is attached to a worksheet:
 
-    >>> from senaite.core.registry import set_registry_record
     >>> set_registry_record("import_analysis_attach_importfile", True)
 
 
@@ -276,6 +277,61 @@ Run the auto import:
     '2.0'
     >>> sample.Cu.getResult()
     '1.0'
+
+The results should be all submitted:
+
+    >>> api.get_workflow_status_of(sample.Au)
+    'to_be_verified'
+
+    >>> api.get_workflow_status_of(sample.Fe)
+    'to_be_verified'
+
+    >>> api.get_workflow_status_of(sample.Cu)
+    'to_be_verified'
+
+
+Basic Instrument Results Import with manual Analysis submission
+...............................................................
+
+Disable auto submission upon import:
+
+    >>> set_registry_record("import_analysis_submit", False)
+
+Add a new sample:
+
+    >>> sample = new_sample([Au, Cu, Fe], client, contact, sampletype)
+
+Setup the import file:
+
+    >>> data = """
+    ... ID,Cu,Fe,Au,end
+    ... {},1,2,3,end
+    ... """.strip().format(sample.getId())
+
+    >>> with open(os.path.join(resultsfolder, new_import_filename()), "w") as f:
+    ...     f.write(data)
+
+Run the auto import:
+
+    >>> import_log = auto_import()
+
+    >>> sample.Au.getResult()
+    '3.0'
+    >>> sample.Fe.getResult()
+    '2.0'
+    >>> sample.Cu.getResult()
+    '1.0'
+
+The results should be **not** submitted:
+
+    >>> api.get_workflow_status_of(sample.Au)
+    'unassigned'
+
+    >>> api.get_workflow_status_of(sample.Fe)
+    'unassigned'
+
+    >>> api.get_workflow_status_of(sample.Cu)
+    'unassigned'
 
 
 Basic Instrument Results Import with Interims
@@ -478,12 +534,12 @@ Test the results:
 The import CSV file should be attached to each analysis:
 
     >>> sample1.Au.getAttachment()[0].getFilename()
-    'import6.csv'
+    'import....csv'
 
     >>> print(sample1.Au.getAttachment()[0].getAttachmentFile().data)
     ID,Au,end
-    W-0010,1,end
-    W-0011,2,end
+    W-...,1,end
+    W-...,2,end
 
 
 Instrument Results Import with Worksheet assigned Analyses and QCs

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -3,6 +3,14 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.7.0: Add registry key for instrument import submit handling"
+      description="Allow to submit imported analysis manually"
+      source="2705"
+      destination="2706"
+      handler=".v02_07_000.import_registry"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Update analysis catalog indexes"
       description="Add boolean 'has_calculation' index to analysis catalog"
       source="2704"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR allows to turn `off` auto-submission (default `on`) for imported results via a registry setting:

<img width="1418" height="268" alt="SCR-20250830-kwss" src="https://github.com/user-attachments/assets/346b40e5-ba55-4abe-86d4-2ec8f176f519" />

The reason for this change is that upon auto-import, the results are always submitted with the user that triggered the cron job, and not a real person, aka. a Lab Contact / Analyst.


## Current behavior before PR

Results are submitted after import

## Desired behavior after PR is merged

Results are not submitted after import, if the registry setting is turned `off`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
