### PR TITLE
Rebuild title FieldIndex on every SENAITE catalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2905 Rebuild title FieldIndex on every SENAITE catalog
 - #2902 Fix blob_to_named_file to handle non-blob AT image/file values
 - #2810 Migrate Laboratory to DX
 - #2901 Add generic unicode title indexer for the `title` FieldIndex

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2731</version>
+  <version>2732</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-senaite.impress:default</dependency>

--- a/src/senaite/core/upgrade/utils.py
+++ b/src/senaite/core/upgrade/utils.py
@@ -398,12 +398,24 @@ def iter_senaite_catalogs():
             yield obj
 
 
-def rebuild_index(catalog, index_name):
-    """Clear an index BTree, then reindex every cataloged object on it
+def rebuild_index(catalog, index_name, clear=True):
+    """Reindex every cataloged object on an index, optionally clearing first
+
+    When `clear` is True (default) the index BTree is wiped before
+    reindexing so stale keys from previous indexers are dropped --
+    needed e.g. when an indexer changes its return type and existing
+    keys would otherwise collide with the new ones (byte vs unicode).
+    Set `clear=False` to keep existing keys and only refresh entries
+    per docid via `reindexIndex`.
 
     Streams progress to the log via a `ZLogHandler` so long-running
     reindexes give feedback every 100 objects instead of going silent
     until the whole catalog is done.
+
+    :param catalog: ZCatalog tool
+    :param index_name: Index id
+    :param clear: Clear the index BTree before reindexing
+    :type clear: bool
     """
     if catalog is None:
         return
@@ -416,10 +428,15 @@ def rebuild_index(catalog, index_name):
     if index is None:
         return
     total = len(catalog)
-    logger.info(
-        "Clearing %s index on %s (%s objects to reindex) ..." % (
-            index_name, catalog.id, total))
-    index.clear()
+    if clear:
+        logger.info(
+            "Clearing %s index on %s (%s objects to reindex) ..." % (
+                index_name, catalog.id, total))
+        index.clear()
+    else:
+        logger.info(
+            "Reindexing %s on %s (%s objects) ..." % (
+                index_name, catalog.id, total))
     pghandler = ZLogHandler(steps=100)
     catalog.reindexIndex(index_name, None, pghandler=pghandler)
     logger.info(

--- a/src/senaite/core/upgrade/utils.py
+++ b/src/senaite/core/upgrade/utils.py
@@ -43,6 +43,7 @@ from plone.namedfile.file import NamedBlobFile
 from plone.namedfile.file import NamedBlobImage
 from senaite.core import logger
 from senaite.core.api.catalog import add_zc_text_index
+from senaite.core.interfaces.catalog import ISenaiteCatalogObject
 from zope.interface import alsoProvides
 from zope.lifecycleevent import modified
 
@@ -386,6 +387,44 @@ def delete_object(obj):
     uncatalog_object(obj)
     parent = aq_parent(obj)
     parent._delObject(obj.getId(), suppress_events=True)
+
+
+def iter_senaite_catalogs():
+    """Yield every catalog tool in the portal that is a SENAITE catalog
+    """
+    portal = api.get_portal()
+    for obj in portal.objectValues():
+        if ISenaiteCatalogObject.providedBy(obj):
+            yield obj
+
+
+def rebuild_index(catalog, index_name):
+    """Clear an index BTree, then reindex every cataloged object on it
+
+    Streams progress to the log via a `ZLogHandler` so long-running
+    reindexes give feedback every 100 objects instead of going silent
+    until the whole catalog is done.
+    """
+    if catalog is None:
+        return
+    if index_name not in catalog.indexes():
+        logger.info(
+            "Skipping %s on %s (index not found)" % (
+                index_name, catalog.id))
+        return
+    index = catalog._catalog.getIndex(index_name)
+    if index is None:
+        return
+    total = len(catalog)
+    logger.info(
+        "Clearing %s index on %s (%s objects to reindex) ..." % (
+            index_name, catalog.id, total))
+    index.clear()
+    pghandler = ZLogHandler(steps=100)
+    catalog.reindexIndex(index_name, None, pghandler=pghandler)
+    logger.info(
+        "Rebuilt %s index on %s (%s objects)" % (
+            index_name, catalog.id, total))
 
 
 def uncatalog_brain(brain):

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -36,6 +36,7 @@ from plone.app.blob.field import BlobWrapper
 from plone.dexterity.utils import createContent
 from plone.namedfile.file import NamedBlobFile
 from Products.CMFEditions.interfaces import IVersioned
+from Products.ZCatalog.ProgressHandler import ZLogHandler
 from senaite.core import logger
 from senaite.core.api import dtime
 from senaite.core.api.catalog import del_column
@@ -1890,7 +1891,12 @@ def rebuild_title_indexes(tool):
     custom catalogs registered by downstream add-ons are also covered.
     """
     logger.info("Rebuild title indexes ...")
