### PR TITLE
Polish client-role upgrade steps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2943 Polish client-role upgrade steps
 - #2940 Grant the global 'Client' role to users with linked_client_uid set
 - #2939 Persist linked user properties through the mutable properties plugin
 - #2938 Remove legacy per-client groups and persisted Owner local roles

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -2294,9 +2294,17 @@ def switch_to_dynamic_client_roles(tool):
     drop_auto_create_client_group_record(portal)
 
 
+REINDEX_BATCH_SIZE = 100
+
+
 def reindex_client_tree_allowed_roles():
     """Reindex `allowedRolesAndUsers` on every IClient + IClientAware
     object so they carry the new `client:<uid>` token.
+
+    Wakes every brain via `getObject()` to reindex the live object.
+    On large installs (50k+ samples) that loads everything into the
+    ZODB cache, so checkpoint a savepoint and deactivate each object
+    after the reindex to keep memory bounded.
     """
     from bika.lims.interfaces import IClient
     from bika.lims.interfaces import IClientAwareMixin
@@ -2323,9 +2331,12 @@ def reindex_client_tree_allowed_roles():
                     or IClientAwareMixin.providedBy(obj)):
                 continue
             obj.reindexObject(idxs=["allowedRolesAndUsers"])
+            obj._p_deactivate()
             if uid:
                 seen.add(uid)
             total += 1
+            if total % REINDEX_BATCH_SIZE == 0:
+                transaction.savepoint(optimistic=True)
             if total % 500 == 0:
                 logger.info("  ... reindexed %s objects" % total)
     logger.info(
@@ -2333,14 +2344,26 @@ def reindex_client_tree_allowed_roles():
 
 
 def backfill_linked_client_uid():
-    """Set the `linked_client_uid` user property for every existing
-    client contact that is already linked to a user account.
+    """Set the `linked_client_uid` and `linked_contact_uid` user
+    properties for every existing client contact already linked to a
+    user account.
+
+    Both properties drive different parts of the runtime: the client
+    UID is what the dynamic local-role provider in
+    `senaite.core.security.clientrole` reads to grant access on the
+    client tree, while the contact UID is the back-reference that
+    resolves a logged-in user to their contact object. The link path
+    in `Contact._linkUser` writes both, so existing links must carry
+    both for parity.
     """
     from bika.lims.interfaces import IClient
     from senaite.core.content.contact import CLIENT_UID_KEY
+    from senaite.core.content.contact import CONTACT_UID_KEY
     from senaite.core.content.contact import _set_user_property
 
-    logger.info("Backfilling `linked_client_uid` on linked users ...")
+    logger.info(
+        "Backfilling `linked_client_uid` and `linked_contact_uid` "
+        "on linked users ...")
     contacts = api.search({"portal_type": "Contact"}, CONTACT_CATALOG)
     updated = 0
     for brain in contacts:
@@ -2352,9 +2375,10 @@ def backfill_linked_client_uid():
         if user is None:
             continue
         _set_user_property(user, CLIENT_UID_KEY, api.get_uid(parent))
+        _set_user_property(user, CONTACT_UID_KEY, api.get_uid(contact))
         updated += 1
     logger.info(
-        "Backfilled `linked_client_uid` on %s users" % updated)
+        "Backfilled linked UID properties on %s users" % updated)
 
 
 def drop_auto_create_client_group_record(portal):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Follow-up polish on the upgrade steps `switch_to_dynamic_client_roles` calls. Found while reviewing the new client-contact mechanism end-to-end. Two improvements: one correctness, one operational.

## Current behavior before PR

`backfill_linked_client_uid` only writes the linked client UID on the user property storage. The runtime link path in `Contact._linkUser` (introduced in #2939) writes both `linked_client_uid` and `linked_contact_uid`. Existing links carried over from before #2939 therefore have only half the shape: the dynamic role provider works (because that one reads `linked_client_uid`), but the contact back-reference that resolves a logged-in user to their contact object is missing. Code that depends on it has no equivalent on legacy installs until someone manually unlinks and re-links every affected user.

`reindex_client_tree_allowed_roles` walks every brain in eight client-tree catalogs and wakes each via `brain.getObject()` to call `reindexObject(idxs=["allowedRolesAndUsers"])`. There is no `transaction.savepoint` and no `_p_deactivate`. On a small install this is fine, but on a real deployment with 50k+ samples plus analyses, partitions, attachments, reports and worksheets, every awoken object stays pinned in the ZODB cache for the entire upgrade transaction. Memory grows monotonically and the upgrade can OOM on a constrained host.

## Desired behavior after PR is merged

`backfill_linked_client_uid` writes both `linked_client_uid` and `linked_contact_uid` on every linked user, matching what the runtime link path writes. The docstring spells out which property drives which subsystem so future readers do not have to derive it. The function name is kept (it is referenced from the existing 2739 → 2740 upgrade-step entry); only the body and docstring change.

`reindex_client_tree_allowed_roles` takes an optimistic `transaction.savepoint` every 100 reindexed objects and calls `_p_deactivate()` on each object after the reindex. Memory stays bounded by the savepoint window, so the upgrade survives on large installs without changing semantics.

## Test plan

- `bin/test-senaite -s senaite.core -t ContactUser` passes
- The two changed functions are called from existing upgrade steps registered in `v02_07_000.zcml` (2739 → 2740). No new upgrade step needed and no metadata version bump, because the destinations don't change.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] and Plone's Python styleguide standards.

[1]: https://www.python.org/dev/peps/pep-0008