### PR TITLE
Patch transaction commit hook for catalog queue to avoid double indexing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2848 Patch transaction commit hook for catalog queue to avoid double indexing
 - #2846 Fix Unit super-/subscript rendering 
 - #2847 Remove nonexisting getSamplePointTitle column index
 - #2776 Refactor: rename SiteView.setCookie to set_cookie in dashboard.pt

--- a/src/senaite/core/patches/cmfcore/configure.zcml
+++ b/src/senaite/core/patches/cmfcore/configure.zcml
@@ -28,6 +28,14 @@
       replacement=".portal_catalog_processor.reindex"
       />
 
+  <!-- Patch `Products.CMFCore.indexing.QueueTM.before_commit` -->
+  <monkey:patch
+      description="Patch QueueTM.before_commit to add re-entrancy guard"
+      class="Products.CMFCore.indexing.QueueTM"
+      original="before_commit"
+      replacement=".queue_tm.before_commit"
+      />
+
   <!-- Patch `Products.CMFCore.WorkflowTool.WorkflowTool._reindexWorkflowVariables` -->
   <monkey:patch
     description="Patch `Products.CMFCore.WorkflowTool.WorkflowTool._reindexWorkflowVariables`"

--- a/src/senaite/core/patches/cmfcore/queue_tm.py
+++ b/src/senaite/core/patches/cmfcore/queue_tm.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301 USA.
+#
+# Copyright 2018-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from Products.CMFCore.indexing import processing
+
+
+def before_commit(self):
+    """Patched before_commit with re-entrancy guard.
+
+    The original QueueTM.before_commit calls queue.process() without
+    adding the queue to the `processing` set. This allows recursive
+    calls to processQueue() (triggered by catalog queries inside
+    processors) to re-enter process(), causing double indexing and
+    UUIDIndex errors.
+
+    This patch adds the same guard that processQueue() uses.
+    """
+    if self.queue not in processing:
+        try:
+            processing.add(self.queue)
+            self.queue.process()
+        finally:
+            processing.remove(self.queue)
+    self.queue.clear()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR patches the `before_commit` transaction hook for queue processing to avoid double indexing if a catalog operation is executed from within the indexing operation, e.g. from a metadata method like `getProgressPercentage`.

The behavior happens currently for the DX migrated Worksheets only (see https://github.com/senaite/senaite.core/pull/2805), but might be causing also double indexing on other places that might be runtime related.

## Current behavior before PR

When a new worksheet is created, the catalog holds two identical catalog brains with different resource IDs (rid):

<img width="2002" height="382" alt="SCR-20260212-iebv" src="https://github.com/user-attachments/assets/2b4a7d37-782d-4f17-8895-e6dfb557c75a" />

<img width="2055" height="533" alt="SCR-20260212-ifro" src="https://github.com/user-attachments/assets/4c2b8f39-3810-4b86-a43b-773aa8853454" />

If the worksheet is deleted, a stale brain remains and the WS appears to be still there:

<img width="666" height="208" alt="SCR-20260212-iges" src="https://github.com/user-attachments/assets/b0e34d0e-963d-4c87-83ce-9a19b55a089e" />

<img width="657" height="170" alt="SCR-20260212-igjk" src="https://github.com/user-attachments/assets/1e21c0e1-968d-4ab8-8c14-c02eb6a84f5e" />

<img width="609" height="161" alt="SCR-20260212-iglu" src="https://github.com/user-attachments/assets/a063f8d3-f200-4282-9186-fb373c31b023" />

Navigating to the WS causes an error (since it was deleted):

<img width="1332" height="143" alt="SCR-20260212-igvj" src="https://github.com/user-attachments/assets/861e7445-6b3f-4dfc-a0aa-b4a7ccf4cbd6" />

## Desired behavior after PR is merged

New Worksheets are only indexed once.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
