### PR TITLE
Add translations for new senaite.app.listing UI strings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 - #2945 Add rangecomment support to dynamic results ranges
+- #2950 Add translations for new senaite.app.listing UI strings
 - #2947 Fix barcodes missing from PDFs behind a virtual-host path
 - #2940 Grant the global 'Client' role to users with linked_client_uid set
 - #2939 Persist linked user properties through the mutable properties plugin

--- a/src/senaite/core/locales/de/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/de/LC_MESSAGES/senaite.core.po
@@ -1279,7 +1279,7 @@ msgstr "Konfiguration auf Standardwerte zurückgesetzt"
 
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
-msgstr "Tabellenüberschriften konfigurieren"
+msgstr "Spalten konfigurieren"
 
 #: bika/lims/content/artemplate.py:173
 msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
@@ -12187,3 +12187,151 @@ msgstr "{} (veraltet)"
 #: bika/lims/controlpanel/bika_instruments.py:173
 msgid "{} weeks and {} day(s)"
 msgstr "{} Woche(n) und {} Tag(e)"
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
+msgstr "Gespeicherte Filter"
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
+msgstr "pro Listenansicht"
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
+msgstr "Noch keine gespeicherten Filter."
+
+# senaite.app.listing: Saved filter presets — footer button to save the current view
+msgid "Save current view"
+msgstr "Aktuelle Ansicht speichern"
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr "Filtername"
+
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr "Mein Filter"
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
+msgstr "Filter umbenennen"
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr "Filter löschen"
+
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr "Beim Öffnen automatisch anwenden"
+
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr "Automatisches Anwenden beenden"
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
+msgstr "auto"
+
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied preset
+msgid "modified"
+msgstr "geändert"
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr "Diesen Filter anwenden"
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the applied preset
+msgid "Click to release this filter"
+msgstr "Klicken, um den Filter zu lösen"
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
+msgstr "Filter mit aktueller Ansicht aktualisieren"
+
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr "Änderungen verwerfen und Filter wiederherstellen"
+
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr "Aktuelle Ansicht weicht vom gespeicherten Filter ab"
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr "Aufsteigend sortieren"
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
+msgstr "Absteigend sortieren"
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
+msgstr "Ansicht zurücksetzen"
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing search
+msgid "Clear search"
+msgstr "Suche leeren"
+
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr "Zum Filtern tippen…"
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
+msgstr "Filtern…"
+
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr "-- Auswählen --"
+
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr "Filter leeren"
+
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr "Konfigurieren"
+
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr "Spalten suchen…"
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr "Sichtbar"
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr "Alle ausblenden"
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
+msgstr "Sichtbare / gesamte Spalten"
+
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr "Ziehen, um die Reihenfolge zu ändern"
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
+msgstr "Diese Spalte ausblenden"
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr "Diese Spalte einblenden"
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr "Auf Standardspalten und -reihenfolge zurücksetzen"
+
+# senaite.app.listing: Column config — empty state for visible section with search
+msgid "No matches in visible columns."
+msgstr "Keine Treffer in sichtbaren Spalten."
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr "Alle Spalten sind ausgeblendet."
+
+# senaite.app.listing: Column config — empty state for hidden section with search
+msgid "No matches in hidden columns."
+msgstr "Keine Treffer in ausgeblendeten Spalten."

--- a/src/senaite/core/locales/de/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/de/LC_MESSAGES/senaite.core.po
@@ -4695,6 +4695,10 @@ msgstr "Zurücksetzen"
 msgid "Reset columns"
 msgstr "Spalten zurücksetzen"
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr "Sichtbarkeit und Reihenfolge der Spalten auf Standard zurücksetzen"
+
 #: bika/lims/browser/publish/templates/email.pt:83
 #: bika/lims/browser/templates/analysisreport_info.pt:154
 msgid "Responsibles"

--- a/src/senaite/core/locales/senaite.core-manual.pot
+++ b/src/senaite/core/locales/senaite.core-manual.pot
@@ -84,6 +84,10 @@ msgstr ""
 msgid "Reset columns"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 # senaite.app.listing: Disable auto fetch transitions
 msgid "Disable auto fetch transitions"
 msgstr ""

--- a/src/senaite/core/locales/senaite.core-manual.pot
+++ b/src/senaite/core/locales/senaite.core-manual.pot
@@ -95,3 +95,152 @@ msgstr ""
 # senaite.core: Sidebar loading state
 msgid "Loading navigation..."
 msgstr ""
