### PR TITLE
Fix duplicate Laboratory object by making setup/laboratory the single canonical Laboratory

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2920 Fix duplicate Laboratory object by making setup/laboratory the single canonical Laboratory
 - #2918 Fix Lab Information setup data import after Laboratory migration to Dexterity
 - #2917 Fix `ClientID` is not displayed in samples listing, but client name
 - #2916 Fix msgid collision on `description_calculation_imports` in Calculation content type

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- #2920 Fix duplicate Laboratory object by making setup/laboratory the single canonical Laboratory
+- #2921 Fix duplicate Laboratory object by making setup/laboratory the single canonical Laboratory
 - #2918 Fix Lab Information setup data import after Laboratory migration to Dexterity
 - #2917 Fix `ClientID` is not displayed in samples listing, but client name
 - #2916 Fix msgid collision on `description_calculation_imports` in Calculation content type

--- a/src/bika/lims/browser/referenceanalysis.py
+++ b/src/bika/lims/browser/referenceanalysis.py
@@ -28,6 +28,7 @@ from Products.CMFCore.WorkflowCore import WorkflowException
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from bika.lims import api
 from bika.lims.browser import BrowserView
 from bika.lims.interfaces.analysis import IRequestAnalysis
 from bika.lims.utils import createPdf, encode_header
@@ -108,7 +109,7 @@ class AnalysesRetractedListReport(BrowserView):
                 email = safe_unicode(manager.getEmailAddress()).encode('utf-8')
                 to = '%s, %s' % (to, formataddr((encode_header(name), email)))
         html = safe_unicode(self.template()).encode('utf-8')
