### PR TITLE
Render NamedImage display widget at a scaled size via @@images

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2949 Render NamedImage display widget at a scaled size via @@images
 - #2947 Fix barcodes missing from PDFs behind a virtual-host path
 - #2940 Grant the global 'Client' role to users with linked_client_uid set
 - #2939 Persist linked user properties through the mutable properties plugin

--- a/src/senaite/core/z3cform/widgets/configure.zcml
+++ b/src/senaite/core/z3cform/widgets/configure.zcml
@@ -10,6 +10,7 @@
   <include package=".hazard_categories" />
   <include package=".listing" />
   <include package=".multiupload" />
+  <include package=".namedimage" />
   <include package=".queryselect" />
   <include package=".remarks" />
   <include package=".selectother" />

--- a/src/senaite/core/z3cform/widgets/namedimage/__init__.py
+++ b/src/senaite/core/z3cform/widgets/namedimage/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.

--- a/src/senaite/core/z3cform/widgets/namedimage/configure.zcml
+++ b/src/senaite/core/z3cform/widgets/namedimage/configure.zcml
@@ -1,0 +1,21 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:z3c="http://namespaces.zope.org/z3c"
+    i18n_domain="z3c.form">
+
+  <!--
+    Override the default plone.formwidget.namedfile display template
+    so that NamedImage fields render a scaled image via the @@images
+    traverser instead of the full-size original. Without this the
+    rendered <img> carries the original pixel dimensions and the
+    browser shows it at full size (e.g. the laboratory's accreditation
+    logo on the Accreditation tab).
+  -->
+  <z3c:widgetTemplate
+      mode="display"
+      widget="plone.formwidget.namedfile.interfaces.INamedImageWidget"
+      layer="senaite.core.interfaces.ISenaiteFormLayer"
+      template="display.pt"
+      />
+
+</configure>

--- a/src/senaite/core/z3cform/widgets/namedimage/display.pt
+++ b/src/senaite/core/z3cform/widgets/namedimage/display.pt
@@ -1,0 +1,22 @@
+<span i18n:domain="plone"
+      tal:define="value python:view.value;
+                  fieldname python:getattr(view.field, '__name__', None);
+                  context python:view.context;
+                  scales python:context.restrictedTraverse('@@images', None)
+                          if (value is not None and fieldname and context is not None)
+                          else None;
+                  scale python:scales.scale(fieldname, scale='mini')
+                         if scales is not None else None"
+      tal:attributes="id view/id;
+                      class view/klass;
+                      style view/style;
+                      title view/title;
+                      lang view/lang">
+    <tal:img tal:condition="scale"
+             tal:replace="structure python:scale.tag()" />
+    <span tal:condition="python:value is None"
+          class="discreet"
+          i18n:translate="no_image">
+        No image
+    </span>
+</span>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The default `plone.formwidget.namedfile` display template renders `NamedImage` fields with an `<img>` tag that points at `@@download` and carries the original pixel dimensions of the uploaded file as `width`/`height` attributes. The browser honors those attributes literally, so a logo uploaded at e.g. 2000×1500 is shown at 2000×1500 on the display view.

This is most visible on the Laboratory content's *Accreditation* tab: the `accreditation_body_logo` field renders the uploaded logo at full size and dominates the page, even though the field description recommends "Maximum size is 175 × 175 pixels".

## Current behavior before PR

On the Laboratory display view, the accreditation logo is rendered at its original pixel size. There is no scaling at the widget level; the only way to constrain it is custom CSS in a downstream package.
<img width="2489" height="1266" alt="SCR-20260614-mkiq" src="https://github.com/user-attachments/assets/7a406551-faba-4b94-b211-4adf5ada229c" />



## Desired behavior after PR is merged

`NamedImage` fields render through Plone's `@@images` traverser at the `mini` scale (200 × 200 max, aspect ratio preserved). The resulting `<img>` tag has the actual scaled dimensions, so logos and other uploaded images display at a sensible size on every dexterity display view that uses `NamedBlobImage` / `NamedImage` fields.

<img width="932" height="849" alt="SCR-20260614-mjbr-2" src="https://github.com/user-attachments/assets/ee13bc6f-c433-44fb-9a6f-df89042bad05" />


## How it works

A new `senaite.core.z3cform.widgets.namedimage` package overrides the display template for `plone.formwidget.namedfile.interfaces.INamedImageWidget` on the `ISenaiteFormLayer` browser layer. The template resolves `@@images` on the widget's content context, asks for the `mini` scale, and emits the resulting `ImageScale.tag()`.

All path expressions that resolve to callable objects (the content context, the `@@images` view) use Python expressions instead of TAL path expressions to avoid `Products.PageTemplates.Expressions.render` auto-calling them — otherwise resolving `view/context` re-enters `BrowserDefault.__call__` and renders the full default view recursively.

The override scope is `INamedImageWidget` in display mode on the SENAITE form layer only; input and hidden modes are untouched.

---

I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html