### PR TITLE
Fix barcodes missing from PDFs behind a virtual-host path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2947 Fix barcodes missing from PDFs behind a virtual-host path
 - #2940 Grant the global 'Client' role to users with linked_client_uid set
 - #2939 Persist linked user properties through the mutable properties plugin
 - #2938 Remove legacy per-client groups and persisted Owner local roles

--- a/src/bika/lims/utils/__init__.py
+++ b/src/bika/lims/utils/__init__.py
@@ -393,10 +393,26 @@ def senaite_url_fetcher(url):
 
     logger.info("Fetching URL '{}' for WeasyPrint".format(url))
 
+    # `data:` URIs (e.g. the data:image/svg+xml barcodes embedded in stickers)
+    # are handled natively by WeasyPrint's default fetcher. Resolving them to a
+    # physical path makes no sense and raises `ValueError` when the request is
+    # served under a virtual-host *path* (e.g. behind a path-based reverse
+    # proxy), which would silently drop the image from the generated PDF.
+    if url.lower().startswith("data:"):
+        return default_url_fetcher(url)
+
     # get the pyhsical path from the URL
     request = api.get_request()
     host = request.get_header("HOST")
-    path = "/".join(request.physicalPathFromURL(url))
+    try:
+        path = "/".join(request.physicalPathFromURL(url))
+    except ValueError:
+        # The URL does not match the current virtual hosting context (e.g. an
+        # external resource, or a path that does not share the virtual-host
+        # root). Let WeasyPrint's default fetcher deal with it.
+        logger.info("URL '{}' does not match the virtual hosting context, "
+                    "passing over to the default URL fetcher...".format(url))
+        return default_url_fetcher(url)
 
     # fetch the object by sub-request
     portal = api.get_portal()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`bika.lims.utils.senaite_url_fetcher` (the WeasyPrint `url_fetcher` used to generate PDFs) calls `request.physicalPathFromURL(url)` for *every* resource URL referenced in the report, including `data:` URIs.

Stickers embed their barcode as an `<img src="data:image/svg+xml;base64,...">` (jquery-barcode `svg` output). When a sticker is printed, the rendered HTML is sent to WeasyPrint, which calls `senaite_url_fetcher` for that `data:` URI.

`physicalPathFromURL` (Zope `ZPublisher/HTTPRequest.py`) splits the URL on "/" and checks the leading segments against the virtual-host script path (`request._script`):

```python
if path[:vhbl] == vhbase:
    path = path[vhbl:]
else:
    raise ValueError('Url does not match virtual hosting context')
```

- When the site is served at the virtual-host root, `request._script` is empty (`vhbl == 0`), the check always passes, and the data: URI falls through to `weasyprint.default_url_fetcher`, which handles it natively.
- When the site is served under a virtual-host path (a non-empty _script, e.g. a `_vh_*` root set by a reverse proxy), the first segment of the data: URI is data:image, which never matches the virtual-host base, so `physicalPathFromURL` raises `ValueError`. WeasyPrint treats this as a failed image fetch and silently drops the image — the PDF renders with a blank barcode while the rest of the document is intact.

This happens with a path-based gateway that fronts several Plone sites under distinct path prefixes and tags each request with a site id used to build the virtual-host root. For example (nginx):

```
# Gateway: route /<site>/... to the matching backend, tagging the request
location /site-a/ {
    proxy_set_header siteid site-a;
    proxy_pass       https://backend-site-a/;
}

# Backend: build the Zope VirtualHost root from the siteid header.
# The trailing _vh_<siteid> segment makes request._script non-empty.
rewrite ^(.*)$ /VirtualHostBase/$scheme/$host/plone/VirtualHostRoot/_vh_$http_siteid$1 break;
```

With this setup `request._script == ['site-a']`, so the check above raises for any data: URI. Genuinely external http(s) images break the same way under a virtual-host path, since the current code calls `physicalPathFromURL` with no fallback.

## Current behavior before PR

- A data: image embedded in a report/sticker (e.g. a barcode) is dropped from the generated PDF when the site is served under a virtual-host path; the rest of the PDF renders normally.
- The same content renders correctly when the site is served at the virtual-host root.

## Desired behavior after PR is merged

- `senaite_url_fetcher` hands `data:` URIs straight to `weasyprint.default_url_fetcher` instead of trying to resolve them to a physical path.
- When `physicalPathFromURL` raises `ValueError` (the URL does not match the current virtual-host context, e.g. an external resource), the fetcher falls back to `default_url_fetcher` rather than propagating the error.
- `data:` images and external images are embedded correctly in generated PDFs regardless of the virtual-host configuration.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
