### PR TITLE
Add IMultiCatalogBehavior to Laboratory FTI and repair existing migrations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2904 Repair existing Laboratory image fields after AT-to-DX migration
 - #2902 Fix blob_to_named_file to handle non-blob AT image/file values
 - #2810 Migrate Laboratory to DX
 - #2901 Add generic unicode title indexer for the `title` FieldIndex

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- #2904 Add IMultiCatalogBehavior to Laboratory FTI and repair existing
-  instances (catalog indexing + leftover OFS.Image field values)
+- #2904 Add IMultiCatalogBehavior to Laboratory FTI and repair existing migrations
 - #2902 Fix blob_to_named_file to handle non-blob AT image/file values
 - #2810 Migrate Laboratory to DX
 - #2901 Add generic unicode title indexer for the `title` FieldIndex

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- #2904 Repair existing Laboratory image fields after AT-to-DX migration
+- #2904 Add IMultiCatalogBehavior to Laboratory FTI and repair existing
+  instances (catalog indexing + leftover OFS.Image field values)
 - #2902 Fix blob_to_named_file to handle non-blob AT image/file values
 - #2810 Migrate Laboratory to DX
 - #2901 Add generic unicode title indexer for the `title` FieldIndex

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2731</version>
+  <version>2732</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-senaite.impress:default</dependency>

--- a/src/senaite/core/profiles/default/types/Laboratory.xml
+++ b/src/senaite/core/profiles/default/types/Laboratory.xml
@@ -36,6 +36,7 @@
     <element value="plone.app.content.interfaces.INameFromTitle"/>
     <element value="plone.app.dexterity.behaviors.metadata.IBasic"/>
     <element value="plone.app.referenceablebehavior.referenceable.IReferenceable" />
+    <element value="bika.lims.interfaces.IMultiCatalogBehavior"/>
   </property>
 
   <!-- Action aliases -->

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -35,6 +35,7 @@ from persistent.list import PersistentList
 from plone.app.blob.field import BlobWrapper
 from plone.dexterity.utils import createContent
 from plone.namedfile.file import NamedBlobFile
+from plone.namedfile.interfaces import INamed
 from Products.CMFEditions.interfaces import IVersioned
 from senaite.core import logger
 from senaite.core.api import dtime
@@ -1104,6 +1105,49 @@ def migrate_laboratory_to_dx(tool):
 
     logger.info("Migrated Laboratory from %s -> %s" % (src, target))
     logger.info("Convert Laboratory to Dexterity [DONE]")
+
+
+LABORATORY_IMAGE_FIELDS = (
+    ("accreditation_body_logo", u"logo.png"),
+)
+
+
+@upgradestep(product, version)
+def repair_laboratory_image_fields(tool):
+    """Re-wrap legacy OFS.Image values left on Laboratory image fields
+
+    Before #2902 the Laboratory-to-DX migration passed AT ImageField
+    values straight through ``blob_to_named_file`` when they were not
+    BlobWrapper instances. The raw ``OFS.Image.Image`` objects were
+    assigned to the new ``NamedBlobImage`` field, which is neither
+    None nor INamed; ``plone.formwidget.namedfile`` then crashes
+    rendering the laboratory view or edit form.
+    """
+    logger.info("Repair laboratory image fields ...")
+    setup = api.get_senaite_setup()
+    laboratory = setup.get("laboratory") if setup else None
+    if laboratory is None:
+        logger.info("No laboratory found, skipping repair")
+        return
+    for fieldname, default_filename in LABORATORY_IMAGE_FIELDS:
+        repair_laboratory_image_field(
+            laboratory, fieldname, default_filename)
+    logger.info("Repair laboratory image fields [DONE]")
+
+
+def repair_laboratory_image_field(laboratory, fieldname, default_filename):
+    """Re-wrap a single image field if it holds a non-INamed legacy value
+    """
+    value = getattr(laboratory, fieldname, None)
+    if value is None:
+        return
+    if INamed.providedBy(value):
+        return
+    named = blob_to_named_file(value, default_filename=default_filename)
+    setattr(laboratory, fieldname, named)
+    logger.info("Repaired %s.%s (%s -> %s)" % (
+        laboratory, fieldname, type(value).__name__,
+        type(named).__name__ if named is not None else None))
 
 
 def to_dx_address(value, address_type=NAIVE_ADDRESS):

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -1119,18 +1119,18 @@ def repair_laboratory_migration(tool):
     Two issues need patching on already-migrated instances:
 
     1. Before #2902, the migration passed AT ImageField values straight
