### PR TITLE
Add text support for interim fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2881 Add text support for interim fields
 - #2888 Improve ID Server admin views
 - #2889 Remove orphan temp objects when renameAfterCreation fails
 - #2887 Set default Seq Type to 'generated' for partition/retest/secondary
@@ -11,7 +12,6 @@ Changelog
 - #2883 Add ViewNavigation permission for sidebar access control
 - #2885 Handle missing split_length values during setup row normalization
 - #2882 Refactor dashboard with permission-based access and async loading
-- #2881 Add text support for interim fields
 - #2880 Fix ConnectionStateError for DataGrid fields in test layers
 - #2879 Fix department and methods not displayed in services' csv export
 - #2878 Fix value of AT's SelectOtherWidget is not rendered in view mode

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Changelog
 - #2883 Add ViewNavigation permission for sidebar access control
 - #2885 Handle missing split_length values during setup row normalization
 - #2882 Refactor dashboard with permission-based access and async loading
+- #2881 Add text support for interim fields
 - #2880 Fix ConnectionStateError for DataGrid fields in test layers
 - #2879 Fix department and methods not displayed in services' csv export
 - #2878 Fix value of AT's SelectOtherWidget is not rendered in view mode

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -42,6 +42,7 @@ from bika.lims.interfaces import IRoutineAnalysis
 from bika.lims.interfaces import ISubmitted
 from bika.lims.utils import check_permission
 from bika.lims.utils import format_supsub
+from bika.lims.utils import formatTextResult
 from senaite.core.utils import format_supsub_unicode
 from bika.lims.utils import formatDecimalMark
 from bika.lims.utils import get_fas_ico
@@ -1240,6 +1241,8 @@ class AnalysesView(ListingView):
     def get_formatted_interim(self, interim):
         """Returns the formatted value of the interim
         """
+        result_type = interim.get("result_type", "")
+
         # get the 'raw' value stored for this interim
         raw_value = interim.get("value")
 
@@ -1256,6 +1259,9 @@ class AnalysesView(ListingView):
         if choices:
             # values are predefined options for selection
             values = [choices.get(v) for v in values]
+        elif result_type in ["string", "text"]:
+            # If string-like result, return without any formatting
+            values = [formatTextResult(value, html=True) for value in values]
         else:
             # values are captured directly by the user
             values = [formatDecimalMark(value, self.dmk) for value in values]

--- a/src/bika/lims/browser/fields/interimfieldsfield.py
+++ b/src/bika/lims/browser/fields/interimfieldsfield.py
@@ -97,6 +97,7 @@ class InterimFieldsField(RecordsField):
             "result_type": DisplayList((
                 ("", _("Numeric")),
                 ("string", _("String")),
+                ("text", _("Text")),
                 ("datetime", _("Datetime")),
                 ("select", _("Selection list")),
                 ("multiselect", _("Multiple selection")),

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -40,6 +40,7 @@ from bika.lims.content.abstractbaseanalysis import AbstractBaseAnalysis
 from bika.lims.content.abstractbaseanalysis import schema
 from bika.lims.interfaces import IDuplicateAnalysis
 from bika.lims.utils import formatDecimalMark
+from bika.lims.utils import formatTextResult
 from bika.lims.utils.analysis import format_numeric_result
 from bika.lims.utils.analysis import get_significant_digits
 from bika.lims.workflow import getTransitionActor
@@ -1065,11 +1066,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
 
         # If string-like result, return without any formatting
         if result_type in ["string", "text"]:
-            if html:
-                result = result if api.is_string(result) else str(result)
-                result = cgi.escape(result)
-                result = result.replace("\n", "<br/>")
-            return result
+            return formatTextResult(result, html=html)
 
         # If a detection limit, return '< LDL' or '> UDL'
         dl = self.getDetectionLimitOperand()

--- a/src/bika/lims/utils/__init__.py
+++ b/src/bika/lims/utils/__init__.py
@@ -22,6 +22,7 @@ import mimetypes
 import os
 import re
 import tempfile
+import cgi
 from email import Encoders
 from email.MIMEBase import MIMEBase
 from time import time
@@ -206,6 +207,20 @@ def formatDecimalMark(value, decimalmark='.'):
         return decimalmark.join(rawval.split('.'))
     except Exception:
         return rawval
+
+
+def formatTextResult(value, html=True):
+    """Format a string-like result value for display.
+
+    If html is True, the value is escaped and newline characters are
+    represented as ``<br/>``.
+    """
+    if not html:
+        return value
+
+    result = value if api.is_string(value) else str(value)
+    result = cgi.escape(result)
+    return result.replace("\n", "<br/>")
 
 
 # encode_header function copied from roundup's rfc2822 package.

--- a/src/bika/lims/utils/analysis.py
+++ b/src/bika/lims/utils/analysis.py
@@ -480,7 +480,7 @@ def format_interim(interim_field, html=True):
 
     elif result_type in ["string", "text"]:
         # If string-like result, return without any formatting
-        values = [formatTextResult(value, html) for value in values]
+        values = [formatTextResult(val, html) for val in values]
     else:
         # default formatting
         setup = api.get_senaite_setup()

--- a/src/bika/lims/utils/analysis.py
+++ b/src/bika/lims/utils/analysis.py
@@ -27,6 +27,7 @@ from bika.lims.interfaces import IBaseAnalysis
 from bika.lims.interfaces import IReferenceSample
 from bika.lims.interfaces.analysis import IRequestAnalysis
 from bika.lims.utils import formatDecimalMark
+from bika.lims.utils import formatTextResult
 from bika.lims.utils import format_supsub
 
 DEFAULT_SKIP_FIELDS = [
@@ -457,6 +458,7 @@ def format_interim(interim_field, html=True):
     for visualization, like formatted_result and formatted_unit
     """
     separator = "<br/>" if html else ", "
+    result_type = interim_field.get("result_type", "")
 
     # copy to prevent persistent changes
     item = copy.deepcopy(interim_field)
@@ -476,6 +478,9 @@ def format_interim(interim_field, html=True):
         texts = [choices.get(v, "") for v in values]
         values = filter(None, texts)
 
+    elif result_type in ["string", "text"]:
+        # If string-like result, return without any formatting
+        values = [formatTextResult(value, html) for value in values]
     else:
         # default formatting
         setup = api.get_senaite_setup()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
This Pull Request adds the Control Type "Text" for interim fields, enabling the introduction of Text for interim values.

## Current behavior before PR

- When adding a new result variable, Control type does not include a Text option.
- In readonly views, multiline interim values may appear as a single line (line breaks not preserved).

## Desired behavior after PR is merged

- The Text control type is available when adding new result variables.
- Users can store textual interim result values using the new text type.
- Readonly display preserves line breaks for string/text interim values for better readability

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
