### PR TITLE
Add setting to trigger transition events on sample creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2792 Add setting to trigger transition events on sample creation
 - #2791 Add TextLineField that strips the value and properly handle encodings
 - #2790 Fix "Show more" button does not appear for the 2nd and 3rd sample remarks
 - #2785 Fix Formatted specification interval rendering is not shown for analyses and reference analyses

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -44,6 +44,7 @@ from DateTime import DateTime
 from Products.Archetypes.event import ObjectInitializedEvent
 from Products.CMFPlone.utils import _createObjectByType
 from senaite.core.api.workflow import check_guard
+from senaite.core.api.workflow import get_transition
 from senaite.core.catalog import SETUP_CATALOG
 from senaite.core.idserver import renameAfterCreation
 from senaite.core.permissions.sample import can_receive
@@ -147,9 +148,10 @@ def create_analysisrequest(client, request, values, analyses=None,
             receive_sample(ar)
 
         else:
-            # sample_due is the default initial status of the sample
-            changeWorkflowState(ar, SAMPLE_WORKFLOW, "sample_due",
-                                action="no_sampling_workflow")
+            # transition to the default initial status of the sample
+            action = "no_sampling_workflow"
+            tr = get_transition(SAMPLE_WORKFLOW, action)
+            changeWorkflowState(ar, SAMPLE_WORKFLOW, tr.new_state_id, action)
 
     renameAfterCreation(ar)
     # AT only

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -48,6 +48,7 @@ from senaite.core.api.workflow import get_transition
 from senaite.core.catalog import SETUP_CATALOG
 from senaite.core.idserver import renameAfterCreation
 from senaite.core.permissions.sample import can_receive
+from senaite.core.registry import get_registry_record
 from senaite.core.workflow import ANALYSIS_WORKFLOW
 from senaite.core.workflow import SAMPLE_WORKFLOW
 from zope import event
@@ -148,10 +149,18 @@ def create_analysisrequest(client, request, values, analyses=None,
             receive_sample(ar)
 
         else:
+            # find out if is necessary to trigger events. It is always more
+            # performant if no events are triggered, but some instances might
+            # need them to work properly
+            key = "trigger_events_on_sample_creation"
+            trigger_events = get_registry_record(key)
+
             # transition to the default initial status of the sample
             action = "no_sampling_workflow"
             tr = get_transition(SAMPLE_WORKFLOW, action)
-            changeWorkflowState(ar, SAMPLE_WORKFLOW, tr.new_state_id, action)
+            changeWorkflowState(ar, SAMPLE_WORKFLOW, tr.new_state_id,
+                                trigger_events=trigger_events,
+                                action=action)
 
     renameAfterCreation(ar)
     # AT only

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2706</version>
+  <version>2707</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/registry/schema.py
+++ b/src/senaite/core/registry/schema.py
@@ -377,6 +377,7 @@ class ISampleRegistry(ISenaiteRegistry):
         ),
         fields=[
             "sample_add_form_allow_multi_paste",
+            "trigger_events_on_sample_creation",
         ],
     )
 
@@ -393,6 +394,22 @@ class ISampleRegistry(ISenaiteRegistry):
                     u"the fields listed here."
         ),
         value_type=schema.ASCIILine(),
+        required=False,
+    )
+
+    trigger_events_on_sample_creation = schema.Bool(
+        title=_(
+            u"label_registry_trigger_events_on_sample_creation",
+            default=u"Trigger events on sample creation"
+        ),
+        description=_(
+            u"description_registry_trigger_events_on_sample_creation",
+            default=u"When enabled, triggers “before” and “after” transition "
+                    u"events upon sample creation. This option is disabled by "
+                    u"default, but certain add-ons may depend on it to "
+                    u"operate correctly."
+        ),
+        default=False,
         required=False,
     )
 

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -3,6 +3,14 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.7.0: Add registry key for trigger events on sample creation"
+      description="Allows to define if after and before events have to be triggered on sample creation"
+      source="2706"
+      destination="2707"
+      handler=".v02_07_000.import_registry"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Add registry key for instrument import submit handling"
       description="Allow to submit imported analysis manually"
       source="2705"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Requests adds a checkbox setting named "Trigger events on sample creation" in the registry. When enabled, triggers "before" and "after" transition events upon sample creation.

## Current behavior before PR

Event handlers for `no_sampling_workflow` transitions are not triggered on sample creation

## Desired behavior after PR is merged

Event handlers for `no_sampling_workflow` transitions are triggered on sample creation

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
