### PR TITLE
Fix ASTM consumer boundary bugs (sender shape, instrument cascade, sample fallback)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2928 Fix ASTM consumer boundary bugs (sender shape, instrument cascade, sample fallback)
 - #2920 Fix TypeError in DynamicAnalysisSpec when xlsx has trailing empty headers
 - #2924 Fix login traceback that blocks running upgrade step 2731
 - #2923 Fix CopyError when migrating AT laboratory to DX

--- a/src/senaite/core/astm/README.md
+++ b/src/senaite/core/astm/README.md
@@ -1,148 +1,161 @@
 # SENAITE ASTM Interface
 
-This package provides a JSON API endpoint and a results importer for the
-[senaite.astm](https://github.com/senaite/senaite.astm) middleware.
+This package receives instrument results from the
+[senaite.astm](https://github.com/senaite/senaite.astm) middleware and
+imports them into SENAITE.
+
+The middleware listens on TCP for lab instruments (ASTM frames or HL7 v2
+over MLLP), parses every session into a JSON envelope, and POSTs it to
+SENAITE's `@@API/senaite/v1/push` endpoint. This package is the
+consumer of that envelope.
 
 
-## JSON Message Format 
+## Envelope format
 
-The required message format of this interface is JSON.
-
-One JSON format comes in the following format:
+The current contract is the **2.x envelope**: one top-level dict with a
+`metadata` block and per-record-type buckets, every bucket a list of
+dicts.
 
     {
-        u'H': [{...}],
-        u'P': [{...}],
-        u'O': [{...}],
-        u'R': [{...}, ...],
-        u'C': [{...}, ...],
-        u'M': [{...}, ...],
-        u'Q': [{...}, ...],
-        u'L': [{...}]
+        "metadata": {
+            "envelope_version": "1.1",
+            "astm":   "<raw ASTM frames>",
+            "lis2a":  "<raw LIS2-A payload>",
+            "hl7":    "<raw HL7 v2 payload>"
+        },
+        "H": [{...}],    # Header
+        "P": [{...}],    # Patient
+        "O": [{...}],    # Order
+        "R": [{...}, ...],   # Result
+        "C": [{...}, ...],   # Comment
+        "M": [{...}, ...],   # Manufacturer info
+        "L": [{...}],    # Terminator
+        "Q": [{...}, ...]    # Request information
     }
-    
-Where all records come as lists of dictionaries.
 
-Please refer to the `senaite.astm.records` module to see the Python aliases for
-the LIS2-A identifiers.
+The bucket layout is transport-agnostic — both ASTM records and HL7
+segments are routed into the same H/P/O/R/C buckets so a downstream
+importer can stay transport-blind. For HL7 the per-record fields are
+keyed by stringified field number, e.g. `envelope["R"][0]["3"]` is
+`OBX-3`; for ASTM the keys match the Python record-class attribute
+names like `result_name`, `sender`, `sample_id`.
+
+`senaite.astm` 1.x produced a looser shape: no `metadata` block, no HL7
+buckets, and `H[0]["sender"]` could be either a dict (`{"name": ...,
+"serial": ...}`) or a list (`[name, serial, version]`). The consumer
+accepts both shapes.
 
 
-## Results Importer
+## Dispatch
 
-The consumer will lookup for a named adapter for an adapter first, where the
-name is equal to the *sender name* of the header record.
+The push consumer is registered for the name `senaite.core.lis2a.import`
+(both 1.x and 2.x middleware default to that consumer name when
+`--message-format json` is set).
 
-Therefore, you could register a specific adapter, e.g. for the Yumizen H550 as follows:
+For every envelope in the batch, the consumer:
 
-``` xml
-    <configure xmlns="http://namespaces.zope.org/zope">
-        <!-- Adapter to handle instrument imports from senaite.astm -->
-        <adapter name="H550" factory=".astm_importer.ASTMImporter" />
-    </configure>
-```
-    
-And implement the `import_data` method like this:
+1. Extracts the sender name from `H[0].sender` (handles both the dict
+   and list shape).
+2. Looks up an `IASTMImporter` *named* adapter for that sender. If none
+   is registered, falls back to the generic unnamed adapter.
+3. Calls `importer.import_data()`.
 
-``` python
-    from bika.lims import api
-    from senaite.core.astm.importer import ASTMImporter as Base
-    from senaite.core.interfaces import IASTMImporter
-    from senaite.core.interfaces import ISenaiteCore
-    from zope.component import adapter
-    from zope.interface import Interface
-    from zope.interface import implementer
+That means a customer project registers one adapter per instrument
+model:
 
-    ALLOWED_SAMPLE_STATES = ["sample_received"]
-
-    @adapter(Interface, Interface, ISenaiteCore)
-    @implementer(IASTMImporter)
-    class ASTMImporter(Base):
-        """ASTM results importer for Yumizen H500/H550
-        """
-
-        def import_data(self):
-            """Import Yumizen H550 Results
-            """
-            if not self.instrument:
-                return self.log("Instrument not found")
-
-            if not self.sample:
-                return self.log("Sample not found")
-
-            self.log("Starting instrument import")
-
-            sample = self.sample
-            sample_id = self.sample.getId()
-            sample_state = api.get_workflow_status_of(self.sample)
-            sender = self.get_sender()
-            instrument = self.instrument
-            instrument_title = self.instrument.Title()
-            analyses = sample.getAnalyses(full_objects=True)
-
-            if sample_state not in ALLOWED_SAMPLE_STATES:
-                return self.log(
-                    "Sample review state must be in %s" %
-                    ", ".join(ALLOWED_SAMPLE_STATES))
-
-            self.log("Starting results import for sample '%s'" % sample_id)
-
-            # crate a new attachment with the message contents
-            filename = "%s.txt" % "_".join(sender)
-            attachment = self.create_attachment(
-                sample.getClient(), self.message, filename=filename)
-            attachments = sample.getAttachment()
-            if attachment not in attachments:
-                attachments.append(attachment)
-                sample.setAttachment(attachments)
-
-            for result in self.get_results():
-                value = result.get("value")
-                ...
+```xml
+<configure xmlns="http://namespaces.zope.org/zope">
+    <adapter name="HemoScreen"
+             factory=".astm_importer.ASTMImporter" />
+</configure>
 ```
 
+The adapter name must equal the `H[0].sender.name` the instrument
+sends.
 
-## ASTM Server Configuration
 
-The consumer and importer support only the JSON format from the middleware.
+## Writing an importer
 
-Therefore, the `senaite.astm` server needs to be started, e.g. like this:
+Subclass `senaite.core.astm.importer.ASTMImporter` and implement
+`import_data`. The base class provides:
 
-    $ senaite-astm-server -m json -u http://admin:admin@localhost:8080/senaite
-    
-For more information, used the command:
+- `self.data` — the parsed envelope.
+- `self.message` — the raw JSON string (use this when storing the
+  payload as an attachment).
+- `self.instrument` — best-matching Instrument from the SENAITE setup,
+  resolved by sender name + serial; logs ambiguous matches.
+- `self.sample` — Sample resolved from the order's sample ID; falls
+  back to `getClientSampleID` only when it has a single hit, and logs
+  ambiguous fallbacks.
+- `self.get_header()`, `self.get_order()`, `self.get_results()`,
+  `self.get_patients()`, `self.get_comments()` — bucket accessors.
+- `self.get_sender()` — `(name, serial, version)` tuple from the
+  header.
+- `self.log(...)` — appends to an `AutoImportLog` content item
+  attached to the instrument; created lazily on first call.
+- `self.create_attachment(container, contents, filename)` — write the
+  raw payload as an `Attachment` on the sample's client.
 
-``` sh
-    $ senaite-astm-server -h
-    
-    usage: senaite-astm-server [-h] [-l LISTEN] [-p PORT] [-o OUTPUT] [-u URL] [-c CONSUMER] [-m MESSAGE_FORMAT]
-                               [-r RETRIES] [-d DELAY] [-v] [--logfile LOGFILE]
+Minimal example:
 
-    optional arguments:
-    -h, --help            show this help message and exit
-    -v, --verbose         Verbose logging (default: False)
-    --logfile LOGFILE     Path to store log files (default: senaite-astm-server.log)
+```python
+from bika.lims import api
+from senaite.core.astm.importer import ASTMImporter as Base
+from senaite.core.interfaces import IASTMImporter, ISenaiteCore
+from zope.component import adapter
+from zope.interface import Interface, implementer
 
-    ASTM SERVER:
-    -l LISTEN, --listen LISTEN
-                            Listen IP address (default: 0.0.0.0)
-    -p PORT, --port PORT  Port to connect (default: 4010)
-    -o OUTPUT, --output OUTPUT
-                            Output directory to write full messages (default: None)
+ALLOWED_SAMPLE_STATES = ["sample_received"]
 
-    SENAITE LIMS:
-    -u URL, --url URL     SENAITE URL address including username and password in the format:
-                            http(s)://<user>:<password>@<senaite_url> (default: None)
-    -c CONSUMER, --consumer CONSUMER
-                            SENAITE push consumer interface (default: senaite.core.lis2a.import)
-    -m MESSAGE_FORMAT, --message-format MESSAGE_FORMAT
-                            Message format to send to SENAITE. Allowed formats: "astm", "lis2a", "json". (default: json)
-    -r RETRIES, --retries RETRIES
-                            Number of attempts of reconnection when SENAITE instance is not reachable. Only has
-                            effect when argument --url is set (default: 3)
-    -d DELAY, --delay DELAY
-                            Time delay in seconds between retries when SENAITE instance is not reachable. Only
-                            has effect when argument --url is set (default: 5)
+
+@adapter(Interface, Interface, ISenaiteCore)
+@implementer(IASTMImporter)
+class ASTMImporter(Base):
+    """ASTM results importer for the Horiba Yumizen H5xx."""
+
+    def import_data(self):
+        if not self.instrument:
+            return self.log("Instrument not found")
+        if not self.sample:
+            return self.log("Sample not found")
+
+        state = api.get_workflow_status_of(self.sample)
+        if state not in ALLOWED_SAMPLE_STATES:
+            return self.log(
+                "Sample state must be in %s" % ALLOWED_SAMPLE_STATES)
+
+        sender = self.get_sender()
+        filename = "%s.txt" % "_".join(sender)
+        self.create_attachment(
+            self.sample.getClient(), self.message, filename=filename)
+
+        for result in self.get_results():
+            # … set the value on the matching analysis …
+            pass
 ```
 
-**☝️ NOTE:** A proper instrument schema needs to be written to extract the required
-fields for the importer, see `senaite.astm.instruments` for examples.
+
+## Server configuration
+
+Point `senaite-astm-server` (or `senaite-hl7-server` from 2.x) at this
+SENAITE instance with `--message-format json`:
+
+    $ senaite-astm-server \
+        -m json \
+        -c senaite.core.lis2a.import \
+        -u http://admin:admin@localhost:8080/senaite
+
+See `senaite-astm-server --help` and `senaite-hl7-server --help` for
+the full option list.
+
+
+## Roadmap
+
+The current pattern asks every customer to write a per-instrument
+adapter. Most adapters do the same six things — extract the sample
+ID, extract the analysis keyword and normalise it, read value /
+status / flag / timestamp, optionally filter (e.g. HemoScreen
+`OBR-4 = OBS` only), and write the result through a shared helper.
+A generic profile-driven importer reading YAML or content-type
+definitions is in the works; see the sketch at
+`sketches/senaite-astm-generic-importer/` in the buildout repo.

--- a/src/senaite/core/astm/consumer.py
+++ b/src/senaite/core/astm/consumer.py
@@ -32,20 +32,29 @@ from zope.interface import implementer
 @adapter(Interface)
 @implementer(IPushConsumer)
 class PushConsumer(object):
-    """Adapter that handles push requests for name "enaite.core.lis2a.import"
+    """Adapter that handles push requests for name "senaite.core.lis2a.import"
     """
     def __init__(self, data):
         self.data = data
         self.request = api.get_request()
 
     def get_sender_name(self, json_data, default=""):
-        """Parse the sender name from the header record
+        """Parse the sender name from the header record.
+
+        The header record's `sender` field can be either a dict
+        (typical 2.x envelope, `{"name": ..., "serial": ...}`) or
+        a tuple/list of three values (older 1.x payloads emitted
+        `[name, serial, version]`). Both shapes are accepted.
         """
         header = json_data.get("H")
-        if not isinstance(header, list) and len(header) != 1:
+        if not isinstance(header, list) or len(header) != 1:
             return default
-        sender = header[0].get("sender", {})
-        return sender.get("name", default)
+        sender = header[0].get("sender")
+        if isinstance(sender, dict):
+            return sender.get("name", default) or default
+        if isinstance(sender, (list, tuple)) and sender:
+            return sender[0] or default
+        return default
 
     def process(self):
         """Processes the LIS2-A compliant message.
@@ -82,10 +91,13 @@ class PushConsumer(object):
             # import the data
             try:
                 result = importer.import_data()
-            except Exception as exc:
-                message = "An error occured in '{}.import_data()'".format(
-                    importer.__class__.__name__)
-                logger.error(exc)
+            except Exception:
+                # Log with traceback, but keep processing the rest of
+                # the batch — one malformed instrument message must
+                # not prevent the next one from being imported.
+                logger.exception(
+                    "Error in %s.import_data() while handling message: %r",
+                    importer.__class__.__name__, message)
                 continue
 
             if api.is_string(result):

--- a/src/senaite/core/astm/importer.py
+++ b/src/senaite/core/astm/importer.py
@@ -21,6 +21,7 @@
 from datetime import datetime
 
 from bika.lims import api
+from senaite.core import logger
 from senaite.core.catalog import SAMPLE_CATALOG
 from senaite.core.catalog import SETUP_CATALOG
 from senaite.core.interfaces import IASTMImporter
@@ -54,61 +55,116 @@ class ASTMImporter(object):
 
     @property
     def instrument(self):
-        """Query the instrument of this import
+        """Query the instrument of this import.
+
+        Candidates are scored against the sender's name and serial
+        and the best match wins. The ranking is:
+
+        - 3: model and serial both match
+        - 2: title and serial both match
+        - 1: model matches (serial mismatch or missing)
+        - 1: title matches (serial mismatch or missing)
+        - 0: no match
+
+        Ties on the top score are logged so the operator can
+        disambiguate; the first such candidate is returned.
         """
         if self._instrument:
             return self._instrument
 
-        instrument = None
         name = self.get_instrument_name()
         serial = self.get_instrument_serial()
         query = {"portal_type": "Instrument"}
-        results = api.search(query, SETUP_CATALOG)
 
-        for brain in results:
+        best_score = 0
+        best_match = None
+        ties = []
+        for brain in api.search(query, SETUP_CATALOG):
             obj = api.get_object(brain)
-            model = obj.getModel()
-            title = obj.Title()
-            serialno = obj.getSerialNo()
-            # lookup instrument by model and serial
-            if model == name and serialno == serial:
-                instrument = obj
-            # lookup instrument by title and serial
-            elif title == name and serialno == serial:
-                instrument = obj
-            # lookup instrument by model only
-            elif model == name:
-                instrument = obj
-            # lookup instrument by title only
-            elif title == name:
-                instrument = obj
+            score = self._score_instrument_candidate(
+                obj, name=name, serial=serial)
+            if score > best_score:
+                best_score = score
+                best_match = obj
+                ties = [obj]
+            elif score == best_score and score > 0:
+                ties.append(obj)
 
-        self._instrument = instrument
-        return instrument
+        if len(ties) > 1:
+            titles = ", ".join(repr(o.Title()) for o in ties)
+            logger.warning(
+                "Multiple instruments matched sender %r/%r equally "
+                "(score=%d): %s — picking the first.",
+                name, serial, best_score, titles)
+
+        self._instrument = best_match
+        return best_match
+
+    @staticmethod
+    def _score_instrument_candidate(obj, name, serial):
+        model = obj.getModel()
+        title = obj.Title()
+        serialno = obj.getSerialNo()
+        if not name:
+            return 0
+        if model == name and serialno == serial:
+            return 3
+        if title == name and serialno == serial:
+            return 2
+        if model == name:
+            return 1
+        if title == name:
+            return 1
+        return 0
 
     @property
     def sample(self):
-        """Query the sample of this import
+        """Query the sample of this import.
+
+        Looks up the sample by `getId` first (the canonical
+        SENAITE Sample ID). If that returns nothing, falls back to
+        `getClientSampleID` — but Client Sample IDs are not unique
+        across clients, so a multi-hit fallback is *not* resolved
+        silently. Ambiguous or empty results are logged so the
+        operator can see what happened instead of getting a silent
+        `None`.
         """
         if self._sample:
             return self._sample
 
-        sample = None
-        # get the sample ID from the data
         sid = self.get_sample_id()
-        # Query by Sample ID
-        query_sid = {"getId": sid}
-        # Query by Client Sample ID
-        query_csid = {"getClientSampleID": sid}
+        if not sid:
+            return None
 
-        results = api.search(query_sid, SAMPLE_CATALOG)
-        if not results:
-            results = api.search(query_csid, SAMPLE_CATALOG)
+        results = api.search({"getId": sid}, SAMPLE_CATALOG)
         if len(results) == 1:
-            sample = api.get_object(results[0])
+            self._sample = api.get_object(results[0])
+            return self._sample
+        if len(results) > 1:
+            logger.warning(
+                "Sample ID %r matched %d samples — refusing to guess",
+                sid, len(results))
+            return None
 
-        self._sample = sample
-        return sample
+        # Fallback: Client Sample ID. Not unique across clients;
+        # accept only when exactly one match is found.
+        results = api.search(
+            {"getClientSampleID": sid}, SAMPLE_CATALOG)
+        if len(results) == 1:
+            logger.info(
+                "Resolved sample for %r via getClientSampleID fallback",
+                sid)
+            self._sample = api.get_object(results[0])
+            return self._sample
+        if len(results) > 1:
+            logger.warning(
+                "Client Sample ID %r matched %d samples across "
+                "clients — refusing to guess", sid, len(results))
+        else:
+            logger.info(
+                "No sample found for %r (tried getId and "
+                "getClientSampleID)", sid)
+        return None
 
     def log(self, message, level="info"):
         """Append log to logs

--- a/src/senaite/core/tests/test_astm_consumer.py
+++ b/src/senaite/core/tests/test_astm_consumer.py
@@ -117,7 +117,6 @@ class GetSenderNameTest(unittest.TestCase):
 
 
 def test_suite():
-    from unittest import TestSuite, makeSuite
-    suite = TestSuite()
-    suite.addTest(makeSuite(GetSenderNameTest))
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(GetSenderNameTest))
     return suite

--- a/src/senaite/core/tests/test_astm_consumer.py
+++ b/src/senaite/core/tests/test_astm_consumer.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+"""Pure-Python tests for senaite.core.astm.consumer.
+
+These tests cover the envelope dispatch surface without spinning up
+a Plone test layer. The intent is to catch regressions in the
+boundary parser (sender name extraction, batch iteration) and to
+pin behaviour across 1.x and 2.x envelope shapes.
+"""
+
+import unittest
+
+from senaite.core.astm.consumer import PushConsumer
+
+
+def envelope_2x(sender_name="HemoScreen", serial="0000-0001"):
+    """A minimal 2.x-style envelope (sender is a dict)."""
+    return {
+        "H": [{
+            "sender": {
+                "name": sender_name,
+                "serial": serial,
+                "version": "2.4",
+            },
+        }],
+        "P": [], "O": [], "R": [], "C": [],
+        "M": [], "L": [], "Q": [],
+        "metadata": {"envelope_version": "1.1", "astm": "", "hl7": ""},
+    }
+
+
+def envelope_1x(sender_name="Pentra XLR"):
+    """A minimal 1.x-style envelope (sender as a list)."""
+    return {
+        "H": [{"sender": [sender_name, "SN-1", "v1"]}],
+        "P": [], "O": [], "R": [],
+    }
+
+
+class GetSenderNameTest(unittest.TestCase):
+    """`PushConsumer.get_sender_name` must accept both envelope
+    shapes and never raise on malformed input.
+    """
+
+    def setUp(self):
+        self.consumer = PushConsumer.__new__(PushConsumer)
+
+    def test_returns_dict_sender_name_for_2x(self):
+        self.assertEqual(
+            self.consumer.get_sender_name(envelope_2x("HemoScreen")),
+            "HemoScreen",
+        )
+
+    def test_returns_list_sender_name_for_1x(self):
+        self.assertEqual(
+            self.consumer.get_sender_name(envelope_1x("Pentra XLR")),
+            "Pentra XLR",
+        )
+
+    def test_missing_header_returns_default(self):
+        self.assertEqual(
+            self.consumer.get_sender_name({}, default="generic"),
+            "generic",
+        )
+
+    def test_non_list_header_returns_default(self):
+        # 1.x payloads occasionally surfaced H as a dict. Must not crash.
+        self.assertEqual(
+            self.consumer.get_sender_name({"H": {"oops": True}}),
+            "",
+        )
+
+    def test_empty_header_returns_default(self):
+        self.assertEqual(
+            self.consumer.get_sender_name({"H": []}), "")
+
+    def test_multiple_headers_returns_default(self):
+        # Ambiguous; refuse to guess. The consumer logs and falls
+        # through to the generic adapter.
+        self.assertEqual(
+            self.consumer.get_sender_name({"H": [{}, {}]}), "")
+
+    def test_dict_sender_without_name_returns_default(self):
+        env = {"H": [{"sender": {"serial": "X"}}]}
+        self.assertEqual(
+            self.consumer.get_sender_name(env, default="fallback"),
+            "fallback",
+        )
+
+    def test_list_sender_empty_returns_default(self):
+        env = {"H": [{"sender": []}]}
+        self.assertEqual(
+            self.consumer.get_sender_name(env, default="fallback"),
+            "fallback",
+        )
+
+    def test_sender_missing_returns_default(self):
+        env = {"H": [{}]}
+        self.assertEqual(self.consumer.get_sender_name(env), "")
+
+
+def test_suite():
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(GetSenderNameTest))
+    return suite


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Boundary hygiene pass on `senaite.core.astm.{consumer,importer}`. Four small bugs were surfaced by a code review of the subpackage in preparation for upcoming work (1.x↔2.x envelope compatibility, generic profile-driven importer); none of them changes the public adapter API, so customer adapters continue to work unchanged.

