### PR TITLE
Fix Unit super-/subscript rendering

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2846 Fix Unit super-/subscript rendering 
 - #2776 Refactor: rename SiteView.setCookie to set_cookie in dashboard.pt
 - #2805 Migrate Worksheets to DX
 - #2775 Auto-add CCContact when hidden on Sample Add form

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -42,6 +42,7 @@ from bika.lims.interfaces import IRoutineAnalysis
 from bika.lims.interfaces import ISubmitted
 from bika.lims.utils import check_permission
 from bika.lims.utils import format_supsub
+from senaite.core.utils import format_supsub_unicode
 from bika.lims.utils import formatDecimalMark
 from bika.lims.utils import get_fas_ico
 from bika.lims.utils import get_image
@@ -547,9 +548,11 @@ class AnalysesView(ListingView):
         unit_choices = obj.getUnitChoices()
         vocab = []
         for unit in unit_choices:
+            value = unit.get("value", "")
+            formatted = format_supsub_unicode(value)
             vocab.append({
-                "ResultValue": unit['value'],
-                "ResultText": unit['value'],
+                "ResultValue": value,
+                "ResultText": formatted,
             })
         return vocab
 

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -117,9 +117,8 @@ Unit = StringField(
     )
 )
 
+
 # A selection of units that are able to update Unit.
-
-
 class UnitChoicesField(RecordsField):
     """Custom RecordsField that converts super/subscript
     HTML tags to Unicode characters for display.

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -53,6 +53,7 @@ from Products.Archetypes.Widget import IntegerWidget
 from Products.Archetypes.Widget import SelectionWidget
 from Products.Archetypes.Widget import StringWidget
 from Products.CMFCore.permissions import View
+from senaite.core.utils import format_supsub_unicode
 from senaite.core.browser.fields.records import RecordsField
 from senaite.core.catalog import SETUP_CATALOG
 from zope.interface import implements
@@ -116,8 +117,26 @@ Unit = StringField(
     )
 )
 
-# A selection of units that are able to update Unit. 
-UnitChoices = RecordsField(
+# A selection of units that are able to update Unit.
+
+
+class UnitChoicesField(RecordsField):
+    """Custom RecordsField that converts super/subscript
+    HTML tags to Unicode characters for display.
+    """
+
+    def getViewFor(self, instance, idx, subfield,
+                   joinWith=", "):
+        """Return Unicode-formatted value for display
+        """
+        raw = self.getRaw(instance)[idx].get(
+            subfield, "")
+        if type(raw) in (type(()), type([])):
+            raw = joinWith.join(raw)
+        return format_supsub_unicode(raw).strip()
+
+
+UnitChoices = UnitChoicesField(
     "UnitChoices",
     schemata="Description",
     type="UnitChoices",

--- a/src/senaite/core/utils/__init__.py
+++ b/src/senaite/core/utils/__init__.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA.
+#
+# Copyright 2018-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+import re
+
+from bika.lims import api
+from bika.lims.utils import format_supsub
+
+# Unicode superscript/subscript character mappings
+SUPERSCRIPT_MAP = {
+    "0": u"\u2070", "1": u"\u00B9", "2": u"\u00B2",
+    "3": u"\u00B3", "4": u"\u2074", "5": u"\u2075",
+    "6": u"\u2076", "7": u"\u2077", "8": u"\u2078",
+    "9": u"\u2079", "+": u"\u207A", "-": u"\u207B",
+    "=": u"\u207C", "(": u"\u207D", ")": u"\u207E",
+    "n": u"\u207F", "i": u"\u2071",
+}
+
+SUBSCRIPT_MAP = {
+    "0": u"\u2080", "1": u"\u2081", "2": u"\u2082",
+    "3": u"\u2083", "4": u"\u2084", "5": u"\u2085",
+    "6": u"\u2086", "7": u"\u2087", "8": u"\u2088",
+    "9": u"\u2089", "+": u"\u208A", "-": u"\u208B",
+    "=": u"\u208C", "(": u"\u208D", ")": u"\u208E",
+}
+
+
+def _to_unicode_char(char, char_map):
+    """Convert a character using the given mapping"""
+    return char_map.get(char, char)
+
+
+def _to_unicode_tag(content, char_map):
+    """Convert tag content to Unicode super/subscript"""
+    return u"".join(
+        _to_unicode_char(c, char_map) for c in content
+    )
+
+
+def format_supsub_unicode(text):
+    """Convert super/subscript notation to Unicode characters.
+
+    Handles both raw notation (^, _) and HTML tags (<sup>, <sub>).
+    Useful for contexts where HTML cannot be rendered, e.g.
+    <option> elements.
+
+    Example: "Bq·kg^-1" -> u"Bq\xb7kg\u207b\xb9"
+    Example: "Bq·kg<sup>-1</sup>" -> u"Bq\xb7kg\u207b\xb9"
+    """
+    if not text:
+        return text
+    text = api.safe_unicode(text)
+    # convert ^ and _ notation to HTML tags first
+    if "^" in text or "_" in text:
+        text = api.safe_unicode(
+            format_supsub(api.to_utf8(text))
+        )
+    # convert <sup>...</sup> to Unicode superscripts
+    text = re.sub(
+        r"<sup>(.*?)</sup>",
+        lambda m: _to_unicode_tag(
+            m.group(1), SUPERSCRIPT_MAP),
+        text,
+        flags=re.IGNORECASE,
+    )
+    # convert <sub>...</sub> to Unicode subscripts
+    text = re.sub(
+        r"<sub>(.*?)</sub>",
+        lambda m: _to_unicode_tag(
+            m.group(1), SUBSCRIPT_MAP),
+        text,
+        flags=re.IGNORECASE,
+    )
+    # strip any remaining HTML tags
+    text = re.sub(r"<[^>]+>", "", text)
+    return text


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the rendering of Units that use super-/subscripts, e.g. Bq·kg<sup>-1</sup>

## Current behavior before PR

The raw string is displayed in Analysis listings, e.g. `Bq·kg<sup>-1</sup>`

<img width="492" height="132" alt="SCR-20260204-lpfd-2" src="https://github.com/user-attachments/assets/6bf1766a-0b7b-4a0c-865d-2b103811c581" />
<img width="572" height="179" alt="SCR-20260204-lppt" src="https://github.com/user-attachments/assets/4a8ec31a-e66d-4ec0-b2ab-2c1523c432ad" />



## Desired behavior after PR is merged

The rendered string in Analysis listings, e.g. Bq·kg<sup>-1</sup>


<img width="523" height="182" alt="SCR-20260204-lorh" src="https://github.com/user-attachments/assets/3634bc48-a13b-4534-a809-81a53201b2a2" />


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