+
+
+# senaite.app.listing: Saved filter presets — toggle title + menu header
+msgid "Saved filters"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — menu subtitle
+msgid "per listing"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — empty state
+msgid "No saved filters yet."
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — footer button to save the current view
+msgid "Save current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — inline editor placeholder
+msgid "Filter name"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — default name when saving
+msgid "My filter"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Rename filter"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — row action tooltip
+msgid "Delete filter"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — star action tooltip
+msgid "Auto-apply on open"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — star action tooltip when active
+msgid "Stop auto-applying"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — micro-tag on the default preset
+msgid "auto"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — dirty indicator on the applied preset
+msgid "modified"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — apply button tooltip
+msgid "Apply this filter"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — release button tooltip on the applied preset
+msgid "Click to release this filter"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Update preset action tooltip
+msgid "Update preset with current view"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — Revert action tooltip
+msgid "Discard edits and restore preset"
+msgstr ""
+
+# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
+msgid "Current view differs from saved"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort ascending"
+msgstr ""
+
+# senaite.app.listing: Column header — sort arrow tooltip / aria-label
+msgid "Sort descending"
+msgstr ""
+
+# senaite.app.listing: Search box — undo / reset-view button tooltip
+msgid "Reset view"
+msgstr ""
+
+# senaite.app.listing: Search box — undo button tooltip when only clearing search
+msgid "Clear search"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — searchable-select placeholder
+msgid "Type to filter..."
+msgstr ""
+
+# senaite.app.listing: Column-filter row — text-input placeholder
+msgid "Filter..."
+msgstr ""
+
+# senaite.app.listing: Column-filter row — boolean select placeholder
+msgid "-- Select --"
+msgstr ""
+
+# senaite.app.listing: Column-filter row — clear button tooltip
+msgid "Clear filter"
+msgstr ""
+
+# senaite.app.listing: Column config — trigger button label
+msgid "Configure"
+msgstr ""
+
+# senaite.app.listing: Column config — search input placeholder
+msgid "Search columns…"
+msgstr ""
+
+# senaite.app.listing: Column config — visible-section header
+msgid "Visible"
+msgstr ""
+
+# senaite.app.listing: Column config — bulk action button
+msgid "Hide all"
+msgstr ""
+
+# senaite.app.listing: Column config — counter title attribute
+msgid "Visible / total columns"
+msgstr ""
+
+# senaite.app.listing: Column config — drag handle tooltip / aria-label
+msgid "Drag to reorder"
+msgstr ""
+
+# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
+msgid "Hide this column"
+msgstr ""
+
+# senaite.app.listing: Column config — plus button tooltip / aria-label
+msgid "Show this column"
+msgstr ""
+
+# senaite.app.listing: Column config — reset link tooltip
+msgid "Reset to default columns and order"
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for visible section with search
+msgid "No matches in visible columns."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state when no columns are visible
+msgid "All columns are hidden."
+msgstr ""
+
+# senaite.app.listing: Column config — empty state for hidden section with search
+msgid "No matches in hidden columns."
+msgstr ""

--- a/src/senaite/core/locales/senaite.core.pot
+++ b/src/senaite/core/locales/senaite.core.pot
@@ -4681,6 +4681,10 @@ msgstr ""
 msgid "Reset columns"
 msgstr ""
 
+# senaite.app.listing: Reset-columns button tooltip
+msgid "Reset column visibility and order to the defaults"
+msgstr ""
+
 #: bika/lims/browser/publish/templates/email.pt:83
 #: bika/lims/browser/templates/analysisreport_info.pt:154
 msgid "Responsibles"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Adds the message catalog entries and German translations for the new UI introduced by senaite/senaite.app.listing#174 and senaite/senaite.app.listing#175. The application code (saved filter presets, split sort arrows, column-filter row, redesigned column-config popover) ships with the listing package; the strings live here.

Related PRs:
- senaite/senaite.app.listing#174 — saved filter presets + column-filter context awareness + header redesign
- senaite/senaite.app.listing#175 — TableColumnConfig redesigned as a searchable popover

## Current behavior before PR

- The 37 user-facing strings introduced by the linked listing PRs have no entry in `senaite.core-manual.pot`, so translators have no source to work from and the German UI falls back to the English originals.
- The existing translation of `Configure Table Columns` reads `Tabellenüberschriften konfigurieren` ("configure table headings"), which is semantically off — the panel manages column **visibility and order**, not headings.

## Desired behavior after PR is merged

- `senaite.core-manual.pot` carries the 37 new entries, grouped by area in the comment prefix (`# senaite.app.listing: <context>`):
  - Saved filter presets — 17 strings (toggle/menu chrome, inline editor, row actions, apply/release flow, dirty / update / revert).
  - Column header — 2 strings (`Sort ascending` / `Sort descending`).
  - Search box — 2 strings (`Reset view` / `Clear search`).
  - Column-filter row — 4 strings (`Type to filter...`, `Filter...`, `-- Select --`, `Clear filter`).
  - Column config — 12 strings (trigger, search, sections, counter, drag/visibility actions, reset, empty states).
- `de/LC_MESSAGES/senaite.core.po` carries the matching German translation for each new entry.
- The existing `Configure Table Columns` translation is updated to `Spalten konfigurieren` — shorter, accurate, matches Bootstrap-app conventions in German.

## Notes

- Strings already present in `senaite.core-manual.pot` or `senaite.core.pot` (e.g. `Configure Table Columns`, `Reset columns`, `Show all`, `Hidden`, `Yes`, `No`, `Delete`, `Cancel`, `Save`, `Search`, `Export`, `Loading...`) were deliberately not duplicated.
- Translators of other languages should re-extract from the updated POT on their next pass.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html