### PR TITLE
Fix uncatalog_object to leave no stale uids in uid_catalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2896 Fix uncatalog_object to leave no stale uids in uid_catalog
 - #2894 Fix DL get flushed on submit
 - #2891 Translate sidebar navigation titles in JSON endpoint
 - #2881 Add text support for interim fields

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -56,6 +56,7 @@ from Products.Archetypes.atapi import DisplayList
 from Products.Archetypes.BaseObject import BaseObject
 from Products.Archetypes.event import ObjectInitializedEvent
 from Products.Archetypes.public import StringField
+from Products.Archetypes.utils import getRelURL
 from Products.Archetypes.utils import mapply
 from Products.CMFCore.interfaces import IFolderish
 from Products.CMFCore.interfaces import ISiteRoot
@@ -472,18 +473,28 @@ def uncatalog_object(obj, recursive=False):
     :param recursive: recursively uncatalog all child objects
     :type obj: ATContentType/DexterityContentType
     """
-    # un-catalog from registered catalogs
-    obj.unindexObject()
-    # explicitly un-catalog from uid_catalog
-    uid_catalog = get_tool("uid_catalog")
-    # the uids of uid_catalog are relative paths to portal root
-    # see Products.Archetypes.UIDCatalog.UIDResolver.catalog_object
-    url = "/".join(obj.getPhysicalPath()[2:])
-    uid_catalog.uncatalog_object(url)
+    # explicitly uncatalog from uid_catalog
+    uid_catalog = get_tool(UID_CATALOG)
+
+    # make sure that both AT/DX paths are uncatalogued
+    rel_url = getRelURL(uid_catalog, obj.getPhysicalPath())
+    abs_url = "/".join(obj.getPhysicalPath())
+
+    # Try to uncatalog with both path variations
+    # Only uncatalog if the path exists in the catalog
+    for path in [rel_url, abs_url]:
+        if path in uid_catalog._catalog.uids:
+            try:
+                uid_catalog.uncatalog_object(path)
+            except Exception:
+                pass
 
     if recursive:
         for child in obj.objectValues():
             uncatalog_object(child, recursive=recursive)
+
+    # uncatalog from registered catalogs
+    obj.unindexObject()
 
 
 def catalog_object(obj, recursive=False):
@@ -494,13 +505,20 @@ def catalog_object(obj, recursive=False):
     :type obj: ATContentType/DexterityContentType
     """
     if is_at_content(obj):
-        # explicitly re-catalog AT types at uid_catalog (DX types are
-        # automatically reindexed in UID catalog on reindexObject)
-        uc = get_tool("uid_catalog")
         # the uids of uid_catalog are relative paths to portal root
         # see Products.Archetypes.UIDCatalog.UIDResolver.catalog_object
-        url = "/".join(obj.getPhysicalPath()[2:])
-        uc.catalog_object(obj, url)
+        uc = get_tool(UID_CATALOG)
+        rel_url = getRelURL(uc, obj.getPhysicalPath())
+        uc.catalog_object(obj, rel_url)
+
+    elif is_dexterity_content(obj):
+        # we catalog the object here below the absolute path, as it is done in
+        # `plone.app.referencablebehavior.uidcatalog``
+        uc = get_tool(UID_CATALOG)
+        abs_url = "/".join(obj.getPhysicalPath())
+        uc.catalog_object(obj, abs_url)
+
+    # reindex in registered catalogs
     obj.reindexObject()
 
     if recursive:

--- a/src/senaite/core/migration/migrator.py
+++ b/src/senaite/core/migration/migrator.py
@@ -29,7 +29,6 @@ from persistent.dict import PersistentDict
 from plone.dexterity.interfaces import IDexterityContent
 from Products.Archetypes.interfaces import IBaseObject
 from Products.Archetypes.interfaces import IField
-from Products.Archetypes.utils import getRelURL
 from senaite.core.interfaces import IContentMigrator
 from senaite.core.interfaces import IFieldMigrator
 from senaite.core.migration.utils import copyPermMap
@@ -98,23 +97,7 @@ class ContentMigrator(object):
     def uncatalog_object(self, obj):
         """Uncatalog the object for all catalogs
         """
