### PR TITLE
Fix Lab Information setup data import after Laboratory migration to Dexterity

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2918 Fix Lab Information setup data import after Laboratory migration to Dexterity
 - #2917 Fix `ClientID` is not displayed in samples listing, but client name
 - #2916 Fix msgid collision on `description_calculation_imports` in Calculation content type
 - #2915 Rename 'Duplicate' sample transition to 'Duplicate Sample' to avoid translation collision with the worksheet duplicate-analysis label

--- a/src/senaite/core/exportimport/setupdata/__init__.py
+++ b/src/senaite/core/exportimport/setupdata/__init__.py
@@ -34,6 +34,7 @@ from bika.lims.utils import to_unicode
 from bika.lims.utils import to_utf8
 from bika.lims.utils.analysis import create_analysis
 from pkg_resources import resource_filename
+from plone.namedfile.file import NamedBlobImage
 from Products.Archetypes.event import ObjectInitializedEvent
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import _createObjectByType
@@ -357,37 +358,44 @@ class Sub_Groups(WorksheetImporter):
 
 class Lab_Information(WorksheetImporter):
 
+    def get_logo(self, filename):
+        """Read a setup data image and return it as a NamedBlobImage
+        """
+        if not filename:
+            return None
+        path = resource_filename(
+            self.dataset_project,
+            "setupdata/%s/%s" % (self.dataset_name, filename))
+        try:
+            file_data = read_file(path)
+        except IOError as msg:
+            logger.warning("%s. Error on sheet: %s" % (msg, self.sheetname))
+            return None
+        return NamedBlobImage(
+            data=file_data, filename=api.safe_unicode(filename))
+
     def Import(self):
         laboratory = self.context.setup.laboratory
         values = {}
         for row in self.get_rows(3):
-            values[row['Field']] = row['Value']
+            values[row["Field"]] = row["Value"]
 
-        if values['AccreditationBodyLogo']:
-            path = resource_filename(
-                self.dataset_project,
-                "setupdata/%s/%s" % (self.dataset_name,
-                                     values['AccreditationBodyLogo']))
-            try:
-                file_data = read_file(path)
-            except Exception as msg:
-                file_data = None
-                logger.warning(msg[0] + " Error on sheet: " + self.sheetname)
-        else:
-            file_data = None
-
-        laboratory.edit(
-            Name=values['Name'],
-            LabURL=values['LabURL'],
-            Confidence=values['Confidence'],
-            LaboratoryAccredited=self.to_bool(values['LaboratoryAccredited']),
-            AccreditationBodyLong=values['AccreditationBodyLong'],
-            AccreditationBody=values['AccreditationBody'],
-            AccreditationBodyURL=values['AccreditationBodyURL'],
-            Accreditation=values['Accreditation'],
-            AccreditationReference=values['AccreditationReference'],
-            AccreditationBodyLogo=file_data,
-            TaxNumber=values['TaxNumber'],
+        api.edit(
+            laboratory,
+            title=api.safe_unicode(values["Name"]),
+            lab_url=api.safe_unicode(values["LabURL"]),
+            confidence=api.to_int(values["Confidence"], default=None),
+            laboratory_accredited=self.to_bool(
+                values["LaboratoryAccredited"]),
+            accreditation_body=api.safe_unicode(values["AccreditationBody"]),
+            accreditation_body_url=api.safe_unicode(
+                values["AccreditationBodyURL"]),
+            accreditation=api.safe_unicode(values["Accreditation"]),
+            accreditation_reference=api.safe_unicode(
+                values["AccreditationReference"]),
+            accreditation_body_logo=self.get_logo(
+                values["AccreditationBodyLogo"]),
+            tax_number=api.safe_unicode(values["TaxNumber"]),
         )
         self.fill_contactfields(values, laboratory)
         self.fill_addressfields(values, laboratory)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The `Laboratory` content type was migrated to Dexterity in #2810, where it became folderish and inherited `edit(title, description)` from `Products.CMFCore.PortalFolder`. The `Lab_Information` setup data importer still called `laboratory.edit()` with the old Archetypes field names, so importing demo/setup data fails with:

```
TypeError: edit() got an unexpected keyword argument 'Name'
```

`Lab_Information` was the only Dexterity-migrated importer still using the Archetypes-style `edit()`; all other `obj.edit(...)` call sites in the importer target types that are still on Archetypes.

## Current behavior before PR

Importing Lab Information (e.g. via the demo dataset `bika.lims.test`) raises `TypeError: edit() got an unexpected keyword argument 'Name'` and the import aborts:

```
INFO    [senaite.core][waitress-1] Loading bika.lims.test: Lab Information
ERROR   [senaite.core][waitress-1] Traceback (most recent call last):
  File ".../senaite/core/browser/form/adapters/data_import.py", line 62, in handle_data_import
    LoadSetupData(self.context, self.request)()
  File ".../senaite/core/exportimport/load_setup_data.py", line 152, in __call__
    adapter(self, workbook, self.dataset_project, self.dataset_name)
  File ".../senaite/core/exportimport/setupdata/__init__.py", line 145, in __call__
    self.Import()
  File ".../senaite/core/exportimport/setupdata/__init__.py", line 390, in Import
    TaxNumber=values['TaxNumber'],
TypeError: edit() got an unexpected keyword argument 'Name'
```

## Desired behavior after PR is merged

Lab Information imports successfully. The importer now uses `api.edit()` with the Dexterity schema field names, matching the pattern already used for the migrated `SampleType` and `AnalysisProfile` importers:

- `Name`/`LabURL`/`Confidence`/... mapped to the DX field names (`title`, `lab_url`, `confidence`, ...).
- `Confidence` converted with `api.to_int` (the field is now `schema.Int`).
- The accreditation logo is wrapped in a `NamedBlobImage` (the field is now a `NamedBlobImage`), via a small `get_logo()` helper.
- The obsolete `AccreditationBodyLong` value is dropped; it never mapped to a field on the Archetypes type either.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html