### PR TITLE
Handle tat as timedelta or dict during AT to DX migration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2834 Handle tat as timedelta or dict during AT to DX migration
 - #2830 Fix TinyMCE hidden Cursor
 - #2829 Fix TypeError in bika_setup rejection widget
 - #2821 Migrate all fields from bika_setup to senaite setup

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -26,6 +26,7 @@ from bika.lims.browser.fields import UIDReferenceField
 from bika.lims.browser.widgets.decimal import DecimalWidget
 from bika.lims.browser.widgets.durationwidget import DurationWidget
 from bika.lims.browser.widgets.recordswidget import RecordsWidget
+from senaite.core.api import dtime
 from senaite.core.browser.widgets.referencewidget import ReferenceWidget
 from bika.lims.config import SERVICE_POINT_OF_CAPTURE
 from bika.lims.content.bikaschema import BikaSchema
@@ -1186,7 +1187,12 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
         return: a dictionary with the keys "days", "hours" and "minutes"
         """
         tat = self.Schema().getField("MaxTimeAllowed").get(self)
-        return tat or self.bika_setup.getDefaultTurnaroundTime()
+        if tat:
+            return tat
+
+        # Convert timedelta to dict for AT format:
+        value = self.bika_setup.getDefaultTurnaroundTime()
+        return dtime.timedelta_to_dict(value, default={})
 
     @security.public
     def getMaxHoldingTime(self):

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -1190,8 +1190,11 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
         if tat:
             return tat
 
-        # Convert timedelta to dict for AT format:
         value = self.bika_setup.getDefaultTurnaroundTime()
+        if isinstance(value, dict):
+            return value
+
+        # Convert timedelta to dict for AT format:
         return dtime.timedelta_to_dict(value, default={})
 
     @security.public

--- a/src/bika/lims/content/abstractroutineanalysis.py
+++ b/src/bika/lims/content/abstractroutineanalysis.py
@@ -214,14 +214,22 @@ class AbstractRoutineAnalysis(AbstractAnalysis, ClientAwareMixin):
         tat = self.getMaxTimeAllowed()
         if not tat:
             return None
-        if api.to_minutes(**tat) == 0:
+
+        # During AT->DX migration, tat might be either a dict or timedelta
+        if isinstance(tat, timedelta):
+            delta = tat
+            minutes = int(delta.total_seconds() / 60)
+        else:
+            # Archetypes format
+            minutes = api.to_minutes(**tat)
+            # delta time when the first analysis is considered as late
+            delta = timedelta(minutes=minutes)
+
+        if minutes == 0:
             return None
         start = self.getStartProcessDate()
         if not start:
             return None
-
-        # delta time when the first analysis is considered as late
-        delta = timedelta(minutes=api.to_minutes(**tat))
 
         # calculated due date
         end = dt2DT(DT2dt(start) + delta)

--- a/src/bika/lims/content/abstractroutineanalysis.py
+++ b/src/bika/lims/content/abstractroutineanalysis.py
@@ -214,22 +214,14 @@ class AbstractRoutineAnalysis(AbstractAnalysis, ClientAwareMixin):
         tat = self.getMaxTimeAllowed()
         if not tat:
             return None
-
-        # During AT->DX migration, tat might be either a dict or timedelta
-        if isinstance(tat, timedelta):
-            delta = tat
-            minutes = int(delta.total_seconds() / 60)
-        else:
-            # Archetypes format
-            minutes = api.to_minutes(**tat)
-            # delta time when the first analysis is considered as late
-            delta = timedelta(minutes=minutes)
-
-        if minutes == 0:
+        if api.to_minutes(**tat) == 0:
             return None
         start = self.getStartProcessDate()
         if not start:
             return None
+
+        # delta time when the first analysis is considered as late
+        delta = timedelta(minutes=api.to_minutes(**tat))
 
         # calculated due date
         end = dt2DT(DT2dt(start) + delta)

--- a/src/senaite/core/tests/doctests/VersionWrapper.rst
+++ b/src/senaite/core/tests/doctests/VersionWrapper.rst
@@ -19,7 +19,6 @@ Needed Imports:
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
     >>> from DateTime import DateTime
-    >>> from datetime import timedelta
     >>> from plone.app.testing import setRoles
     >>> from plone.app.testing import TEST_USER_ID
     >>> from plone.app.testing import TEST_USER_PASSWORD
@@ -79,7 +78,6 @@ LIMS Setup
 
 Setup the Lab for testing:
 
-    >>> bikasetup.setDefaultTurnaroundTime(timedelta(days=5))
     >>> bikasetup.setSelfVerificationEnabled(True)
     >>> analysisservices = bikasetup.bika_analysisservices
     >>> categories = setup.analysiscategories
@@ -322,7 +320,6 @@ content types are migrated to DX, but we keep them here into account for
 legacy and consistency reasons:
 
 - `DurationField` type:
-
     >>> sorted(Ca.getMaxTimeAllowed().items())
     [('days', 5), ('hours', 0), ('minutes', 0), ('seconds', 0)]
 

--- a/src/senaite/core/tests/doctests/VersionWrapper.rst
+++ b/src/senaite/core/tests/doctests/VersionWrapper.rst
@@ -19,6 +19,7 @@ Needed Imports:
     >>> from bika.lims.utils.analysisrequest import create_analysisrequest
     >>> from bika.lims.workflow import doActionFor as do_action_for
     >>> from DateTime import DateTime
+    >>> from datetime import timedelta
     >>> from plone.app.testing import setRoles
     >>> from plone.app.testing import TEST_USER_ID
     >>> from plone.app.testing import TEST_USER_PASSWORD
@@ -78,6 +79,7 @@ LIMS Setup
 
 Setup the Lab for testing:
 
+    >>> bikasetup.setDefaultTurnaroundTime(timedelta(days=5))
     >>> bikasetup.setSelfVerificationEnabled(True)
     >>> analysisservices = bikasetup.bika_analysisservices
     >>> categories = setup.analysiscategories


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
This PR fixes a TypeError that occurs when calculating the due date for an analysis if the MaxTimeAllowed field is a `timedelta` object instead of a dictionary. This situation can arise due to mixed Archetypes/Dexterity field types during or after migration

## Current behavior before PR
- The method `getDueDate` in `AbstractRoutineAnalysis` assumes `MaxTimeAllowed` is always a dictionary.
- If `MaxTimeAllowed` is a`timedelta` (as returned by Dexterity fields), a `TypeError` is raised: `TypeError: to_minutes() argument after ** must be a mapping, not datetime.timedelta`
- This breaks imports and catalog indexing for affected analyses.

## Desired behavior after PR is merged
- `getDueDate` now handles both dictionary and `timedelta` formats for `MaxTimeAllowed`
- No TypeError is raised, and due date calculation works regardless of the underlying field type.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
