### PR TITLE
Remove leftover per-client-group code paths

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2941 Remove leftover per-client-group code paths
 - #2940 Grant the global 'Client' role to users with linked_client_uid set
 - #2939 Persist linked user properties through the mutable properties plugin
 - #2938 Remove legacy per-client groups and persisted Owner local roles

--- a/src/bika/lims/content/client.py
+++ b/src/bika/lims/content/client.py
@@ -44,7 +44,6 @@ from Products.ATContentTypes.content import schemata
 from Products.CMFCore import permissions
 from Products.CMFCore.PortalFolder import PortalFolderBase as PortalFolder
 from Products.CMFCore.utils import _checkPermission
-from Products.CMFPlone.RegistrationTool import get_member_by_login_name
 from senaite.core.browser.fields.multiupload import MultiUploadField
 from senaite.core.browser.widgets.multiuploadwidget import MultiUploadWidget
 from senaite.core.browser.widgets.referencewidget import ReferenceWidget
@@ -267,144 +266,10 @@ class Client(Organisation):
 
     security = ClassSecurityInfo()
     schema = schema
-    GROUP_KEY = "_client_group_id"
 
     def _renameAfterCreation(self, check_auto_id=False):
         from senaite.core.idserver import renameAfterCreation
         renameAfterCreation(self)
-
-    @property
-    def group_id(self):
-        """Client group ID
-        """
-        if not hasattr(self, self.GROUP_KEY):
-            setattr(self, self.GROUP_KEY, self._get_group_id())
-        return getattr(self, self.GROUP_KEY)
-
-    def _get_group_id(self):
-        """Get a valid group ID
-        """
-        # Try first the client ID
-        client_id = self.getClientID()
-        if self.is_valid_group_id(client_id):
-            return client_id
-
-        # Use the context ID
-        context_id = self.getId()
-        if self.is_valid_group_id(context_id):
-            return context_id
-
-        # Use the ID + prefix
-        prefix_id = "group_%s" % client_id or context_id
-        count = 0
-        while not self.is_valid_group_id(prefix_id):
-            count += 1
-            prefix_id = "group_%s_%s" % (count, client_id or context_id)
-
-        return prefix_id
-
-    def is_valid_group_id(self, group_id):
-        """Check if the group ID is valid
-
-        :param group_id: The group ID to validate
-        """
-        # Check for string
-        if not api.is_string(group_id):
-            return False
-
-        # Check for empty string
-        if not len(group_id) > 0:
-            return False
-
-        portal = api.get_portal()
-        # Check if the ID is already used by a user login
-        if get_member_by_login_name(portal, group_id, False):
-            return False
-
-        return True
-
-    @security.public
-    def get_group(self):
-        """Returns our client group
-
-        :returns: Client group object
-        """
-        portal_groups = api.get_tool("portal_groups")
-        return portal_groups.getGroupById(self.group_id)
-
-    @security.private
-    def create_group(self):
-        """Create a new client group
-
-        :returns: Client group object
-        """
-        group = self.get_group()
-
-        # return the existing Group immediately
-        if group:
-            return group
-
-        portal_groups = api.get_tool("portal_groups")
-        group_name = self.getName()
-
-        # Create a new Client Group
-        # NOTE: The global "Client" role is necessary for the client contacts
-        portal_groups.addGroup(self.group_id,
-                               roles=["Client"],
-                               title=group_name)
-
-        # Grant the group the "Owner" role on ourself
-        # NOTE: This will grant each member of this group later immediate
-        #       access to all exisiting objects with the same role.
-        self.manage_setLocalRoles(self.group_id, ["Owner"])
-
-        return self.get_group()
-
-    @security.private
-    def remove_group(self):
-        """Remove the own client group
-
-        :returns: True if the group was removed, otherwise False
-        """
-        group = self.get_group()
-        if not group:
-            return False
-        portal_groups = api.get_tool("portal_groups")
-        # Use the client ID for the group ID
-        portal_groups.removeGroup(self.group_id)
-        # also remove the group attribute
-        delattr(self, self.GROUP_KEY)
-        return True
-
-    @security.private
-    def add_user_to_group(self, user):
-        """Add a user to the client group
-
-        :param user: user/group object or user/group ID
-        :returns: list of new group IDs
-        """
-        group = self.get_group()
-        if not group:
-            group = self.create_group()
-        return api.user.add_group(group, user)
-
-    @security.private
-    def del_user_from_group(self, user):
-        """Add a user to the client group
-
-        :param user: user/group object or user/group ID
-        :returns: list of new group IDs
-        """
-        group = self.get_group()
-        if not group:
-            group = self.create_group()
-        return api.user.del_group(group, user)
-
-    @security.public
-    def getGroupId(self):
-        """Returns the id of the Plone's client-speficic group for this client
-        """
-        return self.group_id
 
     @security.public
     def getContactFromUsername(self, username):

