### PR TITLE
Allow to create sample partitions on copy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2806 Allow to create sample partitions on copy
 - #2804 Allow to skip analyses from partitions on copy
 - #2803 Allow to skip analyses in WF states on copy
 - #2802 Fix KeyError in DX address widget country lookup

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -2014,7 +2014,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         """
         samples = []
         request = self.request
-        for num, record in enumerate(records):
+        for record in records:
             client_uid = record.get("Client")
             client = self.get_object_by_uid(client_uid)
             if not client:

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -53,12 +53,14 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from senaite.core.api import dtime
 from senaite.core.catalog import CONTACT_CATALOG
 from senaite.core.catalog import SETUP_CATALOG
+from senaite.core.interfaces import IAfterCreateSampleHook
 from senaite.core.p3compat import cmp
 from senaite.core.permissions import TransitionMultiResults
 from senaite.core.registry import get_registry_record
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getAdapters
 from zope.component import queryAdapter
+from zope.component import subscribers
 from zope.i18n.locales import locales
 from zope.i18nmessageid import Message
 from zope.interface import alsoProvides
@@ -391,6 +393,7 @@ class AnalysisRequestAddView(BrowserView):
             parent = None
             if source is not None:
                 parent = self.get_parent_ar(source)
+
             for field in fields:
                 value = None
                 fieldname = field.getName()
@@ -1955,6 +1958,9 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             # add the attachments to the record
             valid_record["attachments"] = filter(None, attachments)
 
+            # keep the `_source_uid` in the record for the create process
+            valid_record["_source_uid"] = record.get("_source_uid")
+
             # append the valid record to the list of valid records
             valid_records.append(valid_record)
 
@@ -2007,7 +2013,8 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         """Creates samples for the given records
         """
         samples = []
-        for record in records:
+        request = self.request
+        for num, record in enumerate(records):
             client_uid = record.get("Client")
             client = self.get_object_by_uid(client_uid)
             if not client:
@@ -2015,6 +2022,14 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
             # Pop the attachments
             attachments = record.pop("attachments", [])
+
+            # Pop the source UID
+            source_uid = record.pop("_source_uid", None)
+
+            # Fetch the source object
+            source = None
+            if source_uid:
+                source = api.get_object(source_uid)
 
             # Create as many samples as required
             num_samples = self.get_num_samples(record)
@@ -2024,6 +2039,11 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                 # Create the attachments
                 for attachment_record in attachments:
                     self.create_attachment(sample, attachment_record)
+
+                # Pass the new sample to all subscription hooks
+                hooks = subscribers((sample, request), IAfterCreateSampleHook)
+                for hook in hooks:
+                    hook.update(sample, source=source)
 
                 transaction.savepoint(optimistic=True)
                 samples.append(sample)

--- a/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/src/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -352,6 +352,19 @@
         <input type="hidden" id="ar_count" name="ar_count"
                tal:attributes="value view/ar_count"/>
 
+        <!-- Hidden fields for source UIDs (for partition copying) -->
+        <tal:source_uids tal:repeat="arnum python:range(view.ar_count)"
+                         tal:define="copy_from python:view.get_copy_from()">
+          <tal:source_uid tal:define="source_uid_key python:'_source_uid-{}'.format(arnum);
+                                      source_obj python:copy_from.get(arnum);
+                                      source_uid python:source_obj.UID() if source_obj else None">
+            <input type="hidden"
+                   tal:condition="source_uid"
+                   tal:attributes="name source_uid_key;
+                                   value source_uid"/>
+          </tal:source_uid>
+        </tal:source_uids>
+
         <ul class="nav nav-tabs float-right" id="sample-tabs" style="margin-bottom:-1px;">
           <tal:columns tal:repeat="arnum python:range(view.ar_count)">
             <li class="nav-item" tal:attributes="class string:nav-item nav-item-${arnum}">

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -132,7 +132,8 @@ def create_analysisrequest(client, request, values, analyses=None,
     if parent_sample:
         # Always set partition to received
         date_received = parent_sample.getDateReceived()
-        receive_sample(ar, date_received=date_received)
+        if date_received:
+            receive_sample(ar, date_received=date_received)
 
     if not IReceived.providedBy(ar):
         setup = api.get_setup()

--- a/src/senaite/core/interfaces/__init__.py
+++ b/src/senaite/core/interfaces/__init__.py
@@ -504,3 +504,15 @@ class IWorksheetTemplates(Interface):
 class IWorksheetTemplate(Interface):
     """Marker interface for Worksheet Template
     """
+
+
+class IAfterCreateSampleHook(Interface):
+    """Subscription adapter after the sample was created
+    """
+    def update(sample, source=None):
+        """Update the sample after it was created
+
+        :param sample: The new created sample
+        :param source: The source sample from where this sample was copied,
+                       otherwise None
+        """

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2709</version>
+  <version>2710</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/registry/schema.py
+++ b/src/senaite/core/registry/schema.py
@@ -376,11 +376,28 @@ class ISampleRegistry(ISenaiteRegistry):
             default=u"Samples"
         ),
         fields=[
+            "sample_add_form_copy_partitions",
             "sample_add_form_skip_partition_analyses",
             "sample_add_form_skip_analyses_in_states",
             "sample_add_form_allow_multi_paste",
             "trigger_events_on_sample_creation",
         ],
+    )
+
+    sample_add_form_copy_partitions = schema.Bool(
+        title=_(
+            u"label_registry_sample_add_copy_partitions",
+            default=u"Copy sample structure with partitions"
+        ),
+        description=_(
+            u"description_registry_sample_add_copy_partitions",
+            default=u"When enabled, copying a sample will also create partitions "
+                    u"matching the source sample structure. Each partition will be "
+                    u"created with the same configuration (sample type, container, "
+                    u"preservation) and analyses as the source partition."
+        ),
+        default=False,
+        required=False,
     )
 
     sample_add_form_skip_partition_analyses = schema.Bool(

--- a/src/senaite/core/subscribers/configure.zcml
+++ b/src/senaite/core/subscribers/configure.zcml
@@ -14,4 +14,11 @@
            Products.Archetypes.interfaces.IObjectInitializedEvent"
     handler=".client.on_client_created"/>
 
+  <!-- Sample subscription adapter to update the sample after it was created -->
+  <subscriber
+    for="bika.lims.interfaces.IAnalysisRequest
+         zope.publisher.interfaces.browser.IBrowserRequest"
+    provides="senaite.core.interfaces.IAfterCreateSampleHook"
+    factory=".sample.AfterCreateSampleHook"/>
+
 </configure>

--- a/src/senaite/core/subscribers/sample.py
+++ b/src/senaite/core/subscribers/sample.py
@@ -1,43 +1,73 @@
 # -*- coding: utf-8 -*-
 
+from bika.lims import api
 from bika.lims.utils.analysisrequest import create_partition
+from senaite.core import logger
 from senaite.core.interfaces import IAfterCreateSampleHook
 from senaite.core.registry import get_registry_record
 from zope.interface import implementer
-from bika.lims.utils.analysisrequest import receive_sample
+
+# Registry key constants
+REGISTRY_KEY_COPY_PARTITIONS = "sample_add_form_copy_partitions"
 
 
 @implementer(IAfterCreateSampleHook)
 class AfterCreateSampleHook(object):
-    """Copy samples structure with partitions
-    +"""
+    """Copy sample structure with partitions
+    """
+
     def __init__(self, sample, request):
         self.sample = sample
         self.request = request
 
     def update(self, sample, source=None):
         """Update handler
