### PR TITLE
Fix sticker selection fields are rendered as text

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2858 Fix sticker selection fields are rendered as text
 - #2856 Fix catalog indexer for lab-/supplier contacts
 - #2854 Allow to set sample CC contacts in client
 - #2853 Fix hidden Client field is missing in sample add form

--- a/src/senaite/core/content/senaitesetup.py
+++ b/src/senaite/core/content/senaitesetup.py
@@ -1083,39 +1083,43 @@ class ISetupSchema(model.Schema):
         vocabulary=schema.vocabulary.SimpleVocabulary([
             schema.vocabulary.SimpleTerm("None", "None", _(u"None")),
             schema.vocabulary.SimpleTerm("register", "register",
-                                          _(u"Register")),
+                                         _(u"Register")),
             schema.vocabulary.SimpleTerm("receive", "receive", _(u"Receive")),
         ]),
         required=False,
         default="None",
     )
 
-    auto_sticker_template = schema.TextLine(
+    auto_sticker_template = schema.Choice(
         title=_(u"Default Sticker Template"),
         description=_(
             u"Select the default sticker template used for automatic printing."
         ),
+        vocabulary="senaite.core.vocabularies.stickers",
+        default=u"Code_128_1x48mm.pt",
         required=False,
     )
 
-    small_sticker_template = schema.TextLine(
+    small_sticker_template = schema.Choice(
         title=_(u"Small Sticker Template"),
         description=_(
             u"Choose the default template for 'small' stickers. Note: "
             u"Sample-specific 'small' stickers are configured based on their "
             u"sample type."
         ),
+        vocabulary="senaite.core.vocabularies.stickers",
         default=u"Code_128_1x48mm.pt",
         required=False,
     )
 
-    large_sticker_template = schema.TextLine(
+    large_sticker_template = schema.Choice(
         title=_(u"Large Sticker Template"),
         description=_(
             u"Choose the default template for 'large' stickers. Note: "
             u"Sample-specific 'large' stickers are configured based on their "
             u"sample type."
         ),
+        vocabulary="senaite.core.vocabularies.stickers",
         default=u"Code_128_1x72mm.pt",
         required=False,
     )


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the sticker field types of the SENAITE setup to be rendered as selection fields instead of text fields:
<img width="1088" height="742" alt="SCR-20260305-lrtt" src="https://github.com/user-attachments/assets/fc931bef-0012-4d79-a6ee-02e30dff832a" />

## Current behavior before PR

Text fields are rendered for sticker selections

## Desired behavior after PR is merged

Choice fields are rendered for sticker selections

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
