### PR TITLE
Hide the Manage Portlets menu from the toolbar

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2984 Hide the Manage Portlets menu from the toolbar
 - #2982 Fix auto log-off logging out active users (session refresh interval)
 - #2978 Move front page and landing page fields to the Appearance fieldset
 - #2973 Add PublishTraverseView/JSONView base browser views for AJAX endpoints

--- a/src/senaite/core/browser/contentmenu/menu.py
+++ b/src/senaite/core/browser/contentmenu/menu.py
@@ -18,7 +18,6 @@
 # Copyright 2018-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from AccessControl import getSecurityManager
 from plone.app.contentmenu.menu import \
     DisplaySubMenuItem as BaseDisplaySubMenuItem
 from plone.app.contentmenu.menu import \
@@ -28,7 +27,6 @@ from plone.app.contentmenu.menu import \
 from plone.app.contentmenu.menu import \
     WorkflowSubMenuItem as BaseWorkflowSubMenuItem
 from plone.memoize.instance import memoize
-from plone.portlets.interfaces import ILocalPortletAssignable
 from senaite.core.interfaces import IShowDisplayMenu
 from senaite.core.interfaces import IShowFactoriesMenu
 
@@ -52,18 +50,11 @@ class FactoriesSubMenuItem(BaseFactoriesSubMenuItem):
 
 class PortletManagerSubMenuItem(BasePortletManagerSubMenuItem):
     """The "Manage Portlets" Menu
+
+    SENAITE does not use portlets, so this menu is always hidden.
     """
-    @memoize
     def available(self):
-        secman = getSecurityManager()
-        has_manage_portlets_permission = secman.checkPermission(
-            "Manage portal",
-            self.context
-        )
-        if not has_manage_portlets_permission:
-            return False
-        else:
-            return ILocalPortletAssignable.providedBy(self.context)
+        return False
 
 
 class WorkflowSubMenuItem(BaseWorkflowSubMenuItem):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The toolbar still shows a "Manage portlets" content-view tab (with a dropdown) for managers on portlet-assignable contexts such as the front page. SENAITE does not use portlets: the default portlet assignments are removed at site creation, the sample listings and dashboard are React-based, and no portlet columns are themed or exercised. The management entry point is therefore a dead end that only invites a manager to assign a portlet and end up with an unstyled column that breaks the layout.

The "Manage portlets" tab is rendered by SENAITE's own `PortletManagerSubMenuItem` (`senaite.core.browser.contentmenu.menu`), which overrides the stock content-menu item. Its `available()` returned `True` whenever the current user could "Manage portal" and the context was portlet-assignable. This makes it always unavailable instead, so the tab no longer renders. The underlying portlet machinery is left untouched; only the menu entry is hidden.

## Current behavior before PR

- Managers see a "Manage portlets" tab in the toolbar on portlet-assignable content (e.g. the site front page).

## Desired behavior after PR is merged

- The "Manage portlets" tab is never shown. No portlet functionality is otherwise changed.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html