-    for catalog in iter_senaite_catalogs():
+    catalogs = list(iter_senaite_catalogs())
+    total = len(catalogs)
+    for num, catalog in enumerate(catalogs, start=1):
+        logger.info(
+            "Rebuilding title index on %s (%s/%s) ..." % (
+                catalog.id, num, total))
         rebuild_index(catalog, "title")
     logger.info("Rebuild title indexes [DONE]")
 
@@ -1906,17 +1912,31 @@ def iter_senaite_catalogs():
 
 def rebuild_index(catalog, index_name):
     """Clear an index BTree, then reindex every cataloged object on it
+
+    Streams progress to the log via a `ZLogHandler` so long-running
+    reindexes give feedback every 100 objects instead of going silent
+    until the whole catalog is done.
     """
     if catalog is None:
         return
     if index_name not in catalog.indexes():
+        logger.info(
+            "Skipping %s on %s (index not found)" % (
+                index_name, catalog.id))
         return
     index = catalog._catalog.getIndex(index_name)
     if index is None:
         return
+    total = len(catalog)
+    logger.info(
+        "Clearing %s index on %s (%s objects to reindex) ..." % (
+            index_name, catalog.id, total))
     index.clear()
-    catalog.manage_reindexIndex(ids=(index_name,))
-    logger.info("Rebuilt %s index on %s" % (index_name, catalog.id))
+    pghandler = ZLogHandler(steps=100)
+    catalog.reindexIndex(index_name, None, pghandler=pghandler)
+    logger.info(
+        "Rebuilt %s index on %s (%s objects)" % (
+            index_name, catalog.id, total))
 
 
 @upgradestep(product, version)

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -1879,6 +1879,55 @@ def reindex_labcontact_searchable_text(tool):
 
 
 @upgradestep(product, version)
