### PR TITLE
Integrated Twitter Together GitHub Action

### DIFF
--- a/.github/workflows/twitter-together.yml
+++ b/.github/workflows/twitter-together.yml
@@ -1,0 +1,26 @@
+on: [push, pull_request]
+name: Twitter, together!
+jobs:
+  preview:
+    name: Preview
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: twitter-together/action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  tweet:
+    name: Tweet
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/2.x'
+    steps:
+      - name: checkout 2.x
+        uses: actions/checkout@v3
+      - name: Tweet
+        uses: twitter-together/action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+          TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
+          TWITTER_API_SECRET_KEY: ${{ secrets.TWITTER_API_SECRET_KEY }}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,4 +8,5 @@ recursive-exclude src/senaite/app/listing *
 recursive-exclude src/senaite/app/spotlight *
 recursive-exclude src/senaite/app/supermodel *
 recursive-exclude src *.pyc
+recursive-exclude tweets *
 recursive-exclude webpack *

--- a/tweets/2025-08-30_twitter-together.tweet
+++ b/tweets/2025-08-30_twitter-together.tweet
@@ -1,0 +1,1 @@
+Hooray, we've integrated Twitter Together: https://github.com/twitter-together/action?tab=readme-ov-file#twitter-together

--- a/tweets/README.md
+++ b/tweets/README.md
@@ -1,0 +1,5 @@
+# Twitter Together GitHub Action
+
+This folder contains Tweets that are posted during Push or Merge Actions on 2.x
+
+https://github.com/twitter-together/action?tab=readme-ov-file#twitter-together

--- a/tweets/README.md
+++ b/tweets/README.md
@@ -3,3 +3,5 @@
 This folder contains Tweets that are posted during Push or Merge Actions on 2.x
 
 https://github.com/twitter-together/action?tab=readme-ov-file#twitter-together
+
+New posts should be visible on https://x.com/senaitelims


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR integrates [Twitter Together](https://github.com/twitter-together/action?tab=readme-ov-file#twitter-together) into our repository.

This will post all Tweets (files ending with `.tweet`) in the `tweets` folder on https://x.com/senaitelims

## Current behavior before PR

Twitter, aka. `X` is dead

## Desired behavior after PR is merged

Twitter, aka. `X` is used again by simply adding tweets into the `tweets` directory, e.g. and update when something new PR is created

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
