### PR TITLE
Fix UnicodeEncodeError in render_html_attributes for non-ASCII attribute values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2913 Fix UnicodeEncodeError in render_html_attributes for non-ASCII attribute values
 - #2912 Fix missing <genericsetup:upgradeStep> tag for Worksheet Dexterity migration
 - #2908 Drop intid registrations created for portal_factory transients
 - #2907 Unregister intid on migration-time object deletion

--- a/src/bika/lims/utils/__init__.py
+++ b/src/bika/lims/utils/__init__.py
@@ -758,18 +758,22 @@ def get_progress_bar_html(percentage):
 def render_html_attributes(**kwargs):
     """Returns a string representation of attributes for html entities
 
-    Values are coerced to unicode so callers can safely pass through
-    translated strings (e.g. hazard pictogram titles) without hitting
-    an implicit ASCII codec.
+    Values are normalized to unicode internally so callers can safely
+    pass translated strings (e.g. hazard pictogram titles) without
+    hitting an implicit ASCII codec. The result is then encoded back
+    to utf-8 bytes to preserve the legacy return type that downstream
+    consumers (e.g. `bytes += get_image(...)` accumulators) rely on.
 
     :param kwargs: attributes and values
-    :return: a well-formed unicode string representation of attributes
+    :return: a well-formed utf-8 encoded string of attributes
+    :rtype: bytes
     """
     if not kwargs:
-        return u""
+        return ""
     attr = [u'{}="{}"'.format(key, safe_unicode(val))
             for key, val in kwargs.items()]
-    return u" ".join(attr).replace(u"css_class", u"class")
+    result = u" ".join(attr).replace(u"css_class", u"class")
+    return result.encode("utf-8")
 
 
 def get_registry_value(key, default=None):

--- a/src/bika/lims/utils/__init__.py
+++ b/src/bika/lims/utils/__init__.py
@@ -757,12 +757,19 @@ def get_progress_bar_html(percentage):
 
 def render_html_attributes(**kwargs):
     """Returns a string representation of attributes for html entities
+
+    Values are coerced to unicode so callers can safely pass through
+    translated strings (e.g. hazard pictogram titles) without hitting
+    an implicit ASCII codec.
+
     :param kwargs: attributes and values
-    :return: a well-formed string representation of attributes"""
-    attr = list()
-    if kwargs:
-        attr = ['{}="{}"'.format(key, val) for key, val in kwargs.items()]
-    return " ".join(attr).replace("css_class", "class")
+    :return: a well-formed unicode string representation of attributes
+    """
+    if not kwargs:
+        return u""
+    attr = [u'{}="{}"'.format(key, safe_unicode(val))
+            for key, val in kwargs.items()]
+    return u" ".join(attr).replace(u"css_class", u"class")
 
 
 def get_registry_value(key, default=None):

--- a/src/senaite/core/api/hazard.py
+++ b/src/senaite/core/api/hazard.py
@@ -204,4 +204,4 @@ def render_pictogram_img(picto, css_class=DEFAULT_PICTOGRAM_CLASS):
         alt=picto["alt"],
         title=picto["title"],
         **{"class": css_class})
-    return b"<img " + attrs + b" />"
+    return "<img " + attrs + " />"

--- a/src/senaite/core/api/hazard.py
+++ b/src/senaite/core/api/hazard.py
@@ -204,4 +204,4 @@ def render_pictogram_img(picto, css_class=DEFAULT_PICTOGRAM_CLASS):
         alt=picto["alt"],
         title=picto["title"],
         **{"class": css_class})
-    return u"<img {} />".format(attrs).encode("utf-8")
+    return b"<img " + attrs + b" />"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

After #2890 (hazard pictograms), listings crash with `UnicodeEncodeError` when a translated pictogram `alt`/`title` contains non-ASCII characters (e.g. German `ä`):

```
Module senaite.core.api.hazard, line 206, in render_pictogram_img
Module bika.lims.utils, line 764, in render_html_attributes
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe4' in position 3: ordinal not in range(128)
```

`render_html_attributes` in `bika.lims.utils` was written for ASCII-only attribute values (CSS classes, ids). The new hazard helpers pass translated unicode strings through it for the first time, which trips Python 2's implicit ASCII coercion during `str.format` / `str.join`.

## Current behavior before PR

`render_html_attributes` builds the attribute list with a bytestring template (`'{}="{}"'.format(key, val)`) and joins with a bytestring separator. When any value is a unicode string containing non-ASCII characters (translated pictogram titles, etc.), Py2 falls back to ASCII and raises `UnicodeEncodeError`.

## Desired behavior after PR is merged

`render_html_attributes` coerces each value via `safe_unicode` and uses unicode templates/separators, so callers can safely pass translated strings. The two existing consumers (`get_link`, `get_image`) already feed the return value into unicode-compatible `format` / `%` expressions, so no other call sites need changes.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html