### PR TITLE
Enforce the AccessJSONAPI permission on state-changing JSON API routes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2919 Enforce the AccessJSONAPI permission on state-changing JSON API routes
 - #2917 Fix `ClientID` is not displayed in samples listing, but client name
 - #2916 Fix msgid collision on `description_calculation_imports` in Calculation content type
 - #2915 Rename 'Duplicate' sample transition to 'Duplicate Sample' to avoid translation collision with the worksheet duplicate-analysis label

--- a/src/bika/lims/jsonapi/__init__.py
+++ b/src/bika/lims/jsonapi/__init__.py
@@ -18,20 +18,37 @@
 # Copyright 2018-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import json
+import sys
+import traceback
+
+import Missing
+import six
+from AccessControl import Unauthorized
+from AccessControl import getSecurityManager
+from bika.lims import api
+from bika.lims import logger
+from bika.lims.utils import to_utf8
 from plone.app.textfield import RichTextValue
 from Products.Archetypes.config import TOOL_NAME
 from Products.CMFCore.utils import getToolByName
 from senaite.core.browser.fields.parsing import parse_record_literal
+from senaite.core.permissions import AccessJSONAPI
 
-from bika.lims import api
-from bika.lims.utils import to_utf8
-from bika.lims import logger
 
-import json
-import Missing
-import six
-import sys
-import traceback
+def check_jsonapi_permission(obj):
+    """Check the AccessJSONAPI permission on the given object
+
+    Raises Unauthorized if the current user does not hold the
+    `senaite.core: Access JSON API` permission on the passed-in object.
+    This guards the state-changing JSON API routes against anonymous and
+    under-privileged callers (CWE-862).
+    """
+    if getSecurityManager().checkPermission(AccessJSONAPI, obj):
+        return
+    msg = "You don't have the '{0}' permission on {1}".format(
+        AccessJSONAPI, obj.absolute_url())
+    raise Unauthorized(msg)
 
 
 def handle_errors(f):

--- a/src/bika/lims/jsonapi/create.py
+++ b/src/bika/lims/jsonapi/create.py
@@ -19,16 +19,14 @@
 # Some rights reserved, see README and LICENSE.
 
 import transaction
-from AccessControl import Unauthorized
-from AccessControl import getSecurityManager
-from senaite.core.idserver import renameAfterCreation
+from bika.lims.jsonapi import check_jsonapi_permission
 from bika.lims.jsonapi import set_fields_from_request
 from bika.lims.utils import tmpID
 from plone.jsonapi.core import router
 from plone.jsonapi.core.interfaces import IRouteProvider
 from Products.Archetypes.event import ObjectInitializedEvent
 from Products.CMFPlone.utils import _createObjectByType
-from senaite.core.permissions import AccessJSONAPI
+from senaite.core.idserver import renameAfterCreation
 from zExceptions import BadRequest
 from zope import event
 from zope import interface
@@ -176,10 +174,7 @@ class Create(object):
         site_path = request['PATH_INFO'].replace("/@@API/create", "")
         parent = context.restrictedTraverse(str(site_path + obj_path))
         # normal permissions still apply for this user
-        if not getSecurityManager().checkPermission(AccessJSONAPI, parent):
-            msg = "You don't have the '{0}' permission on {1}".format(
-                AccessJSONAPI, parent.absolute_url())
-            raise Unauthorized(msg)
+        check_jsonapi_permission(parent)
 
         obj_id = request.get("obj_id", "")
         _renameAfterCreation = False

--- a/src/bika/lims/jsonapi/doactionfor.py
+++ b/src/bika/lims/jsonapi/doactionfor.py
@@ -18,15 +18,16 @@
 # Copyright 2018-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import json
+
+import transaction
+from bika.lims.jsonapi import check_jsonapi_permission
 from bika.lims.jsonapi.read import read
 from plone.jsonapi.core import router
 from plone.jsonapi.core.interfaces import IRouteProvider
 from Products.CMFCore.utils import getToolByName
 from zExceptions import BadRequest
 from zope import interface
-import json
-
-import transaction
 
 
 class doActionFor(object):
@@ -73,8 +74,10 @@ class doActionFor(object):
         if len(objects) == 0:
             raise BadRequest("No matching objects found")
         for obj_dict in objects:
+            obj = uc(UID=obj_dict['UID'])[0].getObject()
+            # normal permissions still apply for this user
+            check_jsonapi_permission(obj)
             try:
-                obj = uc(UID=obj_dict['UID'])[0].getObject()
                 workflow.doActionFor(obj, action)
                 obj.reindexObject()
             except Exception as e:
@@ -114,6 +117,8 @@ class doActionFor(object):
             if not obj_path.startswith("/"):
                 obj_path = "/" + obj_path
             obj = context.restrictedTraverse(str(site_path + obj_path))
