### PR TITLE
Allow to skip analyses from partitions on copy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2804 Allow to skip analyses from partitions on copy
 - #2803 Allow to skip analyses in WF states on copy
 - #2800 Fix WrongContainedType on object creation/update via jsonapi
 - #2799 Fix Reference Sample import supplier data

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2803 Allow to skip analyses in WF states on copy
 - #2800 Fix WrongContainedType on object creation/update via jsonapi
 - #2799 Fix Reference Sample import supplier data
 - #2797 Fix sticker rendering error when no configured template was found

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -409,6 +409,10 @@ class AnalysisRequestAddView(BrowserView):
                     value = self.filter_objs_with_states(
                         value, filter_states=skip_states)
 
+                    # Filter out partition analyses if configured
+                    if self.get_skip_partition_analyses() and source:
+                        value = self.filter_partition_analyses(value, source)
+
                 # store the value on the new fieldname
                 new_fieldname = self.get_fieldname(field, arnum)
                 out[new_fieldname] = value
@@ -626,6 +630,13 @@ class AnalysisRequestAddView(BrowserView):
         # convert to plain list to avoid persistent references
         return list(record)
 
+    def get_skip_partition_analyses(self):
+        """Returns whether to skip partition analyses on copy
+        """
+        key = "sample_add_form_skip_partition_analyses"
+        record = get_registry_record(key)
+        return bool(record)
+
     def filter_objs_with_states(self, objs, filter_states=None):
         """Filter out objects that are in the given workflow states
 
@@ -642,6 +653,35 @@ class AnalysisRequestAddView(BrowserView):
             status = api.get_review_status(obj)
             if status not in filter_states:
                 filtered.append(obj)
+        return filtered
+
+    def filter_partition_analyses(self, analyses, source):
+        """Filter out analyses that belong to partitions
+
+        Only keeps analyses that directly belong to the source sample.
+        Analyses from partitions are identified by checking if they are
+        direct children of the source sample.
+
+        :param analyses: List of analysis brains/objects to filter
+        :param source: The source sample object
+        :return: List of analyses that belong directly to the source sample
+        """
+        if not analyses or not source:
+            return analyses
+
+        # Get the physical paths of analyses that directly belong to the source
+        source_analysis_paths = set()
+        for analysis in source.objectValues("Analysis"):
+            source_analysis_paths.add(api.get_path(analysis))
+
+        # Filter the analyses to keep only those in the source
+        filtered = []
+        for analysis in analyses:
+            # Get the object if it's a brain
+            analysis_path = api.get_path(analysis)
+            if analysis_path in source_analysis_paths:
+                filtered.append(analysis)
+
         return filtered
 
 

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -403,11 +403,18 @@ class AnalysisRequestAddView(BrowserView):
                     value = self.get_default_value(
                         field, ar_context, arnum=arnum)
 
-                if fieldname == "Analyses":
+                if fieldname == "Analyses" and value:
                     skip_states = self.get_skip_analyses_states()
                     # filter out analyses in defined WF states, e.g. rejected
-                    value = filter(lambda x: api.get_review_status(x)
-                                   not in skip_states, value)
+                    filtered = []
+                    # NOTE: we use a for loop here, because the filter() with a
+                    # lambda creates a closure which holds references to
+                    # persistent objects, which makes the tests fail
+                    for analysis in value:
+                        status = api.get_review_status(analysis)
+                        if status not in skip_states:
+                            filtered.append(analysis)
+                    value = filtered
 
                 # store the value on the new fieldname
                 new_fieldname = self.get_fieldname(field, arnum)
@@ -606,7 +613,6 @@ class AnalysisRequestAddView(BrowserView):
             widget_type = None
         return widget_type in ALLOW_MULTI_PASTE_WIDGET_TYPES
 
-    @viewcache.memoize
     def get_allowed_multi_paste_fields(self):
         """Returns a list of fields that allow multi paste
         """
@@ -614,7 +620,8 @@ class AnalysisRequestAddView(BrowserView):
         record = get_registry_record(key)
         if not record:
             return []
-        return record
+        # convert to plain list to avoid persistent references
+        return list(record)
 
     def get_skip_analyses_states(self):
         """Returns a list of analyses WF states to skip on copy
