### PR TITLE
Fix auto log-off logging out active users

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- #2982 Fix auto log-off logging out active users (keep session refresh_interval below timeout)
+- #2982 Fix auto log-off logging out active users (session refresh interval)
 - #2978 Move front page and landing page fields to the Appearance fieldset
 - #2973 Add PublishTraverseView/JSONView base browser views for AJAX endpoints
 - #2974 Do not offer all sticker templates to content types without a sticker adapter

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2982 Fix auto log-off logging out active users (keep session refresh_interval below timeout)
 - #2978 Move front page and landing page fields to the Appearance fieldset
 - #2973 Add PublishTraverseView/JSONView base browser views for AJAX endpoints
 - #2974 Do not offer all sticker templates to content types without a sticker adapter

--- a/src/bika/lims/content/bikasetup.py
+++ b/src/bika/lims/content/bikasetup.py
@@ -21,6 +21,7 @@
 from AccessControl import ClassSecurityInfo
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
+from bika.lims import logger
 from bika.lims.browser.fields import DurationField
 from bika.lims.browser.fields import UIDReferenceField
 from bika.lims.browser.widgets import DurationWidget
@@ -1274,7 +1275,17 @@ class BikaSetup(folder.ATFolder):
     security = ClassSecurityInfo()
 
     def setAutoLogOff(self, value):
-        """set session lifetime
+        """Set the session lifetime (auto log-off), in minutes
+
+        Writes the plone.session cookie `timeout` (in seconds). It also keeps
+        the plugin's `refresh_interval` strictly below `timeout` so that an
+        *active* user's session cookie is renewed by the refresh beacon before
+        it expires. Without this, plone.session treats `timeout` as an absolute
+        lifetime measured from login (it does not refresh the ticket on regular
+        requests), so a short auto log-off would log out users even while they
+        are actively working, instead of only when idle.
+
+        A value of 0 disables auto log-off (the cookie never expires).
         """
         value = int(value)
         if value < 0:
@@ -1282,8 +1293,18 @@ class BikaSetup(folder.ATFolder):
         value = value * 60
         acl = api.get_tool("acl_users")
         session = acl.get("session")
-        if session:
-            session.timeout = value
+        if session is None:
+            logger.warn(
+                "No 'session' plugin found in acl_users. Cannot set the "
+                "auto log-off timeout (%s seconds)" % value)
+            return
+        session.timeout = value
+        # Ensure the refresh beacon runs ahead of expiry. Only adjust when the
+        # current interval would defeat the timeout (disabled, or >= timeout),
+        # so a manually-tuned interval below the timeout is preserved.
+        if value and (session.refresh_interval < 0
+                      or session.refresh_interval >= value):
+            session.refresh_interval = max(60, value // 2)
 
     def getAutoLogOff(self):
         """get session lifetime

--- a/src/senaite/core/content/senaitesetup.py
+++ b/src/senaite/core/content/senaitesetup.py
@@ -25,6 +25,7 @@ import six
 from AccessControl import ClassSecurityInfo
 from bika.lims import _
 from bika.lims import api
+from bika.lims import logger
 from plone.app.textfield import IRichTextValue
 from plone.app.textfield.widget import RichTextFieldWidget  # TBD: port to core
 from plone.autoform import directives
@@ -1697,6 +1698,15 @@ class Setup(Container):
     @security.protected(permissions.ModifyPortalContent)
     def setAutoLogOff(self, value):
         """Set session lifetime in minutes
+
+        Writes the plone.session cookie `timeout` (in seconds) and keeps the
+        plugin's `refresh_interval` strictly below `timeout`, so that an
+        *active* user's session cookie is renewed by the refresh beacon before
+        it expires. plone.session does not refresh the ticket on regular
+        requests, so it treats `timeout` as an absolute lifetime from login;
+        without this a short auto log-off would log out users while they are
+        actively working, not only when idle. A value of 0 disables auto
+        log-off (the cookie never expires).
         """
         value = api.to_int(value, default=0)
         if value < 0:
@@ -1704,8 +1714,18 @@ class Setup(Container):
         value = value * 60
         acl = api.get_tool("acl_users")
         session = acl.get("session")
-        if session:
+        if session is None:
+            logger.warn(
+                "No 'session' plugin found in acl_users. Cannot set the "
+                "auto log-off timeout (%s seconds)" % value)
+        else:
             session.timeout = value
+            # Keep the refresh beacon ahead of expiry. Only adjust when the
+            # current interval would defeat the timeout (disabled, or >=
+            # timeout), so a manually-tuned lower interval is preserved.
+            if value and (session.refresh_interval < 0
+                          or session.refresh_interval >= value):
+                session.refresh_interval = max(60, value // 2)
         mutator = self.mutator("auto_log_off")
         return mutator(self, value // 60)
 

--- a/src/senaite/core/tests/doctests/SenaiteSetup.rst
+++ b/src/senaite/core/tests/doctests/SenaiteSetup.rst
@@ -108,6 +108,24 @@ Auto Log Off:
     >>> bikasetup.getAutoLogOff() == senaite_setup.getAutoLogOff()
     True
 
+The value is stored as the plone.session cookie ``timeout`` (in seconds), and
+the plugin's ``refresh_interval`` is kept strictly below it, so an active
+user's cookie is refreshed by the beacon before it can expire:
+
+    >>> session = portal.acl_users.session
+    >>> session.timeout
+    3600
+    >>> 0 < session.refresh_interval < session.timeout
+    True
+
+Setting it to 0 disables auto log-off (the cookie never expires):
+
+    >>> senaite_setup.setAutoLogOff(0)
+    >>> senaite_setup.getAutoLogOff()
+    0
+    >>> session.timeout
+    0
+
 Restrict Worksheet Users Access:
 
     >>> senaite_setup.setRestrictWorksheetUsersAccess(True)


### PR DESCRIPTION
## Description

The **Automatic log-off** setup field (SENAITE Setup → Security) logs users out even while they are **actively working**, not only when idle. A lab that sets a short auto log-off (e.g. 10 minutes) sees every user bounced to the login page on a fixed clock mid-task — registering samples, entering results — regardless of activity.

## Root cause

`setAutoLogOff` writes only the `plone.session` cookie **`timeout`** (in seconds) and leaves **`refresh_interval`** at its default (`3600s`).

But `plone.session` does **not** refresh the `__ac` ticket on ordinary requests — `SessionPlugin.authenticateCredentials()` validates it without re-issuing it (see the `# XXX Should refresh the ticket...` note in `plone/session/plugins/session.py`). The ticket timestamp is fixed at login and only advanced by the periodic **refresh beacon**, which fires every `refresh_interval`. Expiry is an absolute check: `timestamp + timeout > now` (`plone/session/tktauth.py`).

So `timeout` is effectively an **absolute lifetime from login**, not an idle timeout. When `timeout < refresh_interval` (e.g. `600 < 3600`) the cookie dies long before the beacon can ever refresh it, logging out active users. The field's own description ("minutes before a user is automatically logged off") promises an idle timeout it does not deliver.

## Fix

- When a non-zero auto log-off is set, keep `refresh_interval` **strictly below** `timeout` (`max(60, timeout // 2)`), so an active user's cookie is refreshed by the beacon before it can expire — making `AutoLogOff` the idle timeout it claims to be. A manually-tuned interval already below `timeout` is preserved. `0` still disables auto log-off entirely (cookie never expires).
- Log a warning instead of silently doing nothing when the `session` PAS plugin is not found.
- Applied to **both** implementations: the Archetypes `bika_setup` (`bika/lims/content/bikasetup.py`) and the ported Dexterity `senaite_setup` (`senaite/core/content/senaitesetup.py`), which proxy to the same session plugin.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
