### PR TITLE
Strip surrounding whitespace from analysis unit choices so configuration typos don't break the round-trip

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2926 Strip surrounding whitespace from analysis unit choices so configuration typos don't break the round-trip
 - #2924 Fix login traceback that blocks running upgrade step 2731
 - #2923 Fix CopyError when migrating AT laboratory to DX
 - #2921 Fix duplicate Laboratory object by making setup/laboratory the single canonical Laboratory

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -559,7 +559,10 @@ class AnalysesView(ListingView):
         unit_choices = obj.getUnitChoices()
         vocab = []
         for unit in unit_choices:
-            value = unit.get("value", "")
+            # Strip surrounding whitespace so configuration typos like
+            # "mg/L " don't break the round-trip with the analysis's
+            # stored Unit value.
+            value = unit.get("value", "").strip()
             formatted = format_supsub_unicode(value)
             vocab.append({
                 "ResultValue": value,
@@ -738,7 +741,10 @@ class AnalysesView(ListingView):
         item['class']['service'] = 'service_title'
         item['service_uid'] = obj.getServiceUID
         item['Keyword'] = obj.getKeyword
-        item['Unit'] = format_supsub(obj.getUnit) if obj.getUnit else ''
+        # Strip surrounding whitespace from the stored Unit so it can
+        # match the (also-stripped) values in the unit choices dropdown.
+        unit = (obj.getUnit or "").strip()
+        item['Unit'] = format_supsub(unit) if unit else ''
         item['retested'] = obj.getRetestOfUID and True or False
         if self.is_analysis_edition_allowed(obj):
             modal_url = "{}/edit_analysis_modal".format(

--- a/src/senaite/core/browser/widgets/services_widget.py
+++ b/src/senaite/core/browser/widgets/services_widget.py
@@ -211,9 +211,12 @@ class ServicesWidget(DefaultListingWidget):
         :param service: A single service object
         :returns: A list of dicts
         """
+        # Strip surrounding whitespace from configured unit choices so
+        # typos like "mg/L " don't break the round-trip with the
+        # service/analysis stored Unit value.
         return [
-            {"ResultValue": u["value"], "ResultText": u["value"]}
-            for u in service.getUnitChoices()
+            {"ResultValue": value, "ResultText": value}
+            for value in (u["value"].strip() for u in service.getUnitChoices())
         ]
 
     def extract(self):
@@ -301,10 +304,13 @@ class ServicesWidget(DefaultListingWidget):
         item["Hidden"] = hidden
         item["replace"]["Hidden"] = _("Yes") if hidden else _("No")
 
-        # Apply unit settings
+        # Apply unit settings. Strip surrounding whitespace so the
+        # stored Unit matches the (also-stripped) values in the unit
+        # choices dropdown built by `get_unit_vocabulary`.
         unit = self.get_record_value(uid, "unit", obj.getUnit())
-        item["Unit"] = unit or ""
-        item["replace"]["Unit"] = unit and format_supsub(unit) or ""
+        unit = (unit or "").strip()
+        item["Unit"] = unit
+        item["replace"]["Unit"] = format_supsub(unit) if unit else ""
         unit_choices = self.get_unit_vocabulary(obj)
         if unit_choices:
             item["choices"]["Unit"] = unit_choices


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When an Analysis Service's *Units for Selection* (`UnitChoices`) contains an entry with stray leading/trailing whitespace (e.g. `"mg/L "` instead of `"mg/L"`), the analysis ends up with a stored `Unit` that does not match any of the dropdown options on the next reload. The result is a unit column that silently drifts to a different value after retract/reload, even though saving the correct unit appears to work in the moment.

## Current behavior before PR

`get_unit_vocabulary` builds the dropdown from `service.getUnitChoices()` and uses the configured `value` verbatim — whitespace included. The listing then sets `item['Unit']` from the analysis brain's stored `Unit` metadata, also verbatim. When the two strings differ only by whitespace, the rendered `<select>` cannot find a matching option, so the row shows whatever the listing falls back to (first option / empty) instead of the saved unit. Re-saving the right unit fixes it transiently, but any reload (e.g. after retract) re-renders from the same mismatched pair and the wrong value comes back.

This affects both consumers of `UnitChoices`:

- `bika.lims.browser.analyses.view.AnalysesView.get_unit_vocabulary` — the analysis results listing.
- `senaite.core.browser.widgets.services_widget.ServicesWidget.get_unit_vocabulary` — the AR Add/Edit services widget.

## Desired behavior after PR is merged

Both vocabulary builders strip surrounding whitespace on each `value` before emitting it as `ResultValue`/`ResultText`. The corresponding `item['Unit']` (the currently-selected value) is also stripped, in:

- `AnalysesView.folderitem` (`item['Unit'] = format_supsub(unit) if unit`), and
- `ServicesWidget.folderitem` (`item["Unit"]` + `item["replace"]["Unit"]`).

After the fix, a `UnitChoices` entry of `"mg/L "` and a stored analysis `Unit` of either `"mg/L"` or `"mg/L "` resolve to the same canonical `"mg/L"` token, so the dropdown correctly highlights the selected option and the value survives reloads / retract.

The stored values themselves are not migrated — operators can clean them up at their leisure — but the lookup path no longer breaks because of typos.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html