### PR TITLE
Fix circular import between senaite.core.catalog and bika.lims

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2900 Fix circular import between senaite.core.catalog and bika.lims
 - #2899 Suppress profile-remove dialog during bulk ar_add hydration
 - #2741 Commit each created sample individually to reduce ZODB conflicts
 - #2896 Fix uncatalog_object to leave no stale uids in uid_catalog

--- a/src/senaite/core/catalog/base_catalog.py
+++ b/src/senaite/core/catalog/base_catalog.py
@@ -27,14 +27,18 @@ from AccessControl.Permissions import \
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from App.class_init import InitializeClass
-from bika.lims import api
-from bika.lims import logger
 from Products.CMFPlone.CatalogTool import CatalogTool
 from Products.CMFPlone.utils import base_hasattr
 from Products.CMFPlone.utils import safe_callable
 from Products.ZCatalog.ZCatalog import ZCatalog
+from senaite.core import logger
 from senaite.core.interfaces import ISenaiteCatalogObject
 from zope.interface import implementer
+
+# NOTE: `bika.lims` is imported lazily inside functions to avoid a
+# circular import: `senaite.core.catalog.__init__` pulls in this module
+# via `analysis_catalog`, and `bika/lims/__init__.py` re-enters
+# `senaite.core.catalog` through `bika.lims.catalog`.
 
 CATALOG_ID = "senaite_catalog_base"
 CATALOG_TITLE = "Senaite Base Catalog"
@@ -105,6 +109,7 @@ class BaseCatalog(CatalogTool):
     def is_obj_indexable(self, obj, portal_type, mapped_types):
         """Checks if the object can be indexed
         """
+        from bika.lims import api
         if portal_type in mapped_types:
             return True
         if api.is_dexterity_content(obj):
@@ -115,6 +120,7 @@ class BaseCatalog(CatalogTool):
     def get_portal_type(self, obj):
         """Returns the portal type of the object
         """
+        from bika.lims import api
         if not api.is_object(obj):
             return None
         return api.get_portal_type(obj)
@@ -122,6 +128,7 @@ class BaseCatalog(CatalogTool):
     def get_mapped_at_types(self):
         """Returns all mapped AT types from archetype_tool
         """
+        from bika.lims import api
         at = api.get_tool("archetype_tool", default=None)
         if at is None:
             return []


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

There is a latent circular import between `senaite.core.catalog` and
`bika.lims` that surfaces whenever something imports
`senaite.core.catalog` before `bika.lims` has finished loading.

Concrete repro path:

```
$ bin/zopepy -c "from senaite.core.catalog import AUDITLOG_CATALOG"
File ".../senaite/core/catalog/__init__.py", line 26
  from senaite.core.catalog.analysis_catalog import CATALOG_ID as ANALYSIS_CATALOG
File ".../senaite/core/catalog/analysis_catalog.py", line 22
  from senaite.core.catalog.base_catalog import COLUMNS as BASE_COLUMNS
File ".../senaite/core/catalog/base_catalog.py", line 30
  from bika.lims import api
File ".../bika/lims/__init__.py", line 50
  from bika.lims.validators import *
File ".../bika/lims/validators.py", line 30
  from bika.lims.catalog import SETUP_CATALOG
File ".../bika/lims/catalog/__init__.py", line 22
  from senaite.core.catalog import AUDITLOG_CATALOG as CATALOG_AUDITLOG
ImportError: cannot import name AUDITLOG_CATALOG
```

The same cycle is hit by `bin/zodbverify` when it unpickles a class
referenced from the Data.fs root before `bika.lims` has been
imported as a whole. The user sees a flood of
`Could not process … ImportError: cannot import name api` /
`cannot import name AUDITLOG_CATALOG` lines that look like a missing
egg but are really a half-initialised module.

## Current behavior before PR

`senaite/core/catalog/base_catalog.py` imports `bika.lims` at module
level. Since `base_catalog` is pulled in by
`senaite.core.catalog.__init__` (via `analysis_catalog`), it forces
`bika.lims` to fully initialise during `senaite.core.catalog`'s own
init. `bika.lims.__init__` in turn imports `bika.lims.catalog`,
which re-enters `senaite.core.catalog` while it is still mid-init
and the `AUDITLOG_CATALOG` name is not yet bound, raising
`ImportError`.

Under normal Zope startup the cycle is masked by ZCML load order
(`bika.lims` happens to finish first), so it goes unnoticed; but any
tool or test that imports `senaite.core.catalog` cold (zodbverify,
ad-hoc scripts, future test layers) trips it.

## Desired behavior after PR is merged

`senaite.core.catalog` initialises independently of `bika.lims`.
Importing it cold succeeds, and `bin/zodbverify` produces no
spurious `ImportError` records.

This PR:

- Removes the module-level `from bika.lims import api` and
  `from bika.lims import logger` from
  `senaite/core/catalog/base_catalog.py`.
- Switches the file to `from senaite.core import logger`, matching
  the existing convention in `senaite/core/catalog/utils.py`.
- Defers `from bika.lims import api` to function scope in the three
  methods that use it (`is_obj_indexable`, `get_portal_type`,
  `get_mapped_at_types`).
- Adds a short comment explaining why the lazy import is needed so
  it does not get "cleaned up" later.

Verified locally that both import directions now succeed:

```
$ bin/zopepy -c "from senaite.core.catalog import AUDITLOG_CATALOG; print(AUDITLOG_CATALOG)"
senaite_catalog_auditlog
$ bin/zopepy -c "from bika.lims.catalog import SETUP_CATALOG; print(SETUP_CATALOG)"
senaite_catalog_setup
```

`bin/zodbverify` against an existing Data.fs goes from 16 `ImportError` /
`Could not process` records to zero.

---

I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html