### PR TITLE
Prioritize after create sample susbcriber hooks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2809 Prioritize after create sample susbcriber hooks
 - #2808 Sticky form tabbing
 - #2807 Fix traceback when emailing results report and email 'From' not set
 - #2806 Allow to create sample partitions on copy

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -2042,7 +2042,10 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
                 # Pass the new sample to all subscription hooks
                 hooks = subscribers((sample, request), IAfterCreateSampleHook)
-                for hook in hooks:
+                # Lower sort keys are processed first
+                sorted_hooks = sorted(
+                    hooks, key=lambda x: api.to_float(getattr(x, "sort", 10)))
+                for hook in sorted_hooks:
                     hook.update(sample, source=source)
 
                 transaction.savepoint(optimistic=True)

--- a/src/senaite/core/subscribers/sample.py
+++ b/src/senaite/core/subscribers/sample.py
@@ -19,6 +19,7 @@ class AfterCreateSampleHook(object):
     def __init__(self, sample, request):
         self.sample = sample
         self.request = request
+        self.sort = 10
 
     def update(self, sample, source=None):
         """Update handler


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is an improvement for the `IAfterCreateSampleHook` that was introduced in #2806

## Current behavior before PR

Hooks are not processed in order

## Desired behavior after PR is merged

Hooks are processed according to their sort key.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
