### PR TITLE
Added a core's specific AfterAPICreatedObjectEvent for DX

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- #2859 Added a core's specific ObjectInitializedEvent for DX
+- #2859 Added a core's specific AfterAPICreatedObjectEvent for DX
 - #2600 Migrate Calculations to DX
 - #2855 Open edit modal for listing items
 - #2858 Fix sticker selection fields are rendered as text

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2859 Added a core's specific ObjectInitializedEvent for DX
 - #2600 Migrate Calculations to DX
 - #2855 Open edit modal for listing items
 - #2858 Fix sticker selection fields are rendered as text

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -54,7 +54,7 @@ from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.memoize.volatile import DontCache
 from Products.Archetypes.atapi import DisplayList
 from Products.Archetypes.BaseObject import BaseObject
-from Products.Archetypes.event import ObjectInitializedEvent as ATInitEvent
+from Products.Archetypes.event import ObjectInitializedEvent
 from Products.Archetypes.public import StringField
 from Products.Archetypes.utils import mapply
 from Products.CMFCore.interfaces import IFolderish
@@ -69,7 +69,7 @@ from Products.CMFPlone.utils import _createObjectByType
 from Products.CMFPlone.utils import base_hasattr
 from Products.PlonePAS.tools.memberdata import MemberData
 from Products.ZCatalog.interfaces import ICatalogBrain
-from senaite.core.events.lifecycle import ObjectInitializedEvent
+from senaite.core.events.lifecycle import AfterAPICreatedObjectEvent
 from senaite.core.interfaces import IContact
 from senaite.core.interfaces import IContacts
 from senaite.core.interfaces import ITemporaryObject
@@ -212,7 +212,7 @@ def create(container, portal_type, *args, **kwargs):
         # we are no longer under creation
         obj.unmarkCreationFlag()
         # notify that the object was created
-        notify(ATInitEvent(obj))
+        notify(ObjectInitializedEvent(obj))
     else:
         # Avoid circular imports
         from bika.lims.api.snapshot import pause_snapshots_for
@@ -264,8 +264,8 @@ def create(container, portal_type, *args, **kwargs):
         # Manually reindex the object to ensure all indexes are updated
         obj.reindexObject()
         take_snapshot(obj, action="create")
-        # notify that the object was initialized
-        notify(ObjectInitializedEvent(obj))
+        # notify that the object was created
+        notify(AfterAPICreatedObjectEvent(obj))
 
     return obj
 

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -54,7 +54,7 @@ from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.memoize.volatile import DontCache
 from Products.Archetypes.atapi import DisplayList
 from Products.Archetypes.BaseObject import BaseObject
-from Products.Archetypes.event import ObjectInitializedEvent
+from Products.Archetypes.event import ObjectInitializedEvent as ATInitEvent
 from Products.Archetypes.public import StringField
 from Products.Archetypes.utils import mapply
 from Products.CMFCore.interfaces import IFolderish
@@ -69,6 +69,7 @@ from Products.CMFPlone.utils import _createObjectByType
 from Products.CMFPlone.utils import base_hasattr
 from Products.PlonePAS.tools.memberdata import MemberData
 from Products.ZCatalog.interfaces import ICatalogBrain
+from senaite.core.events.lifecycle import ObjectInitializedEvent
 from senaite.core.interfaces import IContact
 from senaite.core.interfaces import IContacts
 from senaite.core.interfaces import ITemporaryObject
@@ -211,7 +212,7 @@ def create(container, portal_type, *args, **kwargs):
         # we are no longer under creation
         obj.unmarkCreationFlag()
         # notify that the object was created
-        notify(ObjectInitializedEvent(obj))
+        notify(ATInitEvent(obj))
     else:
         # Avoid circular imports
         from bika.lims.api.snapshot import pause_snapshots_for
@@ -263,6 +264,8 @@ def create(container, portal_type, *args, **kwargs):
         # Manually reindex the object to ensure all indexes are updated
         obj.reindexObject()
         take_snapshot(obj, action="create")
+        # notify that the object was initialized
+        notify(ObjectInitializedEvent(obj))
 
     return obj
 

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -258,22 +258,15 @@ def create(container, portal_type, *args, **kwargs):
             else:
                 setattr(obj, name, value)
 
