### PR TITLE
Allow to override results in auto-import

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2861 Allow to override results in auto-import
 - #2860 Remove default selected languages
 - #2859 Added a core's specific AfterAPICreatedObjectEvent for DX
 - #2600 Migrate Calculations to DX

--- a/src/senaite/core/exportimport/auto_import_results.py
+++ b/src/senaite/core/exportimport/auto_import_results.py
@@ -67,9 +67,30 @@ class AutoImportResultsView(BrowserView):
         # return the concatenated logs
         return CR.join(self.logs)
 
+    def get_override_settings(self):
+        """Return override settings from request parameters
+
+        Reads ``override_non_empty`` and ``override_with_empty`` query
+        parameters (each ``0`` or ``1``).  Both default to ``0`` (False).
+
+        Example cron invocation::
+
+            curl -k -u admin:secret \\
+              'http://host/senaite/auto_import_results' \\
+              '?override_non_empty=1&override_with_empty=0'
+
+        :returns: [override_non_empty, override_with_empty] as booleans
+        """
+        override_non_empty = bool(
+            int(self.request.get("override_non_empty", 0)))
+        override_with_empty = bool(
+            int(self.request.get("override_with_empty", 0)))
+        return [override_non_empty, override_with_empty]
+
     def auto_import_results(self):
         """Auto import all new instrument import files
         """
+        override = self.get_override_settings()
         interfaces = []
         for brain in self.query_active_instruments():
             instrument = api.get_object(brain)
@@ -108,21 +129,27 @@ class AutoImportResultsView(BrowserView):
                                  instrument=instrument, interface=interface)
                         # skip already imported files
                         continue
-                    self.import_results(instrument, interface, folder, f)
+                    self.import_results(
+                        instrument, interface, folder, f, override=override)
 
             if not interfaces:
                 self.log("No active interfaces defined", instrument=instrument)
 
             self.log("Auto-Import finished")
 
-    def import_results(self, instrument, interface, folder, resultsfile):
+    def import_results(self, instrument, interface, folder, resultsfile,
+                       override=None):
         """Import resultsfile for instrument interface
 
         :param instrument: Instrument object
         :param interface: Interface name. e.g. generic.two_dimension
         :param folder: auto import folder path
         :param resultsfile: the filename of the imported file
+        :param override: override flags [override_non_empty, override_with_empty]
         """
+        if override is None:
+            override = [False, False]
+
         with open(os.path.join(folder, resultsfile), "r") as fileobj:
             wrapped = UploadFileWrapper(fileobj)
             parser = get_automatic_parser(interface, wrapped)
@@ -137,7 +164,8 @@ class AutoImportResultsView(BrowserView):
             tb = None
 
             # lookup automatic importer
-            importer = get_automatic_importer(interface, instrument, parser)
+            importer = get_automatic_importer(
+                interface, instrument, parser, override=override)
             try:
                 importer.process()
             except Exception:

--- a/src/senaite/core/exportimport/instruments/__init__.py
+++ b/src/senaite/core/exportimport/instruments/__init__.py
@@ -251,9 +251,17 @@ def getExim(exim_id):
     return interfaces and interfaces[0][1] or None
 
 
-def get_automatic_importer(exim_id, instrument, parser):
+def get_automatic_importer(exim_id, instrument, parser, override=None):
     """Returns the importer to be used for automatic imports
+
+    :param exim_id: Instrument interface ID
+    :param instrument: Instrument object
+    :param parser: Parser instance
+    :param override: Override flags [override_non_empty, override_with_empty]
     """
+    if override is None:
+        override = [False, False]
+
     adapter = getExim(exim_id)
 
     if IInstrumentAutoImportInterface.providedBy(adapter):
@@ -267,7 +275,7 @@ def get_automatic_importer(exim_id, instrument, parser):
     return AnalysisResultsImporter(
         parser=parser,
         context=api.get_portal(),
-        override=[False, False],
+        override=override,
         instrument_uid=api.get_uid(instrument))
 
 

--- a/src/senaite/core/tests/doctests/AutoImportResults.rst
+++ b/src/senaite/core/tests/doctests/AutoImportResults.rst
@@ -62,6 +62,19 @@ Functional Helpers:
     ...     login(portal, current_user.getUserName())
     ...     return out
 
