### PR TITLE
Fix hidden Client field is missing in sample add form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2853 Fix hidden Client field is missing in sample add form
 - #2852 Allow to set primary sample contact in client
 - #2849 Fix migrate Worksheet step for retry running. Refactoring create worksheet
 - #2850 Edit popup for sample analyses

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -335,7 +335,8 @@ class AnalysisRequestAddView(BrowserView):
             return context.getClient()
         elif parent.portal_type == "Batch":
             return context.getClient()
-        return None
+        # Fallback: walk the full acquisition chain up to find a client
+        return get_client_from_chain(context)
 
     def get_sample(self):
         """Returns the Sample
@@ -503,6 +504,16 @@ class AnalysisRequestAddView(BrowserView):
             if visible is False and visibility != "hidden":
                 continue
             out.append(field)
+
+        # Fields configured as 'edit' but forced hidden by is_field_visible
+        # (e.g. Client when inside a client context) must appear as hidden
+        # inputs so the form submission carries their value.
+        if visibility == "hidden":
+            for field in mv.get_fields_with_visibility("edit", mode):
+                if self.is_field_visible(field) is False:
+                    if field not in out:
+                        out.append(field)
+
         return out
 
     def get_service_categories(self, restricted=True):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an error that occurs if the sample add form is called from a custom content type below a client:

<img width="1156" height="683" alt="SCR-20260226-ntar" src="https://github.com/user-attachments/assets/42ef3f09-22e2-4673-a197-743a01a34174" />

## Current behavior before PR

An error message is displayed that says that the Field `Client` is required, although we're below a client already.

## Desired behavior after PR is merged

The sample can be created below custom content types within a client

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