@@ -623,7 +630,8 @@ class AnalysisRequestAddView(BrowserView):
         record = get_registry_record(key)
         if not record:
             return []
-        return record
+        # convert to plain list to avoid persistent references
+        return list(record)
 
 
 class AnalysisRequestManageView(BrowserView):

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -616,7 +616,6 @@ class AnalysisRequestAddView(BrowserView):
             return []
         return record
 
-    @viewcache.memoize
     def get_skip_analyses_states(self):
         """Returns a list of analyses WF states to skip on copy
         """

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -403,18 +403,11 @@ class AnalysisRequestAddView(BrowserView):
                     value = self.get_default_value(
                         field, ar_context, arnum=arnum)
 
+                # Filter out analyses in certain workflow states when copying
                 if fieldname == "Analyses" and value:
                     skip_states = self.get_skip_analyses_states()
-                    # filter out analyses in defined WF states, e.g. rejected
-                    filtered = []
-                    # NOTE: we use a for loop here, because the filter() with a
-                    # lambda creates a closure which holds references to
-                    # persistent objects, which makes the tests fail
-                    for analysis in value:
-                        status = api.get_review_status(analysis)
-                        if status not in skip_states:
-                            filtered.append(analysis)
-                    value = filtered
+                    value = self.filter_objs_with_states(
+                        value, filter_states=skip_states)
 
                 # store the value on the new fieldname
                 new_fieldname = self.get_fieldname(field, arnum)
@@ -632,6 +625,24 @@ class AnalysisRequestAddView(BrowserView):
             return []
         # convert to plain list to avoid persistent references
         return list(record)
+
+    def filter_objs_with_states(self, objs, filter_states=None):
+        """Filter out objects that are in the given workflow states
+
+        :param objs: List of objects to filter
+        :param filter_states: List of workflow state IDs to exclude
+        :return: List of objects not in the filter_states
+        """
+        if not filter_states:
+            return objs
+        if not isinstance(filter_states, (list, tuple)):
+            return objs
+        filtered = []
+        for obj in objs:
+            status = api.get_review_status(obj)
+            if status not in filter_states:
+                filtered.append(obj)
+        return filtered
 
 
 class AnalysisRequestManageView(BrowserView):

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -402,6 +402,13 @@ class AnalysisRequestAddView(BrowserView):
                     # get the default value of this field
                     value = self.get_default_value(
                         field, ar_context, arnum=arnum)
+
+                if fieldname == "Analyses":
+                    skip_states = self.get_skip_analyses_states()
+                    # filter out analyses in defined WF states, e.g. rejected
+                    value = filter(lambda x: api.get_review_status(x)
+                                   not in skip_states, value)
+
                 # store the value on the new fieldname
                 new_fieldname = self.get_fieldname(field, arnum)
                 out[new_fieldname] = value
@@ -604,6 +611,16 @@ class AnalysisRequestAddView(BrowserView):
         """Returns a list of fields that allow multi paste
         """
         key = "sample_add_form_allow_multi_paste"
+        record = get_registry_record(key)
+        if not record:
+            return []
+        return record
+
+    @viewcache.memoize
+    def get_skip_analyses_states(self):
+        """Returns a list of analyses WF states to skip on copy
+        """
+        key = "sample_add_form_skip_analyses_in_states"
         record = get_registry_record(key)
         if not record:
             return []

--- a/src/senaite/core/config/registry.py
+++ b/src/senaite/core/config/registry.py
@@ -21,3 +21,5 @@
 CLIENT_LANDING_PAGE = "client_landing_page"
 
 WS_PRINT_TMPL_RECORD = "worksheet_print_templates_order"
