### PR TITLE
Fix missing Dexterity FTI utility registration on typeinfo import

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2994 Re-register missing Dexterity FTI utilities on typeinfo import in upgrades
 - #2993 Sync translations and add complete German, Dutch and Spanish translations
 - #2993 Make the dashboard fully translatable
 - #2992 Fix UnicodeEncodeError in Organization.getPrintAddress with non-ASCII address

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- #2994 Re-register missing Dexterity FTI utilities on typeinfo import in upgrades
+- #2996 Fix missing Dexterity FTI utility registration on typeinfo import
 - #2993 Sync translations and add complete German, Dutch and Spanish translations
 - #2993 Make the dashboard fully translatable
 - #2992 Fix UnicodeEncodeError in Organization.getPrintAddress with non-ASCII address

--- a/src/senaite/core/tests/doctests/UpgradeDexterityFTIRegistration.rst
+++ b/src/senaite/core/tests/doctests/UpgradeDexterityFTIRegistration.rst
@@ -1,0 +1,111 @@
+Re-register missing Dexterity FTI utilities
+-------------------------------------------
+
+A Dexterity content type is usable by ``createContent`` only when its
+local ``IDexterityFTI`` utility is registered in the site's component
+registry. That registration is performed by
+``plone.dexterity.fti.register``, which is triggered by the
+``ObjectAddedEvent`` fired when an FTI is *created* in ``portal_types``.
+
+GenericSetup's ``typeinfo`` import only creates -- and therefore only
+registers -- an FTI that does not yet exist. Re-importing a type that
+already exists updates it in place without firing that event, so an FTI
+left behind by a partially-completed upgrade keeps a valid
+``portal_types`` entry but loses its local utility, and content creation
+raises ``ComponentLookupError``.
+
+``senaite.core.upgrade.utils.register_missing_dx_ftis`` reconciles that
+state by (re)registering the utility for any Dexterity FTI that is
+missing it.
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t UpgradeDexterityFTIRegistration
+
+
+Test Setup
+..........
+
+Needed imports:
+
+    >>> from plone.dexterity.interfaces import IDexterityFTI
+    >>> from plone.dexterity.utils import createContent
+    >>> from senaite.core.upgrade.utils import register_missing_dx_ftis
+    >>> from zope.component import ComponentLookupError
+    >>> from zope.component import getSiteManager
+    >>> from zope.component import queryUtility
+
+Variables:
+
+    >>> portal = self.portal
+
+We use ``Samples``, a Dexterity type installed with senaite.core, as the
+subject throughout this test:
+
+    >>> portal_type = "Samples"
+
+Its FTI object is present in ``portal_types`` ...
+
+    >>> fti = portal.portal_types.getTypeInfo(portal_type)
+    >>> IDexterityFTI.providedBy(fti)
+    True
+
+... and its local utility is registered, so content can be created:
+
+    >>> queryUtility(IDexterityFTI, name=portal_type) is not None
+    True
+
+    >>> createContent(portal_type) is not None
+    True
+
+
+Simulate a partially-migrated FTI
+.................................
+
+Unregister the local utility to reproduce the state left behind by an
+interrupted migration: the FTI object stays in ``portal_types`` but the
+utility is gone.
+
+    >>> sm = getSiteManager()
+    >>> sm.unregisterUtility(provided=IDexterityFTI, name=portal_type)
+    True
+
+    >>> queryUtility(IDexterityFTI, name=portal_type) is None
+    True
+
+Now content creation fails, even though the FTI object still exists:
+
+    >>> fti = portal.portal_types.getTypeInfo(portal_type)
+    >>> IDexterityFTI.providedBy(fti)
+    True
+
+    >>> try:
+    ...     createContent(portal_type)
+    ...     print("No error raised")
+    ... except ComponentLookupError:
+    ...     print("ComponentLookupError raised")
+    ComponentLookupError raised
+
+
+Reconcile the registrations
+...........................
+
+``register_missing_dx_ftis`` re-registers the missing utility:
+
+    >>> register_missing_dx_ftis()
+
+    >>> queryUtility(IDexterityFTI, name=portal_type) is not None
+    True
+
+Content can be created again:
+
+    >>> createContent(portal_type) is not None
+    True
+
+The helper is idempotent: running it again when nothing is missing
+leaves the existing registration untouched:
+
+    >>> util = queryUtility(IDexterityFTI, name=portal_type)
+    >>> register_missing_dx_ftis()
+    >>> queryUtility(IDexterityFTI, name=portal_type) is util
+    True

--- a/src/senaite/core/upgrade/utils.py
+++ b/src/senaite/core/upgrade/utils.py
@@ -32,6 +32,8 @@ from bika.lims.api import safe_unicode as u
 from bika.lims.interfaces import IAuditable
 from Persistence import PersistentMapping
 from plone.dexterity.fti import DexterityFTI
