### PR TITLE
Name Partitions as per Sample Template

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2893 Name Sample Partitions as per Sample Template
 - #2891 Translate sidebar navigation titles in JSON endpoint
 - #2881 Add text support for interim fields
 - #2888 Improve ID Server admin views

--- a/src/senaite/core/browser/samples/templates/partition_magic.pt
+++ b/src/senaite/core/browser/samples/templates/partition_magic.pt
@@ -116,7 +116,8 @@
                   <!-- Partitions -->
                   <tr tal:repeat="part_index python:range(number_of_partitions);">
                     <tal:partition define="default_part_name python:'part-%s' % str(part_index + 1);
-                                           partition python:part_index<len(partitions) and partitions[part_index] or default_part_name">
+                                           partition python:part_index<len(partitions) and partitions[part_index] or default_part_name;
+                                           partition_id python:partition.replace(' ', '-')">
 
                       <td style="background-color: #fff;">
                         <!-- Partition number -->
@@ -124,8 +125,8 @@
                           <h3 class="text-muted">
                             <a class="text-decoration-none" style="cursor:pointer;"
                                data-toggle="collapse"
-                               tal:attributes="data-target string:#${partition}-body">
-                              <i tal:attributes="id string:${partition}-toggle-icon"
+                               tal:attributes="data-target string:#${partition_id}-body">
+                              <i tal:attributes="id string:${partition_id}-toggle-icon"
                                  class="fas fa-caret-right"></i>
                               <span tal:condition="python: partition.startswith('part')">
                                <span i18n:translate="">Partition</span>
@@ -142,8 +143,8 @@
 
                         <!-- Partition Body -->
                         <div class="partition-body collapse"
-                             tal:attributes="id string:${partition}-body;
-                                             data-partition partition">
+                             tal:attributes="id string:${partition_id}-body;
+                                             data-partition partition_id">
                           <!-- Internal Use -->
                           <div class="col-sm-2">
                             <div class="form-group">
@@ -164,7 +165,7 @@
                               <select name="partitions.sampletype_uid:records" class="form-control">
                                 <tal:options repeat="sampletype view/get_sampletype_data"
                                              define="ar_sampletype_uid ar/sampletype/uid;
-                                                     part_sampletype_uid python:sample_types.get(partition, ar_sampletype_uid);">
+                                                     part_sampletype_uid python:sample_types.get(partition) or ar_sampletype_uid;">
                                   <option tal:attributes="value sampletype/uid;
                                                           selected python:sampletype.get('uid') == part_sampletype_uid"
                                           tal:content="sampletype/title">

--- a/src/senaite/core/browser/samples/templates/partition_magic.pt
+++ b/src/senaite/core/browser/samples/templates/partition_magic.pt
@@ -131,7 +131,7 @@
                                <span i18n:translate="">Partition</span>
                                <strong tal:content="repeat/part_index/number"/>
                               </span>
-                              <span tal:condition="python: partition.startswith('part') == False">
+                              <span tal:condition="python: not partition.startswith('part')">
                                <span i18n:translate="" tal:content="partition">Partition</span>
                               </span>
                             </a>

--- a/src/senaite/core/browser/samples/templates/partition_magic.pt
+++ b/src/senaite/core/browser/samples/templates/partition_magic.pt
@@ -127,8 +127,13 @@
                                tal:attributes="data-target string:#${partition}-body">
                               <i tal:attributes="id string:${partition}-toggle-icon"
                                  class="fas fa-caret-right"></i>
-                              <span i18n:translate="">Partition</span>
-                              <strong tal:content="repeat/part_index/number"/>
+                              <span tal:condition="python: partition.startswith('part')">
+                               <span i18n:translate="">Partition</span>
+                               <strong tal:content="repeat/part_index/number"/>
+                              </span>
+                              <span tal:condition="python: partition.startswith('part') == False">
+                               <span i18n:translate="" tal:content="partition">Partition</span>
+                              </span>
                             </a>
                           </h3>
                           <!-- Remember the primary uid of this partition -->


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/2892

## Current behavior before PR
Partitions are not shown as per Sample Template
<img width="468" height="374" alt="image" src="https://github.com/user-attachments/assets/64a2d396-a25b-4b3f-ad59-a33347346036" />

## Desired behavior after PR is merged

1.    Partitions to be shown as per Sample Template

<img width="1265" height="325" alt="image" src="https://github.com/user-attachments/assets/d984397f-b0f4-4258-95b4-001785bd7512" />

2. When created by a Sample template, Partition Preview button should work

3. When Partition Sample Types are not specified, it should be the same as the original Sample

<img width="1024" height="382" alt="image" src="https://github.com/user-attachments/assets/edaf1d24-a915-4971-9951-8b1cb9543c84" />
<img width="805" height="403" alt="image" src="https://github.com/user-attachments/assets/d35c587c-5b34-465f-a1e3-561b37555017" />
<img width="338" height="274" alt="image" src="https://github.com/user-attachments/assets/ff20646d-51fb-4e46-b0aa-9e53fa2036d6" />


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
