### PR TITLE
Add 'reattach' workflow transition to re-link detached partitions to their primary

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2925 Add 'reattach' workflow transition to re-link detached partitions to their primary
 - #2924 Fix login traceback that blocks running upgrade step 2731
 - #2923 Fix CopyError when migrating AT laboratory to DX
 - #2921 Fix duplicate Laboratory object by making setup/laboratory the single canonical Laboratory

--- a/src/bika/lims/workflow/analysisrequest/events.py
+++ b/src/bika/lims/workflow/analysisrequest/events.py
@@ -227,6 +227,33 @@ def after_detach(analysis_request):
     map(lambda an: an.reindexObject(), analyses)
 
 
+def after_reattach(analysis_request):
+    """Function triggered after "reattach" transition is performed.
+
+    Inverse of after_detach: restores the partition link to the original
+    primary sample, clears the DetachedFrom backref and swaps the
+    IDetachedPartition marker back to IAnalysisRequestPartition.
+    """
+    parent = analysis_request.getDetachedFrom()
+
+    # Restore the partition link to the primary
+    analysis_request.setParentAnalysisRequest(parent)
+    analysis_request.setDetachedFrom(None)
+
+    # Swap markers: no longer a detached primary, back to being a partition
+    noLongerProvides(analysis_request, IDetachedPartition)
+    alsoProvides(analysis_request, IAnalysisRequestPartition)
+
+    # Reindex both the parent and the reattached partition
+    analysis_request.reindexObject()
+    parent.reindexObject()
+
+    # The parent's aranalysesfield aggregates analyses via catalog search,
+    # so reindex the partition's analyses to make them visible to the parent
+    analyses = analysis_request.getAnalyses(full_objects=True)
+    map(lambda an: an.reindexObject(), analyses)
+
+
 def after_dispatch(sample):
     """Event triggered after "dispatch" transition takes place for a given sample
     """

--- a/src/bika/lims/workflow/analysisrequest/guards.py
+++ b/src/bika/lims/workflow/analysisrequest/guards.py
@@ -20,6 +20,7 @@
 
 from bika.lims import api
 from bika.lims.interfaces import IAnalysisRequest
+from bika.lims.interfaces import IDetachedPartition
 from bika.lims.interfaces import IInternalUse
 from bika.lims.interfaces import IRejected
 from bika.lims.interfaces import IRetracted
