### PR TITLE
Fix multiuploads for cluster setups

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2819 Fix multiuploads for cluster setups
 - #2818 Fix UnicodeDecodeError if analysis unit contains unicode characters
 - #2812 Migrate MultiFile to Dexterity
 - #2815 Remove dependency to plone.app.jquerytools

--- a/src/senaite/core/subscribers/multiupload.py
+++ b/src/senaite/core/subscribers/multiupload.py
@@ -25,7 +25,7 @@ from bika.lims import logger
 from senaite.core.interfaces import IMultiUploadFileCreator
 from senaite.core.interfaces import IMultiUploadFileRemover
 from senaite.core.schema.interfaces import IMultiUploadField
-from senaite.core.z3cform.widgets.multiupload.handler import SESSION_KEY
+from senaite.core.z3cform.widgets.multiupload.storage import get_storage
 from zope.component import getAdapter
 from zope.component import getMultiAdapter
 
@@ -133,14 +133,8 @@ def process_multiupload_fields(obj, event):
     setattr(request, UPLOAD_PROCESSING_KEY, processing_objs)
 
     try:
-        # Get uploaded files from session
-        session = getattr(request, "SESSION", None)
-        if not session:
-            logger.info("No SESSION available, skipping upload processing")
-            return
-
-        # Get uploaded UUID -> file mapping data from session
-        uploaded_files = session.get(SESSION_KEY, {})
+        # Get the shared upload storage (cluster-safe)
+        storage = get_storage()
 
         # Get all MultiUploadField fields
         fields = get_multiupload_fields(obj)
@@ -170,10 +164,11 @@ def process_multiupload_fields(obj, event):
             # Create File/Image objects for each upload UUID
             created_uids = []
             for upload_uuid in upload_uuids:
-                file_data = uploaded_files.get(upload_uuid)
+                # Retrieve file data from shared storage
+                file_data = storage.retrieve(upload_uuid)
                 if not file_data:
                     logger.warning(
-                        "Upload data for UUID {} not found in session"
+                        "Upload data for UUID {} not found in storage"
                         .format(upload_uuid))
                     continue
 
@@ -183,6 +178,8 @@ def process_multiupload_fields(obj, event):
                     created_uids.append(uid)
                     # Mark created object as processing
                     processing_objs.add(uid)
+                    # Remove from storage after successful creation
+                    storage.remove(upload_uuid)
 
             # Combine submitted UIDs (existing) with newly created UIDs
             new_value = submitted_uids + created_uids