-        """
 
+        :param sample: The newly created sample
+        :param source: The source sample to copy from (optional)
+        """
         # Return immediately if we do not have a source sample
         # or the registry settings is set to False
         if not source or not self.get_copy_partitions():
             return
 
-        # get the partition config from the source sample
-        configs = self.get_partition_configurations(source)
-        # create the partitions in the created sample
-        self.create_partitions_from_config(sample, configs)
+        # Check if the source sample has partitions
+        if not self.has_partitions(source):
+            return
 
-        # immediately receive the sample
-        receive_sample(sample)
+        # Get the partition config from the source sample
+        configs = self.get_partition_configurations(source)
+
+        # Nothing to do if we have no configs
+        if not configs:
+            return
+
+        # Create the partitions in the target sample
+        self.create_partitions_from_config(sample, configs)
 
     def get_copy_partitions(self):
         """Returns whether to copy the sample structure with partitions
+
+        :return: Boolean indicating if partition copying is enabled
         """
-        key = "sample_add_form_copy_partitions"
-        record = get_registry_record(key)
+        record = get_registry_record(REGISTRY_KEY_COPY_PARTITIONS)
         return bool(record)
+
+    def has_partitions(self, sample):
+        """Check if the sample has partitions
+
+        :param source: The source sample object
+        :return: True if valid, False otherwise
+        """
+        if not sample:
+            return False
+
+        partitions = sample.getDescendantsUIDs()
+
+        if not partitions:
+            return False
+
+        return True
 
     def get_partition_configurations(self, source):
         """Extract partition configurations from the source sample
@@ -92,13 +122,17 @@ class AfterCreateSampleHook(object):
             return []
 
         created_partitions = []
-        for config in configurations:
+        for idx, config in enumerate(configurations):
             analyses = config.get("analyses", [])
-
             sample_type = config.get("sample_type")
             container = config.get("container")
             preservation = config.get("preservation")
             internal_use = config.get("internal_use")
+
+            logger.debug(
+                "Creating partition {} of {} for sample {}".format(
+                    idx + 1, len(configurations), api.get_id(primary_sample))
+            )
 
             # Create the partition
             partition = create_partition(

--- a/src/senaite/core/subscribers/sample.py
+++ b/src/senaite/core/subscribers/sample.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+
+from bika.lims.utils.analysisrequest import create_partition
+from senaite.core.interfaces import IAfterCreateSampleHook
+from senaite.core.registry import get_registry_record
+from zope.interface import implementer
+from bika.lims.utils.analysisrequest import receive_sample
+
+
+@implementer(IAfterCreateSampleHook)
+class AfterCreateSampleHook(object):
+    """Copy samples structure with partitions
+    +"""
+    def __init__(self, sample, request):
+        self.sample = sample
+        self.request = request
+
+    def update(self, sample, source=None):
+        """Update handler
+        """
+
+        # Return immediately if we do not have a source sample
+        # or the registry settings is set to False
+        if not source or not self.get_copy_partitions():
+            return
+
+        # get the partition config from the source sample
+        configs = self.get_partition_configurations(source)
+        # create the partitions in the created sample
+        self.create_partitions_from_config(sample, configs)
+
+        # immediately receive the sample
+        receive_sample(sample)
+
+    def get_copy_partitions(self):
+        """Returns whether to copy the sample structure with partitions
+        """
+        key = "sample_add_form_copy_partitions"
+        record = get_registry_record(key)
+        return bool(record)
+
+    def get_partition_configurations(self, source):
+        """Extract partition configurations from the source sample
+
+        Returns a list of dictionaries containing partition configuration:
+        - analyses: list of analysis objects
+        - sample_type: SampleType UID or None
+        - container: Container UID or None
+        - preservation: Preservation UID or None
+
+        :param source: The source sample object
+        :return: List of partition configuration dictionaries
+        """
+        if not source:
+            return []
+
+        # Get all partitions from the source
+        partitions = source.getDescendants(all_descendants=False)
+        if not partitions:
+            return []
+
+        configurations = []
+        for partition in partitions:
+            # Get analyses that belong to this partition
+            analyses = partition.getAnalyses(full_objects=True)
+
+            # Get partition-specific settings
+            sample_type = partition.getSampleType()
+            container = partition.getContainer()
+            preservation = partition.getPreservation()
+            internal_use = partition.getInternalUse()
+
+            config = {
+                "analyses": analyses,
+                "sample_type": sample_type,
+                "container": container,
+                "preservation": preservation,
+                "internal_use": internal_use,
+            }
+            configurations.append(config)
+
+        return configurations
+
+    def create_partitions_from_config(self, primary_sample, configurations):
+        """Create partitions for a sample based on configurations
+
+        :param primary_sample: The primary sample object
+        :param configurations: List of partition configuration dicts
+        :return: List of created partition objects
+        """
+        if not configurations:
+            return []
+
+        created_partitions = []
+        for config in configurations:
+            analyses = config.get("analyses", [])
+
+            sample_type = config.get("sample_type")
+            container = config.get("container")
+            preservation = config.get("preservation")
+            internal_use = config.get("internal_use")
+
+            # Create the partition
+            partition = create_partition(
+                analysis_request=primary_sample,
+                request=self.request,
+                analyses=analyses,
+                sample_type=sample_type,
+                container=container,
+                preservation=preservation,
+                internal_use=internal_use,
+            )
+            created_partitions.append(partition)
+
+        return created_partitions

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -3,6 +3,14 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.7.0: Add registry key to copy sample structure with partitions"
+      description="Allows to copy the entire sample structure including partitions when copying a sample"
+      source="2709"
+      destination="2710"
+      handler=".v02_07_000.import_registry"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Add registry key to skip partition analyses on copy"
       description="Allows to skip analyses from partitions when copying a sample"
       source="2708"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR allows to copy all partitions on copy.

<img width="1832" height="354" alt="SCR-20251030-lfud" src="https://github.com/user-attachments/assets/1b7e34db-f793-4073-ac88-0d18b9fcf0e3" />

It also introduces a new subscription adapter `IAfterCreateSampleHook` that can be used to modify sample attributes and contents *after* it was created, e.g. like creating the partitions or copy any additional contents, e.g. attachments etc., of the source over to the new sample.

## Current behavior before PR

Only the root sample is copied, even if it has partitions.

## Desired behavior after PR is merged

The entire partition structure is created on sample copy

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
