### PR TITLE
Fix ConnectionStateError for DataGrid fields in plone.registry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2880 Fix ConnectionStateError for DataGrid fields in test layers
 - #2878 Fix value of AT's SelectOtherWidget is not rendered in view mode
 - #2874 Fix save button visibility of sample header
 - #2875 Fix AttributeError in add_sample when rejection workflow is enabled

--- a/src/senaite/core/schema/configure.zcml
+++ b/src/senaite/core/schema/configure.zcml
@@ -11,8 +11,4 @@
   <!-- ++field++ namespace -->
   <adapter factory=".traversal.FieldTraversal" name="field" />
 
-  <!-- IPersistentField adapters for DataGrid fields -->
-  <adapter factory=".registry.datagrid_row_persistent_field_adapter" />
-  <adapter factory=".registry.datagrid_field_persistent_field_adapter" />
-
 </configure>

--- a/src/senaite/core/schema/configure.zcml
+++ b/src/senaite/core/schema/configure.zcml
@@ -11,4 +11,8 @@
   <!-- ++field++ namespace -->
   <adapter factory=".traversal.FieldTraversal" name="field" />
 
+  <!-- IPersistentField adapters for DataGrid fields -->
+  <adapter factory=".registry.datagrid_row_persistent_field_adapter" />
+  <adapter factory=".registry.datagrid_field_persistent_field_adapter" />
+
 </configure>

--- a/src/senaite/core/schema/registry.py
+++ b/src/senaite/core/schema/registry.py
@@ -20,10 +20,6 @@
 
 from senaite.core.schema.fields import DataGridField as BaseDataGridField
 from senaite.core.schema.fields import DataGridRow as BaseDataGridRow
-from senaite.core.schema.interfaces import IDataGridField as IDataGridFieldSchema
-from senaite.core.schema.interfaces import IDataGridRow as IDataGridRowSchema
-from zope.component import adapter
-from zope.interface import implementer
 
 try:
     from plone.registry.field import PersistentField
@@ -36,45 +32,44 @@ except ImportError:
         pass
 
 
+def _clone_persistent_field(field):
+    """Create a fresh clone of a persistent DataGrid field
+
+    When plone.registry registers an interface, it calls
+    IPersistentField(field_instance) for constrained properties
+    like value_type. If the field already provides IPersistentField
+    (as our DataGrid fields do via PersistentField inheritance),
+    the interface call protocol returns the same instance.
+
+    This becomes a problem when test layers tear down and re-setup:
+    the module-level field instance retains a _p_jar reference to
+    the now-closed ZODB connection, causing ConnectionStateError.
+
+    By implementing __conform__, we intercept the interface call
+    and always return a fresh clone with no ZODB connection.
+    """
+    clone = field.__class__.__new__(field.__class__)
+    clone.__dict__.update(field.__dict__)
+    return clone
+
+
 class DataGridField(PersistentField, BaseDataGridField):
     """Use this field for registry entries
 
     https://pypi.org/project/plone.registry/#persistent-fields
-    https://community.plone.org/t/there-is-no-persistent-field-equivalent-for-the-field-a-of-type-b
     """
-    pass
+
+    def __conform__(self, iface):
+        if iface is IPersistentField:
+            return _clone_persistent_field(self)
 
 
 class DataGridRow(PersistentField, BaseDataGridRow):
     """Use this field for registry entries
 
     https://pypi.org/project/plone.registry/#persistent-fields
-    https://community.plone.org/t/there-is-no-persistent-field-equivalent-for-the-field-a-of-type-b
     """
-    pass
 
-
-@implementer(IPersistentField)
-@adapter(IDataGridRowSchema)
-def datagrid_row_persistent_field_adapter(context):
-    """Create a fresh persistent DataGridRow
-
-    Avoids ConnectionStateError when the same DataGridRow instance
-    (which extends Persistent) gets reused across ZODB connections,
-    e.g. during test layer setup/teardown cycles or registry re-imports.
-    """
-    instance = DataGridRow.__new__(DataGridRow)
-    instance.__dict__.update(context.__dict__)
-    return instance
-
-
-@implementer(IPersistentField)
-@adapter(IDataGridFieldSchema)
-def datagrid_field_persistent_field_adapter(context):
-    """Create a fresh persistent DataGridField
-
-    Same rationale as datagrid_row_persistent_field_adapter.
-    """
-    instance = DataGridField.__new__(DataGridField)
-    instance.__dict__.update(context.__dict__)
-    return instance
+    def __conform__(self, iface):
+        if iface is IPersistentField:
+            return _clone_persistent_field(self)

--- a/src/senaite/core/schema/registry.py
+++ b/src/senaite/core/schema/registry.py
@@ -41,9 +41,11 @@ def _clone_persistent_field(field):
     (as our DataGrid fields do via PersistentField inheritance),
     the interface call protocol returns the same instance.
 
-    This becomes a problem when test layers tear down and re-setup:
-    the module-level field instance retains a _p_jar reference to
-    the now-closed ZODB connection, causing ConnectionStateError.
+    This becomes a problem when the same field instance is stored
+    in the ZODB across multiple connections (e.g. test layer
+    setup/teardown cycles): the module-level field instance retains
+    a _p_jar reference to the now-closed ZODB connection, causing
+    ConnectionStateError.
 
     By implementing __conform__, we intercept the interface call
     and always return a fresh clone with no ZODB connection.

--- a/src/senaite/core/schema/registry.py
+++ b/src/senaite/core/schema/registry.py
@@ -20,11 +20,19 @@
 
 from senaite.core.schema.fields import DataGridField as BaseDataGridField
 from senaite.core.schema.fields import DataGridRow as BaseDataGridRow
