### PR TITLE
Fix AttributeError in add_sample when rejection workflow is enabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2875 Fix AttributeError in add_sample when rejection workflow is enabled
 - #2872 Use AT accessor/mutator in GenericSetup field adapter
 - #2870 Do a full commit every 1000 migrated worksheets
 - #2869 Add adapter lookup for client searchable text index

--- a/src/bika/lims/browser/widgets/rejectionwidget.py
+++ b/src/bika/lims/browser/widgets/rejectionwidget.py
@@ -19,14 +19,9 @@
 # Some rights reserved, see README and LICENSE.
 
 from AccessControl import ClassSecurityInfo
+from bika.lims import api
 from Products.Archetypes.Registry import registerWidget
 from Products.Archetypes.Widget import TypesWidget
-
-try:
-    from zope.component.hooks import getSite
-except Exception:
-    # Plone < 4.3
-    from zope.app.component.hooks import getSite
 
 
 class RejectionWidget(TypesWidget):
@@ -53,22 +48,8 @@ class RejectionWidget(TypesWidget):
 
     def rejectionOptionsList(self):
         "Return a sorted list with the options defined in bikasetup"
-        plone = getSite()
-        settings = plone.bika_setup
-        # RejectionReasons will return something like:
-        # [{'checkbox': u'on', 'textfield-2': u'b', 'textfield-1': u'c', 'textfield-0': u'a'}]
-        if len(settings.RejectionReasons) > 0:
-            reject_reasons = settings.RejectionReasons[0]
-        else:
-            return []
-        sorted_keys = sorted(reject_reasons.keys())
-        if 'checkbox' in sorted_keys:
-            sorted_keys.remove('checkbox')
-        # Building the list with the values only because the keys are not needed any more
-        items = []
-        for key in sorted_keys:
-            items.append(reject_reasons[key].strip())
-        return items
+        setup = api.get_senaite_setup()
+        return setup.getRejectionReasons()
 
     def isRejectionEnabled(self, dd):
         """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the rejection widget is properly rendered and populated with rejection options from setup in add sample form

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module bika.lims.browser.analysisrequest.add2, line 121, in __call__
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 215, in render
  Module chameleon.template, line 192, in render
  Module 50339ddd89f8ed786a49ba8260fbdeca, line 5109, in render
  Module 3e2b5eb4f2e4b566127e45a61092882a, line 1428, in render_master
  Module 3e2b5eb4f2e4b566127e45a61092882a, line 407, in render_content
  Module 50339ddd89f8ed786a49ba8260fbdeca, line 2659, in __fill_content_core
  Module 0bbc335c106968ef2343e8d0ea506e99, line 404, in render_edit
  Module zope.tales.pythonexpr, line 73, in __call__
   - __traceback_info__: (widget.rejectionOptionsList())
  Module <string>, line 1, in <module>
  Module bika.lims.browser.widgets.rejectionwidget, line 60, in rejectionOptionsList
AttributeError: 'RequestContainer' object has no attribute 'RejectionReasons'

 - Expression: "python:widget.rejectionOptionsList()"
 - Filename:   ... ins/senaite_templates/senaite_widgets/rejectionwidget.pt
 - Location:   (line 53: col 35)
 - Source:     ... l:define="list python:widget.rejectionOptionsList();"
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Expression: "provider:plone.abovecontentbody"
 - Filename:   ... te/core/browser/main_template/templates/main_template.pt
 - Location:   (line 132: col 84)
 - Source:     ...
                                     ^
 - Expression: "here/main_template/macros/master"
 - Filename:   ... c/bika/lims/browser/analysisrequest/templates/ar_add2.pt
 - Location:   (line 4: col 23)
 - Source:     metal:use-macro="here/main_template/macros/master"
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  request: <WSGIRequest, URL=http://localhost:9090/senaite/samples/ar_add>
               attrs: {}
               container: <Samples at /senaite/samples>
               traverse_subpath: []
               template: <Products.Five.browser.pagetemplatefile.ViewPageTemplateFile object at 0x7fbb492bde90>
               translate: <function translate at 0x7fbb371be050>
               macroname: u'master'
               repeat: <Products.PageTemplates.engine.RepeatDictWrapper object at 0x7fbb464dd2d0>
               views: <Products.Five.browser.pagetemplatefile.ViewMapper object at 0x7fbb441c4bd0>
               args: ()
               here: <Samples at /senaite/samples>
               user: <PropertiedUser 'admin'>
               nothing: None
               default: <DEFAULT>
               modules: <Products.PageTemplates.ZRPythonExpr._SecureModuleImporter object at 0x7fbb55fa9fd0>
               loop: {u'field': <Products.PageTemplates.engine.RepeatItem object at 0x7fbb4d221250>, u'arnum': <Products.PageTemplates.engine.RepeatItem object at 0x7fbb4430cad0>}
               context: <Samples at /senaite/samples>
               view: <Products.Five.browser.metaconfigure.AnalysisRequestAddView object at 0x7fbb47330510>
               root: <Application at >
               options: {}
               target_language: None
```

## Desired behavior after PR is merged

Rejection widget is rendered correctly in Sample add form

<img width="861" height="271" alt="20260402181934" src="https://github.com/user-attachments/assets/24a6c5f1-51d0-48a3-b61a-136f0c366a9d" />


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
