### PR TITLE
Fix CopyError when migrating AT laboratory to DX

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2923 Fix CopyError when migrating AT laboratory to DX
 - #2921 Fix duplicate Laboratory object by making setup/laboratory the single canonical Laboratory
 - #2922 Initialize unset Dexterity schema fields in api.create so ObjectAddedEvent subscribers don't read through acquisition
 - #2919 Enforce the AccessJSONAPI permission on state-changing JSON API routes

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -1075,9 +1075,10 @@ def migrate_at_laboratory_to_dx(src, destination):
     Laboratory object.
     """
     portal_type = "Laboratory"
+    src_id = api.get_id(src)
     target_id = tmpID()
 
-    target = destination.get(target_id)
+    target = destination.get(src_id)
     if not target:
         # Don't use the api to skip the auto-id generation
         target = createContent(portal_type, id=target_id)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a traceback that occurs when migrating Laboratory AT content to DX (upgrade step 2731).

Got the traceback on a migration from `2706 → 2737`.

## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 666, in __call__
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 399, in upgrade_product
  Module Products.GenericSetup.tool, line 1202, in upgradeProfile
  Module Products.GenericSetup.upgrade, line 185, in doStep
  Module senaite.core.upgrade.v02_07_000, line 1067, in migrate_laboratory_to_dx
  Module senaite.core.upgrade.v02_07_000, line 1170, in migrate_at_laboratory_to_dx
  Module senaite.core.migration.migrator, line 114, in copy_id
  Module plone.folder.ordered, line 202, in manage_renameObject
  Module OFS.CopySupport, line 363, in manage_renameObject
CopyError: Invalid Id
```

## Desired behavior after PR is merged

No traceback, laboratory properly migrated to DX under `setup`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
