### PR TITLE
Disable Cancel Button in Sample Registration Form after Save

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2837 Disable Cancel Button in Sample Registration Form after Save
 - #2836 Rollback temporary samples on error during creation
 - #2830 Fix TinyMCE hidden Cursor
 - #2829 Fix TypeError in bika_setup rejection widget

--- a/src/senaite/core/browser/static/js/senaite.core.analysisrequest.add.coffee
+++ b/src/senaite/core/browser/static/js/senaite.core.analysisrequest.add.coffee
@@ -2037,6 +2037,10 @@ class window.AnalysisRequestAdd
     save_and_copy_button = $("input[name=save_and_copy_button]")
     save_and_copy_button.prop "disabled": yes
 
+    # deactivate the cancel button
+    cancel_button = $("input[name=cancel_button]")
+    cancel_button.prop "disabled": yes
+
 
   ###*
    * Event handler when Ajax request finished
@@ -2054,6 +2058,10 @@ class window.AnalysisRequestAdd
     # reactivate the save and copy button
     save_and_copy_button = $("input[name=save_and_copy_button]")
     save_and_copy_button.prop "disabled": no
+
+    # reactivate the cancel button
+    cancel_button = $("input[name=cancel_button]")
+    cancel_button.prop "disabled": no
 
 
   ###*

--- a/src/senaite/core/browser/static/js/senaite.core.analysisrequest.add.js
+++ b/src/senaite/core/browser/static/js/senaite.core.analysisrequest.add.js
@@ -2262,7 +2262,7 @@ window.AnalysisRequestAdd = class AnalysisRequestAdd {
   }
 
   on_ajax_start() {
-    var save_and_copy_button, save_button;
+    var cancel_button, save_and_copy_button, save_button;
     console.debug("°°° on_ajax_start °°°");
     // deactivate the save button
     save_button = $("input[name=save_button]");
@@ -2272,13 +2272,18 @@ window.AnalysisRequestAdd = class AnalysisRequestAdd {
     save_button[0].value = _t("Loading ...");
     // deactivate the save and copy button
     save_and_copy_button = $("input[name=save_and_copy_button]");
-    return save_and_copy_button.prop({
+    save_and_copy_button.prop({
+      "disabled": true
+    });
+    // deactivate the cancel button
+    cancel_button = $("input[name=cancel_button]");
+    return cancel_button.prop({
       "disabled": true
     });
   }
 
   on_ajax_end() {
-    var save_and_copy_button, save_button;
+    var cancel_button, save_and_copy_button, save_button;
     console.debug("°°° on_ajax_end °°°");
     // reactivate the save button
     save_button = $("input[name=save_button]");
@@ -2288,7 +2293,12 @@ window.AnalysisRequestAdd = class AnalysisRequestAdd {
     save_button[0].value = _t("Save");
     // reactivate the save and copy button
     save_and_copy_button = $("input[name=save_and_copy_button]");
-    return save_and_copy_button.prop({
+    save_and_copy_button.prop({
+      "disabled": false
+    });
+    // reactivate the cancel button
+    cancel_button = $("input[name=cancel_button]");
+    return cancel_button.prop({
       "disabled": false
     });
   }


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR disables the Cancel Button in the Sample Registration Form once the User clicked on the Save Button.

## Current behavior before PR

The Cancel Button was still active after save and suggested the operation was cancelled.
However, the Sample creation process was still active in and created the samples in the background.

## Desired behavior after PR is merged

Disable the Cancel button after the user clicked Save, because the process cannot be stopped at this point.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
