### PR TITLE
Skip problematic worksheets in upgrade step 2711

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2865 Skip problematic worksheets in upgrade step 2711
 - #2862 Updated Webpack Dependencies
 - #2864 Fix upgrade step AT type removal calls
 - #2861 Allow to override results in auto-import

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -1309,18 +1309,33 @@ def migrate_worksheets_to_dx(tool):
     total = len(brains)
     logger.info("Found {} Worksheet objects to migrate".format(total))
 
+    catalog = api.get_tool(WORKSHEET_CATALOG)
+    problematic = []
     for num, brain in enumerate(brains, start=1):
-        # Get the object
-        worksheet = api.get_object(brain)
-
         if num % 100 == 0:
             logger.info(
                 "Progress: {}/{} worksheets migrated".format(num, total))
+        brain_path = brain.getPath()
+        try:
+            worksheet = api.get_object(brain)
+        except (AttributeError, KeyError) as exc:
+            logger.warn(
+                "Cannot get Worksheet at %s: %s" % (brain_path, exc))
+            catalog.uncatalog_object(brain_path)
+            problematic.append(brain_path)
+            continue
         migrate_worksheet_to_dx(worksheet, new_dx_folder)
 
     # remove old AT folder
     if origin and len(origin) == 0:
         portal.manage_delObjects(["worksheets-old"])
+
+    if problematic:
+        logger.warn(
+            "Migration finished with {} skipped Worksheet(s):".format(
+                len(problematic)))
+        for path in problematic:
+            logger.warn("  Stale brain removed, AT WS at: %s" % path)
 
     logger.info("Convert Worksheet's to Dexterity [DONE]")
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an error that appears for sites with stale Worksheet catalog brains.

## Current behavior before PR

Traceback occurs:
```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.GenericSetup.tool, line 1135, in manage_doUpgrades
  Module Products.GenericSetup.upgrade, line 185, in doStep
  Module senaite.core.upgrade, line 39, in wrap_func_args
  Module senaite.core.upgrade.v02_07_000, line 1314, in migrate_worksheets_to_dx
  Module bika.lims.api, line 608, in get_object
  Module Products.ZCatalog.CatalogBrains, line 91, in getObject
  Module OFS.Traversable, line 360, in restrictedTraverse
  Module OFS.Traversable, line 343, in unrestrictedTraverse
   - __traceback_info__: ([], 'WS25-10522')
KeyError: 'WS25-10522'

```

## Desired behavior after PR is merged

Miggration step is continued and the stale catalog brain is removed.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
