### PR TITLE
Persist linked user properties through the mutable properties plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,9 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- #2936 Remove legacy per-client groups and persisted Owner local roles
-- #2935 Disable @@sharing on the client tree
+- #2939 Make _set_linked_client_uid tolerant of property plugins that return dicts
+- #2938 Remove legacy per-client groups and persisted Owner local roles
+- #2937 Disable @@sharing on the client tree
 - #2934 Grant client access via a dynamic local-role provider instead of per-client groups
 - #2933 Hide 'Client' role column and strip direct Client role assignments
 - #2928 Fix ASTM consumer boundary bugs (sender shape, instrument cascade, sample fallback)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- #2939 Make _set_linked_client_uid tolerant of property plugins that return dicts
+- #2939 Persist linked user properties through the mutable properties plugin
 - #2938 Remove legacy per-client groups and persisted Owner local roles
 - #2937 Disable @@sharing on the client tree
 - #2934 Grant client access via a dynamic local-role provider instead of per-client groups

--- a/src/bika/lims/content/contact.py
+++ b/src/bika/lims/content/contact.py
@@ -46,20 +46,21 @@ CONTACT_UID_KEY = "linked_contact_uid"
 CLIENT_UID_KEY = "linked_client_uid"
 
 
-def _set_linked_client_uid(user, client_uid):
-    """Persist `linked_client_uid` on a user's mutable property storage.
+def _set_user_property(user, key, value):
+    """Persist a string property on a user's mutable property storage.
 
-    See `senaite.core.content.contact._set_linked_client_uid` for the
+    See `senaite.core.content.contact._set_user_property` for the
     rationale; this is the AT-side mirror so contacts on either base
