### PR TITLE
Fix formatted specification interval rendering for reference analyses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 2.7.0 (unreleased)
 ------------------
-- #2785 Fix Formatted specification interval rendering is not shown
+- #2785 Fix Formatted specification interval rendering is not shown for analyses and reference analyses
 - #2776 Fix Imported Worksheet Templates not editable after Load Setup Data
 - #2781 Fix formatted specification interval for result options
 - #2780 Fix result options text not displayed if it contains character entities

--- a/src/bika/lims/api/analysis.py
+++ b/src/bika/lims/api/analysis.py
@@ -184,7 +184,7 @@ def get_formatted_interval(analysis_or_results_range, default=_marker):
     :param analysis_or_results_range: analysis, dict or ResultsRangeDict
     """
     analysis = None
-    if IAnalysis.providedBy(analysis_or_results_range):
+    if IAnalysis.providedBy(analysis_or_results_range) or IReferenceAnalysis.providedBy(analysis_or_results_range):
         analysis = analysis_or_results_range
         results_range = analysis.getResultsRange()
     else:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/2785
It was previously closed without considering Reference Analysis in PR: [2786](https://github.com/senaite/senaite.core/pull/2786)

## Current behavior before PR
Internal specifications are only rendered for routine analysis, not for reference analysis (QC analysis).
## Desired behavior after PR is merged
Internal specifications must be rendered for both routine and reference analysis.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
