### PR TITLE
Fix sticker rendering error when no configured template was found

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2797 Fix sticker rendering error when no configured template was found
 - #2793 Fix APIError: Expected string type, got '<type 'NoneType'>'
 - #2792 Add setting to trigger transition events on sample creation
 - #2791 Add TextLineField that strips the value and properly handle encodings

--- a/src/senaite/core/browser/stickers/view.py
+++ b/src/senaite/core/browser/stickers/view.py
@@ -252,6 +252,9 @@ class StickerView(BrowserView):
         self.current_item = item
         templates_dir = "templates/stickers"
         embedt = self.get_selected_template()
+        if not embedt:
+            return "<div class='text-center py-5'>{}</div>".format(
+                _("Please select a sticker template"))
         if embedt.find(":") >= 0:
             prefix, embedt = embedt.split(":")
             templates_dir = self._getStickersTemplatesDirectory(prefix)
@@ -359,4 +362,10 @@ class StickerView(BrowserView):
             return setup.getSmallStickerTemplate()
         elif size == "large":
             return setup.getLargeStickerTemplate()
-        return setup.getAutoStickerTemplate()
+        auto_sticker_tpl = setup.getAutoStickerTemplate()
+        if not auto_sticker_tpl:
+            # Handle an edge case when the LIMS setup has not been saved yet
+            templates = get_sticker_templates(
+                filter_by_type=self.filter_by_type)
+            return templates[0].get("id", "") if templates else ""
+        return auto_sticker_tpl


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR handles an edge case, when the LIMS setup was not yet saved and thus, no valid auto sticker template is available in the system.

## Current behavior before PR

Traceback occurs when trying to render a sticker for a new sample, e.g. after the demo data was imported.

## Desired behavior after PR is merged

The first available template is used when no other template was found

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