-    set the same property the dynamic role provider reads.
+    write through the mutable properties plugin instead of the cached
+    user sheets.
     """
     from Products.PluggableAuthService.interfaces.plugins import \
         IPropertiesPlugin
 
     portal_memberdata = user._tool
-    if not portal_memberdata.hasProperty(CLIENT_UID_KEY):
-        portal_memberdata.manage_addProperty(CLIENT_UID_KEY, "", "string")
-        logger.info("Registered user property {}".format(CLIENT_UID_KEY))
+    if not portal_memberdata.hasProperty(key):
+        portal_memberdata.manage_addProperty(key, "", "string")
+        logger.info("Registered user property {}".format(key))
 
     acl_users = portal_memberdata.acl_users
     for plugin_id, plugin in acl_users.plugins.listPlugins(IPropertiesPlugin):
@@ -67,18 +68,19 @@ def _set_linked_client_uid(user, client_uid):
         if sheet is None:
             continue
         # Some property plugins return a plain dict rather than a
-        # PropertySheet; ignore those — we want the mutable_properties
-        # plugin's sheet, which exposes hasProperty/setProperty.
+        # PropertySheet (e.g. pas.plugins.ldap for non-LDAP users);
+        # ignore those — we want the mutable_properties plugin's
+        # sheet, which exposes hasProperty/setProperty.
         has = getattr(sheet, "hasProperty", None)
         setter = getattr(sheet, "setProperty", None)
         if not callable(has) or not callable(setter):
             continue
-        if not has(CLIENT_UID_KEY):
+        if not has(key):
             continue
-        setter(user, CLIENT_UID_KEY, client_uid)
+        setter(user, key, value)
         return
     logger.warn(
-        "No mutable properties plugin accepted '{}'".format(CLIENT_UID_KEY))
+        "No mutable properties plugin accepted '{}'".format(key))
 
 
 schema = Person.schema.copy() + atapi.Schema((
@@ -266,18 +268,13 @@ class Contact(Person):
                              .format(username, ",".join(
                                  map(lambda x: x.Title(), contact))))
 
-        # Linked Contact UID is used in member profile as backreference
-        try:
-            user.getProperty(CONTACT_UID_KEY)
-        except ValueError:
-            logger.info("Adding User property {}".format(CONTACT_UID_KEY))
-            user._tool.manage_addProperty(CONTACT_UID_KEY, "", "string")
-
-        # Set the UID as a User Property
+        # Set the UID as a User Property — write through the mutable
+        # properties plugin so it persists for users whose cached
+        # property sheets predate the registration of the property.
         uid = self.UID()
-        user.setMemberProperties({CONTACT_UID_KEY: uid})
+        _set_user_property(user, CONTACT_UID_KEY, uid)
         logger.info("Linked Contact UID {} to User {}".format(
-            user.getProperty(CONTACT_UID_KEY), username))
+            user.getProperty(CONTACT_UID_KEY, ""), username))
 
         # Set the Username
         self.setUsername(user.getId())
@@ -301,7 +298,7 @@ class Contact(Person):
         #      indexed on client-tree content (`client:<uid>`) do not
         #      need to be rewritten when contacts are linked.
         if IClient.providedBy(self.aq_parent):
-            _set_linked_client_uid(user, self.aq_parent.UID())
+            _set_user_property(user, CLIENT_UID_KEY, self.aq_parent.UID())
 
         return True
 
@@ -317,7 +314,7 @@ class Contact(Person):
         user = self.getUser()
 
         # Unset the UID from the User Property
-        user.setMemberProperties({CONTACT_UID_KEY: ""})
+        _set_user_property(user, CONTACT_UID_KEY, "")
         logger.info("Unlinked Contact UID from User {}"
                     .format(user.getProperty(CONTACT_UID_KEY, "")))
 
@@ -336,7 +333,7 @@ class Contact(Person):
         # Clear the linked client UID so the dynamic role provider no
         # longer grants access on the client tree.
         if IClient.providedBy(self.aq_parent):
-            _set_linked_client_uid(user, "")
+            _set_user_property(user, CLIENT_UID_KEY, "")
 
         return True
 

--- a/src/bika/lims/content/contact.py
+++ b/src/bika/lims/content/contact.py
@@ -64,10 +64,16 @@ def _set_linked_client_uid(user, client_uid):
     acl_users = portal_memberdata.acl_users
     for plugin_id, plugin in acl_users.plugins.listPlugins(IPropertiesPlugin):
         sheet = plugin.getPropertiesForUser(user)
-        if sheet is None or not sheet.hasProperty(CLIENT_UID_KEY):
+        if sheet is None:
             continue
+        # Some property plugins return a plain dict rather than a
+        # PropertySheet; ignore those — we want the mutable_properties
+        # plugin's sheet, which exposes hasProperty/setProperty.
+        has = getattr(sheet, "hasProperty", None)
         setter = getattr(sheet, "setProperty", None)
-        if setter is None:
+        if not callable(has) or not callable(setter):
+            continue
+        if not has(CLIENT_UID_KEY):
             continue
         setter(user, CLIENT_UID_KEY, client_uid)
         return

--- a/src/senaite/core/content/contact.py
+++ b/src/senaite/core/content/contact.py
@@ -68,10 +68,16 @@ def _set_linked_client_uid(user, client_uid):
     acl_users = portal_memberdata.acl_users
     for plugin_id, plugin in acl_users.plugins.listPlugins(IPropertiesPlugin):
         sheet = plugin.getPropertiesForUser(user)
-        if sheet is None or not sheet.hasProperty(CLIENT_UID_KEY):
+        if sheet is None:
             continue
+        # Some property plugins return a plain dict rather than a
+        # PropertySheet; ignore those — we want the mutable_properties
+        # plugin's sheet, which exposes hasProperty/setProperty.
+        has = getattr(sheet, "hasProperty", None)
         setter = getattr(sheet, "setProperty", None)
-        if setter is None:
+        if not callable(has) or not callable(setter):
+            continue
+        if not has(CLIENT_UID_KEY):
             continue
         setter(user, CLIENT_UID_KEY, client_uid)
         return

--- a/src/senaite/core/content/contact.py
+++ b/src/senaite/core/content/contact.py
@@ -49,21 +49,24 @@ CONTACT_UID_KEY = "linked_contact_uid"
 CLIENT_UID_KEY = "linked_client_uid"
 
 
-def _set_linked_client_uid(user, client_uid):
-    """Persist `linked_client_uid` on a user's mutable property storage.
+def _set_user_property(user, key, value):
+    """Persist a string property on a user's mutable property storage.
 
     Registers the property on portal_memberdata the first time it's
     needed, then writes the value via the ZODB mutable property
-    plugin. Going through the plugin directly avoids the cache-staleness
-    bug in `MemberData.setMemberProperties`, where the user's already-
-    attached property sheets are built with the schema as it was at
-    user-creation time and silently ignore properties registered
-    later.
+    plugin. Going through the plugin directly avoids the cache-
+    staleness bug in `MemberData.setMemberProperties`: the user's
+    already-attached property sheets are built with the schema as it
+    was at user-creation time and silently ignore properties
+    registered later in the same request (e.g. when linking a brand-
+    new user to a contact also registers the property for the first
+    time). The plugin's sheet, by contrast, reflects current
+    portal_memberdata.propertyMap on every call.
     """
     portal_memberdata = user._tool