-        # Manually reindex the object to ensure all indexes are updated
-        obj.reindexObject()
-
-        # notify that the object was created. We do this here before resuming
-        # and manually taking the snapshot because IAfterAPICreatedObjectEvent
-        # extends IObjectModifiedEvent, that would trigger a version bump
-        # before the object is fully created
-        notify(AfterAPICreatedObjectEvent(obj))
-
         # Resume snapshots and manually create the initial snapshot
         # now that the object is fully initialized with all fields set
         resume_snapshots_for(obj)
-
         # Manually reindex the object to ensure all indexes are updated
         obj.reindexObject()
         take_snapshot(obj, action="create")
+
+        # notify that the object was created using api.create
+        notify(AfterAPICreatedObjectEvent(obj))
 
     return obj
 

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -258,14 +258,22 @@ def create(container, portal_type, *args, **kwargs):
             else:
                 setattr(obj, name, value)
 
+        # Manually reindex the object to ensure all indexes are updated
+        obj.reindexObject()
+
+        # notify that the object was created. We do this here before resuming
+        # and manually taking the snapshot because IAfterAPICreatedObjectEvent
+        # extends IObjectModifiedEvent, that would trigger a version bump
+        # before the object is fully created
+        notify(AfterAPICreatedObjectEvent(obj))
+
         # Resume snapshots and manually create the initial snapshot
         # now that the object is fully initialized with all fields set
         resume_snapshots_for(obj)
+
         # Manually reindex the object to ensure all indexes are updated
         obj.reindexObject()
         take_snapshot(obj, action="create")
-        # notify that the object was created
-        notify(AfterAPICreatedObjectEvent(obj))
 
     return obj
 

--- a/src/senaite/core/events/lifecycle.py
+++ b/src/senaite/core/events/lifecycle.py
@@ -1,16 +1,14 @@
 # -*- coding: utf-8 -*-
 
 from zope.interface import implementer
-from zope.lifecycleevent import ObjectModifiedEvent
-from zope.lifecycleevent.interfaces import IObjectModifiedEvent
+from zope.interface.interfaces import IObjectEvent
+from zope.interface.interfaces import ObjectEvent
 
 
-class IAfterAPICreatedObjectEvent(IObjectModifiedEvent):
-    """An object is being initialised, i.e. populated for the first time
-    """
+class IAfterAPICreatedObjectEvent(IObjectEvent):
+    """An object has been created using api.create"""
 
 
 @implementer(IAfterAPICreatedObjectEvent)
-class AfterAPICreatedObjectEvent(ObjectModifiedEvent):
-    """An object is being initialised, i.e. populated for the first time
-    """
+class AfterAPICreatedObjectEvent(ObjectEvent):
+    """An object has been created using api.create"""

--- a/src/senaite/core/events/lifecycle.py
+++ b/src/senaite/core/events/lifecycle.py
@@ -1,17 +1,16 @@
 # -*- coding: utf-8 -*-
 
-
 from zope.interface import implementer
 from zope.lifecycleevent import ObjectModifiedEvent
 from zope.lifecycleevent.interfaces import IObjectModifiedEvent
 
 
-class IObjectInitializedEvent(IObjectModifiedEvent):
+class IAfterAPICreatedObjectEvent(IObjectModifiedEvent):
     """An object is being initialised, i.e. populated for the first time
     """
 
 
-@implementer(IObjectInitializedEvent)
-class ObjectInitializedEvent(ObjectModifiedEvent):
+@implementer(IAfterAPICreatedObjectEvent)
+class AfterAPICreatedObjectEvent(ObjectModifiedEvent):
     """An object is being initialised, i.e. populated for the first time
     """

--- a/src/senaite/core/events/lifecycle.py
+++ b/src/senaite/core/events/lifecycle.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+
+from zope.interface import implementer
+from zope.lifecycleevent import ObjectModifiedEvent
+from zope.lifecycleevent.interfaces import IObjectModifiedEvent
+
+
+class IObjectInitializedEvent(IObjectModifiedEvent):
+    """An object is being initialised, i.e. populated for the first time
+    """
+
+
+@implementer(IObjectInitializedEvent)
+class ObjectInitializedEvent(ObjectModifiedEvent):
+    """An object is being initialised, i.e. populated for the first time
+    """

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -94,6 +94,50 @@ Created objects are properly indexed::
     >>> brains[0].getKeyword
     'DUM'
 
