### PR TITLE
Fix ExpressionError in edit-analysis modal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2975 Fix ExpressionError in edit-analysis modal
 - #2898 Add AllowManualEntry for select result options
 - #2967 Fix My Organization menu action hidden for client users
 - #2966 Fix UnicodeDecodeError when filtering samples by a non-ASCII client name

--- a/src/senaite/core/browser/modals/analysis/templates/edit_analysis.pt
+++ b/src/senaite/core/browser/modals/analysis/templates/edit_analysis.pt
@@ -150,7 +150,7 @@
                    tal:define="other view/get_result_other_text;
                                is_manual view/is_result_selected_option_manual"
                    tal:attributes="value other;
-                                   style python:is_manual and '' or 'display:none;'"/>
+                                   style python:is_manual and '' or 'display:none'"/>
 
             <!-- Multi-line result types (outside input-group) -->
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

PR #2898 added a manual-entry text input to the edit-analysis modal (`edit_analysis.pt`). Its `style` attribute is set via a `tal:attributes` expression ending in a string literal `'display:none;'`.

In TAL, the semicolon is the separator between attribute definitions, so a literal `;` must be doubled (`;;`). The unescaped `;` inside `'display:none;'` is consumed as a separator: Chameleon truncates the expression to `python:is_manual and '' or 'display:none` and parses the dangling `'` as a new attribute expression, raising `ExpressionError: Invalid variable name "'"`.

The fix drops the (unnecessary) trailing semicolon from the inline style.

## Current behavior before PR

Clicking an analysis title in the analyses listing to open the edit-analysis modal returns `{"error_type": "ExpressionError"}`, with `ExpressionError: Invalid variable name "'"` at line 153 of `edit_analysis.pt`:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.core.browser.modals.analysis.form, line 68, in __call__
  Module z3c.form.form, line 163, in render
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 215, in render
  Module chameleon.template, line 192, in render
  Module b64e7b2506f652d3ff11001cadd8f43e, line 1122, in render
ExpressionError: Invalid variable name "'"
```

The modal never renders

## Desired behavior after PR is merged

The edit-analysis modal renders correctly. The manual-entry input is shown when the selected result option allows manual entry (`is_manual` truthy) and hidden (`display:none`) otherwise.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