-       through ``blob_to_named_file`` when they were not BlobWrapper
-       instances. The raw ``OFS.Image.Image`` objects were assigned to
-       the new ``NamedBlobImage`` field, which is neither None nor
-       INamed; ``plone.formwidget.namedfile`` then crashes rendering
+       through `blob_to_named_file` when they were not BlobWrapper
+       instances. The raw `OFS.Image.Image` objects were assigned to
+       the new `NamedBlobImage` field, which is neither None nor
+       INamed; `plone.formwidget.namedfile` then crashes rendering
        the laboratory view or edit form.
 
     2. The new Laboratory FTI was missing the
-       ``IMultiCatalogBehavior`` behavior, so the catalog multiplex
+       `IMultiCatalogBehavior` behavior, so the catalog multiplex
        processor refused to index it in any non-portal catalog. The
        result is that the laboratory is absent from
-       ``senaite_catalog_setup`` and any code that resolves it through
-       catalog (e.g. ``SuperModel`` lookups in impress) gets nothing.
+       `senaite_catalog_setup` and any code that resolves it through
+       catalog (e.g. `SuperModel` lookups in impress) gets nothing.
     """
     logger.info("Repair laboratory migration ...")
 

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -1113,26 +1113,47 @@ LABORATORY_IMAGE_FIELDS = (
 
 
 @upgradestep(product, version)
-def repair_laboratory_image_fields(tool):
-    """Re-wrap legacy OFS.Image values left on Laboratory image fields
+def repair_laboratory_migration(tool):
+    """Repair the Laboratory-to-DX migration
 
-    Before #2902 the Laboratory-to-DX migration passed AT ImageField
-    values straight through ``blob_to_named_file`` when they were not
-    BlobWrapper instances. The raw ``OFS.Image.Image`` objects were
-    assigned to the new ``NamedBlobImage`` field, which is neither
-    None nor INamed; ``plone.formwidget.namedfile`` then crashes
-    rendering the laboratory view or edit form.
+    Two issues need patching on already-migrated instances:
+
+    1. Before #2902, the migration passed AT ImageField values straight
+       through ``blob_to_named_file`` when they were not BlobWrapper
+       instances. The raw ``OFS.Image.Image`` objects were assigned to
+       the new ``NamedBlobImage`` field, which is neither None nor
+       INamed; ``plone.formwidget.namedfile`` then crashes rendering
+       the laboratory view or edit form.
+
+    2. The new Laboratory FTI was missing the
+       ``IMultiCatalogBehavior`` behavior, so the catalog multiplex
+       processor refused to index it in any non-portal catalog. The
+       result is that the laboratory is absent from
+       ``senaite_catalog_setup`` and any code that resolves it through
+       catalog (e.g. ``SuperModel`` lookups in impress) gets nothing.
     """
-    logger.info("Repair laboratory image fields ...")
+    logger.info("Repair laboratory migration ...")
+
+    # Re-import typeinfo so the FTI picks up IMultiCatalogBehavior
+    tool.runImportStepFromProfile(profile, "typeinfo")
+
     setup = api.get_senaite_setup()
     laboratory = setup.get("laboratory") if setup else None
     if laboratory is None:
         logger.info("No laboratory found, skipping repair")
         return