@@ -241,6 +242,26 @@ def guard_detach(analysis_request):
     """
     # Detach transition can only be done to partitions
     return analysis_request.isPartition()
+
+
+def guard_reattach(analysis_request):
+    """Returns whether 'reattach' transition can be performed or not.
+
+    Only allowed on samples previously detached via the 'detach' transition,
+    when the original parent is still reachable and both share the same
+    review state. The same-state check keeps the partition consistent with
+    the parent's state machine after re-attaching.
+    """
+    if not IDetachedPartition.providedBy(analysis_request):
+        return False
+
+    parent = analysis_request.getDetachedFrom()
+    if not parent:
+        return False
+
+    parent_state = api.get_workflow_status_of(parent)
+    sample_state = api.get_workflow_status_of(analysis_request)
+    return parent_state == sample_state
 
 
 def guard_dispatch(sample):

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2737</version>
+  <version>2738</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-senaite.impress:default</dependency>

--- a/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
+++ b/src/senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
@@ -414,6 +414,7 @@
     <!-- TRANSITIONS -->
     <exit-transition transition_id="cancel"/>
     <exit-transition transition_id="detach" />
+    <exit-transition transition_id="reattach" />
     <exit-transition transition_id="receive"/>
     <exit-transition transition_id="submit"/>
     <exit-transition transition_id="reject" />
@@ -509,6 +510,7 @@
     <!-- TRANSITIONS -->
     <exit-transition transition_id="cancel"/>
     <exit-transition transition_id="detach"/>
+    <exit-transition transition_id="reattach"/>
     <exit-transition transition_id="prepublish"/>
     <exit-transition transition_id="submit"/>
     <exit-transition transition_id="reject" />
@@ -606,6 +608,7 @@
     <exit-transition transition_id="reject" />
     <exit-transition transition_id="rollback_to_receive" />
     <exit-transition transition_id="detach" />
+    <exit-transition transition_id="reattach" />
     <exit-transition transition_id="create_partitions" />
     <exit-transition transition_id="dispatch" />
     <exit-transition transition_id="multi_results"/>
@@ -707,6 +710,7 @@
     <exit-transition transition_id="preserve"/>
     <exit-transition transition_id="reject" />
     <exit-transition transition_id="detach" />
+    <exit-transition transition_id="reattach" />
     <exit-transition transition_id="dispatch" />
     <exit-transition transition_id="multi_results"/>
     <exit-transition transition_id="duplicate_sample"/>
@@ -797,6 +801,7 @@
     <exit-transition transition_id="invalidate" />
     <exit-transition transition_id="rollback_to_receive" />
     <exit-transition transition_id="detach" />
+    <exit-transition transition_id="reattach" />
     <exit-transition transition_id="create_partitions" />
     <exit-transition transition_id="dispatch" />
     <exit-transition transition_id="multi_results"/>
@@ -1562,6 +1567,26 @@
     <action url="" category="workflow" icon="">Detach</action>
     <guard>
       <guard-expression>python:here.guard_handler("detach")</guard-expression>
+      <guard-permission>senaite.core: Transition: Detach Sample Partition</guard-permission>
+    </guard>
+  </transition>
+
+  <!-- Transition: Reattach
+       Inverse of "detach": restores the partition link from a detached
+       sample back to its original primary. The guard limits this to
+       samples that still carry IDetachedPartition, whose original primary
+       is still reachable, and whose review state matches the primary's
+       state — so re-merging cannot break the parent's state machine.
+
+       Like "detach", this transition has no new_state and therefore does
+       not change the current state of the object.
+  -->
+  <transition transition_id="reattach" title="Reattach" new_state=""
+              trigger="USER" before_script="" after_script=""
+              i18n:attributes="title">
+    <action url="" category="workflow" icon="">Reattach</action>
+    <guard>
+      <guard-expression>python:here.guard_handler("reattach")</guard-expression>
       <guard-permission>senaite.core: Transition: Detach Sample Partition</guard-permission>
     </guard>
   </transition>

--- a/src/senaite/core/tests/doctests/SampleReattach.rst
+++ b/src/senaite/core/tests/doctests/SampleReattach.rst
@@ -148,6 +148,35 @@ allowed:
     False
 
 
+Reattach coexists with siblings created in the meantime
+.......................................................
+
+Building on the previous step, the partition is detached again,
+a fresh partition is created on the primary (which picks up the
+next counter value), and the detached one is then reattached.
+Both partitions must coexist with unique IDs:
+
+    >>> _ = do_action_for(partition, "detach")
+    >>> partition_id = partition.getId()
+    >>> sibling = create_partition(primary, request, primary.getAnalyses())
+    >>> sibling.getId() != partition_id
+    True
+    >>> success, message = do_action_for(partition, "reattach")
+    >>> success
+    True
+    >>> partition.getParentAnalysisRequest() == primary
+    True
+    >>> descendant_ids = sorted(d.getId() for d in primary.getDescendants())
+    >>> descendant_ids == sorted([partition_id, sibling.getId()])
+    True
+
+The partition's original ID survives the round-trip — `reattach`
+only restores the parent link, it does not rename:
+
+    >>> partition.getId() == partition_id
+    True
+
+
 Guard rejects when parent and detached sample drift apart
 .........................................................
 

--- a/src/senaite/core/tests/doctests/SampleReattach.rst
+++ b/src/senaite/core/tests/doctests/SampleReattach.rst
@@ -166,8 +166,15 @@ Both partitions must coexist with unique IDs:
     True
     >>> partition.getParentAnalysisRequest() == primary
     True
+
+The reattached partition coexists with the partitions that were
+created in the meantime — both `fresh` (from the previous step) and
+`sibling`:
+
     >>> descendant_ids = sorted(d.getId() for d in primary.getDescendants())
-    >>> descendant_ids == sorted([partition_id, sibling.getId()])
+    >>> expected = sorted(
+    ...     [partition_id, fresh.getId(), sibling.getId()])
+    >>> descendant_ids == expected
     True
 
 The partition's original ID survives the round-trip — `reattach`

--- a/src/senaite/core/tests/doctests/SampleReattach.rst
+++ b/src/senaite/core/tests/doctests/SampleReattach.rst
@@ -1,0 +1,175 @@
+Sample reattach
+---------------
+
+The `reattach` workflow transition is the inverse of `detach`. It
+re-links a previously detached partition back to its original primary
+sample. The guard only allows the transition when the original primary
+is still reachable and both samples share the same review state, so
+re-merging cannot break the parent's state machine.
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t SampleReattach
+
+
+Test Setup
+..........
+
+Imports:
+
+    >>> from DateTime import DateTime
+    >>> from bika.lims import api
+    >>> from bika.lims.interfaces import IAnalysisRequestPartition
+    >>> from bika.lims.interfaces import IDetachedPartition
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.utils.analysisrequest import create_partition
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+    >>> from bika.lims.workflow import isTransitionAllowed
+
+Functional helpers:
+
+    >>> def timestamp(format="%Y-%m-%d"):
+    ...     return DateTime().strftime(format)
+
+Variables:
+
+    >>> date_now = timestamp()
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = portal.setup
+    >>> bika_setup = portal.bika_setup
+    >>> sampletypes = setup.sampletypes
+    >>> analysiscategories = setup.analysiscategories
+    >>> bika_analysisservices = bika_setup.bika_analysisservices
+
+Test user — Lab Manager:
+
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import setRoles
+    >>> setRoles(portal, TEST_USER_ID, ['Manager', 'LabManager'])
+
+
+Setup Client, Contact, SampleType and AnalysisService
+.....................................................
+
+    >>> clients = self.portal.clients
+    >>> client = api.create(clients, "Client", Name="ACME", ClientID="A")
+    >>> contact = api.create(client, "Contact", Firstname="John", Surname="Doe")
+    >>> sampletype = api.create(sampletypes, "SampleType",
+    ...     Prefix="water", MinimumVolume="100 ml")
+    >>> category = api.create(analysiscategories, "AnalysisCategory",
+    ...     title="Water")
+    >>> service = api.create(bika_analysisservices, "AnalysisService",
+    ...     title="PH", ShortTitle="ph", Category=category, Keyword="PH")
+
+
+Create the primary Sample and partition it
+..........................................
+
+    >>> values = {
+    ...     "Client": client.UID(),
+    ...     "Contact": contact.UID(),
+    ...     "SamplingDate": date_now,
+    ...     "DateSampled": date_now,
+    ...     "SampleType": sampletype.UID(),
+    ... }
+    >>> primary = create_analysisrequest(client, request, values,
+    ...                                  [service.UID()])
+    >>> _ = do_action_for(primary, "receive")
+    >>> api.get_workflow_status_of(primary)
+    'sample_received'
+
+Create a partition off the primary:
+
+    >>> partition = create_partition(primary, request, primary.getAnalyses())
+    >>> IAnalysisRequestPartition.providedBy(partition)
+    True
+    >>> partition.getParentAnalysisRequest() == primary
+    True
+
+
+Detach the partition
+....................
+
+    >>> success, message = do_action_for(partition, "detach")
+    >>> success
+    True
+
+After detach the partition no longer points at the primary, it carries
+`IDetachedPartition` (and loses `IAnalysisRequestPartition`), and the
+`DetachedFrom` reference points back at the primary:
+
+    >>> partition.getParentAnalysisRequest() is None
+    True
+    >>> IDetachedPartition.providedBy(partition)
+    True
+    >>> IAnalysisRequestPartition.providedBy(partition)
+    False
+    >>> partition.getDetachedFrom() == primary
+    True
+
+
+Reattach the partition
+......................
+
+The guard accepts the transition because the primary is still
+reachable and both samples are in the same review state:
+
+    >>> isTransitionAllowed(partition, "reattach")
+    True
+
+    >>> success, message = do_action_for(partition, "reattach")
+    >>> success
+    True
+
+After reattach the link to the primary is restored, the markers are
+swapped back, and `DetachedFrom` is cleared:
+
+    >>> partition.getParentAnalysisRequest() == primary
+    True
+    >>> IAnalysisRequestPartition.providedBy(partition)
+    True
+    >>> IDetachedPartition.providedBy(partition)
+    False
+    >>> partition.getDetachedFrom() is None
+    True
+
+
+Guard rejects when the partition is not detached
+................................................
+
+A fresh partition has never been detached, so `reattach` is not
+allowed:
+
+    >>> fresh = create_partition(primary, request, primary.getAnalyses())
+    >>> IDetachedPartition.providedBy(fresh)
+    False
+    >>> isTransitionAllowed(fresh, "reattach")
+    False
+
+
+Guard rejects when parent and detached sample drift apart
+.........................................................
+
+Detach the partition again, then push the primary into a different
+review state. The guard must refuse the transition:
+
+    >>> _ = do_action_for(partition, "detach")
+    >>> IDetachedPartition.providedBy(partition)
+    True
+    >>> api.get_workflow_status_of(partition)
+    'sample_received'
+
+Move the primary to `to_be_verified` without touching the detached
+partition:
+
+    >>> from bika.lims.utils import changeWorkflowState
+    >>> _ = changeWorkflowState(
+    ...     primary, "senaite_sample_workflow", "to_be_verified")
+    >>> api.get_workflow_status_of(primary)
+    'to_be_verified'
+
+States differ — the guard rejects reattach:
+
+    >>> isTransitionAllowed(partition, "reattach")
+    False

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -271,6 +271,21 @@ def import_rolemap(tool):
 
 
 @upgradestep(product, version)
+def setup_reattach_transition(tool):
+    """Register the new 'reattach' workflow transition.
+
+    Re-imports the sample workflow so existing instances pick up
+    the 'reattach' transition (guarded by the existing
+    "Detach Sample Partition" permission) and the matching
+    exit-transitions on the live sample states.
+    """
+    portal = tool.aq_inner.aq_parent
+    setup = portal.portal_setup
+
+    setup.runImportStepFromProfile(profile, "workflow")
+
+
+@upgradestep(product, version)
 def setup_duplicate_sample_transition(tool):
     """Register the new 'duplicate_sample' workflow transition.
 

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -3,6 +3,17 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.7.0: Add 'reattach' workflow transition"
+      description="Register the reattach workflow transition that
+                   re-links a detached partition back to its primary.
+                   The transition reuses the existing
+                   'Detach Sample Partition' permission."
+      source="2737"
+      destination="2738"
+      handler=".v02_07_000.setup_reattach_transition"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Consolidate duplicate Laboratory objects"
       description="Keep a single Laboratory at setup/laboratory, migrate it
                    to Dexterity if needed and remove the empty duplicate

