### PR TITLE
Ensure string values for ID formatting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2833 Ensure string values for ID formatting
 - #2830 Fix TinyMCE hidden Cursor
 - #2829 Fix TypeError in bika_setup rejection widget
 - #2821 Migrate all fields from bika_setup to senaite setup

--- a/src/senaite/core/content/senaitesetup.py
+++ b/src/senaite/core/content/senaitesetup.py
@@ -42,6 +42,7 @@ from senaite.core.schema import RichTextField
 from senaite.core.schema import UIDReferenceField
 from senaite.core.schema.fields import DataGridField
 from senaite.core.schema.fields import DataGridRow
+from senaite.core.schema.textlinefield import TextLineField
 from senaite.core.z3cform.widgets.datagrid import DataGridWidgetFactory
 from senaite.core.z3cform.widgets.duration.widget import DurationWidgetFactory
 from zope import schema
@@ -182,12 +183,12 @@ class IIDFormattingRecordSchema(Interface):
     """Schema for ID formatting configuration records
     """
 
-    portal_type = schema.TextLine(
+    portal_type = TextLineField(
         title=_(u"Portal Type"),
         required=False,
     )
 
-    form = schema.TextLine(
+    form = TextLineField(
         title=_(u"Format"),
         required=False,
     )
@@ -199,7 +200,7 @@ class IIDFormattingRecordSchema(Interface):
         default="",
     )
 
-    context = schema.TextLine(
+    context = TextLineField(
         title=_(u"Context"),
         required=False,
     )
@@ -211,12 +212,12 @@ class IIDFormattingRecordSchema(Interface):
         default="",
     )
 
-    counter_reference = schema.TextLine(
+    counter_reference = TextLineField(
         title=_(u"Counter Ref"),
         required=False,
     )
 
-    prefix = schema.TextLine(
+    prefix = TextLineField(
         title=_(u"Prefix"),
         required=False,
     )

--- a/src/senaite/core/content/senaitesetup.py
+++ b/src/senaite/core/content/senaitesetup.py
@@ -2194,21 +2194,26 @@ class Setup(Container):
     def getIDFormatting(self):
         """Get ID formatting configuration
         Normalizes None values to empty strings for Choice fields
+        Ensures string values are returned as byte strings (not unicode)
         """
         accessor = self.accessor("id_formatting")
         value = accessor(self)
         if not value:
             return DEFAULT_ID_FORMATTING
 
-        # Normalize None values to empty strings for Choice fields
+        # Normalize values: convert `None` to empty strings and unicode to
+        # bytes to prevent `UnicodeDecodeError` when formatting with UTF-8
+        # encoded values
         normalized = []
         for row in value:
-            normalized_row = dict(row)
-            # Convert None to empty string for Choice fields
-            if normalized_row.get("sequence_type") is None:
-                normalized_row["sequence_type"] = ""
-            if normalized_row.get("counter_type") is None:
-                normalized_row["counter_type"] = ""
+            normalized_row = {}
+            for key, val in row.items():
+                if val is None:
+                    normalized_row[key] = ""
+                elif isinstance(val, unicode):
+                    normalized_row[key] = val.encode("utf-8")
+                else:
+                    normalized_row[key] = val
             normalized.append(normalized_row)
 
         return normalized

--- a/src/senaite/core/content/senaitesetup.py
+++ b/src/senaite/core/content/senaitesetup.py
@@ -20,6 +20,7 @@
 
 from datetime import timedelta
 
+import six
 from AccessControl import ClassSecurityInfo
 from bika.lims import _
 from bika.lims import api
@@ -2201,16 +2202,17 @@ class Setup(Container):
         if not value:
             return DEFAULT_ID_FORMATTING
 
-        # Normalize values: convert `None` to empty strings and unicode to
-        # bytes to prevent `UnicodeDecodeError` when formatting with UTF-8
-        # encoded values
+        # Normalize values: convert `None` to empty strings
+        # In Python 2: convert unicode to bytes to prevent `UnicodeDecodeError`
+        # when formatting with UTF-8 encoded values
+        # In Python 3: keep strings as unicode (no conversion needed)
         normalized = []
         for row in value:
             normalized_row = {}
             for key, val in row.items():
                 if val is None:
                     normalized_row[key] = ""
-                elif isinstance(val, unicode):
+                elif six.PY2 and isinstance(val, six.text_type):
                     normalized_row[key] = val.encode("utf-8")
                 else:
                     normalized_row[key] = val

--- a/src/senaite/core/tests/doctests/SenaiteSetup.rst
+++ b/src/senaite/core/tests/doctests/SenaiteSetup.rst
@@ -1215,11 +1215,14 @@ ID Formatting:
     >>> len(formatting)
     2
 
+Note: In Python 2, getIDFormatting returns byte strings (not unicode) to prevent
+UnicodeDecodeError when formatting IDs with UTF-8 encoded values:
+
     >>> formatting[0]["portal_type"]
-    u'AnalysisRequest'
+    'AnalysisRequest'
 
     >>> formatting[0]["form"]
-    u'AR-{seq:04d}'
+    'AR-{seq:04d}'
 
     >>> bikasetup_formatting = bikasetup.getIDFormatting()
     >>> len(bikasetup_formatting)
@@ -1237,7 +1240,7 @@ ID Formatting:
     1
 
     >>> formatting2[0]["portal_type"]
-    u'Batch'
+    'Batch'
 
     >>> senaite_formatting2 = senaite_setup.getIDFormatting()
     >>> len(senaite_formatting2)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a `UnicodeDecodeError` in the Sample ID generation if the Sample Type Prefix contains unicode characters.

NOTE: This happens only for instances that have already migrated to the new DX setup, since the ID formatting field returns all string values as unicodes, e.g. the `form` and `prefix`.
This causes an automatic unicode conversion in the formatting and results in a `UnicodeDecodeError` for UTF8 encoded strings.

## Current behavior before PR

`UnicodeDecodeError` happens during Sample ID formatting, if the Sample Type Prefix contains unicode characters.

## Desired behavior after PR is merged

ID generation works for Samples, even if the Sample Type Prefix contains unicode characters.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
