### PR TITLE
Fix WrongContainedType on object creation/update via jsonapi

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2800 Fix WrongContainedType on object creation/update via jsonapi
 - #2797 Fix sticker rendering error when no configured template was found
 - #2793 Fix APIError: Expected string type, got '<type 'NoneType'>'
 - #2792 Add setting to trigger transition events on sample creation

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -2115,7 +2115,15 @@ def validate(obj):
         if isinstance(value, six.string_types):
             value = safe_unicode(value)
         if is_string_field(field):
-            # provide UTF8 encoded strings for e.g. the ID field.
+            # Provide UTF-8 encoded strings for StringField or NativeString.
+            # This prevents a WrongType error when the value is unicode instead
+            # of str. For example, the field used to store an object's ID is a
+            # StringField, which only accepts str. However, in Senaite, values
+            # are stored as unicode and returned as UTF-8 to maintain AT legacy
+            # behavior.
+            # Note that this "trick" only applies to top-level fields: a
+            # WrongContainedType error will be raised if the field is, e.g., a
+            # DataGridField whose subfield inherits from NativeString.
             missing_value = getattr(field, "missing_value", None)
             value = to_utf8(value, default=None) or missing_value
 

--- a/src/senaite/core/content/organization.py
+++ b/src/senaite/core/content/organization.py
@@ -23,6 +23,7 @@ import copy
 from AccessControl import ClassSecurityInfo
 from bika.lims import senaiteMessageFactory as _
 from senaite.core.schema import AddressField
+from senaite.core.schema import EmailField
 from senaite.core.schema import PhoneField
 from senaite.core.schema.addressfield import BILLING_ADDRESS
 from senaite.core.schema.addressfield import PHYSICAL_ADDRESS
@@ -30,7 +31,6 @@ from senaite.core.schema.addressfield import POSTAL_ADDRESS
 from senaite.core.z3cform.widgets.address import AddressWidget
 from senaite.core.content.base import Container
 from plone.supermodel import model
-from plone.schema.email import Email
 from plone.autoform import directives
 from Products.CMFCore import permissions
 from Products.CMFPlone.utils import safe_unicode
@@ -89,7 +89,7 @@ class IOrganizationSchema(model.Schema):
         ]
     )
 