--- a/tweets/2026-05-29-PR2925.tweet
+++ b/tweets/2026-05-29-PR2925.tweet
@@ -1,0 +1,5 @@
+SENAITE partitions can now be reattached to their primary sample.
+A new workflow transition restores the link to the original
+parent — symmetrical with detach and guarded by a same-state
+check, so re-merging never breaks the parent's workflow.
+https://github.com/senaite/senaite.core/pull/2925

--- a/tweets/2026-05-29-PR2925.tweet
+++ b/tweets/2026-05-29-PR2925.tweet
@@ -1,5 +1,0 @@
-SENAITE partitions can now be reattached to their primary sample.
-A new workflow transition restores the link to the original
-parent — symmetrical with detach and guarded by a same-state
-check, so re-merging never breaks the parent's workflow.
-https://github.com/senaite/senaite.core/pull/2925


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Follow-up to #2886. With #2886, detaching a partition no longer collides on partition IDs — but detach is still a one-way door. This PR adds the inverse `reattach` transition so a previously detached partition can be re-linked to its original primary sample.

## Current behavior before PR

`detach` unsets `ParentAnalysisRequest`, sets `DetachedFrom` to the primary, swaps the `IAnalysisRequestPartition` marker for `IDetachedPartition`, and turns the partition into a standalone primary sample. There is no built-in transition to undo that: the operator has to live with the detach decision or rebuild the partition by hand.

