### PR TITLE
Validate inter-field limits from the instance when there is no form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #3000 Validate inter-field limits from the instance when there is no form
 - #2997 Fix listing widget doctest for the new data-catalog table attribute
 - #2996 Fix missing Dexterity FTI utility registration on typeinfo import
 - #2993 Sync translations and add complete German, Dutch and Spanish translations

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -1285,8 +1285,12 @@ class InlineFieldValidator:
 
     def __call__(self, value, *args, **kwargs):
         field = kwargs['field']
-        request = kwargs['REQUEST']
+        request = kwargs.get('REQUEST')
         instance = kwargs['instance']
+
+        # skip inter-field validation when REQUEST is not available (API context)
+        if request is None:
+            return
 
         # extract the request values
         data = request.get(field.getName())
@@ -1469,6 +1473,22 @@ class ServiceConditionsValidator(object):
 validation.register(ServiceConditionsValidator())
 
 
+def get_sibling_value(instance, request, field_name):
+    """Return a sibling field's value for inter-field validation.
+
+    Prefer the value submitted in the form: during an interactive edit
+    the form holds the new values while the instance still holds the old
+    ones. Fall back to the instance's current value when there is no form
+    -- e.g. the JSON API or scripts, where the instance already holds the
+    new value by the time validation runs.
+    """
+    form = getattr(request, "form", None) or {}
+    if field_name in form:
+        return form.get(field_name)
+    field = instance.getField(field_name)
+    return field.get(instance) if field else None
+
+
 class LowerLimitOfDetectionValidator(object):
     """Validates that the Lower Limit of Detection (LLOD) is lower than or
     equal to the Lower Limit of Quantification (LLOQ)
@@ -1484,8 +1504,8 @@ class LowerLimitOfDetectionValidator(object):
         default = instance.getField(field_name).getDefault(instance)
         llod = api.to_float(value, default)
 
-        form = kwargs["REQUEST"].form
-        lloq = form.get("LowerLimitOfQuantification", None)
+        lloq = get_sibling_value(
+            instance, kwargs.get("REQUEST"), "LowerLimitOfQuantification")
         lloq = api.to_float(lloq, llod)
         if llod > lloq:
             return _t(_(
@@ -1511,9 +1531,8 @@ class LowerLimitOfQuantificationValidator(object):
         default = instance.getField(field_name).getDefault(instance)
         lloq = api.to_float(value, default)
 
-        # compare with the lower limit of detection
-        form = kwargs["REQUEST"].form
-        uloq = form.get("UpperLimitOfQuantification", None)
+        uloq = get_sibling_value(
+            instance, kwargs.get("REQUEST"), "UpperLimitOfQuantification")
         uloq = api.to_float(uloq, lloq)
         if lloq >= uloq:
             return _t(_(
@@ -1539,9 +1558,8 @@ class UpperLimitOfQuantificationValidator(object):
         default = instance.getField(field_name).getDefault(instance)
         uloq = api.to_float(value, default)
 
-        # compare with the lower limit of detection
-        form = kwargs["REQUEST"].form
-        ulod = form.get("UpperDetectionLimit", None)
+        ulod = get_sibling_value(
+            instance, kwargs.get("REQUEST"), "UpperDetectionLimit")
         ulod = api.to_float(ulod, uloq)
         if uloq > ulod:
             return _t(_(


### PR DESCRIPTION
## Summary

Supersedes #2972. Fixes the same crash (`AttributeError: 'NoneType' object has no attribute 'form'`) but keeps the inter-field limit validation working outside a form instead of disabling it.

## Problem

The LLOD/LLOQ/ULOQ validators and `InlineFieldValidator` read from `kwargs["REQUEST"].form`. `REQUEST` is `None` outside an interactive form submission (JSON API, `bin/instance run`, upgrade scripts, tests), so creating e.g. an `AnalysisService` via `senaite.jsonapi` raises:

```
No objects could be created: 'NoneType' object has no attribute 'form'
```

## Why not just skip when REQUEST is None (#2972)

The three limit validators exist to enforce `LLOD ≤ LLOQ ≤ ULOQ`. Returning early when there is no form stops the crash but silently disables that validation for every programmatic caller — you could then create an `AnalysisService` with `LLOD > LLOQ` through the API and it would pass.

Detecting "am I the JSON API?" would be worse: a field validator should not know about the transport, and it would have to enumerate every non-form caller (scripts, tests, future APIs).

## This change

The reason the validators read the form is timing: during an interactive edit the form holds the *new* values while the instance still holds the *old* ones. Outside a form there is no such gap — by the time validation runs the instance already holds the new values.

So a small helper reads the sibling value from the submitted form when present and falls back to the instance otherwise:

```python
def get_sibling_value(instance, request, field_name):
    form = getattr(request, "form", None) or {}
    if field_name in form:
        return form.get(field_name)
    field = instance.getField(field_name)
    return field.get(instance) if field else None
```

The three limit validators use it, so the check keeps working in both contexts, transport-agnostic. `InlineFieldValidator` delegates to per-field callables that genuinely need a request, so it keeps #2972's early return.

## Testing

- Reproduces (`AnalysisService` create via `senaite.jsonapi` raised `WrongContainedType`/`'NoneType'…form` before).
- `senaite.jsonapi` create doctest (which creates an `AnalysisService` via testbrowser) stays green.