### PR TITLE
Pin plone.jsonapi.core to 0.8.0 and add find-links for its sdist

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #2999 Pin plone.jsonapi.core to 0.8.0 and add find-links for its sdist
 - #2997 Fix listing widget doctest for the new data-catalog table attribute
 - #2996 Fix missing Dexterity FTI utility registration on typeinfo import
 - #2993 Sync translations and add complete German, Dutch and Spanish translations

--- a/buildout.base.cfg
+++ b/buildout.base.cfg
@@ -1,9 +1,14 @@
 [buildout]
 index = https://pypi.org/simple/
 extends = https://dist.plone.org/release/5.2-latest/versions.cfg
+# plone.jsonapi.core 0.8.0 ships on PyPI under the PEP 625 normalized
+# sdist name (plone_jsonapi_core-0.8.0.tar.gz), which this py2.7 buildout
+# cannot match. Pull the legacy dotted-name sdist attached to the GitHub
+# release instead, and pin the version below.
 find-links =
     https://dist.plone.org/release/5.2-latest/
     https://dist.plone.org/thirdparty/
+    https://github.com/collective/plone.jsonapi.core/releases/download/0.8.0/plone.jsonapi.core-0.8.0.tar.gz
 
 parts =
     instance
@@ -91,3 +96,4 @@ scripts = zopepy
 # versions taken from requirements.txt
 setuptools =
 zc.buildout =
+plone.jsonapi.core = 0.8.0


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`plone.jsonapi.core` 0.8.0 was just released. Its sdist is published on PyPIunder the PEP 625 normalized filename `plone_jsonapi_core-0.8.0.tar.gz` (underscores) instead of the legacy dotted `plone.jsonapi.core-0.8.0.tar.gz`.

The `setuptools` 44.1.1 / `zc.buildout` 2.13.3 pair we are pinned to on Python 2.7 derives the project name from the sdist filename as-is and does not apply PEP 503 name normalization, so it never matches an underscored filename against the dotted `plone.jsonapi.core` requirement. The candidate is effectively invisible to the resolver.

`plone.jsonapi.core` is a hard dependency of `senaite.core` itself (`setup.py`), so this affects every buildout in the stack, not just the JSON API packages. The same change was applied to `senaite.docker` in https://github.com/senaite/senaite.docker/pull/38 — this PR is the equivalent for the shared development buildout.

Both changes go into `buildout.base.cfg`, which is extended over HTTP by 11 add-ons (`abx`, `ast`, `databox`, `diagnosis`, `fhir`, `jsonapi`, `microorganism`, `off.server`, `patient`, `referral`, `storage`), so they all pick the fix up automatically once this lands on `2.x`.

## Current behavior before PR

Running buildout resolves `plone.jsonapi.core` from PyPI, where 0.8.0 is not matchable under Python 2.7, so it silently sticks to the last release carrying a legacy-named sdist. On a warm eggs cache the version is never revisited at all: CI runs `bin/buildout -N` (do not look for newer versions), and the cache key is `hashFiles('buildout.cfg', 'requirements.txt')` — which does not include `buildout.base.cfg`. An already-installed, unpinned `plone.jsonapi.core` therefore satisfies the requirement forever.

## Desired behavior after PR is merged

Two changes to `buildout.base.cfg`:

1. A `find-links` entry pointing at the legacy dotted-name sdist attached to the upstream GitHub release, which the Python 2.7 resolver *can* match:

   https://github.com/collective/plone.jsonapi.core/releases/download/0.8.0/plone.jsonapi.core-0.8.0.tar.gz

2. An explicit pin in `[versions]`:

   plone.jsonapi.core = 0.8.0

The pin is what makes the fix actually take effect: it invalidates any older cached egg, so `-N` builds are forced to fetch 0.8.0 from the new `find-links` rather than reusing what is already in `eggs/`.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
