### PR TITLE
Rename 'Duplicate' sample transition to 'Duplicate Sample'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #PR Rename 'Duplicate' sample transition to 'Duplicate Sample' to avoid translation collision with the worksheet duplicate-analysis label
 - #2914 Skip DublinCore creators/contributors when duplicating a sample
 - #2903 Refactor record parsing to use ast.literal_eval to prevent code execution
 - #2895 Add 'duplicate_sample' workflow transition for samples (with global toggle in setup)

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2735</version>
+  <version>2736</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-senaite.impress:default</dependency>

--- a/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
+++ b/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
@@ -1610,9 +1610,9 @@
        derived from the source via the AnalysisRequestDuplicate ID
        template. The transition does not change the source's state.
   -->
-  <transition transition_id="duplicate_sample" title="Duplicate" new_state="" trigger="USER"
+  <transition transition_id="duplicate_sample" title="Duplicate Sample" new_state="" trigger="USER"
               before_script="" after_script="" i18n:attributes="title">
-    <action url="" category="listing" icon="">Duplicate</action>
+    <action url="" category="listing" icon="">Duplicate Sample</action>
     <guard>
       <guard-expression>python:here.guard_handler("duplicate_sample")</guard-expression>
       <guard-permission>senaite.core: Add AnalysisRequest</guard-permission>

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -3,6 +3,17 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.7.0: Rename 'Duplicate' transition title to 'Duplicate Sample'"
+      description="Re-import the workflow so the new transition title
+                   replaces the previous bare 'Duplicate' label, which
+                   collided in translations with the worksheet
+                   duplicate-analysis label."
+      source="2735"
+      destination="2736"
+      handler=".v02_07_000.setup_duplicate_sample_transition"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Add 'duplicate_sample' workflow transition"
       description="Register the duplicate_sample workflow transition.
                    The transition reuses the AddAnalysisRequest


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The new sample workflow transition added in #2895 has the title `Duplicate`. The bare `Duplicate` msgid is already in use as the listing label for the worksheet duplicate-analysis row (`senaite/core/browser/worksheets/worksheet/analyses_listing.py:556`), where the German translation `Kopie` is correct.

Because the workflow XML uses the same English string, both UI elements share the single msgid and therefore the single translation. Running `bin/update_core_translations` against the German PO collapses both references onto `msgid "Duplicate" → msgstr "Kopie"`, so the new sample-duplication button renders as `Kopie` instead of `Duplikat` / `Probe duplizieren`.

## Current behavior before PR

`senaite_sample_workflow/definition.xml` defines the new transition as:

```xml
<transition transition_id="duplicate_sample" title="Duplicate" ...>
  <action ...>Duplicate</action>
</transition>
```

`msgid "Duplicate"` is shared between the worksheet duplicate-analysis label and the sample-duplicate transition title; the German PO maps it to `Kopie`.

## Desired behavior after PR is merged

The transition title becomes `Duplicate Sample`, a distinct msgid that translators can target without affecting the worksheet label. The English UI also improves (the button sits next to other sample actions like `Copy to new` / `Print sample`; the qualifier matches the surrounding labels).

- Workflow XML: `title="Duplicate Sample"`, `<action>Duplicate Sample</action>`.
- `metadata.xml` bumped to `2736`.
- New upgrade step in `v02_07_000.zcml` reuses the existing `setup_duplicate_sample_transition` handler to re-import the workflow profile on already-installed sites so they pick up the new title.
- German translation (`Probe duplizieren`) and other locale strings will land in the next translation update PR (in flight separately).

## Files touched

- `src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml`
- `src/senaite/core/profiles/default/metadata.xml`
- `src/senaite/core/upgrade/v02_07_000.zcml`
- `CHANGES.rst`

## Migration

Upgrade step `2735 → 2736` re-imports the workflow profile. The existing `setup_duplicate_sample_transition` handler is reused; no new Python code.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html