### PR TITLE
Do a full commit every 1000 migrated worksheets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+-#2870 Do a full commit every 1000 migrated worksheets
+
 - #2869 Add adapter lookup for client searchable text index
 - #2868 Fix auto CC contacts set in the client for new samples
 - #2867 Remove stale AT reference objects

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -1364,10 +1364,10 @@ def migrate_worksheets_to_dx(tool):
     catalog = api.get_tool(WORKSHEET_CATALOG)
     problematic = []
     for num, brain in enumerate(brains, start=1):
-        if num % 100 == 0:
+        if num % 1000 == 0:
             logger.info(
                 "Progress: {}/{} worksheets migrated".format(num, total))
-            transaction.savepoint()
+            transaction.commit()
         brain_path = brain.getPath()
         try:
             worksheet = api.get_object(brain)

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -1322,7 +1322,9 @@ def migrate_worksheets_to_dx(tool):
     type_info = pt.getTypeInfo(portal)
     allowed_types = type_info.allowed_content_types
 
-    origin = None
+    # in case the upgrade step fails with partial migrated contents
+    origin = portal.get("worksheets-old", None)
+
     # check if WS folder is AT
     ws_container = portal.get("worksheets", None)
     if ws_container is not None and api.is_at_content(ws_container):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes upgrade step 2720 for sites with many worksheets, e.g. < 50k worksheets.

## Current behavior before PR

Upgrade step fails on the final transaction

## Desired behavior after PR is merged

Upgrade step succeeds with partial commits

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
