### PR TITLE
Centralize intid cleanup in api.delete

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2910 Centralize intid cleanup in api.delete
 - #2908 Drop intid registrations created for portal_factory transients
 - #2907 Unregister intid on migration-time object deletion
 - #2909 Restore getPrintAddress on the DX Organization content type

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -77,7 +77,7 @@ from senaite.core.interfaces import ITemporaryObject
 from z3c.form.validator import Data as ValidatorData
 from zope import globalrequest
 from zope.annotation.interfaces import IAttributeAnnotatable
-from zope.component import createObject
+from zope.component import getAllUtilitiesRegisteredFor
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
 from zope.container.contained import notifyContainerModified
@@ -88,7 +88,7 @@ from zope.interface import Invalid
 from zope.interface import alsoProvides
 from zope.interface import directlyProvides
 from zope.interface import noLongerProvides
-from zope.lifecycleevent import ObjectCreatedEvent
+from zope.intid.interfaces import IIntIds
 from zope.lifecycleevent import ObjectMovedEvent
 from zope.publisher.browser import TestRequest
 from zope.schema import getFieldsInOrder
@@ -526,6 +526,23 @@ def catalog_object(obj, recursive=False):
             catalog_object(child, recursive=recursive)
 
 
+def unregister_intid(obj):
+    """Unregister the object from all IIntIds utilities
+
+    Useful when deleting an object without firing IObjectRemovedEvent,
+    so its intid keyref does not survive as an orphan in storage.
+
+    :param obj: object to unregister
+    :type obj: ATContentType/DexterityContentType
+    """
+    for intids in getAllUtilitiesRegisteredFor(IIntIds):
+        try:
+            intids.unregister(obj)
+        except KeyError:
+            # not registered with this utility
+            pass
+
+
 def delete(obj, check_permissions=True, suppress_events=False):
     """Deletes the given object
 
@@ -540,8 +557,14 @@ def delete(obj, check_permissions=True, suppress_events=False):
 
     # un-catalog the object from all catalogs (uid_catalog included)
     uncatalog_object(obj)
+    if suppress_events:
+        # five.intid's removal subscriber listens on IObjectRemovedEvent,
+        # which is suppressed here — drop the keyref manually to avoid an
+        # orphan entry pinning the dead oid in storage.
+        unregister_intid(obj)
+
     # delete the object
-    parent = get_parent(obj)
+    parent = aq_parent(obj)
     parent._delObject(obj.getId(), suppress_events=suppress_events)
 
 

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -77,7 +77,6 @@ from senaite.core.interfaces import ITemporaryObject
 from z3c.form.validator import Data as ValidatorData
 from zope import globalrequest
 from zope.annotation.interfaces import IAttributeAnnotatable
-from zope.component import getAllUtilitiesRegisteredFor
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
 from zope.container.contained import notifyContainerModified
@@ -88,7 +87,6 @@ from zope.interface import Invalid
 from zope.interface import alsoProvides
 from zope.interface import directlyProvides
 from zope.interface import noLongerProvides
-from zope.intid.interfaces import IIntIds
 from zope.lifecycleevent import ObjectMovedEvent
 from zope.publisher.browser import TestRequest
 from zope.schema import getFieldsInOrder
@@ -526,23 +524,6 @@ def catalog_object(obj, recursive=False):
             catalog_object(child, recursive=recursive)
 
 
-def unregister_intid(obj):
-    """Unregister the object from all IIntIds utilities
-
-    Useful when deleting an object without firing IObjectRemovedEvent,
-    so its intid keyref does not survive as an orphan in storage.
-
-    :param obj: object to unregister
-    :type obj: ATContentType/DexterityContentType
-    """
-    for intids in getAllUtilitiesRegisteredFor(IIntIds):
-        try:
-            intids.unregister(obj)
-        except KeyError:
-            # not registered with this utility
-            pass
-
-
 def delete(obj, check_permissions=True, suppress_events=False):
     """Deletes the given object
 
@@ -561,7 +542,8 @@ def delete(obj, check_permissions=True, suppress_events=False):
         # five.intid's removal subscriber listens on IObjectRemovedEvent,
         # which is suppressed here — drop the keyref manually to avoid an
         # orphan entry pinning the dead oid in storage.
