### PR TITLE
Fix result options text not displayed if it contains character entities

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2780 Fix result options text not displayed if it contains character entities
 - #2768 Pin magnitude to a Python 2 compatible version
 - #2762 Fix performance of analysis dependency calculations
 - #2767 Show "Save" button in sample header if at least one field is editable

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -908,9 +908,9 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             ))
 
             # Result might contain a single result option
-            match = values_texts.get(str(result))
-            if match:
-                return match
+            text = values_texts.get(str(result))
+            if text:
+                return cgi.escape(text) if html else text
 
             # Result might be a string with multiple options e.g. "['2', '1']"
             try:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the display of result option texts containing HTML entities, e.g. `<`.

## Current behavior before PR

A result option text starting with `<` is not displayed after save:

<img width="377" height="70" alt="SCR-20250903-tgrf" src="https://github.com/user-attachments/assets/cc2a7c26-fb35-48c6-bb75-bc1b3d49cab7" />

<img width="451" height="180" alt="SCR-20250903-thdn" src="https://github.com/user-attachments/assets/bff6cdc3-1fda-4963-869f-5cd7f38ffa32" />


## Desired behavior after PR is merged

Result option texts starting with `<` are displayed after submit

<img width="421" height="182" alt="SCR-20250903-thoa" src="https://github.com/user-attachments/assets/36cfacc7-14e8-4c8b-b4a1-b9d60e7a4311" />



--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
