### PR TITLE
Fix AT validators crashing when REQUEST is None in API context

### DIFF
--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -1285,8 +1285,12 @@ class InlineFieldValidator:
 
     def __call__(self, value, *args, **kwargs):
         field = kwargs['field']
-        request = kwargs['REQUEST']
+        request = kwargs.get('REQUEST')
         instance = kwargs['instance']
+
+        # skip inter-field validation when REQUEST is not available (API context)
+        if request is None:
+            return
 
         # extract the request values
         data = request.get(field.getName())
@@ -1484,6 +1488,9 @@ class LowerLimitOfDetectionValidator(object):
         default = instance.getField(field_name).getDefault(instance)
         llod = api.to_float(value, default)
 
+        # skip inter-field validation when REQUEST is not available (API context)
+        if kwargs.get("REQUEST") is None:
+            return
         form = kwargs["REQUEST"].form
         lloq = form.get("LowerLimitOfQuantification", None)
         lloq = api.to_float(lloq, llod)
@@ -1511,6 +1518,9 @@ class LowerLimitOfQuantificationValidator(object):
         default = instance.getField(field_name).getDefault(instance)
         lloq = api.to_float(value, default)
 
+        # skip inter-field validation when REQUEST is not available (API context)
+        if kwargs.get("REQUEST") is None:
+            return
         # compare with the lower limit of detection
         form = kwargs["REQUEST"].form
         uloq = form.get("UpperLimitOfQuantification", None)
@@ -1539,6 +1549,9 @@ class UpperLimitOfQuantificationValidator(object):
         default = instance.getField(field_name).getDefault(instance)
         uloq = api.to_float(value, default)
 
+        # skip inter-field validation when REQUEST is not available (API context)
+        if kwargs.get("REQUEST") is None:
+            return
         # compare with the lower limit of detection
         form = kwargs["REQUEST"].form
         ulod = form.get("UpperDetectionLimit", None)


### PR DESCRIPTION
Validators lower_limit_of_detection_validator,
lower_limit_of_quantification_validator,
upper_limit_of_quantification_validator, and inline_field_validator assume that the REQUEST kwarg is never None during AT schema validation.

This holds for web form submissions but breaks when validation is triggered via senaite.jsonapi or plone.restapi, where REQUEST=None is passed to obj.validate(data=True). The result is an AttributeError that prevents any create or update of AnalysisService (and any AT content type using these validators) through the API.

Fix: add an early return when REQUEST is None, skipping the inter-field comparison that only makes sense in a form submission context where all related fields are submitted together.

## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR

## Desired behavior after PR is merged

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