+def rebuild_title_indexes(tool):
+    """Clear and rebuild the title FieldIndex on every SENAITE catalog
+
+    #2901 reindexed the title index across all base catalogs so a new
+    generic indexer could populate them with unicode keys. The reindex
+    rewrites entries per docid but does not clear the BTree first, so
+    pre-existing byte-string keys for non-ASCII titles remain. Any
+    subsequent insert of a unicode key (e.g. when creating or editing
+    a DX object whose title contains non-ASCII characters) then raises
+    `UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3` on
+    BTree key comparison.
+
+    Clearing the index before reindexing wipes all stale byte-string
+    keys and lets the (post-#2901) indexer repopulate the BTree with
+    a single unicode key type. Catalogs are discovered dynamically by
+    walking the portal and filtering on `ISenaiteCatalogObject`, so
+    custom catalogs registered by downstream add-ons are also covered.
+    """
+    logger.info("Rebuild title indexes ...")
+    for catalog in iter_senaite_catalogs():
+        rebuild_index(catalog, "title")
+    logger.info("Rebuild title indexes [DONE]")
+
+
+def iter_senaite_catalogs():
+    """Yield every catalog tool in the portal that is a SENAITE catalog
+    """
+    portal = api.get_portal()
+    for obj in portal.objectValues():
+        if ISenaiteCatalogObject.providedBy(obj):
+            yield obj
+
+
+def rebuild_index(catalog, index_name):
+    """Clear an index BTree, then reindex every cataloged object on it
+    """
+    if catalog is None:
+        return
+    if index_name not in catalog.indexes():
+        return
+    index = catalog._catalog.getIndex(index_name)
+    if index is None:
+        return
+    index.clear()
+    catalog.manage_reindexIndex(ids=(index_name,))
+    logger.info("Rebuilt %s index on %s" % (index_name, catalog.id))
+
+
+@upgradestep(product, version)
 def cleanup_sample_catalog(tool):
     """Clean up senaite_catalog_sample indexes and metadata columns
 

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -36,7 +36,6 @@ from plone.app.blob.field import BlobWrapper
 from plone.dexterity.utils import createContent
 from plone.namedfile.file import NamedBlobFile
 from Products.CMFEditions.interfaces import IVersioned
-from Products.ZCatalog.ProgressHandler import ZLogHandler
 from senaite.core import logger
 from senaite.core.api import dtime
 from senaite.core.api.catalog import del_column
@@ -68,7 +67,9 @@ from senaite.core.upgrade.utils import UpgradeUtils
 from senaite.core.upgrade.utils import blob_to_named_file
 from senaite.core.upgrade.utils import copy_snapshots
 from senaite.core.upgrade.utils import delete_object
+from senaite.core.upgrade.utils import iter_senaite_catalogs
 from senaite.core.upgrade.utils import permanently_allow_type_for
+from senaite.core.upgrade.utils import rebuild_index
 from senaite.core.upgrade.utils import remove_at_portal_types
 from senaite.core.upgrade.utils import uncatalog_object
 from senaite.core.upgrade.v02_06_000 import get_setup_folder
@@ -1899,44 +1900,6 @@ def rebuild_title_indexes(tool):
                 catalog.id, num, total))
         rebuild_index(catalog, "title")
     logger.info("Rebuild title indexes [DONE]")
-
-
-def iter_senaite_catalogs():
-    """Yield every catalog tool in the portal that is a SENAITE catalog
-    """
-    portal = api.get_portal()
-    for obj in portal.objectValues():
-        if ISenaiteCatalogObject.providedBy(obj):
-            yield obj
-
-
-def rebuild_index(catalog, index_name):
-    """Clear an index BTree, then reindex every cataloged object on it
-
-    Streams progress to the log via a `ZLogHandler` so long-running
-    reindexes give feedback every 100 objects instead of going silent
-    until the whole catalog is done.
-    """
-    if catalog is None:
-        return
-    if index_name not in catalog.indexes():
-        logger.info(
-            "Skipping %s on %s (index not found)" % (
-                index_name, catalog.id))
-        return
-    index = catalog._catalog.getIndex(index_name)
-    if index is None:
-        return
-    total = len(catalog)
-    logger.info(
-        "Clearing %s index on %s (%s objects to reindex) ..." % (
-            index_name, catalog.id, total))
-    index.clear()
-    pghandler = ZLogHandler(steps=100)
-    catalog.reindexIndex(index_name, None, pghandler=pghandler)
-    logger.info(
-        "Rebuilt %s index on %s (%s objects)" % (
-            index_name, catalog.id, total))
 
 
 @upgradestep(product, version)

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -40,21 +40,13 @@ from senaite.core import logger
 from senaite.core.api import dtime
 from senaite.core.api.catalog import del_column
 from senaite.core.api.catalog import del_index
-from senaite.core.api.catalog import get_index
 from senaite.core.api.catalog import reindex_index
 from senaite.core.catalog import ANALYSIS_CATALOG
 from senaite.core.catalog import CONTACT_CATALOG
 from senaite.core.catalog import REPORT_CATALOG
 from senaite.core.catalog import SAMPLE_CATALOG
-from senaite.core.catalog import SENAITE_CATALOG
 from senaite.core.catalog import SETUP_CATALOG
 from senaite.core.catalog import WORKSHEET_CATALOG
-from senaite.core.catalog.attachments_catalog import \
-    CATALOG_ID as ATTACHMENTS_CATALOG
-from senaite.core.catalog.auditlog_catalog import \
-    CATALOG_ID as AUDITLOG_CATALOG
-from senaite.core.catalog.autoimportlog_catalog import \
-    CATALOG_ID as AUTOIMPORTLOG_CATALOG
 from senaite.core.catalog.client_catalog import CATALOG_ID as CLIENT_CATALOG
 from senaite.core.catalog.analysis_catalog import INDEXES as ANALYSIS_INDEXES
 from senaite.core.config import PROJECTNAME as product
@@ -1931,11 +1923,13 @@ def rebuild_index(catalog, index_name):
 def cleanup_sample_catalog(tool):
     """Clean up senaite_catalog_sample indexes and metadata columns
 
