### PR TITLE
Fix msgid collision on description_calculation_imports in Calculation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #PR Fix msgid collision on `description_calculation_imports` in Calculation content type
 - #2914 Skip DublinCore creators/contributors when duplicating a sample
 - #2903 Refactor record parsing to use ast.literal_eval to prevent code execution
 - #2895 Add 'duplicate_sample' workflow transition for samples (with global toggle in setup)

--- a/src/senaite/core/content/calculation.py
+++ b/src/senaite/core/content/calculation.py
@@ -242,7 +242,7 @@ class ICalculationSchema(model.Schema):
     interim_fields = InterimFields(
         title=_(u"label_calculation_interims",
                 default=u"Calculation Interim Fields"),
-        description=_(u"description_calculation_imports",
+        description=_(u"description_calculation_interims",
                       default=u"Define interim fields such as vessel mass, "
                       u"dilution factors, should your calculation require "
                       u"them. The field title specified here will be used "


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`bin/update_core_translations` warned that `msgid description_calculation_imports` is registered at two different code locations with two different defaults:

```
src/senaite/core/content/calculation.py:245
src/senaite/core/content/calculation.py:268
```

The interim-fields description (line 245) reused the imports field's msgid by mistake — the corresponding `title` already uses `label_calculation_interims`, so the description should match.

## Current behavior before PR

Both the `interim_fields` description and the `imports` description on the `Calculation` content type carry `msgid="description_calculation_imports"` with two different default texts. i18n extractors keep only one of the two defaults; translators have no way to give each field its own help text.

## Desired behavior after PR is merged

The `interim_fields` description gets its own msgid `description_calculation_interims`, mirroring its title (`label_calculation_interims`). The collision warning from `bin/update_core_translations` goes away. The PO files (English and locales) gain a new entry on the next translation update; the existing `description_calculation_imports` entry stays in place for the imports field.

## Files touched

- `src/senaite/core/content/calculation.py`
- `CHANGES.rst`

## Migration

None. Translations for the new msgid will be added in the next translation update PR.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html