### PR TITLE
Fix KeyError on AllowManualEntry when importing result options without the column

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2977 Fix KeyError on AllowManualEntry when importing result options without the column
 - #2965 Filter samples by their analyses in the samples listing
 - #2975 Fix ExpressionError in edit-analysis modal
 - #2898 Add AllowManualEntry for select result options

--- a/src/senaite/core/exportimport/setupdata/__init__.py
+++ b/src/senaite/core/exportimport/setupdata/__init__.py
@@ -1496,7 +1496,7 @@ class Analysis_Services(WorksheetImporter):
             sro = service.getResultOptions()
             sro.append({'ResultValue': row['ResultValue'],
                         'ResultText': row['ResultText'],
-                        'AllowManualEntry': row['AllowManualEntry']})
+                        'AllowManualEntry': row.get('AllowManualEntry', False)})
             service.setResultOptions(sro)
 
     def load_service_uncertainties(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Importing setup data (`AnalysisService ResultOptions` sheet) fails with a `KeyError: 'AllowManualEntry'` on setup files that predate #2898, which added the `AllowManualEntry` subfield to result options. `load_result_options` read the column with `row['AllowManualEntry']`, so any sheet without that column aborts the whole import.

## Current behavior before PR

Loading setup data without an `AllowManualEntry` column raises:

```
File ".../exportimport/setupdata/__init__.py", line 1499, in load_result_options
    'AllowManualEntry': row['AllowManualEntry']})
KeyError: 'AllowManualEntry'
```

## Desired behavior after PR is merged

The column is optional. When it is absent, the result option defaults to `AllowManualEntry = False`, matching how the consumer (`browser/modals/analysis/form.py`) already treats a missing/falsy value.