### PR TITLE
Fix catalog indexer for lab-/supplier contacts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- #2856 Fix searchable zext index for lab contacts
+- #2856 Fix searchable text index for lab-/supplier contacts
 - #2854 Allow to set sample CC contacts in client
 - #2853 Fix hidden Client field is missing in sample add form
 - #2852 Allow to set primary sample contact in client

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- #2856 Fix searchable text index for lab-/supplier contacts
+- #2856 Fix catalog indexer for lab-/supplier contacts
 - #2854 Allow to set sample CC contacts in client
 - #2853 Fix hidden Client field is missing in sample add form
 - #2852 Allow to set primary sample contact in client

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2856 Fix searchable zext index for lab contacts
 - #2854 Allow to set sample CC contacts in client
 - #2853 Fix hidden Client field is missing in sample add form
 - #2852 Allow to set primary sample contact in client

--- a/src/senaite/core/catalog/indexer/configure.zcml
+++ b/src/senaite/core/catalog/indexer/configure.zcml
@@ -11,7 +11,11 @@
   <adapter name="client_searchable_text" factory=".client.client_searchable_text"/>
 
   <!-- Contact Indexer -->
-  <adapter name="listing_searchable_text" factory=".contact.listing_searchable_text"/>
+  <adapter name="listing_searchable_text"
+      factory=".contact.listing_searchable_text"
+      for="senaite.core.interfaces.IContact
+           senaite.core.interfaces.catalog.IContactCatalog"
+      provides="plone.indexer.interfaces.IIndexer"/>
   <adapter name="listing_searchable_text"
       factory=".contact.listing_searchable_text"
       for="bika.lims.interfaces.ILabContact
@@ -22,7 +26,11 @@
       for="bika.lims.interfaces.ISupplierContact
            senaite.core.interfaces.catalog.IContactCatalog"
       provides="plone.indexer.interfaces.IIndexer"/>
-  <adapter name="getParentUID" factory=".contact.getParentUID"/>
+  <adapter name="getParentUID"
+      factory=".contact.getParentUID"
+      for="senaite.core.interfaces.IContact
+           senaite.core.interfaces.catalog.IContactCatalog"
+      provides="plone.indexer.interfaces.IIndexer"/>
   <adapter name="getParentUID"
       factory=".contact.getParentUID"
       for="bika.lims.interfaces.ILabContact
@@ -33,7 +41,11 @@
       for="bika.lims.interfaces.ISupplierContact
            senaite.core.interfaces.catalog.IContactCatalog"
       provides="plone.indexer.interfaces.IIndexer"/>
-  <adapter name="sortable_title" factory=".contact.sortable_title"/>
+  <adapter name="sortable_title"
+      factory=".contact.sortable_title"
+      for="senaite.core.interfaces.IContact
+           senaite.core.interfaces.catalog.IContactCatalog"
+      provides="plone.indexer.interfaces.IIndexer"/>
   <adapter name="sortable_title"
       factory=".contact.sortable_title"
       for="bika.lims.interfaces.ILabContact

--- a/src/senaite/core/catalog/indexer/configure.zcml
+++ b/src/senaite/core/catalog/indexer/configure.zcml
@@ -12,6 +12,14 @@
 
   <!-- Contact Indexer -->
   <adapter name="listing_searchable_text" factory=".contact.listing_searchable_text"/>
+  <adapter name="listing_searchable_text"
+      factory=".contact.listing_searchable_text"
+      for="bika.lims.interfaces.ILabContact
+           senaite.core.interfaces.catalog.IContactCatalog"/>
+  <adapter name="listing_searchable_text"
+      factory=".contact.listing_searchable_text"
+      for="bika.lims.interfaces.ISupplierContact
+           senaite.core.interfaces.catalog.IContactCatalog"/>
   <adapter name="getParentUID" factory=".contact.getParentUID"/>
   <adapter name="sortable_title" factory=".contact.sortable_title"/>
 

--- a/src/senaite/core/catalog/indexer/configure.zcml
+++ b/src/senaite/core/catalog/indexer/configure.zcml
@@ -11,42 +11,39 @@
   <adapter name="client_searchable_text" factory=".client.client_searchable_text"/>
 
   <!-- Contact Indexer -->
