### PR TITLE
Fix value of AT's SelectOtherWidget is not rendered in view mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2878 Fix value of AT's SelectOtherWidget is not rendered in view mode
 - #2874 Fix save button visibility of sample header
 - #2875 Fix AttributeError in add_sample when rejection workflow is enabled
 - #2872 Use AT accessor/mutator in GenericSetup field adapter

--- a/src/senaite/core/browser/widgets/selectotherwidget.py
+++ b/src/senaite/core/browser/widgets/selectotherwidget.py
@@ -90,6 +90,16 @@ class SelectOtherWidget(StringWidget):
             return func(context)
         return None
 
+    def get_value_text(self, context, field):
+        """Returns the field value's text
+        """
+        value = field.get(context) or ""
+        choices = self.get_choices(context, field)
+        text = dict(choices).get(value)
+        if text:
+            return text
+        return value
+
     def get_choices(self, context, field):
         """Returns the predefined options for this field
         """

--- a/src/senaite/core/skins/senaite_templates/senaite_widgets/selectotherwidget.pt
+++ b/src/senaite/core/skins/senaite_templates/senaite_widgets/selectotherwidget.pt
@@ -8,6 +8,7 @@
 
   <!-- VIEW MACRO -->
   <metal:view_macro define-macro="view">
+    <span tal:content="python:field.widget.get_value_text(context, field)"></span>
   </metal:view_macro>
 
   <!-- EDIT MACRO -->


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that the value of an AT field becomes visible in `mode=view` when `SelectOtherWidget` is used.

## Current behavior before PR

Field value is not displayed in `mode=view`

## Desired behavior after PR is merged

Field value is displayed in `mode=view`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