--- a/src/senaite/core/subscribers/multiupload.py
+++ b/src/senaite/core/subscribers/multiupload.py
@@ -62,12 +62,22 @@ def on_object_modified(obj, event):
     Also handles deletion of removed File/Image objects.
     """
 
-    # Prevent infinite recursion for deletion handler
+    # Early check: does object have MultiUploadField fields?
+    fields = get_multiupload_fields(obj)
+    if not fields:
+        return  # No multiupload fields, skip entirely
+
+    # Get request
     request = api.get_request()
     if not request:
         # Use test request if no real request is available (e.g., test setup)
         request = api.get_test_request()
 
+    # Check for upload data OR submitted UIDs (for deletion detection)
+    if not has_multiupload_activity(fields, request, obj):
+        return  # No multiupload activity
+
+    # Prevent infinite recursion for deletion handler
     processing_objs = getattr(request, UPLOAD_DELETING_KEY, set())
 
     obj_uid = api.get_uid(obj)
@@ -82,9 +92,6 @@ def on_object_modified(obj, event):
     setattr(request, UPLOAD_DELETING_KEY, processing_objs)
 
     try:
-        # Get all MultiUploadField fields
-        fields = get_multiupload_fields(obj)
-
         # Track current values before processing (for deletion detection)
         current_values = track_current_uids(fields, obj)
 
@@ -124,6 +131,19 @@ def process_multiupload_fields(obj, event):
         # Already processing this object, skip to prevent recursion
         return
 
+    # Get all MultiUploadField fields - early return if none
+    fields = get_multiupload_fields(obj)
+    if not fields:
+        return  # No fields to process
+
+    # Check for upload data - early return if none
+    if not has_upload_uuids(fields, request, obj):
+        return  # No upload data
+
+    # Determine form prefix (needed later for processing)
+    form_prefix = "form.widgets." if api.is_dexterity_content(obj) else ""
+
+    # NOW log (only if we're actually processing)
     logger.info("="*80)
     logger.info("process_multiupload_fields called for {}".format(
         api.get_path(obj)))
@@ -135,14 +155,6 @@ def process_multiupload_fields(obj, event):
     try:
         # Get the shared upload storage (cluster-safe)
         storage = get_storage()
-
-        # Get all MultiUploadField fields
-        fields = get_multiupload_fields(obj)
-
-        # z3c.form uses form prefixes for DX contents
-        form_prefix = ""
-        if api.is_dexterity_content(obj):
-            form_prefix = "form.widgets."
 
         # Process each MultiUploadField
         for name, field in fields.items():
@@ -293,6 +305,63 @@ def get_multiupload_fields(obj):
     fields = api.get_fields(obj)
     return {name: field for name, field in fields.items()
             if IMultiUploadField.providedBy(field)}
+
+
+def has_multiupload_activity(fields, request, obj):
+    """Check if there is any multiupload activity in the request
+
+    Checks for:
+    - New upload UUIDs in request (field.data parameter)
+    - Field submissions for deletion detection (field parameter)
+
+    :param fields: Dictionary of field name -> field pairs
+    :param request: The request object
+    :param obj: The object being processed
+    :returns: True if there's multiupload activity, False otherwise
+    """
+    if not fields:
+        return False
+
+    # Determine form prefix based on content type
+    form_prefix = "form.widgets." if api.is_dexterity_content(obj) else ""
+
+    for name in fields.keys():
+        # Check for new uploads
+        data_key = "{}{}.data".format(form_prefix, name)
+        if request.get(data_key):
+            return True
+
+        # Check for field submission (deletion scenario)
+        field_key = "{}{}".format(form_prefix, name)
+        if field_key in request.form:
+            return True
+
+    return False
+
+
+def has_upload_uuids(fields, request, obj):
+    """Check if there are upload UUIDs in the request
+
+    Only checks for new upload UUIDs (field.data parameter),
+    not field submissions.
+
+    :param fields: Dictionary of field name -> field pairs
+    :param request: The request object
+    :param obj: The object being processed
+    :returns: True if there are upload UUIDs, False otherwise
+    """
+    if not fields:
+        return False
+
+    # Determine form prefix based on content type
+    form_prefix = "form.widgets." if api.is_dexterity_content(obj) else ""
+
+    for name in fields.keys():
+        data_key = "{}{}.data".format(form_prefix, name)
+        if request.get(data_key):
+            return True
+
+    return False
 
 
 def track_current_uids(fields, obj):

--- a/src/senaite/core/tests/doctests/MultiUploadField.rst
+++ b/src/senaite/core/tests/doctests/MultiUploadField.rst
@@ -89,7 +89,7 @@ Create a client to hold test documents:
 
 
 Testing Temporary Upload Storage
----------------------------------
+--------------------------------
 
 Before simulating file uploads, let's test the storage directly:
 

--- a/src/senaite/core/tests/doctests/MultiUploadField.rst
+++ b/src/senaite/core/tests/doctests/MultiUploadField.rst
@@ -5,6 +5,10 @@ MultiUploadField is a field that allows multiple file uploads to be attached
 to a content object. Files are stored as separate File or Image objects within
 the container, and their UIDs are stored in the field.
 
+This test covers the complete upload workflow including the cluster-safe
+temporary storage mechanism that allows uploads to be shared across multiple
+ZEO client instances.
+
 Running this test from the buildout directory:
 
     bin/test test_textual_doctests -t MultiUploadField
@@ -84,6 +88,61 @@ Create a client to hold test documents:
     >>> client_path = api.get_path(client)
 
 
+Testing Temporary Upload Storage
+---------------------------------
+
+Before simulating file uploads, let's test the storage directly:
+
+    >>> from senaite.core.z3cform.widgets.multiupload.storage import get_storage
+
+    >>> storage = get_storage()
+
+Store a test upload:
+
+    >>> test_data = b"Test data for storage"
+    >>> success = storage.store(
+    ...     "test-storage-uuid",
+    ...     u"test.txt",
+    ...     "text/plain",
+    ...     test_data
+    ... )
+    >>> success
+    True
+
+    >>> transaction.commit()
+
+Retrieve the upload:
+
+    >>> retrieved = storage.retrieve("test-storage-uuid")
+    >>> retrieved["filename"]
+    u'test.txt'
+
+    >>> retrieved["content_type"]
+    'text/plain'
+
+    >>> retrieved["data"] == test_data
+    True
+
+    >>> "timestamp" in retrieved
+    True
+
+Remove the upload:
+
+    >>> removed = storage.remove("test-storage-uuid")
+    >>> removed
+    True
+
+Verify it's gone:
+
+    >>> storage.retrieve("test-storage-uuid") is None
+    True
+
+Attempt to retrieve non-existent upload:
+
+    >>> storage.retrieve("non-existent-uuid") is None
+    True
+
+
 Simulating File Upload
 ----------------------
 
@@ -96,34 +155,30 @@ Let's simulate the file upload process:
     >>> file_data_3 = b"PNG image data here"
 
 
-2. Store files in session (simulating upload handler):
+2. Store files in shared ZODB storage (simulating upload handler):
 
-    >>> from senaite.core.z3cform.widgets.multiupload.handler import SESSION_KEY
+    >>> from senaite.core.z3cform.widgets.multiupload.storage import get_storage
 
-    >>> session_data = {}
-    >>> request.SESSION = session_data
+    >>> storage = get_storage()
 
     >>> upload_uuid_1 = "test-uuid-1"
     >>> upload_uuid_2 = "test-uuid-2"
     >>> upload_uuid_3 = "test-uuid-3"
 
-    >>> session_data[SESSION_KEY] = {
-    ...     upload_uuid_1: {
-    ...         "filename": u"test1.txt",
-    ...         "content_type": "text/plain",
-    ...         "data": file_data_1,
-    ...     },
-    ...     upload_uuid_2: {
-    ...         "filename": u"test2.txt",
-    ...         "content_type": "text/plain",
-    ...         "data": file_data_2,
-    ...     },
-    ...     upload_uuid_3: {
-    ...         "filename": u"test3.png",
-    ...         "content_type": "image/png",
-    ...         "data": file_data_3,
-    ...     },
-    ... }
+Store each upload in the shared storage:
+
+    >>> storage.store(upload_uuid_1, u"test1.txt", "text/plain", file_data_1)
+    True
+
+    >>> storage.store(upload_uuid_2, u"test2.txt", "text/plain", file_data_2)
+    True
+
+    >>> storage.store(upload_uuid_3, u"test3.png", "image/png", file_data_3)
+    True
+
+Commit the transaction so the storage is persisted:
+
+    >>> transaction.commit()
 
 
 3. Simulate form submission with upload UUIDs:
@@ -140,11 +195,12 @@ Let's simulate the file upload process:
     >>> from senaite.core.interfaces import IMultiUploadFileCreator
     >>> from zope.component import getMultiAdapter
 
-Let's create the files using the adapter:
+Let's create the files using the adapter and retrieve from storage:
 
     >>> created_uids = []
     >>> for upload_uuid in [upload_uuid_1, upload_uuid_2, upload_uuid_3]:
-    ...     file_data_dict = session_data[SESSION_KEY][upload_uuid]
+    ...     # Retrieve file data from shared storage
+    ...     file_data_dict = storage.retrieve(upload_uuid)
     ...     filename = file_data_dict["filename"]
     ...     content_type = file_data_dict["content_type"]
     ...     data = file_data_dict["data"]
@@ -170,9 +226,23 @@ Let's create the files using the adapter:
     ...         obj = api.create(client, portal_type, title=filename, file=blob)
     ...
     ...     created_uids.append(api.get_uid(obj))
+    ...
+    ...     # Clean up storage after creating the file
+    ...     removed = storage.remove(upload_uuid)
 
     >>> len(created_uids)
     3
+
+Verify uploads were removed from storage after processing:
+
+    >>> storage.retrieve(upload_uuid_1) is None
+    True
+
+    >>> storage.retrieve(upload_uuid_2) is None
+    True
+
+    >>> storage.retrieve(upload_uuid_3) is None
+    True
 
 
 5. Set the field value with the created UIDs:

--- a/src/senaite/core/z3cform/widgets/multiupload/README.md
+++ b/src/senaite/core/z3cform/widgets/multiupload/README.md
@@ -1,0 +1,409 @@
+# MultiUpload Widget
+
+The MultiUpload widget provides a user-friendly interface for uploading multiple files (images or documents) to SENAITE objects. It features drag-and-drop functionality, preview thumbnails, and seamless integration with SENAITE's content types.
+
+## Overview
+
+The widget handles file uploads in two phases:
+
+1. **Upload Phase**: Files are uploaded via AJAX and stored temporarily
+2. **Save Phase**: When the form is saved, temporary uploads are converted to permanent File/Image objects
+
+This two-phase approach provides immediate user feedback during uploads while maintaining transaction safety during form submission.
+
+## Architecture
+
+### Components
+
+**Widget (`widget.py`)**
+- z3c.form widget for MultiUploadField
+- Renders the React-based upload interface
+- Manages field data (list of File/Image UIDs)
+
+**Upload Handler (`handler.py`)**
+- Browser view: `@@multiupload_handler`
+- Accepts AJAX file uploads from the widget
+- Stores files temporarily with a unique UUID
+- Returns upload metadata to the client
+
+**Temporary Storage (`storage.py`)**
+- Cluster-safe ZODB-based storage for uploaded files
+- Uses portal annotations with OOBTree for concurrent access
+- Self-cleaning: automatically removes expired uploads
+- Shared across all ZEO client instances
+
+**Event Subscriber (`subscribers/multiupload.py`)**
+- Triggered on object add/modify events
+- Converts temporary uploads to permanent File/Image objects
+- Handles file deletion when removed from fields
+- Cleans up temporary storage after processing
+
+### Data Flow
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1. User uploads file via drag & drop                       │
+└────────────────────────┬────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 2. AJAX POST to @@multiupload_handler                      │
+│    - File data sent to handler                             │
+└────────────────────────┬────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 3. Handler stores file in temporary ZODB storage           │
+│    - Generates UUID (e.g., "a1b2c3d4-...")                 │
+│    - Stores: {filename, content_type, data, timestamp}     │
+└────────────────────────┬────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 4. Handler returns UUID to client                          │
+│    Response: {"id": "uuid", "filename": "...", ...}        │
+└────────────────────────┬────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 5. Widget stores UUID in hidden field                      │
+│    - Displayed as preview/thumbnail to user                │
+│    - Multiple files = multiple UUIDs                       │
+└────────────────────────┬────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 6. User clicks "Save" on form                              │
+│    - Form submits with UUIDs + existing File UIDs          │
+└────────────────────────┬────────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 7. Event handler processes MultiUploadField fields         │
+│    - Retrieves file data from storage by UUID              │
+│    - Creates File/Image objects as children                │
+│    - Updates field with new File UIDs                      │
+│    - Removes temporary uploads from storage                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Usage
+
+### Defining a MultiUpload Field
+
+```python
+from senaite.core.schema import MultiUploadField
+from zope.interface import Interface
+
+class IMyContent(Interface):
+    """My content type schema"""
+
+    attachments = MultiUploadField(
+        title=u"Attachments",
+        description=u"Upload multiple files or images",
+        required=False,
+    )
+```
+
+### Accessing Uploaded Files
+
+```python
+from bika.lims import api
+
+# Get the object
+obj = api.get_object(brain_or_uid)
+
+# Get uploaded files (returns list of File/Image objects)
+files = obj.attachments
+
+# Iterate through files
+for file_obj in files:
+    filename = file_obj.file.filename
+    content_type = file_obj.file.contentType
+    size = file_obj.file.getSize()
+    data = file_obj.file.data
+```
+
+### Programmatic File Addition
+
+```python
+from senaite.core.interfaces import IMultiUploadFileCreator
+from zope.component import getMultiAdapter
+
+# Get the field
+field = IMyContent["attachments"]
+
+# Get the creator adapter
+creator = getMultiAdapter((obj, field), IMultiUploadFileCreator)
+
+# Create a File object
+file_obj = creator.create(
+    filename=u"document.pdf",
+    content_type="application/pdf",
+    data=binary_data
+)
+
+# Add to field
+current = obj.attachments or []
+obj.attachments = current + [file_obj]
+```
+
+## Temporary Storage
+
+### How It Works
+
+Uploaded files are stored temporarily in a shared ZODB container until the form is saved:
+
+- **Storage Location**: `IAnnotations(portal)["senaite.core.multiupload.storage"]`
+- **Structure**: OOBTree with UUID keys
+- **Expiration**: 2 hours (default)
+- **Self-Cleaning**: Every 100 operations
+
+### Cluster Safety
+
+The storage is designed for clustered environments:
+
+- **Shared via ZEO**: All instances access the same ZODB container
+- **Concurrent Safe**: OOBTree handles concurrent writes with ZODB conflict resolution
+- **No Sticky Sessions**: Uploads and form saves can hit different instances
+
+### Concurrency Model
+
+Multiple users can upload simultaneously without conflicts:
+
+```python
+# User A uploads
+container["uuid-a"] = UploadRecord(...)  # Stored
+
+# User B uploads (concurrent)
+container["uuid-b"] = UploadRecord(...)  # Stored
+
+# No conflict: Different keys, OOBTree merges automatically
+```
+
+### Self-Cleaning
+
+Inspired by `plone.memoize.CleanupDict`:
+
+1. Counter increments on each `store()` operation
+2. Every 100 operations, cleanup runs automatically
+3. Uploads older than 2 hours are removed
+4. Counter resets after cleanup
+
+## Configuration
+
+### Storage Settings
+
+Edit `storage.py` to adjust:
+
+```python
+# Maximum age before uploads are removed (seconds)
+DEFAULT_EXPIRATION_SECONDS = 7200  # 2 hours
+
+# Operations between automatic cleanups
+CLEANUP_INTERVAL = 100
+```
+
+### Manual Cleanup
+
+Trigger cleanup programmatically:
+
+```python
+from senaite.core.z3cform.widgets.multiupload.storage import get_storage
+
+storage = get_storage()
+removed = storage.cleanup(max_age_seconds=3600)  # 1 hour
+logger.info("Removed {} expired uploads".format(removed))
+```
+
+### Monitoring
+
+Check instance logs for storage activity:
+
+```
+INFO: Stored upload a1b2c3d4-... for file report.pdf (51234 bytes)
+INFO: Auto-cleanup triggered after 100 operations
+INFO: Cleaned up 5 expired upload(s)
+INFO: Removed upload a1b2c3d4-...
+WARNING: Upload e5f6g7h8-... not found in storage
+```
+
+## Troubleshooting
+
+### Files Not Appearing After Upload
+
+**Symptom**: Files upload successfully but don't appear on the object after save.
+
+**Possible Causes**:
+1. Upload UUID not found in storage
+2. Event handler not triggered
+3. Field not properly configured
+
+**Debug Steps**:
+```python
+# Check storage contents
+from senaite.core.z3cform.widgets.multiupload.storage import get_storage
+
+storage = get_storage()
+container = storage._get_container()
+print("Uploads in storage:", len(container))
+print("UUIDs:", list(container.keys()))
+
+# Check if file data exists
+file_data = storage.retrieve("uuid-here")
+print("File data:", file_data)
+```
+
+### High Memory Usage
+
+**Symptom**: Instance memory grows significantly.
+
+**Possible Causes**:
+1. Large files stored in memory
+2. Cleanup not running
+3. Many expired uploads not removed
+
+**Solutions**:
+```python
+# Force cleanup
+storage = get_storage()
+removed = storage.cleanup(max_age_seconds=1800)  # 30 minutes
+
+# Check container size
+container = storage._get_container()
+total_size = sum(
+    len(record.data) for record in container.values()
+)
+print("Storage size: {} MB".format(total_size / 1024 / 1024))
+```
+
+### ZODB Conflict Errors
+
+**Symptom**: ConflictError in logs during high upload volume.
+
+**Expected Behavior**: ZODB automatically retries conflicted transactions (up to 3 times).
+
+**If Persistent**:
+- Check that CLEANUP_INTERVAL isn't too low (increases writes)
+- Verify OOBTree is used (not regular dict)
+- Review concurrent upload patterns
+
+## API Reference
+
+### Storage API
+
+```python
+from senaite.core.z3cform.widgets.multiupload.storage import get_storage
+
+storage = get_storage(context=None)
+
+# Store upload
+success = storage.store(
+    upload_id="uuid",
+    filename=u"file.pdf",
+    content_type="application/pdf",
+    data=binary_data
+)
+
+# Retrieve upload
+file_data = storage.retrieve("uuid")
+# Returns: {"filename": "...", "content_type": "...",
+#           "data": b"...", "timestamp": 123456789}
+
+# Remove upload
+removed = storage.remove("uuid")
+
+# Cleanup expired uploads
+count = storage.cleanup(max_age_seconds=7200)
+```
+
+### Handler API
+
+```python
+# AJAX POST to @@multiupload_handler
+# Content-Type: multipart/form-data
+
+# Response:
+{
+    "id": "uuid-string",
+    "filename": "document.pdf",
+    "content_type": "application/pdf",
+    "size": 51234,
+    "status": "success"
+}
+```
+
+## Development
+
+### Running Tests
+
+Run the comprehensive doctest for MultiUploadField:
+
+```bash
+bin/test-senaite -t MultiUploadField
+```
+
+This test covers:
+- Temporary upload storage operations
+- File upload simulation
+- File/Image creation from uploads
+- Storage cleanup after processing
+- Field validation
+- File deletion via adapter
+
+### Adding Custom File Types
+
+Implement `IMultiUploadFileCreator` adapter:
+
+```python
+from senaite.core.interfaces import IMultiUploadFileCreator
+from zope.component import adapter
+from zope.interface import implementer
+
+@implementer(IMultiUploadFileCreator)
+@adapter(IMyContent, IMultiUploadField)
+class MyFileCreator(object):
+
+    def __init__(self, context, field):
+        self.context = context
+        self.field = field
+
+    def create(self, filename, content_type, data):
+        # Custom File/Image creation logic
+        file_id = self.generate_id(filename)
+        self.context.invokeFactory("File", file_id)
+        file_obj = self.context[file_id]
+        file_obj.file = NamedBlobFile(
+            data=data,
+            filename=filename,
+            contentType=content_type
+        )
+        return file_obj
+```
+
+### Extending Storage
+
+Subclass `TemporaryUploadStorage` for custom behavior:
+
+```python
+from senaite.core.z3cform.widgets.multiupload.storage import (
+    TemporaryUploadStorage
+)
+
+class MyCustomStorage(TemporaryUploadStorage):
+
+    def store(self, upload_id, filename, content_type, data):
+        # Custom validation
+        if len(data) > 10 * 1024 * 1024:  # 10MB
+            logger.error("File too large: {}".format(filename))
+            return False
+
+        # Call parent implementation
+        return super(MyCustomStorage, self).store(
+            upload_id, filename, content_type, data
+        )
+```
+
+## License
+
+This is part of SENAITE.CORE and is licensed under GPLv2.

--- a/src/senaite/core/z3cform/widgets/multiupload/handler.py
+++ b/src/senaite/core/z3cform/widgets/multiupload/handler.py
@@ -1,4 +1,22 @@
 # -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
 
 import uuid
 

--- a/src/senaite/core/z3cform/widgets/multiupload/handler.py
+++ b/src/senaite/core/z3cform/widgets/multiupload/handler.py
@@ -1,25 +1,20 @@
 # -*- coding: utf-8 -*-
 
-import threading
 import uuid
 
 from bika.lims import api
 from bika.lims.decorators import returns_json
 from Products.Five.browser import BrowserView
-from senaite.core import logger
-
-# Global lock for session access - shared across all threads
-SESSION_LOCK = threading.Lock()
-SESSION_KEY = "multiupload_files"
+from senaite.core.z3cform.widgets.multiupload.storage import get_storage
 
 
 class MultiUploadHandler(BrowserView):
     """Handler for multiupload widget AJAX requests
 
     This view receives file uploads from the React multiupload widget
