### PR TITLE
Only consult ar_add idempotency cache on a publisher retry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2906 Only consult ar_add idempotency cache on a publisher retry
 - #2905 Rebuild title FieldIndex on every SENAITE catalog
 - #2904 Add IMultiCatalogBehavior to Laboratory FTI and repair existing migrations
 - #2902 Fix blob_to_named_file to handle non-blob AT image/file values

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -25,6 +25,7 @@ from collections import OrderedDict
 from datetime import datetime
 from datetime import timedelta
 from random import uniform
+from threading import current_thread
 from threading import Lock
 
 import six
@@ -121,15 +122,24 @@ def cache_key(method, self, obj):
 
 
 def _submission_fingerprint(request):
-    """Content-based fingerprint of the submission body. Stable across
-    Zope publisher-level retries on the same worker because Zope
-    rebuilds the request from the same WSGI environ (and body bytes)
-    on each attempt.
+    """Content-based fingerprint of the submission body, scoped to
+    the worker thread. Stable across Zope publisher-level retries
+    of the same request (Zope re-publishes on the same worker
+    thread, reusing the same WSGI environ and body bytes), but
+    distinct between concurrent same-body submissions on different
+    workers — which is what we want when an operator hammers
+    "Submit" across several browser tabs whose form bodies happen
+    to be byte-identical.
 
-    Two distinct submissions whose body is byte-identical produce the
-    same fingerprint, so the fingerprint is only safe to use for the
-    cache *lookup* when the request is actually a publisher retry —
-    see `_is_publisher_retry`.
+    Two distinct submissions whose body is byte-identical and which
+    happen to land on the same worker still produce the same
+    fingerprint, but waitress only handles one request at a time
+    per worker so two requests on the same thread are serialised by
+    construction and cannot race on the in-flight cache entry.
+
+    The fingerprint is only safe to use for the cache *lookup* when
+    the request is actually a publisher retry — see
+    `_is_publisher_retry`.
     """
     method = request.get("REQUEST_METHOD", "") or ""
     path = request.get("PATH_INFO", "") or ""
@@ -137,7 +147,8 @@ def _submission_fingerprint(request):
     raw = "{}\n{}\n{}".format(method, path, body)
     if isinstance(raw, unicode):
         raw = raw.encode("utf-8")
-    return hashlib.sha256(raw).hexdigest()
+    body_hash = hashlib.sha256(raw).hexdigest()
+    return "{}:{}".format(current_thread().ident, body_hash)
 
 
 def _is_publisher_retry(request):

--- a/src/bika/lims/browser/analysisrequest/add2.py
+++ b/src/bika/lims/browser/analysisrequest/add2.py
@@ -125,6 +125,11 @@ def _submission_fingerprint(request):
     Zope publisher-level retries on the same worker because Zope
     rebuilds the request from the same WSGI environ (and body bytes)
     on each attempt.
+
+    Two distinct submissions whose body is byte-identical produce the
+    same fingerprint, so the fingerprint is only safe to use for the
+    cache *lookup* when the request is actually a publisher retry —
+    see `_is_publisher_retry`.
     """
     method = request.get("REQUEST_METHOD", "") or ""
     path = request.get("PATH_INFO", "") or ""
@@ -133,6 +138,17 @@ def _submission_fingerprint(request):
     if isinstance(raw, unicode):
         raw = raw.encode("utf-8")
     return hashlib.sha256(raw).hexdigest()
+
+
+def _is_publisher_retry(request):
+    """True iff the publisher already re-published this request after
+    a previous attempt raised TransientError. Zope increments
+    `retry_count` on every retry and propagates it to the rebuilt
+    request, so a value > 0 unambiguously means we are inside a
+    retry. On a fresh first attempt the attribute is 0 (or missing on
+    non-HTTP requests).
+    """
+    return getattr(request, "retry_count", 0) > 0
 
 
 def _inflight_get(key):
@@ -2230,18 +2246,33 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         ConflictError and re-publishes the request, we recognise the
         submission by its body fingerprint and return the
         already-committed samples instead of creating duplicates.