+The core's ``IAfterAPICreatedObjectEvent`` is fired after a DX content is
+created via ``api.create()``. This event is useful for subscribers that need to
+act on the object after it has been fully initialized (UID assigned, fields
+set, snapshot taken)::
+
+    >>> from senaite.core.events.lifecycle import IAfterAPICreatedObjectEvent
+    >>> from zope.component import getGlobalSiteManager
+
+Register a dummy event handler that records events::
+
+    >>> initialized_events = []
+    >>> def on_initialized(obj, event):
+    ...     initialized_events.append((obj, event))
+    >>> gsm = getGlobalSiteManager()
+    >>> gsm.registerHandler(on_initialized, (None, IAfterAPICreatedObjectEvent))
+
+Create a DX content type via ``api.create()``::
+
+    >>> sampletype = api.create(
+    ...     portal.setup.sampletypes, "SampleType",
+    ...     title="Test SampleType", Prefix="TST")
+
+The event handler was called with the created object::
+
+    >>> len(initialized_events) > 0
+    True
+    >>> obj, event = initialized_events[-1]
+    >>> obj == sampletype
+    True
+    >>> IAfterAPICreatedObjectEvent.providedBy(event)
+    True
+
+The object is fully initialized when the event fires (has UID, is indexed)::
+
+    >>> api.get_uid(obj) is not None
+    True
+    >>> obj.Title()
+    'Test SampleType'
+
+Cleanup the event handler::
+
+    >>> gsm.unregisterHandler(on_initialized, (None, IAfterAPICreatedObjectEvent))
+    True
+
 
 Editing Content
 ...............

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -1165,7 +1165,7 @@ This function returns the version as an integer::
     >>> calc = api.create(portal.setup.calculations, "Calculation", title="Test Calculation")
 
     >>> api.get_version(calc)
-    0
+    1
 
 Calling the modified event will create a new version::
 
@@ -1173,7 +1173,7 @@ Calling the modified event will create a new version::
 
     >>> modified(calc)
     >>> api.get_version(calc)
-    1
+    2
 
 
 Getting a Browser View

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -1165,7 +1165,7 @@ This function returns the version as an integer::
     >>> calc = api.create(portal.setup.calculations, "Calculation", title="Test Calculation")
 
     >>> api.get_version(calc)
-    1
+    0
 
 Calling the modified event will create a new version::
 
@@ -1173,7 +1173,7 @@ Calling the modified event will create a new version::
 
     >>> modified(calc)
     >>> api.get_version(calc)
-    2
+    1
 
 
 Getting a Browser View


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

We cannot rely on the default `zope.lifecyclevent.ObjectAddedEvent` cause `api.create` does assign the field values after the event is triggered by `addContentToContainer`.

We detected this issue after #2831

## Current behavior before PR

With this subscriber declaration:

```xml
<!-- ResultsReport created -->
<subscriber
    for="senaite.core.interfaces.IResultsReport
         zope.lifecycleevent.interfaces.IObjectAddedEvent"
    handler=".resultsreport.on_object_created" />
```

we get this when a `ResultsReport` object is created:

```python
41     def on_object_created(instance, event):
42         import pdb;pdb.set_trace()
43  ->     samples = instance.getContainedSamples() 

(Pdb++) event
<zope.lifecycleevent.ObjectAddedEvent object at 0x7fd1c036d650>
(Pdb++) instance
<ResultsReport at /senaite/clients/client-1/26SE00080/resultsreport-10>
(Pdb++) instance.sample
(Pdb++) instance.contained_samples
[]
(Pdb++) instance.getPdf()
```

## Desired behavior after PR is merged

With this subscriber declaration:

```xml
<!-- ResultsReport created -->
<subscriber
    for="senaite.core.interfaces.IResultsReport
         senaite.core.events.lifecycle.IAfterAPICreatedObjectEvent"
    handler=".resultsreport.on_object_created" />
```

we get this when a `ResultsReport` object is created:

```python
41     def on_object_created(instance, event):
42         import pdb;pdb.set_trace()
43  ->     samples = instance.getContainedSamples()

(Pdb++) event
<senaite.core.events.lifecycle.AfterAPICreatedObjectEvent object at 0x7fbcc4044910>
(Pdb++) instance
<ResultsReport at /senaite/clients/client-1/26SE00080/resultsreport-11>
(Pdb++) instance.sample
['a257b1d1e2224fafa615926b7f32aa5f']
(Pdb++) instance.contained_samples
[u'a257b1d1e2224fafa615926b7f32aa5f']
(Pdb++) instance.getPdf()
<plone.namedfile.file.NamedBlobFile object at 0x7fbcc59cacd0>
```


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
