### PR TITLE
Allow to set sample CC contacts in client

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2854 Allow to set sample CC contacts in client
 - #2852 Allow to set primary sample contact in client
 - #2849 Fix migrate Worksheet step for retry running. Refactoring create worksheet
 - #2850 Edit popup for sample analyses

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -972,7 +972,9 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
         # Set the default contact, but only if empty. The Contact field is
         # flushed each time the Client changes, so we can assume that if there
-        # is a selected contact, it belongs to current client already
+        # is a selected contact, it belongs to current client already.
+        # get_contact_info already merges the client's CCContacts, so the
+        # Contact cascade carries the full merged CCContact list.
         default_contact = self.get_default_contact(client=obj)
         if default_contact:
             contact_info = self.get_contact_info(default_contact)
@@ -988,28 +990,50 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
         return info
 
+    def _get_merged_cc_contact_values(self, client, contact):
+        """Return a merged, deduplicated CCContact value list.
+
+        Combines CCContacts from the client and from the given contact
+        (primary contact). Client entries come first.
+        """
+        seen = set()
+        values = []
+
+        def add_cc(cc):
+            uid = api.get_uid(cc)
+            if uid in seen:
+                return
+            seen.add(uid)
+            values.append({
+                "uid": uid,
+                "title": cc.getFullname(),
+                "fullname": cc.getFullname(),
+                "email": cc.getEmailAddress(),
+            })
+
+        if client:
+            for cc in client.getCCContact():
+                add_cc(cc)
+        if contact:
+            for cc in contact.getCCContact():
+                add_cc(cc)
+
+        return values
+
     @cache(cache_key)
     def get_contact_info(self, obj):
-        """Returns the client info of an object
+        """Returns the contact info of an object
         """
-
         info = self.get_base_info(obj)
         fullname = obj.getFullname()
         email = obj.getEmailAddress()
 
-        # Note: It might get a circular dependency when calling:
-        #       map(self.get_contact_info, obj.getCCContact())
-        cccontacts = []
-        for contact in obj.getCCContact():
-            uid = api.get_uid(contact)
-            fullname = contact.getFullname()
-            email = contact.getEmailAddress()
-            cccontacts.append({
-                "uid": uid,
-                "title": fullname,
-                "fullname": fullname,
-                "email": email
-            })
+        # Merge CCContacts from the contact's parent client (if any) and the
+        # contact itself, deduplicated by UID.
+        # Note: do NOT call get_contact_info recursively on CCContacts here
+        #       to avoid circular dependencies.
+        client = get_client_from_chain(obj)
+        cccontacts = self._get_merged_cc_contact_values(client, obj)
 
         info.update({
             "fullname": fullname,

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -1012,7 +1012,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             })
 
         if client:
-            for cc in client.getCCContact():
+            for cc in client.getCCContacts():
                 add_cc(cc)
         if contact:
             for cc in contact.getCCContact():

--- a/src/bika/lims/content/client.py
+++ b/src/bika/lims/content/client.py
@@ -126,7 +126,7 @@ schema = Organisation.schema.copy() + Schema((
         allowed_types=("Contact", ),
         multiValued=1,
         widget=ReferenceWidget(
-            label=_("CC Contact"),
+            label=_("CC Contacts"),
             description=_(
                 "Default CC contacts for new samples. "
                 "If set, these contacts are automatically "

--- a/src/bika/lims/content/client.py
+++ b/src/bika/lims/content/client.py
@@ -119,6 +119,41 @@ schema = Organisation.schema.copy() + Schema((
         ),
     ),
 
+    UIDReferenceField(
+        "CCContacts",
+        schemata="Preferences",
+        required=0,
+        allowed_types=("Contact", ),
+        multiValued=1,
+        widget=ReferenceWidget(
+            label=_("CC Contact"),
+            description=_(
+                "Default CC contacts for new samples. "
+                "If set, these contacts are automatically "
+                "selected in the sample add form."),
+            catalog=CONTACT_CATALOG,
+            query="get_contact_field_query",
+            colModel=[
+                {
+                    "columnName": "scope",
+                    "width": "10",
+                    "label": "",
+                    "align": "center",
+                },
+                {
+                    "columnName": "getFullname",
+                    "width": "50",
+                    "label": _("Name"),
+                },
+                {
+                    "columnName": "getEmailAddress",
+                    "width": "40",
+                    "label": _("Email"),
+                },
+            ],
+        ),
+    ),
+
     EmailsField(
         "CCEmails",
         schemata="Preferences",


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is additional to #2852 and allows to set CC Contacts for all samples in clients:

<img width="1158" height="597" alt="SCR-20260226-pvye" src="https://github.com/user-attachments/assets/f65f6dd7-dc6e-46e4-9c3c-281ffe8ebaed" />


## Current behavior before PR

CC Contacts can be only set for individual contacts

## Desired behavior after PR is merged

CC Contacts can be set per client

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