-  <adapter name="listing_searchable_text"
-      factory=".contact.listing_searchable_text"
-      for="senaite.core.interfaces.IContact
-           senaite.core.interfaces.catalog.IContactCatalog"/>
+  <adapter name="listing_searchable_text" factory=".contact.listing_searchable_text"/>
   <adapter name="listing_searchable_text"
       factory=".contact.listing_searchable_text"
       for="bika.lims.interfaces.ILabContact
-           senaite.core.interfaces.catalog.IContactCatalog"/>
+           senaite.core.interfaces.catalog.IContactCatalog"
+      provides="plone.indexer.interfaces.IIndexer"/>
   <adapter name="listing_searchable_text"
       factory=".contact.listing_searchable_text"
       for="bika.lims.interfaces.ISupplierContact
-           senaite.core.interfaces.catalog.IContactCatalog"/>
-  <adapter name="getParentUID"
-      factory=".contact.getParentUID"
-      for="senaite.core.interfaces.IContact
-           senaite.core.interfaces.catalog.IContactCatalog"/>
+           senaite.core.interfaces.catalog.IContactCatalog"
+      provides="plone.indexer.interfaces.IIndexer"/>
+  <adapter name="getParentUID" factory=".contact.getParentUID"/>
   <adapter name="getParentUID"
       factory=".contact.getParentUID"
       for="bika.lims.interfaces.ILabContact
-           senaite.core.interfaces.catalog.IContactCatalog"/>
+           senaite.core.interfaces.catalog.IContactCatalog"
+      provides="plone.indexer.interfaces.IIndexer"/>
   <adapter name="getParentUID"
       factory=".contact.getParentUID"
       for="bika.lims.interfaces.ISupplierContact
-           senaite.core.interfaces.catalog.IContactCatalog"/>
-  <adapter name="sortable_title"
-      factory=".contact.sortable_title"
-      for="senaite.core.interfaces.IContact
-           senaite.core.interfaces.catalog.IContactCatalog"/>
+           senaite.core.interfaces.catalog.IContactCatalog"
+      provides="plone.indexer.interfaces.IIndexer"/>
+  <adapter name="sortable_title" factory=".contact.sortable_title"/>
   <adapter name="sortable_title"
       factory=".contact.sortable_title"
       for="bika.lims.interfaces.ILabContact
-           senaite.core.interfaces.catalog.IContactCatalog"/>
+           senaite.core.interfaces.catalog.IContactCatalog"
+      provides="plone.indexer.interfaces.IIndexer"/>
   <adapter name="sortable_title"
       factory=".contact.sortable_title"
       for="bika.lims.interfaces.ISupplierContact
-           senaite.core.interfaces.catalog.IContactCatalog"/>
+           senaite.core.interfaces.catalog.IContactCatalog"
+      provides="plone.indexer.interfaces.IIndexer"/>
 
   <!-- Label Indexer -->
   <adapter name="labels" factory=".label.labels"/>

--- a/src/senaite/core/catalog/indexer/configure.zcml
+++ b/src/senaite/core/catalog/indexer/configure.zcml
@@ -12,10 +12,7 @@
 
   <!-- Contact Indexer -->
   <adapter name="listing_searchable_text"
-      factory=".contact.listing_searchable_text"
-      for="senaite.core.interfaces.IContact
-           senaite.core.interfaces.catalog.IContactCatalog"
-      provides="plone.indexer.interfaces.IIndexer"/>
+      factory=".contact.listing_searchable_text"/>
   <adapter name="listing_searchable_text"
       factory=".contact.listing_searchable_text"
       for="bika.lims.interfaces.ILabContact
@@ -27,10 +24,7 @@
            senaite.core.interfaces.catalog.IContactCatalog"
       provides="plone.indexer.interfaces.IIndexer"/>
   <adapter name="getParentUID"
-      factory=".contact.getParentUID"
-      for="senaite.core.interfaces.IContact
-           senaite.core.interfaces.catalog.IContactCatalog"
-      provides="plone.indexer.interfaces.IIndexer"/>
+      factory=".contact.getParentUID"/>
   <adapter name="getParentUID"
       factory=".contact.getParentUID"
       for="bika.lims.interfaces.ILabContact
@@ -42,10 +36,7 @@
            senaite.core.interfaces.catalog.IContactCatalog"
       provides="plone.indexer.interfaces.IIndexer"/>
   <adapter name="sortable_title"
