### PR TITLE
Add adapter lookup for client searchable text index

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2869 Add adapter lookup for client searchable text index
 - #2868 Fix auto CC contacts set in the client for new samples
 - #2867 Remove stale AT reference objects
 - #2866 Add transaction savepoints to large upgradesteps

--- a/src/senaite/core/catalog/indexer/client.py
+++ b/src/senaite/core/catalog/indexer/client.py
@@ -24,9 +24,7 @@ from bika.lims.interfaces import IListingSearchableTextProvider
 from plone.indexer import indexer
 from senaite.core.interfaces.catalog import IClientCatalog
 from zope.component import getAdapters
-
-
-CLIENT_CATALOG_ID = "senaite_catalog_client"
+from senaite.core.catalog import CLIENT_CATALOG
 
 
 @indexer(IClient, IClientCatalog)
@@ -50,7 +48,7 @@ def client_searchable_text(instance):
     tokens.update(instance.getPrintAddress())
 
     # allow add-ons to contribute additional tokens via named adapters
-    catalog = api.get_tool(CLIENT_CATALOG_ID)
+    catalog = api.get_tool(CLIENT_CATALOG)
     providers = getAdapters(
         (instance, api.get_request(), catalog),
         IListingSearchableTextProvider)

--- a/src/senaite/core/catalog/indexer/client.py
+++ b/src/senaite/core/catalog/indexer/client.py
@@ -20,29 +20,49 @@
 
 from bika.lims import api
 from bika.lims.interfaces import IClient
+from bika.lims.interfaces import IListingSearchableTextProvider
 from plone.indexer import indexer
 from senaite.core.interfaces.catalog import IClientCatalog
+from zope.component import getAdapters
+
+
+CLIENT_CATALOG_ID = "senaite_catalog_client"
 
 
 @indexer(IClient, IClientCatalog)
 def client_searchable_text(instance):
-    """Extract search tokens for ZC text index
-    """
+    """Extract search tokens for ZC text index.
 
-    tokens = [
+    Add-ons can contribute additional tokens by registering a named
+    multi-adapter for (IClient, IRequest, IClientCatalog) that provides
+    IListingSearchableTextProvider.
+    """
+    tokens = set([
         instance.getClientID(),
         instance.getName(),
         instance.getPhone(),
         instance.getFax(),
         instance.getEmailAddress(),
         instance.getTaxNumber(),
-    ]
+    ])
 
     # extend address lines
-    tokens.extend(instance.getPrintAddress())
+    tokens.update(instance.getPrintAddress())
 
-    # remove duplicates and filter out emtpies
-    tokens = filter(None, set(tokens))
+    # allow add-ons to contribute additional tokens via named adapters
+    catalog = api.get_tool(CLIENT_CATALOG_ID)
+    providers = getAdapters(
+        (instance, api.get_request(), catalog),
+        IListingSearchableTextProvider)
+    for name, provider in providers:
+        try:
+            value = provider()
+        except Exception:
+            continue
+        if isinstance(value, (list, tuple)):
+            tokens.update(map(api.safe_unicode, value))
+        elif value:
+            tokens.add(api.safe_unicode(value))
 
-    # return a single unicode string with all the concatenated tokens
+    tokens = filter(None, tokens)
     return u" ".join(map(api.safe_unicode, tokens))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds the possibility to extend the client searchable text index with a named adapter.

## Current behavior before PR

It is not possible to extend custom search tokens to the client listing searchable text

## Desired behavior after PR is merged

It is possible to extend the client searchable text index with an adapter

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
