### PR TITLE
Fix inconsistent Profile filtering on multi-sample creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2826 Fix inconsistent Profile filtering on multi-sample creation
 - #2819 Fix multiuploads for cluster setups
 - #2817 Fix QR code render for multi-page stickers
 - #2818 Fix UnicodeDecodeError if analysis unit contains unicode characters

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -17,7 +17,7 @@
 #
 # Copyright 2018-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
-
+import copy
 import json
 from collections import OrderedDict
 from datetime import datetime
@@ -1480,7 +1480,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                 continue
             metadata[key] = {obj_info["uid"]: obj_info}
 
-        return metadata
+        return copy.deepcopy(metadata)
 
     def get_template_additional_info(self, metadata):
         template_to_services = {}
@@ -1567,14 +1567,6 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             obj, key, record=record), objects)
         return filter(None, objects)
 
-    def object_info_cache_key(method, self, obj, key, **kw):
-        if obj is None or not key:
-            raise DontCache
-        field_name = key.lower()
-        obj_key = api.get_cache_key(obj)
-        return "-".join([field_name, obj_key] + kw.keys())
-
-    @cache(object_info_cache_key)
     def get_object_info(self, obj, key, record=None):
         """Returns the object info metadata for the passed in object and key
         :param obj: the object from which extract the info from
@@ -1649,9 +1641,8 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         record = record if record else {}
         sample_type_uid = record.get("SampleType")
         if api.is_uid(sample_type_uid):
-            fields = ["Template", "Specification", "Profiles", "SamplePoint"]
-            for field in fields:
-                queries[field]["sampletype_uid"] = [sample_type_uid, ""]
+            st_queries = self.get_sampletype_queries(sample_type_uid, record)
+            queries.update(st_queries)
 
         return queries
 

--- a/src/senaite/core/browser/static/js/senaite.core.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/senaite.core.analysisrequest.add.coffee
@@ -116,7 +116,7 @@ class window.AnalysisRequestAdd
   ###
   recalculate_records: =>
     @ajax_post_form("recalculate_records").done (records) ->
-      console.debug "Recalculate Analyses: Records=", records
+      console.debug "Recalculate Records=", records
       # remember a services snapshot
       @records_snapshot = records
       # trigger event for whom it might concern
@@ -653,7 +653,9 @@ class window.AnalysisRequestAdd
     me = this
     chain = Promise.resolve()
     $.each record.filter_queries, (field_name, query) ->
-      field = $("#" + field_name + "-#{arnum}")
+      field_id = field_name + "-#{arnum}"
+      field = $("#" + field_id)
+      console.debug("Apply filter query from #{record.id} to #{field_id}: #{JSON.stringify(query)}")
       chain = chain.then () ->
         me.set_reference_field_query field, query
 
@@ -674,7 +676,8 @@ class window.AnalysisRequestAdd
 
     # set the new query
     controller.set_search_query(query)
-    console.debug("Set custom search query for field #{field.selector}: #{JSON.stringify(query)}")
+    field_id = field.attr "id"
+    console.debug("Set custom search query for field #{field_id}: #{JSON.stringify(query)}")
 
     # check if the target field needs to be flushed
     target_field_name = field.closest("tr[fieldname]").attr "fieldname"
@@ -1391,7 +1394,6 @@ class window.AnalysisRequestAdd
     selected = if event.type is "select" then yes else no
     deselected = not selected
     manually_deselected = @deselected_uids[field_name] or []
-    record = @records_snapshot[arnum] or {}
     metadata = @get_metadata_for(arnum, field_name)
 
     # reset all dependent filter queries

--- a/src/senaite/core/browser/static/js/senaite.core.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/senaite.core.analysisrequest.add.js
@@ -487,7 +487,7 @@ window.AnalysisRequestAdd = class AnalysisRequestAdd {
 
   recalculate_records() {
     return this.ajax_post_form("recalculate_records").done(function(records) {
-      console.debug("Recalculate Analyses: Records=", records);
+      console.debug("Recalculate Records=", records);
       // remember a services snapshot
       this.records_snapshot = records;
       // trigger event for whom it might concern
@@ -1000,8 +1000,10 @@ window.AnalysisRequestAdd = class AnalysisRequestAdd {
     me = this;
     chain = Promise.resolve();
     return $.each(record.filter_queries, function(field_name, query) {
-      var field;
-      field = $("#" + field_name + `-${arnum}`);
+      var field, field_id;
+      field_id = field_name + `-${arnum}`;
+      field = $("#" + field_id);
+      console.debug(`Apply filter query from ${record.id} to ${field_id}: ${JSON.stringify(query)}`);
       return chain = chain.then(function() {
         return me.set_reference_field_query(field, query);
       });
@@ -1009,7 +1011,7 @@ window.AnalysisRequestAdd = class AnalysisRequestAdd {
   }
 
   set_reference_field_query(field, query) {
-    var controller, data, me, target_base_query, target_catalog, target_field_label, target_field_name, target_query, target_value;
+    var controller, data, field_id, me, target_base_query, target_catalog, target_field_label, target_field_name, target_query, target_value;
     controller = this.get_widget_controller(field);
     // No controller found, return immediately
     // -> happens when the field is hidden or absent
@@ -1018,7 +1020,8 @@ window.AnalysisRequestAdd = class AnalysisRequestAdd {
     }
     // set the new query
     controller.set_search_query(query);
-    console.debug(`Set custom search query for field ${field.selector}: ${JSON.stringify(query)}`);
+    field_id = field.attr("id");
+    console.debug(`Set custom search query for field ${field_id}: ${JSON.stringify(query)}`);
     // check if the target field needs to be flushed
     target_field_name = field.closest("tr[fieldname]").attr("fieldname");
     target_field_label = field.closest("tr[fieldlabel]").attr("fieldlabel");
@@ -1620,7 +1623,7 @@ window.AnalysisRequestAdd = class AnalysisRequestAdd {
   }
 
   on_referencefield_value_changed(event) {
-    var $el, after_change, arnum, deselected, el, event_data, field_name, filter_queries, manually_deselected, me, metadata, record, ref, selected, value;
+    var $el, after_change, arnum, deselected, el, event_data, field_name, filter_queries, manually_deselected, me, metadata, ref, selected, value;
     me = this;
     el = event.currentTarget;
     $el = $(el);
@@ -1630,7 +1633,6 @@ window.AnalysisRequestAdd = class AnalysisRequestAdd {
     selected = event.type === "select" ? true : false;
     deselected = !selected;
     manually_deselected = this.deselected_uids[field_name] || [];
-    record = this.records_snapshot[arnum] || {};
     metadata = this.get_metadata_for(arnum, field_name);
     // reset all dependent filter queries
     if (deselected && metadata) {

--- a/webpack/package.json
+++ b/webpack/package.json
@@ -59,5 +59,6 @@
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-cli": "^6.0.1",
     "webpack-merge-and-include-globally": "^2.3.4"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/webpack/package.json
+++ b/webpack/package.json
@@ -59,6 +59,5 @@
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-cli": "^6.0.1",
     "webpack-merge-and-include-globally": "^2.3.4"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the Profiles available for selection when creating multiple samples in add sample form are consistent with both selected client and sample type

## Steps to reproduce

1. Create a Sample Type "Blood"
2. Create a Sample Type "Serum"
3. Create an Analysis Profile "Blood Profile", with "Blood" Sample Type assigned
4. Create an Analysis Profile "Serum Profile", with "Serum" Sample Type assigned
5. Create an Analysis Profile "Dummy Profile", without "Sample Types" assigned
6. Go to Add Sample form and create "2" samples. Click to "Show all" (top-right)
7. Choose a Client for Sample 1
8. Choose same Client for Sample 2
9. Select Sample Type "Blood" for Sample 1
10. Select Sample Type "Serum" for Sample 2
11. Analysis Profile "Blood Profile" is displayed for selection in both Samples
12. Analysis Profile "Serum Profile" is not displayed for selection in Sample 2 

## Current behavior before PR

The list of available Profiles for selection on sample creation is not consistent with the sample type and client selected

## Desired behavior after PR is merged

The list of available Profiles for selection on sample creation is consistent with the sample type and client selected

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
