### PR TITLE
Remove nonexisting `getSamplePointTitle` column index

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2847 Remove nonexisting getSamplePointTitle column index
 - #2776 Refactor: rename SiteView.setCookie to set_cookie in dashboard.pt
 - #2805 Migrate Worksheets to DX
 - #2775 Auto-add CCContact when hidden on Sample Add form

--- a/src/senaite/core/browser/samples/view.py
+++ b/src/senaite/core/browser/samples/view.py
@@ -210,7 +210,6 @@ class SamplesView(ListingView):
             ("getSamplePointTitle", {
                 "title": _("Sample Point"),
                 "sortable": True,
-                "index": "getSamplePointTitle",
                 "toggle": False}),
             ("getStorageLocation", {
                 "title": _("Storage Location"),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the nonexisting `getSamplePointTitle` column index for the samples listing.

## Current behavior before PR

Filtering is provided for this column

## Desired behavior after PR is merged

No filtering is provided for this column

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
