### PR TITLE
Fix WrongType on object creation/update via jsonapi

### DIFF
--- a/src/senaite/core/schema/uidreferencefield.py
+++ b/src/senaite/core/schema/uidreferencefield.py
@@ -36,7 +36,7 @@ from zope.annotation.interfaces import IAnnotations
 from zope.event import notify
 from zope.interface import alsoProvides
 from zope.interface import implementer
-from zope.schema import ASCIILine
+from zope.schema import TextLine
 from zope.schema import List
 
 BACKREFS_STORAGE = "senaite.core.schema.uidreferencefield.backreferences"
@@ -118,7 +118,7 @@ class UIDReferenceField(List, BaseField):
     """Stores UID references to other objects
     """
 
-    value_type = ASCIILine(title=u"UID")
+    value_type = TextLine(title=u"UID")
 
     def __init__(self, allowed_types=None, multi_valued=True, **kw):
         if allowed_types is None:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

<code>UIDReferenceField</code> fields internally rely on <code>ASCIILine</code>, which only accepts native <code>str</code> values in Python 2. However, due to legacy Archetypes behavior and the JSONAPI request handling pipeline, incoming field values are always decoded as unicode before validation. As a result, JSONAPI delivers unicode UIDs while the underlying zope.schema validation layer expects str bytes, causing a WrongType error. This mismatch does not occur in standard UI forms because Archetypes/Dexterity widgets convert or coerce values differently, but JSONAPI exposes the type inconsistency directly.

## Current behavior before PR

Validator rises a <code>WrongType</code> error when a <code>unicode</code> value is set for <code>UIDReferenceField</code> type fields.

## Desired behavior after PR is merged
Validator does not fail when a <code>unicode</code> is set for <code>UIDReferenceField</code> type fields via jsonapi.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
