### PR TITLE
Forward results override flags to custom auto-import adapters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2981 Forward results override flags to custom auto-import adapters
 - #2978 Move front page and landing page fields to the Appearance fieldset
 - #2973 Add PublishTraverseView/JSONView base browser views for AJAX endpoints
 - #2974 Do not offer all sticker templates to content types without a sticker adapter

--- a/src/senaite/core/exportimport/instruments/README.md
+++ b/src/senaite/core/exportimport/instruments/README.md
@@ -46,10 +46,12 @@ In `my_instrument.py`:
         def get_automatic_importer(self, instrument, parser, **kw):
             """Called during automated results import
             """
+            # honor the override flags forwarded by the auto-import view
+            override = kw.get("override", self.override)
             # initialize the base class with the required parameters
             super(MyInstrumentImporter, self).__init__(
                 parser, self.context,
-                override=self.override,
+                override=override,
                 allowed_sample_states=self.allowed_sample_states,
                 allowed_analysis_states=self.allowed_analysis_states,
                 instrument_uid=api.get_uid(instrument))

--- a/src/senaite/core/exportimport/instruments/__init__.py
+++ b/src/senaite/core/exportimport/instruments/__init__.py
@@ -266,7 +266,11 @@ def get_automatic_importer(exim_id, instrument, parser, override=None):
 
     if IInstrumentAutoImportInterface.providedBy(adapter):
         try:
-            return adapter.get_automatic_importer(instrument, parser)
+            # Forward the override flags so custom auto-import adapters can
+            # honor them. The adapter contract accepts ``**kw``, so passing
+            # the override is backward compatible.
+            return adapter.get_automatic_importer(
+                instrument, parser, override=override)
         except (NotImplementedError, AttributeError, TypeError, ValueError):
             # BBB: Fallback to default analysis results importer
             pass


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The auto-import results view reads the `override_non_empty` and `override_with_empty` request parameters and passes the resulting flags into `get_automatic_importer(exim_id, instrument, parser, override=override)`.

However, `get_automatic_importer` only forwards those flags to the default `AnalysisResultsImporter`. When the instrument interface provides `IInstrumentAutoImportInterface`, the importer is obtained via `adapter.get_automatic_importer(instrument, parser)` without the `override` argument, so custom auto-import adapters never receive the flags. As a result, running the automatic import (e.g. via a cron job) always keeps existing results even when the override parameters are set, while manual import through the instrument import view works as expected.

## Current behavior before PR

For instrument interfaces that provide `IInstrumentAutoImportInterface`, the override flags are dropped: `get_automatic_importer` calls the adapter without passing `override`, so the importer falls back to `[False, False]` and never overrides existing results on auto-import.

## Desired behavior after PR is merged

The override flags are forwarded to the adapter: `adapter.get_automatic_importer(instrument, parser, override=override)`. The adapter contract already accepts `**kw`, so this is backward compatible, and the base contract / README example are updated to honor `kw.get("override", self.override)`. Custom auto-import adapters can now respect the override parameters passed to the auto-import view.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html