### PR TITLE
Add a SENAITE-specific Manage Viewlets view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2985 Add a SENAITE-specific Manage Viewlets view
 - #2982 Fix auto log-off logging out active users (session refresh interval)
 - #2978 Move front page and landing page fields to the Appearance fieldset
 - #2973 Add PublishTraverseView/JSONView base browser views for AJAX endpoints

--- a/src/senaite/core/browser/viewlets/configure.zcml
+++ b/src/senaite/core/browser/viewlets/configure.zcml
@@ -1,9 +1,27 @@
 <configure xmlns="http://namespaces.zope.org/zope"
            xmlns:browser="http://namespaces.zope.org/browser"
+           xmlns:plone="http://namespaces.plone.org/plone"
            i18n_domain="senaite.core">
 
   <!-- package includes -->
   <include package=".sample" />
+
+  <!-- Static resources for the viewlets (css, js, images), served at
+       ++plone++senaite.core.viewlets -->
+  <plone:static
+      directory="static"
+      type="plone"
+      name="senaite.core.viewlets"
+      />
+
+  <!-- SENAITE-specific @@manage-viewlets view -->
+  <browser:page
+      for="*"
+      name="manage-viewlets"
+      class=".manageviewlets.ManageViewlets"
+      permission="cmf.ManagePortal"
+      layer="senaite.core.interfaces.ISenaiteCore"
+      />
 
   <!-- Favicon Viewlet -->
   <browser:viewlet

--- a/src/senaite/core/browser/viewlets/manageviewlets.py
+++ b/src/senaite/core/browser/viewlets/manageviewlets.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.CORE.
+#
+# SENAITE.CORE is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2018-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from plone.app.viewletmanager.manager import ManageViewlets as Base
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
+
+class ManageViewlets(Base):
+    """SENAITE-specific `@@manage-viewlets` view.
+
+    Behaves like the stock view (each viewlet manager renders its own
+    show/hide/reorder box in place, so the managers appear nested and
+    positioned exactly as they are on the site), but renders through the
+    SENAITE main template and styles the manager/viewlet boxes into clean
+    nested boxes (see the accompanying `manage-viewlets.pt`).
+    """
+    index = ViewPageTemplateFile("templates/manage-viewlets.pt")

