### PR TITLE
Fix traceback when emailing results report and email 'From' not set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2807 Fix traceback when emailing results report and email 'From' not set
 - #2806 Allow to create sample partitions on copy
 - #2804 Allow to skip analyses from partitions on copy
 - #2803 Allow to skip analyses in WF states on copy

--- a/src/bika/lims/browser/publish/emailview.py
+++ b/src/bika/lims/browser/publish/emailview.py
@@ -31,6 +31,7 @@ from bika.lims import _
 from bika.lims import api
 from bika.lims import logger
 from bika.lims.api import mail as mailapi
+from bika.lims.api.mail import is_valid_email_address
 from bika.lims.api.security import get_user
 from bika.lims.api.security import get_user_id
 from bika.lims.api.snapshot import take_snapshot
@@ -175,11 +176,19 @@ class EmailView(BrowserView):
         if not self.reports:
             message = _("No reports found")
             self.add_status_message(message, "error")
+        if not is_valid_email_address(self.email_sender_address):
+            message = _(
+                "The email 'From' address is invalid. Please verify the "
+                "\"Publication 'From' address\" in Setup > Notifications "
+                "and/or the \"Site 'From' address\" in Site Setup > Mail."
+            )
+            self.add_status_message(message, "error")
 
         if not all([self.email_recipients_and_responsibles,
                     self.email_subject,
                     self.email_body,
-                    self.reports]):
+                    self.reports,
+                    is_valid_email_address(self.email_sender_address)]):
             return False
         return True
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a traceback that pops up when the user tries to email a results report but the email 'Form' is empty or not valid. It displays a message instead.

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module bika.lims.browser.publish.emailview, line 84, in __call__
  Module bika.lims.browser.publish.emailview, line 141, in form_action_send
  Module bika.lims.browser.publish.emailview, line 550, in send_email
  Module bika.lims.api.mail, line 241, in send_email
  Module Products.MailHost.MailHost, line 214, in send
  Module Products.MailHost.MailHost, line 436, in _mungeHeaders
MailHostError: Message missing SMTP Header 'From'
```

## Desired behavior after PR is merged

<img width="727" height="85" alt="20251030171601" src="https://github.com/user-attachments/assets/89353dd0-4b45-4d9a-86b9-cd998401e8d2" />


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
