### PR TITLE
Use UnorderedOrdering for Clients to avoid ZODB conflicts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2897 Use UnorderedOrdering for Clients to avoid ZODB conflicts
 - #2894 Fix DL get flushed on submit
 - #2891 Translate sidebar navigation titles in JSON endpoint
 - #2881 Add text support for interim fields

--- a/src/bika/lims/content/configure.zcml
+++ b/src/bika/lims/content/configure.zcml
@@ -8,6 +8,30 @@
 
   <adapter name="BatchDate" factory=".batch.BatchDate" />
 
+  <!--
+    Use plone.folder's UnorderedOrdering as the IOrdering adapter for
+    Client objects.
+
+    The default DefaultOrdering keeps a `plone.folder.ordered.order`
+    PersistentList annotation that grows with the number of children:
+    every `_setObject` calls `notifyAdded` which appends to the list.
+    PersistentList has no `_p_resolveConflict()`, so two concurrent
+    appends collide and the conflict propagates to the client through
+    the publisher's retry loop. On a Client holding tens of thousands
+    of children the annotation becomes a measurable bottleneck for
+    sample registration, with the time per save growing roughly with
+    the number of children.
+
+    Sample listings in SENAITE never depend on the parent folder's
+    manual ordering — they sort catalog brains. Switching IClient to
+    UnorderedOrdering removes the hot-spot at no functional cost.
+    -->
+  <adapter
+      for="bika.lims.interfaces.IClient"
+      factory="plone.folder.unordered.UnorderedOrdering"
+      provides="plone.folder.interfaces.IOrdering"
+      />
+
   <browser:page
       for="*"
       name="getcontainers"

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2726</version>
+  <version>2727</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-senaite.impress:default</dependency>

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -110,7 +110,6 @@ def upgrade(tool):
     return True
 
 
