### PR TITLE
Rollback temporary samples on error during creation

### DIFF
--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -2057,22 +2057,34 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             # Create as many samples as required
             num_samples = self.get_num_samples(record)
             for idx in range(num_samples):
-                sample = crar(client, self.request, record)
+                # Create a savepoint before each sample creation to allow
+                # proper rollback if sample creation fails
+                sp = transaction.savepoint()
+                try:
+                    sample = crar(client, self.request, record)
 
-                # Create the attachments
-                for attachment_record in attachments:
-                    self.create_attachment(sample, attachment_record)
+                    # Create the attachments
+                    for attachment_record in attachments:
+                        self.create_attachment(sample, attachment_record)
 
-                # Pass the new sample to all subscription hooks
-                hooks = subscribers((sample, request), IAfterCreateSampleHook)
-                # Lower sort keys are processed first
-                sorted_hooks = sorted(
-                    hooks, key=lambda x: api.to_float(getattr(x, "sort", 10)))
-                for hook in sorted_hooks:
-                    hook.update(sample, source=source)
+                    # Pass the new sample to all subscription hooks
+                    hooks = subscribers(
+                        (sample, request), IAfterCreateSampleHook)
+                    # Lower sort keys are processed first
+                    sorted_hooks = sorted(
+                        hooks, key=lambda x: api.to_float(
+                            getattr(x, "sort", 10)))
+                    for hook in sorted_hooks:
+                        hook.update(sample, source=source)
 
-                transaction.savepoint(optimistic=True)
-                samples.append(sample)
+                    transaction.savepoint(optimistic=True)
+                    samples.append(sample)
+                except Exception:
+                    # Roll back to the savepoint before this sample creation
+                    # This properly reverts all changes including catalog
+                    # entries, workflow history, annotations, etc.
+                    sp.rollback()
+                    raise
 
         return samples
 

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -2036,7 +2036,6 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         """Creates samples for the given records
         """
         samples = []
-        request = self.request
         for record in records:
             client_uid = record.get("Client")
             client = self.get_object_by_uid(client_uid)
@@ -2057,36 +2056,50 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             # Create as many samples as required
             num_samples = self.get_num_samples(record)
             for idx in range(num_samples):
-                # Create a savepoint before each sample creation to allow
-                # proper rollback if sample creation fails
-                sp = transaction.savepoint()
-                try:
-                    sample = crar(client, self.request, record)
-
-                    # Create the attachments
-                    for attachment_record in attachments:
-                        self.create_attachment(sample, attachment_record)
-
-                    # Pass the new sample to all subscription hooks
-                    hooks = subscribers(
-                        (sample, request), IAfterCreateSampleHook)
-                    # Lower sort keys are processed first
-                    sorted_hooks = sorted(
-                        hooks, key=lambda x: api.to_float(
-                            getattr(x, "sort", 10)))
-                    for hook in sorted_hooks:
-                        hook.update(sample, source=source)
-
-                    transaction.savepoint(optimistic=True)
-                    samples.append(sample)
-                except Exception:
-                    # Roll back to the savepoint before this sample creation
-                    # This properly reverts all changes including catalog
-                    # entries, workflow history, annotations, etc.
-                    sp.rollback()
-                    raise
+                sample = self.create_sample(
+                    client, record, attachments=attachments, source=source)
+                samples.append(sample)
 
         return samples
+
+    def create_sample(self, client, record, attachments=None, source=None):
+        """Creates a single sample with proper transaction handling
+
+        :param client: The client container where the sample will be created
+        :param record: Dict with sample data (field names to values)
+        :param attachments: List of attachment records to add to the sample
+        :param source: Source object for sample hooks (e.g., for copy/partition)
+        :return: The created sample object
+        """
+        # Create a savepoint before sample creation to allow proper rollback
+        # if sample creation fails (e.g., ID generation error)
+        sp = transaction.savepoint()
+        try:
+            # Create the sample
+            sample = crar(client, self.request, record)
+
+            # Create the attachments
+            if attachments:
+                for attachment_record in attachments:
+                    self.create_attachment(sample, attachment_record)
+
+            # Pass the new sample to all subscription hooks
+            hooks = subscribers((sample, self.request), IAfterCreateSampleHook)
+            # Lower sort keys are processed first
+            sorted_hooks = sorted(
+                hooks, key=lambda x: api.to_float(getattr(x, "sort", 10)))
+            for hook in sorted_hooks:
+                hook.update(sample, source=source)
+
+            # Commit the sample creation
+            transaction.savepoint(optimistic=True)
+            return sample
+        except Exception:
+            # Roll back to the savepoint before this sample creation
+            # This properly reverts all changes including catalog entries,
+            # workflow history, annotations, etc.
+            sp.rollback()
+            raise
 
     def get_num_samples(self, record):
         """Return the number of samples to create for the given record


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR applies proper transaction rollback on sample creation if e.g. an error occurs in the ID server.

## Current behavior before PR

Temporary sample objects stay in the system if an error occurs in the `renameAfterCreation` function due to invalid ID configuration.

<img width="685" height="741" alt="SCR-20251219-qexa" src="https://github.com/user-attachments/assets/719c31fd-601b-4e57-82f5-67ba897653e4" />

<img width="885" height="498" alt="SCR-20251219-qfbr" src="https://github.com/user-attachments/assets/b9ec7e34-0fd3-4282-8bc5-50cef619a1d1" />

## Desired behavior after PR is merged

Transaction is properly rolled back if an error occurs during sample creation or ID server generation

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