+    >>> def auto_import_with_override(user, override_non_empty=0,
+    ...                               override_with_empty=0):
+    ...     current_user = api.user.get_user()
+    ...     login(portal, user)
+    ...     request.set("override_non_empty", str(override_non_empty))
+    ...     request.set("override_with_empty", str(override_with_empty))
+    ...     view = api.get_view("auto_import_results")
+    ...     out = view()
+    ...     request.set("override_non_empty", "0")
+    ...     request.set("override_with_empty", "0")
+    ...     login(portal, current_user.getUserName())
+    ...     return out
+
 
 Variables:
 
@@ -328,3 +341,67 @@ Autologs should be created:
     2... W-0004 result for 'Fe': '2'
     2... W-0004: Analysis Au, Cu, Fe imported sucessfully
     2... Import finished successfully: 1 Samples and 3 results updated
+
+
+Test override settings via request parameters
+.............................................
+
+Reset ``Au`` to numeric result type so the results are floatable:
+
+    >>> Au.setStringResult(False)
+
+Create a new sample and import results to give it existing values:
+
+    >>> sample5 = new_sample([Au])
+    >>> sample5
+    <AnalysisRequest at /plone/clients/client-1/W-0005>
+
+    >>> with open(os.path.join(resultsfolder, "import5.csv"), "w") as f:
+    ...     f.write("SampleID,Au\n")
+    ...     f.write("%s,99\n" % sample5.getId())
+
+    >>> log = auto_import("analyst")
+    >>> sample5.Au.getResult()
+    '99.0'
+
+By default the import does not override already set results. Create a new
+results file for the same sample with a different value:
+
+    >>> with open(os.path.join(resultsfolder, "import6.csv"), "w") as f:
+    ...     f.write("SampleID,Au\n")
+    ...     f.write("%s,88\n" % sample5.getId())
+
+Default import (no override flags) keeps the existing result:
+
+    >>> log = auto_import("analyst")
+    >>> sample5.Au.getResult()
+    '99.0'
+
+The log reports that the existing result was kept:
+
+    >>> "kept due to the selected override option" in log
+    True
+
+Now import with ``override_non_empty=1`` — the existing result should be
+overwritten:
+
+    >>> with open(os.path.join(resultsfolder, "import7.csv"), "w") as f:
+    ...     f.write("SampleID,Au\n")
+    ...     f.write("%s,77\n" % sample5.getId())
+
+    >>> log = auto_import_with_override("analyst", override_non_empty=1)
+    >>> sample5.Au.getResult()
+    '77.0'
+
+The log confirms the override setting was active:
+
+    >>> autolog = instrument.objectValues("AutoImportLog")[-1]
+    >>> print autolog.getResults()
+    2... [INFO] Parsing file .../results/import7.csv
+    2... [INFO] End of file reached successfully: 1 objects, 1 analyses, 1 results
+    2... [INFO] Allowed sample states: sample_received, to_be_verified
+    2... [INFO] Allowed analysis states: unassigned, assigned, to_be_verified
+    2... [INFO] Override non-empty analysis results
+    2... [INFO] W-0005 result for 'Au': '77.0'
+    2... [INFO] W-0005: Analysis Au imported sucessfully
+    2... [INFO] Import finished successfully: 1 Samples and 1 results updated


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The auto-import view (`auto_import_results`) did not support result override settings.
Manual imports via the form-based importer allow users to configure whether existing results should be overwritten (`override_non_empty`) and whether empty values should be used to overwrite existing results (`override_with_empty`).
No equivalent control existed for the automated cron-based import.

## Current behavior before PR

The auto-import view always runs with override disabled (`[False, False]`), regardless of what is passed in the request.
There is no way to configure override behavior from a cron job or external script without modifying the source code.

## Desired behavior after PR is merged

The auto-import view accepts two optional query parameters:

- `override_non_empty`: set to `1` to allow existing non-empty results to be overwritten (default: `0`)
- `override_with_empty` — set to `1` to also overwrite existing results with an empty value (default: `0`)

Both parameters default to 0 so existing cron jobs are unaffected.

Example usage:

```cron
  */2 * * * * curl -k -u admin:[password] 'http://localhost:8080/senaite/auto_import_results?override_non_empty=1&override_with_empty=0' > /dev/null 2>&1
```

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