+
+        The cache is only consulted when the request is itself a
+        publisher retry (`retry_count > 0`). On a fresh first attempt
+        we always create the samples, because two independent
+        submissions with identical bodies (same client, same defaults,
+        no operator-supplied identifier) hash to the same fingerprint
+        and a cache lookup would silently return the previously
+        created samples instead of creating a new one — manifesting
+        as a "successfully created" UI banner for a sample that was
+        never written (see #2741 follow-up).
         """
         fingerprint = _submission_fingerprint(self.request)
-        existing_uids = _inflight_get(fingerprint)
-        if existing_uids:
-            logger.info(
-                "Resuming ar_add submission after publisher retry; "
-                "%d sample(s) already committed", len(existing_uids))
-            return [api.get_object_by_uid(uid) for uid in existing_uids]
+        if _is_publisher_retry(self.request):
+            existing_uids = _inflight_get(fingerprint)
+            if existing_uids:
+                logger.info(
+                    "Resuming ar_add submission after publisher retry "
+                    "(attempt=%d); %d sample(s) already committed",
+                    self.request.retry_count, len(existing_uids))
+                return [api.get_object_by_uid(uid)
+                        for uid in existing_uids]
 
         # Reference the list inside the cache so each successful
         # per-sample commit immediately updates the entry visible to a
-        # retry on the same worker thread.
+        # retry on the same worker thread. Set unconditionally so a
+        # publisher retry of *this* request (retry_count >= 1) finds
+        # the in-flight UIDs and resumes mid-batch.
         committed_uids = []
         _inflight_set(fingerprint, committed_uids)
 

--- a/src/senaite/core/tests/doctests/SampleCreationConflictRetry.rst
+++ b/src/senaite/core/tests/doctests/SampleCreationConflictRetry.rst
@@ -178,12 +178,45 @@ stubbing the plone utility on the view's context:
     >>> msg.mapping["rows"]
     u'#2 (CSID-A12), #5 (ref-9), #7 (-)'
 
+In-flight cache is gated on publisher retries
+.............................................
+
+The in-flight cache short-circuits sample creation when the same
+fingerprint has already been registered. It must only do so when the
+current request is a publisher-level retry of the originating
+submission. On a fresh first attempt two independent submissions with
+identical bodies (same client, same defaults, no operator-supplied
+identifier) hash to the same fingerprint, and treating that as a hit
+would return the previously created samples instead of creating a
+new one — surfacing to the operator as a "successfully created"
+banner for a sample that was never written.
+
+`_is_publisher_retry` consults Zope's `retry_count` attribute, which
+is 0 on the first attempt and incremented on every re-publish:
+
+    >>> add2._is_publisher_retry(request)
+    False
+    >>> request.retry_count = 1
+    >>> add2._is_publisher_retry(request)
+    True
+    >>> request.retry_count = 0
+
+A request that has no `retry_count` attribute at all (non-HTTP
+requests, test layers, ...) is treated as a fresh first attempt:
+
+    >>> class BareRequest(object):
+    ...     pass
+    >>> add2._is_publisher_retry(BareRequest())
+    False
+
 Cleanup
 .......
 
-Restore the patched transaction operations, sleep, and registry flag so
-later tests run in a pristine environment:
+Restore the patched transaction operations, sleep, registry flag,
+and in-flight cache so later tests run in a pristine environment:
 
+    >>> request.retry_count = 0
+    >>> add2._inflight.clear()
     >>> add2.transaction = original_txn_module
     >>> add2.time = original_time_module
     >>> add2.MAX_CREATE_ATTEMPTS = original_max_attempts

--- a/src/senaite/core/tests/doctests/SampleCreationConflictRetry.rst
+++ b/src/senaite/core/tests/doctests/SampleCreationConflictRetry.rst
@@ -209,6 +209,33 @@ requests, test layers, ...) is treated as a fresh first attempt:
     >>> add2._is_publisher_retry(BareRequest())
     False
 
+Fingerprint is scoped to the worker thread
+..........................................
+
+`_submission_fingerprint` mixes the current worker thread id into
+the hash. Zope publisher retries re-publish on the same worker, so
+the retry sees the same fingerprint as the original attempt and
+recovers the in-flight UIDs as expected. Two concurrent submissions
+with byte-identical bodies on *different* workers (e.g. an operator
+hitting Submit across several browser tabs in quick succession)
+produce different fingerprints and therefore cannot overwrite each
+other's in-flight cache entries.
+
+The fingerprint must start with the current thread's identifier:
+
+    >>> import threading
+    >>> fp = add2._submission_fingerprint(request)
+    >>> tid = str(threading.current_thread().ident)
+    >>> fp.startswith(tid + ":")
+    True
+
+A second call on the same thread with the same body returns the
+same fingerprint (publisher retries are idempotent on the same
+worker):
+
+    >>> add2._submission_fingerprint(request) == fp
+    True
+
 Cleanup
 .......
 

--- a/tweets/2026-05-21-PR2906.tweet
+++ b/tweets/2026-05-21-PR2906.tweet
@@ -1,0 +1,2 @@
+Fixed a sneaky bug in the new sample add form: rapid identical submissions were silently swallowed by the publisher-retry idempotency cache. Now the cache only kicks in when Zope is actually retrying, not on every fresh submission.
+https://github.com/senaite/senaite.core/pull/2906


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Follow-up to #2741. The per-commit sample-creation path added an in-flight cache to make `_create_samples_per_commit` idempotent across Zope publisher-level retries. The cache key is `SHA-256(METHOD + PATH_INFO + BODY)`, the TTL is 600 s, and the lookup happens on every request.

The lookup is too greedy in two distinct ways, addressed by the two commits below.

### Problem 1 — lookup fires on every request, not just retries

Two *independent* submissions whose body is byte-identical produce the same fingerprint and hit the cache, even though no publisher retry occurred. In routine clinical-lab data entry that happens whenever an operator re-submits the same form values within ten minutes — same Client, same SampleType, default values, blank `ClientSampleID`/`ClientReference`, stable Plone `_authenticator`. The cache returns the previously created sample's UID, no new sample is written, and the UI shows the standard "Sample X was successfully created" banner using the *previous* sample's ID. The operator believes the sample was created.

A downstream deployment running #2741 in production reported the user-visible symptom and the logs confirm it: 84 `Resuming ar_add submission after publisher retry` entries today across two ZEO clients, but only one real `ConflictError` on `/ar_add` over the same window — i.e. ~83 false positives. The hits cluster on single-minute bursts (7 in one minute, 5 in another) consistent with an operator hammering Save.

Shortening the TTL is not a real fix: production `POST /ajax_ar_add/submit` durations on the same host range from 200 ms to 195 s (heavy/contended batches), so any TTL short enough to dodge the false-positive window is also short enough to break the legitimate retry it was meant to protect.

### Problem 2 — concurrent same-body submissions clobber each other's in-flight entries

Even with the lookup gated on a real retry (commit 1), two tabs submitting the same body to two different waitress workers each call `_inflight_set(fingerprint, committed_uids)` on entry. The second `_inflight_set` pops the first one and replaces it. If the *first* request then hits a `ConflictError` and Zope re-publishes it, the retry would look up the fingerprint and find the *second* request's UID list, "resuming" with someone else's samples.

This requires (a) concurrent same-fingerprint submissions on different workers, (b) a real publisher-level transient on one of them. Both are rare; together rarer. But the "operator hammers Submit across five browser tabs" workflow reported from at least one site is exactly the workload that maximises the chance.

## Current behavior before PR

- `_create_samples_per_commit` consults `_inflight_get(fingerprint)` on every request. Any submission whose body matches a still-cached previous submission is short-circuited regardless of whether the publisher actually retried, returning the previously created samples and emitting `Resuming ar_add submission after publisher retry` to the log.
- The cache key is body-only, so two concurrent submissions of identical body race on the same key.

## Desired behavior after PR is merged

- The cache is only consulted when the current request is itself a publisher retry. On a fresh first attempt the method always proceeds to create samples; the cache entry is still *registered* so a subsequent retry of *this* request can resume mid-batch.
- The cache key includes the current worker thread's identifier, so two concurrent same-body submissions on different workers cannot overwrite each other's in-flight entries. Zope's publisher retry mechanism re-publishes on the same worker thread, so a real retry sees the same fingerprint as the original attempt.

## Implementation details

**Commit 1 — `Only consult ar_add idempotency cache on a publisher retry`**

- New helper `_is_publisher_retry(request)` in `bika.lims.browser.analysisrequest.add2`. Returns `True` iff `getattr(request, "retry_count", 0) > 0`. Missing-attribute safety so test layers and non-HTTP requests don't crash.
- `_create_samples_per_commit` now wraps the existing cache lookup in `if _is_publisher_retry(self.request):`. The `_inflight_set` call afterwards is unchanged and unconditional, so a real retry of the same request still recovers the committed UIDs.
- Log line now includes the retry attempt number for diagnostic visibility: `Resuming ar_add submission after publisher retry (attempt=N); M sample(s) already committed`.
- TTL stays at `INFLIGHT_CACHE_TTL = 600` because the false-positive class is eliminated by the gate; the TTL only needs to cover the duration of a single in-flight request plus its retry budget, and 600 s comfortably bounds the observed 195 s worst-case `submit` latency.

**Commit 2 — `Scope the in-flight fingerprint to the worker thread`**

- `_submission_fingerprint(request)` now prepends `threading.current_thread().ident` to the body hash. Zope's retry mechanism re-publishes on the same worker thread (`transaction_pubevents` in `WSGIPublisher.py`), so a retried request sees the same fingerprint as its originating attempt. Two concurrent same-body submissions on different waitress workers produce different fingerprints and cannot collide on the in-flight cache.
- waitress only handles one request at a time per worker, so two requests that *do* land on the same thread are serialised by construction and cannot race on the cache entry either.

## Tests

`SampleCreationConflictRetry.rst` gains two new sections:

- *In-flight cache is gated on publisher retries* — `_is_publisher_retry` returns `False` on `retry_count == 0`, `True` on `retry_count == 1`, and `False` for requests lacking the attribute.
- *Fingerprint is scoped to the worker thread* — the fingerprint starts with the current thread's identifier and is stable across calls on the same thread.

The existing per-row retry / portal-message tests remain unchanged.

## Files touched

- `src/bika/lims/browser/analysisrequest/add2.py` — `_is_publisher_retry` helper, gated lookup, log line, thread-scoped fingerprint.
- `src/senaite/core/tests/doctests/SampleCreationConflictRetry.rst` — new sections verifying the gate and the thread-scoping.
- `CHANGES.rst` — entry for #2906.
- `tweets/2026-05-21-PR2906.tweet` — twitter-together entry.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html