-    if not portal_memberdata.hasProperty(CLIENT_UID_KEY):
-        portal_memberdata.manage_addProperty(CLIENT_UID_KEY, "", "string")
-        logger.info("Registered user property {}".format(CLIENT_UID_KEY))
+    if not portal_memberdata.hasProperty(key):
+        portal_memberdata.manage_addProperty(key, "", "string")
+        logger.info("Registered user property {}".format(key))
 
     acl_users = portal_memberdata.acl_users
     for plugin_id, plugin in acl_users.plugins.listPlugins(IPropertiesPlugin):
@@ -71,18 +74,19 @@ def _set_linked_client_uid(user, client_uid):
         if sheet is None:
             continue
         # Some property plugins return a plain dict rather than a
-        # PropertySheet; ignore those — we want the mutable_properties
-        # plugin's sheet, which exposes hasProperty/setProperty.
+        # PropertySheet (e.g. pas.plugins.ldap for non-LDAP users);
+        # ignore those — we want the mutable_properties plugin's
+        # sheet, which exposes hasProperty/setProperty.
         has = getattr(sheet, "hasProperty", None)
         setter = getattr(sheet, "setProperty", None)
         if not callable(has) or not callable(setter):
             continue
-        if not has(CLIENT_UID_KEY):
+        if not has(key):
             continue
-        setter(user, CLIENT_UID_KEY, client_uid)
+        setter(user, key, value)
         return
     logger.warn(
-        "No mutable properties plugin accepted '{}'".format(CLIENT_UID_KEY))
+        "No mutable properties plugin accepted '{}'".format(key))
 
 
 class IContactSchema(IPersonSchema):
@@ -281,18 +285,13 @@ class Contact(Person):
                              .format(username, ",".join(
                                  map(lambda x: x.Title(), contact))))
 
-        # Linked Contact UID is used in member profile as backreference
-        try:
-            user.getProperty(CONTACT_UID_KEY)
-        except ValueError:
-            logger.info("Adding User property {}".format(CONTACT_UID_KEY))
-            user._tool.manage_addProperty(CONTACT_UID_KEY, "", "string")
-
-        # Set the UID as a User Property
+        # Set the UID as a User Property — write through the mutable
+        # properties plugin so it persists for users whose cached
+        # property sheets predate the registration of the property.
         uid = self.UID()
-        user.setMemberProperties({CONTACT_UID_KEY: uid})
+        _set_user_property(user, CONTACT_UID_KEY, uid)
         logger.info("Linked Contact UID {} to User {}".format(
-            user.getProperty(CONTACT_UID_KEY), username))
+            user.getProperty(CONTACT_UID_KEY, ""), username))
 
         # Set the Username
         self.setUsername(user.getId())
@@ -320,7 +319,7 @@ class Contact(Person):
         #      indexed on client-tree content (`client:<uid>`) do not
         #      need to be rewritten when contacts are linked.
         if IClient.providedBy(self.aq_parent):
-            _set_linked_client_uid(user, self.aq_parent.UID())
+            _set_user_property(user, CLIENT_UID_KEY, self.aq_parent.UID())
 
         return True
 
@@ -336,7 +335,7 @@ class Contact(Person):
         user = self.getUser()
 
         # Unset the UID from the User Property
-        user.setMemberProperties({CONTACT_UID_KEY: ""})
+        _set_user_property(user, CONTACT_UID_KEY, "")
         logger.info("Unlinked Contact UID from User {}"
                     .format(user.getProperty(CONTACT_UID_KEY, "")))
 
@@ -359,7 +358,7 @@ class Contact(Person):
         # Clear the linked client UID so the dynamic role provider no
         # longer grants access on the client tree.
         if IClient.providedBy(self.aq_parent):
-            _set_linked_client_uid(user, "")
+            _set_user_property(user, CLIENT_UID_KEY, "")
 
         return True
 

--- a/src/senaite/core/tests/doctests/ContactUser.rst
+++ b/src/senaite/core/tests/doctests/ContactUser.rst
@@ -126,6 +126,25 @@ role is persisted on the client folder::
     >>> portal_user1.getProperty("linked_client_uid") == client1.UID()
     True
 
