### PR TITLE
Reset newly added datagrid rows to avoid inheriting stale values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2989 Reset newly added datagrid rows to avoid inheriting stale values
 - #2985 Add a SENAITE-specific Manage Viewlets view
 - #2971 Make the Sample Dispatch workflow optional and lock analyses on dispatch
 - #2970 Add an optional Sample Dispose workflow

--- a/src/senaite/core/z3cform/static/datagrid.js
+++ b/src/senaite/core/z3cform/static/datagrid.js
@@ -220,8 +220,51 @@ document.addEventListener("DOMContentLoaded", () => {
       new_row.dataset.oldIndex = new_row.dataset.index; // store for replacing.
       delete new_row.dataset.index; // fresh row.
       new_row.classList.remove("datagridwidget-empty-row");
+      // The template row markup may carry a stale `selected` option or a
+      // pre-filled value. Clear native form controls so the new row always
+      // starts empty. React sub-widgets are remounted on `datagrid:row_added`.
+      this.reset_row_values(new_row);
       this.init_row(new_row);
       return new_row;
+    }
+
+    reset_row_values(row) {
+      // Reset selects: deselect everything, then prefer an empty-valued
+      // option (blank choice); fall back to the first option for single
+      // selects so we never inherit the template's stale selection.
+      row.querySelectorAll("select").forEach(function (select) {
+        let options = Array.prototype.slice.call(select.options);
+        options.forEach(function (option) {
+          option.selected = false;
+        });
+        if (select.multiple) {
+          return;
+        }
+        let blank = options.filter(function (option) {
+          return option.value === "";
+        })[0];
+        if (blank) {
+          blank.selected = true;
+        } else if (options.length > 0) {
+          select.selectedIndex = 0;
+        }
+      });
+      // Reset inputs: clear text-like values, uncheck checkboxes/radios.
+      // Skip hidden inputs (structural markers like `-empty-marker`).
+      row.querySelectorAll("input").forEach(function (input) {
+        let type = (input.getAttribute("type") || "text").toLowerCase();
+        if (type === "hidden") {
+          return;
+        }
+        if (type === "checkbox" || type === "radio") {
+          input.checked = false;
+        } else {
+          input.value = "";
+        }
+      });
+      row.querySelectorAll("textarea").forEach(function (textarea) {
+        textarea.value = "";
+      });
     }
 
     update_order_index(datagrid) {


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When a new row is added to a DX datagrid widget (`DataGridWidget`), the client-side `datagrid.js` clones the hidden template (`TT`) row verbatim. The clone carries over any `selected` option or pre-filled value present in the template markup, and `reindex_row()` only rewrites `name`/`id`/`for` attributes. React sub-widgets are remounted on the `datagrid:row_added` event, but a plain z3c.form `select` (a `Choice` sub-field) is never re-initialised, so a freshly added row shows a stale, pre-selected value instead of a blank entry.

## Current behavior before PR

Adding a row to a datagrid whose row schema contains a `Choice` (select) sub-field produces a new row that already shows a value (the template's selected option), which reads as "the entry cannot be changed".

## Desired behavior after PR is merged

A newly added datagrid row always starts empty: selects fall back to their blank option (or the first option), text inputs are cleared, checkboxes and radios are unchecked, and textareas are emptied. Hidden structural inputs (empty markers, the row counter) are left intact so `extract()` keeps working, and React sub-widgets keep being remounted on `datagrid:row_added`.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html