-      factory=".contact.sortable_title"
-      for="senaite.core.interfaces.IContact
-           senaite.core.interfaces.catalog.IContactCatalog"
-      provides="plone.indexer.interfaces.IIndexer"/>
+      factory=".contact.sortable_title"/>
   <adapter name="sortable_title"
       factory=".contact.sortable_title"
       for="bika.lims.interfaces.ILabContact

--- a/src/senaite/core/catalog/indexer/configure.zcml
+++ b/src/senaite/core/catalog/indexer/configure.zcml
@@ -11,7 +11,10 @@
   <adapter name="client_searchable_text" factory=".client.client_searchable_text"/>
 
   <!-- Contact Indexer -->
-  <adapter name="listing_searchable_text" factory=".contact.listing_searchable_text"/>
+  <adapter name="listing_searchable_text"
+      factory=".contact.listing_searchable_text"
+      for="senaite.core.interfaces.IContact
+           senaite.core.interfaces.catalog.IContactCatalog"/>
   <adapter name="listing_searchable_text"
       factory=".contact.listing_searchable_text"
       for="bika.lims.interfaces.ILabContact
@@ -20,8 +23,30 @@
       factory=".contact.listing_searchable_text"
       for="bika.lims.interfaces.ISupplierContact
            senaite.core.interfaces.catalog.IContactCatalog"/>
-  <adapter name="getParentUID" factory=".contact.getParentUID"/>
-  <adapter name="sortable_title" factory=".contact.sortable_title"/>
+  <adapter name="getParentUID"
+      factory=".contact.getParentUID"
+      for="senaite.core.interfaces.IContact
+           senaite.core.interfaces.catalog.IContactCatalog"/>
+  <adapter name="getParentUID"
+      factory=".contact.getParentUID"
+      for="bika.lims.interfaces.ILabContact
+           senaite.core.interfaces.catalog.IContactCatalog"/>
+  <adapter name="getParentUID"
+      factory=".contact.getParentUID"
+      for="bika.lims.interfaces.ISupplierContact
+           senaite.core.interfaces.catalog.IContactCatalog"/>
+  <adapter name="sortable_title"
+      factory=".contact.sortable_title"
+      for="senaite.core.interfaces.IContact
+           senaite.core.interfaces.catalog.IContactCatalog"/>
+  <adapter name="sortable_title"
+      factory=".contact.sortable_title"
+      for="bika.lims.interfaces.ILabContact
+           senaite.core.interfaces.catalog.IContactCatalog"/>
+  <adapter name="sortable_title"
+      factory=".contact.sortable_title"
+      for="bika.lims.interfaces.ISupplierContact
+           senaite.core.interfaces.catalog.IContactCatalog"/>
 
   <!-- Label Indexer -->
   <adapter name="labels" factory=".label.labels"/>

--- a/src/senaite/core/catalog/indexer/contact.py
+++ b/src/senaite/core/catalog/indexer/contact.py
@@ -20,20 +20,21 @@
 
 from bika.lims import api
 from bika.lims.interfaces import IClient
+from plone.indexer.delegate import DelegatingIndexerFactory
 
 
-def sortable_title(instance):
+def _sortable_title(instance):
     return instance.getFullname().lower()
 
 
-def getParentUID(instance):
+def _getParentUID(instance):
     parent = instance.aq_parent
     if not IClient.providedBy(parent):
         return ""
     return parent.UID()
 
 
-def listing_searchable_text(instance):
+def _listing_searchable_text(instance):
     """Extract search tokens for ZC text index
     """
 
@@ -61,3 +62,8 @@ def listing_searchable_text(instance):
 
     # return a single unicode string with all the concatenated tokens
     return u" ".join(map(api.safe_unicode, tokens))
+
+
+sortable_title = DelegatingIndexerFactory(_sortable_title)
+getParentUID = DelegatingIndexerFactory(_getParentUID)
+listing_searchable_text = DelegatingIndexerFactory(_listing_searchable_text)

--- a/src/senaite/core/catalog/indexer/contact.py
+++ b/src/senaite/core/catalog/indexer/contact.py
@@ -20,23 +20,12 @@
 
 from bika.lims import api
 from bika.lims.interfaces import IClient