-    and stores them temporarily in the session, returning a unique ID.
-    The actual File/Image objects are created later in the widget's
-    process_form method.
+    and stores them temporarily in shared ZODB storage, returning a
+    unique ID. The actual File/Image objects are created later when the
+    form is saved via the event subscriber.
     """
 
     def __call__(self):
@@ -42,11 +37,10 @@ class MultiUploadHandler(BrowserView):
         return self.upload(upload)
 
     def upload(self, upload):
-        """Store the uploaded file temporarily in the session
+        """Store the uploaded file temporarily in shared ZODB storage
 
-        NOTE: Uses a global threading.Lock to prevent race conditions
-              when multiple threads try to write to the session
-              simultaneously.
+        Uses cluster-safe ZODB storage instead of SESSION to ensure
+        uploads are visible across all ZEO client instances.
 
         :param upload: The uploaded file object
         :returns: JSON response with upload ID and file info
@@ -69,12 +63,12 @@ class MultiUploadHandler(BrowserView):
         # and read later by process_form
         upload_id = str(uuid.uuid4())
 
-        # Store in session with thread-safe locking
-        success = self.store_in_session(
+        # Store in shared ZODB storage (cluster-safe)
+        success = self.store_in_storage(
             upload_id, filename, content_type, data)
 
         if not success:
-            return self.fail("Failed to store file in session", 500)
+            return self.fail("Failed to store file in storage", 500)
 
         return self.send_json({
             "id": upload_id,
@@ -84,9 +78,12 @@ class MultiUploadHandler(BrowserView):
             "status": "success"
         })
 
-    def store_in_session(
+    def store_in_storage(
             self, upload_id, filename, content_type, data):
-        """Store uploaded file data in session with thread-safe locking
+        """Store uploaded file data in shared ZODB storage
+
+        Uses the cluster-safe TemporaryUploadStorage which stores
+        uploads in portal annotations accessible to all ZEO clients.
 
         :param upload_id: The unique upload ID
         :param filename: The filename
@@ -94,47 +91,8 @@ class MultiUploadHandler(BrowserView):
         :param data: The file data bytes
         :returns: True if stored successfully, False otherwise
         """
