### PR TITLE
Add transaction savepoints to large upgradesteps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2865 Skip problematic worksheets in upgrade step 2711
 - #2862 Updated Webpack Dependencies
 - #2864 Fix upgrade step AT type removal calls
 - #2861 Allow to override results in auto-import

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2866 Add transaction savepoints to large upgradesteps
 - #2865 Skip problematic worksheets in upgrade step 2711
 - #2862 Updated Webpack Dependencies
 - #2864 Fix upgrade step AT type removal calls

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -1095,9 +1095,16 @@ def migrate_arreport_to_resultsreport(tool):
         # Get the object
         arreport = api.get_object(brain)
 
-        if num % 100 == 0:
+        if num % 1000 == 0:
             logger.info("Progress: {}/{} reports migrated".format(num, total))
-            transaction.savepoint()
+            # NOTE: We do a full transaction commit to avoid the following
+            # error during this upgrade:
+            #
+            # Traceback (innermost last):
+            #   [...]
+            #   Module ZEO.TransactionBuffer, line 56, in store
+            # IOError: [Errno 28] No space left on device
+            transaction.commit()
 
         # Skip if already migrated to Dexterity
         if not api.is_at_content(arreport):

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -20,6 +20,7 @@
 
 
 import json
+import transaction
 from datetime import timedelta
 
 from bika.lims import api
@@ -212,8 +213,10 @@ def migrate_calculations_to_dx(tool):
 
     # copy items from old -> new container
     objects = origin.objectValues()
-    for src in objects:
+    for num, src in enumerate(objects, start=1):
         migrate_calculation_to_dx(src, destination)
+        if num % 100 == 0:
+            transaction.savepoint()
 
     # copy snapshots for the container
     copy_snapshots(origin, destination)
@@ -403,6 +406,7 @@ def strip_calc_interims_from_services(tool):
         if num and num % 100 == 0:
             logger.info(
                 "Processing services {}/{}".format(num, total))
+            transaction.savepoint()
         service = api.get_object(brain)
         _strip_calc_interims(service)
         service._p_deactivate()
@@ -533,6 +537,7 @@ def migrate_contacts_to_dx(tool):
 
         if num % 100 == 0:
             logger.info("Progress: {}/{} contacts migrated".format(num, total))
+            transaction.savepoint()
 
         # Skip if already migrated to Dexterity
         if not api.is_at_content(contact):
@@ -678,6 +683,7 @@ def migrate_multifiles_to_dx(tool):
 
         if num % 100 == 0:
             logger.info("Progress: {}/{} multifiles migrated".format(num, total))
+            transaction.savepoint()
 
         # Skip if already migrated to Dexterity
         if not api.is_at_content(multifile):
@@ -867,6 +873,7 @@ def link_contact_users(tool):
         if num and num % 100 == 0:
             logger.info("Linking contacts to users {0}/{1}"
                         .format(num, total))
+            transaction.savepoint()
 
         contact = api.get_object(brain)
         username = contact.getUsername()
@@ -1090,6 +1097,7 @@ def migrate_arreport_to_resultsreport(tool):
 
         if num % 100 == 0:
             logger.info("Progress: {}/{} reports migrated".format(num, total))
+            transaction.savepoint()
 
         # Skip if already migrated to Dexterity
         if not api.is_at_content(arreport):
@@ -1315,6 +1323,7 @@ def migrate_worksheets_to_dx(tool):
         if num % 100 == 0:
             logger.info(
                 "Progress: {}/{} worksheets migrated".format(num, total))
+            transaction.savepoint()
         brain_path = brain.getPath()
         try:
             worksheet = api.get_object(brain)
@@ -1346,7 +1355,10 @@ def cleanup_rejected_worksheets():
     logger.info("Cleanup rejected worksheets...")
 
     rejected_analysis_query = {"portal_type": "RejectAnalysis"}
-    for brain in api.search(rejected_analysis_query, ANALYSIS_CATALOG):
+    for num, brain in enumerate(
+            api.search(rejected_analysis_query, ANALYSIS_CATALOG)):
+        if num and num % 100 == 0:
+            transaction.savepoint()
         rejected_analysis = api.get_object(brain)
         api.delete(rejected_analysis, False)
         logger.info("Delete rejected analysis {}".format(rejected_analysis))
@@ -1355,7 +1367,10 @@ def cleanup_rejected_worksheets():
         "portal_type": "Worksheet",
         "review_state": "rejected",
     }
-    for brain in api.search(rejected_worksheets, WORKSHEET_CATALOG):
+    for num, brain in enumerate(
+            api.search(rejected_worksheets, WORKSHEET_CATALOG)):
+        if num and num % 100 == 0:
+            transaction.savepoint()
         ws = api.get_object(brain)
         if ws.objectValues():
             continue

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -1309,18 +1309,33 @@ def migrate_worksheets_to_dx(tool):
     total = len(brains)
     logger.info("Found {} Worksheet objects to migrate".format(total))
 
+    catalog = api.get_tool(WORKSHEET_CATALOG)
+    problematic = []
     for num, brain in enumerate(brains, start=1):
-        # Get the object
-        worksheet = api.get_object(brain)
-
         if num % 100 == 0:
             logger.info(
                 "Progress: {}/{} worksheets migrated".format(num, total))
+        brain_path = brain.getPath()
+        try:
+            worksheet = api.get_object(brain)
+        except (AttributeError, KeyError) as exc:
+            logger.warn(
+                "Cannot get Worksheet at %s: %s" % (brain_path, exc))
+            catalog.uncatalog_object(brain_path)
+            problematic.append(brain_path)
+            continue
         migrate_worksheet_to_dx(worksheet, new_dx_folder)
 
     # remove old AT folder
     if origin and len(origin) == 0:
         portal.manage_delObjects(["worksheets-old"])
+
+    if problematic:
+        logger.warn(
+            "Migration finished with {} skipped Worksheet(s):".format(
+                len(problematic)))
+        for path in problematic:
+            logger.warn("  Stale brain removed, AT WS at: %s" % path)
 
     logger.info("Convert Worksheet's to Dexterity [DONE]")
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds `transaction.savepoint()` calls to large upgrade steps to avoid transaction buffer overflows:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 182, in transaction_pubevents
  Module transaction._manager, line 257, in commit
  Module transaction._manager, line 134, in commit
  Module transaction._transaction, line 282, in commit
  Module transaction._transaction, line 273, in commit
  Module transaction._transaction, line 456, in _commitResources
  Module transaction._transaction, line 430, in _commitResources
  Module ZODB.Connection, line 493, in commit
  Module ZODB.Connection, line 1055, in _commit_savepoint
  Module ZODB.mvccadapter, line 210, in store
  Module ZEO.ClientStorage, line 570, in store
  Module ZEO.TransactionBuffer, line 56, in store
IOError: [Errno 28] No space left on device
```

**☝️ NOTE** Please merge #2865 first

## Current behavior before PR

Large upgrade steps with a lot of blobs are committed at once, causing an overflow of the Transaction Buffer

## Desired behavior after PR is merged

Transaction savepoints are done every 100 objects to flush the current buffer

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