-from bika.lims.interfaces import ILabContact
-from bika.lims.interfaces import ISupplierContact
-from senaite.core.interfaces import IContact
-from plone.indexer import indexer
-from senaite.core.interfaces.catalog import IContactCatalog
 
 
-@indexer(IContact, IContactCatalog)
-@indexer(ILabContact, IContactCatalog)
-@indexer(ISupplierContact, IContactCatalog)
 def sortable_title(instance):
     return instance.getFullname().lower()
 
 
-@indexer(IContact, IContactCatalog)
-@indexer(ILabContact, IContactCatalog)
-@indexer(ISupplierContact, IContactCatalog)
 def getParentUID(instance):
     parent = instance.aq_parent
     if not IClient.providedBy(parent):
@@ -44,9 +33,6 @@ def getParentUID(instance):
     return parent.UID()
 
 
-@indexer(IContact, IContactCatalog)
-@indexer(ILabContact, IContactCatalog)
-@indexer(ISupplierContact, IContactCatalog)
 def listing_searchable_text(instance):
     """Extract search tokens for ZC text index
     """

--- a/src/senaite/core/catalog/indexer/contact.py
+++ b/src/senaite/core/catalog/indexer/contact.py
@@ -20,21 +20,26 @@
 
 from bika.lims import api
 from bika.lims.interfaces import IClient
-from plone.indexer.delegate import DelegatingIndexerFactory
+from plone.indexer import indexer
+from senaite.core.interfaces import IContact
+from senaite.core.interfaces.catalog import IContactCatalog
 
 
-def _sortable_title(instance):
+@indexer(IContact, IContactCatalog)
+def sortable_title(instance):
     return instance.getFullname().lower()
 
 
-def _getParentUID(instance):
+@indexer(IContact, IContactCatalog)
+def getParentUID(instance):
     parent = instance.aq_parent
     if not IClient.providedBy(parent):
         return ""
     return parent.UID()
 
 
-def _listing_searchable_text(instance):
+@indexer(IContact, IContactCatalog)
+def listing_searchable_text(instance):
     """Extract search tokens for ZC text index
     """
 
@@ -62,8 +67,3 @@ def _listing_searchable_text(instance):
 
     # return a single unicode string with all the concatenated tokens
     return u" ".join(map(api.safe_unicode, tokens))
-
-
-sortable_title = DelegatingIndexerFactory(_sortable_title)
-getParentUID = DelegatingIndexerFactory(_getParentUID)
-listing_searchable_text = DelegatingIndexerFactory(_listing_searchable_text)

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2721</version>
+  <version>2722</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-Products.CMFEditions:CMFEditions</dependency>

--- a/src/senaite/core/tests/doctests/Contacts.rst
+++ b/src/senaite/core/tests/doctests/Contacts.rst
@@ -1,8 +1,7 @@
 Contacts
 --------
 
-Tests catalog indexing behavior for all contact types: `Contact`,
-`LabContact`, and `SupplierContact`.
+Tests catalog indexing behavior for contact types in the contact catalog.
 
 Running this test from the buildout directory:
 
@@ -50,25 +49,10 @@ The Contact should be indexed in the contact catalog:
     >>> len(brains)
     1
 
-Searching by `listing_searchable_text` should find the Contact by first name:
+The `getFullname` index should return the contact's full name:
 
     >>> brains = api.search(
-    ...     {
-    ...         "portal_type": "Contact",
-    ...         "listing_searchable_text": "Rita",
-    ...     },
-    ...     CONTACT_CATALOG,
-    ... )
-    >>> len(brains)
-    1
-
-Searching by last name should also return the Contact:
-
-    >>> brains = api.search(
-    ...     {
-    ...         "portal_type": "Contact",
-    ...         "listing_searchable_text": "Mohale",
-    ...     },
+    ...     {"portal_type": "Contact", "getFullname": "Rita Mohale"},
     ...     CONTACT_CATALOG,
     ... )
     >>> len(brains)
@@ -90,6 +74,9 @@ The `sortable_title` index should allow sorting by full name:
 
 LabContact Catalog Indexing
 ...........................
+
+The `listing_searchable_text` adapter must be registered for `ILabContact`
+so that text search returns results for lab contacts.
 
 Create a LabContact with known attributes:
 
@@ -132,71 +119,13 @@ Searching by last name should also return the LabContact:
     >>> len(brains)
     1
 
