### PR TITLE
Fix upgrade step AT type removal calls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2864 Fix upgrade step AT type removal calls
 - #2861 Allow to override results in auto-import
 - #2860 Remove default selected languages
 - #2859 Added a core's specific AfterAPICreatedObjectEvent for DX

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -514,7 +514,7 @@ def migrate_contacts_to_dx(tool):
     logger.info("Migrating Contacts to Dexterity ...")
 
     # Ensure old AT types are flushed first
-    remove_at_portal_types(tool)
+    remove_at_portal_types(tool, REMOVE_AT_TYPES)
 
     # run required import steps
     tool.runImportStepFromProfile(profile, "typeinfo")
@@ -659,7 +659,7 @@ def migrate_multifiles_to_dx(tool):
     logger.info("Migrating Multifiles to Dexterity ...")
 
     # Ensure old AT types are flushed first
-    remove_at_portal_types(tool)
+    remove_at_portal_types(tool, REMOVE_AT_TYPES)
 
     # run required import steps
     tool.runImportStepFromProfile(profile, "typeinfo")
@@ -812,7 +812,7 @@ def create_setup_contacts_folder(tool):
     logger.info("Creating Contacts container in setup folder ...")
 
     # Ensure old AT types are flushed first
-    remove_at_portal_types(tool)
+    remove_at_portal_types(tool, REMOVE_AT_TYPES)
 
     # run required import steps
     tool.runImportStepFromProfile(profile, "typeinfo")
@@ -844,7 +844,7 @@ def setup_custom_image_and_file_types(tool):
     """
     logger.info("Setup custom File and Image types ...")
     # Ensure old AT types are flushed first
-    remove_at_portal_types(tool)
+    remove_at_portal_types(tool, REMOVE_AT_TYPES)
     portal = tool.aq_inner.aq_parent
     tool.runImportStepFromProfile(profile, "typeinfo")
     tool.runImportStepFromProfile(profile, "workflow")
@@ -1070,7 +1070,7 @@ def migrate_arreport_to_resultsreport(tool):
     logger.info("Migrating ARReport to Dexterity ResultsReport ...")
 
     # Remove AT portal type and install DX portal type
-    remove_at_portal_types(tool)
+    remove_at_portal_types(tool, REMOVE_AT_TYPES)
     tool.runImportStepFromProfile(profile, "typeinfo")
     tool.runImportStepFromProfile(profile, "workflow")
 
@@ -1288,7 +1288,7 @@ def migrate_worksheets_to_dx(tool):
         origin = portal.get("worksheets-old")
 
     # ensure old AT types are flushed first
-    remove_at_portal_types(tool)
+    remove_at_portal_types(tool, REMOVE_AT_TYPES)
 
     # run required import steps
     tool.runImportStepFromProfile(profile, "typeinfo")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes *again* the following traceback when running upgrade steps:
```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.GenericSetup.tool, line 1135, in manage_doUpgrades
  Module Products.GenericSetup.upgrade, line 185, in doStep
  Module senaite.core.upgrade, line 39, in wrap_func_args
  Module senaite.core.upgrade.v02_07_000, line 522, in migrate_contacts_to_dx
  Module Products.GenericSetup.tool, line 375, in runImportStepFromProfile
  Module Products.GenericSetup.tool, line 1323, in _doRunImportStep
   - __traceback_info__: typeinfo
  Module Products.CMFCore.exportimport.typeinfo, line 222, in importTypesTool
  Module Products.GenericSetup.utils, line 933, in importObjects
   - __traceback_info__: portal_types
  Module Products.GenericSetup.utils, line 929, in importObjects
   - __traceback_info__: types/Calculation
  Module Products.GenericSetup.utils, line 530, in _importBody
  Module Products.CMFCore.exportimport.typeinfo, line 61, in _importNode
  Module Products.GenericSetup.utils, line 762, in _initProperties
ValueError: undefined property 'add_permission'
```

 
## Current behavior before PR

The function `remove_at_portal_types` was called w/o `REMOVE_AT_TYPES`


## Desired behavior after PR is merged

The function `remove_at_portal_types` is called correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