-        with SESSION_LOCK:
-            logger.info(
-                u"Acquired lock for upload {}".format(upload_id))
-
-            # IMPORTANT: Sync the ZODB connection to get fresh data
-            # Without this, we see stale data from transaction snapshot
-            session = self.request.SESSION
-            # Sync ZODB connection if available
-            if hasattr(session, '_p_jar') and \
-                    session._p_jar is not None:
-                session._p_jar.sync()
-
-            # Get or create the uploads dict
-            uploaded_files = session.get(SESSION_KEY, {})
-
-            # Add this upload
-            uploaded_files[upload_id] = {
-                "data": data,
-                "filename": filename,
-                "content_type": content_type,
-            }
-
-            # Store back to session - triggers ZODB change detection
-            session[SESSION_KEY] = uploaded_files
-
-            # Verify it was stored
-            total = len(session.get(SESSION_KEY, {}))
-            if upload_id in session.get(SESSION_KEY, {}):
-                logger.info(
-                    u"✓ Stored upload {} for file {} (total: {})"
-                    .format(upload_id, filename, total))
-                logger.info(
-                    u"Released lock for upload {}".format(upload_id))
-                return True
-            else:
-                logger.error(
-                    u"✗ FAILED to store upload {} for file {}"
-                    .format(upload_id, filename))
-                logger.info(
-                    u"Released lock for upload {}".format(upload_id))
-                return False
+        storage = get_storage()
+        return storage.store(upload_id, filename, content_type, data)
 
     def get_content_type(self, upload):
         """Get the MIME type of the uploaded file

--- a/src/senaite/core/z3cform/widgets/multiupload/storage.py
+++ b/src/senaite/core/z3cform/widgets/multiupload/storage.py
@@ -43,9 +43,6 @@ STORAGE_KEY = "senaite.core.multiupload.storage"
 # Default expiration time for uploads (2 hours)
 DEFAULT_EXPIRATION_SECONDS = 7200
 
-# Cleanup interval: run cleanup every N operations
-CLEANUP_INTERVAL = 100
-
 
 class ITemporaryUploadStorage(Interface):
     """Interface for temporary upload storage"""
@@ -91,9 +88,6 @@ class TemporaryUploadStorage(object):
 
     Each upload is stored with a unique UUID key, preventing conflicts
     between concurrent uploads from different users.
-
-    Self-cleaning: Expired uploads are automatically removed every
-    CLEANUP_INTERVAL operations (similar to plone.memoize.CleanupDict).
     """
 
     def __init__(self, context=None):