-The `sortable_title` index should be populated and allow sorting by full name:
+The `sortable_title` index should allow ordering results by full name:
 
     >>> brains = api.search(
     ...     {
     ...         "portal_type": "LabContact",
     ...         "UID": api.get_uid(labcontact),
     ...         "sort_on": "sortable_title",
-    ...     },
-    ...     CONTACT_CATALOG,
-    ... )
-    >>> len(brains)
-    1
-
-LabContacts are not inside a client, so `getParentUID` should be empty:
-
-    >>> brain = api.search({"UID": api.get_uid(labcontact)}, CONTACT_CATALOG)[0]
-    >>> brain.getParentUID
-    ''
-
-
-SupplierContact Catalog Indexing
-.................................
-
-Create a Supplier and a SupplierContact:
-
-    >>> supplier = api.create(
-    ...     bikasetup.bika_suppliers,
-    ...     "Supplier",
-    ...     Name="Test Supplier",
-    ... )
-    >>> suppliercontact = api.create(
-    ...     supplier,
-    ...     "SupplierContact",
-    ...     Firstname="Jane",
-    ...     Lastname="Tester",
-    ...     EmailAddress="jane@supplier.test",
-    ... )
-    >>> processing = processQueue()
-
-The SupplierContact should be indexed in the contact catalog:
-
-    >>> brains = api.search(
-    ...     {"UID": api.get_uid(suppliercontact)}, CONTACT_CATALOG
-    ... )
-    >>> len(brains)
-    1
-
-Searching by `listing_searchable_text` should find the SupplierContact by first name:
-
-    >>> brains = api.search(
-    ...     {
-    ...         "portal_type": "SupplierContact",
-    ...         "listing_searchable_text": "Jane",
-    ...     },
-    ...     CONTACT_CATALOG,
-    ... )
-    >>> len(brains)
-    1
-
-Searching by last name should also return the SupplierContact:
-
-    >>> brains = api.search(
-    ...     {
-    ...         "portal_type": "SupplierContact",
-    ...         "listing_searchable_text": "Tester",
     ...     },
     ...     CONTACT_CATALOG,
     ... )

--- a/src/senaite/core/tests/doctests/Contacts.rst
+++ b/src/senaite/core/tests/doctests/Contacts.rst
@@ -38,7 +38,7 @@ Create a global Contact in the setup contacts folder:
     ...     setup.contacts,
     ...     "Contact",
     ...     Firstname="Rita",
-    ...     Lastname="Mohale",
+    ...     Surname="Mohale",
     ...     EmailAddress="rita@lab.test",
     ... )
     >>> processing = processQueue()
@@ -84,7 +84,7 @@ Create a LabContact with known attributes:
     ...     bikasetup.bika_labcontacts,
     ...     "LabContact",
     ...     Firstname="William",
-    ...     Lastname="Testperson",
+    ...     Surname="Testperson",
     ...     EmailAddress="william@lab.test",
     ... )
     >>> processing = processQueue()

--- a/src/senaite/core/tests/doctests/Contacts.rst
+++ b/src/senaite/core/tests/doctests/Contacts.rst
@@ -1,13 +1,12 @@
-LabContact
-----------
+Contacts
+--------
 
-Tests that the `listing_searchable_text`, `sortable_title`, and `getParentUID`
-indexes are correctly populated for `LabContact` and `SupplierContact` objects
-in the contact catalog.
+Tests catalog indexing behavior for all contact types: `Contact`,
+`LabContact`, and `SupplierContact`.
 
 Running this test from the buildout directory:
 
-    bin/test test_textual_doctests -t LabContact
+    bin/test test_textual_doctests -t Contacts
 
 
 Test Setup
@@ -25,13 +24,72 @@ Variables:
 
     >>> portal = self.portal
     >>> request = self.request
+    >>> setup = portal.setup
     >>> bikasetup = portal.bika_setup
 
     >>> setRoles(portal, TEST_USER_ID, ["LabManager"])
 
 
