### PR TITLE
Fix reference sample import supplier data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 2.7.0 (unreleased)
 ------------------
-
+- #2799 Fix Reference Sample import supplier data
 - #2797 Fix sticker rendering error when no configured template was found
 - #2793 Fix APIError: Expected string type, got '<type 'NoneType'>'
 - #2792 Add setting to trigger transition events on sample creation

--- a/src/senaite/core/exportimport/setupdata/__init__.py
+++ b/src/senaite/core/exportimport/setupdata/__init__.py
@@ -2276,8 +2276,8 @@ class Reference_Samples(WorksheetImporter):
         for row in self.get_rows(3):
             if not row['id']:
                 continue
-            supplier = bsc(portal_type='Supplier',
-                           getName=row.get('Supplier_title', ''))[0].getObject()
+            supplier = self.get_object(bsc, 'Supplier',
+                                       row.get('Supplier_title', ''))
             obj = _createObjectByType("ReferenceSample", supplier, row['id'])
             ref_def = self.get_object(bsc, 'ReferenceDefinition',
                                       row.get('ReferenceDefinition_title'))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR

The supplier is not assigned correctly in the reference sample importer. The object is imported, but with a different supplier.

## Desired behavior after PR is merged

The Supplier_title defined in imported worksheet should define the supplier of object imported.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