## Desired behavior after PR is merged

A new `reattach` workflow transition restores the partition link. The guard accepts the transition only when:

- the sample provides `IDetachedPartition` (i.e. it actually came out of a `detach`),
- the original primary referenced via `DetachedFrom` is still reachable, and
- both samples share the same review state.

The same-state check is the key guarantee: detach happens with both sides at the same state, so symmetric reattach can only succeed if the two haven't drifted. A detached partition that was independently received/submitted/published can no longer be re-merged into a primary that did not progress identically — and vice versa.

When the transition runs, `after_reattach` mirrors `after_detach`:

- `ParentAnalysisRequest` is set back to the original primary,
- `DetachedFrom` is cleared,
- `IDetachedPartition` is dropped and `IAnalysisRequestPartition` re-applied,
- the partition, the primary, and the partition's analyses are reindexed so the aggregated `getAnalyses` view on the primary picks them back up.

### Workflow wiring

- Transition `reattach` has empty `new_state` (same pattern as `detach`) so the partition keeps its current review state.
- Exit-transitions for `reattach` are added in the same five states where `detach` is exposed: `sample_due`, `sample_received`, `to_be_verified`, `to_be_preserved`, `verified`.
- The transition reuses the existing `senaite.core: Transition: Detach Sample Partition` permission — no new permission, no rolemap changes.

### Upgrade step

Profile version is bumped from `2737` to `2738`. The new `setup_reattach_transition` upgrade step re-imports the `workflow` step from the senaite.core profile so existing instances pick up the new transition and exit-transitions.

### Tests

New doctest `SampleReattach.rst` covers:

- the happy path (detach → reattach restores parent link and markers, clears `DetachedFrom`),
- the guard rejecting a fresh partition that was never detached, and
- the guard rejecting a detached partition once its review state has drifted from the primary's.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html