### PR TITLE
Fix TypeError in DynamicAnalysisSpec when xlsx has trailing empty headers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2920 Fix TypeError in DynamicAnalysisSpec when xlsx has trailing empty headers
 - #2918 Fix Lab Information setup data import after Laboratory migration to Dexterity
 - #2917 Fix `ClientID` is not displayed in samples listing, but client name
 - #2916 Fix msgid collision on `description_calculation_imports` in Calculation content type

--- a/src/senaite/core/content/dynamicanalysisspec.py
+++ b/src/senaite/core/content/dynamicanalysisspec.py
@@ -112,6 +112,13 @@ class DynamicAnalysisSpec(Container):
             if num > 0:
                 break
             header = [cell.value for cell in row]
+        # Excel often pads the used range with trailing empty cells; drop them
+        # so downstream getattr(obj, column) calls don't blow up on a None
+        # column name. Empty cells in the middle of the header are left as-is
+        # because removing them would shift the column/value alignment used
+        # by get_specs (zip(keys, row_cells)).
+        while header and not (api.is_string(header[-1]) and header[-1].strip()):
+            header.pop()
         return header
 
     def get_specs(self):

--- a/src/senaite/core/content/dynamicanalysisspec.py
+++ b/src/senaite/core/content/dynamicanalysisspec.py
@@ -73,6 +73,22 @@ class IDynamicAnalysisSpecSchema(model.Schema):
         except (IndexError, AttributeError):
             raise Invalid(
                 _("First sheet does not contain a valid column definition"))
+        # Strip trailing empty header cells (Excel pads the used range with
+        # blank cells when otherwise-empty columns carry any formatting).
+        while header and (header[-1] is None or
+                          (api.is_string(header[-1])
+                           and not header[-1].strip())):
+            header.pop()
+        # Every remaining header must be a usable column name, since the
+        # dynamic results-range adapter looks up sample attributes through
+        # getattr(obj, column) -- a non-string column raises TypeError at
+        # sample creation time.
+        for idx, col in enumerate(header):
+            if not api.is_string(col) or not col.strip():
+                raise Invalid(_(
+                    "Column {} of the header row has no name. "
+                    "Please remove empty columns from the spreadsheet "
+                    "and upload it again.".format(idx + 1)))
         for col in REQUIRED_COLUMNS:
             if col not in header:
                 raise Invalid(_("Column '{}' is missing".format(col)))

--- a/src/senaite/core/tests/doctests/DynamicAnalysisSpec.rst
+++ b/src/senaite/core/tests/doctests/DynamicAnalysisSpec.rst
@@ -123,6 +123,28 @@ We can also get the specs by Keyword:
     [[u'Mg', u'Method A', u'5', u'6'], [u'Mg', u'Method B', u'7', u'8']]
 
 
+Excel files in the wild often pad the used range with trailing empty cells
+(formatting on otherwise blank columns is enough to extend ``max_col``).
+Those padded cells come back as ``None`` headers; ``get_header`` must drop
+them, since downstream consumers use header values as Python attribute names
+via ``getattr(obj, column)`` -- which raises ``TypeError`` on a non-string:
+
+    >>> def to_excel_with_padding(data, padding=4):
+    ...     workbook = Workbook()
+    ...     first_sheet = workbook.get_active_sheet()
+    ...     reader = csv.reader(StringIO(data))
+    ...     for i, row in enumerate(reader):
+    ...         if i == 0:
+    ...             row = row + [None] * padding
+    ...         first_sheet.append(row)
+    ...     return NamedBlobFile(save_virtual_workbook(workbook))
+
+    >>> ds_padded = api.create(setup.dynamicanalysisspecs, "DynamicAnalysisSpec")
+    >>> ds_padded.specs_file = to_excel_with_padding(data)
+    >>> ds_padded.get_header()
+    [u'Keyword', u'Method', u'min', u'max']
+
+
 Hooking in a Dynamic Analysis Specification
 ...........................................
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When the .xlsx attached to a `DynamicAnalysisSpec` has trailing empty header cells in row 1 — a common artifact of files produced in Excel/LibreOffice, where formatting on otherwise-empty columns is enough to extend the sheet's max_col — `get_header()` returns a list whose last entries are None. Downstream, D`efaultDynamicResultsRange.get_match_data` uses each header value as a Python attribute name via `getattr(self.analysis, column, marker)` ([`adapters/dynamicresultsrange.py:106`](https://github.com/senaite/senaite.core/blob/5d1bb21a271bf42494de2ce67eabd8de0a0c0260/src/bika/lims/adapters/dynamicresultsrange.py#L106)), which raises:

```
TypeError: getattr(): attribute name must be string
```

The traceback originates from `setSpecification → setResultsRange → match → get_match_data`, so the user-visible symptom is sample creation aborting whenever the picked Specification is linked to a `DynamicAnalysisSpec` that has padded headers, with an opaque 500-flavoured backend error that is easy to misread as a permissions problem.

The existing validate_specs_file invariant on the schema only checks that `REQUIRED_COLUMNS` (`Keyword`, `min`, `max`) are present — it does not reject None or whitespace-only headers, which is why such files have been accepted at upload time.

## Current behavior before PR

Reproduce with an .xlsx that has 4 valid header columns (`Keyword`, `Method`, `min`, `max`) and 4 trailing row-1 cells with no value (any combination of: formatting applied, value cleared, column later resized):

```
>>> spec.get_header()
[u'Keyword', u'Method', u'min', u'max', None, None, None, None]
```

Upload succeeds. Any sample creation that triggers the dynamic results-range adapter aborts with `TypeError: getattr(): attribute name must be string`:


```
Traceback (most recent call last): File "/home/senaite/senaite/src/senaite.core/src/bika/lims/browser/analysisrequest/add2.py", line 2073, in ajax_submit   samples = self.create_samples(valid_records) File "/home/senaite/senaite/src/senaite.core/src/bika/lims/browser/analysisrequest/add2.py", line 2126, in create_samples   client, record, attachments=attachments, source=source) File "/home/senaite/senaite/src/senaite.core/src/bika/lims/browser/analysisrequest/add2.py", line 2145, in create_sample   sample = crar(client, self.request, record) File "/home/senaite/senaite/src/senaite.core/src/bika/lims/utils/analysisrequest.py", line 104, in create_analysisrequest   ar.setSpecification(specification) File "/home/senaite/senaite/src/senaite.core/src/bika/lims/content/analysisrequest.py", line 1489, in setSpecification   self.setResultsRange(spec.getResultsRange(), recursive=False) File "/home/senaite/senaite/src/senaite.core/src/bika/lims/content/analysisrequest.py", line 1514, in setResultsRange   analysis.setResultsRange(result_range) File "/home/senaite/senaite/src/senaite.core/src/bika/lims/content/abstractroutineanalysis.py", line 299, in setResultsRange   spec.update(adapter()) File "/home/senaite/senaite/src/senaite.core/src/bika/lims/adapters/dynamicresultsrange.py", line 206, in __call__   return self.get_results_range() File "/home/senaite/senaite/src/senaite.core/src/bika/lims/adapters/dynamicresultsrange.py", line 183, in get_results_range   specs = filter(self.match, specs) File "/home/senaite/senaite/src/senaite.core/src/bika/lims/adapters/dynamicresultsrange.py", line 120, in match   data = self.get_match_data() File "/home/senaite/senaite/eggs/plone.memoize-3.0.0-py2.7.egg/plone/memoize/instance.py", line 53, in memogetter   val = func(*args, **kwargs) File "/home/senaite/senaite/src/senaite.core/src/bika/lims/adapters/dynamicresultsrange.py", line 106, in get_match_data   an_value = getattr(self.analysis, column, marker)
TypeError: getattr(): attribute name must be string
```

## Desired behavior after PR is merged

Two complementary layers:

Upload-time validation. validate_specs_file is extended to reject any .xlsx whose header row contains a None, non-string, or whitespace-only value (after trimming trailing empty cells, which are considered Excel padding and silently ignored). The error message names the offending column index so the uploader knows where to look:

Column 5 of the header row has no name. Please remove empty columns from the spreadsheet and upload it again.

The existing `REQUIRED_COLUMNS` presence check still runs after this.

Read-side defence. `get_header()` strips trailing non-string entries before returning, so any already-uploaded files that escaped prior validation no longer trigger the `TypeError` at sample creation. Existing deployments do not need a data migration; the already-stored bad files become functional on next read.

```
>>> spec.get_header()
[u'Keyword', u'Method', u'min', u'max']
```

A doctest covering the trailing-padded scenario is added.

## Implementation note

Both layers only act on trailing non-string entries. Filtering Nones mid-row would silently misalign `get_specs`' `dict(zip(keys, row_cells))` and produce wrong dynamic-range matches against later columns . A middle gap remains an upload-time error (clear message to fix the file) and, for legacy data, surfaces as the existing `TypeError` rather than silent misalignment

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
