### PR TITLE
Add TextLineField that strips the value and properly handle encodings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2791 Add TextLineField that strips the value and properly handle encodings
 - #2790 Fix "Show more" button does not appear for the 2nd and 3rd sample remarks
 - #2785 Fix Formatted specification interval rendering is not shown for analyses and reference analyses
 - #2776 Fix Imported Worksheet Templates not editable after Load Setup Data

--- a/src/senaite/core/content/department.py
+++ b/src/senaite/core/content/department.py
@@ -32,6 +32,7 @@ from senaite.core.config.widgets import get_labcontact_columns
 from senaite.core.content.base import Container
 from senaite.core.interfaces import IDepartment
 from senaite.core.schema import UIDReferenceField
+from senaite.core.schema import TextLineField
 from senaite.core.z3cform.widgets.uidreference import UIDReferenceWidgetFactory
 from zope import schema
 from zope.interface import Invalid
@@ -43,7 +44,7 @@ class IDepartmentSchema(model.Schema):
     """Schema interface
     """
 
-    title = schema.TextLine(
+    title = TextLineField(
         title=_(
             u"title_department_title",
             default=u"Name"
@@ -71,7 +72,7 @@ class IDepartmentSchema(model.Schema):
                       widget_css_input="text-primary text-monospace",
                       after_text_input="<i class='fas fa-id-card'></i>",
                       after_css_input="text-primary")
-    department_id = schema.TextLine(
+    department_id = TextLineField(
         title=_(
             u"title_department_id",
             default=u"Department ID"
@@ -145,13 +146,12 @@ class Department(Container):
     @security.protected(permissions.View)
     def getDepartmentID(self):
         accessor = self.accessor("department_id")
-        value = accessor(self) or ""
-        return value.encode("utf-8")
+        return accessor(self) or ""
 
     @security.protected(permissions.ModifyPortalContent)
     def setDepartmentID(self, value):
         mutator = self.mutator("department_id")
-        mutator(self, api.safe_unicode(value))
+        mutator(self, value)
 
     # BBB: AT schema field property
     DepartmentID = property(getDepartmentID, setDepartmentID)

--- a/src/senaite/core/schema/__init__.py
+++ b/src/senaite/core/schema/__init__.py
@@ -40,6 +40,7 @@ from .phonefield import PhoneField
 from .richtextfield import RichTextField
 from .selectotherfield import ISelectOtherField
 from .selectotherfield import SelectOtherField
+from .textlinefield import TextLineField
 from .uidreferencefield import IUIDReferenceField
 from .uidreferencefield import UIDReferenceField
 

--- a/src/senaite/core/schema/textlinefield.py
+++ b/src/senaite/core/schema/textlinefield.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+import six
+
+from Products.CMFPlone.utils import safe_unicode
+from zope import schema
+
+
+class TextLineField(schema.TextLine):
+    """A text field with no newlines and without leading and trailing spaces.
+    """
+
+    def set(self, object, value):
+        """Set the field's value to the given object.
+        The value is converted to a Unicode string to preserve compatibility
+        with the legacy behavior of auto-generated setters in AT content types.
+        Leading and trailing whitespaces are removed before assignment.
+        """
+        value = safe_unicode(value)
+        if isinstance(value, six.string_types):
+            value = value.strip()
+        super(TextLineField, self).set(object, value)
+
+    def get(self, object):
+        """Sets the value of this field from the given object.
+        The returned value is encoded as UTF-8 to maintain compatibility with
+        the legacy behavior of auto-generated getters in AT content types.
+        """
+        value = super(TextLineField, self).get(object)
+        if isinstance(value, six.string_types):
+            value = value.encode("utf-8")
+        return value


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds a new `TextLineField` that inherits from `zope.schema.TextLine`. This new field ensures the setter and getter are compliant with the with the legacy behavior of auto-generated setters and getters in AT content types. Besides, it removes leading and trailing whitespaces.

## Current behavior before PR

The text field is not aware of trailing and leading whitespaces

## Desired behavior after PR is merged

The text field is aware of trailing and leading whitespaces

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
