### PR TITLE
Fix APIError: Expected string type, got '<type 'NoneType'>'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2793 Fix APIError: Expected string type, got '<type 'NoneType'>'
 - #2792 Add setting to trigger transition events on sample creation
 - #2791 Add TextLineField that strips the value and properly handle encodings
 - #2790 Fix "Show more" button does not appear for the 2nd and 3rd sample remarks

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -71,6 +71,7 @@ from Products.CMFPlone.utils import safe_unicode
 from Products.PlonePAS.tools.memberdata import MemberData
 from Products.ZCatalog.interfaces import ICatalogBrain
 from senaite.core.interfaces import ITemporaryObject
+from z3c.form.validator import Data as ValidatorData
 from zope import globalrequest
 from zope.annotation.interfaces import IAttributeAnnotatable
 from zope.component import getUtility
@@ -2100,16 +2101,14 @@ def validate(obj):
             getattr(field, "_type", None) in [str]
 
     errors = {}
+    obj_data = {}
 
     # iterate through object fields and validate each
     fields = get_fields(obj)
-
     for field_name, field in fields.items():
-        if field_name in SKIP_VALIDATION_FIELDS:
-            continue
 
+        # extract the field value
         value = getattr(obj, field_name, None)
-
         if callable(value):
             # Handle callable values, e.g. effective, expired etc.
             value = value()
@@ -2119,6 +2118,12 @@ def validate(obj):
             # provide UTF8 encoded strings for e.g. the ID field.
             missing_value = getattr(field, "missing_value", None)
             value = to_utf8(value, default=None) or missing_value
+
+        # update obj_data for later use with invariants
+        obj_data[field_name] = value
+
+        if field_name in SKIP_VALIDATION_FIELDS:
+            continue
 
         try:
             field.validate(value)
@@ -2134,17 +2139,18 @@ def validate(obj):
     # validate invariants from schema
     sch = get_schema(obj)
     try:
-        sch.validateInvariants(obj)
+        sch.validateInvariants(ValidatorData(sch, obj_data, obj))
     except Invalid as ex:
-        errors[sch.getName()] = translate(ex.message)
+        errors[sch.getName()] = translate(ex.message) or type(ex).__name__
 
     # validate invariants from behaviors
     for behavior_id in get_behaviors(obj):
         behavior = lookup_behavior_registration(behavior_id)
+        sch = behavior.interface
         try:
-            behavior.interface.validateInvariants(obj)
+            sch.validateInvariants(ValidatorData(sch, obj_data, obj))
         except Invalid as ex:
-            errors[behavior_id] = translate(ex.message)
+            errors[behavior_id] = translate(ex.message) or type(ex).__name__
 
     return errors
 

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -2080,7 +2080,7 @@ def to_list(value):
     return list(value)
 
 
-def validate(obj, invariants=True):
+def validate(obj):
     """Validates the full object
 
     :param obj: the object to validate the data against
@@ -2116,8 +2116,9 @@ def validate(obj, invariants=True):
         if isinstance(value, six.string_types):
             value = safe_unicode(value)
         if is_string_field(field):
-            # provide UTF8 encoded strings for stringfields, e.g. the ID field.
-            value = to_utf8(value)
+            # provide UTF8 encoded strings for e.g. the ID field.
+            missing_value = getattr(field, "missing_value", None)
+            value = to_utf8(value, default=None) or missing_value
 
         try:
             field.validate(value)
@@ -2128,7 +2129,7 @@ def validate(obj, invariants=True):
             if value is not None:
                 errors[field_name] = "wrong type"
         except Invalid as ex:
-            errors[field_name] = translate(ex.message)
+            errors[field_name] = translate(ex.message) or type(ex).__name__
 
     # validate invariants from schema
     sch = get_schema(obj)

--- a/src/senaite/core/content/organization.py
+++ b/src/senaite/core/content/organization.py
@@ -23,6 +23,7 @@ import copy
 from AccessControl import ClassSecurityInfo
 from bika.lims import senaiteMessageFactory as _
 from senaite.core.schema import AddressField
+from senaite.core.schema import PhoneField
 from senaite.core.schema.addressfield import BILLING_ADDRESS
 from senaite.core.schema.addressfield import PHYSICAL_ADDRESS
 from senaite.core.schema.addressfield import POSTAL_ADDRESS
@@ -33,6 +34,7 @@ from plone.schema.email import Email
 from plone.autoform import directives
 from Products.CMFCore import permissions
 from Products.CMFPlone.utils import safe_unicode
+from senaite.core.z3cform.widgets.phone import PhoneWidgetFactory
 from zope import schema
 from zope.interface import implementer
 
@@ -57,7 +59,8 @@ class IOrganizationSchema(model.Schema):
         required=False,
     )
 
-    phone = schema.TextLine(
+    directives.widget("phone", PhoneWidgetFactory)
+    phone = PhoneField(
         title=_(
             u"title_organization_phone",
             default=u"Phone"
@@ -65,7 +68,8 @@ class IOrganizationSchema(model.Schema):
         required=False,
     )
 
-    fax = schema.TextLine(
+    directives.widget("fax", PhoneWidgetFactory)
+    fax = PhoneField(
         title=_(
             u"title_organization_fax",
             default=u"Fax"

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -2522,9 +2522,49 @@ It also takes invariants into consideration:
     >>> api.validate(category)
     {}
 
-It is also possible to validate standard DX content types:
+    >>> category.sort_key = None
+    >>> api.validate(category)
+    {}
+
+And handles missing values for native string fields gracefully:
+
+    >>> suppliers = self.portal.setup.suppliers
+    >>> data = {
+    ...     "title": "My supplier",
+    ... }
+    >>> supplier = api.create(suppliers, "Supplier", **data)
+    >>> api.validate(supplier)
+    {}
+
+    >>> supplier.phone = ""
+    >>> api.validate(supplier)
+    {}
+
+    >>> supplier.phone = None
+    >>> api.validate(supplier)
+    {}
+
+    >>> supplier.email = "my@email.com"
+    >>> api.validate(supplier)
+    {}
+
+    >>> supplier.email = "wrong"
+    >>> api.validate(supplier)
+    {'email': 'wrong'}
+
+    >>> supplier.email = ""
+    >>> api.validate(supplier)
+    {}
+
+    >>> supplier.email = None
+    >>> api.validate(supplier)
+    {}
+
+It is also possible to validate standard AT content types:
 
     >>> client = self.portal.clients["client-1"]
+    >>> api.validate(client)
+    {'ClientID': u'Client ID is required, please correct.'}
 
 A standard Plone folder:
 

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -2550,7 +2550,7 @@ And handles missing values for native string fields gracefully:
 
     >>> supplier.email = "wrong"
     >>> api.validate(supplier)
-    {'email': 'wrong'}
+    {'email': u'wrong'}
 
     >>> supplier.email = ""
     >>> api.validate(supplier)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes an error that arises when validating an object with `api.validate` with a non-required native string field without a value set.

## Current behavior before PR

```
APIError: Expected string type, got '<type 'NoneType'>'
```

## Desired behavior after PR is merged

No traceback when the field has no value set

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