-        lab = self.context.bika_setup.laboratory
+        lab = api.get_senaite_setup().laboratory
         mime_msg = MIMEMultipart('related')
         mime_msg['Subject'] = self.title
         mime_msg['From'] = formataddr(

--- a/src/bika/lims/browser/worksheet/views/printview.py
+++ b/src/bika/lims/browser/worksheet/views/printview.py
@@ -214,7 +214,7 @@ class PrintView(BrowserView):
                   accreditation_body, accreditation_logo, logo
         """
         portal = self.context.portal_url.getPortalObject()
-        lab = self.context.bika_setup.laboratory
+        lab = api.get_senaite_setup().laboratory
         lab_address = lab.getPostalAddress() \
             or lab.getBillingAddress() \
             or lab.getPhysicalAddress()

--- a/src/bika/lims/profiles/default/structure/bika_setup/.objects
+++ b/src/bika/lims/profiles/default/structure/bika_setup/.objects
@@ -4,4 +4,3 @@ bika_analysisspecs,AnalysisSpecs
 bika_instruments,Instruments
 bika_labcontacts,LabContacts
 bika_referencedefinitions,ReferenceDefinitions
-laboratory,Laboratory

--- a/src/senaite/core/browser/worksheets/worksheet/printview.py
+++ b/src/senaite/core/browser/worksheets/worksheet/printview.py
@@ -223,7 +223,7 @@ class PrintView(BrowserView):
                   accreditation_body, accreditation_logo, logo
         """
         portal = self.context.portal_url.getPortalObject()
-        lab = self.context.bika_setup.laboratory
+        lab = api.get_senaite_setup().laboratory
         lab_address = lab.getPostalAddress() \
             or lab.getBillingAddress() \
             or lab.getPhysicalAddress()

--- a/src/senaite/core/content/senaitesetup.py
+++ b/src/senaite/core/content/senaitesetup.py
@@ -2532,16 +2532,3 @@ class Setup(Container):
         """Return true if the rejection workflow is enabled
         """
         return self.getEnableRejectionWorkflow()
-
-    @property
-    def laboratory(self):
-        """Get the laboratory object via acquisition
-        The laboratory is stored in bika_setup which is in the portal root
-        """
-        bika_setup = api.get_bika_setup()
-        if bika_setup:
-            return bika_setup.laboratory
-        # when we finally migrated it...
-        elif "laboratory" in self.objectIds():
-            return self["laboratry"]
-        return None

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2736</version>
+  <version>2737</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-senaite.impress:default</dependency>

--- a/src/senaite/core/tests/doctests/Permissions.rst
+++ b/src/senaite/core/tests/doctests/Permissions.rst
@@ -147,15 +147,14 @@ Laboratory
 ..........
 
 The Laboratory object holds all needed information about the lab itself.
-It lives inside the `bika_setup` folder.
+It lives inside the `setup` folder.
 
 Test Workflow
 ~~~~~~~~~~~~~
 
-A `laboratory` lives in the root of a bika installation, or more precisely, the
-portal object::
+A `laboratory` lives inside the `setup` folder::
 
-    >>> laboratory = portal.bika_setup.laboratory
+    >>> laboratory = portal.setup.laboratory
 
 The `laboratory` folder follows the `senaite_laboratory_workflow` and is
 initially in the `active` state::

--- a/src/senaite/core/tests/doctests/ShowPrices.rst
+++ b/src/senaite/core/tests/doctests/ShowPrices.rst
@@ -49,7 +49,7 @@ Variables:
     >>> portal = self.portal
     >>> setup = portal.setup
     >>> bikasetup = portal.bika_setup
-    >>> laboratory = bikasetup.laboratory
+    >>> laboratory = setup.laboratory
     >>> portal_url = portal.absolute_url()
 
 We need certain permissions to create and access objects used in this test,

--- a/src/senaite/core/tests/test_laboratory_consolidation.py
+++ b/src/senaite/core/tests/test_laboratory_consolidation.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.lims import api
+from plone.dexterity.utils import createContent
+from plone.registry.interfaces import IRegistry
+from Products.CMFPlone.interfaces import IEditingSchema
+from senaite.core.tests.base import BaseTestCase
+from senaite.core.upgrade.v02_07_000 import consolidate_laboratory
+from zope.component import getUtility
+
+
+class TestLaboratoryConsolidation(BaseTestCase):
+    """Regression tests for the duplicate Laboratory object
+
+    The Laboratory must live as a single DX object at `setup/laboratory`.
+    A stale `setup/laboratory-1` and/or a `bika_setup/laboratory` must not
+    survive.
+    """
+
+    def setUp(self):
+        super(TestLaboratoryConsolidation, self).setUp()
+        # Disable link-integrity: low-level (un)containment of the setup
+        # folder in the test harness fires the linkintegrity retriever on
+        # a RequestContainer, which is unrelated to what we test here.
+        registry = getUtility(IRegistry)
+        editing = registry.forInterface(IEditingSchema, prefix="plone")
+        editing.enable_link_integrity_checks = False
+
+    def get_laboratory_ids(self, container):
+        return [oid for oid in container.objectIds()
+                if api.get_portal_type(container._getOb(oid)) == "Laboratory"]
+
+    def test_profile_creates_single_laboratory_in_setup(self):
+        setup = api.get_senaite_setup()
+        bika_setup = api.get_bika_setup()
+
+        # exactly one Laboratory, in setup, with the canonical id
+        self.assertEqual(self.get_laboratory_ids(setup), ["laboratory"])
+        self.assertNotIn("laboratory-1", setup.objectIds())
+        self.assertEqual(self.get_laboratory_ids(bika_setup), [])
+
+        # the accessor resolves to the contained DX object
+        lab = api.get_senaite_setup().laboratory
+        self.assertEqual(api.get_id(lab), "laboratory")
+        self.assertEqual(api.get_parent(lab), setup)
+
+    def test_consolidate_keeps_data_lab_and_removes_duplicates(self):
+        setup = api.get_senaite_setup()
+        bika_setup = api.get_bika_setup()
+
+        # Reproduce the reported state: the data-bearing Laboratory lives
+        # in bika_setup (where the old `laboratory` property pointed) and
+        # an empty `setup/laboratory-1` was left behind.
+        if "laboratory" in setup.objectIds():
+            setup._delObject("laboratory")
+
+        data_lab = createContent(
+            "Laboratory", id="laboratory", title="My Real Lab")
+        bika_setup._setObject("laboratory", data_lab)
+
+        empty_lab = createContent(
+            "Laboratory", id="laboratory-1", title="Laboratory")
+        setup._setObject("laboratory-1", empty_lab)
+
+        consolidate_laboratory(api.get_tool("portal_setup"))
+
+        # single Laboratory at setup/laboratory holding the real data
+        self.assertEqual(self.get_laboratory_ids(setup), ["laboratory"])
+        self.assertEqual(self.get_laboratory_ids(bika_setup), [])
+        lab = setup._getOb("laboratory")
+        self.assertEqual(api.get_title(lab), "My Real Lab")
+
+    def test_consolidate_is_idempotent(self):
+        setup = api.get_senaite_setup()
+
+        # already in the consolidated state
+        consolidate_laboratory(api.get_tool("portal_setup"))
+
+        self.assertEqual(self.get_laboratory_ids(setup), ["laboratory"])
+
+
+def test_suite():
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestLaboratoryConsolidation))
+    return suite

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -1062,7 +1062,19 @@ def migrate_laboratory_to_dx(tool):
         logger.info(
             "Laboratory already migrated: {}".format(api.get_path(src)))
         return