+            # normal permissions still apply for this user
+            check_jsonapi_permission(obj)
             if obj_path.startswith(site_path):
                 obj_path = obj_path[len(site_path):]
             try:

--- a/src/bika/lims/jsonapi/getusers.py
+++ b/src/bika/lims/jsonapi/getusers.py
@@ -18,6 +18,7 @@
 # Copyright 2018-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from bika.lims.jsonapi import check_jsonapi_permission
 from plone.jsonapi.core import router
 from plone.jsonapi.core.interfaces import IRouteProvider
 from Products.CMFCore.utils import getToolByName
@@ -67,12 +68,15 @@ class getUsers(object):
         >>> browser.contents
         'No roles specified'
         """
+        # normal permissions still apply for this user
+        check_jsonapi_permission(context)
+
         roles = request.get('roles','')
 
         if len(roles) == 0:
             raise BadRequest("No roles specified")
-        
-        mtool = getToolByName(context, 'portal_membership') 
+
+        mtool = getToolByName(context, 'portal_membership')
         users = []
         for user in mtool.searchForMembers(roles=roles):
             uid = user.getId()

--- a/src/bika/lims/jsonapi/remove.py
+++ b/src/bika/lims/jsonapi/remove.py
@@ -18,12 +18,13 @@
 # Copyright 2018-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import transaction
+from bika.lims.jsonapi import check_jsonapi_permission
 from plone.jsonapi.core import router
 from plone.jsonapi.core.interfaces import IRouteProvider
 from Products.CMFCore.utils import getToolByName
 from zExceptions import BadRequest
 from zope import interface
-import transaction
 
 
 class Remove(object):
@@ -78,14 +79,17 @@ class Remove(object):
             "success": True,
             "error": False,
         }
-        
+
         data = uc(UID=_uid)
         if not data:
             raise BadRequest("No objects found")
-        
+
         for proxy in data:
+            obj = proxy.getObject()
+            # normal permissions still apply for this user
+            check_jsonapi_permission(obj)
             try:
-                parent = proxy.getObject().aq_parent
+                parent = obj.aq_parent
                 parent.manage_delObjects([proxy.id])
             except Exception as e:
                 savepoint.rollback()

--- a/src/bika/lims/jsonapi/update.py
+++ b/src/bika/lims/jsonapi/update.py
@@ -18,15 +18,17 @@
 # Copyright 2018-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from bika.lims.jsonapi import set_fields_from_request
-from Products.CMFCore.utils import getToolByName
-from plone.jsonapi.core import router
-from plone.jsonapi.core.interfaces import IRouteProvider
-from zExceptions import BadRequest
-from zope import interface
 import json
+
 import six
 import transaction
+from bika.lims.jsonapi import check_jsonapi_permission
+from bika.lims.jsonapi import set_fields_from_request
+from plone.jsonapi.core import router
+from plone.jsonapi.core.interfaces import IRouteProvider
+from Products.CMFCore.utils import getToolByName
+from zExceptions import BadRequest
+from zope import interface
 
 
 class Update(object):
@@ -146,6 +148,9 @@ class Update(object):
             ret['error'] = True
             return ret
 
+        # normal permissions still apply for this user
+        check_jsonapi_permission(obj)
+
         try:
             fields = set_fields_from_request(obj, request)
             if not fields:
@@ -225,6 +230,8 @@ class Update(object):
             if obj_path.startswith(site_path):
                 obj_path = obj_path[len(site_path):]
             obj = context.restrictedTraverse(str(site_path + obj_path))
+            # normal permissions still apply for this user
+            check_jsonapi_permission(obj)
             this_ret = {
                 "url": router.url_for("update_many", force_external=True),
                 "success": False,

--- a/src/senaite/core/tests/test_jsonapi_security.py
+++ b/src/senaite/core/tests/test_jsonapi_security.py
@@ -18,6 +18,7 @@
 # Copyright 2018-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+import base64
 import json
 
 import transaction
@@ -28,6 +29,7 @@ from plone.app.testing import FunctionalTesting
 from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import TEST_USER_PASSWORD
 from plone.app.testing import login
 from plone.app.testing import logout
 from plone.app.testing import setRoles
@@ -96,6 +98,20 @@ class TestJSONAPISecurity(BaseTestCase):
             ("getusers", "roles:list=Manager"),
         ]
 
+    def get_authenticated_browser(self, username=TEST_USER_NAME,
+                                  password=TEST_USER_PASSWORD):
+        """Return a browser authenticated via HTTP Basic Auth
+
+        Basic Auth is used on purpose: it avoids rendering the Plone
+        login form (and any z3c.form widgets), keeping the test focused
+        on the API permission check.
+        """
+        browser = self.getBrowser(loggedIn=False)
+        credentials = base64.b64encode(
+            "%s:%s" % (username, password))
+        browser.addHeader("Authorization", "Basic %s" % credentials)
+        return browser
+
     def open_api(self, browser, route, query):
         """Open the given API route with the passed-in query string
         """
@@ -127,7 +143,7 @@ class TestJSONAPISecurity(BaseTestCase):
         setRoles(self.portal, TEST_USER_ID, ["Member"])
         transaction.commit()
         for route, query in self.get_gated_routes():
-            browser = self.getBrowser(loggedIn=True)
+            browser = self.get_authenticated_browser()
             self.assert_blocked(browser, route, query)
 
     def test_getusers_gate_is_the_blocker_for_member(self):
@@ -139,7 +155,7 @@ class TestJSONAPISecurity(BaseTestCase):
         """
         setRoles(self.portal, TEST_USER_ID, ["Member"])
         transaction.commit()