--- a/src/senaite/core/browser/viewlets/static/css/manage-viewlets.css
+++ b/src/senaite/core/browser/viewlets/static/css/manage-viewlets.css
@@ -1,0 +1,103 @@
+/* Styles for the SENAITE `@@manage-viewlets` view.
+ *
+ * Each viewlet manager emits a `.managedViewlets` wrapper in place, so the
+ * boxes appear nested and positioned exactly as on the site. */
+.managedViewlets { margin: .35rem 0; }
+.managedViewlets dl { margin: 0; }
+
+/* Outer box: a viewlet manager */
+.managedViewlets dl.viewletmanager {
+  border: 1px solid #ced4da;
+  border-radius: .375rem;
+  margin: .5rem 0;
+  background: #f8f9fa;
+}
+.managedViewlets dl.viewletmanager > dt {
+  font-family: monospace;
+  font-size: .78rem;
+  padding: .4rem .6rem;
+  background: #e9ecef;
+  border-bottom: 1px solid #ced4da;
+  border-radius: .375rem .375rem 0 0;
+  color: #343a40;
+}
+.managedViewlets dl.viewletmanager > dd {
+  margin: 0;
+  padding: .4rem .6rem;
+}
+
+/* Inner box: a viewlet */
+.managedViewlets dl.viewlet {
+  border: 1px solid #dee2e6;
+  border-radius: .3rem;
+  margin: .35rem 0;
+  background: #fff;
+}
+/* Reserve space on the right for the up | down | hide/show columns, so the
+ * controls line up regardless of which ones are present. */
+.managedViewlets dl.viewlet > dt {
+  position: relative;
+  min-height: 1.7rem;
+  font-size: .8rem;
+  padding: .4rem 8rem .4rem .55rem;
+  border-bottom: 1px solid #eef0f2;
+}
+.managedViewlets dl.viewlet > dd {
+  margin: 0;
+  padding: .45rem .55rem;
+  font-size: .85rem;
+  overflow-x: auto;
+}
+.managedViewlets dl.viewlet.hiddenViewlet { opacity: .55; }
+
+/* Control links rendered as small, fixed-width buttons, each pinned to its
+ * own column measured from the right edge of the row. */
+.managedViewlets dl.viewlet > dt > a {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  padding: .05rem 0;
+  border: 1px solid #ced4da;
+  border-radius: .25rem;
+  background: #fff;
+  color: #495057;
+  text-align: center;
+  text-decoration: none;
+  font-size: .72rem;
+  line-height: 1.5;
+}
+.managedViewlets dl.viewlet > dt > a:hover { background: #e9ecef; }
+.managedViewlets dl.viewlet > dt > a.up,
+.managedViewlets dl.viewlet > dt > a.down { width: 1.6rem; }
+.managedViewlets dl.viewlet > dt > a.hide,
+.managedViewlets dl.viewlet > dt > a.show { width: 3.2rem; }
+.managedViewlets dl.viewlet > dt > a.up { right: 5.7rem; }
+.managedViewlets dl.viewlet > dt > a.down { right: 3.9rem; }
+.managedViewlets dl.viewlet > dt > a.hide,
+.managedViewlets dl.viewlet > dt > a.show { right: .55rem; }
+.managedViewlets dl.viewlet > dt > a.hide {
+  border-color: #f1aeb5; color: #b02a37;
+}
+.managedViewlets dl.viewlet > dt > a.show {
+  border-color: #a3cfbb; color: #146c43;
+}
+
+/* Toggle which action link is visible per viewlet state */
+.managedViewlets dl.viewlet > dt > a.show { display: none; }
+.managedViewlets dl.viewlet > dt > a.hide { display: inline-block; }
+.managedViewlets dl.viewlet.hiddenViewlet > dt > a.hide { display: none; }
+.managedViewlets dl.viewlet.hiddenViewlet > dt > a.show {
+  display: inline-block;
+}
+
+/* Keep the page chrome clean: suppress the in-place management boxes of the
+ * toolbar, portal-top header, main navigation and status message managers,
+ * which only hold hidden/legacy or navigational viewlets and otherwise
+ * clutter the top of the page. */
+#senaite-toolbar .managedViewlets,
+#portal-top .managedViewlets,
+#portal-mainnavigation .managedViewlets,
+#global_statusmessage .managedViewlets { display: none; }
+
+/* Page heading, pinned above the content-region management boxes */
+.senaite-manage-viewlets-header { margin: .5rem 0 1rem; }

--- a/src/senaite/core/browser/viewlets/templates/manage-viewlets.pt
+++ b/src/senaite/core/browser/viewlets/templates/manage-viewlets.pt
@@ -1,0 +1,35 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="context/main_template/macros/master"
+      i18n:domain="senaite.core">
+<body>
+
+  <metal:head fill-slot="head_slot"
+              tal:define="portal_url context/@@plone_portal_state/portal_url">
+    <link rel="stylesheet" type="text/css" media="screen"
+          tal:attributes="href string:${portal_url}/++plone++senaite.core.viewlets/css/manage-viewlets.css" />
+  </metal:head>
+
+  <metal:statusmessage fill-slot="global_statusmessage">
+    <div class="senaite-manage-viewlets-header">
+      <h1 class="documentFirstHeading"
+          i18n:translate="title_manage_viewlets">
+        Manage Viewlets
+      </h1>
+      <p class="documentDescription text-muted"
+         i18n:translate="description_manage_viewlets">
+        The viewlet managers and their viewlets are shown in place, nested and
+        positioned as they appear on the site. Use the controls to hide, show
+        or reorder each viewlet.
+      </p>
+    </div>
+  </metal:statusmessage>
+
+  <!-- Suppress the default content title; the heading is rendered above -->
+  <metal:content-title fill-slot="content-title" />
+
+</body>
+</html>

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2750</version>
+  <version>2751</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-senaite.impress:default</dependency>

--- a/src/senaite/core/profiles/default/viewlets.xml
+++ b/src/senaite/core/profiles/default/viewlets.xml
@@ -73,16 +73,20 @@
   <!-- Hidden viewlets in plone.belowcontent -->
   <hidden manager="plone.belowcontent" skinname="*" purge="True">
     <viewlet name="plone.manage_portlets_fallback" />
+    <viewlet name="plone.belowcontenttitle.keywords" />
+    <viewlet name="plone.nextprevious" />
   </hidden>
 
   <!-- Hidden viewlets in plone.belowcontentbody -->
   <hidden manager="plone.belowcontentbody" skinname="*" purge="True">
     <viewlet name="plone.abovecontenttitle.documentactions" />
+    <viewlet name="plone.belowcontentbody.relateditems" />
   </hidden>
 
   <!-- Hidden viewlets in plone.portalfooter -->
   <hidden manager="plone.portalfooter" skinname="*" purge="True">
     <viewlet name="plone.site_actions"/>
+    <viewlet name="plone.analytics" />
   </hidden>
 
 </object>

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -101,6 +101,19 @@ PORTAL_FOLDER_ITEMS = {
 
 
 @upgradestep(product, version)
+def hide_legacy_viewlets(tool):
+    """Hide the analytics, keywords, next/previous navigation and related
+    items viewlets, which are not used in SENAITE, by reimporting the
+    viewlets step.
+    """
+    portal = tool.aq_inner.aq_parent
+    setup = portal.portal_setup
+    logger.info("Hiding unused viewlets ...")
+    setup.runImportStepFromProfile(profile, "viewlets")
+    logger.info("Hiding unused viewlets [DONE]")
+
+
+@upgradestep(product, version)
 def upgrade(tool):
     portal = tool.aq_inner.aq_parent
     ut = UpgradeUtils(portal)

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -3,6 +3,16 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.7.0: Hide unused viewlets"
+      description="Hide the analytics, keywords, next/previous navigation and
+                   related items viewlets, which are not used in SENAITE, by
+                   reimporting the viewlets step."
+      source="2750"
+      destination="2751"
+      handler=".v02_07_000.hide_legacy_viewlets"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Register the 'dispose' sample workflow transition"
       description="Register the new `senaite.core: Transition: Dispose Sample`
                    permission (granted to LabManager, Manager), the 'disposed'


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The stock `@@manage-viewlets` view renders the whole page with every viewlet manager in management mode. On a SENAITE site this looks broken: the management boxes are injected into the toolbar and header chrome, the SENAITE-specific managers rendered via custom managers do not show cleanly, and the boxes are unstyled.

This PR registers a SENAITE-specific `@@manage-viewlets` view (for the `ISenaiteCore` layer) that reuses the stock in-place mechanism (so the managers stay nested and positioned exactly as they are on the site) but renders through the SENAITE main template and styles the manager/viewlet boxes into clean, nested boxes:

- The manager and viewlet boxes are styled with clear headers, dimmed "hidden" viewlets and uniform, right-aligned Hide/Show and reorder controls (each control pinned to its own column so they line up regardless of which ones are present).
- The management boxes of the toolbar, portal-top header, main navigation and status message managers are suppressed, since they only hold hidden/legacy or navigational viewlets and otherwise clutter the top of the page. The page chrome renders normally and the heading sits at the top of the content.
- The view itself is a thin subclass of the stock `ManageViewlets`; all show/hide/reorder handling is inherited.

While working on this view it became obvious that a few viewlets are shipped but never used in SENAITE. They are now hidden via `viewlets.xml`, with an upgrade step (and a metadata version bump) so existing installations pick them up as well:

- `plone.analytics` (in `plone.portalfooter`)
- `plone.belowcontenttitle.keywords` (in `plone.belowcontent`)
- `plone.nextprevious` (in `plone.belowcontent`)
- `plone.belowcontentbody.relateditems` (in `plone.belowcontentbody`)

## Current behavior before PR

- `@@manage-viewlets` injects unstyled management boxes into the SENAITE toolbar and header chrome and is hard to read.
- The analytics, keywords, next/previous and related-items viewlets are registered and rendered even though SENAITE does not use them.

## Desired behavior after PR is merged

- `@@manage-viewlets` renders a clean, nested, in-place listing of the viewlet managers and their viewlets with aligned controls, on top of the normal SENAITE chrome.
- The four unused viewlets are hidden on new installs and, via the upgrade step, on existing ones.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html