### PR TITLE
Fix UnicodeDecodeError if analysis unit contains unicode characters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 - #2818 Fix UnicodeDecodeError if analysis unit contains unicode characters
+- #2818 Fix UnicodeDecodeError if analysis unit contains unicode characters
 - #2812 Migrate MultiFile to Dexterity
 - #2815 Remove dependency to plone.app.jquerytools
 - #2816 Fix custom actions and behaviors are missing

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -883,9 +883,9 @@ class AnalysesView(ListingView):
         """Render HTML element for unit
         """
         if css_class is None:
-            css_class = "unit d-inline-block py-2 small text-secondary text-nowrap"
-        return "<span class='{css_class}'>{unit}</span>".format(
-            unit=unit, css_class=css_class)
+            css_class = u"unit d-inline-block py-2 small text-secondary text-nowrap"
+        return u"<span class='{css_class}'>{unit}</span>".format(
+            unit=safe_unicode(unit), css_class=css_class)
 
     def get_category_title(self, analysis):
         """Returns the title of the category the analysis is assigned to
@@ -1098,7 +1098,7 @@ class AnalysesView(ListingView):
 
         if is_editable and calculation:
             url = analysis_brain.getURL()
-            item["after"]["Result"] = item["after"].get("Result") or ""
+            item["after"]["Result"] = item["after"].get("Result") or u""
             item["after"]["Result"] += get_link(
                 "{}/action/recalculate".format(url),
                 value="<i class='small text-secondary fas fa-sync'></i>",


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a `UnicodeDecodeError` if the analysis unit contains unicode characters and is a calculation.

## Current behavior before PR

The following traceback occurs in the analyses listing:
```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.app.listing.view, line 246, in __call__
  Module senaite.app.listing.ajax, line 112, in handle_subpath
  Module senaite.core.decorators, line 40, in decorator
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 379, in ajax_folderitems
  Module senaite.app.listing.decorators, line 88, in wrapper
  Module senaite.app.listing.ajax, line 258, in get_folderitems
  Module bika.lims.browser.analyses.view, line 815, in folderitems
  Module senaite.app.listing.view, line 982, in folderitems
  Module bika.lims.browser.analyses.view, line 764, in folderitem
  Module bika.lims.browser.analyses.view, line 1105, in _folder_item_calculation
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 72: ordinal not in range(128)
```

## Desired behavior after PR is merged

Analyses get displayed correctly.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