+
+    # Re-wrap legacy OFS.Image values on the named-file fields
     for fieldname, default_filename in LABORATORY_IMAGE_FIELDS:
         repair_laboratory_image_field(
             laboratory, fieldname, default_filename)
-    logger.info("Repair laboratory image fields [DONE]")
+
+    # Reindex so the multiplex processor now lands the laboratory in
+    # senaite_catalog_setup (and the other catalogs mapped to it)
+    laboratory.reindexObject()
+    logger.info("Reindexed %s" % laboratory)
+
+    logger.info("Repair laboratory migration [DONE]")
 
 
 def repair_laboratory_image_field(laboratory, fieldname, default_filename):

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -4,13 +4,15 @@
 
 
   <genericsetup:upgradeStep
-      title="SENAITE.CORE 2.7.0: Repair laboratory image fields"
-      description="Re-wrap raw OFS.Image values that the previous
-                   Laboratory-to-DX migration assigned to NamedBlobImage
-                   fields so the file widget can render them again."
+      title="SENAITE.CORE 2.7.0: Repair laboratory migration"
+      description="Re-import typeinfo so the Laboratory FTI picks up the
+                   IMultiCatalogBehavior (without it the laboratory is
+                   never indexed in senaite_catalog_setup), re-wrap raw
+                   OFS.Image values left on the NamedBlobImage fields by
+                   the original migration, and reindex the live object."
       source="2731"
       destination="2732"
-      handler=".v02_07_000.repair_laboratory_image_fields"
+      handler=".v02_07_000.repair_laboratory_migration"
       profile="senaite.core:default"/>
 
   <genericsetup:upgradeStep

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -4,6 +4,16 @@
 
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.7.0: Repair laboratory image fields"
+      description="Re-wrap raw OFS.Image values that the previous
+                   Laboratory-to-DX migration assigned to NamedBlobImage
+                   fields so the file widget can render them again."
+      source="2731"
+      destination="2732"
+      handler=".v02_07_000.repair_laboratory_image_fields"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Migrate Laboratory to Dexterity"
       description="Ensure Laboratory is using Dexterity schema and clean up AT remnants"
       source="2730"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Follow-up to #2810 (Migrate Laboratory to DX) and #2902 (Fix `blob_to_named_file`).

## Current behavior before PR

The Laboratory FTI added in #2810 is missing the `bika.lims.interfaces.IMultiCatalogBehavior` behavior.

`senaite.core.catalog.catalog_multiplex_processor.CatalogMultiplexProcessor.supports_multi_catalogs` short-circuits on DX content that does not provide it:

```python
if api.is_dexterity_content(obj) and \
   IMultiCatalogBehavior(obj, None) is None:
    return False
```

Without that behavior, `reindexObject()` only touches `portal_catalog`. The laboratory is therefore never indexed in `senaite_catalog_setup`, even though `CATALOG_MAPPINGS` maps `Laboratory` to `SETUP_CATALOG`.

Independently, on instances that migrated before #2902 the laboratory's `accreditation_body_logo` still holds a raw `OFS.Image.Image` value, which makes `plone.formwidget.namedfile` crash when the view or edit form renders the file widget.

## Desired behavior after PR is merged

1. Add `bika.lims.interfaces.IMultiCatalogBehavior` to `Laboratory.xml` so new and freshly-migrated instances are indexed in `senaite_catalog_setup` (and any other mapped catalogs) automatically by the multiplex processor.

2. New upgrade step `repair_laboratory_migration` (2731 -> 2732):
   - Re-imports `typeinfo` so the existing FTI picks up `IMultiCatalogBehavior` without requiring a profile reinstall.
   - Re-wraps any non-`INamed` value on `LABORATORY_IMAGE_FIELDS` (currently just `accreditation_body_logo`) via the now-fixed `blob_to_named_file`.
   - Calls `laboratory.reindexObject()` so the multiplex processor finally lands it in `senaite_catalog_setup`.