+Linking also writes the back-reference to the linked contact on
+the user profile, so a logged-in user can be resolved back to its
+contact via the `linked_contact_uid` property::
+
+    >>> portal_user1.getProperty("linked_contact_uid") == contact1.UID()
+    True
+
+Both keys are registered on portal_memberdata the first time a
+contact is linked. The write goes through the mutable_properties
+plugin, which reads its schema from portal_memberdata on every
+call, so the property is persisted even when it was registered in
+the same request as the user was created::
+
+    >>> portal_memberdata = portal.portal_memberdata
+    >>> bool(portal_memberdata.hasProperty("linked_contact_uid"))
+    True
+    >>> bool(portal_memberdata.hasProperty("linked_client_uid"))
+    True
+
 The user does not get the `Client` role globally; the role is
 granted dynamically on the client tree only::
 
@@ -180,6 +199,16 @@ The user has no local owner role anymore on the client::
     Traceback (most recent call last):
     ...
     Unauthorized: ...
+
+Both linked-UID properties on the user are cleared by unlinkUser,
+so the dynamic role provider no longer grants any role and a
+re-link starts from a clean state::
+
+    >>> portal_user1 = portal.acl_users.getUserById(user1.getId())
+    >>> portal_user1.getProperty("linked_client_uid", "")
+    ''
+    >>> portal_user1.getProperty("linked_contact_uid", "")
+    ''
 
 LabContact users
 ----------------

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -2337,7 +2337,8 @@ def backfill_linked_client_uid():
     client contact that is already linked to a user account.
     """
     from bika.lims.interfaces import IClient
-    from senaite.core.content.contact import _set_linked_client_uid
+    from senaite.core.content.contact import CLIENT_UID_KEY
+    from senaite.core.content.contact import _set_user_property
 
     logger.info("Backfilling `linked_client_uid` on linked users ...")
     contacts = api.search({"portal_type": "Contact"}, CONTACT_CATALOG)
@@ -2350,7 +2351,7 @@ def backfill_linked_client_uid():
         user = contact.getUser()
         if user is None:
             continue
-        _set_linked_client_uid(user, api.get_uid(parent))
+        _set_user_property(user, CLIENT_UID_KEY, api.get_uid(parent))
         updated += 1
     logger.info(
         "Backfilled `linked_client_uid` on %s users" % updated)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Follow-up to #2934. Two distinct symptoms with the same root cause:

1. Creating a user from a Client Contact's *Login details* form blew up with:

   ```
   AttributeError: 'dict' object has no attribute 'hasProperty'
     File ".../senaite/core/content/contact.py", line 71, in _set_linked_client_uid
   ```

   The helper introduced in #2934 iterates every `IPropertiesPlugin` and calls `hasProperty`/`setProperty` on whatever `getPropertiesForUser` returns. `pas.plugins.ldap`'s `LDAPPlugin.getPropertiesForUser` returns `LDAPUserPropertySheet` for LDAP users and a plain `{}` (dict) for every other principal. The dict path is what crashed; the LDAP sheet path is harmless but also irrelevant — `linked_client_uid` is never part of the LDAP attrmap, so it could never live there.

2. `linked_contact_uid` was still written via `user.setMemberProperties({...})`, which walks the user's cached property sheets. Those sheets are built at `_findUser` time with the schema as it was *then* — so when `_linkUser` registers `linked_contact_uid` on `portal_memberdata` just-in-time for a brand-new user in the same request, the cached `mutable_properties` sheet's schema doesn't include it, `canWriteProperty` returns False, and the write silently no-ops. Same fragility, just no traceback to make it visible.

The same code lives in the AT mirror at `src/bika/lims/content/contact.py`.

Also fixes two stale PR numbers in `CHANGES.rst` — #2935 and #2936 were closed without merging; the merged equivalents are #2937 and #2938.

## Current behavior before PR

- Linking or creating a user on a Client Contact raises `AttributeError: 'dict' object has no attribute 'hasProperty'` whenever any `IPropertiesPlugin` (e.g. `pas.plugins.ldap`) returns a non-PropertySheet for the target user. The transaction is aborted and the user is never created.
- For brand-new users where `linked_contact_uid` is registered in the same request as the link, the property write silently no-ops because the user's cached `mutable_properties` sheet predates the registration.

## Desired behavior after PR is merged

- Generalise the helper into `_set_user_property(user, key, value)` and route both `linked_contact_uid` and `linked_client_uid` through it.
- Skip any `getPropertiesForUser` return that does not expose `hasProperty`/`setProperty`, then fall through to the ZODB `mutable_properties` plugin, which writes the property into the OOBTree-backed sheet whose schema reflects current `portal_memberdata.propertyMap` on every call. Works uniformly for ZODB and LDAP-sourced users — the dynamic role provider reads the property via `user.getProperty(...)` either way.
- Update the existing upgrade backfill (`backfill_linked_client_uid`) to use the new name.