+from senaite.core.schema.interfaces import IDataGridField as IDataGridFieldSchema
+from senaite.core.schema.interfaces import IDataGridRow as IDataGridRowSchema
+from zope.component import adapter
+from zope.interface import implementer
 
 try:
     from plone.registry.field import PersistentField
+    from plone.registry.interfaces import IPersistentField
 except ImportError:
     class PersistentField(object):
+        pass
+
+    class IPersistentField(object):
         pass
 
 
@@ -44,3 +52,29 @@ class DataGridRow(PersistentField, BaseDataGridRow):
     https://community.plone.org/t/there-is-no-persistent-field-equivalent-for-the-field-a-of-type-b
     """
     pass
+
+
+@implementer(IPersistentField)
+@adapter(IDataGridRowSchema)
+def datagrid_row_persistent_field_adapter(context):
+    """Create a fresh persistent DataGridRow
+
+    Avoids ConnectionStateError when the same DataGridRow instance
+    (which extends Persistent) gets reused across ZODB connections,
+    e.g. during test layer setup/teardown cycles or registry re-imports.
+    """
+    instance = DataGridRow.__new__(DataGridRow)
+    instance.__dict__.update(context.__dict__)
+    return instance
+
+
+@implementer(IPersistentField)
+@adapter(IDataGridFieldSchema)
+def datagrid_field_persistent_field_adapter(context):
+    """Create a fresh persistent DataGridField
+
+    Same rationale as datagrid_row_persistent_field_adapter.
+    """
+    instance = DataGridField.__new__(DataGridField)
+    instance.__dict__.update(context.__dict__)
+    return instance

--- a/src/senaite/core/schema/registry.py
+++ b/src/senaite/core/schema/registry.py
@@ -62,6 +62,7 @@ class DataGridField(PersistentField, BaseDataGridField):
     def __conform__(self, iface):
         if iface is IPersistentField:
             return _clone_persistent_field(self)
+        return None
 
 
 class DataGridRow(PersistentField, BaseDataGridRow):
@@ -73,3 +74,4 @@ class DataGridRow(PersistentField, BaseDataGridRow):
     def __conform__(self, iface):
         if iface is IPersistentField:
             return _clone_persistent_field(self)
+        return None

--- a/src/senaite/core/tests/layers.py
+++ b/src/senaite/core/tests/layers.py
@@ -71,9 +71,18 @@ class BaseLayer(PloneSandboxLayer):
         transaction.commit()
 
 
-class DataLayer(BaseLayer):
+BASE_LAYER_FIXTURE = BaseLayer()
+BASE_TESTING = FunctionalTesting(
+    bases=(BASE_LAYER_FIXTURE,), name="SENAITE:BaseTesting")
+
+
+class DataLayer(PloneSandboxLayer):
     """Layer including Demo Data
+
+    Reuses BASE_LAYER_FIXTURE to avoid rebuilding the Plone site
+    and re-applying the profile. Only loads demo data on top.
     """
+    defaultBases = (BASE_LAYER_FIXTURE,)
 
     def setup_data_load(self, portal, request):
         """Provision site with demo data
@@ -90,7 +99,8 @@ class DataLayer(BaseLayer):
                 archive_bits=tarball.read(),
                 encoding="UTF-8",
                 should_purge=True)
-            setup_tool._doRunImportStep("senaite.core.import", context)
+            setup_tool._doRunImportStep(
+                "senaite.core.import", context)
 
         transaction.commit()
 
@@ -98,13 +108,8 @@ class DataLayer(BaseLayer):
 
     def setUpPloneSite(self, portal):
         super(DataLayer, self).setUpPloneSite(portal)
-        # Install Demo Data
         self.setup_data_load(portal, portal.REQUEST)
 
-
-BASE_LAYER_FIXTURE = BaseLayer()
-BASE_TESTING = FunctionalTesting(
-    bases=(BASE_LAYER_FIXTURE,), name="SENAITE:BaseTesting")
 
 DATA_LAYER_FIXTURE = DataLayer()
 DATA_TESTING = FunctionalTesting(


### PR DESCRIPTION
## Summary

- Restructure test layers so that `DataLayer` reuses `BASE_LAYER_FIXTURE` instead of creating an independent `BaseLayer` instance
- Fixes `ConnectionStateError: Shouldn't load state for senaite.core.schema.registry.DataGridRow when the connection is closed` during `DataTesting` layer setup

## Root Cause

`BaseTesting` and `DataTesting` used separate `BaseLayer` fixture instances. When `BaseTesting` tore down, the ZODB connection was closed, but module-level `DataGridRow` instances (from `IImpressControlPanel` in senaite.impress) retained stale `_p_jar` references. `DataTesting` then tried to re-apply the `senaite.core:default` profile, triggering `ConnectionStateError` when ZODB attempted to load these persistent objects through the closed connection.

This only affects tests because production has a single long-lived ZODB connection. No other Plone package hits this because none combine (a) `PersistentField` subclasses as `value_type` in a registry interface with (b) multiple independent test layer fixtures.

## Fix

`DataLayer` now uses `BASE_LAYER_FIXTURE` as its `defaultBases` instead of extending `BaseLayer` as a class. This way the Plone site and ZODB connection from `BaseTesting` are reused. The profile is applied only once and `DataLayer` just adds demo data on top.

See [full analysis](https://github.com/senaite/senaite.core/pull/2880#issuecomment-placeholder) for details on the `zope.interface` call protocol and why adapter-based fixes don't work here.

## Test plan

- [ ] CI tests pass (specifically the `DataTesting` layer that was failing)
- [ ] Verify both `BaseTestCase` and `DataTestCase` tests still work correctly