### PR TITLE
Fix HiddenProfiles list to actually hide bundled add-on profiles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2983 Fix HiddenProfiles list to actually hide bundled add-on profiles
 - #2982 Fix auto log-off logging out active users (session refresh interval)
 - #2978 Move front page and landing page fields to the Appearance fieldset
 - #2973 Add PublishTraverseView/JSONView base browser views for AJAX endpoints

--- a/src/senaite/core/setuphandlers.py
+++ b/src/senaite/core/setuphandlers.py
@@ -81,9 +81,11 @@ class HiddenProfiles(object):
             "Products.TextIndexNG3:default",
             "archetypes.multilingual:default",
             "archetypes.referencebrowserwidget:default",
-            "collective.js.jqueryui:default"
+            "collective.js.jqueryui:base",
+            "collective.js.jqueryui:bbb",
+            "collective.js.jqueryui:default",
+            "plone.app.caching:default",
             "plone.app.iterate:default",
-            "plone.app.iterate:plone.app.iterate",
             "plone.app.iterate:test",
             "plone.app.iterate:uninstall",
             "plone.app.jquery:default",


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The `HiddenProfiles` utility in `setuphandlers.py` had a missing comma between two adjacent string literals, so Python silently concatenated them:

```python
"collective.js.jqueryui:default"      # <-- missing comma
"plone.app.iterate:default",
```

The two entries collapsed into the single, non-matching string `"collective.js.jqueryui:defaultplone.app.iterate:default"`. As a result neither `collective.js.jqueryui:default` nor `plone.app.iterate:default` was ever hidden from the Add-ons control panel and the site-creation extension-profile picker, defeating the intent of both entries. Because a non-matching entry is silently ignored (no error is raised), the regression went unnoticed.

While fixing this, the dead `plone.app.iterate:plone.app.iterate` entry (a profile id that does not exist; the package only ships `default`, `test` and `uninstall`) is removed, and the remaining bundled add-on profiles that clutter the Add-ons panel are hidden as well: `collective.js.jqueryui:base`, `collective.js.jqueryui:bbb`, and `plone.app.caching:default`.

This only affects visibility in the Add-ons control panel and the site-creation profile picker. It does not install, uninstall, or otherwise change any content.

## Current behavior before PR

- `collective.js.jqueryui:default` and `plone.app.iterate:default` are not hidden (string-concatenation bug).
- The non-existent `plone.app.iterate:plone.app.iterate` id sits in the list doing nothing.
- `collective.js.jqueryui` (base/bbb) and `plone.app.caching` install profiles show up in the Add-ons control panel.

## Desired behavior after PR is merged

- Both previously broken entries are correctly hidden.
- The dead profile id is removed.
- The additional bundled profiles are hidden from the Add-ons control panel and the site-creation profile picker.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html