+from plone.dexterity.fti import register as register_dx_fti
+from plone.dexterity.interfaces import IDexterityFTI
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import get_installer
 from Products.ZCatalog.ProgressHandler import ZLogHandler
@@ -43,6 +45,7 @@ from plone.namedfile.file import NamedBlobImage
 from senaite.core import logger
 from senaite.core.api.catalog import add_zc_text_index
 from senaite.core.interfaces.catalog import ISenaiteCatalogObject
+from zope.component import queryUtility
 from zope.interface import alsoProvides
 from zope.lifecycleevent import modified
 
@@ -454,6 +457,48 @@ def uncatalog_brain(brain):
     logger.warn(80*"*")
     catalog.uncatalog_object(path)
     return True
+
+
+def register_missing_dx_ftis():
+    """Register the local IDexterityFTI utility for any Dexterity FTI in
+    portal_types that is missing it.
+
+    GenericSetup's `typeinfo` import fires an ObjectAddedEvent (which
+    triggers `plone.dexterity.fti.ftiAdded` -> `register`, registering
+    the local IDexterityFTI utility) only when the FTI is *created*.
+    Re-importing a type that already exists updates it in place without
+    re-registering. As a result, a DX FTI left behind by an interrupted
+    migration ends up with a valid portal_types entry whose
+    `createContent` lookup raises
+    `ComponentLookupError(IDexterityFTI, <type>)`, and re-running the
+    upgrade never recovers because the object still "exists".
+
+    This reconciles that state: it is idempotent (only registers the
+    utility when missing) and cheap (one queryUtility per DX type).
+    """
+    pt = api.get_tool("portal_types")
+    for fti in pt.objectValues():
+        if not IDexterityFTI.providedBy(fti):
+            continue
+        type_id = fti.getId()
+        if queryUtility(IDexterityFTI, name=type_id) is None:
+            logger.info("Registering missing DX FTI utility: %s" % type_id)
+            register_dx_fti(fti)
+
+
+def import_typeinfo(tool, profile):
+    """Run the `typeinfo` import step for the given profile and ensure
+    every Dexterity FTI has its local utility registered.
+
+    Migration steps that create Dexterity content right after importing
+    the type information must use this instead of calling
+    `runImportStepFromProfile(profile, "typeinfo")` directly, so that an
+    FTI left over from a partially-completed upgrade does not break
+    content creation with a ComponentLookupError.
+    See `register_missing_dx_ftis`.
+    """
+    tool.runImportStepFromProfile(profile, "typeinfo")
+    register_missing_dx_ftis()
 
 
 def remove_at_portal_types(tool, types_to_remove=[]):

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -71,6 +71,7 @@ from senaite.core.upgrade.utils import UpgradeUtils
 from senaite.core.upgrade.utils import blob_to_named_file
 from senaite.core.upgrade.utils import copy_snapshots
 from senaite.core.upgrade.utils import delete_object
+from senaite.core.upgrade.utils import import_typeinfo
 from senaite.core.upgrade.utils import iter_senaite_catalogs
 from senaite.core.upgrade.utils import permanently_allow_type_for
 from senaite.core.upgrade.utils import rebuild_index
@@ -550,7 +551,7 @@ def migrate_calculations_to_dx(tool):
     remove_at_portal_types(tool, REMOVE_AT_TYPES)
 
     # run required import steps
-    tool.runImportStepFromProfile(profile, "typeinfo")
+    import_typeinfo(tool, profile)
     tool.runImportStepFromProfile(profile, "workflow")
 
     # get the old container
@@ -912,7 +913,7 @@ def migrate_contacts_to_dx(tool):
     remove_at_portal_types(tool, REMOVE_AT_TYPES)
 
     # run required import steps