--- a/src/bika/lims/profiles/default/types/Client.xml
+++ b/src/bika/lims/profiles/default/types/Client.xml
@@ -40,7 +40,6 @@
   <alias from="analysisrequests" to="base_view"/>
   <alias from="edit" to="base_edit"/>
   <alias from="view" to="base_view"/>
-  <alias from="sharing" to="@@sharing" />
 
   <action title="Edit"
           action_id="edit"

--- a/src/senaite/core/browser/clients/client/contacts/login_details.py
+++ b/src/senaite/core/browser/clients/client/contacts/login_details.py
@@ -35,7 +35,6 @@ from Products.CMFPlone.controlpanel.browser.usergroups_usersoverview import \
     UsersOverviewControlPanel
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from senaite.core.catalog import CLIENT_CATALOG
 from senaite.core.config.groups import HIDDEN_GROUPS
 from senaite.core.p3compat import cmp
 
@@ -78,26 +77,14 @@ class ContactLoginDetailsView(BrowserView):
         users_view = UsersOverviewControlPanel(self.context, self.request)
         return users_view.doSearch("")
 
-    @view.memoize
-    def get_clients_groups(self):
-        """Returns the client-specific groups
-        """
-        groups = []
-        cat = api.get_tool(CLIENT_CATALOG)
-        for brain in cat(portal_type="Client"):
-            if brain.getGroupId:
-                groups.append(brain.getGroupId)
-        return groups
-
     def get_laboratory_groups(self):
         """Return the groups available for laboratory users
         """
         gtool = api.get_tool("portal_groups")
         groups = gtool.listGroupIds()
 
-        # exclude hidden (Administrators, etc.) and client-specific groups
-        to_skip = HIDDEN_GROUPS + self.get_clients_groups()
-        groups = filter(lambda group: group not in to_skip, groups)
+        # exclude hidden (Administrators, etc.)
+        groups = filter(lambda group: group not in HIDDEN_GROUPS, groups)
 
         # sort them
         return sorted(groups)

