### PR TITLE
Fix department and methods not displayed in services' csv export

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2879 Fix department and methods not displayed in services' csv export
 - #2878 Fix value of AT's SelectOtherWidget is not rendered in view mode
 - #2874 Fix save button visibility of sample header
 - #2875 Fix AttributeError in add_sample when rejection workflow is enabled

--- a/src/bika/lims/controlpanel/bika_analysisservices.py
+++ b/src/bika/lims/controlpanel/bika_analysisservices.py
@@ -329,6 +329,8 @@ class AnalysisServicesView(ControlPanelListingView):
         # Methods
         methods = obj.getMethods()
         if methods:
+            titles = [api.get_title(method) for method in methods]
+            item["Methods"] = ", ".join(titles)
             links = map(
                 lambda m: get_link(
                     m.absolute_url(), value=m.Title(), css_class="link"),
@@ -354,6 +356,7 @@ class AnalysisServicesView(ControlPanelListingView):
         if department:
             title = api.get_title(department)
             url = api.get_url(department)
+            item["Department"] = title
             item["replace"]["Department"] = get_link(url, title)
 
         # Unit


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the `csv` file generated when the "Export" button from services listing is clicked contains the names of department and methods each service is assigned to.

<img width="892" height="348" alt="20260421145208" src="https://github.com/user-attachments/assets/533349b9-2a8c-4b6b-a4df-630e36891c79" />


## Current behavior before PR

The columns "Department" and "Method" of the `csv` file are empty

## Desired behavior after PR is merged

The columns "Department" and "Method" of the `csv` file are empty

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