-        browser = self.getBrowser(loggedIn=True)
+        browser = self.get_authenticated_browser()
         self.open_api(browser, "getusers", "roles:list=Manager")
         self.assertIn('"success": false', browser.contents)
         self.assertIn("Access JSON API", browser.contents)
@@ -152,7 +168,7 @@ class TestJSONAPISecurity(BaseTestCase):
         """
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
         transaction.commit()
-        browser = self.getBrowser(loggedIn=True)
+        browser = self.get_authenticated_browser()
         self.open_api(browser, "getusers", "roles:list=Manager")
         self.assertIn('"success": true', browser.contents)
 

--- a/src/senaite/core/tests/test_jsonapi_security.py
+++ b/src/senaite/core/tests/test_jsonapi_security.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+import json
+
+import transaction
+from AccessControl import Unauthorized
+from bika.lims import api
+from bika.lims.jsonapi import check_jsonapi_permission
+from plone.app.testing import FunctionalTesting
+from plone.app.testing import PloneSandboxLayer
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import login
+from plone.app.testing import logout
+from plone.app.testing import setRoles
+from senaite.core.tests.base import BaseTestCase
+from senaite.core.tests.layers import BASE_LAYER_FIXTURE
+from six.moves.urllib.parse import quote
+
+
+class JSONAPILayer(PloneSandboxLayer):
+    """Layer that also wires up plone.jsonapi.core so the `@@API` view
+    (and its routes) is published, which is not the case in the base
+    layer because z3c.autoinclude does not run during tests.
+    """
+    defaultBases = (BASE_LAYER_FIXTURE,)
+
+    def setUpZope(self, app, configurationContext):
+        super(JSONAPILayer, self).setUpZope(app, configurationContext)
+        import plone.jsonapi.core
+        self.loadZCML(package=plone.jsonapi.core)
+
+
+JSONAPI_FIXTURE = JSONAPILayer()
+JSONAPI_TESTING = FunctionalTesting(
+    bases=(JSONAPI_FIXTURE,), name="SENAITE:JSONAPISecurityTesting")
+
+
+class TestJSONAPISecurity(BaseTestCase):
+    """Regression tests for GHSA-jrw6-7x4q-w25j
+
+    The state-changing JSON API routes (`update`, `update_many`, `remove`,
+    `doActionFor`, `doActionFor_many`) and the user-enumeration route
+    (`getusers`) must enforce the `AccessJSONAPI` permission. The `@@API`
+    view itself is published with `zope2.View`, which Anonymous holds on
+    the site root, so the per-route permission check is the only barrier
+    against anonymous / under-privileged callers (CWE-862).
+
+    `bika_setup` is the object the advisory PoC abused: its UID is
+    resolvable, so each route reaches the permission check.
+
+    Note: the `@@API` view wraps every route in the jsonapi error
+    handler, so a route that raises `Unauthorized` answers with a JSON
+    error (`"success": false`) carrying the message instead of an HTTP
+    401. The state change is still prevented because the permission
+    check runs before any mutation. This matches the existing,
+    already-secured `create` route.
+    """
+    layer = JSONAPI_TESTING
+
+    def setUp(self):
+        super(TestJSONAPISecurity, self).setUp()
+        self.portal_url = self.portal.absolute_url()
+        self.target = self.portal.bika_setup
+        self.target_uid = api.get_uid(self.target)
+
+    def get_gated_routes(self):
+        """Return (route, query) for every permission-gated API route
+        """
+        values = quote(json.dumps({"/bika_setup": {"Title": "hacked"}}))
+        paths = quote(json.dumps(["/bika_setup"]))
+        return [
+            ("update", "obj_uid=%s&Title=hacked" % self.target_uid),
+            ("update_many", "input_values=%s" % values),
+            ("remove", "UID=%s" % self.target_uid),
+            ("doActionFor", "UID=%s&action=reject" % self.target_uid),
+            ("doActionFor_many", "action=reject&f=%s" % paths),
+            ("getusers", "roles:list=Manager"),
+        ]
+
+    def open_api(self, browser, route, query):
+        """Open the given API route with the passed-in query string
+        """
+        url = "{0}/@@API/{1}?{2}".format(self.portal_url, route, query)
+        browser.open(url)
+
+    def assert_blocked(self, browser, route, query):
+        """The route must answer with an authorization failure
+        """
+        self.open_api(browser, route, query)
+        self.assertIn('"success": false', browser.contents)
+        self.assertIn("Unauthorized", browser.contents)
+
+    def test_anonymous_is_blocked_on_all_gated_routes(self):
+        """Anonymous callers must not reach any gated route
+        """
+        logout()
+        for route, query in self.get_gated_routes():
+            browser = self.getBrowser(loggedIn=False)
+            self.assert_blocked(browser, route, query)
+
+    def test_unprivileged_member_is_blocked_on_all_gated_routes(self):
+        """Authenticated users without AccessJSONAPI are blocked too
+
+        This isolates the permission check from incidental View
+        protection: a plain Member can resolve the target object but
+        still lacks `AccessJSONAPI`.
+        """
+        setRoles(self.portal, TEST_USER_ID, ["Member"])
+        transaction.commit()
+        for route, query in self.get_gated_routes():
+            browser = self.getBrowser(loggedIn=True)
+            self.assert_blocked(browser, route, query)
+
+    def test_getusers_gate_is_the_blocker_for_member(self):
+        """The AccessJSONAPI check itself is what blocks the call
+
+        `getusers` checks the permission on the site root, which a
+        Member can view, so the answer must name the AccessJSONAPI
+        permission (it cannot be incidental View protection).
+        """
+        setRoles(self.portal, TEST_USER_ID, ["Member"])
+        transaction.commit()
+        browser = self.getBrowser(loggedIn=True)
+        self.open_api(browser, "getusers", "roles:list=Manager")
+        self.assertIn('"success": false', browser.contents)
+        self.assertIn("Access JSON API", browser.contents)
+
+    def test_privileged_user_passes_the_permission_gate(self):
+        """A user holding AccessJSONAPI is not blocked by the gate
+
+        Uses the non-destructive `getusers` route to confirm the gate
+        does not over-block legitimate callers.
+        """
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        transaction.commit()
+        browser = self.getBrowser(loggedIn=True)
+        self.open_api(browser, "getusers", "roles:list=Manager")
+        self.assertIn('"success": true', browser.contents)
+
+    def test_check_permission_helper_denies_anonymous(self):
+        """The shared helper raises Unauthorized for anonymous callers
+        """
+        logout()
+        self.assertRaises(
+            Unauthorized, check_jsonapi_permission, self.target)
+
+    def test_check_permission_helper_allows_privileged(self):
+        """The shared helper passes for a user holding AccessJSONAPI
+        """
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+        login(self.portal, TEST_USER_NAME)
+        # must not raise and returns None
+        self.assertIsNone(check_jsonapi_permission(self.target))
+
+
+def test_suite():
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestJSONAPISecurity))
+    return suite


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The JSON API state-changing routes do not enforce the `senaite.core: Access JSON API` permission, unlike the `create` route. The `@@API` view is published with `zope2.View`, which Anonymous holds on the site root, so these routes are reachable by anonymous and under-privileged callers (CWE-862, Missing Authorization).

The remote-code-execution sink behind the same report was already removed in #2903 (literal record parsing). This PR closes the remaining authorization gap on the routes.

Routes gated:

- `update`, `update_many`
- `remove`
- `doActionFor`, `doActionFor_many`
- `getusers`

## Current behavior before PR

Anonymous or under-privileged callers can reach the state-changing JSON API routes (and `getusers` leaks user information), because only `create` enforces `AccessJSONAPI`.

## Desired behavior after PR is merged

Every state-changing route enforces `AccessJSONAPI` on the resolved target object before any mutation or state change, and `getusers` enforces it on the site root before enumerating members.

Implementation notes:

- Added a shared `check_jsonapi_permission()` helper in `bika.lims.jsonapi`, called on the target object before any write. The `create` route now uses the same helper, so the check has a single source of truth.
- The check is placed outside the routes' `try/except` blocks so the `Unauthorized` is not masked as a `BadRequest`.
- The `@@API` view wraps routes in the jsonapi error handler, so an `Unauthorized` is returned as a JSON error (`"success": false`) rather than an HTTP 401, consistent with the existing `create` route. The state change is still prevented because the permission check runs first.
- Added a regression test (`test_jsonapi_security`) that exercises all gated routes for anonymous and under-privileged (Member) callers, confirms a privileged caller still passes the gate, and covers the shared helper. A small test layer loads `plone.jsonapi.core` so the `@@API` view is published during tests.

CSRF hardening (removing `IDisableCSRFProtection`) is intentionally out of scope for this PR and will be handled separately.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html