### PR TITLE
Normalize Title to unicode in catalog title FieldIndex

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2901 Normalize Title to unicode in catalog title FieldIndex
 - #2873 Catalog/cleanup sample catalog indexes
 - #2900 Fix circular import between senaite.core.catalog and bika.lims
 - #2899 Suppress profile-remove dialog during bulk ar_add hydration

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- #2901 Normalize Title to unicode in catalog title FieldIndex
+- #2901 Add generic unicode title indexer for the `title` FieldIndex
 - #2873 Catalog/cleanup sample catalog indexes
 - #2900 Fix circular import between senaite.core.catalog and bika.lims
 - #2899 Suppress profile-remove dialog during bulk ar_add hydration

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -859,8 +859,10 @@ def get_title(brain_or_object):
     :rtype: string
     """
     if is_brain(brain_or_object) and base_hasattr(brain_or_object, "Title"):
-        return brain_or_object.Title
-    return get_object(brain_or_object).Title()
+        title = brain_or_object.Title
+    else:
+        title = get_object(brain_or_object).Title()
+    return to_utf8(title, default="")
 
 
 def get_description(brain_or_object):

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -859,10 +859,8 @@ def get_title(brain_or_object):
     :rtype: string
     """
     if is_brain(brain_or_object) and base_hasattr(brain_or_object, "Title"):
-        title = brain_or_object.Title
-    else:
-        title = get_object(brain_or_object).Title()
-    return to_utf8(title, default="")
+        return brain_or_object.Title
+    return get_object(brain_or_object).Title()
 
 
 def get_description(brain_or_object):

--- a/src/senaite/core/catalog/base_catalog.py
+++ b/src/senaite/core/catalog/base_catalog.py
@@ -57,7 +57,7 @@ INDEXES = [
     ("path", "", "ExtendedPathIndex"),
     ("portal_type", "", "FieldIndex"),
     ("review_state", "", "FieldIndex"),
-    ("title", "Title", "FieldIndex"),
+    ("title", "", "FieldIndex"),
     ("UID", "", "UUIDIndex"),
 ]
 

--- a/src/senaite/core/catalog/indexer/configure.zcml
+++ b/src/senaite/core/catalog/indexer/configure.zcml
@@ -6,7 +6,7 @@
   <adapter name="is_active" factory=".generic.is_active"/>
   <adapter name="listing_searchable_text" factory=".generic.listing_searchable_text"/>
   <adapter name="sortable_title" factory=".generic.sortable_title"/>
-  <adapter name="Title" factory=".generic.Title"/>
+  <adapter name="title" factory=".generic.title"/>
 
   <!-- Client Indexer -->
   <adapter name="client_searchable_text" factory=".client.client_searchable_text"/>

--- a/src/senaite/core/catalog/indexer/configure.zcml
+++ b/src/senaite/core/catalog/indexer/configure.zcml
@@ -6,6 +6,7 @@
   <adapter name="is_active" factory=".generic.is_active"/>
   <adapter name="listing_searchable_text" factory=".generic.listing_searchable_text"/>
   <adapter name="sortable_title" factory=".generic.sortable_title"/>
+  <adapter name="Title" factory=".generic.Title"/>
 
   <!-- Client Indexer -->
   <adapter name="client_searchable_text" factory=".client.client_searchable_text"/>

--- a/src/senaite/core/catalog/indexer/generic.py
+++ b/src/senaite/core/catalog/indexer/generic.py
@@ -39,17 +39,18 @@ def is_active(instance):
 
 @indexer(IContentish)
 def Title(instance):
-    """Normalize Title() to UTF-8 bytes for the `title` FieldIndex.
+    """Normalize Title() to unicode for the `title` FieldIndex.
 
     Some content types (e.g. Organisation) return UTF-8 bytes from
     Title() while others return unicode. Mixing both in the same
     FieldIndex OOBTree triggers UnicodeDecodeError on key comparison
     under Python 2 as soon as a non-ASCII byte string meets a
