### PR TITLE
Fix UnicodeDecodeError from non-ASCII organisation titles in the title index

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2986 Fix UnicodeDecodeError from non-ASCII organisation titles in the title index
 - #2982 Fix auto log-off logging out active users (session refresh interval)
 - #2978 Move front page and landing page fields to the Appearance fieldset
 - #2973 Add PublishTraverseView/JSONView base browser views for AJAX endpoints

--- a/src/senaite/core/catalog/indexer/organisation.py
+++ b/src/senaite/core/catalog/indexer/organisation.py
@@ -18,6 +18,7 @@
 # Copyright 2018-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from bika.lims import api
 from bika.lims.interfaces import IOrganisation
 from plone.indexer import indexer
 
@@ -26,7 +27,14 @@ from plone.indexer import indexer
 def title(instance):
     """Organisation objects does not use the built-in title, rather it uses
     Name schema field. We need this type-specific index to simulate the default
-    behavior for index `title`
+    behavior for index `title`.
+
+    The `Name` is coerced to unicode (like the generic `title` indexer) so the
+    shared `title` FieldIndex holds a single, consistent unicode key type. A
+    non-ASCII byte-string key would otherwise raise a `UnicodeDecodeError` on
+    Python 2 when compared against a unicode query value.
     """
     name = getattr(instance, "Name", None)
-    return name or ""
+    if not name:
+        return u""
+    return api.safe_unicode(name)

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2750</version>
+  <version>2751</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-senaite.impress:default</dependency>

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -101,6 +101,27 @@ PORTAL_FOLDER_ITEMS = {
 
 
 @upgradestep(product, version)
+def reindex_organisation_title(tool):
+    """Rebuild the `title` index in the setup and client catalogs with
+    unicode keys.
+
+    The organisation `title` indexer returned the raw `Name`, so a non-ASCII
+    organisation name (Client, Supplier, Manufacturer, Laboratory) ended up as
+    a byte-string key in the shared `title` FieldIndex. Any query on `title`
+    then raised a UnicodeDecodeError when comparing the unicode query value
+    against those keys. The indexer now normalizes to unicode; the index BTree
+    must be cleared before reindexing (a plain per-object reindex would insert
+    a unicode key next to the old byte-string keys and hit the same error), so
+    `rebuild_index` clears and repopulates it with unicode keys only.
+    """
+    for catalog_id in [SETUP_CATALOG, CLIENT_CATALOG]:
+        catalog = api.get_tool(catalog_id)
+        logger.info("Rebuilding 'title' index on %s ..." % catalog_id)
+        rebuild_index(catalog, "title")
+    logger.info("Rebuilding 'title' index [DONE]")
+
+
+@upgradestep(product, version)
 def upgrade(tool):
     portal = tool.aq_inner.aq_parent
     ut = UpgradeUtils(portal)

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -3,6 +3,19 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.7.0: Reindex organisation titles with unicode keys"
+      description="The organisation `title` indexer now normalizes the Name to
+                   unicode, matching the generic title indexer. Rebuild the
+                   `title` index in the setup and client catalogs so existing
+                   non-ASCII organisation names (Client, Supplier, ...) become
+                   unicode keys and title queries stop raising a
+                   UnicodeDecodeError."
+      source="2750"
+      destination="2751"
+      handler=".v02_07_000.reindex_organisation_title"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Register the 'dispose' sample workflow transition"
       description="Register the new `senaite.core: Transition: Dispose Sample`
                    permission (granted to LabManager, Manager), the 'disposed'


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Adding a label to a client (or any content) raises a `UnicodeDecodeError` when the setup or client catalog already holds an organisation (Client, Supplier, Manufacturer, Laboratory) whose `Name` contains non-ASCII characters.

The label modal checks for a duplicate via `get_label_by_name`, which runs a `title` query against the setup catalog. The query value is already coerced to unicode, but the crash happens on the index side:

The organisation `title` indexer is registered for `IOrganisation`, which is more specific than the generic `title` indexer, so it wins for every organisation. Unlike the generic indexer (which returns `api.safe_unicode(Title())`), it returned the raw `Name`. For a non-ASCII name that is a UTF-8 byte string, so the shared `title` FieldIndex ends up with a byte-string key. Any later query on `title` walks the index BTree and compares the unicode query value against that byte-string key, and Python 2 decodes it as ASCII, raising the error.

The trigger in the report was labelling, but the root cause is the byte-string key in the shared `title` index, so any `title` query could hit it.

## Traceback

```
2026-07-10 10:11:56,039 ERROR   [Zope.SiteErrorLog:252][waitress-1] .../clients/client17-1/manage_labels_modal
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.core.browser.modals.manage_labels, line 52, in __call__
  Module senaite.core.browser.modals.manage_labels, line 145, in handle_submit
  Module senaite.core.api.label, line 125, in get_label_by_name
  Module senaite.core.api.label, line 112, in query_labels
  Module bika.lims.api, line 1188, in search
  Module Products.CMFPlone.CatalogTool, line 468, in searchResults
  Module Products.ZCatalog.ZCatalog, line 627, in searchResults
  Module Products.ZCatalog.Catalog, line 1094, in searchResults
  Module Products.ZCatalog.Catalog, line 637, in search
  Module Products.ZCatalog.Catalog, line 567, in _search_index
  Module Products.PluginIndexes.unindex, line 583, in query_index
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 6: ordinal not in range(128)
```

## Current behavior before PR

- The `IOrganisation` `title` indexer stores the raw `Name`, so non-ASCII organisation names become byte-string keys in the shared `title` FieldIndex.
- Any `title` query (e.g. the label duplicate check when labelling a client) raises `UnicodeDecodeError`.

## Desired behavior after PR is merged

- The `IOrganisation` `title` indexer normalizes the `Name` to unicode with `api.safe_unicode`, matching the generic `title` indexer, so the index only ever holds unicode keys.
- An upgrade step rebuilds the `title` index in the setup and client catalogs so existing byte-string keys become unicode. The index BTree is cleared before reindexing (a plain per-object reindex would insert a unicode key next to the surviving byte-string keys and hit the same error), following the approach already used by `reindex_client_title`.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html