### PR TITLE
Fix formatted specification interval for result options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2780 Fix result options text not displayed if it contains character entities
 - #2768 Pin magnitude to a Python 2 compatible version
 - #2762 Fix performance of analysis dependency calculations
 - #2767 Show "Save" button in sample header if at least one field is editable

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2781 Fix formatted specification interval for result options
 - #2780 Fix result options text not displayed if it contains character entities
 - #2768 Pin magnitude to a Python 2 compatible version
 - #2762 Fix performance of analysis dependency calculations

--- a/src/bika/lims/api/analysis.py
+++ b/src/bika/lims/api/analysis.py
@@ -18,6 +18,7 @@
 # Copyright 2018-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import cgi
 from collections import Mapping
 
 from bika.lims import api
@@ -176,18 +177,34 @@ def is_out_of_range(brain_or_object, result=_marker):
     return True, not in_shoulder
 
 
-def get_formatted_interval(results_range, default=_marker):
+def get_formatted_interval(analysis_or_results_range, default=_marker):
     """Returns a string representation of the interval defined by the results
     range passed in
-    :param results_range: a dict or a ResultsRangeDict
+
+    :param analysis_or_results_range: analysis, dict or ResultsRangeDict
     """
+    analysis = None
+    if IAnalysis.providedBy(analysis_or_results_range):
+        analysis = analysis_or_results_range
+        results_range = analysis.getResultsRange()
+    else:
+        results_range = analysis_or_results_range
+
     if not isinstance(results_range, Mapping):
         if default is not _marker:
             return default
         api.fail("Type not supported")
+
     results_range = ResultsRangeDict(results_range)
     min_str = results_range.min if api.is_floatable(results_range.min) else None
     max_str = results_range.max if api.is_floatable(results_range.max) else None
+
+    if analysis:
+        min_text = analysis.getResultOptionTextByValue(min_str)
+        min_str = cgi.escape(min_text) if min_text else None
+        max_text = analysis.getResultOptionTextByValue(max_str)
+        max_str = cgi.escape(max_text) if max_text else None
+
     if min_str is None and max_str is None:
         if default is not _marker:
             return default

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -1425,13 +1425,14 @@ class AnalysesView(ListingView):
         results_range = analysis.getResultsRange()
 
         # get the results range interval properly formatted
-        value = get_formatted_interval(results_range, "")
+        value = get_formatted_interval(analysis, "")
 
-        # for non-floatable analyses, display the comment instead
-        result_type = analysis.getResultType()
-        if result_type not in ["numeric", "string"]:
-            comment = results_range.get("rangecomment")
-            value = comment if comment else value
+        # show comment if the result is out of range
+        out_range, out_shoulders = is_out_of_range(analysis)
+        comment = results_range.get("rangecomment")
+        if out_range and comment:
+            img = get_image("comment_ico.png", title=comment)
+            self._append_html_element(item, "Specification", img)
 
         item["Specification"] = value
 

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -908,9 +908,9 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             ))
 
             # Result might contain a single result option
-            match = values_texts.get(str(result))
-            if match:
-                return match
+            text = values_texts.get(str(result))
+            if text:
+                return cgi.escape(text) if html else text
 
             # Result might be a string with multiple options e.g. "['2', '1']"
             try:

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -1202,6 +1202,19 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
             return {}
         return max_hold_time
 
+    def getResultOptionTextByValue(self, value, default=""):
+        """Returns the ResultText for a given ResultValue from the ResultOptions
+
+        :param value: The ResultValue of the option to be retrieved
+        :type value: str
+        :return: Result text
+        """
+        options = self.getResultOptions() or []
+        for option in options:
+            if option.get("ResultValue") == value:
+                return option.get("ResultText", default)
+        return default
+
     # TODO Remove. ResultOptionsType field was replaced by ResulType field
     def getResultOptionsType(self):
         if self.getStringResult():


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**☝️ NOTE** Please merge #2780 first

This PR fixes the formatted specification interval rendering for result options

## Current behavior before PR

If the result comes from a result option, e.g. `4` for `<B4`, the specification either rendered as e.g. `[4;4]`, or if the specification has a comment, the comment is always used (even if it is in range).

<img width="635" height="118" alt="SCR-20250903-tstc" src="https://github.com/user-attachments/assets/6833254b-85f0-4134-acf1-3e227d354a9c" />

## Desired behavior after PR is merged

If the result comes from a result option, the specification translates the interval according to the matching result options


<img width="617" height="112" alt="SCR-20250903-ttjf" src="https://github.com/user-attachments/assets/6bbc7cb3-08ef-4fe0-a360-1f4aa3b03cfb" />

Furthermore, if a comment is used, it is displayed next to the interval:
<img width="633" height="138" alt="SCR-20250903-ttth" src="https://github.com/user-attachments/assets/3de6f76e-39a3-4643-a115-1c05fc668ad7" />



--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
