### PR TITLE
Cover catalog token and sidebar grant for linked client users

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2944 Cover catalog token and sidebar grant for linked client users
 - #2940 Grant the global 'Client' role to users with linked_client_uid set
 - #2939 Persist linked user properties through the mutable properties plugin
 - #2938 Remove legacy per-client groups and persisted Owner local roles

--- a/src/senaite/core/tests/doctests/ContactUser.rst
+++ b/src/senaite/core/tests/doctests/ContactUser.rst
@@ -145,6 +145,67 @@ the same request as the user was created::
     >>> bool(portal_memberdata.hasProperty("linked_client_uid"))
     True
 
+The property is persisted by the mutable_properties PAS plugin
+(not by an in-memory sheet from another property plugin). Reading
+the property sheet back directly proves the value lives there::
+
+    >>> mutable_properties = portal.acl_users.mutable_properties
+    >>> sheet = mutable_properties.getPropertiesForUser(portal_user1)
+    >>> sheet.getProperty("linked_client_uid") == client1.UID()
+    True
+    >>> sheet.getProperty("linked_contact_uid") == contact1.UID()
+    True
+
+The dynamic role provider works alongside a catalog-side token: the
+client and every IClientAwareMixin descendant carry a stable
+`client:<client_uid>` entry in `allowedRolesAndUsers`, so a linked
+client user can find their content without any persisted local
+role::
+
+    >>> from senaite.core.catalog import CLIENT_CATALOG
+    >>> client_brain = portal[CLIENT_CATALOG](UID=client1.UID())[0]
+    >>> ("client:" + client1.UID()) in client_brain.allowedRolesAndUsers
+    True
+
+`BaseCatalog._listAllowedRolesAndUsers` injects the matching token
+for any user whose `linked_client_uid` is set. The injection is
+what closes the loop with the indexer above — a catalog query by
+the linked user picks up the client's content while no other
+client's token is added::
+
+    >>> catalog = portal[CLIENT_CATALOG]
+    >>> tokens = catalog._listAllowedRolesAndUsers(portal_user1)
+    >>> ("client:" + client1.UID()) in tokens
+    True
+    >>> ("client:" + client2.UID()) in tokens
+    False
+
+A user without a linked client gets no `client:` token at all, so
+the runtime cost of the override is one member-property read per
+query::
+
+    >>> portal_user2 = portal.acl_users.getUserById(user2.getId())
+    >>> tokens2 = catalog._listAllowedRolesAndUsers(portal_user2)
+    >>> [t for t in tokens2 if t.startswith("client:")]
+    []
+
+The `senaite.core: View Navigation` permission gates the sidebar
+viewlet. It is granted to the `Client` role, and the global
+provider's role grant must reach the portal root, otherwise linked
+client users would have no navigation panel after login. Asserting
+the permission resolves for the linked user is the regression
+sentinel that protects the sidebar render::
+
+    >>> from AccessControl import getSecurityManager
+    >>> from AccessControl.SecurityManagement import newSecurityManager
+    >>> from AccessControl.SecurityManagement import setSecurityManager
+    >>> previous_sm = getSecurityManager()
+    >>> newSecurityManager(None, portal_user1)
+    >>> bool(getSecurityManager().checkPermission(
+    ...     "senaite.core: View Navigation", portal))
+    True
+    >>> setSecurityManager(previous_sm)
+
 The user does not get the `Client` role globally; the role is
 granted dynamically on the client tree only::
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Extend the `ContactUser` doctest with assertions that close three coverage gaps in the new client-contact mechanism merged in #2934, #2939 and #2940. No production code changes.

## Current behavior before PR

The doctest already covers the high-level link/unlink flow, the dynamic role grant per-context, and the global Client role grant at the portal root. Three pieces stay uncovered:

The link path writes the user properties via a plugin walk. Nothing asserts that the values actually land on the `mutable_properties` PAS plugin (i.e. on a persistent sheet) as opposed to an in-memory sheet from another plugin that happens to be earlier in the registration order.

The dynamic role mechanism has two halves: the runtime provider (covered) and the catalog `client:<uid>` token injected by both the `allowedRolesAndUsers` indexer and `BaseCatalog._listAllowedRolesAndUsers`. Nothing asserts the token actually lands on indexed objects or that the injection happens for the asking user (and does not happen for users without a linked client).

The sidebar regression closed by #2940 is a `senaite.core: View Navigation` permission check at the portal root. Without a regression sentinel, any future refactor of the global role provider could reintroduce the silent-sidebar bug.

## Desired behavior after PR is merged

The doctest reads the property sheet returned by `acl_users.mutable_properties.getPropertiesForUser(user)` directly and asserts both `linked_client_uid` and `linked_contact_uid` carry the expected UIDs. The values cannot be coming from any plugin other than `mutable_properties` after this check.

The doctest asserts the `client:<client_uid>` token appears in `client_brain.allowedRolesAndUsers` and that `BaseCatalog._listAllowedRolesAndUsers` returns the matching token for the linked user but not the token of any other client. A second user with no link gets no `client:` token at all.

The doctest installs the linked user as the current security manager and calls `checkPermission("senaite.core: View Navigation", portal)`. It asserts the permission resolves to True, then restores the previous security manager so the rest of the test suite is unaffected. This is the exact check performed by `SidebarViewletManager.has_view_navigation_permission` and would have caught the pre-#2940 regression.

## Test plan

- `bin/test-senaite -s senaite.core -t ContactUser` passes

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] and Plone's Python styleguide standards.

[1]: https://www.python.org/dev/peps/pep-0008