### PR TITLE
Docker GitHub Action: Include arm64 platform

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,6 +46,7 @@ jobs:
           context: ${{ github.workspace }}/senaite.docker/latest
           file: ${{ github.workspace }}/senaite.docker/latest/Dockerfile
           no-cache: true
+          platforms: linux/amd64,linux/arm64
           push: true
           # https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
           tags: senaite/senaite:edge,senaite/senaite:${{ github.ref_name }}


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR builds the the latest Docker container for `arm64` platforms

## Current behavior before PR

Only `amd64` platform supported

## Desired behavior after PR is merged

Both platforms are supported

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
