### PR TITLE
Fix colliding reference analyses group IDs within the same transaction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #3003 Fix colliding reference analyses group IDs within the same transaction
 - #3000 Validate inter-field limits from the instance when there is no form
 - #2999 Pin plone.jsonapi.core to 0.8.0 and add find-links for its sdist
 - #2997 Fix listing widget doctest for the new data-catalog table attribute

--- a/src/senaite/core/content/worksheet.py
+++ b/src/senaite/core/content/worksheet.py
@@ -617,8 +617,21 @@ class Worksheet(Container):
         if not IReferenceSample.providedBy(reference):
             # Not a ReferenceSample, so this is a duplicate
             prefix = reference.id + "-D"
-        cat = api.get_tool(ANALYSIS_CATALOG)
-        ids = cat.Indexes["getReferenceAnalysesGroupID"].uniqueValues()
+
+        # Search for the group IDs in use for this reference sample. Note we
+        # rely on a catalog search here, and not on the unique values of the
+        # index, cause the latter bypasses the indexing queue and therefore it
+        # does not see the reference analyses created within this transaction.
+        # Note as well that ":" is the character that comes right after "9", so
+        # the range covers all the group IDs made of this prefix and digits
+        query = {
+            "getReferenceAnalysesGroupID": {
+                "query": [prefix, prefix + ":"],
+                "range": "min:max",
+            },
+        }
+        brains = api.search(query, ANALYSIS_CATALOG)
+        ids = set([brain.getReferenceAnalysesGroupID for brain in brains])
         rr = re.compile("^" + prefix + r"[\d+]+$")
         ids = [int(i.split(prefix)[1]) for i in ids if i and rr.match(i)]
         ids.sort()

--- a/src/senaite/core/tests/doctests/WorksheetApplyTemplate.rst
+++ b/src/senaite/core/tests/doctests/WorksheetApplyTemplate.rst
@@ -461,6 +461,33 @@ as the rest of the slots:
     >>> [ref for ref in ref9_uids if ref not in refs_uids]
     []
 
+Reference analyses from the same slot share the same group ID, and each new
+group of reference analyses created from the same reference sample is numbered
+right after the last one:
+
+    >>> gid6 = list(set([ref.getReferenceAnalysesGroupID() for ref in ref6]))
+    >>> gid9 = list(set([ref.getReferenceAnalysesGroupID() for ref in ref9]))
+    >>> len(gid6) == len(gid9) == 1
+    True
+
+    >>> [gid.startswith(control.getId() + "-") for gid in gid6 + gid9]
+    [True, True]
+
+    >>> num6 = int(gid6[0].split("-")[-1])
+    >>> num9 = int(gid9[0].split("-")[-1])
+    >>> num9 == num6 + 1
+    True
+
+Therefore, the next group ID for this reference sample comes right after the
+last one in use. Note the reference analyses of the last group were created
+within this same transaction, so the next group ID has to be resolved with a
+catalog search, that flushes the indexing queue first, and not by reading the
+index directly:
+
+    >>> expected = "{}-{}".format(control.getId(), str(num9 + 1).zfill(3))
+    >>> worksheet.nextRefAnalysesGroupID(control) == expected
+    True
+
 Reject any remaining analyses awaiting for assignment:
 
     >>> query = {"portal_type": "Analysis", "review_state": "unassigned"}


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`Worksheet.nextRefAnalysesGroupID` resolves the group IDs already in use by reading the unique values of the `getReferenceAnalysesGroupID` index directly:

```python
cat = api.get_tool(ANALYSIS_CATALOG)
ids = cat.Indexes["getReferenceAnalysesGroupID"].uniqueValues()
```

Reading the index this way bypasses the indexing queue (processQueue is only called on catalog searches), so the reference analyses created earlier within the same transaction are not visible yet, and the ID returned can be one that is already in use.

## Current behavior before PR

When two groups of reference analyses from the same reference sample are created within the same request, the second group gets the same group ID as the first one. Reproducible when a worksheet template with more than one slot for controls (or blanks) resolving to the same reference sample is applied, and also when reference analyses are added manually more than once before the request finishes:

```python
>>> worksheet.addReferenceAnalyses(control, [Cu.UID(), Fe.UID()])   # QC-002-001
>>> worksheet.addReferenceAnalyses(control, [Cu.UID(), Fe.UID()])   # QC-002-002
>>> worksheet.nextRefAnalysesGroupID(control)
'QC-002-002'    # already in use!
```

On top of that, uniqueValues() walks through all the unique values of the index, that grows with every reference and duplicate analysis created in the system, and it is called once per slot reserved for controls/blanks when a worksheet template is applied.

## Desired behavior after PR is merged

The group IDs in use are resolved with a catalog search, that flushes the indexing queue first, so groups created within the same transaction are taken into account and the ID returned is always free:

```python
>>> worksheet.nextRefAnalysesGroupID(control)
'QC-002-003'
```

The search is restricted to the range of group IDs starting with the prefix of the reference sample (":" is the character right after "9", so the range covers the prefix followed by digits), instead of scanning every unique value of the index.

The WorksheetApplyTemplate doctest covers this now: it asserts that each new group of reference analyses from the same reference sample is numbered right after the last one, and that nextRefAnalysesGroupID does not hand out an ID already in use. Those assertions fail on 2.x and pass with this PR.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
