### PR TITLE
Fix KeyError in DX address widget country lookup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2802 Fix KeyError in DX address widget country lookup
 - #2797 Fix sticker rendering error when no configured template was found
 - #2793 Fix APIError: Expected string type, got '<type 'NoneType'>'
 - #2792 Add setting to trigger transition events on sample creation

--- a/src/senaite/core/z3cform/widgets/address.py
+++ b/src/senaite/core/z3cform/widgets/address.py
@@ -230,7 +230,7 @@ class AddressWidget(HTMLFormElement, Widget):
         sub2 = {}
 
         for item in self.get_value():
-            country = item.get("country")
+            country = api.safe_unicode(item.get("country", ""))
             if country and country not in sub1:
                 subdivisions = geo.get_subdivisions(country, [])
                 sub1[country] = map(lambda sub: sub.name, subdivisions)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a `KeyError` that is raised for migrated contacts, where the country comes in as a UTF8 encoded string, but `geo.get_subdivisions(country, []))` converts it into unicode.

<img width="802" height="719" alt="SCR-20251027-txxp" src="https://github.com/user-attachments/assets/c430a87f-3f37-489b-9631-b12f053374a1" />

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module plone.z3cform.layout, line 63, in __call__
  Module plone.z3cform.layout, line 57, in update
  Module z3c.form.form, line 162, in render
  Module zope.browserpage.viewpagetemplatefile, line 49, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module 1431f6543453f9b8a49498c017d18d40, line 115, in render
  Module 73ecf953a65ae4d6915b8a3970538476, line 2202, in render_titlelessform
  Module 73ecf953a65ae4d6915b8a3970538476, line 728, in render_fields
  Module 73ecf953a65ae4d6915b8a3970538476, line 150, in render_widget_rendering
  Module 73ecf953a65ae4d6915b8a3970538476, line 1022, in render_field
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module zope.browserpage.simpleviewclass, line 41, in __call__
  Module zope.browserpage.viewpagetemplatefile, line 81, in __call__
  Module zope.browserpage.viewpagetemplatefile, line 49, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 192, in render
  Module 435522afe45de9a0118fa4baec5cde5b, line 1144, in render
  Module 435522afe45de9a0118fa4baec5cde5b, line 603, in render_widget_wrapper
  Module zope.tales.expressions, line 250, in __call__
  Module Products.PageTemplates.Expressions, line 225, in _eval
  Module Products.PageTemplates.Expressions, line 155, in render
  Module z3c.form.widget, line 154, in render
  Module zope.browserpage.viewpagetemplatefile, line 49, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 215, in render
  Module chameleon.template, line 192, in render
  Module bccebaf36798ef4ea619b14550d0ce61, line 116, in render
  Module zope.tales.pythonexpr, line 73, in __call__
   - __traceback_info__: (view.get_input_widget_attributes()) Module <string>, line 1, in <module> Module senaite.core.z3cform.widgets.address, line 241, in get_input_widget_attributes KeyError: '\xc3\x85land Islands'
```

## Desired behavior after PR is merged



--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
