### PR TITLE
Hide 'Client' role column and strip direct Client role assignments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #XXXX Hide the global 'Client' role column in user/group prefs and strip directly-assigned Client roles from existing users
 - #2928 Fix ASTM consumer boundary bugs (sender shape, instrument cascade, sample fallback)
 - #2925 Add 'reattach' workflow transition to re-link detached partitions to their primary
 - #2926 Strip surrounding whitespace from analysis unit choices so configuration typos don't break the round-trip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- #XXXX Hide the global 'Client' role column in user/group prefs and strip directly-assigned Client roles from existing users
+- #2933 Hide the global 'Client' role column in user/group prefs and strip directly-assigned Client roles from existing users
 - #2928 Fix ASTM consumer boundary bugs (sender shape, instrument cascade, sample fallback)
 - #2925 Add 'reattach' workflow transition to re-link detached partitions to their primary
 - #2926 Strip surrounding whitespace from analysis unit choices so configuration typos don't break the round-trip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- #2933 Hide the global 'Client' role column in user/group prefs and strip directly-assigned Client roles from existing users
+- #2933 Hide 'Client' role column and strip direct Client role assignments
 - #2928 Fix ASTM consumer boundary bugs (sender shape, instrument cascade, sample fallback)
 - #2925 Add 'reattach' workflow transition to re-link detached partitions to their primary
 - #2926 Strip surrounding whitespace from analysis unit choices so configuration typos don't break the round-trip

--- a/src/senaite/core/config/roles.py
+++ b/src/senaite/core/config/roles.py
@@ -19,11 +19,12 @@
 # Some rights reserved, see README and LICENSE.
 
 HIDDEN_ROLES = [
-    "Owner",
+    "Client",
     "ClientGuest",
     "Contributor",
     "Editor",
     "Member",
+    "Owner",
     "Reader",
     "Reviewer",
     "Site Administrator",

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2738</version>
+  <version>2739</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-senaite.impress:default</dependency>

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -2209,3 +2209,49 @@ def add_sample_catalog_indexes(tool):
             )
 
     logger.info("Adding new indexes to sample catalog [DONE]")
+
+
+@upgradestep(product, version)
+def strip_global_client_role(tool):
+    """Remove directly-assigned global 'Client' role from users.
+
+    The 'Client' role is now granted implicitly to users via membership
+    in the per-client group (the group itself carries ``roles=["Client"]``).
+    A user with the role assigned directly through the portal role
+    manager but no client-group membership has the Client landing page
+    but no Owner role on any client folder, which is a half-configured
+    state with no useful access.
+
+    Iterate the principals assigned the 'Client' role via the portal
+    role manager and remove the direct assignment. Users keep the role
+    indirectly through group membership where applicable.
+    """
+    logger.info("Stripping global 'Client' role from users ...")
+    acl = api.get_tool("acl_users")
+    prm = getattr(acl, "portal_role_manager", None)
+    if prm is None:
+        logger.warn(
+            "No portal_role_manager available; nothing to strip")
+        return
+
+    principals = prm.listAssignedPrincipals("Client")
+    total = len(principals)
+    logger.info(
+        "Found %s principals with directly-assigned 'Client' role"
+        % total)
+
+    removed = 0
+    for principal_id, _title in principals:
+        try:
+            prm.removeRoleFromPrincipal("Client", principal_id)
+        except KeyError:
+            logger.warn(
+                "Could not remove 'Client' from '%s'" % principal_id)
+            continue
+        removed += 1
+        logger.info(
+            "Removed direct 'Client' role from '%s'" % principal_id)
+
+    logger.info(
+        "Stripped global 'Client' role from %s/%s principals"
+        % (removed, total))

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -3,6 +3,19 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.7.0: Strip the global 'Client' role from users"
+      description="Remove the directly-assigned global 'Client' role from
+                   every user. The role is now granted implicitly via
+                   membership in the per-client group, so a direct
+                   assignment is redundant and produces a half-configured
+                   user that has the Client landing page but no Owner
+                   role on any client folder."
+      source="2738"
+      destination="2739"
+      handler=".v02_07_000.strip_global_client_role"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Add 'reattach' workflow transition"
       description="Register the reattach workflow transition that
                    re-links a detached partition back to its primary.


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: n/a

The `Client` role is granted implicitly to users via membership in the per-client group (the group itself carries `roles=["Client"]`). A user with the role assigned directly through the portal role manager but no client-group membership lands on the Client landing page yet has no Owner role on any client folder — a half-configured state with no useful access.

The "Client" column in `@@usergroup-userprefs` (and the equivalent for groups) actively misleads admins into producing such half-configured users. It should not be exposed; the proper path is to add the user to the client group, which grants the role implicitly.

## Current behavior before PR

- `@@usergroup-userprefs` shows a `Client` checkbox column. Ticking it assigns the global `Client` role directly via `portal_role_manager`, but does not link the user to any client.
- Same for `@@usergroup-groupprefs`.
- Existing users may already carry a directly-assigned global `Client` role from earlier admin actions.

## Desired behavior after PR is merged

- `Client` is added to `HIDDEN_ROLES` and no longer rendered as a column in either prefs view.
- An upgrade step (`2738 -> 2739`) walks every principal listed by `portal_role_manager.listAssignedPrincipals("Client")` and removes the direct role assignment. Users keep the role indirectly through client-group membership where applicable. Roles assigned by other PAS plugins (e.g. `pas.plugins.ldap` group-role mapping) are not touched.
- `HIDDEN_ROLES` is sorted alphabetically while at it.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html