-        unregister_intid(obj)
+        from senaite.core.api import delete_intid  # noqa
+        delete_intid(obj)
 
     # delete the object
     parent = aq_parent(obj)

--- a/src/senaite/core/api/__init__.py
+++ b/src/senaite/core/api/__init__.py
@@ -105,6 +105,7 @@ def add_intid(obj):
         try:
             intids.register(obj)
         except KeyError:
+            # already registered with this utility
             pass
 
     # return the newly created IntId

--- a/src/senaite/core/api/__init__.py
+++ b/src/senaite/core/api/__init__.py
@@ -33,7 +33,14 @@ import inspect
 
 from bika.lims import api as _bika_api
 from Products.CMFPlone.utils import safe_callable
+from zope.component import getAllUtilitiesRegisteredFor
+from zope.component import getUtility
 from zope.component.hooks import getSite
+from zope.intid.interfaces import IIntIds
+from zope.intid.interfaces import IntIdMissingError
+from zope.intid.interfaces import ObjectMissingError
+
+_marker = object()
 
 
 def get_portal():
@@ -51,6 +58,74 @@ def get_portal_url():
     :rtype: str
     """
     return get_portal().absolute_url()
+
+
+def get_object_by_intid(intid, default=_marker):
+    """Returns the object by its IntId
+
+    :param intid: the IntId of the object
+    :type intid: int
+    :returns: the object whose IntId matches with the intid provided
+    :rtype: ATContentType/DexterityContentType
+    """
+    intids = getUtility(IIntIds)
+    try:
+        return intids.getObject(intid)
+    except ObjectMissingError:
+        if default is _marker:
+            raise
+        return default
+
+
+def get_intid(obj, default=_marker):
+    """Returns the IntId of the given object
+
+    :param obj: object to get the IntId from
+    :type obj: ATContentType/DexterityContentType
+    :returns: The IntId of the given object
+    :rtype: int
+    """
+    intids = getUtility(IIntIds)
+    try:
+        return intids.getId(obj)
+    except IntIdMissingError:
+        if default is _marker:
+            raise
+        return default
+
+
+def add_intid(obj):
+    """Registers the object to all IIntIds utilities
+
+    :param obj: object to register to all IIntIds utilities
+    :type obj: ATContentType/DexterityContentType
+    :returns: The IntId of the object
+    """
+    for intids in getAllUtilitiesRegisteredFor(IIntIds):
+        try:
+            intids.register(obj)
+        except KeyError:
+            pass
+
+    # return the newly created IntId
+    return get_intid(obj)
+
+
+def delete_intid(obj):
+    """Unregister the object from all IIntIds utilities
+
+    Useful when deleting an object without firing IObjectRemovedEvent,
+    so its intid keyref does not survive as an orphan in storage.
+
+    :param obj: object to unregister
+    :type obj: ATContentType/DexterityContentType
+    """
+    for intids in getAllUtilitiesRegisteredFor(IIntIds):
+        try:
+            intids.unregister(obj)
+        except KeyError:
+            # not registered with this utility
+            pass
 
 
 def _accepts_no_args(callable_obj):

--- a/src/senaite/core/migration/migrator.py
+++ b/src/senaite/core/migration/migrator.py
@@ -21,7 +21,6 @@
 import json
 
 import six
-from Acquisition import aq_parent
 from bika.lims import api
 from bika.lims import logger
 from bika.lims.interfaces import IAuditable
@@ -102,14 +101,7 @@ class ContentMigrator(object):
     def catalog_object(self, obj):
         """Catalog the object in all registered catalogs
         """
-        # explicitly catalog in uid_catalog
-        uid_catalog = api.get_tool(UID_CATALOG)
-        # we catalog the object here below the absolute path, as it is done in
-        # `plone.app.referencablebehavior.uidcatalog``
-        abs_url = "/".join(obj.getPhysicalPath())
-        uid_catalog.catalog_object(obj, abs_url)
-        # reindex in registered catalogs
-        obj.reindexObject()
+        api.catalog_object(obj)
 
     def copy_id(self, src, target):
         """Set id on object
@@ -175,9 +167,7 @@ class ContentMigrator(object):
     def delete_object(self, obj):
         """delete the object w/o firing events
         """