--- a/src/senaite/core/catalog/client_catalog.py
+++ b/src/senaite/core/catalog/client_catalog.py
@@ -42,7 +42,6 @@ COLUMNS = BASE_COLUMNS + [
     "getClientID",
     "getName",
     "getEmailAddress",  # used in reference widget columns
-    "getGroupId",
 ]
 
 TYPES = [

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2742</version>
+  <version>2744</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-senaite.impress:default</dependency>

--- a/src/senaite/core/tests/doctests/ContactUser.rst
+++ b/src/senaite/core/tests/doctests/ContactUser.rst
@@ -119,7 +119,8 @@ The dynamic local-role provider grants access on the client tree
 from that property; no per-client group is created and no local
 role is persisted on the client folder::
 
-    >>> client1.get_group() is None
+    >>> portal_groups = portal.portal_groups
+    >>> portal_groups.getGroupById(client1.getId()) is None
     True
 
     >>> portal_user1 = portal.acl_users.getUserById(user1.getId())

--- a/src/senaite/core/tests/doctests/Permissions.rst
+++ b/src/senaite/core/tests/doctests/Permissions.rst
@@ -502,7 +502,8 @@ profile. The dynamic local-role provider grants access on the
 client tree from that property — no per-client group is created
 and no local role is persisted on the client folder::
 
-    >>> client.get_group() is None
+    >>> portal_groups = portal.portal_groups
+    >>> portal_groups.getGroupById(client.getId()) is None
     True
 
     >>> portal_user = portal.acl_users.getUserById(user.getId())

--- a/src/senaite/core/upgrade/v02_05_000.py
+++ b/src/senaite/core/upgrade/v02_05_000.py
@@ -19,7 +19,6 @@
 # Some rights reserved, see README and LICENSE.
 
 import transaction
-from Acquisition import aq_base
 from bika.lims import api
 from bika.lims.api import security
 from bika.lims.interfaces import IReceived
@@ -40,7 +39,6 @@ from senaite.core.config import PROJECTNAME as product
 from senaite.core.config.registry import CLIENT_LANDING_PAGE
 from senaite.core.permissions import ManageBika
 from senaite.core.permissions import TransitionReceiveSample
-from senaite.core.registry import get_registry_record
 from senaite.core.registry import set_registry_record
 from senaite.core.setuphandlers import _run_import_step
 from senaite.core.setuphandlers import add_dexterity_items
@@ -276,95 +274,24 @@ def import_registry(tool):
 
 
 def create_client_groups(tool):
-    """Create for all Clients an explicit Group
+    """No-op. Pre-2.7 SENAITE created a group per Client to carry the
+    'Client' role + Owner local role. With #2934/#2938 access is granted
+    dynamically by `senaite.core.security.clientrole`, so creating the
+    legacy groups would only generate work for `remove_legacy_client_groups`
+    to undo at the 2.7 step.
     """
-    logger.info("Create client groups ...")
-    clients = api.search({"portal_type": "Client"}, CLIENT_CATALOG)
-    total = len(clients)
-    for num, client in enumerate(clients):
-        obj = api.get_object(client)
-        logger.info("Processing client %s/%s: %s"
-                    % (num+1, total, obj.getName()))
-
-        # recreate the group
-        obj.remove_group()
-
-        # skip group creation
-        if not get_registry_record("auto_create_client_group", True):
-            logger.info("Auto group creation is disabled in registry. "
-                        "Skipping group creation ...")
-            continue
-
-        group = obj.create_group()
-        # add all linked client contacts to the group
-        for contact in obj.getContacts():
-            user = contact.getUser()
-            if not user:
-                continue
-            logger.info("Adding user '%s' to the client group '%s'"
-                        % (user.getId(), group.getId()))
-            obj.add_user_to_group(user)
-
-    logger.info("Create client groups [DONE]")
+    logger.info("Skipping legacy per-client group creation; "
+                "client access is now granted dynamically.")
 
 
 def reindex_client_security(tool):
-    """Reindex client object security to grant the owner role for the client
-       group to all contents
+    """No-op. The persisted Owner local role this step refreshed was
+    removed by `remove_legacy_client_groups` in 2.7, and the
+    `allowedRolesAndUsers` index is rebuilt with the new `client:<uid>`
+    token by `switch_to_dynamic_client_roles`.
     """
-    logger.info("Reindex client security ...")
-
-    clients = api.search({"portal_type": "Client"}, CLIENT_CATALOG)
-    total = len(clients)
-    for num, client in enumerate(clients):
-        obj = api.get_object(client)
-        logger.info("Processing client %s/%s: %s"
-                    % (num+1, total, obj.getName()))
-
-        if not obj.get_group():
-            logger.info("No client group exists for client %s. "
-                        "Skipping reindexing ..." % obj.getName())
-            continue
-
-        _recursive_reindex_object_security(obj)
-
-        logger.info("Commiting client %s/%s" % (num+1, total))
-        transaction.commit()
-        logger.info("Commit done")
-
-        # Flush the object from memory
-        obj._p_deactivate()
-
-    logger.info("Reindex client security [DONE]")
-
-
-def _recursive_reindex_object_security(obj):
-    """Recursively reindex object security for the given object
-    """
-    if hasattr(aq_base(obj), "objectValues"):
-        children = obj.objectValues()
-        for num, child_obj in enumerate(children):
-            if num and num % 100 == 0:
-                path = api.get_path(obj)
-                logger.info("{}: committing children {} ...".format(path, num))
-                transaction.commit()
-            _recursive_reindex_object_security(child_obj)
-
-    # We don't do obj.reindexObject(idxs=["allowedRolesAndUsers"]) because
-    # the function reindex the whole object (metadata included) if the catalog
-    # does not contain the index 'allowedRolesAndUsers'. This makes the system
-    # to consume a lot of RAM when thousands of objects need to be processed.
-    # Also, the function does other stuff like refreshing Etag and so on, that
-    # are things that we are not interested at all, actually. We just want the
-    # index allowedRolesAndUsers to be updated, nothing else
-    idx = "allowedRolesAndUsers"
-    for cat in api.get_catalogs_for(obj):
-        if idx not in cat.indexes():
-            continue
-        path = api.get_path(obj)
-        cat.catalog_object(obj, path, idxs=[idx], update_metadata=0)
-
-    obj._p_deactivate()
+    logger.info("Skipping legacy client security reindex; "
+                "the dynamic role provider handles this in 2.7.")
 
 
 def add_content_actions(tool):

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -2215,16 +2215,17 @@ def add_sample_catalog_indexes(tool):
 def strip_global_client_role(tool):
     """Remove directly-assigned global 'Client' role from users.
 
-    The 'Client' role is now granted implicitly to users via membership
-    in the per-client group (the group itself carries ``roles=["Client"]``).
-    A user with the role assigned directly through the portal role
-    manager but no client-group membership has the Client landing page
-    but no Owner role on any client folder, which is a half-configured
-    state with no useful access.
+    The 'Client' role is now granted dynamically by the
+    ILocalRoleProvider in `senaite.core.security.clientrole` based on
+    the user's `linked_client_uid` member property. A user with the
+    role assigned directly through the portal role manager but no
+    contact link has the Client landing page but no Owner role on any
+    client folder, which is a half-configured state with no useful
+    access.
 
     Iterate the principals assigned the 'Client' role via the portal
-    role manager and remove the direct assignment. Users keep the role
-    indirectly through group membership where applicable.
+    role manager and remove the direct assignment. Users keep the
+    role dynamically wherever their `linked_client_uid` matches.
     """
     logger.info("Stripping global 'Client' role from users ...")
     acl = api.get_tool("acl_users")
@@ -2463,3 +2464,42 @@ def remove_legacy_client_groups(tool):
         "Legacy client-group cleanup: %s groups removed, "
         "%s local-role grants cleared on %s clients"
         % (removed_groups, cleared_local_roles, total))
