### PR TITLE
Fix DL get flushed on submit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2894 Fix DL get flushed on submit
 - #2891 Translate sidebar navigation titles in JSON endpoint
 - #2881 Add text support for interim fields
 - #2888 Improve ID Server admin views

--- a/src/bika/lims/browser/workflow/analysis.py
+++ b/src/bika/lims/browser/workflow/analysis.py
@@ -100,7 +100,9 @@ class WorkflowActionSubmitAdapter(WorkflowActionGenericAdapter):
             analysis.setUncertainty(uncertainty)
 
             # Save detection limit
-            dlimit = self.get_form_value("DetectionLimitOperand", uid, "")
+            default = analysis.getDetectionLimitOperand()
+            dlimit = self.get_form_value("DetectionLimitOperand", uid,
+                                         default=default)
             analysis.setDetectionLimitOperand(dlimit)
 
             # Interim fields


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR solves an issue with manual set detection limits on submission for calculated results.

This PR is related to https://github.com/senaite/senaite.core/pull/1286

## Current behavior before PR

A correctly saved lower detection limit is flushed after submission

<img width="270" height="70" alt="SCR-20260506-ofgs" src="https://github.com/user-attachments/assets/c2fb6113-dee5-4498-9762-20159e8ef1b6" />
<img width="255" height="76" alt="SCR-20260506-ofpq" src="https://github.com/user-attachments/assets/2042c74d-7de2-47a7-ae9f-75508d58d4f5" />

## Desired behavior after PR is merged

The result is correctly stored as a detection limit

<img width="224" height="78" alt="SCR-20260506-ogcs" src="https://github.com/user-attachments/assets/4e730d88-a90a-4c05-bb0c-f90d0178187e" />

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
