### PR TITLE
Fix worksheet template analysis filtering for selected samples

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2988 Fix worksheet template analysis filtering for selected samples
 - #2976 Surface orphaned sample partitions as top-level rows in listings
 - #2982 Fix auto log-off logging out active users (session refresh interval)
 - #2978 Move front page and landing page fields to the Appearance fieldset

--- a/src/senaite/core/api/worksheet.py
+++ b/src/senaite/core/api/worksheet.py
@@ -44,18 +44,15 @@ def create_worksheet(analyst, instrument=None, template=None, analyses=None):
                     instrument=instrument,
                     results_layout=layout)
 
-    unassigned_analyses = []
-    analyses = api.to_list(analyses)
-    analyses = list(filter(None, analyses))
-    for analysis in analyses:
-        an = api.get_object(analysis)
-        ws_uid = an.getWorksheetUID()
-        # collect all unassigned analyses
-        if not all([ws_uid, api.is_uid(ws_uid)]):
-            unassigned_analyses.append(an)
-        ws.addAnalysis(an)
-    if template is not None:
-        ws.applyWorksheetTemplate(template, analyses=unassigned_analyses)
+    if analyses is not None:
+        analyses = api.to_list(analyses)
+        analyses = list(filter(None, analyses))
+    if template:
+        # Let the template filter the selected analyses by service, method and
+        # instrument before they are assigned to the worksheet.
+        ws.applyWorksheetTemplate(template, analyses=analyses)
+    else:
+        ws.addAnalyses(analyses or [])
 
     ws.reindexObject()
     return ws

--- a/src/senaite/core/tests/doctests/WorksheetApplyTemplate.rst
+++ b/src/senaite/core/tests/doctests/WorksheetApplyTemplate.rst
@@ -41,6 +41,7 @@ Needed Imports:
     >>> from plone.app.testing import TEST_USER_ID
     >>> from plone.app.testing import TEST_USER_PASSWORD
     >>> from plone.app.testing import setRoles
+    >>> from senaite.core.api.worksheet import create_worksheet
 
 Functional Helpers:
 
@@ -729,6 +730,49 @@ Reject any remaining analyses awaiting for assignment:
     >>> query = {"portal_type": "Analysis", "review_state": "unassigned"}
     >>> objs = map(api.get_object, api.search(query, "senaite_catalog_analysis"))
     >>> success = map(lambda obj: doActionFor(obj, "reject"), objs)
+
+
+Create Worksheet from Samples with a Template
+..............................................
+
+When analyses from selected samples are passed while creating a worksheet,
+the worksheet template must restrict which services are assigned.
+
+Create and receive a sample with `Cu` and `Fe` analyses:
+
+    >>> service_uids = [Cu.UID(), Fe.UID()]
+    >>> sample = create_analysisrequest(client, request, values, service_uids)
+    >>> success = doActionFor(sample, "receive")
+    >>> analyses = sample.getAnalyses(full_objects=True)
+
+Create a worksheet template that only contains `Cu`:
+
+    >>> layout = [
+    ...     {'pos': '1', 'type': 'a',
+    ...      'blank_ref': '',
+    ...      'control_ref': '',
+    ...      'dup': ''},
+    ... ]
+    >>> cu_template = api.create(setup.worksheettemplates,
+    ...                          "WorksheetTemplate",
+    ...                          title="Cu only WS Template",
+    ...                          Layout=layout,
+    ...                          Services=[Cu.UID()])
+
+Create the worksheet from all analyses of the selected sample:
+
+    >>> worksheet = create_worksheet(TEST_USER_ID,
+    ...                              template=cu_template,
+    ...                              analyses=analyses)
+
+Only the analysis listed in the worksheet template is assigned:
+
+    >>> [analysis.getServiceUID() for analysis in worksheet.getAnalyses()] == \
+    ... [Cu.UID()]
+    True
+    >>> [analysis.getServiceUID() for analysis in analyses
+    ...  if not analysis.getWorksheetUID()] == [Fe.UID()]
+    True
 
 
 Assignment of Worksheet Template with Method


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/2987
Fix worksheet creation from selected samples so that only analyses configured in the selected Worksheet Template are assigned.
Previously, if a selected sample contained U3O8 Solution ppm and pH while the template contained only U3O8 Solution ppm, both analyses were added to the worksheet.

## Current behavior before PR
create_worksheet() assigned all analyses from the selected samples before applying the Worksheet Template. Once assigned, the template could not filter out services that were not
  configured on it.
  
## Desired behavior after PR is merged
 - Let applyWorksheetTemplate() filter selected analyses before assignment when a template is supplied.
  - Continue adding all selected analyses when no template is supplied.
  - Preserve worksheet creation from the Worksheets listing, where analyses=None searches for matching unassigned analyses
  
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
