### PR TITLE
Allow to skip analyses in WF states on copy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2803 Allow to skip analyses in WF states on copy
 - #2800 Fix WrongContainedType on object creation/update via jsonapi
 - #2799 Fix Reference Sample import supplier data
 - #2797 Fix sticker rendering error when no configured template was found

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -403,11 +403,18 @@ class AnalysisRequestAddView(BrowserView):
                     value = self.get_default_value(
                         field, ar_context, arnum=arnum)
 
-                if fieldname == "Analyses":
+                if fieldname == "Analyses" and value:
                     skip_states = self.get_skip_analyses_states()
                     # filter out analyses in defined WF states, e.g. rejected
-                    value = filter(lambda x: api.get_review_status(x)
-                                   not in skip_states, value)
+                    filtered = []
+                    # NOTE: we use a for loop here, because the filter() with a
+                    # lambda creates a closure which holds references to
+                    # persistent objects, which makes the tests fail
+                    for analysis in value:
+                        status = api.get_review_status(analysis)
+                        if status not in skip_states:
+                            filtered.append(analysis)
+                    value = filtered
 
                 # store the value on the new fieldname
                 new_fieldname = self.get_fieldname(field, arnum)
@@ -606,7 +613,6 @@ class AnalysisRequestAddView(BrowserView):
             widget_type = None
         return widget_type in ALLOW_MULTI_PASTE_WIDGET_TYPES
 
-    @viewcache.memoize
     def get_allowed_multi_paste_fields(self):
         """Returns a list of fields that allow multi paste
         """
@@ -614,7 +620,8 @@ class AnalysisRequestAddView(BrowserView):
         record = get_registry_record(key)
         if not record:
             return []
