### PR TITLE
Support validating only selected fields for partial updates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #3002 Support validating only selected fields for partial updates
 - #3000 Validate inter-field limits from the instance when there is no form
 - #2999 Pin plone.jsonapi.core to 0.8.0 and add find-links for its sdist
 - #2997 Fix listing widget doctest for the new data-catalog table attribute

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -2307,15 +2307,33 @@ def to_list(value):
     return list(value)
 
 
-def validate(obj):
-    """Validates the full object
+def validate(obj, fields=None):
+    """Validates the object, optionally restricted to the given fields
 
     :param obj: the object to validate the data against
     :type obj: ATContentType/DexterityContentType
+    :param fields: optional iterable of field names to restrict validation
+        to. When provided, only those fields are validated and cross-field
+        (schema and behavior) invariants are skipped. This is meant for
+        partial updates, where re-validating untouched fields can raise
+        spurious errors -- e.g. a stored legacy value that no longer passes
+        its own field validator, or a behavior default lookup that fails.
+    :type fields: list/tuple/set/None
     :returns: a dict with field names as keys and errors as values
     """
     if is_at_content(obj):
-        return obj.validate(data=True)
+        if fields is None:
+            return obj.validate(data=True)
+        # Partial validation: check only the requested AT fields.
+        errors = {}
+        for field_name in fields:
+            field = obj.getField(field_name)
+            if field is None:
+                continue
+            error = field.validate(field.get(obj), obj)
+            if error:
+                errors[field_name] = error
+        return errors
 
     if not is_dexterity_content(obj):
         raise TypeError("%r is not supported" % type(obj))
@@ -2330,8 +2348,13 @@ def validate(obj):
     obj_data = {}
 
     # iterate through object fields and validate each
-    fields = get_fields(obj)
-    for field_name, field in fields.items():
+    obj_fields = get_fields(obj)
+    if fields is None:
+        field_names = list(obj_fields.keys())
+    else:
+        field_names = [name for name in fields if name in obj_fields]
+    for field_name in field_names:
+        field = obj_fields[field_name]
 
         # extract the field value
         value = getattr(obj, field_name, None)
@@ -2369,6 +2392,11 @@ def validate(obj):
                 errors[field_name] = "wrong type"
         except Invalid as ex:
             errors[field_name] = translate(ex.message) or type(ex).__name__
+
+    # Cross-field invariants only make sense for a full-object validation;
+    # skip them when validating a subset of fields (partial update).
+    if fields is not None:
+        return errors
 
     # validate invariants from schema
     sch = get_schema(obj)

--- a/src/senaite/core/tests/test_validation.py
+++ b/src/senaite/core/tests/test_validation.py
@@ -20,6 +20,7 @@
 
 import unittest
 
+from bika.lims import api
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import login
@@ -272,6 +273,43 @@ class Tests(DataTestCase):
                 None,
                 ICalculationSchema,
                 None).validate(self.portal.REQUEST.form))
+
+
+    def test_validate_only_selected_fields(self):
+        login(self.portal, TEST_USER_NAME)
+
+        # AT content: this fixture service does not fully validate (it has a
+        # required field left unset), which is exactly the partial-update
+        # scenario -- an untouched field that would fail a full validation.
+        services = self.portal.bika_setup.bika_analysisservices
+        service = services["analysisservice-1"]
+
+        full = api.validate(service)
+        self.assertTrue(full, "expected the fixture service to have errors")
+
+        # pick a real (non-invariant) field that fails the full validation
+        offending = None
+        for name in sorted(full):
+            if service.getField(name) is not None:
+                offending = name
+                break
+        self.assertIsNotNone(offending)
+
+        # scoping to the offending field still reports it
+        self.assertIn(offending, api.validate(service, fields=[offending]))
+
+        # scoping to a valid field skips the offending (untouched) ones
+        self.assertEqual({}, api.validate(service, fields=["title"]))
+
+        # unknown field names are ignored, not raised
+        self.assertEqual({}, api.validate(service, fields=["NoSuchField"]))
+
+        # DX content: a subset of valid fields validates without errors and
+        # without triggering cross-field / behavior invariants
+        sampletypes = self.portal.setup.sampletypes
+        sampletype = sampletypes.objectValues()[0]
+        self.assertEqual({}, api.validate(sampletype, fields=["title"]))
+        self.assertEqual({}, api.validate(sampletype, fields=["NoSuchField"]))
 
 
 def test_suite():


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`api.validate()` always validates the whole object, including every schema and behavior invariant. That is correct for object creation, but it makes a partial update fail on fields the caller never touched — for example an Archetypes field whose stored legacy value no longer passes its own validator, or a Dexterity behavior default lookup (`IExcludeFromNavigationDefault`) that raises during invariant checking. Consumers that patch a single field (e.g. the JSON API `update` route) cannot work around this today.

This adds an optional `fields` argument. When given, only those field names are validated and the cross-field schema/behavior invariants are skipped, which is the correct granularity for a partial update. The full-object behavior (no `fields`, used on creation) is unchanged.

## Current behavior before PR

`api.validate(obj)` re-validates the entire object. Updating one field can return errors for unrelated, untouched fields, or raise on a behavior invariant, blocking the update.

## Desired behavior after PR is merged

`api.validate(obj, fields=["Specification"])` validates only the listed fields and skips invariants. `api.validate(obj)` keeps validating the full object as before. Unknown field names are ignored. Covered by a new test in `test_validation.py` (AT and DX content).

--
I confirm I have coded it according to [PEP8][1] and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html