+
+
+@upgradestep(product, version)
+def drop_client_catalog_group_id_column(tool):
+    """Drop the `getGroupId` metadata column from `senaite_catalog_client`.
+
+    The column mirrored the legacy per-client group id. After the
+    dynamic role provider replaces the group mechanism, the column is
+    dead weight and every brain that still carries a stale value
+    misleads any code that reads it.
+    """
+    catalog = api.get_tool("senaite_catalog_client", default=None)
+    if catalog is None:
+        return
+    if del_column(catalog, "getGroupId"):
+        logger.info(
+            "Dropped 'getGroupId' column from senaite_catalog_client")
+
+
+@upgradestep(product, version)
+def remove_client_sharing_alias(tool):
+    """Drop the `sharing` method alias from the Client FTI.
+
+    The alias used to route `/<client>/sharing` to `@@sharing`. The
+    `manage_access` action that exposed it was removed by
+    `remove_client_manage_access_action`, but the alias itself kept
+    the view reachable by direct URL. Sharing on the client tree is
+    redundant now that access is granted dynamically.
+    """
+    types_tool = api.get_tool("portal_types")
+    fti = types_tool.getTypeInfo("Client")
+    if fti is None:
+        return
+    aliases = dict(fti.getMethodAliases() or {})
+    if "sharing" not in aliases:
+        return
+    del aliases["sharing"]
+    fti.setMethodAliases(aliases)
+    logger.info("Removed 'sharing' method alias from Client FTI")

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -3,6 +3,29 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.7.0: Remove 'sharing' alias from Client FTI"
+      description="Drop the `sharing` method alias on the Client FTI.
+                   The alias still routed `/&lt;client&gt;/sharing` to
+                   @@sharing after `manage_access` was removed; the
+                   alias is dead weight once access is granted
+                   dynamically by the ILocalRoleProvider."
+      source="2743"
+      destination="2744"
+      handler=".v02_07_000.remove_client_sharing_alias"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.7.0: Drop 'getGroupId' column from client catalog"
+      description="Remove the `getGroupId` metadata column from
+                   `senaite_catalog_client`. The column mirrored the
+                   legacy per-client group id and now only carries
+                   stale values."
+      source="2742"
+      destination="2743"
+      handler=".v02_07_000.drop_client_catalog_group_id_column"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Remove legacy per-client groups and persisted Owner local roles"
       description="Iterate every Client, remove the per-client group
                    created by the legacy auto-create mechanism, clear


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Follow-up cleanup after #2938 removed the per-client group + persisted Owner local-role mechanism. Several leftover code paths still referenced the dead mechanism. They are dead weight today and a foot-gun for any future caller that rebuilds the state we just stripped.

