### PR TITLE
Fix clientID is not displayed in samples listing, but client name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2917 Fix `ClientID` is not displayed in samples listing, but client name
 - #2916 Fix msgid collision on `description_calculation_imports` in Calculation content type
 - #2915 Rename 'Duplicate' sample transition to 'Duplicate Sample' to avoid translation collision with the worksheet duplicate-analysis label
 - #2914 Skip DublinCore creators/contributors when duplicating a sample

--- a/src/bika/lims/utils/__init__.py
+++ b/src/bika/lims/utils/__init__.py
@@ -691,7 +691,9 @@ def get_link_for(obj, **kwargs):
     if not obj:
         return ""
     href = api.get_url(obj)
-    value = api.get_title(obj)
+    value = kwargs.pop("value", None)
+    if not value:
+        value = api.get_title(obj)
     return get_link(href=href, value=value, **kwargs)
 
 

--- a/src/senaite/core/browser/samples/view.py
+++ b/src/senaite/core/browser/samples/view.py
@@ -511,7 +511,7 @@ class SamplesView(ListingView):
         if client:
             item["replace"]["Client"] = get_link_for(client)
             item["replace"]["ClientID"] = get_link_for(
-                client, display_value=obj.getClientID)
+                client, value=obj.getClientID)
 
         # Analyses count — [verified, total, not_submitted, to_be_verified]
         analysesnum = obj.getAnalysesNum
@@ -543,7 +543,7 @@ class SamplesView(ListingView):
             batch = self.get_object_by_uid(obj.getBatchUID)
             if batch:
                 item["replace"]["BatchID"] = get_link_for(
-                    batch, display_value=obj.getBatchID)
+                    batch, value=obj.getBatchID)
 
         # Dates
         item["SamplingDate"] = self.str_date(obj.getSamplingDate)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

They way the link for ClientID column was generated was changed with https://github.com/senaite/senaite.core/pull/2873 , causing the link to not longer display the ClientID, but the name of the client.

## Current behavior before PR

The link of column "ClientID" do not displays the client ID, but the client name

## Desired behavior after PR is merged

The link of column "ClientID" displays the client ID

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
