### PR TITLE
Fix WrongType Error when downloading Reports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2857 Fix WrongType Error when downloading Reports
 - #2856 Fix catalog indexer for lab-/supplier contacts
 - #2854 Allow to set sample CC contacts in client
 - #2853 Fix hidden Client field is missing in sample add form

--- a/src/bika/lims/browser/workflow/client.py
+++ b/src/bika/lims/browser/workflow/client.py
@@ -52,7 +52,7 @@ class WorkflowActionDownloadReportsAdapter(RequestContextAware):
                     _("Could not load PDF for sample {}"
                       .format(sample_id)), "warning")
                 continue
-            pdf.filename = "{}.pdf".format(sample_id)
+            pdf.filename = api.safe_unicode("{}.pdf".format(sample_id))
             pdfs.append(pdf)
 
         if len(pdfs) == 1:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a Traceback that occurs when downloading multiple Analysis Report PDFs.

## Current behavior before PR

Traceback occurs:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module bika.lims.browser.workflow, line 149, in __call__
  Module bika.lims.browser.workflow.client, line 55, in __call__
  Module zope.schema.fieldproperty, line 86, in __set__
  Module zope.schema._bootstrapfields, line 298, in validate
  Module zope.schema._bootstrapfields, line 513, in _validate
  Module zope.schema._bootstrapfields, line 349, in _validate
WrongType: ('ErzP-0008.pdf', <type 'unicode'>, 'filename')
```

## Desired behavior after PR is merged

PDFs are archived and downloaded correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
