### PR TITLE
Sort analysis categories on the analysis specification listing by SortKey

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2927 Sort analysis categories on the analysis specification listing by SortKey
 - #2920 Fix TypeError in DynamicAnalysisSpec when xlsx has trailing empty headers
 - #2924 Fix login traceback that blocks running upgrade step 2731
 - #2923 Fix CopyError when migrating AT laboratory to DX

--- a/src/bika/lims/browser/widgets/analysisspecificationwidget.py
+++ b/src/bika/lims/browser/widgets/analysisspecificationwidget.py
@@ -68,6 +68,12 @@ class AnalysisSpecificationView(BikaListingView):
             self.show_categories = True
             self.expand_all_categories = False
 
+        # Track which category titles are referenced by the services in
+        # this listing. Resolved against the catalog-ordered set of all
+        # AnalysisCategory objects in `folderitems` so the rendered
+        # category groups follow the configured SortKey ordering.
+        self.found_categories = []
+
         # Operator Choices
         self.min_operator_choices = to_choices(MIN_OPERATORS)
         self.max_operator_choices = to_choices(MAX_OPERATORS)
@@ -189,7 +195,22 @@ class AnalysisSpecificationView(BikaListingView):
 
     def folderitems(self):
         items = super(AnalysisSpecificationView, self).folderitems()
-        self.categories.sort()
+        if self.show_categories_enabled():
+            # The AnalysisCategory `sortable_title` indexer folds SortKey
+            # into the value (see senaite.core.catalog.indexer.
+            # analysiscategory), so querying the setup catalog ordered
+            # by `sortable_title` gives the categories in SortKey order.
+            catalog = api.get_tool("senaite_catalog_setup")
+            brains = catalog({
+                "portal_type": "AnalysisCategory",
+                "sort_on": "sortable_title",
+            })
+            self.categories = [
+                b.Title for b in brains
+                if b.Title in self.found_categories
+            ]
+        else:
+            self.categories.sort()
         return items
 
     def folderitem(self, obj, item, index):
@@ -221,8 +242,8 @@ class AnalysisSpecificationView(BikaListingView):
         # get the category
         if self.show_categories_enabled():
             category = obj.getCategoryTitle()
-            if category not in self.categories:
-                self.categories.append(category)
+            if category not in self.found_categories:
+                self.found_categories.append(category)
             item["category"] = category
 
         item["Title"] = title


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Port of the long-standing #2191 (open since 2022). The analysis specification listing renders its category headings alphabetically, ignoring the SortKey configured on each `AnalysisCategory`. This PR sorts the visible category groups by SortKey so the specification editor matches the order configured in *Setup → Analysis Categories*.

## Current behavior before PR

`AnalysisSpecificationView.folderitems` ends with `self.categories.sort()` — a plain alphabetical sort over the strings appended in `folderitem`. The configured SortKey on each `AnalysisCategory` (a `FloatField` on the category type) is ignored, so labs that organize categories by reporting order rather than alphabetically see the wrong ordering in the specification edit view.

## Desired behavior after PR is merged

Category groups in the specification listing follow the SortKey order configured on the `AnalysisCategory` setup objects. Categories with no SortKey set fall back to the high default already used by the catalog indexer.

### How

- `folderitem` now appends the visited category title to a new `self.found_categories` list instead of writing directly into `self.categories`.
- `folderitems` resolves the rendering order by querying `senaite_catalog_setup` once for all `AnalysisCategory` brains sorted by `sortable_title`. The `AnalysisCategory` `sortable_title` indexer is already wired to `sortable_sortkey_title` in `senaite/core/catalog/indexer/analysiscategory.py`, so the catalog ordering folds in SortKey by construction. `self.categories` is then built by filtering that pre-sorted list down to the titles seen in this listing.
- When categorization is disabled (`getCategoriseAnalysisServices()` returns False) the previous plain `self.categories.sort()` path is preserved, since there is no SortKey concept to apply.

No new permissions, no schema changes, no upgrade step needed — the indexer this relies on already exists.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html