+
+SKIP_ANALYSES_STATES_ON_COPY = ["rejected"]

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2707</version>
+  <version>2708</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2708</version>
+  <version>2709</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/registry/schema.py
+++ b/src/senaite/core/registry/schema.py
@@ -21,8 +21,8 @@
 from bika.lims import senaiteMessageFactory as _
 from plone.autoform import directives
 from plone.supermodel import model
+from senaite.core.config.registry import SKIP_ANALYSES_STATES_ON_COPY
 from z3c.form.browser.checkbox import CheckBoxFieldWidget
-
 from zope import schema
 
 
@@ -376,9 +376,26 @@ class ISampleRegistry(ISenaiteRegistry):
             default=u"Samples"
         ),
         fields=[
+            "sample_add_form_skip_analyses_in_states",
             "sample_add_form_allow_multi_paste",
             "trigger_events_on_sample_creation",
         ],
+    )
+
+    sample_add_form_skip_analyses_in_states = schema.List(
+        title=_(
+            u"label_registry_sample_add_skip_analyses_in_states",
+            default=u"Skip analyses workflow states on copy"
+        ),
+        description=_(
+            u"description_registry_sample_add_skip_analyses_in_states",
+            default=u"Add all analyses workflow states that should be "
+                    u"skipped when copying analyses to a new sample in the "
+                    u"sample add form."
+        ),
+        value_type=schema.ASCIILine(),
+        required=False,
+        default=SKIP_ANALYSES_STATES_ON_COPY,
     )
 
     sample_add_form_allow_multi_paste = schema.List(

--- a/src/senaite/core/registry/schema.py
+++ b/src/senaite/core/registry/schema.py
@@ -376,10 +376,26 @@ class ISampleRegistry(ISenaiteRegistry):
             default=u"Samples"
         ),
         fields=[
+            "sample_add_form_skip_partition_analyses",
             "sample_add_form_skip_analyses_in_states",
             "sample_add_form_allow_multi_paste",
             "trigger_events_on_sample_creation",
         ],
+    )
+
+    sample_add_form_skip_partition_analyses = schema.Bool(
+        title=_(
+            u"label_registry_sample_add_skip_partition_analyses",
+            default=u"Skip partition analyses on copy"
+        ),
+        description=_(
+            u"description_registry_sample_add_skip_partition_analyses",
+            default=u"When enabled, analyses from partitions will be excluded "
+                    u"when copying a sample. Only analyses that directly belong "
+                    u"to the source sample will be copied to the new sample."
+        ),
+        default=False,
+        required=False,
     )
 
     sample_add_form_skip_analyses_in_states = schema.List(

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -3,6 +3,14 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.7.0: Add registry key to skip analyses in defined WF states"
+      description="Allows to define WF states for Analyses to skip for new copies, e.g. rejected etc."
+      source="2707"
+      destination="2708"
+      handler=".v02_07_000.import_registry"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Add registry key for trigger events on sample creation"
       description="Allows to define if after and before events have to be triggered on sample creation"
       source="2706"

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -3,6 +3,14 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.7.0: Add registry key to skip partition analyses on copy"
+      description="Allows to skip analyses from partitions when copying a sample"
+      source="2708"
+      destination="2709"
+      handler=".v02_07_000.import_registry"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Add registry key to skip analyses in defined WF states"
       description="Allows to define WF states for Analyses to skip for new copies, e.g. rejected etc."
       source="2707"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**☝️ NOTE:** Please merge #2803 before this one.

This PR allows to skip analyses from partitions on copy.

<img width="1709" height="281" alt="SCR-20251028-liez" src="https://github.com/user-attachments/assets/a25e7ec3-178a-4781-b091-68ba4b48ad05" />

## Current behavior before PR

Analyses from partitions are always copied for new samples

## Desired behavior after PR is merged

Analyses from partitions are not copied for new samples if disabled in the registry

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