-LabContact listing_searchable_text Indexing
-...........................................
+Contact Catalog Indexing
+........................
+
+Create a global Contact in the setup contacts folder:
+
+    >>> contact = api.create(
+    ...     setup.contacts,
+    ...     "Contact",
+    ...     Firstname="Rita",
+    ...     Lastname="Mohale",
+    ...     EmailAddress="rita@lab.test",
+    ... )
+    >>> processing = processQueue()
+
+The Contact should be indexed in the contact catalog:
+
+    >>> brains = api.search({"UID": api.get_uid(contact)}, CONTACT_CATALOG)
+    >>> len(brains)
+    1
+
+Searching by `listing_searchable_text` should find the Contact by first name:
+
+    >>> brains = api.search(
+    ...     {
+    ...         "portal_type": "Contact",
+    ...         "listing_searchable_text": "Rita",
+    ...     },
+    ...     CONTACT_CATALOG,
+    ... )
+    >>> len(brains)
+    1
+
+Searching by last name should also return the Contact:
+
+    >>> brains = api.search(
+    ...     {
+    ...         "portal_type": "Contact",
+    ...         "listing_searchable_text": "Mohale",
+    ...     },
+    ...     CONTACT_CATALOG,
+    ... )
+    >>> len(brains)
+    1
+
+The `sortable_title` index should allow sorting by full name:
+
+    >>> brains = api.search(
+    ...     {
+    ...         "portal_type": "Contact",
+    ...         "UID": api.get_uid(contact),
+    ...         "sort_on": "sortable_title",
+    ...     },
+    ...     CONTACT_CATALOG,
+    ... )
+    >>> len(brains)
+    1
+
+
+LabContact Catalog Indexing
+...........................
 
 Create a LabContact with known attributes:
 
@@ -42,9 +100,6 @@ Create a LabContact with known attributes:
     ...     Lastname="Testperson",
     ...     EmailAddress="william@lab.test",
     ... )
-
-Process the indexing queue to ensure the object is cataloged:
-
     >>> processing = processQueue()
 
 The LabContact should be indexed in the contact catalog:
@@ -77,12 +132,7 @@ Searching by last name should also return the LabContact:
     >>> len(brains)
     1
 