-    unicode key. Coerce to UTF-8 bytes here so the index holds a
-    single, consistent key type and the catalog metadata column for
-    `Title` keeps returning bytes as before.
+    unicode key. Coerce to unicode here so the index and metadata
+    column both hold a single, consistent key type. Callers that
+    need a UTF-8 byte string can use `api.get_title`, which mirrors
+    the return type of the `Title()` content method.
     """
-    return api.to_utf8(instance.Title(), default="")
+    return api.safe_unicode(instance.Title())
 
 
 @indexer(IContentish)

--- a/src/senaite/core/catalog/indexer/generic.py
+++ b/src/senaite/core/catalog/indexer/generic.py
@@ -38,17 +38,21 @@ def is_active(instance):
 
 
 @indexer(IContentish)
-def Title(instance):
-    """Normalize Title() to unicode for the `title` FieldIndex.
+def title(instance):
+    """Populate the `title` FieldIndex with the unicode Title().
 
-    Some content types (e.g. Organisation) return UTF-8 bytes from
-    Title() while others return unicode. Mixing both in the same
-    FieldIndex OOBTree triggers UnicodeDecodeError on key comparison
-    under Python 2 as soon as a non-ASCII byte string meets a
-    unicode key. Coerce to unicode here so the index and metadata
-    column both hold a single, consistent key type. Callers that
-    need a UTF-8 byte string can use `api.get_title`, which mirrors
-    the return type of the `Title()` content method.
+    The `title` FieldIndex defined in base_catalog has no `attr` set,
+    so the catalog wrapper reads `obj.title` and delegates here for
+    every IContentish object. Returning `api.safe_unicode(Title())`
+    gives the index a single, consistent unicode key type across all
+    content types so non-ASCII titles can be queried as unicode:
+
+        catalog(title=u"Café")
+
+    The `Title` metadata column is independent of this indexer and
+    keeps whatever the content's `Title()` method returns (bytes for
+    most SENAITE AT types, unicode for DX content), so existing
+    consumers of `brain.Title` are unaffected.
     """
     return api.safe_unicode(instance.Title())
 

--- a/src/senaite/core/catalog/indexer/generic.py
+++ b/src/senaite/core/catalog/indexer/generic.py
@@ -24,7 +24,6 @@ from Products.CMFCore.interfaces import IContentish
 from Products.CMFPlone.CatalogTool import \
     sortable_title as plone_sortable_title
 from Products.CMFPlone.utils import safe_callable
-from Products.CMFPlone.utils import safe_unicode
 from senaite.core.catalog import SENAITE_CATALOG
 from senaite.core.catalog.utils import get_searchable_text_tokens
 from senaite.core.interfaces import ISenaiteCatalog
@@ -40,19 +39,17 @@ def is_active(instance):
 
 @indexer(IContentish)
 def Title(instance):
-    """Normalize Title() to unicode for the `title` FieldIndex.
+    """Normalize Title() to UTF-8 bytes for the `title` FieldIndex.
 
     Some content types (e.g. Organisation) return UTF-8 bytes from
-    Title(), while others return unicode. Mixing both in the same
+    Title() while others return unicode. Mixing both in the same
     FieldIndex OOBTree triggers UnicodeDecodeError on key comparison
     under Python 2 as soon as a non-ASCII byte string meets a
-    unicode key. Coerce to unicode here so the index holds a
-    single, consistent key type.
+    unicode key. Coerce to UTF-8 bytes here so the index holds a
+    single, consistent key type and the catalog metadata column for
+    `Title` keeps returning bytes as before.
     """
-    title = instance.Title()
-    if safe_callable(title):
-        title = title()
-    return safe_unicode(title or u"")
+    return api.to_utf8(instance.Title(), default="")
 
 
 @indexer(IContentish)

--- a/src/senaite/core/catalog/indexer/generic.py
+++ b/src/senaite/core/catalog/indexer/generic.py
@@ -24,6 +24,7 @@ from Products.CMFCore.interfaces import IContentish
 from Products.CMFPlone.CatalogTool import \
     sortable_title as plone_sortable_title
 from Products.CMFPlone.utils import safe_callable
+from Products.CMFPlone.utils import safe_unicode
 from senaite.core.catalog import SENAITE_CATALOG
 from senaite.core.catalog.utils import get_searchable_text_tokens
 from senaite.core.interfaces import ISenaiteCatalog
@@ -35,6 +36,23 @@ def is_active(instance):
     Otherwise returns True
     """
     return api.is_active(instance)
