### PR TITLE
Pin plumber version for Python 2 compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2845 Pin plumber to a Python 2 compatible version
 - #2775 Auto-add CCContact when hidden on Sample Add form
 - #2828 RemarksField type for Dexterity content types
 - #2841 Fix detection limit misconfiguration in analysis service edit view

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,8 @@ setup(
         "et-xmlfile<2.0.0",
         # magnitude > 1.0.1 does ot support Python 2.x anymore
         "magnitude==1.0.1",
+        # plumber >= 2.0.0 does not support Python 2.x anymore
+        "plumber<2.0.0",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the following error that occurs when building a new Docker image:
```
185.9 Traceback (most recent call last):
185.9   File "/usr/local/lib/python2.7/site-packages/zc/buildout/buildout.py", line 2183, in main
185.9     getattr(buildout, command)(args)
185.9   File "/usr/local/lib/python2.7/site-packages/zc/buildout/buildout.py", line 825, in install
185.9     installed_files = self[part]._call(recipe.install)
185.9   File "/usr/local/lib/python2.7/site-packages/zc/buildout/buildout.py", line 1611, in _call
185.9     return f()
185.9   File "/home/senaite/senaitelims/eggs/cp27mu/plone.recipe.zope2instance-6.13.0-py2.7.egg/plone/recipe/zope2instance/recipe.py", line 148, in install
185.9     self.build_zope_conf()
185.9   File "/home/senaite/senaitelims/eggs/cp27mu/plone.recipe.zope2instance-6.13.0-py2.7.egg/plone/recipe/zope2instance/recipe.py", line 707, in build_zope_conf
185.9     requirements, ws = self.egg.working_set(["plone.recipe.zope2instance"])
185.9   File "/home/senaite/senaitelims/eggs/cp27mu/zc.recipe.egg-2.0.7-py2.7.egg/zc/recipe/egg/egg.py", line 87, in working_set
185.9     allow_unknown_extras=bool_option(buildout_section, 'allow-unknown-extras')
185.9   File "/home/senaite/senaitelims/eggs/cp27mu/zc.recipe.egg-2.0.7-py2.7.egg/zc/recipe/egg/egg.py", line 168, in _working_set
185.9     allow_unknown_extras=allow_unknown_extras)
185.9   File "/usr/local/lib/python2.7/site-packages/zc/buildout/easy_install.py", line 963, in install
185.9     return installer.install(specs, working_set)
185.9   File "/usr/local/lib/python2.7/site-packages/zc/buildout/easy_install.py", line 736, in install
185.9     for dist in self._get_dist(req, ws):
185.9   File "/usr/local/lib/python2.7/site-packages/zc/buildout/easy_install.py", line 580, in _get_dist
185.9     dists = [_move_to_eggs_dir_and_compile(dist, self._dest)]
185.9   File "/usr/local/lib/python2.7/site-packages/zc/buildout/easy_install.py", line 1751, in _move_to_eggs_dir_and_compile
185.9     [tmp_loc] = glob.glob(os.path.join(tmp_dest, '*'))
185.9 ValueError: need more than 0 values to unpack```


## Current behavior before PR

Docker build fails

## Desired behavior after PR is merged

Docker build succeeds

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