-
-LabContact sortable_title Indexing
-...................................
-
-The `sortable_title` index should be populated and allow sorting by full name.
-Query with a sort to verify the index is present:
+The `sortable_title` index should be populated and allow sorting by full name:
 
     >>> brains = api.search(
     ...     {
@@ -95,21 +145,15 @@ Query with a sort to verify the index is present:
     >>> len(brains)
     1
 
+LabContacts are not inside a client, so `getParentUID` should be empty:
 
-LabContact getParentUID Indexing
-.................................
-
-LabContacts are not inside a client, so `getParentUID` should return an empty
-string:
-
-    >>> brains = api.search({"UID": api.get_uid(labcontact)}, CONTACT_CATALOG)
-    >>> brain = brains[0]
+    >>> brain = api.search({"UID": api.get_uid(labcontact)}, CONTACT_CATALOG)[0]
     >>> brain.getParentUID
     ''
 
 
-SupplierContact listing_searchable_text Indexing
-................................................
+SupplierContact Catalog Indexing
+.................................
 
 Create a Supplier and a SupplierContact:
 
@@ -125,9 +169,6 @@ Create a Supplier and a SupplierContact:
     ...     Lastname="Tester",
     ...     EmailAddress="jane@supplier.test",
     ... )
-
-Process the indexing queue:
-
     >>> processing = processQueue()
 
 The SupplierContact should be indexed in the contact catalog:
@@ -138,7 +179,7 @@ The SupplierContact should be indexed in the contact catalog:
     >>> len(brains)
     1
 
-Searching by `listing_searchable_text` should find the SupplierContact:
+Searching by `listing_searchable_text` should find the SupplierContact by first name:
 
     >>> brains = api.search(
     ...     {

--- a/src/senaite/core/tests/doctests/LabContact.rst
+++ b/src/senaite/core/tests/doctests/LabContact.rst
@@ -1,0 +1,163 @@
+LabContact
+----------
+
+Tests that the `listing_searchable_text`, `sortable_title`, and `getParentUID`
+indexes are correctly populated for `LabContact` and `SupplierContact` objects
+in the contact catalog.
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t LabContact
+
+
+Test Setup
+..........
+
+Needed Imports:
+
+    >>> from bika.lims import api
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import setRoles
+    >>> from Products.CMFCore.indexing import processQueue
+    >>> from senaite.core.catalog import CONTACT_CATALOG
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> bikasetup = portal.bika_setup
+
+    >>> setRoles(portal, TEST_USER_ID, ["LabManager"])
+
+
+LabContact listing_searchable_text Indexing
+...........................................
+
+Create a LabContact with known attributes:
+
+    >>> labcontact = api.create(
+    ...     bikasetup.bika_labcontacts,
+    ...     "LabContact",
+    ...     Firstname="William",
+    ...     Lastname="Testperson",
+    ...     EmailAddress="william@lab.test",
+    ... )
+
+Process the indexing queue to ensure the object is cataloged:
+
+    >>> processing = processQueue()
+
+The LabContact should be indexed in the contact catalog:
+
+    >>> brains = api.search({"UID": api.get_uid(labcontact)}, CONTACT_CATALOG)
+    >>> len(brains)
+    1
+
+Searching by `listing_searchable_text` should find the LabContact by first name:
+
+    >>> brains = api.search(
+    ...     {
+    ...         "portal_type": "LabContact",
+    ...         "listing_searchable_text": "William",
+    ...     },
+    ...     CONTACT_CATALOG,
+    ... )
+    >>> len(brains)
+    1
+
+Searching by last name should also return the LabContact:
+
+    >>> brains = api.search(
+    ...     {
+    ...         "portal_type": "LabContact",
+    ...         "listing_searchable_text": "Testperson",
+    ...     },
+    ...     CONTACT_CATALOG,
+    ... )
+    >>> len(brains)
+    1
+
+
+LabContact sortable_title Indexing
+...................................
+
+The `sortable_title` index should be populated and allow sorting by full name.
+Query with a sort to verify the index is present:
+
+    >>> brains = api.search(
+    ...     {
+    ...         "portal_type": "LabContact",
+    ...         "UID": api.get_uid(labcontact),
+    ...         "sort_on": "sortable_title",
+    ...     },
+    ...     CONTACT_CATALOG,
+    ... )
+    >>> len(brains)
+    1
+
+
+LabContact getParentUID Indexing
+.................................
+
+LabContacts are not inside a client, so `getParentUID` should return an empty
+string:
+
+    >>> brains = api.search({"UID": api.get_uid(labcontact)}, CONTACT_CATALOG)
+    >>> brain = brains[0]
+    >>> brain.getParentUID
+    ''
+
+
+SupplierContact listing_searchable_text Indexing
+................................................
+
+Create a Supplier and a SupplierContact:
+
+    >>> supplier = api.create(
+    ...     bikasetup.bika_suppliers,
+    ...     "Supplier",
+    ...     Name="Test Supplier",
+    ... )
+    >>> suppliercontact = api.create(
+    ...     supplier,
+    ...     "SupplierContact",
+    ...     Firstname="Jane",
+    ...     Lastname="Tester",
+    ...     EmailAddress="jane@supplier.test",
+    ... )
+
+Process the indexing queue:
+
+    >>> processing = processQueue()
+
+The SupplierContact should be indexed in the contact catalog:
+
+    >>> brains = api.search(
+    ...     {"UID": api.get_uid(suppliercontact)}, CONTACT_CATALOG
+    ... )
+    >>> len(brains)
+    1
+
+Searching by `listing_searchable_text` should find the SupplierContact:
+
+    >>> brains = api.search(
+    ...     {
+    ...         "portal_type": "SupplierContact",
+    ...         "listing_searchable_text": "Jane",
+    ...     },
+    ...     CONTACT_CATALOG,
+    ... )
+    >>> len(brains)
+    1
+
+Searching by last name should also return the SupplierContact:
+
+    >>> brains = api.search(
+    ...     {
+    ...         "portal_type": "SupplierContact",
+    ...         "listing_searchable_text": "Tester",
+    ...     },
+    ...     CONTACT_CATALOG,
+    ... )
+    >>> len(brains)
+    1

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -33,6 +33,7 @@ from persistent.list import PersistentList
 from bika.lims.browser.fields.uidreferencefield import get_backreferences
 from senaite.core import logger
 from senaite.core.api import dtime
+from senaite.core.api.catalog import reindex_index
 from senaite.core.catalog import ANALYSIS_CATALOG
 from senaite.core.catalog import CONTACT_CATALOG
 from senaite.core.catalog import REPORT_CATALOG
@@ -1255,4 +1256,25 @@ def migrate_analysis_columns_to_setup(tool):
 
     logger.info(
         "Migrating analysis columns order to setup [DONE]"
+    )
+
+
+@upgradestep(product, version)
+def reindex_labcontact_searchable_text(tool):
+    """Reindex listing_searchable_text for LabContact and SupplierContact
+
+    The listing_searchable_text adapter was only registered for the new
+    DX Contact type (senaite.core.interfaces.IContact), causing the
+    ZCTextIndex to store no data for the legacy AT LabContact and
+    SupplierContact types. Explicit ZCML registrations were added for
+    bika.lims.interfaces.ILabContact and bika.lims.interfaces.ISupplierContact.
+    This step reindexes the affected index so existing objects become
+    searchable.
+    """
+    logger.info(
+        "Reindexing listing_searchable_text in contact catalog ..."
+    )
+    reindex_index(CONTACT_CATALOG, "listing_searchable_text")
+    logger.info(
+        "Reindexing listing_searchable_text in contact catalog [DONE]"
     )

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -1261,20 +1261,26 @@ def migrate_analysis_columns_to_setup(tool):
 
 @upgradestep(product, version)
 def reindex_labcontact_searchable_text(tool):
-    """Reindex listing_searchable_text for LabContact and SupplierContact
+    """Reindex contact catalog indexes for LabContact and SupplierContact
 
-    The listing_searchable_text adapter was only registered for the new
-    DX Contact type (senaite.core.interfaces.IContact), causing the
-    ZCTextIndex to store no data for the legacy AT LabContact and
-    SupplierContact types. Explicit ZCML registrations were added for
-    bika.lims.interfaces.ILabContact and bika.lims.interfaces.ISupplierContact.
-    This step reindexes the affected index so existing objects become
-    searchable.
+    The listing_searchable_text, sortable_title and getParentUID adapters
+    were only registered for the new DX Contact type
+    (senaite.core.interfaces.IContact), causing the indexes to store no
+    data for the legacy AT LabContact and SupplierContact types. Explicit
+    ZCML registrations were added for bika.lims.interfaces.ILabContact and
+    bika.lims.interfaces.ISupplierContact. This step reindexes the affected
+    indexes so existing objects are correctly indexed.
     """
-    logger.info(
-        "Reindexing listing_searchable_text in contact catalog ..."
-    )
-    reindex_index(CONTACT_CATALOG, "listing_searchable_text")
-    logger.info(
-        "Reindexing listing_searchable_text in contact catalog [DONE]"
-    )
+    indexes = [
+        "listing_searchable_text",
+        "sortable_title",
+        "getParentUID",
+    ]
+    for index in indexes:
+        logger.info(
+            "Reindexing %s in contact catalog ..." % index
+        )
+        reindex_index(CONTACT_CATALOG, index)
+        logger.info(
+            "Reindexing %s in contact catalog [DONE]" % index
+        )

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -3,8 +3,8 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
-      title="SENAITE.CORE 2.7.0: Reindex LabContact searchable text"
-      description="Reindex listing_searchable_text in contact catalog for LabContact and SupplierContact"
+      title="SENAITE.CORE 2.7.0: Reindex LabContact catalog indexes"
+      description="Reindex listing_searchable_text, sortable_title and getParentUID in contact catalog for LabContact and SupplierContact"
       source="2721"
       destination="2722"
       handler=".v02_07_000.reindex_labcontact_searchable_text"

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -3,6 +3,14 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.7.0: Reindex LabContact searchable text"
+      description="Reindex listing_searchable_text in contact catalog for LabContact and SupplierContact"
+      source="2721"
+      destination="2722"
+      handler=".v02_07_000.reindex_labcontact_searchable_text"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Migrate analysis columns order to setup"
       description="Move analysis columns order settings from registry to SENAITE setup"
       source="2720"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue in the labcontacts/suppliercontacts listing, so that no contacts were found when using the `listing_searchable_text` index.

The `listing_searchable_text` adapter was only registered for the new DX Contact type (`senaite.core.interfaces.IContact`), causing the `ZCTextIndex` to store no data for the legacy AT LabContact and SupplierContact types.

## Current behavior before PR

No lab-/suppliercontacts found when searching via `listing_searchable_text`

## Desired behavior after PR is merged

Free text searches work again.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