-        # explicitly uncatalog from uid_catalog
-        uid_catalog = api.get_tool(UID_CATALOG)
-        # make sure that both AT/DX paths are uncatalogued
-        rel_url = getRelURL(uid_catalog, obj.getPhysicalPath())
-        abs_url = "/".join(obj.getPhysicalPath())
-
-        # Try to uncatalog with both path variations
-        # Only uncatalog if the path exists in the catalog
-        for path in [rel_url, abs_url]:
-            if path in uid_catalog._catalog.uids:
-                try:
-                    uid_catalog.uncatalog_object(path)
-                except Exception:
-                    pass
-
-        # uncatalog from registered catalogs
-        obj.unindexObject()
+        api.uncatalog_object(obj)
 
     def catalog_object(self, obj):
         """Catalog the object in all registered catalogs

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -2479,6 +2479,46 @@ Even from `uid_catalog`:
     >>> any(uc(UID=uid))
     False
 
+The `uid_catalog` keys AT and DX content with different path conventions:
+AT content is keyed by the path **relative** to the portal root, while
+DX content is keyed by the **absolute** path. The function takes care of
+both variants so that no stale path is left behind.
+
+The AT relative path key for the client is gone after un-cataloging:
+
+    >>> at_rel_path = "/".join(client.getPhysicalPath()[2:])
+    >>> at_rel_path in uc._catalog.uids
+    False
+
+The same function works for Dexterity content. Create a fresh DX object
+to verify:
+
+    >>> dx_obj = api.create(
+    ...     portal.setup.sampletypes, "SampleType",
+    ...     title="Catalog Test SampleType", Prefix="CTS")
+    >>> dx_uid = api.get_uid(dx_obj)
+    >>> dx_catalogs = api.get_catalogs_for(dx_obj)
+    >>> all(cat(UID=dx_uid) for cat in dx_catalogs)
+    True
+    >>> any(uc(UID=dx_uid))
+    True
+
+Un-cataloging removes it from the registered catalogs and from
+`uid_catalog`:
+
+    >>> api.uncatalog_object(dx_obj)
+    >>> any(cat(UID=dx_uid) for cat in dx_catalogs)
+    False
+    >>> any(uc(UID=dx_uid))
+    False
+
+The DX absolute path key in `uid_catalog` is also gone:
+
+    >>> dx_abs_path = "/".join(dx_obj.getPhysicalPath())
+    >>> dx_abs_path in uc._catalog.uids
+    False
+
+
 Catalog an object
 .................
 
@@ -2495,6 +2535,50 @@ Even in `uid_catalog`:
 
     >>> uc = api.get_tool("uid_catalog")
     >>> len(uc(UID=uid)) == 1
+    True
+
+The AT content is keyed in `uid_catalog` by its relative path:
+
+    >>> at_rel_path in uc._catalog.uids
+    True
+
+It works for Dexterity content too, which is keyed in `uid_catalog`
+by its absolute path:
+
+    >>> api.catalog_object(dx_obj)
+    >>> all(cat(UID=dx_uid) for cat in dx_catalogs)
+    True
+    >>> len(uc(UID=dx_uid)) == 1
+    True
+    >>> dx_abs_path in uc._catalog.uids
+    True
+
+
+Recursive (un)cataloging
+........................
+
+Both functions accept a `recursive` argument to walk children. The
+`client` already holds children created in earlier sections of this
+test, so we can reuse them:
+
+    >>> child_uids = [api.get_uid(c) for c in client.objectValues()]
+    >>> child_uids and all(any(uc(UID=cuid)) for cuid in child_uids)
+    True
+
+Un-cataloging the parent recursively also un-catalogs the children:
+
+    >>> api.uncatalog_object(client, recursive=True)
+    >>> any(uc(UID=uid))
+    False
+    >>> any(any(uc(UID=cuid)) for cuid in child_uids)
+    False
+
+Re-cataloging the parent recursively brings the children back:
+
+    >>> api.catalog_object(client, recursive=True)
+    >>> any(uc(UID=uid))
+    True
+    >>> all(any(uc(UID=cuid)) for cuid in child_uids)
     True
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Fix `api.uncatalog_object` so it removes both the AT and the DX path entries from `uid_catalog`, plus doctest coverage for the fix.

## Current behavior before PR

`uid_catalog` keys content by two different path conventions:

- AT content is registered under its **relative** path (e.g. `clients/client-1`), as done by `Products.Archetypes.UIDCatalog.UIDResolver.catalog_object`.
- DX content is registered under its **absolute** path (e.g. `/senaite/setup/sampletypes/sampletype-1`), as done by `plone.app.referenceablebehavior.uidcatalog`.

`api.uncatalog_object` only tried the relative path, so DX objects (and any AT object that had been re-cataloged by the DX machinery during a migration) left a stale entry behind in `uid_catalog`. `api.catalog_object` had the symmetric problem: it always used the relative path, so DX content ended up keyed inconsistently.

The same logic was duplicated in `senaite.core.migration.migrator.ContentMigrator`.

## Desired behavior after PR is merged

- `api.uncatalog_object` resolves both the relative and the absolute path for the object and removes whichever is present in `uid_catalog._catalog.uids`, so no stale uid is left behind.
- `api.catalog_object` dispatches on `is_at_content` / `is_dexterity_content` and registers the object under the matching path convention.
- `ContentMigrator.uncatalog_object` / `catalog_object` delegate to `api`, removing the duplicated logic.
- `API.rst` doctest now exercises both functions against AT and DX content, checks the `uid_catalog._catalog.uids` keys directly so a regression that leaves stale uids behind is caught, and adds a `Recursive (un)cataloging` section.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