+
     destination = api.get_senaite_setup()
+    migrate_at_laboratory_to_dx(src, destination)
+
+    logger.info("Convert Laboratory to Dexterity [DONE]")
+
+
+def migrate_at_laboratory_to_dx(src, destination):
+    """Create a DX Laboratory in `destination` from the AT `src`, copy all
+    data over, remove the AT source and adopt its id. Returns the new DX
+    Laboratory object.
+    """
+    portal_type = "Laboratory"
     target_id = tmpID()
 
     target = destination.get(target_id)
@@ -1160,7 +1172,92 @@ def migrate_laboratory_to_dx(tool):
     target.reindexObject()
 
     logger.info("Migrated Laboratory from %s -> %s" % (src, target))
-    logger.info("Convert Laboratory to Dexterity [DONE]")
+    return target
+
+
+def get_laboratory_objects(containers):
+    """Return all Laboratory objects contained in the given containers
+    """
+    laboratories = []
+    for container in containers:
+        if container is None:
+            continue
+        for object_id in list(container.objectIds()):
+            obj = container._getOb(object_id, None)
+            if obj is None:
+                continue
+            if api.get_portal_type(obj) == "Laboratory":
+                laboratories.append(obj)
+    return laboratories
+
+
+def pick_primary_laboratory(setup, bika_setup):
+    """Pick the Laboratory that holds the live data
+
+    The former `SenaiteSetup.laboratory` property returned
+    `bika_setup.laboratory`, so any data entered through the UI lives
+    there. Fall back to the setup folder otherwise.
+    """
+    candidates = []
+    if bika_setup is not None and "laboratory" in bika_setup.objectIds():
+        candidates.append(bika_setup._getOb("laboratory"))
+    if "laboratory" in setup.objectIds():
+        candidates.append(setup._getOb("laboratory"))
+    if "laboratory-1" in setup.objectIds():
+        candidates.append(setup._getOb("laboratory-1"))
+    # any other Laboratory as last resort
+    candidates.extend(get_laboratory_objects([setup, bika_setup]))
+    return candidates[0] if candidates else None
+
+
+def consolidate_laboratory(tool):
+    """Consolidate duplicate Laboratory objects into a single
+    `setup/laboratory`
+
+    The Laboratory was only half-moved into the DX `setup` folder: the
+    bika.lims structure profile still created `bika_setup/laboratory`
+    and `add_dexterity_setup_items` produced an empty `setup/laboratory-1`
+    (the `laboratory` id was blocked by the former
+    `SenaiteSetup.laboratory` property). This keeps the single
+    data-bearing Laboratory, migrates it to DX inside `setup` if needed,
+    removes the duplicates and ensures the canonical id `laboratory`.
+    """
+    logger.info("Consolidate Laboratory ...")
+
+    setup = api.get_senaite_setup()
+    bika_setup = api.get_bika_setup()
+
+    primary = pick_primary_laboratory(setup, bika_setup)
+    if primary is None:
+        logger.warning("No Laboratory object found, nothing to consolidate")
+        return
+
+    primary_uid = api.get_uid(primary)
+
+    # Remove every other Laboratory so the `laboratory` id becomes free
+    for lab in get_laboratory_objects([setup, bika_setup]):
+        if api.get_uid(lab) == primary_uid:
+            continue
+        logger.info("Removing duplicate Laboratory: %s" % api.get_path(lab))
+        api.delete(lab, check_permissions=False)
+
+    # Ensure the type is allowed in the setup folder
+    permanently_allow_type_for(api.get_portal_type(setup), "Laboratory")
+
+    # Ensure the primary is a DX object living in the setup folder
+    if api.is_at_content(primary):
+        primary = migrate_at_laboratory_to_dx(primary, setup)
+    elif api.get_path(api.get_parent(primary)) != api.get_path(setup):
+        primary = api.move_object(primary, setup, check_constraints=False)
+
+    # Ensure the canonical id is `laboratory`
+    if api.get_id(primary) != "laboratory":
+        parent = api.get_parent(primary)
+        parent.manage_renameObject(api.get_id(primary), "laboratory")
+        primary = parent._getOb("laboratory")
+
+    primary.reindexObject()
+    logger.info("Consolidate Laboratory [DONE]: %s" % api.get_path(primary))
 
 
 LABORATORY_IMAGE_FIELDS = (

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -3,6 +3,17 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.7.0: Consolidate duplicate Laboratory objects"
+      description="Keep a single Laboratory at setup/laboratory, migrate it
+                   to Dexterity if needed and remove the empty duplicate
+                   (e.g. laboratory-1) left behind by the half-finished
+                   Laboratory-to-DX migration."
+      source="2736"
+      destination="2737"
+      handler=".v02_07_000.consolidate_laboratory"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Rename 'Duplicate' transition title to 'Duplicate Sample'"
       description="Re-import the workflow so the new transition title
                    replaces the previous bare 'Duplicate' label, which


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

After the Laboratory was migrated to Dexterity, two `Laboratory` objects were created on every install:

- `bika_setup/laboratory` — still created by the bika.lims structure profile and returned by the `SenaiteSetup.laboratory` property, so it received all data (including the Lab Information demo import from #2918).
- `setup/laboratory-1` — created empty by `add_dexterity_setup_items`. The `laboratory` id was blocked by the `SenaiteSetup.laboratory` `@property`, so Plone's name chooser (`check_id`) appended the `-1` suffix.

This was a half-finished move of the Laboratory into the DX `setup` folder (#2810 / #2821): the property still pointed at `bika_setup`, the structure profile still created `bika_setup/laboratory`, and the property/contained-object id collision blocked the intended `setup/laboratory`. It is a real duplicate object, not a `@@lims-setup` view artifact.

## Current behavior before PR

Two `Laboratory` objects exist: a populated `bika_setup/laboratory` and an empty `setup/laboratory-1`.

```
setup.objectIds():       [..., 'laboratory-1', ...]   # empty
bika_setup.objectIds():  [..., 'laboratory']          # populated
setup.laboratory         -> bika_setup/laboratory (via the property)
```

## Desired behavior after PR is merged

A single canonical Laboratory lives at `setup/laboratory` (DX), and `setup.laboratory` resolves to it.

- Remove the `SenaiteSetup.laboratory` `@property` so the contained DX child can use the `laboratory` id and `setup.laboratory` resolves to it via containment.
- Drop the `laboratory` entry from the bika.lims `bika_setup` structure profile so it is no longer created there.
- Repoint the remaining `bika_setup.laboratory` accessors to `api.get_senaite_setup().laboratory`.
- Add a `consolidate_laboratory` upgrade step (2736 -> 2737) for existing instances: keep the data-bearing Laboratory (the one the property pointed at), migrate it to Dexterity inside `setup` if needed, remove the duplicates, and adopt the canonical `laboratory` id. `migrate_laboratory_to_dx` is refactored to reuse a `migrate_at_laboratory_to_dx` helper.
- Add regression tests covering the fresh-install state, consolidation of an existing duplicate, and idempotency.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html