### PR TITLE
Fix partition ID collision after detach

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2886 Fix partition ID collision after detach
 - #2882 Refactor dashboard with permission-based access and async loading
 - #2880 Fix ConnectionStateError for DataGrid fields in test layers
 - #2879 Fix department and methods not displayed in services' csv export

--- a/src/bika/lims/content/analysisrequest.py
+++ b/src/bika/lims/content/analysisrequest.py
@@ -1271,6 +1271,7 @@ schema = BikaSchema.copy() + Schema((
     UIDReferenceField(
         "DetachedFrom",
         allowed_types=("AnalysisRequest",),
+        relationship="AnalysisRequestDetachedFrom",
         mode="rw",
         read_permission=View,
         write_permission=ModifyPortalContent,

--- a/src/senaite/core/idserver/idserver.py
+++ b/src/senaite/core/idserver/idserver.py
@@ -150,19 +150,18 @@ def get_retest_count(context, default=0):
     return count
 
 
+PARTITION_DETACHED_RELATIONSHIP = "AnalysisRequestDetachedFrom"
+
+
 def get_partition_count(context, default=0):
     """Returns the number of partitions of this AR
 
-    Avoids ID collisions when a new partition is created on a parent
-    that previously had partitions detached. The next partition
-    number is the maximum of:
-
-    - The highest existing partition suffix found in the parent's
-      container. Detached partitions keep living in the container
-      after the detach transition, so this is the source of truth
-      regardless of how the ID format is configured or whether the
-      number generator counter has been seeded.
-    - The active descendants count, as a final safety net.
+    Counts both active descendants (samples with `ParentAnalysisRequest`
+    pointing to the parent) and detached partitions (samples whose
+    `ParentAnalysisRequest` was unset by the detach transition but
+    whose `DetachedFrom` still references the parent). Both sources
+    are annotation-backed backrefs, so the lookup is O(1) and works
+    regardless of ID format, custom adapters, or container layout.
     """
     if not is_ar(context):
         return default
@@ -172,96 +171,15 @@ def get_partition_count(context, default=0):
     if not parent:
         return default
 
-    # Walk the parent's container for sample IDs matching the partition
-    # pattern. This catches detached partitions (no longer descendants
-    # of the parent) and any partition created via custom code paths
-    # that bypassed the standard ID server.
-    container_count = get_max_partition_suffix_in_container(parent)
-
-    # Active descendants as a final safety net.
-    descendants_count = len(parent.getDescendants())
+    active = len(parent.getDescendants())
+    detached = len(get_backreferences(
+        parent, relationship=PARTITION_DETACHED_RELATIONSHIP))
 
     # XXX: we need to count one up because the new partition only shows up in
     #      parent.getDescendants() *after* it has been renamed, because
     #      temporary objects don't get indexed!
     #      https://github.com/senaite/senaite.core/pull/2632
-    return max(container_count, descendants_count) + 1
-
-
-PARTITION_COUNTER_PLACEHOLDER_RE = re.compile(
-    r"\{(?:partition_count|seq|alpha)[^}]*\}")
-
-
-def get_max_partition_suffix_in_container(parent):
-    """Find the highest partition number issued for the given parent
-    sample by inspecting its container for sibling IDs that match the
-    configured partition ID format.
-
-    Reads the partition format from the IDFormatting config so that
-    customized prefixes (e.g. '{parent_ar_id}-PART-{partition_count}')
-    are honored. Returns 0 when the prefix cannot be resolved (e.g.
-    the template references variables that are not available here),
-    in which case `get_partition_count` falls back on the descendants
-    count.
-    """
-    container = api.get_parent(parent)
-    if container is None:
-        return 0
-
-    config = get_config(None, portal_type=PORTAL_TYPE_SAMPLE_PARTITION)
-    template = config.get("form", "")
-    if not template:
-        return 0
-
-    # Locate the counter placeholder; everything before it is the
-    # static prefix portion that identifies partitions of this parent.
-    placeholder_match = PARTITION_COUNTER_PLACEHOLDER_RE.search(template)
-    if not placeholder_match:
-        return 0
-    prefix_template = template[:placeholder_match.start()]
-
-    try:
-        prefix = prefix_template.format(
-            **_partition_prefix_variables(parent))
-    except (KeyError, ValueError, AttributeError):
-        return 0
-    if not prefix:
-        return 0
-
-    # Scan the container for sample IDs starting with this prefix and
-    # consume the leading digits as the partition counter.
-    pattern = re.compile(r"^" + re.escape(prefix) + r"(\d+)")
-    max_num = 0
-    for obj_id in container.objectIds():
-        match = pattern.match(obj_id)
-        if not match:
-            continue
-        try:
-            num = int(match.group(1))
-        except ValueError:
-            continue
-        if num > max_num:
-            max_num = num
-    return max_num
-
-
-def _partition_prefix_variables(parent):
-    """Return the variables commonly used in partition ID prefix
-    templates. Custom add-ons that inject exotic variables via an
-    `IIdServerVariables` adapter are not consulted here; if a custom
-    template requires those, the prefix interpolation falls back to
-    returning 0 and `get_partition_count` uses the descendants count.
-    """
-    parent_ar_id = api.get_id(parent)
-    sample_type = parent.getSampleType()
-    return {
-        "parent_ar_id": parent_ar_id,
-        "parent_base_id": strip_suffix(parent_ar_id),
-        "year": get_current_year(),
-        "yymmdd": get_yymmdd(),
-        "clientId": parent.getClientID(),
-        "sampleType": sample_type.getPrefix() if sample_type else "",
-    }
+    return active + detached + 1
 
 
 def get_secondary_count(context, default=0):

--- a/src/senaite/core/idserver/idserver.py
+++ b/src/senaite/core/idserver/idserver.py
@@ -57,6 +57,8 @@ SAMPLE_TYPES = [
     PORTAL_TYPE_SAMPLE_SECONDARY,
 ]
 
+PARTITION_DETACHED_RELATIONSHIP = "AnalysisRequestDetachedFrom"
+
 
 def get_objects_in_sequence(brain_or_object, ctype, cref):
     """Return a list of items
@@ -148,9 +150,6 @@ def get_retest_count(context, default=0):
         invalidated = invalidated.getInvalidated()
 
     return count
-
-
-PARTITION_DETACHED_RELATIONSHIP = "AnalysisRequestDetachedFrom"
 
 
 def get_partition_count(context, default=0):

--- a/src/senaite/core/idserver/idserver.py
+++ b/src/senaite/core/idserver/idserver.py
@@ -157,11 +157,12 @@ def get_partition_count(context, default=0):
     that previously had partitions detached. The next partition
     number is the maximum of:
 
-    - The number generator's persistent counter for this parent.
     - The highest existing partition suffix found in the parent's
-      container (covers detached partitions, which keep living in the
-      container after the detach transition).
-    - The active descendants count.
+      container. Detached partitions keep living in the container
+      after the detach transition, so this is the source of truth
+      regardless of how the ID format is configured or whether the
+      number generator counter has been seeded.
+    - The active descendants count, as a final safety net.
     """
     if not is_ar(context):
         return default
@@ -171,29 +172,20 @@ def get_partition_count(context, default=0):
     if not parent:
         return default
 
-    parent_id = api.get_id(parent)
-
-    # Number generator stores the highest partition number ever issued
-    # for this parent (incl. detached ones, when seeded).
-    number_generator = getUtility(INumberGenerator)
-    key = make_storage_key(
-        PORTAL_TYPE_SAMPLE_PARTITION, api.normalize_filename(parent_id))
-    storage_count = number_generator.get(key, 0)
-
     # Walk the parent's container for sample IDs matching the partition
     # pattern. This catches detached partitions (no longer descendants
-    # of the parent) and any partition created before the storage key
-    # was populated.
+    # of the parent) and any partition created via custom code paths
+    # that bypassed the standard ID server.
     container_count = get_max_partition_suffix_in_container(parent)
 
     # Active descendants as a final safety net.
     descendants_count = len(parent.getDescendants())
 
     # XXX: we need to count one up because the new partition only shows up in
-    #      parent.getDescendants() / number generator *after* it has been
-    #      renamed, because temporary objects don't get indexed!
+    #      parent.getDescendants() *after* it has been renamed, because
+    #      temporary objects don't get indexed!
     #      https://github.com/senaite/senaite.core/pull/2632
-    return max(storage_count, container_count, descendants_count) + 1
+    return max(container_count, descendants_count) + 1
 
 
 def get_max_partition_suffix_in_container(parent):

--- a/src/senaite/core/idserver/idserver.py
+++ b/src/senaite/core/idserver/idserver.py
@@ -45,11 +45,16 @@ from zope.component import getAdapters
 from zope.component import getUtility
 from zope.component import queryAdapter
 
-AR_TYPES = [
-    "AnalysisRequest",
-    "AnalysisRequestRetest",
-    "AnalysisRequestPartition",
-    "AnalysisRequestSecondary",
+PORTAL_TYPE_SAMPLE = "AnalysisRequest"
+PORTAL_TYPE_SAMPLE_RETEST = "AnalysisRequestRetest"
+PORTAL_TYPE_SAMPLE_PARTITION = "AnalysisRequestPartition"
+PORTAL_TYPE_SAMPLE_SECONDARY = "AnalysisRequestSecondary"
+
+SAMPLE_TYPES = [
+    PORTAL_TYPE_SAMPLE,
+    PORTAL_TYPE_SAMPLE_RETEST,
+    PORTAL_TYPE_SAMPLE_PARTITION,
+    PORTAL_TYPE_SAMPLE_SECONDARY,
 ]
 
 
@@ -97,11 +102,11 @@ def get_type_id(context, **kw):
 
     # Override by provided marker interface
     if IAnalysisRequestPartition.providedBy(context):
-        return "AnalysisRequestPartition"
+        return PORTAL_TYPE_SAMPLE_PARTITION
     elif IAnalysisRequestRetest.providedBy(context):
-        return "AnalysisRequestRetest"
+        return PORTAL_TYPE_SAMPLE_RETEST
     elif IAnalysisRequestSecondary.providedBy(context):
-        return "AnalysisRequestSecondary"
+        return PORTAL_TYPE_SAMPLE_SECONDARY
 
     return api.get_portal_type(context)
 
@@ -147,6 +152,12 @@ def get_retest_count(context, default=0):
 
 def get_partition_count(context, default=0):
     """Returns the number of partitions of this AR
+
+    Uses the number generator's persistent counter so that detached
+    partitions are still counted, avoiding ID collisions when a new
+    partition is created on a parent that previously had partitions
+    detached. Falls back to the descendants count for installs where
+    the storage key was not yet populated.
     """
     if not is_ar(context):
         return default
@@ -156,11 +167,24 @@ def get_partition_count(context, default=0):
     if not parent:
         return default
 
+    # Number generator stores the highest partition number ever issued
+    # for this parent (incl. detached ones).
+    number_generator = getUtility(INumberGenerator)
+    parent_id = api.normalize_filename(api.get_id(parent))
+    key = make_storage_key(PORTAL_TYPE_SAMPLE_PARTITION, parent_id)
+    storage_count = number_generator.get(key, 0)
+
+    # The descendants count is used as a safety net: if the storage key
+    # is unset (e.g. partitions imported without going through the ID
+    # server), this ensures we still issue a number greater than any
+    # existing descendant.
+    descendants_count = len(parent.getDescendants())
+
     # XXX: we need to count one up because the new partition only shows up in
-    #      parent.getDescendants() *after* it has been renamed, because
-    #      temporary objects don't get indexed!
+    #      parent.getDescendants() / number generator *after* it has been
+    #      renamed, because temporary objects don't get indexed!
     #      https://github.com/senaite/senaite.core/pull/2632
-    return len(parent.getDescendants()) + 1
+    return max(storage_count, descendants_count) + 1
 
 
 def get_secondary_count(context, default=0):

--- a/src/senaite/core/idserver/idserver.py
+++ b/src/senaite/core/idserver/idserver.py
@@ -153,11 +153,15 @@ def get_retest_count(context, default=0):
 def get_partition_count(context, default=0):
     """Returns the number of partitions of this AR
 
-    Uses the number generator's persistent counter so that detached
-    partitions are still counted, avoiding ID collisions when a new
-    partition is created on a parent that previously had partitions
-    detached. Falls back to the descendants count for installs where
-    the storage key was not yet populated.
+    Avoids ID collisions when a new partition is created on a parent
+    that previously had partitions detached. The next partition
+    number is the maximum of:
+
+    - The number generator's persistent counter for this parent.
+    - The highest existing partition suffix found in the parent's
+      container (covers detached partitions, which keep living in the
+      container after the detach transition).
+    - The active descendants count.
     """
     if not is_ar(context):
         return default
@@ -167,24 +171,55 @@ def get_partition_count(context, default=0):
     if not parent:
         return default
 
+    parent_id = api.get_id(parent)
+
     # Number generator stores the highest partition number ever issued
-    # for this parent (incl. detached ones).
+    # for this parent (incl. detached ones, when seeded).
     number_generator = getUtility(INumberGenerator)
-    parent_id = api.normalize_filename(api.get_id(parent))
-    key = make_storage_key(PORTAL_TYPE_SAMPLE_PARTITION, parent_id)
+    key = make_storage_key(
+        PORTAL_TYPE_SAMPLE_PARTITION, api.normalize_filename(parent_id))
     storage_count = number_generator.get(key, 0)
 
-    # The descendants count is used as a safety net: if the storage key
-    # is unset (e.g. partitions imported without going through the ID
-    # server), this ensures we still issue a number greater than any
-    # existing descendant.
+    # Walk the parent's container for sample IDs matching the partition
+    # pattern. This catches detached partitions (no longer descendants
+    # of the parent) and any partition created before the storage key
+    # was populated.
+    container_count = get_max_partition_suffix_in_container(parent)
+
+    # Active descendants as a final safety net.
     descendants_count = len(parent.getDescendants())
 
     # XXX: we need to count one up because the new partition only shows up in
     #      parent.getDescendants() / number generator *after* it has been
     #      renamed, because temporary objects don't get indexed!
     #      https://github.com/senaite/senaite.core/pull/2632
-    return max(storage_count, descendants_count) + 1
+    return max(storage_count, container_count, descendants_count) + 1
+
+
+def get_max_partition_suffix_in_container(parent):
+    """Find the highest partition number issued for the given parent
+    sample by inspecting its container for sibling IDs matching the
+    pattern '<parent_id>-P<NN>'.
+    """
+    parent_id = api.get_id(parent)
+    container = api.get_parent(parent)
+    if container is None:
+        return 0
+    prefix = "{}-P".format(parent_id)
+    max_num = 0
+    for obj_id in container.objectIds():
+        if not obj_id.startswith(prefix):
+            continue
+        suffix = obj_id[len(prefix):]
+        # Only consider purely numeric suffixes; nested partitions
+        # (e.g. '<parent_id>-P01-P02') contain another '-' and are
+        # skipped here.
+        if not suffix.isdigit():
+            continue
+        num = int(suffix)
+        if num > max_num:
+            max_num = num
+    return max_num
 
 
 def get_secondary_count(context, default=0):

--- a/src/senaite/core/idserver/idserver.py
+++ b/src/senaite/core/idserver/idserver.py
@@ -188,30 +188,80 @@ def get_partition_count(context, default=0):
     return max(container_count, descendants_count) + 1
 
 
+PARTITION_COUNTER_PLACEHOLDER_RE = re.compile(
+    r"\{(?:partition_count|seq|alpha)[^}]*\}")
+
+
 def get_max_partition_suffix_in_container(parent):
     """Find the highest partition number issued for the given parent
-    sample by inspecting its container for sibling IDs matching the
-    pattern '<parent_id>-P<NN>'.
+    sample by inspecting its container for sibling IDs that match the
+    configured partition ID format.
+
+    Reads the partition format from the IDFormatting config so that
+    customized prefixes (e.g. '{parent_ar_id}-PART-{partition_count}')
+    are honored. Returns 0 when the prefix cannot be resolved (e.g.
+    the template references variables that are not available here),
+    in which case `get_partition_count` falls back on the descendants
+    count.
     """
-    parent_id = api.get_id(parent)
     container = api.get_parent(parent)
     if container is None:
         return 0
-    prefix = "{}-P".format(parent_id)
+
+    config = get_config(None, portal_type=PORTAL_TYPE_SAMPLE_PARTITION)
+    template = config.get("form", "")
+    if not template:
+        return 0
+
+    # Locate the counter placeholder; everything before it is the
+    # static prefix portion that identifies partitions of this parent.
+    placeholder_match = PARTITION_COUNTER_PLACEHOLDER_RE.search(template)
+    if not placeholder_match:
+        return 0
+    prefix_template = template[:placeholder_match.start()]
+
+    try:
+        prefix = prefix_template.format(
+            **_partition_prefix_variables(parent))
+    except (KeyError, ValueError, AttributeError):
+        return 0
+    if not prefix:
+        return 0
+
+    # Scan the container for sample IDs starting with this prefix and
+    # consume the leading digits as the partition counter.
+    pattern = re.compile(r"^" + re.escape(prefix) + r"(\d+)")
     max_num = 0
     for obj_id in container.objectIds():
-        if not obj_id.startswith(prefix):
+        match = pattern.match(obj_id)
+        if not match:
             continue
-        suffix = obj_id[len(prefix):]
-        # Only consider purely numeric suffixes; nested partitions
-        # (e.g. '<parent_id>-P01-P02') contain another '-' and are
-        # skipped here.
-        if not suffix.isdigit():
+        try:
+            num = int(match.group(1))
+        except ValueError:
             continue
-        num = int(suffix)
         if num > max_num:
             max_num = num
     return max_num
+
+
+def _partition_prefix_variables(parent):
+    """Return the variables commonly used in partition ID prefix
+    templates. Custom add-ons that inject exotic variables via an
+    `IIdServerVariables` adapter are not consulted here; if a custom
+    template requires those, the prefix interpolation falls back to
+    returning 0 and `get_partition_count` uses the descendants count.
+    """
+    parent_ar_id = api.get_id(parent)
+    sample_type = parent.getSampleType()
+    return {
+        "parent_ar_id": parent_ar_id,
+        "parent_base_id": strip_suffix(parent_ar_id),
+        "year": get_current_year(),
+        "yymmdd": get_yymmdd(),
+        "clientId": parent.getClientID(),
+        "sampleType": sample_type.getPrefix() if sample_type else "",
+    }
 
 
 def get_secondary_count(context, default=0):

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2725</version>
+  <version>2726</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-senaite.impress:default</dependency>

--- a/src/senaite/core/tests/doctests/IDServer.rst
+++ b/src/senaite/core/tests/doctests/IDServer.rst
@@ -650,3 +650,42 @@ gets `-P03`, even though no descendants are left:
     True
     >>> number_generator.get(key)
     3
+
+
+Partition IDs survive a missing storage counter
+...............................................
+
+On an install upgraded from a version that did not seed the partition
+counter, the storage key may be empty even though partitions exist.
+The partition count must still avoid colliding with already-existing
+sample IDs in the parent's container.
+
+Create a fresh primary, two partitions, then wipe the counter to
+simulate a legacy install:
+
+    >>> primary2 = create_analysisrequest(client, request, values, service_uids)
+    >>> primary2_id = primary2.getId()
+    >>> _ = do_action_for(primary2, "receive")
+    >>> q1 = create_partition(primary2, request, primary2.getAnalyses())
+    >>> q2 = create_partition(primary2, request, primary2.getAnalyses())
+    >>> q1.getId() == "{}-P01".format(primary2_id)
+    True
+    >>> q2.getId() == "{}-P02".format(primary2_id)
+    True
+
+Detach the second partition and wipe the storage counter:
+
+    >>> _ = do_action_for(q2, "detach")
+    >>> key2 = "analysisrequestpartition-{}".format(primary2_id)
+    >>> number_generator.set_number(key2, 0)
+    0
+
+The next partition must still avoid the existing `-P01` and `-P02`
+IDs in the client folder, even with no storage counter and only one
+active descendant:
+
+    >>> primary2.getDescendants()
+    [<AnalysisRequest at .../...-P01>]
+    >>> q3 = create_partition(primary2, request, primary2.getAnalyses())
+    >>> q3.getId() == "{}-P03".format(primary2_id)
+    True

--- a/src/senaite/core/tests/doctests/IDServer.rst
+++ b/src/senaite/core/tests/doctests/IDServer.rst
@@ -574,9 +574,11 @@ Create a new Analysis Request with same format and check again:
 Partition IDs survive detach
 ............................
 
-Partition numbers are issued by a persistent counter so that detached
-partitions are still counted, avoiding ID collisions when a new partition
-is created on a parent that previously had partitions detached.
+Partition numbers are derived from both active descendants and detached
+partitions, so a new partition never collides with the ID of a sibling
+that was detached earlier. Both relationships use annotation-based
+backrefs and are resolved via `getDescendants` and `get_backreferences`
+respectively.
 
 Configure a standard ID format for samples and partitions:
 
@@ -597,6 +599,7 @@ Configure a standard ID format for samples and partitions:
 Imports for the partition flow:
 
     >>> from bika.lims.utils.analysisrequest import create_partition
+    >>> from bika.lims.browser.fields.uidreferencefield import get_backreferences
 
 Create a primary sample and receive it:
 
@@ -610,82 +613,38 @@ Create the first partition. The partition gets the suffix `-P01`:
     >>> p1.getId() == "{}-P01".format(primary_id)
     True
 
-The number generator's counter for this parent is now 1:
-
-    >>> key = "analysisrequestpartition-{}".format(primary_id)
-    >>> number_generator.get(key)
-    1
-
-Detach the first partition. The detach unsets `ParentAnalysisRequest`,
-so the partition is no longer a descendant of the primary, but it
-keeps existing in the client folder with its `-P01` ID:
+Detach the first partition. The detach unsets `ParentAnalysisRequest`
+and sets `DetachedFrom` to the primary, which now carries an
+annotation backref under the `AnalysisRequestDetachedFrom`
+relationship:
 
     >>> _ = do_action_for(p1, "detach")
     >>> p1.getParentAnalysisRequest() is None
     True
     >>> primary.getDescendants()
     []
+    >>> backref = get_backreferences(
+    ...     primary, relationship="AnalysisRequestDetachedFrom")
+    >>> len(backref)
+    1
 
-Creating another partition must not reuse the `-P01` suffix. Before
-the fix, `get_partition_count` derived the next number from
-`parent.getDescendants()` (now empty) and produced `-P01` again,
-colliding with the still-existing detached partition. With the fix,
-the persistent counter still reports 1, so the next partition gets
+Creating another partition must not reuse the `-P01` suffix. The
+detached backref keeps the count accurate, so the next partition gets
 `-P02`:
 
     >>> p2 = create_partition(primary, request, primary.getAnalyses())
     >>> p2.getId() == "{}-P02".format(primary_id)
     True
-    >>> number_generator.get(key)
-    2
 
 Detach `-P02` as well and create a third partition. The new partition
-gets `-P03`, even though no descendants are left:
+gets `-P03`, even though no active descendants are left:
 
     >>> _ = do_action_for(p2, "detach")
     >>> primary.getDescendants()
     []
+    >>> len(get_backreferences(
+    ...     primary, relationship="AnalysisRequestDetachedFrom"))
+    2
     >>> p3 = create_partition(primary, request, primary.getAnalyses())
     >>> p3.getId() == "{}-P03".format(primary_id)
-    True
-    >>> number_generator.get(key)
-    3
-
-
-Partition IDs survive a missing storage counter
-...............................................
-
-On an install upgraded from a version that did not seed the partition
-counter, the storage key may be empty even though partitions exist.
-The partition count must still avoid colliding with already-existing
-sample IDs in the parent's container.
-
-Create a fresh primary, two partitions, then wipe the counter to
-simulate a legacy install:
-
-    >>> primary2 = create_analysisrequest(client, request, values, service_uids)
-    >>> primary2_id = primary2.getId()
-    >>> _ = do_action_for(primary2, "receive")
-    >>> q1 = create_partition(primary2, request, primary2.getAnalyses())
-    >>> q2 = create_partition(primary2, request, primary2.getAnalyses())
-    >>> q1.getId() == "{}-P01".format(primary2_id)
-    True
-    >>> q2.getId() == "{}-P02".format(primary2_id)
-    True
-
-Detach the second partition and wipe the storage counter:
-
-    >>> _ = do_action_for(q2, "detach")
-    >>> key2 = "analysisrequestpartition-{}".format(primary2_id)
-    >>> number_generator.set_number(key2, 0)
-    0
-
-The next partition must still avoid the existing `-P01` and `-P02`
-IDs in the client folder, even with no storage counter and only one
-active descendant:
-
-    >>> primary2.getDescendants()
-    [<AnalysisRequest at .../...-P01>]
-    >>> q3 = create_partition(primary2, request, primary2.getAnalyses())
-    >>> q3.getId() == "{}-P03".format(primary2_id)
     True

--- a/src/senaite/core/tests/doctests/IDServer.rst
+++ b/src/senaite/core/tests/doctests/IDServer.rst
@@ -569,3 +569,84 @@ Create a new Analysis Request with same format and check again:
     >>> last_number = number_generator.get("analysisrequest-NGwater")
     >>> alpha.to_decimal('AA002') == last_number
     True
+
+
+Partition IDs survive detach
+............................
+
+Partition numbers are issued by a persistent counter so that detached
+partitions are still counted, avoiding ID collisions when a new partition
+is created on a parent that previously had partitions detached.
+
+Configure a standard ID format for samples and partitions:
+
+    >>> id_formatting = [
+    ...     {'form': '{sampleType}-{seq:04d}',
+    ...      'portal_type': 'AnalysisRequest',
+    ...      'prefix': 'analysisrequest',
+    ...      'sequence_type': 'generated',
+    ...      'split_length': 1},
+    ...     {'form': '{parent_ar_id}-P{partition_count:02d}',
+    ...      'portal_type': 'AnalysisRequestPartition',
+    ...      'prefix': 'analysisrequestpartition',
+    ...      'sequence_type': 'generated',
+    ...      'split_length': 1},
+    ... ]
+    >>> setup.setIDFormatting(id_formatting)
+
+Imports for the partition flow:
+
+    >>> from bika.lims.utils.analysisrequest import create_partition
+
+Create a primary sample and receive it:
+
+    >>> primary = create_analysisrequest(client, request, values, service_uids)
+    >>> primary_id = primary.getId()
+    >>> _ = do_action_for(primary, "receive")
+
+Create the first partition. The partition gets the suffix `-P01`:
+
+    >>> p1 = create_partition(primary, request, primary.getAnalyses())
+    >>> p1.getId() == "{}-P01".format(primary_id)
+    True
+
+The number generator's counter for this parent is now 1:
+
+    >>> key = "analysisrequestpartition-{}".format(primary_id)
+    >>> number_generator.get(key)
+    1
+
+Detach the first partition. The detach unsets `ParentAnalysisRequest`,
+so the partition is no longer a descendant of the primary, but it
+keeps existing in the client folder with its `-P01` ID:
+
+    >>> _ = do_action_for(p1, "detach")
+    >>> p1.getParentAnalysisRequest() is None
+    True
+    >>> primary.getDescendants()
+    []
+
+Creating another partition must not reuse the `-P01` suffix. Before
+the fix, `get_partition_count` derived the next number from
+`parent.getDescendants()` (now empty) and produced `-P01` again,
+colliding with the still-existing detached partition. With the fix,
+the persistent counter still reports 1, so the next partition gets
+`-P02`:
+
+    >>> p2 = create_partition(primary, request, primary.getAnalyses())
+    >>> p2.getId() == "{}-P02".format(primary_id)
+    True
+    >>> number_generator.get(key)
+    2
+
+Detach `-P02` as well and create a third partition. The new partition
+gets `-P03`, even though no descendants are left:
+
+    >>> _ = do_action_for(p2, "detach")
+    >>> primary.getDescendants()
+    []
+    >>> p3 = create_partition(primary, request, primary.getAnalyses())
+    >>> p3.getId() == "{}-P03".format(primary_id)
+    True
+    >>> number_generator.get(key)
+    3

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -28,6 +28,7 @@ from bika.lims.api import safe_unicode as u
 from bika.lims.api import snapshot as snap_api
 from bika.lims.browser.fields.uidreferencefield import get_backreferences
 from bika.lims.interfaces import IAuditable
+from bika.lims.interfaces import IDetachedPartition
 from bika.lims.interfaces import IInvalidated
 from bika.lims.utils import tmpID
 from persistent.list import PersistentList
@@ -117,13 +118,9 @@ def seed_detached_partition_backrefs(tool):
     pointer but no backref. Re-set the field to trigger backref
     maintenance on the link.
     """
-    from bika.lims.interfaces import IDetachedPartition
-
-    portal_type = "AnalysisRequest"
-    iface = IDetachedPartition.__identifier__
     query = {
-        "portal_type": portal_type,
-        "object_provides": iface,
+        "portal_type": "AnalysisRequest",
+        "object_provides": IDetachedPartition.__identifier__,
     }
     brains = api.search(query, SAMPLE_CATALOG)
     total = len(brains)

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -108,6 +108,49 @@ def upgrade(tool):
 
 
 @upgradestep(product, version)
+def seed_detached_partition_backrefs(tool):
+    """Seed annotation backrefs for already-detached partitions.
+
+    The `DetachedFrom` field gained a `relationship` attribute so the
+    UIDReferenceField now maintains backrefs on `setDetachedFrom`. Any
+    detached partition created before this change has the forward UID
+    pointer but no backref. Re-set the field to trigger backref
+    maintenance on the link.
+    """
+    from bika.lims.interfaces import IDetachedPartition
+
+    portal_type = "AnalysisRequest"
+    iface = IDetachedPartition.__identifier__
+    query = {
+        "portal_type": portal_type,
+        "object_provides": iface,
+    }
+    brains = api.search(query, SAMPLE_CATALOG)
+    total = len(brains)
+    logger.info(
+        "Seeding DetachedFrom backrefs for {} detached partitions".format(
+            total))
+
+    seeded = 0
+    for num, brain in enumerate(brains, start=1):
+        sample = api.get_object(brain)
+        field = sample.getField("DetachedFrom")
+        if field is None:
+            continue
+        target = field.get(sample)
+        if target is None:
+            continue
+        # Re-setting via the field link API ensures the backref
+        # annotation gets created on the target.
+        field.link_reference(target, sample)
+        seeded += 1
+        if num % 100 == 0:
+            logger.info("  ... seeded {}/{}".format(num, total))
+
+    logger.info("Seeded DetachedFrom backrefs for {} samples".format(seeded))
+
+
+@upgradestep(product, version)
 def import_rolemap(tool):
     """Import rolemap step from profiles
     """

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -3,6 +3,15 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.7.0: Seed DetachedFrom backrefs"
+      description="Seed annotation backrefs for detached partitions so that
+                   the partition counter accounts for them"
+      source="2725"
+      destination="2726"
+      handler=".v02_07_000.seed_detached_partition_backrefs"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Add ViewDashboard and ViewNavigation permissions"
       description="Import rolemap for new ViewDashboard and ViewNavigation permissions"
       source="2724"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a partition ID collision that occurs after the ``detach`` transition is performed on a partition.

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.core.browser.samples.partition_magic, line 98, in __call__
  Module iaea.lims.patches.utils.analysisrequest, line 30, in patched_create_partition
  Module bika.lims.utils.analysisrequest, line 522, in create_partition
  Module bika.lims.utils.analysisrequest, line 170, in create_analysisrequest
  Module senaite.core.idserver.idserver, line 553, in renameAfterCreation
  Module plone.folder.ordered, line 202, in manage_renameObject
  Module OFS.CopySupport, line 363, in manage_renameObject
CopyError: Invalid Id
```

## Current behavior before PR

``get_partition_count`` derives the next partition number from ``parent.getDescendants()``.

The ``after_detach`` event handler (``bika/lims/workflow/analysisrequest/events.py``) sets the partition's ``ParentAnalysisRequest`` to ``None``, so the detached partition is no longer counted as a descendant of its original parent.

As a result, creating a new partition on a parent that previously had a partition detached reuses the same suffix (``-P01``), colliding with the still-existing detached partition. The sample render breaks and subsequent partition creation behaves unexpectedly.

Reproduction:

1. Create partition ``-P01`` of a sample.
2. Detach ``-P01``.
3. Try to create another partition on the same parent.

## Desired behavior after PR is merged

``get_partition_count`` now uses the number generator's persistent counter as the source of truth. The counter is monotonic and stays accurate across detach: once a partition number has been issued, the counter is never decremented.

The descendants count is still consulted as a safety net for partitions that were imported without going through the ID server (in which case the storage key would be unset). The implementation uses ``max(storage_count, descendants_count) + 1`` to cover both cases.

Walkthrough:

- First partition: storage=0, descendants=0 → 1 → ``-P01`` (storage bumps to 1)
- Second partition: storage=1, descendants=1 → 2 → ``-P02``
- Detach ``-P02``, create another: storage=2, descendants=1 → 3 → ``-P03``. No collision.

This PR also extracts the four sample portal types as module-level constants (``PORTAL_TYPE_SAMPLE``, ``PORTAL_TYPE_SAMPLE_RETEST``, ``PORTAL_TYPE_SAMPLE_PARTITION``, ``PORTAL_TYPE_SAMPLE_SECONDARY``) and renames ``AR_TYPES`` to ``SAMPLE_TYPES`` for readability.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008