### PR TITLE
Fix formatted specification interval rendering

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changelog
 
 2.7.0 (unreleased)
 ------------------
+- #2785 Fix Formatted specification interval rendering is not shown
 - #2776 Fix Imported Worksheet Templates not editable after Load Setup Data
 - #2781 Fix formatted specification interval for result options
 - #2780 Fix result options text not displayed if it contains character entities

--- a/src/bika/lims/api/analysis.py
+++ b/src/bika/lims/api/analysis.py
@@ -201,9 +201,9 @@ def get_formatted_interval(analysis_or_results_range, default=_marker):
 
     if analysis:
         min_text = analysis.getResultOptionTextByValue(min_str)
-        min_str = cgi.escape(min_text) if min_text else None
+        min_str = cgi.escape(min_text) if min_text else min_str
         max_text = analysis.getResultOptionTextByValue(max_str)
-        max_str = cgi.escape(max_text) if max_text else None
+        max_str = cgi.escape(max_text) if max_text else max_str
 
     if min_str is None and max_str is None:
         if default is not _marker:

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -1209,9 +1209,11 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
         :type value: str
         :return: Result text
         """
+        if value is None:
+            return default
         options = self.getResultOptions() or []
         for option in options:
-            if option.get("ResultValue") == value:
+            if api.to_float(option.get("ResultValue")) == api.to_float(value):
                 return option.get("ResultText", default)
         return default
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/2785

## Current behavior before PR
The specs internals are not shown in Sample listing view and Worksheet.
<img width="815" height="547" alt="image" src="https://github.com/user-attachments/assets/da271bf0-bfff-451e-849f-e7c9f311d76f" />

## Desired behavior after PR is merged
The specs internals are shown in worksheet and sample view.
If the result comes from a result option, the specification translates the interval according to the matching result options

<img width="756" height="301" alt="image" src="https://github.com/user-attachments/assets/ce64f47c-0d07-4fac-ba83-082c00b210ee" />
<img width="472" height="262" alt="image" src="https://github.com/user-attachments/assets/aeeac218-ab28-4219-95b6-991e63a83f98" />
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
