### PR TITLE
Initialize unset RichText schema fields in api.create

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2922 Initialize unset Dexterity schema fields in api.create so ObjectAddedEvent subscribers don't read through acquisition
 - #2918 Fix Lab Information setup data import after Laboratory migration to Dexterity
 - #2917 Fix `ClientID` is not displayed in samples listing, but client name
 - #2916 Fix msgid collision on `description_calculation_imports` in Calculation content type

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -41,6 +41,7 @@ from OFS.event import ObjectWillBeMovedEvent
 from plone import api as ploneapi
 from plone.api.exc import InvalidParameterError
 from plone.app.layout.viewlets.content import ContentHistoryView
+from plone.app.textfield import RichText
 from plone.behavior.interfaces import IBehaviorAssignable
 from plone.behavior.registration import lookup_behavior_registration
 from plone.dexterity.interfaces import IDexterityContent
@@ -240,6 +241,15 @@ def create(container, portal_type, *args, **kwargs):
         content = createContent(portal_type, id=id or tmp_id, title=title,
                                 **other_kwargs)
 
+        # Initialize the remaining schema fields so the object is fully
+        # formed *before* addContentToContainer fires ObjectAddedEvent.
+        # createContent() does not initialize schema fields, so they stay
+        # absent as instance attributes. A subscriber that reads such a
+        # field (e.g. plone.app.linkintegrity reading RichText fields)
+        # would otherwise trigger an attribute lookup that falls through
+        # acquisition to the request container and raises AttributeError.
+        initialize_schema_fields(content, schema_fields, skip=field_kwargs)
+
         # Pause snapshots to prevent ObjectAddedEvent from creating
         # an incomplete snapshot (fields not yet set)
         pause_snapshots_for(content)
@@ -268,6 +278,43 @@ def create(container, portal_type, *args, **kwargs):
         notify(AfterAPICreatedObjectEvent(obj))
 
     return obj
+
+
+def initialize_schema_fields(content, fields, skip=None):
+    """Initialize unset RichText schema fields to their missing_value
+
+    `plone.dexterity.utils.createContent` does not initialize schema
+    fields, so they remain absent as instance attributes until written.
+    `plone.app.linkintegrity` reads every RichText field of an object on
+    `ObjectAddedEvent` through a raw attribute lookup; for an unset field
+    that lookup falls through acquisition to the request container and
+    raises AttributeError, which aborts object creation (e.g. during site
+    setup). Assigning the RichText fields their `missing_value` makes the
+    object fully formed before it is added to its container.
+
+    Only RichText fields are touched on purpose: they are the field type
+    link integrity inspects, and initializing unrelated fields would
+    change the empty-state semantics other code relies on. Field defaults
+    are not materialized here either, because some `defaultFactory`
+    callables depend on the object already being placed (e.g. the Setup
+    publication email body renders a view bound to the not-yet-created
+    setup); the content types apply their defaults lazily through their
+    accessors anyway.
+
+    :param content: the freshly created (not yet contained) DX object
+    :param fields: name -> field mapping for the content's portal type
+    :param skip: field names to leave untouched (e.g. provided kwargs)
+    """
+    skip = skip or []
+    for name, field in fields.items():
+        if name in skip or field.readonly:
+            continue
+        if not isinstance(field, RichText):
+            continue
+        # leave fields that are already set as instance attributes
+        if name in content.__dict__:
+            continue
+        setattr(content, name, field.missing_value)
 
 
 def copy_object(source, container=None, portal_type=None, *args, **kwargs):

--- a/src/senaite/core/tests/test_api_create_schema_defaults.py
+++ b/src/senaite/core/tests/test_api_create_schema_defaults.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from bika.lims import api
+from plone.app.linkintegrity.retriever import DXGeneral
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from senaite.core.tests.base import BaseTestCase
+from senaite.core.upgrade.utils import temporary_allow_type
+
+
+class TestAPICreateSchemaDefaults(BaseTestCase):
+    """api.create must initialize DX schema fields so the object is fully
+    formed before ObjectAddedEvent fires (regression for the link
+    integrity retriever crashing on unset RichText fields during site
+    creation).
+    """
+
+    def setUp(self):
+        super(TestAPICreateSchemaDefaults, self).setUp()
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+    def create_setup(self, obj_id):
+        with temporary_allow_type(self.portal, "Setup"):
+            return api.create(
+                self.portal, "Setup", id=obj_id, title="Test Setup")
+
+    def test_richtext_field_is_initialized_on_create(self):
+        setup = self.create_setup("setup_init")
+        # the RichText field must be a real instance attribute, so a raw
+        # getattr does not fall through acquisition to the request
+        # container
+        self.assertIn("email_body_sample_publication", setup.__dict__)
+
+    def test_link_integrity_retriever_does_not_crash(self):
+        # This reproduces the exact path that broke site creation: the
+        # link integrity retriever reads the RichText fields of the newly
+        # added object via a raw getattr.
+        setup = self.create_setup("setup_links")
+        retriever = DXGeneral(setup)
+        # must not raise AttributeError
+        links = retriever.retrieveLinks()
+        self.assertIsInstance(links, set)
+
+
+def test_suite():
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestAPICreateSchemaDefaults))
+    return suite


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Creating a new SENAITE site fails while the `SENAITE Setup` folder is created:

```
AttributeError: 'RequestContainer' object has no attribute 'email_body_sample_publication'
```

Root cause: `plone.dexterity.utils.createContent` does not initialize schema fields, so they stay absent as instance attributes until written. On `ObjectAddedEvent` (fired by `addContentToContainer`), `plone.app.linkintegrity` reads every RichText field of the new object through a raw attribute lookup. For an unset field, that lookup falls through acquisition to the request container and raises, aborting object creation.

This is independent of content type: it affects any DX object created via `api.create` that has a RichText field, once link integrity is active during creation (intid/relation catalog present).

## Current behavior before PR

Creating a DX object with a RichText field via `api.create` while link integrity is active raises `AttributeError` from the link integrity retriever, because the RichText fields are not yet materialized when `ObjectAddedEvent` fires.

## Desired behavior after PR is merged

`api.create` assigns each unset RichText field its `missing_value` right after `createContent` and before `addContentToContainer`, so the object is fully formed before the event fires. The retriever then reads `None` instead of falling through acquisition.

Implementation notes:

- Only RichText fields are touched on purpose: they are the field type link integrity inspects, and initializing unrelated fields changes the empty-state semantics other code relies on (initializing all fields broke ~50 doctests in testing).
- Field `defaultFactory` defaults are intentionally not materialized: some depend on the object already being placed (e.g. the Setup publication email body renders a view bound to the not-yet-created setup). The content types apply their defaults lazily through their accessors anyway.
- Added a regression test that creates a `Setup` via `api.create` and runs `plone.app.linkintegrity`'s retriever against it, asserting it does not raise.

The full `senaite.core.tests` suite passes (151 tests, 0 failures).

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html