### PR TITLE
Use AT accessor/mutator in GenericSetup field adapter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
--#2870 Do a full commit every 1000 migrated worksheets
-
+- #2872 Use AT accessor/mutator in GenericSetup field adapter
+- #2870 Do a full commit every 1000 migrated worksheets
 - #2869 Add adapter lookup for client searchable text index
 - #2868 Fix auto CC contacts set in the client for new samples
 - #2867 Remove stale AT reference objects

--- a/src/senaite/core/exportimport/genericsetup/adapters.py
+++ b/src/senaite/core/exportimport/genericsetup/adapters.py
@@ -99,11 +99,25 @@ class ATFieldNodeAdapter(NodeAdapterBase):
             logger.info("Skipping readonly field %s.%s" % (
                 self.context.__class__.__name__, self.field.__name__))
             return
+        # Prefer the custom mutator over field.set() to support proxy
+        # fields (e.g. bikasetup -> senaitesetup) and allow custom
+        # setters to handle format conversion during import
+        if not api.is_dexterity_content(self.context):
+            mutator = self.field.getMutator(self.context)
+            if mutator is not None:
+                return mutator(value, **kw)
         return self.field.set(self.context, value, **kw)
 
     def get_field_value(self):
         """Get the field value
         """
+        # Prefer the custom accessor over field.get() to support proxy
+        # fields (e.g. bikasetup -> senaitesetup) and ensure we export
+        # the current value rather than stale AT storage data
+        if not api.is_dexterity_content(self.context):
+            accessor = self.field.getAccessor(self.context)
+            if accessor is not None:
+                return accessor()
         return self.field.get(self.context)
 
     def get_json_value(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The `ATFieldNodeAdapter` used `field.get()` and `field.set()` directly to export/import field values. This bypasses any custom accessor or mutator defined on the field, which is a problem for proxy fields on `bika_setup` that delegate to `senaite_setup`.

After the AT to DX migration in #2821, the old field values remain in AT storage (they are not cleaned up by the upgrade step). The accessors and mutators on `bika_setup` correctly proxy to `senaite_setup`, but `field.get()`/`field.set()` read/write directly from AT storage, returning stale pre-migration data.

## Current behavior before PR

```
2026-03-31 11:46:27,831 ERROR   [Zope.SiteErrorLog:252][waitress-0] 1774950387.830.169081372652 http://localhost:9090/senaite/portal_setup/manage_importTarball
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.GenericSetup.tool, line 647, in manage_importTarball
  Module Products.GenericSetup.tool, line 405, in runAllImportStepsFromProfile
  Module Products.GenericSetup.tool, line 1511, in _runImportStepsFromContext
  Module Products.GenericSetup.tool, line 1323, in _doRunImportStep
   - __traceback_info__: senaite.core.import
  Module senaite.core.exportimport.genericsetup.structure, line 601, in import_xml
  Module senaite.core.exportimport.genericsetup.structure, line 573, in importObjects
   - __traceback_info__: senaite
  Module senaite.core.exportimport.genericsetup.structure, line 569, in importObjects
   - __traceback_info__: senaite/bika_setup
  Module Products.GenericSetup.utils, line 530, in _importBody
  Module senaite.core.exportimport.genericsetup.structure, line 268, in _importNode
  Module senaite.core.exportimport.genericsetup.structure, line 326, in _initFields
  Module senaite.core.exportimport.genericsetup.adapters, line 159, in _importNode
  Module senaite.core.exportimport.genericsetup.adapters, line 140, in set_node_value
  Module senaite.core.exportimport.genericsetup.adapters, line 102, in set_field_value
  Module Products.Archetypes.Field, line 1657, in set
   - __traceback_info__: ([{u'textfield-7': u'Not tested: Serological testing not being offered at this time', u'textfield-6': u'Not tested: Testing not being offered at this time', u'textfield-5': u'Sample does not meet diagnostic criteria for referral', u'textfield-4': u'CMV IgM and EBV IgM testing not offered at CARPHA', u'textfield-3': u'No sample received', u'textfield-2': u'Sample previously tested', u'textfield-1': u'Sample leaked', u'textfield-0': u'Sample quantity not sufficient', u'textfield-9': u'Sample contaminated', u'textfield-8': u'No patient form received', u'checkbox': u'on', u'textfield-13': u'Test not offered at CARPHA', u'textfield-12': u'Sample not viable. Please submit new sample', u'textfield-11': u'Sample does not meet criteria for testing', u'textfield-10': u'Sample inappropriate'}], <type 'list'>)
AttributeError: 'dict' object has no attribute 'strip'
```

## Desired behavior after PR is merged

The genericsetup tarball is imported without errors

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
