### PR TITLE
Fix UnicodeDecodeError in get_link when href contains non-ASCII bytes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2948 Fix UnicodeDecodeError in get_link when href contains non-ASCII bytes
 - #2947 Fix barcodes missing from PDFs behind a virtual-host path
 - #2940 Grant the global 'Client' role to users with linked_client_uid set
 - #2939 Persist linked user properties through the mutable properties plugin

--- a/src/bika/lims/utils/__init__.py
+++ b/src/bika/lims/utils/__init__.py
@@ -693,6 +693,13 @@ def get_link(href, value=None, csrf=True, **kwargs):
     """
     if not href:
         return ""
+    # Decode href to unicode up front. Callers commonly pass an
+    # f-string/.format() result that contains a content field value
+    # (phone, email, URL). On Py2 that result is a bytestring;
+    # mixing it into the unicode template below would trigger an
+    # implicit ASCII decode and raise on any non-ASCII byte
+    # (e.g. a UTF-8 en-dash 0xe2 0x80 0x93 inside a phone number).
+    href = u(href)
     anchor_value = value and u(value) or href
     attr = render_html_attributes(**kwargs)
     # Add a CSRF token


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR

`bika.lims.utils.get_link` raises `UnicodeDecodeError` when called with an `href` argument that contains non-ASCII bytes. The function builds its result via `u'<a href="{}" {}>{}</a>'.format(href, attr, anchor_value)`. On Python 2, mixing a bytestring `href` into a unicode template triggers an implicit decode through `sys.getdefaultencoding()` (`ascii`), which fails on any byte outside `0x00-0x7f`.

Multiple callers in the codebase build `href` via `"prefix:{}".format(field_value)` where `field_value` is a content-field value stored as a UTF-8 bytestring. A common real-world trigger is a phone number containing a UTF-8 en-dash:

```python
>>> from bika.lims.utils import get_link
>>> phone = "+49 (0) 30 1234 56 \xe2\x80\x93 78"
>>> get_link("tel:{}".format(phone), phone)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../bika/lims/utils/__init__.py", line 700, in get_link
    return u'<a href="{}" {}>{}</a>'.format(href, attr, anchor_value)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 23: ordinal not in range(128)
```

This blocks the clients listing (`/senaite/clients/base_view/folderitems`) for any installation that has a client whose phone field contains a UTF-8 en-dash, em-dash, non-breaking space, or other non-ASCII byte. The same code path runs through every place that builds a `mailto:`/`tel:`/`http:` href from a content field.

## Desired behavior after PR is merged

`get_link` decodes `href` to unicode via `safe_unicode` before format-substituting it. The function returns a unicode result regardless of input encoding. Callers do not need to coerce field values to unicode at every call site.

Same example with the fix applied:

```python
>>> get_link("tel:{}".format(phone), phone)
u'<a href="tel:+49 (0) 30 1234 56 – 78" >+49 (0) 30 1234 56 – 78</a>'
```

The clients listing renders normally, the `tel:` anchor includes the en-dash, and every other caller that previously crashed on non-ASCII href bytes now works.

I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] and the project's Python styleguide.

[1]: https://www.python.org/dev/peps/pep-0008