-    email = Email(
+    email = EmailField(
         title=_(
             u"title_organization_email",
             default=u"Email"

--- a/src/senaite/core/schema/__init__.py
+++ b/src/senaite/core/schema/__init__.py
@@ -17,7 +17,7 @@
 #
 # Copyright 2018-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
-
+from senaite.core.schema.interfaces import IEmailField
 from zope.interface import classImplementsFirst
 
 from .addressfield import AddressField
@@ -27,6 +27,7 @@ from .coordinatefield import LatitudeCoordinateField
 from .coordinatefield import LongitudeCoordinateField
 from .datetimefield import DatetimeField
 from .durationfield import DurationField
+from .emailfield import EmailField
 from .fields import IntField
 from .gpscoordinatesfield import GPSCoordinatesField
 from .interfaces import ICoordinateField
@@ -48,6 +49,7 @@ classImplementsFirst(AddressField, IAddressField)
 classImplementsFirst(CoordinateField, ICoordinateField)
 classImplementsFirst(DatetimeField, IDatetimeField)
 classImplementsFirst(DurationField, IDurationField)
+classImplementsFirst(EmailField, IEmailField)
 classImplementsFirst(GPSCoordinatesField, IGPSCoordinatesField)
 classImplementsFirst(IntField, IIntField)
 classImplementsFirst(PhoneField, IPhoneField)

--- a/src/senaite/core/schema/__init__.py
+++ b/src/senaite/core/schema/__init__.py
@@ -17,7 +17,7 @@
 #
 # Copyright 2018-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
-from senaite.core.schema.interfaces import IEmailField
+
 from zope.interface import classImplementsFirst
 
 from .addressfield import AddressField
@@ -33,6 +33,7 @@ from .gpscoordinatesfield import GPSCoordinatesField
 from .interfaces import ICoordinateField
 from .interfaces import IDatetimeField
 from .interfaces import IDurationField
+from .interfaces import IEmailField
 from .interfaces import IGPSCoordinatesField
 from .interfaces import IIntField
 from .interfaces import IRichTextField

--- a/src/senaite/core/schema/emailfield.py
+++ b/src/senaite/core/schema/emailfield.py
@@ -1,0 +1,32 @@
+import re
+
+from plone.schema import _
+from senaite.core.schema.interfaces import IEmailField
+from senaite.core.schema.textlinefield import TextLineField
+from zope.interface import implementer
+from zope.schema.interfaces import ValidationError
+
+# Taken from http://www.regular-expressions.info/email.html
+_isemail = r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}"
+_isemail = re.compile(_isemail).match
+
+
+class InvalidEmail(ValidationError):
+    __doc__ = _("""The specified email is not valid.""")
+
+
+@implementer(IEmailField)
+class EmailField(TextLineField):
+    """Email schema field
+
+    NOTE: This is an "almost" copy of plone.schema.email.Email, but inherits
+     from TextLineField instead of NativeStringLine. Thereby, accepts (and
+     stores) unicode
+    """
+
+    def _validate(self, value):
+        super(EmailField, self)._validate(value)
+        if _isemail(value):
+            return
+
+        raise InvalidEmail(value)

--- a/src/senaite/core/schema/emailfield.py
+++ b/src/senaite/core/schema/emailfield.py
@@ -26,7 +26,7 @@ class EmailField(TextLineField):
 
     def _validate(self, value):
         super(EmailField, self)._validate(value)
-        if _isemail(value):
+        if not value or _isemail(value):
             return
 
         raise InvalidEmail(value)

--- a/src/senaite/core/schema/emailfield.py
+++ b/src/senaite/core/schema/emailfield.py
@@ -1,14 +1,11 @@
-import re
+# -*- coding: utf-8 -*-
 
+from bika.lims.api.mail import is_valid_email_address
 from plone.schema import _
 from senaite.core.schema.interfaces import IEmailField
 from senaite.core.schema.textlinefield import TextLineField
 from zope.interface import implementer
 from zope.schema.interfaces import ValidationError
-
-# Taken from http://www.regular-expressions.info/email.html
-_isemail = r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}"
-_isemail = re.compile(_isemail).match
 
 
 class InvalidEmail(ValidationError):
@@ -26,7 +23,7 @@ class EmailField(TextLineField):
 
     def _validate(self, value):
         super(EmailField, self)._validate(value)
-        if not value or _isemail(value):
+        if not value or is_valid_email_address(value):
             return
 
         raise InvalidEmail(value)

--- a/src/senaite/core/schema/interfaces.py
+++ b/src/senaite/core/schema/interfaces.py
@@ -26,6 +26,8 @@ from zope.schema.interfaces import IField
 from zope.schema.interfaces import IInt
 from zope.schema.interfaces import IList
 from zope.schema.interfaces import INativeString
+from zope.schema.interfaces import INativeStringLine
+from zope.schema.interfaces import ITextLine
 from zope.schema.interfaces import ITimedelta
 
 
@@ -74,7 +76,7 @@ class IRichTextField(IRichText):
     """
 
 
-class IPhoneField(INativeString):
+class IPhoneField(ITextLine):
     """Input type "phone" widget
     """
 

--- a/src/senaite/core/schema/interfaces.py
+++ b/src/senaite/core/schema/interfaces.py
@@ -26,7 +26,6 @@ from zope.schema.interfaces import IField
 from zope.schema.interfaces import IInt
 from zope.schema.interfaces import IList
 from zope.schema.interfaces import INativeString
-from zope.schema.interfaces import INativeStringLine
 from zope.schema.interfaces import ITextLine
 from zope.schema.interfaces import ITimedelta
 

--- a/src/senaite/core/schema/interfaces.py
+++ b/src/senaite/core/schema/interfaces.py
@@ -75,6 +75,10 @@ class IRichTextField(IRichText):
     """Senaite rich text field
     """
 
+class IEmailField(ITextLine):
+    """Input type "email" widget
+    """
+
 
 class IPhoneField(ITextLine):
     """Input type "phone" widget

--- a/src/senaite/core/schema/phonefield.py
+++ b/src/senaite/core/schema/phonefield.py
@@ -18,14 +18,13 @@
 # Copyright 2018-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from senaite.core.schema.fields import BaseField
 from senaite.core.schema.interfaces import IPhoneField
+from senaite.core.schema.textlinefield import TextLineField
 from zope.interface import implementer
-from zope.schema import NativeString
 
 
 @implementer(IPhoneField)
-class PhoneField(NativeString, BaseField):
+class PhoneField(TextLineField):
     """A field that handles phone numbers
     """
     def _validate(self, value):

--- a/src/senaite/core/schema/textlinefield.py
+++ b/src/senaite/core/schema/textlinefield.py
@@ -3,10 +3,11 @@
 import six
 
 from Products.CMFPlone.utils import safe_unicode
+from senaite.core.schema.fields import BaseField
 from zope import schema
 
 
-class TextLineField(schema.TextLine):
+class TextLineField(schema.TextLine, BaseField):
     """A text field with no newlines and without leading and trailing spaces.
     """
 

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -2560,6 +2560,24 @@ And handles missing values for native string fields gracefully:
     >>> api.validate(supplier)
     {}
 
+Empties and unicode types are supported:
+
+    >>> supplier.phone = u""
+    >>> api.validate(supplier)
+    {}
+
+    >>> supplier.phone=u"612345678"
+    >>> api.validate(supplier)
+    {}
+
+    >>> supplier.email = u""
+    >>> api.validate(supplier)
+    {}
+
+    >>> supplier.email=u"my@email.com"
+    >>> api.validate(supplier)
+    {}
+
 It is also possible to validate standard AT content types:
 
     >>> client = self.portal.clients["client-1"]

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -2552,6 +2552,10 @@ And handles missing values for native string fields gracefully:
     >>> api.validate(supplier)
     {'email': u'wrong'}
 
+    >>> supplier.email = "wrong@email"
+    >>> api.validate(supplier)
+    {'email': u'wrong@email'}
+
     >>> supplier.email = ""
     >>> api.validate(supplier)
     {}


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`NativeString` and `NativeStringField` fields only support `str` types. However, for compatibility with the legacy AT behavior, the jsonapi and other related logic assume that field values are always stored as Unicode, while getters return the value converted to UTF-8.

This Pull Request updates the core's `PhoneField` type to follow this principle, thereby preventing `WrongType` or `WrongContainedType` errors during object creation or update.

> [!Note]
> This `WrongContainedType` was detected for [`additional_phone_numbers` field](https://github.com/senaite/senaite.patient/blob/6ba30f35ad72c8725a57b12162e3031a12fe7893/src/senaite/patient/content/patient.py#L282-L294) when trying to create a Patient via jsonapi. The `value_type` of this `DataGriedField` is [`IAdditionalPhoneNumbersSchema`](https://github.com/senaite/senaite.patient/blob/6ba30f35ad72c8725a57b12162e3031a12fe7893/src/senaite/patient/content/schema.py#L85-L111), whose `phone` subfield is from `PhoneField` type.

## Current behavior before PR

Validator rises a `WrongType` error when a `unicode` value is set for `PhoneField` or `EmailField`

## Desired behavior after PR is merged

Validator does not fail when a `unicode` value is set for `PhoneField` or `EmailField`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
