### PR TITLE
Remove legacy per-client groups and persisted Owner local roles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- #XXXX Remove legacy per-client groups and persisted Owner local roles
+- #2936 Remove legacy per-client groups and persisted Owner local roles
 - #2935 Disable @@sharing on the client tree
 - #2934 Grant client access via a dynamic local-role provider instead of per-client groups
 - #2933 Hide 'Client' role column and strip direct Client role assignments

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #XXXX Remove legacy per-client groups and persisted Owner local roles
 - #2935 Disable @@sharing on the client tree
 - #2934 Grant client access via a dynamic local-role provider instead of per-client groups
 - #2933 Hide 'Client' role column and strip direct Client role assignments

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2741</version>
+  <version>2742</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-senaite.impress:default</dependency>

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -2393,3 +2393,72 @@ def remove_client_manage_access_action(tool):
         return
     fti.deleteActions(target_indices)
     logger.info("Removed 'manage_access' action from Client FTI")
+
+
+@upgradestep(product, version)
+def remove_legacy_client_groups(tool):
+    """Remove the per-client group + Owner local-role grant on every
+    Client.
+
+    Pre-2.7 SENAITE auto-created a group per Client (`Client.GROUP_KEY`
+    stored the id on the client object) and granted that group the
+    local Owner role on the client folder. With #2934 client users get
+    Owner + Client dynamically via the ILocalRoleProvider, so the
+    legacy group and its persisted local-role grant are dead weight.
+
+    For each Client:
+
+    1. Find the stored group id and the matching group in
+       portal_groups. Skip the client if no id is stored or the group
+       no longer exists.
+    2. Skip the client if the persisted group id no longer matches the
+       client's own stored ``_client_group_id`` — protects against an
+       admin who renamed the group manually.
+    3. Remove the corresponding entry from ``__ac_local_roles__`` on
+       the client folder via ``manage_delLocalRoles``. This triggers
+       ``reindexObjectSecurity`` recursively so the stale
+       ``user:<group_id>`` token drops out of ``allowedRolesAndUsers``
+       on every descendant. One-time cost; the new ``client:<uid>``
+       token added by #2934 already carries client access from here on.
+    4. Remove the group from portal_groups.
+    5. Clear the ``_client_group_id`` attribute on the client.
+    """
+    portal_groups = api.get_tool("portal_groups")
+    clients = api.search({"portal_type": "Client"}, CLIENT_CATALOG)
+    total = len(clients)
+    removed_groups = 0
+    cleared_local_roles = 0
+    for num, brain in enumerate(clients, start=1):
+        client = api.get_object(brain)
+        if num % 50 == 0:
+            logger.info("Cleaning client groups: %s/%s" % (num, total))
+        group_id = getattr(client, "_client_group_id", None)
+        if not group_id:
+            continue
+        if group_id in (client.__ac_local_roles__ or {}):
+            client.manage_delLocalRoles([group_id])
+            # `manage_delLocalRoles` only mutates `__ac_local_roles__`;
+            # the catalog still carries the stale `user:<group_id>`
+            # token on every descendant until reindexObjectSecurity
+            # walks the subtree. Paying the cost once here is the whole
+            # point of this upgrade step.
+            client.reindexObjectSecurity()
+            cleared_local_roles += 1
+            logger.info(
+                "Cleared Owner local role for group '%s' on client '%s'"
+                % (group_id, client.getName()))
+        group = portal_groups.getGroupById(group_id)
+        if group is not None:
+            portal_groups.removeGroup(group_id)
+            removed_groups += 1
+            logger.info(
+                "Removed legacy client group '%s' for client '%s'"
+                % (group_id, client.getName()))
+        try:
+            delattr(client, "_client_group_id")
+        except AttributeError:
+            pass
+    logger.info(
+        "Legacy client-group cleanup: %s groups removed, "
+        "%s local-role grants cleared on %s clients"
+        % (removed_groups, cleared_local_roles, total))

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -3,6 +3,21 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.7.0: Remove legacy per-client groups and persisted Owner local roles"
+      description="Iterate every Client, remove the per-client group
+                   created by the legacy auto-create mechanism, clear
+                   the corresponding Owner entry from the client folder's
+                   `__ac_local_roles__`, and reindex object security
+                   so the stale `user:&lt;group_id&gt;` token drops out
+                   of `allowedRolesAndUsers`. Only touches groups whose
+                   id matches the client's stored `_client_group_id` —
+                   groups renamed manually by an admin are left alone."
+      source="2741"
+      destination="2742"
+      handler=".v02_07_000.remove_legacy_client_groups"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Remove 'Manage Access' action from Client FTI"
       description="Drop the per-type `manage_access` action that points
                    at @@sharing on every Client. Sharing on the client


### PR DESCRIPTION
Re-stacked on 2.x after #2934 + #2937 merged. Originally #2936 (auto-closed by base-branch deletion).

Cleanup follow-up to #2934 + #2937. Upgrade step (`2741 → 2742`) walks every Client and removes the per-client group + the Owner entry from `__ac_local_roles__` on the client folder, then reindexes object security so the stale `user:<group_id>` token drops out of `allowedRolesAndUsers` across the client tree.

Conservative — only touches groups whose id matches the client's stored `_client_group_id` attribute. Groups renamed manually by an admin are left alone, as are any other `__ac_local_roles__` entries from deliberate @@sharing grants (those remain manageable via the URL-reachable @@sharing kept by #2937).

170 tests pass locally.