-@upgradestep(product, version)
 def drop_client_ordering_annotations(tool):
     """Remove the legacy IOrdering annotations from every Client.
 

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -45,6 +45,7 @@ from senaite.core.catalog import REPORT_CATALOG
 from senaite.core.catalog import SAMPLE_CATALOG
 from senaite.core.catalog import SETUP_CATALOG
 from senaite.core.catalog import WORKSHEET_CATALOG
+from senaite.core.catalog.client_catalog import CATALOG_ID as CLIENT_CATALOG
 from senaite.core.catalog.analysis_catalog import INDEXES as ANALYSIS_INDEXES
 from senaite.core.config import PROJECTNAME as product
 from senaite.core.interfaces import IContentMigrator
@@ -66,6 +67,7 @@ from senaite.core.upgrade.utils import permanently_allow_type_for
 from senaite.core.upgrade.utils import remove_at_portal_types
 from senaite.core.upgrade.utils import uncatalog_object
 from senaite.core.upgrade.v02_06_000 import get_setup_folder
+from zope.annotation.interfaces import IAnnotations
 from zope.component import getMultiAdapter
 from zope.interface import alsoProvides
 from zope.interface import noLongerProvides
@@ -106,6 +108,64 @@ def upgrade(tool):
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
+
+
+@upgradestep(product, version)
+def drop_client_ordering_annotations(tool):
+    """Remove the legacy IOrdering annotations from every Client.
+
+    Clients now use `plone.folder.unordered.UnorderedOrdering` as
+    their `IOrdering` adapter, so the previous default-ordering
+    annotations are no longer maintained:
+
+      - `plone.folder.ordered.order` — a `PersistentList` of every
+        child id, mutated on every `_setObject` via
+        `DefaultOrdering.notifyAdded`. On a Client with thousands of
+        children this list grows to many tens of thousands of entries
+        and, because `PersistentList` has no `_p_resolveConflict()`,
+        every concurrent registration on the same Client collided on
+        it and the conflict propagated all the way to the
+        publisher's retry loop.
+
+      - `plone.folder.ordered.pos` — companion `OIBTree` mapping
+        child id -> position. No longer read by anything once the
+        adapter is unordered.
+
+    Removing both annotations after the adapter switch frees the
+    storage they occupy and removes a stale hot-mutation bucket from
+    the ZODB cache. The adapter override is what stops new writes
+    from touching them; this step is hygiene.
+    """
+    ORDER_KEY = "plone.folder.ordered.order"
+    POS_KEY = "plone.folder.ordered.pos"
+
+    query = {"portal_type": "Client"}
+    brains = api.search(query, CLIENT_CATALOG)
+    total = len(brains)
+    logger.info(
+        "Dropping IOrdering annotations from {} clients".format(total))
+
+    cleaned = 0
+    for num, brain in enumerate(brains, start=1):
+        client = api.get_object(brain)
+        ann = IAnnotations(client)
+        had_order = ORDER_KEY in ann
+        had_pos = POS_KEY in ann
+        if not (had_order or had_pos):
+            continue
+        ann.pop(ORDER_KEY, None)
+        ann.pop(POS_KEY, None)
+        client._p_changed = True
+        cleaned += 1
+        if num % 100 == 0:
+            logger.info(
+                "  ... processed {}/{} clients ({} cleaned)".format(
+                    num, total, cleaned))
+            transaction.savepoint()
+
+    logger.info(
+        "Dropped IOrdering annotations from {}/{} clients".format(
+            cleaned, total))
 
 
 @upgradestep(product, version)

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -3,6 +3,19 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.7.0: Drop ordering annotations from Clients"
+      description="Remove the plone.folder.ordered.order PersistentList and
+                   plone.folder.ordered.pos OIBTree annotations from every
+                   Client. Clients now use UnorderedOrdering as their
+                   IOrdering adapter, so these annotations are no longer
+                   maintained and become a stale ZODB conflict spot if left
+                   in place."
+      source="2726"
+      destination="2727"
+      handler=".v02_07_000.drop_client_ordering_annotations"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Seed DetachedFrom backrefs"
       description="Seed annotation backrefs for detached partitions so that
                    the partition counter accounts for them"


### PR DESCRIPTION
## Description

Switch the `IOrdering` adapter for `Client` from `plone.folder.default.DefaultOrdering` to `plone.folder.unordered.UnorderedOrdering`.

A `Client` is a folderish content type. With the default adapter, Plone keeps a `plone.folder.ordered.order` annotation — a flat `persistent.list.PersistentList` of every child id, mutated on every `_setObject` via `notifyAdded(obj_id)` (`order.append(...)`). `PersistentList` does not implement `_p_resolveConflict()`, so two concurrent registrations on the same Client always conflict on this single annotation OID and the conflict propagates all the way to the publisher's 3-retry loop. The cost of each retry grows linearly with the size of the list because `PersistentList` rewrites the whole pickle on every mutation.

For deployments where a single Client accumulates tens of thousands of children — common when a lab uses one Client as a catch-all for routine in-house samples — this manifests as multi-minute waits during sample save and a steady stream of ConflictError tracebacks on a single low OID. With `UnorderedOrdering` the adapter's `notifyAdded`/`notifyRemoved` become no-ops; `idsInOrder()` falls back to `aq_base(client).objectIds(ordered=False)`, which reads the BTreeFolder2 internal tree (scales, has built-in conflict resolution).

The change is interface-scoped to `IClient` only. `AnalysisRequest`, `ARReport`, `Batch`, `Worksheet`, `Contact`, `Patient` and other folderish content continue to use `DefaultOrdering`. `getLastResultsReport()` and friends, which read `sample.objectIds("ARReport")[-1]`, are unaffected.

Sample listings never depend on a Client's manual ordering — they sort catalog brains by `created` / `getDateReceived` / state — so removing the ordering on Client is a no-op for the UI.

## Migration

Existing Clients still carry their `plone.folder.ordered.order` `PersistentList` and `plone.folder.ordered.pos` `OIBTree` annotations from prior writes. They are no longer maintained but remain on disk. The new upgrade step `drop_client_ordering_annotations` (profile version `2726 → 2727`) iterates every Client found via `CLIENT_CATALOG` and removes both annotations, taking `transaction.savepoint()` every 100 clients.

The adapter override is what stops new writes from touching the annotations; the upgrade step is hygiene to free their storage.

## Verified downstream

The same change has been deployed downstream in a SENAITE add-on with several days of runtime under heavy concurrent write load. The targeted `PersistentList` OID went from being the single largest contributor to ConflictErrors to zero occurrences, with no new hot spot emerging in its place. The remaining conflict traffic is on BTree-* catalog index buckets, which the ZEO server with application eggs auto-resolves transparently.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