## Current behavior before PR

`bika.lims.content.client.Client` still exposes the whole legacy group API — `GROUP_KEY`, `group_id`, `_get_group_id`, `is_valid_group_id`, `get_group`, `create_group`, `remove_group`, `add_user_to_group`, `del_user_from_group`, `getGroupId`. `create_group` still calls `manage_setLocalRoles(group_id, ["Owner"])` and `portal_groups.addGroup(..., roles=["Client"])`, which is exactly the persisted state that #2938 strips. Any third-party view, REST consumer or doctest calling `create_group()` re-introduces the legacy state on a migrated site.

`senaite_catalog_client` carries the `getGroupId` metadata column. The 2.7 upgrade step deletes `_client_group_id` from every Client but does not refresh client-catalog metadata, so brains return stale strings on every install. `login_details.get_clients_groups` reads it for an exclusion filter that no longer has anything to exclude.

The Client FTI still aliases `sharing` to `@@sharing`, so `/<client>/sharing` is reachable by direct URL even though #2937 removed the `manage_access` action that linked to it. An admin clicking through to the (now custom) sharing view can still write persistent local roles on a Client.

`v02_05_000.create_client_groups` and `reindex_client_security` call `Client.create_group()` / `Client.get_group()` to set up the per-client group + Owner local role on upgrade. A clean upgrade from < 2.5 through to 2.7 first creates the legacy state, then strips it again at the 2.7 step — pure busy-work.

`strip_global_client_role` still has a docstring describing the dead per-client group as the mechanism by which the Client role is granted. Two PRs later, the comment lies.

## Desired behavior after PR is merged

The Client group API is gone from `Client`. The class no longer has any code path that re-introduces a per-client group or persisted Owner local role.

`getGroupId` is removed from the `senaite_catalog_client` columns. A new upgrade step (2742 → 2743) drops the column on live installs.

The `sharing` alias is removed from the Client FTI XML. A second new upgrade step (2743 → 2744) scrubs the alias from the live FTI. `metadata.xml` is bumped to 2744 alongside.

`v02_05_000.create_client_groups` and `reindex_client_security` are reduced to logged no-ops. They keep their entries in the upgrade-step ZCML so historical upgrade paths from < 2.5 still resolve, but do nothing — the 2.7 dynamic-role machinery handles client access on the destination version.

The `strip_global_client_role` docstring now describes the dynamic ILocalRoleProvider model in `senaite.core.security.clientrole`.

`login_details.get_clients_groups` is removed; `get_laboratory_groups` filters against `HIDDEN_GROUPS` only.

Both doctests (`ContactUser.rst` and `Permissions.rst`) no longer call the removed `client.get_group()` API. They assert directly against `portal_groups.getGroupById(client.getId())`, which is the actual claim: no per-client group exists.

## Test plan

- `bin/test-senaite -s senaite.core -t ContactUser` passes
- `bin/test-senaite -s senaite.core -t Permissions` passes

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] and Plone's Python styleguide standards.

[1]: https://www.python.org/dev/peps/pep-0008