### PR TITLE
Fix save button visibility of sample header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2874 Fix save button visibility of sample header
 - #2872 Use AT accessor/mutator in GenericSetup field adapter
 - #2870 Do a full commit every 1000 migrated worksheets
 - #2869 Add adapter lookup for client searchable text index

--- a/src/senaite/core/browser/viewlets/templates/sampleheader.pt
+++ b/src/senaite/core/browser/viewlets/templates/sampleheader.pt
@@ -39,20 +39,36 @@
           <div class="pr-3" tal:condition="python:view.can_manage_sample_fields()">
             <a class="text-decoration-none"
                target="_blank"
+               title="Manage sample fields"
+               i18n:attributes="title"
                tal:attributes="href python:context.absolute_url() + '/manage-sample-fields'">
-              <i class="fas fa-tasks"></i>
+              <i class="fas fa-sliders-h"></i>
             </a>
           </div>
           <!-- Toggle standard fields visibility -->
           <div tal:condition="python:render_standard_fields">
-            <a href="#" class="text-decoration-none" data-toggle="collapse" data-target="#sampleheader-standard-fields">
+            <a href="#" class="text-decoration-none"
+               data-toggle="collapse"
+               data-target="#sampleheader-standard-fields">
               <tal:toggleicons tal:condition="python:show_standard_fields">
-                <i id="toggle-show-icon" class="fas fa-window-maximize"></i>
-                <i id="toggle-hide-icon" class="fas fa-window-minimize d-none"></i>
+                <i id="toggle-show-icon"
+                   class="fas fa-chevron-up"
+                   title="Hide additional fields"
+                   i18n:attributes="title"></i>
+                <i id="toggle-hide-icon"
+                   class="fas fa-chevron-down d-none"
+                   title="Show additional fields"
+                   i18n:attributes="title"></i>
               </tal:toggleicons>
               <tal:toggleicons tal:condition="python:not show_standard_fields">
-                <i id="toggle-show-icon" class="fas fa-window-maximize d-none"></i>
-                <i id="toggle-hide-icon" class="fas fa-window-minimize"></i>
+                <i id="toggle-show-icon"
+                   class="fas fa-chevron-up d-none"
+                   title="Hide additional fields"
+                   i18n:attributes="title"></i>
+                <i id="toggle-hide-icon"
+                   class="fas fa-chevron-down"
+                   title="Show additional fields"
+                   i18n:attributes="title"></i>
               </tal:toggleicons>
             </a>
           </div>
@@ -109,7 +125,7 @@
               </tal:batch>
             </tr>
           </table>
-      </div>
+        </div>
 
         <!-- Standard fields -->
         <div id="sampleheader-standard-fields" class="table-responsive"
@@ -165,7 +181,7 @@
           </table>
         </div>
 
-        <tal:controls condition="python:render_prominent_fields and render_standard_fields">
+        <tal:controls condition="python:render_prominent_fields or render_standard_fields">
           <!-- Save Button -->
           <input tal:condition="python:view.show_save"
                  class="btn btn-sm btn-primary mt-2"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an issue with the save button visibility below the sample fields.
Furthermore, the icons were improved to be more intuitive in their functionality:
<img width="56" height="24" alt="SCR-20260402-likl" src="https://github.com/user-attachments/assets/87c62a05-4c57-4589-aa94-b475d30c79e4" />


## Current behavior before PR

The save button disappears if all standard fields are removed. I.e. only prominent fields are displayed.

## Desired behavior after PR is merged

The save button is visible even if only prominent fields are rendered.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