@@ -114,46 +108,8 @@ class TemporaryUploadStorage(object):
         annotations = IAnnotations(self.context)
         if STORAGE_KEY not in annotations:
             container = OOBTree()
-            # Initialize metadata using a special key
-            container["__metadata__"] = {"cleanup_counter": 0}
             annotations[STORAGE_KEY] = container
         return annotations[STORAGE_KEY]
-
-    def _auto_cleanup(self):
-        """Automatically cleanup expired uploads periodically
-
-        Similar to plone.memoize.CleanupDict, this runs cleanup every
-        CLEANUP_INTERVAL operations to prevent the storage from
-        growing indefinitely.
-        """
-        try:
-            container = self._get_container()
-
-            # Get or initialize metadata
-            metadata = container.get("__metadata__", {"cleanup_counter": 0})
-
-            # Increment counter
-            counter = metadata.get("cleanup_counter", 0) + 1
-            metadata["cleanup_counter"] = counter
-            container["__metadata__"] = metadata
-
-            # Run cleanup every CLEANUP_INTERVAL operations
-            if counter >= CLEANUP_INTERVAL:
-                logger.info(
-                    u"Auto-cleanup triggered after {} operations".format(
-                        counter))
-                removed = self.cleanup()
-                # Reset counter
-                metadata["cleanup_counter"] = 0
-                container["__metadata__"] = metadata
-                return removed
-
-        except Exception as e:
-            logger.error(
-                u"Auto-cleanup failed: {}".format(
-                    api.safe_unicode(str(e))))
-
-        return 0
 
     def store(self, upload_id, filename, content_type, data):
         """Store uploaded file data
@@ -170,8 +126,7 @@ class TemporaryUploadStorage(object):
         :returns: True if stored successfully
         """
         try:
-            # Trigger auto-cleanup periodically
-            self._auto_cleanup()
+            self.cleanup()
 
             container = self._get_container()
 
@@ -263,10 +218,7 @@ class TemporaryUploadStorage(object):
 
             # Find expired uploads
             for upload_id, record in container.items():
-                # Skip metadata key
-                if upload_id == "__metadata__":
-                    continue
-                if record.timestamp < cutoff_time:
+                if getattr(record, "timestamp", 0) < cutoff_time:
                     to_remove.append(upload_id)
 
             # Remove expired uploads

--- a/src/senaite/core/z3cform/widgets/multiupload/storage.py
+++ b/src/senaite/core/z3cform/widgets/multiupload/storage.py
@@ -1,0 +1,300 @@
+# -*- coding: utf-8 -*-
+"""
+Temporary upload storage for multiupload widget
+
+This module provides a cluster-safe storage mechanism for temporarily
+storing uploaded files before they are converted to actual File/Image
+objects. Unlike SESSION storage, this storage is properly shared across
+all ZEO clients via ZODB.
+"""
+
+import time
+
+from bika.lims import api
+from BTrees.OOBTree import OOBTree
+from persistent import Persistent
+from senaite.core import logger
+from zope.annotation.interfaces import IAnnotations
+from zope.interface import Interface
+from zope.interface import implementer
+
+# Storage key in portal annotations
+STORAGE_KEY = "senaite.core.multiupload.storage"
+
+# Default expiration time for uploads (2 hours)
+DEFAULT_EXPIRATION_SECONDS = 7200
+
+# Cleanup interval: run cleanup every N operations
+CLEANUP_INTERVAL = 100
+
+
+class ITemporaryUploadStorage(Interface):
+    """Interface for temporary upload storage"""
+
+    def store(upload_id, filename, content_type, data):
+        """Store uploaded file data
+
+        :param upload_id: Unique identifier for the upload
+        :param filename: Name of the uploaded file
+        :param content_type: MIME type of the file
+        :param data: Binary file data
+        :returns: True if stored successfully
+        """
+
+    def retrieve(upload_id):
+        """Retrieve uploaded file data
+
+        :param upload_id: Unique identifier for the upload
+        :returns: Dictionary with file data or None if not found
+        """
+
+    def remove(upload_id):
+        """Remove uploaded file data
+
+        :param upload_id: Unique identifier for the upload
+        :returns: True if removed successfully
+        """
+
+    def cleanup(max_age_seconds=DEFAULT_EXPIRATION_SECONDS):
+        """Remove uploads older than specified age
+
+        :param max_age_seconds: Maximum age in seconds
+        :returns: Number of uploads removed
+        """
+
+
+@implementer(ITemporaryUploadStorage)
+class TemporaryUploadStorage(object):
+    """Cluster-safe temporary storage for uploaded files
+
+    This implementation uses portal annotations to store uploads in a
+    shared ZODB container that is accessible to all ZEO clients.
+
+    Each upload is stored with a unique UUID key, preventing conflicts
+    between concurrent uploads from different users.
+
+    Self-cleaning: Expired uploads are automatically removed every
+    CLEANUP_INTERVAL operations (similar to plone.memoize.CleanupDict).
+    """
+
+    def __init__(self, context=None):
+        """Initialize the storage
+
+        :param context: Context object (usually portal)
+        """
+        self.context = context or api.get_portal()
+
+    def _get_container(self):
+        """Get or create the storage container
+
+        Uses OOBTree which has built-in ZODB conflict resolution for
+        concurrent writes of different keys.
+
+        :returns: OOBTree container for uploads
+        """
+        annotations = IAnnotations(self.context)
+        if STORAGE_KEY not in annotations:
+            container = OOBTree()
+            # Initialize metadata using a special key
+            container["__metadata__"] = {"cleanup_counter": 0}
+            annotations[STORAGE_KEY] = container
+        return annotations[STORAGE_KEY]
+
+    def _auto_cleanup(self):
+        """Automatically cleanup expired uploads periodically
+
+        Similar to plone.memoize.CleanupDict, this runs cleanup every
+        CLEANUP_INTERVAL operations to prevent the storage from
+        growing indefinitely.
+        """
+        try:
+            container = self._get_container()
+
+            # Get or initialize metadata
+            metadata = container.get("__metadata__", {"cleanup_counter": 0})
+
+            # Increment counter
+            counter = metadata.get("cleanup_counter", 0) + 1
+            metadata["cleanup_counter"] = counter
+            container["__metadata__"] = metadata
+
+            # Run cleanup every CLEANUP_INTERVAL operations
+            if counter >= CLEANUP_INTERVAL:
+                logger.info(
+                    u"Auto-cleanup triggered after {} operations".format(
+                        counter))
+                removed = self.cleanup()
+                # Reset counter
+                metadata["cleanup_counter"] = 0
+                container["__metadata__"] = metadata
+                return removed
+
+        except Exception as e:
+            logger.error(
+                u"Auto-cleanup failed: {}".format(
+                    api.safe_unicode(str(e))))
+
+        return 0
+
+    def store(self, upload_id, filename, content_type, data):
+        """Store uploaded file data
+
+        Thread-safe and cluster-safe. Multiple concurrent uploads with
+        different upload_ids will not conflict.
+
+        Also triggers automatic cleanup of expired uploads periodically.
+
+        :param upload_id: Unique identifier for the upload
+        :param filename: Name of the uploaded file
+        :param content_type: MIME type of the file
+        :param data: Binary file data
+        :returns: True if stored successfully
+        """
+        try:
+            # Trigger auto-cleanup periodically
+            self._auto_cleanup()
+
+            container = self._get_container()
+
+            # Create upload record
+            upload_record = UploadRecord(
+                upload_id=upload_id,
+                filename=filename,
+                content_type=content_type,
+                data=data
+            )
+
+            # Store in container - OOBTree handles concurrent additions
+            container[upload_id] = upload_record
+
+            logger.info(
+                u"Stored upload {} for file {} ({} bytes)".format(
+                    upload_id, filename, len(data)))
+
+            return True
+
+        except Exception as e:
+            logger.error(
+                u"Failed to store upload {}: {}".format(
+                    upload_id, api.safe_unicode(str(e))))
+            return False
+
+    def retrieve(self, upload_id):
+        """Retrieve uploaded file data
+
+        :param upload_id: Unique identifier for the upload
+        :returns: Dictionary with file data or None if not found
+        """
+        try:
+            container = self._get_container()
+            record = container.get(upload_id)
+
+            if record is None:
+                logger.warning(
+                    u"Upload {} not found in storage".format(upload_id))
+                return None
+
+            # Return as dictionary
+            return {
+                "filename": record.filename,
+                "content_type": record.content_type,
+                "data": record.data,
+                "timestamp": record.timestamp
+            }
+
+        except Exception as e:
+            logger.error(
+                u"Failed to retrieve upload {}: {}".format(
+                    upload_id, api.safe_unicode(str(e))))
+            return None
+
+    def remove(self, upload_id):
+        """Remove uploaded file data
+
+        :param upload_id: Unique identifier for the upload
+        :returns: True if removed successfully
+        """
+        try:
+            container = self._get_container()
+            if upload_id in container:
+                del container[upload_id]
+                logger.info(u"Removed upload {}".format(upload_id))
+                return True
+            return False
+
+        except Exception as e:
+            logger.error(
+                u"Failed to remove upload {}: {}".format(
+                    upload_id, api.safe_unicode(str(e))))
+            return False
+
+    def cleanup(self, max_age_seconds=DEFAULT_EXPIRATION_SECONDS):
+        """Remove uploads older than specified age
+
+        This should be called periodically (e.g., via cron job) to
+        prevent the storage from growing indefinitely.
+
+        :param max_age_seconds: Maximum age in seconds
+        :returns: Number of uploads removed
+        """
+        try:
+            container = self._get_container()
+            cutoff_time = time.time() - max_age_seconds
+            to_remove = []
+
+            # Find expired uploads
+            for upload_id, record in container.items():
+                # Skip metadata key
+                if upload_id == "__metadata__":
+                    continue
+                if record.timestamp < cutoff_time:
+                    to_remove.append(upload_id)
+
+            # Remove expired uploads
+            for upload_id in to_remove:
+                del container[upload_id]
+
+            if to_remove:
+                logger.info(
+                    u"Cleaned up {} expired upload(s)".format(
+                        len(to_remove)))
+
+            return len(to_remove)
+
+        except Exception as e:
+            logger.error(
+                u"Failed to cleanup uploads: {}".format(
+                    api.safe_unicode(str(e))))
+            return 0
+
+
+class UploadRecord(Persistent):
+    """Persistent record for a single upload
+
+    Stores file data and metadata in ZODB.
+    """
+
+    def __init__(self, upload_id, filename, content_type, data):
+        """Initialize upload record
+
+        :param upload_id: Unique identifier
+        :param filename: File name
+        :param content_type: MIME type
+        :param data: Binary file data
+        """
+        self.upload_id = upload_id
+        self.filename = filename
+        self.content_type = content_type
+        self.data = data
+        self.timestamp = time.time()
+
+
+def get_storage(context=None):
+    """Get the temporary upload storage utility
+
+    Convenience function to get storage instance.
+
+    :param context: Optional context object
+    :returns: ITemporaryUploadStorage implementation
+    """
+    return TemporaryUploadStorage(context)