-        self.uncatalog_object(obj)
-        parent = aq_parent(obj)
-        parent._delObject(obj.getId(), suppress_events=True)
+        api.delete(obj, check_permissions=False, suppress_events=True)
 
     def copy_fields(self, src, target, mapping):
         """Copy fields

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -2582,6 +2582,48 @@ Re-cataloging the parent recursively brings the children back:
     True
 
 
+Unregister the intid of an object
+.................................
+
+This function removes ``obj``'s registration from every ``IIntIds`` utility in
+the site. It exists because the standard removal path (`five.intid`'s
+``IObjectRemovedEvent`` subscriber) is bypassed when an object is deleted with
+``suppress_events=True`` — a common pattern in migrations. Without an explicit
+unregister, the intid keyref would survive the deletion and pin the dead oid in
+storage.
+
+Look up the global intid utility:
+
+    >>> from zope.component import queryUtility
+    >>> from zope.intid.interfaces import IIntIds
+    >>> intids = queryUtility(IIntIds)
+
+Newly created objects are registered by ``five.intid`` on
+``IObjectAddedEvent``:
+
+    >>> intid_client = api.create(
+    ...     portal.clients, "Client", title="IntId Client")
+    >>> intids.queryId(intid_client) is not None
+    True
+
+``unregister_intid`` drops the registration from the utility:
+
+    >>> api.unregister_intid(intid_client)
+    >>> intids.queryId(intid_client) is None
+    True
+
+Calling it again on an already-unregistered object is a safe no-op
+(``KeyError`` from the underlying utility is swallowed):
+
+    >>> api.unregister_intid(intid_client)
+    >>> intids.queryId(intid_client) is None
+    True
+
+Clean up:
+
+    >>> api.delete(intid_client, check_permissions=False)
+
+
 Delete an object
 ................
 
@@ -2612,6 +2654,43 @@ Unless we explicitly tell the system to bypass security check:
     False
 
 
+Deletion and intid bookkeeping
+..............................
+
+``api.delete`` keeps the ``IIntIds`` utility in sync regardless of whether
+removal events are fired. By default, deletion fires ``IObjectRemovedEvent``
+and the ``five.intid`` subscriber drops the object's intid registration:
+
+    >>> from zope.component import queryUtility
+    >>> from zope.intid.interfaces import IIntIds
+    >>> intids = queryUtility(IIntIds)
+
+    >>> events_client = api.copy_object(
+    ...     client, title="Client to delete (events)")
+    >>> intids.queryId(events_client) is not None
+    True
+
+    >>> api.delete(events_client, check_permissions=False)
+    >>> intids.queryId(events_client) is None
+    True
+
+When ``suppress_events=True`` is passed — the path used by migrations and
+upgrade steps — ``IObjectRemovedEvent`` is *not* fired, so the ``five.intid``
+subscriber never runs. To avoid orphan intid entries pinning the dead oid in
+storage, ``api.delete`` invokes ``unregister_intid`` itself before calling
+``_delObject``:
+
+    >>> silent_client = api.copy_object(
+    ...     client, title="Client to delete (no events)")
+    >>> intids.queryId(silent_client) is not None
+    True
+
+    >>> api.delete(
+    ...     silent_client, check_permissions=False, suppress_events=True)
+    >>> intids.queryId(silent_client) is None
+    True
+
+
 Move an object
 ..............
 
@@ -2634,7 +2713,7 @@ Move the contact to the destination client:
     >>> dest.hasObject(id)
     False
     >>> contact
-    <Contact at /plone/clients/client-5/contact-4>
+    <Contact at /plone/clients/client-8/contact-4>
     >>> contact = api.move_object(contact, dest, check_constraints=False)
     >>> api.get_parent(contact) == dest
     True
@@ -2643,7 +2722,7 @@ Move the contact to the destination client:
     >>> orig.hasObject(id)
     False
     >>> contact
-    <Contact at /plone/clients/client-6/contact-4>
+    <Contact at /plone/clients/client-9/contact-4>
 
 It does nothing if destination is the same as the origin:
 
@@ -2675,7 +2754,7 @@ Unless we grant enough permissions to remove the object from origin:
     >>> dest.hasObject(id)
     False
     >>> contact
-    <Contact at /plone/clients/client-5/contact-4>
+    <Contact at /plone/clients/client-8/contact-4>
 
 Still, destination container must allow the object's type:
 

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -2582,48 +2582,6 @@ Re-cataloging the parent recursively brings the children back:
     True
 
 
-Unregister the intid of an object
-.................................
-
-This function removes ``obj``'s registration from every ``IIntIds`` utility in
-the site. It exists because the standard removal path (`five.intid`'s
-``IObjectRemovedEvent`` subscriber) is bypassed when an object is deleted with
-``suppress_events=True`` — a common pattern in migrations. Without an explicit
-unregister, the intid keyref would survive the deletion and pin the dead oid in
-storage.
-
-Look up the global intid utility:
-
-    >>> from zope.component import queryUtility
-    >>> from zope.intid.interfaces import IIntIds
-    >>> intids = queryUtility(IIntIds)
-
-Newly created objects are registered by ``five.intid`` on
-``IObjectAddedEvent``:
-
-    >>> intid_client = api.create(
-    ...     portal.clients, "Client", title="IntId Client")
-    >>> intids.queryId(intid_client) is not None
-    True
-
-``unregister_intid`` drops the registration from the utility:
-
-    >>> api.unregister_intid(intid_client)
-    >>> intids.queryId(intid_client) is None
-    True
-
-Calling it again on an already-unregistered object is a safe no-op
-(``KeyError`` from the underlying utility is swallowed):
-
-    >>> api.unregister_intid(intid_client)
-    >>> intids.queryId(intid_client) is None
-    True
-
-Clean up:
-
-    >>> api.delete(intid_client, check_permissions=False)
-
-
 Delete an object
 ................
 
@@ -2677,8 +2635,8 @@ and the ``five.intid`` subscriber drops the object's intid registration:
 When ``suppress_events=True`` is passed — the path used by migrations and
 upgrade steps — ``IObjectRemovedEvent`` is *not* fired, so the ``five.intid``
 subscriber never runs. To avoid orphan intid entries pinning the dead oid in
-storage, ``api.delete`` invokes ``unregister_intid`` itself before calling
-``_delObject``:
+storage, ``api.delete`` delegates to ``senaite.core.api.delete_intid`` before
+calling ``_delObject``:
 
     >>> silent_client = api.copy_object(
     ...     client, title="Client to delete (no events)")
@@ -2713,7 +2671,7 @@ Move the contact to the destination client:
     >>> dest.hasObject(id)
     False
     >>> contact
-    <Contact at /plone/clients/client-8/contact-4>
+    <Contact at /plone/clients/client-7/contact-4>
     >>> contact = api.move_object(contact, dest, check_constraints=False)
     >>> api.get_parent(contact) == dest
     True
@@ -2722,7 +2680,7 @@ Move the contact to the destination client:
     >>> orig.hasObject(id)
     False
     >>> contact
-    <Contact at /plone/clients/client-9/contact-4>
+    <Contact at /plone/clients/client-8/contact-4>
 
 It does nothing if destination is the same as the origin:
 
@@ -2754,7 +2712,7 @@ Unless we grant enough permissions to remove the object from origin:
     >>> dest.hasObject(id)
     False
     >>> contact
-    <Contact at /plone/clients/client-8/contact-4>
+    <Contact at /plone/clients/client-7/contact-4>
 
 Still, destination container must allow the object's type:
 

--- a/src/senaite/core/tests/doctests/API_core.rst
+++ b/src/senaite/core/tests/doctests/API_core.rst
@@ -199,6 +199,15 @@ To exercise the write helpers on a disposable object, create a new client.
     ...     client.getPhysicalPath()
     True
 
+Calling ``add_intid`` on an object that already has an IntId is a no-op — it
+returns the existing IntId without allocating a new one:
+
+    >>> api.add_intid(client) == client_intid
+    True
+
+    >>> api.get_intid(client) == client_intid
+    True
+
 Drop the registration with ``delete_intid`` and confirm the same default-marker
 behaviour applies to ``get_intid``:
 

--- a/src/senaite/core/tests/doctests/API_core.rst
+++ b/src/senaite/core/tests/doctests/API_core.rst
@@ -123,3 +123,132 @@ A bogus UID matches no brain and falls back to ``default``:
     >>> api.get_attr("does-not-exist", "Title",
     ...              catalog="portal_catalog", default="missing")
     'missing'
+
+
+IntId helpers
+.............
+
+The site's ``IIntIds`` utility maps every persistent content object to a
+stable integer id used by relation storage and other cross-reference machinery.
+``senaite.core.api`` wraps the bare utility with four thin helpers.
+
+The setup folder and the clients folder are both persistent containers that
+``five.intid`` registered with the ``IIntIds`` utility on site creation:
+
+    >>> setup = self.portal.setup
+    >>> clients = self.portal.clients
+
+``get_intid`` returns the IntId of an object:
+
+    >>> setup_intid = api.get_intid(setup)
+    >>> isinstance(setup_intid, int)
+    True
+
+    >>> clients_intid = api.get_intid(clients)
+    >>> isinstance(clients_intid, int)
+    True
+
+    >>> setup_intid != clients_intid
+    True
+
+``get_object_by_intid`` is the inverse — given an IntId, return the object it
+points to:
+
+    >>> api.get_object_by_intid(setup_intid).getPhysicalPath() == \
+    ...     setup.getPhysicalPath()
+    True
+
+    >>> api.get_object_by_intid(clients_intid).getPhysicalPath() == \
+    ...     clients.getPhysicalPath()
+    True
+
+Looking up an unknown IntId raises by default…
+
+    >>> try:
+    ...     api.get_object_by_intid(-1)
+    ... except KeyError:
+    ...     print("missing")
+    missing
+
+…unless a ``default`` is supplied, in which case it is returned:
+
+    >>> api.get_object_by_intid(-1, default=None) is None
+    True
+
+    >>> api.get_object_by_intid(-1, default="absent")
+    'absent'
+
+To exercise the write helpers on a disposable object, create a new client.
+``api.create`` requires elevated permissions:
+
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import setRoles
+    >>> setRoles(self.portal, TEST_USER_ID, ['Manager',])
+
+    >>> from bika.lims import api as bika_api
+    >>> client = bika_api.create(clients, "Client", title="IntId Client")
+
+``five.intid``'s add-subscriber registered the new client automatically, so
+``get_intid`` already returns a value:
+
+    >>> client_intid = api.get_intid(client)
+    >>> isinstance(client_intid, int)
+    True
+
+    >>> api.get_object_by_intid(client_intid).getPhysicalPath() == \
+    ...     client.getPhysicalPath()
+    True
+
+Drop the registration with ``delete_intid`` and confirm the same default-marker
+behaviour applies to ``get_intid``:
+
+    >>> api.delete_intid(client)
+
+    >>> try:
+    ...     api.get_intid(client)
+    ... except KeyError:
+    ...     print("missing")
+    missing
+
+    >>> api.get_intid(client, default=None) is None
+    True
+
+The setup and clients folders are unaffected — ``delete_intid`` only touches
+the object it is called with:
+
+    >>> api.get_intid(setup) == setup_intid
+    True
+
+    >>> api.get_intid(clients) == clients_intid
+    True
+
+Calling ``delete_intid`` again on an already-unregistered object is a safe
+no-op (the underlying ``KeyError`` is swallowed):
+
+    >>> api.delete_intid(client)
+
+``add_intid`` registers the object with every ``IIntIds`` utility and returns
+the (possibly new) IntId:
+
+    >>> new_intid = api.add_intid(client)
+    >>> isinstance(new_intid, int)
+    True
+
+The registration is reachable from both sides again:
+
+    >>> api.get_intid(client) == new_intid
+    True
+
+    >>> api.get_object_by_intid(new_intid).getPhysicalPath() == \
+    ...     client.getPhysicalPath()
+    True
+
+Re-registering an already-registered object is idempotent — the returned IntId
+does not change:
+
+    >>> api.add_intid(client) == new_intid
+    True
+
+Clean up:
+
+    >>> bika_api.delete(client, check_permissions=False)

--- a/src/senaite/core/upgrade/utils.py
+++ b/src/senaite/core/upgrade/utils.py
@@ -27,7 +27,6 @@ from pkg_resources import parse_version
 
 import transaction
 from Acquisition import aq_base
-from Acquisition import aq_parent
 from bika.lims import api
 from bika.lims.api import safe_unicode as u
 from bika.lims.interfaces import IAuditable
@@ -43,8 +42,6 @@ from plone.namedfile.file import NamedBlobFile
 from plone.namedfile.file import NamedBlobImage
 from senaite.core import logger
 from senaite.core.api.catalog import add_zc_text_index
-from zope.component import getAllUtilitiesRegisteredFor
-from zope.intid.interfaces import IIntIds
 from senaite.core.interfaces.catalog import ISenaiteCatalogObject
 from zope.interface import alsoProvides
 from zope.lifecycleevent import modified
@@ -383,37 +380,10 @@ def catalog_object(obj):
     obj.reindexObject()
 
 
-def unregister_intid(obj):
-    """Unregister `obj` from every `IIntIds` utility in the site.
-
-    `_delObject(..., suppress_events=True)` is the standard
-    migration path and it deliberately suppresses
-    `IObjectRemovedEvent`, which is what `five.intid`'s subscriber
-    listens on to drop the deleted object's `KeyReferenceToPersistent`
-    from `intids.refs` / `intids.ids`. Without an explicit call here
-    the intid entry survives, pinning the dead object's oid in the
-    FileStorage so a subsequent pack cannot reclaim it.
-
-    Mirrors the manual uid_catalog cleanup that `uncatalog_object`
-    already does for the same reason.
-    """
-    for intids in getAllUtilitiesRegisteredFor(IIntIds):
-        try:
-            intids.unregister(obj)
-        except KeyError:
-            # Object was never registered with this utility; nothing
-            # to drop. Matches `intids.unregister`'s own behaviour
-            # when it cannot find the keyref.
-            pass
-
-
 def delete_object(obj):
     """delete the object w/o firing events
     """
-    uncatalog_object(obj)
-    unregister_intid(obj)
-    parent = aq_parent(obj)
-    parent._delObject(obj.getId(), suppress_events=True)
+    api.delete(obj, check_permissions=False, suppress_events=True)
 
 
 def iter_senaite_catalogs():


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
#2907 added an `unregister_intid` helper to `senaite.core.upgrade.utils` and called it from the upgrade-time `delete_object` shim, so that objects deleted with `suppress_events=True` no longer leak an entry in `IIntIds.refs` / `IIntIds.ids`. #2908 reached the same conclusion from the add-form side: every `portal_factory` transient was registering an intid that survived the discarded `TempFolder`.

Both fixes share the same primitive (drop the keyref from every `IIntIds` utility) but live in different layers. Anywhere else in the codebase that deletes content via `_delObject(..., suppress_ events=True)` — or via `api.delete(obj, suppress_events=True)` — would have to remember to do the cleanup by hand.

## Current behavior before PR

- `unregister_intid` is private to `senaite.core.upgrade.utils` and is only invoked from the upgrade `delete_object` shim.
- `bika.lims.api.delete(obj, suppress_events=True)` leaves an orphan intid keyref behind, pinning the dead oid in the FileStorage so a subsequent pack cannot reclaim it.
- `senaite.core.migration.migrator.ContentMigrator.delete_object` duplicates the uncatalog/`aq_parent`/`_delObject` dance and silently leaks intids — same bug as the pre-#2907 upgrade path.

 ## Desired behavior after PR is merged
 - `bika.lims.api.unregister_intid(obj)` is the canonical, public helper for dropping an object from every `IIntIds` utility.
 - `bika.lims.api.delete(obj, suppress_events=True)` calls `unregister_intid` itself before `_delObject`, so callers don't have to remember the cleanup. The default path (`suppress_events=False`) is unchanged — `five.intid`'s `IObjectRemovedEvent` subscriber still does the work. 
 - `senaite.core.upgrade.utils.delete_object` and `senaite.core.migration.migrator.ContentMigrator.delete_object` both collapse to a single `api.delete(obj, check_permissions=False, suppress_events=True)` call.
 - New doctest sections in `API.rst` cover `unregister_intid` and both deletion paths (events fired vs. suppressed) to guard against regressions.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
