### PR TITLE
Fix QR code render for multi-page stickers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 2.7.0 (unreleased)
 ------------------
-
+- #2817 Fix QR code render for multi-page stickers
 - #2812 Migrate MultiFile to Dexterity
 - #2815 Remove dependency to plone.app.jquerytools
 - #2816 Fix custom actions and behaviors are missing

--- a/src/senaite/core/browser/stickers/templates/stickers/QR_1x14mmx39mm.css
+++ b/src/senaite/core/browser/stickers/templates/stickers/QR_1x14mmx39mm.css
@@ -20,7 +20,7 @@ Sticker margins: 8mm, 1mm
     z-index: 1000;
 }
 
-.sticker .barcode {
+.sticker .qrcode {
     margin: 0 auto;
     padding: 1mm 0 !important;
     text-align: center;

--- a/src/senaite/core/browser/stickers/templates/stickers/QR_1x14mmx39mm.pt
+++ b/src/senaite/core/browser/stickers/templates/stickers/QR_1x14mmx39mm.pt
@@ -5,6 +5,7 @@
   <!-- QR Code -->
   <div class="qrcode"
        data-size="36"
+       data-render="image"
        tal:attributes="data-text python:sample_id;">
   </div>
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The 1x14mm QR sticker template does not render correctly to PDF if more than one number of copies is selected (the same error occurs if more than one sample is selected).

## Current behavior before PR
PDF rendering for 1 x 14 mm QR sticker template for multiple stickers only renders the first QR code, even though it displays correctly in the preview.

Preview:
<img width="389" height="532" alt="image" src="https://github.com/user-attachments/assets/1f4eeabe-fc06-4de7-94d7-a34b6b4f9587" />

Rendered:
<img width="141" height="591" alt="image" src="https://github.com/user-attachments/assets/c090db50-4ad9-4823-981e-45c296beff89" />

## Desired behavior after PR is merged
The QR code must be rendered on all stickers

## To reproduce de Error
Senaite 2.x docker
Import sample data
Create sample
Print sticker with qr template

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