--- a/src/senaite/core/z3cform/widgets/multiupload/storage.py
+++ b/src/senaite/core/z3cform/widgets/multiupload/storage.py
@@ -1,12 +1,22 @@
 # -*- coding: utf-8 -*-
-"""
-Temporary upload storage for multiupload widget
-
-This module provides a cluster-safe storage mechanism for temporarily
-storing uploaded files before they are converted to actual File/Image
-objects. Unlike SESSION storage, this storage is properly shared across
-all ZEO clients via ZODB.
-"""
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
 
 import time
 
@@ -17,6 +27,15 @@ from senaite.core import logger
 from zope.annotation.interfaces import IAnnotations
 from zope.interface import Interface
 from zope.interface import implementer
+
+__doc__ = """
+Temporary upload storage for multiupload widget
+
+This module provides a cluster-safe storage mechanism for temporarily
+storing uploaded files before they are converted to actual File/Image
+objects. Unlike SESSION storage, this storage is properly shared across
+all ZEO clients via ZODB.
+"""
 
 # Storage key in portal annotations
 STORAGE_KEY = "senaite.core.multiupload.storage"

--- a/src/senaite/core/z3cform/widgets/multiupload/widget.py
+++ b/src/senaite/core/z3cform/widgets/multiupload/widget.py
@@ -1,4 +1,22 @@
 # -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
 
 import json
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is complementary for the multi file upload introduced in https://github.com/senaite/senaite.core/pull/2813

## Current behavior before PR

Files might not be uploaded in cluster setups with HAProxy in front, because the used session object is bound to on instance.

## Desired behavior after PR is merged

Files are correctly uploaded in cluster setups, because a central, transaction-safe storage is used

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