-        return record
+        # convert to plain list to avoid persistent references
+        return list(record)
 
     def get_skip_analyses_states(self):
         """Returns a list of analyses WF states to skip on copy
@@ -623,7 +630,8 @@ class AnalysisRequestAddView(BrowserView):
         record = get_registry_record(key)
         if not record:
             return []
-        return record
+        # convert to plain list to avoid persistent references
+        return list(record)
 
 
 class AnalysisRequestManageView(BrowserView):

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -616,7 +616,6 @@ class AnalysisRequestAddView(BrowserView):
             return []
         return record
 
-    @viewcache.memoize
     def get_skip_analyses_states(self):
         """Returns a list of analyses WF states to skip on copy
         """

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -403,18 +403,11 @@ class AnalysisRequestAddView(BrowserView):
                     value = self.get_default_value(
                         field, ar_context, arnum=arnum)
 
+                # Filter out analyses in certain workflow states when copying
                 if fieldname == "Analyses" and value:
                     skip_states = self.get_skip_analyses_states()
-                    # filter out analyses in defined WF states, e.g. rejected
-                    filtered = []
-                    # NOTE: we use a for loop here, because the filter() with a
-                    # lambda creates a closure which holds references to
-                    # persistent objects, which makes the tests fail
-                    for analysis in value:
-                        status = api.get_review_status(analysis)
-                        if status not in skip_states:
-                            filtered.append(analysis)
-                    value = filtered
+                    value = self.filter_objs_with_states(
+                        value, filter_states=skip_states)
 
                 # store the value on the new fieldname
                 new_fieldname = self.get_fieldname(field, arnum)
@@ -632,6 +625,24 @@ class AnalysisRequestAddView(BrowserView):
             return []
         # convert to plain list to avoid persistent references
         return list(record)
+
+    def filter_objs_with_states(self, objs, filter_states=None):
+        """Filter out objects that are in the given workflow states
+
+        :param objs: List of objects to filter
+        :param filter_states: List of workflow state IDs to exclude
+        :return: List of objects not in the filter_states
+        """
+        if not filter_states:
+            return objs
+        if not isinstance(filter_states, (list, tuple)):
+            return objs
+        filtered = []
+        for obj in objs:
+            status = api.get_review_status(obj)
+            if status not in filter_states:
+                filtered.append(obj)
+        return filtered
 
 
 class AnalysisRequestManageView(BrowserView):

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -402,6 +402,13 @@ class AnalysisRequestAddView(BrowserView):
                     # get the default value of this field
                     value = self.get_default_value(
                         field, ar_context, arnum=arnum)
+
+                if fieldname == "Analyses":
+                    skip_states = self.get_skip_analyses_states()
+                    # filter out analyses in defined WF states, e.g. rejected
+                    value = filter(lambda x: api.get_review_status(x)
+                                   not in skip_states, value)
+
                 # store the value on the new fieldname
                 new_fieldname = self.get_fieldname(field, arnum)
                 out[new_fieldname] = value
@@ -604,6 +611,16 @@ class AnalysisRequestAddView(BrowserView):
         """Returns a list of fields that allow multi paste
         """
         key = "sample_add_form_allow_multi_paste"
+        record = get_registry_record(key)
+        if not record:
+            return []
+        return record
+
+    @viewcache.memoize
+    def get_skip_analyses_states(self):
+        """Returns a list of analyses WF states to skip on copy
+        """
+        key = "sample_add_form_skip_analyses_in_states"
         record = get_registry_record(key)
         if not record:
             return []

--- a/src/senaite/core/config/registry.py
+++ b/src/senaite/core/config/registry.py
@@ -21,3 +21,5 @@
 CLIENT_LANDING_PAGE = "client_landing_page"
 
 WS_PRINT_TMPL_RECORD = "worksheet_print_templates_order"
+
+SKIP_ANALYSES_STATES_ON_COPY = ["rejected"]

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2707</version>
+  <version>2708</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/registry/schema.py
+++ b/src/senaite/core/registry/schema.py
@@ -21,8 +21,8 @@
 from bika.lims import senaiteMessageFactory as _
 from plone.autoform import directives
 from plone.supermodel import model
+from senaite.core.config.registry import SKIP_ANALYSES_STATES_ON_COPY
 from z3c.form.browser.checkbox import CheckBoxFieldWidget
-
 from zope import schema
 
 
@@ -376,9 +376,26 @@ class ISampleRegistry(ISenaiteRegistry):
             default=u"Samples"
         ),
         fields=[
+            "sample_add_form_skip_analyses_in_states",
             "sample_add_form_allow_multi_paste",
             "trigger_events_on_sample_creation",
         ],
+    )
+
+    sample_add_form_skip_analyses_in_states = schema.List(
+        title=_(
+            u"label_registry_sample_add_skip_analyses_in_states",
+            default=u"Skip analyses workflow states on copy"
+        ),
+        description=_(
+            u"description_registry_sample_add_skip_analyses_in_states",
+            default=u"Add all analyses workflow states that should be "
+                    u"skipped when copying analyses to a new sample in the "
+                    u"sample add form."
+        ),
+        value_type=schema.ASCIILine(),
+        required=False,
+        default=SKIP_ANALYSES_STATES_ON_COPY,
     )
 
     sample_add_form_allow_multi_paste = schema.List(

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -3,6 +3,14 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.7.0: Add registry key to skip analyses in defined WF states"
+      description="Allows to define WF states for Analyses to skip for new copies, e.g. rejected etc."
+      source="2707"
+      destination="2708"
+      handler=".v02_07_000.import_registry"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Add registry key for trigger events on sample creation"
       description="Allows to define if after and before events have to be triggered on sample creation"
       source="2706"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR allows to define WF states for Analyses that should **not** be copied for new samples:

<img width="1440" height="446" alt="SCR-20251028-jgcm" src="https://github.com/user-attachments/assets/6c8b9c84-f77c-4d96-888e-97f6e65f3286" />

## Current behavior before PR

Rejected analyses from the source sample are copied over to the new sample.
It is not possible to define Analyses States to ignore/skip

## Desired behavior after PR is merged

Rejected analyses are not copied by default to the new sample.
It is possible in the registry to define additional WF states for Analyses to ignore/skip


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