The package also accepts `senaite.astm` 1.x envelopes (where `H[0].sender` could be a list `[name, serial, version]` instead of the 2.x dict). Both shapes now route through the same dispatch.

## Current behavior before PR

- `PushConsumer.get_sender_name` has `and` where `or` was meant — a non-list `H` (e.g. `None`, a stray dict, or a 1.x edge case) crashes inside `len(header)` before the default can return.
- `PushConsumer.process`'s per-message exception clause builds an error string into a local named `message` (shadowing the loop variable), never logs it, and logs the exception without a traceback.
- `ASTMImporter.instrument` iterates every Instrument and overwrites the match on every loop pass — a weaker later match (title-only) silently displaces a stronger earlier match (model+serial).
- `ASTMImporter.sample` falls back from `getId` to `getClientSampleID` with no logging and no client scoping. Client Sample IDs are not unique across clients, so a multi-hit fallback silently returns `None`, and a single-hit fallback can import into the wrong client's sample.
- The dispatch consumer name docstring reads `"enaite.core.lis2a.import"` (missing `s`).
- The `README.md` documents an outdated envelope shape and does not mention the 2.x `metadata` block or HL7 transport.

## Desired behavior after PR is merged

- `get_sender_name` returns the default cleanly when `H` is not a one-element list. The sender is accepted as either a dict (`{"name": ..., "serial": ..., "version": ...}` — 2.x) or a list/tuple (`[name, serial, version]` — 1.x).
- `process` uses `logger.exception(...)` (traceback + offending payload) and no longer shadows the loop variable.
- `instrument` ranks candidates (model+serial = 3, title+serial = 2, model = 1, title = 1) and returns the best score; logs when multiple candidates tie at the top.
- `sample` keeps the `getClientSampleID` fallback for backwards compatibility but only accepts a single hit; ambiguous or empty results are logged so the operator sees what happened instead of getting a silent `None`.
- `README.md` rewritten: documents the current 2.x envelope (with `metadata.envelope_version`, raw payload in `metadata.{astm,lis2a,hl7}`, the H/P/O/R/C/M/L/Q bucket layout shared with HL7), the named-adapter dispatch, and the importer API.
- New unit test `senaite/core/tests/test_astm_consumer.py` covers `get_sender_name` across both envelope shapes plus empty/missing/multi-header/no-name edge cases.