### PR TITLE
Merge linked-user property sheets in first-non-empty-wins order

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2945 Merge linked-user property sheets in first-non-empty-wins order
 - #2940 Grant the global 'Client' role to users with linked_client_uid set
 - #2939 Persist linked user properties through the mutable properties plugin
 - #2938 Remove legacy per-client groups and persisted Owner local roles

--- a/src/senaite/core/browser/clients/client/contacts/login_details.py
+++ b/src/senaite/core/browser/clients/client/contacts/login_details.py
@@ -115,9 +115,20 @@ class ContactLoginDetailsView(BrowserView):
         out = {}
         plone_user = user.getUser()
         userid = plone_user.getId()
+        # Merge property sheets in "first non-empty wins" order. PAS
+        # lists sheets in plugin priority order (highest first); a
+        # blind ``out.update(dict(ps.propertyItems()))`` lets a later,
+        # lower-priority sheet (e.g. ``mutable_properties`` with an
+        # empty ``email`` for a linked LDAP user) clobber the value
+        # from a higher-priority sheet (e.g. ``pasldap``). That's the
+        # opposite of how ``member.getProperty`` resolves the same
+        # lookup. Mirror PAS semantics here instead.
         for sheet in plone_user.listPropertysheets():
             ps = plone_user.getPropertysheet(sheet)
-            out.update(dict(ps.propertyItems()))
+            for key, value in ps.propertyItems():
+                if value in (None, ""):
+                    continue
+                out.setdefault(key, value)
 
         portal = api.get_portal()
         mtool = getToolByName(self.context, "portal_membership")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The Login Details panel on a Client Contact shows the linked Plone user's name, username, **email**, and last-login. For LDAP users the email field appears empty even though the LDAP entry has `mail` set and the membership-tool lookup returns the value correctly:

```
member.getProperty('email')               -> 'rb@ridingbytes.com'
pasldap sheet      .getProperty('email')  -> 'rb@ridingbytes.com'
mutable_properties .getProperty('email')  -> ''
```

The view shows nothing.

## Current behavior before PR

`ContactLoginDetailsView.get_user_properties` (`login_details.py:118-120`) merges every property sheet into one dict via plain `dict.update`:

```python
out = {}
for sheet in plone_user.listPropertysheets():
    ps = plone_user.getPropertysheet(sheet)
    out.update(dict(ps.propertyItems()))
```

`listPropertysheets()` returns the sheets in PAS plugin priority order, **highest first**. A blind `update` lets the **last** (lowest-priority) sheet clobber the values from the higher-priority sheet. For any LDAP user with a stub `mutable_properties` record (e.g. one created by the `migrate-to-emaillogin` walk, or any future code path that touches `mutable_properties` before a value is set), the empty string from `mutable_properties` overwrites the real value from the LDAP plugin.

That's the opposite of how `member.getProperty(name)` resolves the same lookup -- PAS returns the value from the first sheet whose `hasProperty(name)` is true.

The user sees a clean LDAP entry, a healthy `member.getProperty('email')` answer, a correctly-prioritised `IPropertiesPlugin` order, and an empty field in the UI. There is no obvious place to look unless you trace into this view.

## Desired behavior after PR is merged

Merge sheets in "first non-empty wins" order so the view's lookup mirrors what `member.getProperty` would return. Empty strings and `None` from later (lower-priority) sheets do not overwrite a real value from an earlier sheet:

```python
for sheet in plone_user.listPropertysheets():
    ps = plone_user.getPropertysheet(sheet)
    for key, value in ps.propertyItems():
        if value in (None, ""):
            continue
        out.setdefault(key, value)
```

After the change, the linked LDAP user's email is the LDAP `mail` attribute as expected.

## Test plan

- Verified locally against an LDAP-backed install where `mail=rb@ridingbytes.com` and `mutable_properties` holds `email=''`. Before: empty. After: `rb@ridingbytes.com`.
- `bin/test-senaite -s senaite.core -t ContactUser` passes.

The change is internal to `get_user_properties`; the templated card and the link/unlink flow are untouched.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] and Plone's Python styleguide standards.

[1]: https://www.python.org/dev/peps/pep-0008