+
+
+@indexer(IContentish)
+def Title(instance):
+    """Normalize Title() to unicode for the `title` FieldIndex.
+
+    Some content types (e.g. Organisation) return UTF-8 bytes from
+    Title(), while others return unicode. Mixing both in the same
+    FieldIndex OOBTree triggers UnicodeDecodeError on key comparison
+    under Python 2 as soon as a non-ASCII byte string meets a
+    unicode key. Coerce to unicode here so the index holds a
+    single, consistent key type.
+    """
+    title = instance.Title()
+    if safe_callable(title):
+        title = title()
+    return safe_unicode(title or u"")
 
 
 @indexer(IContentish)

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -1751,11 +1751,11 @@ def reindex_labcontact_searchable_text(tool):
 def cleanup_sample_catalog(tool):
     """Clean up senaite_catalog_sample indexes and metadata columns
 
-    - Fix title FieldIndex: set indexed_attrs to "Title" on every catalog
-      that inherits from base_catalog so the index stores the object's
-      Title() value rather than a lowercase "title" attribute that does
-      not exist on AnalysisRequest (and is empty / inconsistent on
-      other AT types).
+    - Reindex the title FieldIndex on every catalog that inherits from
+      base_catalog so it picks up the new generic `title` indexer that
+      returns a unicode Title for any IContentish object. Previously
+      only Organisation contributed entries via its type-specific
+      indexer, so the index was effectively empty for everything else.
     - Remove obsolete FieldIndexes getProvince and getDistrict from the
       sample catalog. Client geography belongs on the client catalog and
       is not meaningful as a sample catalog index; reindexing is also
@@ -1767,10 +1767,9 @@ def cleanup_sample_catalog(tool):
     """
     logger.info("Cleaning up sample catalog indexes and columns ...")
 
-    # Fix the title FieldIndex on every catalog that inherits the base
-    # indexes definition. The base_catalog change to ("title", "Title",
-    # "FieldIndex") only applies to fresh installs; existing catalogs
-    # need indexed_attrs updated and a reindex.
+    # Reindex the title FieldIndex on every catalog that inherits the
+    # base indexes definition so the new generic `title` indexer
+    # populates entries for every content type.
     base_catalogs = [
         ATTACHMENTS_CATALOG,
         AUDITLOG_CATALOG,
@@ -1784,18 +1783,9 @@ def cleanup_sample_catalog(tool):
         WORKSHEET_CATALOG,
     ]
     for catalog_id in base_catalogs:
-        cat = api.get_tool(catalog_id)
-        title_index = get_index(cat, "title")
-        if title_index is None:
+        if get_index(api.get_tool(catalog_id), "title") is None:
             continue
-        if not hasattr(title_index, "indexed_attrs"):
-            continue
-        if title_index.indexed_attrs == ["Title"]:
-            continue
-        title_index.indexed_attrs = ["Title"]
-        logger.info(
-            "Updated title index indexed_attrs to 'Title' on %s",
-            catalog_id)
+        logger.info("Reindexing title index on %s", catalog_id)
         reindex_index(catalog_id, "title")
 
     catalog = api.get_tool(SAMPLE_CATALOG)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Companion fix to #2873. After merging that PR, running the
`cleanup_sample_catalog` upgrade step crashes with:

```
File "Products/PluginIndexes/unindex.py", line 213,
    in insertForwardIndexEntry
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3
    in position 10: ordinal not in range(128)
```

## Current behavior before PR

`base_catalog.py` now defines the `title` FieldIndex with
`indexed_attrs=["Title"]`, which means the index reads
`obj.Title()` on every content object. Title return types are
not consistent across SENAITE content:

- `Organisation.Title()` (and subclasses such as `Client`) ends
  with `.encode("utf-8")` and returns `str` (bytes).
- DX content and most other types return `unicode`.

The FieldIndex stores those values as keys in an `OOBTree`.
Under Python 2, comparing a `str` containing a non-ASCII byte
(e.g. `b"Caf\xc3\xa9"`) against a `unicode` key triggers an
implicit ASCII decode of the bytes and raises
`UnicodeDecodeError`, aborting `manage_reindexIndex` during the
upgrade step.

The change to `indexed_attrs=["Title"]` also bypasses the
`@indexer(IOrganisation)` adapter named `title` in
`catalog/indexer/organisation.py`, since `plone.indexer`
dispatches by the attribute name the catalog wrapper reads
(`Title`, not `title`).

## Desired behavior after PR is merged

Register a generic `@indexer(IContentish)` named `Title` in
`catalog/indexer/generic.py` that coerces the result of
`Title()` through `safe_unicode`. `IIndexableObjectWrapper`
consults this adapter only during catalog indexing, so the
FieldIndex always receives a `unicode` key and the
`OOBTree` never has to compare mixed key types. The real
`Title()` method on content objects is unaffected outside the
catalog code path.

No additional upgrade step is required: the failed
`cleanup_sample_catalog` transaction aborts, leaving the
profile metadata version unchanged, so re-running upgrades
replays step 2724 against the new, consistently-typed indexer
and finishes cleanly.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html