### PR TITLE
Fix blob_to_named_file to handle non-blob AT image/file values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- Fix `blob_to_named_file` to also convert non-blob AT
+  `ImageField`/`FileField` values (`OFS.Image.Image`/`File`)
+  so the Laboratory DX migration produces a usable
+  `NamedBlobImage` instead of leaving the legacy object in place
 - #2810 Migrate Laboratory to DX
 - #2901 Add generic unicode title indexer for the `title` FieldIndex
 - #2873 Catalog/cleanup sample catalog indexes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- Fix `blob_to_named_file` to also convert non-blob AT
-  `ImageField`/`FileField` values (`OFS.Image.Image`/`File`)
-  so the Laboratory DX migration produces a usable
-  `NamedBlobImage` instead of leaving the legacy object in place
+- #2902 Fix blob_to_named_file to handle non-blob AT image/file values
 - #2810 Migrate Laboratory to DX
 - #2901 Add generic unicode title indexer for the `title` FieldIndex
 - #2873 Catalog/cleanup sample catalog indexes

--- a/src/senaite/core/upgrade/utils.py
+++ b/src/senaite/core/upgrade/utils.py
@@ -36,6 +36,8 @@ from plone.dexterity.fti import DexterityFTI
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import get_installer
 from Products.ZCatalog.ProgressHandler import ZLogHandler
+from OFS.Image import File as OFSFile
+from OFS.Image import Image as OFSImage
 from plone.app.blob.field import BlobWrapper
 from plone.namedfile.file import NamedBlobFile
 from plone.namedfile.file import NamedBlobImage
@@ -433,15 +435,38 @@ def remove_at_portal_types(tool, types_to_remove=[]):
 
 
 def blob_to_named_file(blob, default_filename=u"file"):
-    """Convert an AT BlobWrapper to a Dexterity NamedBlobFile/Image
+    """Convert an AT file/image value to a Dexterity NamedBlobFile/Image.
+
+    Accepts:
+    * A ``plone.app.blob.field.BlobWrapper`` (blob-aware AT fields).
+    * An ``OFS.Image.Image`` / ``OFS.Image.File`` (the value stored
+      by plain Archetypes ``ImageField`` / ``FileField``).
+
+    Anything else falsy returns ``None``. Anything else truthy is
+    returned unchanged, so legacy callers that already pass
+    ``NamedBlobFile``/``NamedBlobImage`` instances keep working.
     """
     if not blob:
         return None
-    if not isinstance(blob, BlobWrapper):
+
+    if isinstance(blob, BlobWrapper):
+        filename = u(blob.getFilename() or default_filename)
+        content_type = blob.getContentType() or ""
+        data = blob.data
+    elif isinstance(blob, (OFSImage, OFSFile)):
+        # ``filename`` attribute is set on upload but may be empty;
+        # fall back to the persistent id, then the default.
+        filename = u(getattr(blob, "filename", None)
+                     or blob.getId()
+                     or default_filename)
+        content_type = blob.getContentType() or ""
+        data = bytes(blob.data) if blob.data is not None else b""
+    else:
+        # Unknown shape (e.g. already a NamedBlobFile from a partial
+        # earlier migration); leave it for the field setter to deal
+        # with.
         return blob
-    filename = u(blob.getFilename() or default_filename)
-    content_type = blob.getContentType() or ""
-    data = blob.data
+
     if content_type.startswith("image/"):
         return NamedBlobImage(
             data=data,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Companion fix to #2810. The DX migration of `Laboratory` introduced in that PR crashes the edit form whenever the source AT laboratory had an `AccreditationBodyLogo`, because the helper used to convert the legacy field value into a Dexterity `NamedBlob*` returns the wrong thing for plain (non-blob) Archetypes image fields.

The traceback users see on `/senaite/setup/laboratory/@@edit` after migration:

```
LocationError: (<NamedImageWidget 'form.widgets.accreditation_body_logo'>,
                'file_content_type')
 - Expression: "doc_type view/file_content_type"
 - Filename:   .../plone/formwidget/namedfile/image_input.pt:28
```

The crash itself originates upstream in `plone.formwidget.namedfile.widget._mimetype` falling into `registry.lookupExtension(None)`, which raises `AttributeError` on `None.find('.')`. That bubbles out of the `file_content_type` property and TAL traversal converts it to a `LocationError`. But the *reason* the widget ends up in that state is that the DX field holds an `OFS.Image.Image` instead of a `NamedBlobImage`, which is the migration bug fixed here.

## Current behavior before PR

`senaite.core.upgrade.utils.blob_to_named_file` was written assuming the only legacy shape it would ever see is a `plone.app.blob.field.BlobWrapper` (blob-aware AT fields):

```python
def blob_to_named_file(blob, default_filename=u"file"):
    if not blob:
        return None
    if not isinstance(blob, BlobWrapper):
        return blob   # ← returns the AT image object unchanged
    ...
```

But `bika.lims.content.laboratory` declares `AccreditationBodyLogo` as a plain `Products.Archetypes.public.ImageField`, not a blob-aware variant. The accessor `src.getAccreditationBodyLogo()` returns a `Products.Archetypes.Field.Image` instance (subclass of `OFS.Image.Image`). `isinstance(..., BlobWrapper)` is `False`, so the helper short-circuits and returns the `OFS.Image.Image` verbatim. The migration assigns that to `target.accreditation_body_logo`, which expects either `None` or a `NamedBlobImage`. The next form render sees a value that is truthy but has no `contentType`, no `filename`, and is not recognised by `INamed`, so the widget's mimetype fallback chain ends in `lookupExtension(None)` and the edit form 500s.

Same hole affects any future migration of a non-blob `ImageField` / `FileField` to a DX `NamedBlob*` field via this helper.

## Desired behavior after PR is merged

`blob_to_named_file` recognises the `OFS.Image.Image` / `OFS.Image.File` shape as well, extracts `data`, `contentType`, and `filename` (`.filename` attribute when set, falling back to `getId()`, then the supplied default), and builds a proper `NamedBlobImage` / `NamedBlobFile`:

```python
if isinstance(blob, BlobWrapper):
    ...
elif isinstance(blob, (OFSImage, OFSFile)):
    filename = u(getattr(blob, "filename", None)
                 or blob.getId()
                 or default_filename)
    content_type = blob.getContentType() or ""
    data = bytes(blob.data) if blob.data is not None else b""
else:
    return blob
```

Behaviour for the existing `BlobWrapper` path is unchanged. Anything else truthy is still returned unchanged, so callers that already pass a `NamedBlob*` instance (e.g. partially re-run migrations) keep working.

## Repair path for sites that already migrated

Sites that already ran #2810 against an AT laboratory with an accreditation logo will have the broken `OFS.Image.Image` sitting on `target.accreditation_body_logo`. Two ways out:

1. Clear the field through the ZMI on the DX laboratory and re-upload the logo through the edit form once the widget is no longer crashing.
2. (If desired in a follow-up) ship a small idempotent upgrade step that walks `setup/laboratory`, runs the new `blob_to_named_file` over the current `accreditation_body_logo` value, and writes the result back. Not included in this PR to keep the scope minimal.

---

I confirm I have tested this PR thoroughly and coded it according to [PEP8](https://www.python.org/dev/peps/pep-0008) and [Plone's Python styleguide](https://docs.plone.org/develop/styleguide/python.html) standards.