-    tool.runImportStepFromProfile(profile, "typeinfo")
+    import_typeinfo(tool, profile)
 
     # Find all Contact objects (excluding LabContact and SupplierContact)
     query = {
@@ -1058,7 +1059,7 @@ def migrate_multifiles_to_dx(tool):
     remove_at_portal_types(tool, REMOVE_AT_TYPES)
 
     # run required import steps
-    tool.runImportStepFromProfile(profile, "typeinfo")
+    import_typeinfo(tool, profile)
 
     # Find all Multifile objects
     query = {
@@ -1198,7 +1199,7 @@ def migrate_laboratory_to_dx(tool):
     remove_at_portal_types(tool, REMOVE_AT_TYPES)
 
     # run required import steps
-    tool.runImportStepFromProfile(profile, "typeinfo")
+    import_typeinfo(tool, profile)
 
     portal_type = "Laboratory"
     query = {
@@ -1444,7 +1445,7 @@ def repair_laboratory_migration(tool):
     logger.info("Repair laboratory migration ...")
 
     # Re-import typeinfo so the FTI picks up IMultiCatalogBehavior
-    tool.runImportStepFromProfile(profile, "typeinfo")
+    import_typeinfo(tool, profile)
 
     setup = api.get_senaite_setup()
     laboratory = setup.get("laboratory") if setup else None
@@ -1502,7 +1503,7 @@ def create_setup_contacts_folder(tool):
     remove_at_portal_types(tool, REMOVE_AT_TYPES)
 
     # run required import steps
-    tool.runImportStepFromProfile(profile, "typeinfo")
+    import_typeinfo(tool, profile)
     tool.runImportStepFromProfile(profile, "actions")
 
     setup = api.get_senaite_setup()
@@ -1533,7 +1534,7 @@ def setup_custom_image_and_file_types(tool):
     # Ensure old AT types are flushed first
     remove_at_portal_types(tool, REMOVE_AT_TYPES)
     portal = tool.aq_inner.aq_parent
-    tool.runImportStepFromProfile(profile, "typeinfo")
+    import_typeinfo(tool, profile)
     tool.runImportStepFromProfile(profile, "workflow")
     # Needed for the updated Client.xml action
     _run_import_step(portal, "typeinfo", "profile-bika.lims:default")
@@ -1759,7 +1760,7 @@ def migrate_arreport_to_resultsreport(tool):
 
     # Remove AT portal type and install DX portal type
     remove_at_portal_types(tool, REMOVE_AT_TYPES)
-    tool.runImportStepFromProfile(profile, "typeinfo")
+    import_typeinfo(tool, profile)
     tool.runImportStepFromProfile(profile, "workflow")
 
     # Update AnalysisRequest to allow ResultsReport as subobject
@@ -1989,7 +1990,7 @@ def migrate_worksheets_to_dx(tool):
     remove_at_portal_types(tool, REMOVE_AT_TYPES)
 
     # run required import steps
-    tool.runImportStepFromProfile(profile, "typeinfo")
+    import_typeinfo(tool, profile)
     tool.runImportStepFromProfile(profile, "workflow")
     tool.runImportStepFromProfile(profile, "rolemap")
     tool.runImportStepFromProfile(profile, "plone.app.registry")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Discovered while upgrading an instance from upgrade step 2706 to 2754.

Several 2.7.0 Archetypes→Dexterity migration steps run the GenericSetup `typeinfo` import step and then immediately create Dexterity content (e.g. the destination container in `migrate_worksheets_to_dx` → `get_destination_folder` → `add_dexterity_items` → `createContent`).

A Dexterity type is only usable by `createContent` when its local `IDexterityFTI` utility is registered in the site's component registry. That registration happens in `plone.dexterity.fti.register`, which is triggered by the `ObjectAddedEvent` fired when an FTI is *created* in `portal_types`.

GenericSetup's `typeinfo` import fires that event only for FTIs it creates. When a type already exists it is updated in place, no event is fired, and no (re)registration happens. As a result, an FTI left behind by a partially-completed / interrupted upgrade keeps a valid `portal_types` entry but has no local utility, and re-running the upgrade can never recover.

## Current behavior before PR

Re-running the upgrade after an interrupted Dexterity migration fails in `createContent`, and keeps failing on every retry. The only workaround is manual re-registration of the FTI utility from a debug shell.

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 666, in call
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 399, in upgrade_product
  Module Products.GenericSetup.tool, line 1202, in upgradeProfile
  Module Products.GenericSetup.upgrade, line 185, in doStep
  Module senaite.core.upgrade, line 39, in wrap_func_args
  Module senaite.core.upgrade.v02_07_000, line 1998, in migrate_worksheets_to_dx
  Module senaite.core.upgrade.v02_07_000, line 900, in get_destination_folder
  Module senaite.core.setuphandlers, line 304, in add_dexterity_items
  Module bika.lims.api, line 242, in create
  Module plone.dexterity.utils, line 112, in createContent
  Module zope.component._api, line 165, in getUtility
ComponentLookupError: (<InterfaceClass plone.dexterity.interfaces.IDexterityFTI>, 'Worksheets')
```

## Desired behavior after PR is merged

A new idempotent helper `register_missing_dx_ftis()` in `senaite.core.upgrade.utils` re-registers the local `IDexterityFTI` utility for any Dexterity FTI in `portal_types` that is missing it. A thin `import_typeinfo(tool, profile)` wrapper runs the `typeinfo` import and then reconciles registrations; all `typeinfo`-then-create migration steps in `v02_07_000.py` use it. Interrupted migrations now self-heal on plain re-run, with no manual intervention.

A doctest (`UpgradeDexterityFTIRegistration.rst`) reproduces the broken state and verifies the reconciliation and its idempotency.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
