### PR TITLE
Fix detection limit misconfiguration in analysis service edit view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2841 Fix detection limit misconfiguration in analysis service edit view
 - #2840 Fix setting readonly form fields
 - #2831 Migrate ARReport to Dexterity
 - #2838 Fix 'add_permission' error when upgrading from 2711 to 2718

--- a/src/senaite/core/browser/form/adapters/analysisservice.py
+++ b/src/senaite/core/browser/form/adapters/analysisservice.py
@@ -205,3 +205,19 @@ class EditForm(EditFormAdapterBase):
         else:
             self.add_show_field("ResultOptions")
             self.add_show_field("ResultOptionsSorting")
+
+        # do not display the fields related with the manual entry of detection
+        # limits unless the result type is numeric. Otherwise users could
+        # select a detection limit from the dropdown during result entry while
+        # also entering a string-based result. Because the system would
+        # interpret the result as non-numeric, the detection limit would be
+        # treated as not applicable and, consequently, not displayed in the
+        # final result
+        if result_type == "numeric":
+            self.add_show_field("DetectionLimitSelector")
+            self.add_show_field("AllowManualDetectionLimit")
+        else:
+            self.add_hide_field("DetectionLimitSelector")
+            self.add_hide_field("AllowManualDetectionLimit")
+            self.add_update_field("DetectionLimitSelector", False)
+            self.add_update_field("AllowManualDetectionLimit", False)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request hides detection limit fields for non-numeric result types in AnalysisService edit form. Previously, users could enable "Detection Limit Selector" or "Allow Manual Detection Limit" while setting a non-numeric result type (string, text, datetime). This caused detection limits entered during result entry to be silently ignored since non-numeric results don't support detection limits.

## Current behavior before PR

Is possible to select a non-numeric value for ResultType and at the same time, enable the the introduction of detection limit

## Desired behavior after PR is merged

Is not possible to select a non-numeric value for ResultType and at the same time, enable the the introduction of detection limit

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
