### PR TITLE
Handle missing split_length values during setup row normalization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2885 Handle missing split_length values during setup row normalization
 - #2882 Refactor dashboard with permission-based access and async loading
 - #2880 Fix ConnectionStateError for DataGrid fields in test layers
 - #2879 Fix department and methods not displayed in services' csv export

--- a/src/senaite/core/content/senaitesetup.py
+++ b/src/senaite/core/content/senaitesetup.py
@@ -2394,9 +2394,9 @@ class Setup(Container):
                     if normalized_row.get(key) is None:
                         normalized_row[key] = ""
                 # Ensure split_length is an int
-                if normalized_row.get("split_length"):
-                    normalized_row["split_length"] = api.to_int(
-                        normalized_row["split_length"], default=1)
+                split_length = normalized_row.get("split_length")
+                split_length_int = api.to_int(split_length, default=1)
+                normalized_row["split_length"] = max(split_length_int, 1)
                 normalized.append(normalized_row)
             value = normalized
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/2884

## Current behavior before PR
<img width="537" height="247" alt="image" src="https://github.com/user-attachments/assets/13d9265e-bd00-4c76-a9fe-38f4f5351db0" />
Shows error after running upgrade script with data that has missing Split Length values

## Desired behavior after PR is merged

Set missing Split Length to 1

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
