### PR TITLE
Fixed typo in recalculation message ("Result recalucated" → "Result recalculated")

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2811 Fixed typo in recalculation message ("Result recalucated" → "Result recalculated")
 - #2809 Prioritize after create sample susbcriber hooks
 - #2808 Sticky form tabbing
 - #2807 Fix traceback when emailing results report and email 'From' not set

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- #2811 Fixed typo in recalculation message ("Result recalucated" → "Result recalculated")
+- #2811 Fix typo in recalculation message ("Result recalucated" → "Result recalculated")
 - #2809 Prioritize after create sample susbcriber hooks
 - #2808 Sticky form tabbing
 - #2807 Fix traceback when emailing results report and email 'From' not set

--- a/src/senaite/core/browser/listing/actions/analysis.py
+++ b/src/senaite/core/browser/listing/actions/analysis.py
@@ -37,4 +37,4 @@ class ActionView(BaseActionView):
             return self.message(
                 "Failed to recalculate result", False, title=title)
 
-        return self.message("Result recalucated", True, title=title)
+        return self.message("Result recalculated", True, title=title)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a minor typo in the `ActionView.recalculate()` method message string, where the user-facing message previously displayed `Result recalucated` instead of `Result recalculated`.

## Current behavior before PR
When recalculating results in the Analyses view, the confirmation message shows a spelling error:

> **Result recalucated**

## Desired behavior after PR is merged
After merging this PR, the message will display correctly as:

> **Result recalculated**

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