-    - Reindex the title FieldIndex on every catalog that inherits from
-      base_catalog so it picks up the new generic `title` indexer that
-      returns a unicode Title for any IContentish object. Previously
-      only Organisation contributed entries via its type-specific
-      indexer, so the index was effectively empty for everything else.
+    - Clear and rebuild the title FieldIndex on every SENAITE catalog
+      so the (post-#2901) generic `title` indexer repopulates the
+      BTree with unicode keys for every content type. Clearing first
+      avoids the `UnicodeDecodeError` that
+      `manage_reindexIndex`-without-clear leaves behind when stale
+      byte-string keys for non-ASCII titles meet new unicode keys
+      during BTree comparison.
     - Remove obsolete FieldIndexes getProvince and getDistrict from the
       sample catalog. Client geography belongs on the client catalog and
       is not meaningful as a sample catalog index; reindexing is also
@@ -1947,26 +1941,11 @@ def cleanup_sample_catalog(tool):
     """
     logger.info("Cleaning up sample catalog indexes and columns ...")
 
-    # Reindex the title FieldIndex on every catalog that inherits the
-    # base indexes definition so the new generic `title` indexer
-    # populates entries for every content type.
-    base_catalogs = [
-        ATTACHMENTS_CATALOG,
-        AUDITLOG_CATALOG,
-        AUTOIMPORTLOG_CATALOG,
-        CLIENT_CATALOG,
-        CONTACT_CATALOG,
-        REPORT_CATALOG,
-        SAMPLE_CATALOG,
-        SENAITE_CATALOG,
-        SETUP_CATALOG,
-        WORKSHEET_CATALOG,
-    ]
-    for catalog_id in base_catalogs:
-        if get_index(api.get_tool(catalog_id), "title") is None:
-            continue
-        logger.info("Reindexing title index on %s", catalog_id)
-        reindex_index(catalog_id, "title")
+    # Clear and rebuild the title FieldIndex on every SENAITE catalog
+    # so the generic `title` indexer repopulates entries for every
+    # content type with a consistent unicode key type.
+    for catalog in iter_senaite_catalogs():
+        rebuild_index(catalog, "title")
 
     catalog = api.get_tool(SAMPLE_CATALOG)
 

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -1923,13 +1923,6 @@ def rebuild_index(catalog, index_name):
 def cleanup_sample_catalog(tool):
     """Clean up senaite_catalog_sample indexes and metadata columns
 
-    - Clear and rebuild the title FieldIndex on every SENAITE catalog
-      so the (post-#2901) generic `title` indexer repopulates the
-      BTree with unicode keys for every content type. Clearing first
-      avoids the `UnicodeDecodeError` that
-      `manage_reindexIndex`-without-clear leaves behind when stale
-      byte-string keys for non-ASCII titles meet new unicode keys
-      during BTree comparison.
     - Remove obsolete FieldIndexes getProvince and getDistrict from the
       sample catalog. Client geography belongs on the client catalog and
       is not meaningful as a sample catalog index; reindexing is also
@@ -1938,14 +1931,14 @@ def cleanup_sample_catalog(tool):
       getDistrict, getClientURL, getTemplateURL, getPhysicalPath. URLs
       are fragile (hostname-dependent) and better resolved at render
       time via memoized UID lookups. getPhysicalPath is unused.
+
+    The title FieldIndex used to be reindexed here as part of the
+    #2901 follow-up. That step has moved to `rebuild_title_indexes`
+    (a later upgrade step), which clears the BTree before reindexing
+    to avoid the byte/unicode key mix that
+    `manage_reindexIndex`-without-clear leaves behind.
     """
     logger.info("Cleaning up sample catalog indexes and columns ...")
-
-    # Clear and rebuild the title FieldIndex on every SENAITE catalog
-    # so the generic `title` indexer repopulates entries for every
-    # content type with a consistent unicode key type.
-    for catalog in iter_senaite_catalogs():
-        rebuild_index(catalog, "title")
 
     catalog = api.get_tool(SAMPLE_CATALOG)
 

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -1931,12 +1931,6 @@ def cleanup_sample_catalog(tool):
       getDistrict, getClientURL, getTemplateURL, getPhysicalPath. URLs
       are fragile (hostname-dependent) and better resolved at render
       time via memoized UID lookups. getPhysicalPath is unused.
-
-    The title FieldIndex used to be reindexed here as part of the
-    #2901 follow-up. That step has moved to `rebuild_title_indexes`
-    (a later upgrade step), which clears the BTree before reindexing
-    to avoid the byte/unicode key mix that
-    `manage_reindexIndex`-without-clear leaves behind.
     """
     logger.info("Cleaning up sample catalog indexes and columns ...")
 

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -4,6 +4,18 @@
 
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.7.0: Rebuild title indexes"
+      description="Clear and rebuild the title FieldIndex on every SENAITE
+                   catalog so stale byte-string keys from before #2901
+                   are replaced with unicode keys. Without this, any
+                   insert of a non-ASCII unicode title raises
+                   UnicodeDecodeError on BTree key comparison."
+      source="2731"
+      destination="2732"
+      handler=".v02_07_000.rebuild_title_indexes"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Migrate Laboratory to Dexterity"
       description="Ensure Laboratory is using Dexterity schema and clean up AT remnants"
       source="2730"

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -35,11 +35,9 @@
 
   <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Clean up sample catalog indexes and columns"
-      description="Fix title index indexed_attrs across all base catalogs,
-                   remove Province/District indexes, and remove obsolete
-                   metadata columns (getClientURL, getTemplateURL,
-                   getPhysicalPath, getProvince, getDistrict) from the
-                   sample catalog"
+      description="Remove Province/District indexes and obsolete metadata
+                   columns (getClientURL, getTemplateURL, getPhysicalPath,
+                   getProvince, getDistrict) from the sample catalog."
       source="2728"
       destination="2729"
       handler=".v02_07_000.cleanup_sample_catalog"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Follow-up to #2901 (Add generic unicode title indexer for the `title` FieldIndex).

## Current behavior before PR

#2901 swapped the `title` FieldIndex over to a generic indexer that returns `safe_unicode(instance.Title())` and reindexed the index across every base catalog via `cleanup_sample_catalog`. `manage_reindexIndex` rewrites entries per docid but does not clear the BTree, so byte-string keys for non-ASCII titles indexed *before* #2901 remained next to the new unicode keys.

Any subsequent insert of a unicode key on the same FieldIndex triggers BTree key comparison against an existing byte-string key. Under Python 2 that comparison falls back to the ASCII codec for the bytes side and raises:

```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 2:
ordinal not in range(128)
```

Reproduces e.g. when creating a Calculation with `Glührückstand` as title, or when reindexing any migrated Organisation/Contact whose title contains umlauts. The full traceback bottoms out in `Products.PluginIndexes.unindex._index_object` -> `insertForwardIndexEntry`.

## Desired behavior after PR is merged

New upgrade step `rebuild_title_indexes` (2731 -> 2732):

- Walks the portal and picks every tool that provides `ISenaiteCatalogObject` (so custom catalogs registered by downstream add-ons are covered automatically).
- For each one, `clear()`s the `title` FieldIndex BTree and then reindexes it via `manage_reindexIndex`.

After running the step, every title FieldIndex contains a single, consistent unicode key type, and new inserts of non-ASCII titles no longer fail.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html