### PR TITLE
Skip DublinCore creators/contributors when duplicating a sample

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- #PR Skip DublinCore creators/contributors when duplicating a sample
+- #2914 Skip DublinCore creators/contributors when duplicating a sample
 - #2903 Refactor record parsing to use ast.literal_eval to prevent code execution
 - #2895 Add 'duplicate_sample' workflow transition for samples (with global toggle in setup)
 - #2910 Centralize intid cleanup in api.delete

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #PR Skip DublinCore creators/contributors when duplicating a sample
 - #2903 Refactor record parsing to use ast.literal_eval to prevent code execution
 - #2895 Add 'duplicate_sample' workflow transition for samples (with global toggle in setup)
 - #2910 Centralize intid cleanup in api.delete

--- a/src/bika/lims/utils/analysisrequest.py
+++ b/src/bika/lims/utils/analysisrequest.py
@@ -98,6 +98,13 @@ DUPLICATE_SKIP_FIELDS = [
     "creation_date",
     "id",
     "modification_date",
+    # DublinCore bookkeeping: the duplicate's Creator /
+    # contributors must reflect the user performing the
+    # duplicate action, not the source's. AT initialization
+    # populates these with the current user already; copying
+    # from source would overwrite that.
+    "creators",
+    "contributors",
 ]
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The `duplicate_sample` workflow transition added in #2895 currently copies the source's `Creator` (and `contributors`) onto the duplicate. The duplicate is a fresh sibling: ownership of the new sample belongs to the user who performed the duplicate action, not to whoever originally created the source.

Discovered on a deployment where the duplicate appeared in listings as authored by the source's creator instead of the operator who clicked Duplicate.

## Current behavior before PR

`create_duplicate_of` delegates field copying to `copy_field_values`, which iterates the source's full schema and writes each field onto the duplicate. `DUPLICATE_SKIP_FIELDS` lists the lineage / state / source-run fields that must not be carried over, but the DublinCore bookkeeping fields `creators` and `contributors` are not in the list, so the source's user gets re-applied on top of the values that AT initialization had set with the current user during `_processForm`. Net result: `duplicate.Creator()` returns the source's creator and `duplicate.listCreators()` matches the source.

## Desired behavior after PR is merged

`creators` and `contributors` are added to `DUPLICATE_SKIP_FIELDS`. AT initialization populates both fields with the current user during `_processForm`, and `copy_field_values` now leaves them alone. The duplicate's `Creator()` is the user who triggered the duplicate transition. No effect on existing duplicates (this only changes how new duplicates are created).

This matches the same exclusion the partition flow applies (`create_partition` `partition_skip_fields` at `bika/lims/utils/analysisrequest.py:678-691`), where the rationale is identical.

## Files touched

- `src/bika/lims/utils/analysisrequest.py` — add `creators` and `contributors` to `DUPLICATE_SKIP_FIELDS`
- `CHANGES.rst` — entry under 2.7.0

## Migration

None.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html