### PR TITLE
Fix login traceback that blocks running upgrade step 2731

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2924 Fix login traceback that blocks running upgrade step 2731
 - #2923 Fix CopyError when migrating AT laboratory to DX
 - #2921 Fix duplicate Laboratory object by making setup/laboratory the single canonical Laboratory
 - #2922 Initialize unset Dexterity schema fields in api.create so ObjectAddedEvent subscribers don't read through acquisition

--- a/src/senaite/core/browser/login/login.py
+++ b/src/senaite/core/browser/login/login.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims import api
+from senaite.core import logger
 from Products.CMFPlone.browser.login.login import LoginForm as BaseLoginForm
 
 
@@ -46,5 +47,14 @@ class LoginForm(BaseLoginForm):
 
     @property
     def lab_name(self):
-        lab = api.get_senaite_setup().laboratory
-        return api.get_title(lab)
+        try:
+            lab = api.get_senaite_setup().laboratory
+            return api.get_title(lab)
+        except AttributeError as e:
+            # This might happen if the upgrade step 2731 in charge of migrating
+            # Laboratory AT content type to DX has not been run yet and the
+            # setting "ShowLabNameInLogin" was set to True in setup.
+            # User cannot login, so is not possible to run the migration step
+            # See https://github.com/senaite/senaite.core/pull/2924
+            logger.error("setup.laboratory not found: %s" % str(e))
+            return ""


### PR DESCRIPTION
When `ShowLabNameInLogin` is enabled in setup and the upgrade step 2731 (migration of the `Laboratory` AT content type to Dexterity) has not yet run, the login page raises an `AttributeError: 'RequestContainer' object has no attribute 'laboratory'` while resolving `view.lab_name` in `login.pt`. Because the user cannot log in, they also cannot trigger the upgrade step that would resolve the underlying schema mismatch — the instance is effectively locked out.

## Current behavior before PR

`LoginForm.lab_name` calls `api.get_senaite_setup().laboratory` and `api.get_title(lab)` unconditionally. If `setup.laboratory` is not yet available (pre-2731 state), the chameleon template render fails with:

```
AttributeError: 'RequestContainer' object has no attribute 'laboratory'
```
and the `/login` view returns a 500, preventing the admin from authenticating and running the migration.

## Desired behavior after PR is merged

`LoginForm.lab_name` catches the `AttributeError`, logs the failure, and returns an empty string. The login page renders, the admin can sign in, and the upgrade step 2731 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
