### PR TITLE
Fix "Show more" button does not appear for the 2nd and 3rd sample remarks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Changelog
 
 2.7.0 (unreleased)
 ------------------
+
+- #2790 Fix "Show more" button does not appear for the 2nd and 3rd sample remarks
 - #2785 Fix Formatted specification interval rendering is not shown for analyses and reference analyses
 - #2776 Fix Imported Worksheet Templates not editable after Load Setup Data
 - #2781 Fix formatted specification interval for result options

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt
@@ -73,7 +73,7 @@
             <div class="record-content" tal:content="structure record/html_content"></div>
           </div>
         </tal:block>
-        <div tal:condition="python:len(records) > 3" class="mt-3">
+        <div tal:condition="python:len(records) >= 1" class="mt-3">
           <button type="button"
                   class="toggleRemarks btn btn-link btn-sm p-0">
             <span class="show-more-text" i18n:translate="">Show more</span>

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt
@@ -73,7 +73,7 @@
             <div class="record-content" tal:content="structure record/html_content"></div>
           </div>
         </tal:block>
-        <div tal:condition="python:len(records) >= 1" class="mt-3">
+        <div tal:condition="python:len(records) > 1" class="mt-3">
           <button type="button"
                   class="toggleRemarks btn btn-link btn-sm p-0">
             <span class="show-more-text" i18n:translate="">Show more</span>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue where the 2nd and 3rd sample remarks do not appear anymore, untill a 4th remark was added and the "Show more" button appears.

## Current behavior before PR

2nd and 3rd sample remarks are hidden (after reload) and no "Show more" button is displayed

## Desired behavior after PR is merged

The "Show more" button is displayed after a second sample remark has been added



--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
