### PR TITLE
Fix missing <genericsetup:upgradeStep> tag for Worksheet Dexterity migration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2912 Fix missing <genericsetup:upgradeStep> tag for Worksheet Dexterity migration
 - #2908 Drop intid registrations created for portal_factory transients
 - #2907 Unregister intid on migration-time object deletion
 - #2909 Restore getPrintAddress on the DX Organization content type

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -141,6 +141,7 @@
       handler=".v02_07_000.migrate_analysis_columns_to_setup"
       profile="senaite.core:default"/>
 
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Migrate Worksheet objects to Dexterity"
       description="Convert Worksheet content type from Archetypes to Dexterity"
       source="2719"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/pull/2810

While migrating Laboratory to Dexterity, the opening `<genericsetup:upgradeStep` tag was accidentally omitted for the "Migrate Worksheet objects to Dexterity" upgrade step in `v02_07_000.zcml` (lines 144–150).

## Current behavior before PR

The `v02_07_000.zcml` file is missing the `<genericsetup:upgradeStep` opening tag for the step that migrates Worksheet objects from Archetypes to Dexterity (source `2719` → destination `2720`). 

## Desired behavior after PR is merged

The missing `<genericsetup:upgradeStep` opening tag is restored, so the Worksheet-to-Dexterity migration step is correctly registered and executed during the 2.7.0 upgrade.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
