### PR TITLE
Speed up the creation of worksheets with a worksheet template

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #3004 Speed up the creation of worksheets with a worksheet template
 - #3003 Fix colliding reference analyses group IDs within the same transaction
 - #3000 Validate inter-field limits from the instance when there is no form
 - #2999 Pin plone.jsonapi.core to 0.8.0 and add find-links for its sdist

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -571,6 +571,57 @@ def catalog_object(obj, recursive=False):
             catalog_object(child, recursive=recursive)
 
 
+def reindex(obj, idxs_cols=None):
+    """Reindex the object in all the catalogs it is registered to
+
+    When `idxs_cols` is set, only the indexes and metadata columns with those
+    names are updated, instead of recomputing the whole metadata record of the
+    object. This is way cheaper for objects with expensive metadata (e.g.
+    samples), as long as the caller knows which indexes and columns are
+    affected by the change. The `uid_catalog` is taken into account as well,
+    but only when it has indexes or columns with those names.
+
+    Note that when no `idxs_cols` are passed-in, the object is reindexed with
+    `reindexObject`, that only refreshes the record of the `uid_catalog` for AT
+    contents. Use `catalog_object` when the record of a DX content has to be
+    refreshed in the `uid_catalog` too.
+
+    :param obj: object to reindex
+    :type obj: ATContentType/DexterityContentType
+    :param idxs_cols: names of the indexes and metadata columns to update.
+        Everything is reindexed when None or empty
+    """
+    if not idxs_cols:
+        obj.reindexObject()
+        return
+
+    # the uid_catalog is not amongst the catalogs the object is registered to,
+    # but it keeps a record of the object as well
+    catalogs = get_catalogs_for(obj) + [get_tool(UID_CATALOG)]
+
+    for catalog in catalogs:
+        indexes = [name for name in idxs_cols if name in catalog.indexes()]
+        columns = [name for name in idxs_cols if name in catalog.schema()]
+        if not indexes and not columns:
+            # this catalog has no such indexes or columns
+            continue
+
+        uid = None
+        if catalog.id == UID_CATALOG:
+            # the uid_catalog keeps the records of AT contents with a path
+            # relative to the portal root, while those of DX contents are kept
+            # with the absolute path, same as `catalog_object` does
+            path = obj.getPhysicalPath()
+            uid = "/".join(path)
+            if is_at_content(obj):
+                uid = getRelURL(catalog, path)
+
+        # Note we do not pass the uid for the rest of catalogs on purpose, so
+        # each one resolves it from the physical path of the object, exactly as
+        # it does when the object is reindexed
+        catalog.catalog_object(obj, uid, idxs=indexes, update_metadata=columns)
+
+
 def delete(obj, check_permissions=True, suppress_events=False):
     """Deletes the given object
 

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -571,27 +571,32 @@ def catalog_object(obj, recursive=False):
             catalog_object(child, recursive=recursive)
 
 
-def reindex(obj, idxs_cols=None):
+def reindex(obj, idxs=None, cols=None):
     """Reindex the object in all the catalogs it is registered to
 
-    When `idxs_cols` is set, only the indexes and metadata columns with those
-    names are updated, instead of recomputing the whole metadata record of the
-    object. This is way cheaper for objects with expensive metadata (e.g.
-    samples), as long as the caller knows which indexes and columns are
-    affected by the change. The `uid_catalog` is taken into account as well,
-    but only when it has indexes or columns with those names.
+    Only the indexes with the names passed-in through `idxs` are reindexed, or
+    all of them when `idxs` is None. Catalogs that do not have any of these
+    indexes are skipped. The `uid_catalog` is taken into account as well,
+    although the object is not registered to it.
 
-    Note that when no `idxs_cols` are passed-in, the object is reindexed with
-    `reindexObject`, that only refreshes the record of the `uid_catalog` for AT
-    contents. Use `catalog_object` when the record of a DX content has to be
-    refreshed in the `uid_catalog` too.
+    The same applies to the metadata: all the columns of the object are
+    recomputed when `cols` is None, and only those with the names passed-in
+    otherwise. Recomputing only some columns is way cheaper for objects with
+    expensive metadata (e.g. samples), as long as the caller knows which ones
+    are affected by the change. Pass an empty list to not touch the metadata.
+
+    Note that when neither `idxs` nor `cols` are passed-in, the object is
+    reindexed with `reindexObject`, that only refreshes the record of the
+    `uid_catalog` for AT contents. Use `catalog_object` when the record of a DX
+    content has to be refreshed in the `uid_catalog` too.
 
     :param obj: object to reindex
     :type obj: ATContentType/DexterityContentType
-    :param idxs_cols: names of the indexes and metadata columns to update.
-        Everything is reindexed when None or empty
+    :param idxs: names of the indexes to reindex. All of them when None
+    :param cols: names of the metadata columns to recompute. All of them when
+        None, none of them when empty
     """
-    if not idxs_cols:
+    if idxs is None and cols is None:
         obj.reindexObject()
         return
 
@@ -600,10 +605,21 @@ def reindex(obj, idxs_cols=None):
     catalogs = get_catalogs_for(obj) + [get_tool(UID_CATALOG)]
 
     for catalog in catalogs:
-        indexes = [name for name in idxs_cols if name in catalog.indexes()]
-        columns = [name for name in idxs_cols if name in catalog.schema()]
-        if not indexes and not columns:
-            # this catalog has no such indexes or columns
+        indexes = idxs
+        if idxs is not None:
+            indexes = [name for name in idxs if name in catalog.indexes()]
+            if not indexes:
+                # this catalog has none of these indexes
+                continue
+
+        # `update_metadata` of senaite's catalogs takes a list of columns, or
+        # the usual boolean meaning when all of them have to be recomputed
+        metadata = 1
+        if cols is not None:
+            metadata = [name for name in cols if name in catalog.schema()]
+
+        if not indexes and not metadata:
+            # nothing to reindex or to recompute in this catalog
             continue
 
         uid = None
@@ -619,7 +635,7 @@ def reindex(obj, idxs_cols=None):
         # Note we do not pass the uid for the rest of catalogs on purpose, so
         # each one resolves it from the physical path of the object, exactly as
         # it does when the object is reindexed
-        catalog.catalog_object(obj, uid, idxs=indexes, update_metadata=columns)
+        catalog.catalog_object(obj, uid, idxs=indexes, update_metadata=metadata)
 
 
 def delete(obj, check_permissions=True, suppress_events=False):

--- a/src/bika/lims/workflow/analysis/events.py
+++ b/src/bika/lims/workflow/analysis/events.py
@@ -41,7 +41,10 @@ def after_assign(analysis):
     """Function triggered after an 'assign' transition for the analysis passed
     in is performed.
     """
-    reindex_request(analysis)
+    # `assigned_state` is the only value of the sample that depends on whether
+    # its analyses are assigned to a worksheet or not, so there is no need to
+    # recompute the whole catalog record of the sample (and of its ancestors)
+    reindex_request(analysis, idxs=["assigned_state"])
 
 
 def before_unassign(analysis):
@@ -312,6 +315,9 @@ def after_publish(analysis):
 def reindex_request(analysis, idxs=None):
     """Reindex the Analysis Request the analysis belongs to, as well as the
     ancestors recursively
+
+    When `idxs` is set, only the indexes and metadata columns with those names
+    are updated, instead of recomputing the whole catalog record of the sample
     """
     if not IRequestAnalysis.providedBy(analysis) or \
             IDuplicateAnalysis.providedBy(analysis):
@@ -321,7 +327,7 @@ def reindex_request(analysis, idxs=None):
     request = analysis.getRequest()
     ancestors = [request] + request.getAncestors(all_ancestors=True)
     for ancestor in ancestors:
-        ancestor.reindexObject()
+        api.reindex(ancestor, idxs_cols=idxs)
 
 
 def remove_analysis_from_worksheet(analysis):

--- a/src/bika/lims/workflow/analysis/events.py
+++ b/src/bika/lims/workflow/analysis/events.py
@@ -327,7 +327,8 @@ def reindex_request(analysis, idxs=None):
     request = analysis.getRequest()
     ancestors = [request] + request.getAncestors(all_ancestors=True)
     for ancestor in ancestors:
-        api.reindex(ancestor, idxs_cols=idxs)
+        # note `assigned_state` is both an index and a metadata column
+        api.reindex(ancestor, idxs=idxs, cols=idxs)
 
 
 def remove_analysis_from_worksheet(analysis):

--- a/src/senaite/core/api/worksheet.py
+++ b/src/senaite/core/api/worksheet.py
@@ -54,5 +54,4 @@ def create_worksheet(analyst, instrument=None, template=None, analyses=None):
     else:
         ws.addAnalyses(analyses or [])
 
-    ws.reindexObject()
     return ws

--- a/src/senaite/core/content/worksheet.py
+++ b/src/senaite/core/content/worksheet.py
@@ -469,8 +469,7 @@ class Worksheet(Container):
 
         # Cannot add an analysis if not open, unless a retest
         if api.get_review_status(self) not in ["open", "to_be_verified"]:
-            retracted = analysis.getRetestOf()
-            retracted_uid = retracted and api.get_uid(retracted) or None
+            retracted_uid = analysis.getRawRetestOf()
             if retracted_uid not in self.getRawAnalyses():
                 return
 
@@ -539,7 +538,8 @@ class Worksheet(Container):
         if analysis.getWorksheet() == self:
             doActionFor(analysis, "unassign")
 
-    def addReferenceAnalyses(self, reference, services, slot=None):
+    def addReferenceAnalyses(self, reference, services, slot=None,
+                             reindex=True):
         """ Creates and add reference analyses to the slot by using the
         reference sample and service uids passed in.
         If no destination slot is defined, the most suitable slot will be used,
@@ -547,6 +547,9 @@ class Worksheet(Container):
         :param reference: reference sample to which ref analyses belong
         :param service_uids: he uid of the services to create analyses from
         :param slot: slot where reference analyses must be stored
+        :param reindex: whether to reindex this worksheet once the reference
+            analyses are added. Set it to False when the caller reindexes the
+            worksheet afterwards
         :return: the list of reference analyses added
         """
         service_uids = list()
@@ -568,7 +571,8 @@ class Worksheet(Container):
         if not slot_to:
             # Find the suitable slot to add these references
             slot_to = self.get_suitable_slot_for_reference(reference)
-            return self.addReferenceAnalyses(reference, service_uids, slot_to)
+            return self.addReferenceAnalyses(reference, service_uids, slot_to,
+                                             reindex=reindex)
 
         processed = list()
         for analysis in self.get_analyses_at(slot_to):
@@ -585,14 +589,20 @@ class Worksheet(Container):
         ref_analyses = list()
         for service in services:
             service_obj = api.get_object(service)
-            ref_analysis = self.add_reference_analysis(reference, service_obj,
-                                                       slot_to, ref_gid)
+            ref_analysis = self.add_reference_analysis(
+                reference, service_obj, slot_to, ref_gid, reindex=False)
             if not ref_analysis:
                 continue
             ref_analyses.append(ref_analysis)
+
+        if reindex and ref_analyses:
+            # reindex this worksheet once, after all the analyses are added
+            self.reindexObject()
+
         return ref_analyses
 
-    def add_reference_analysis(self, reference, service, slot, ref_gid=None):
+    def add_reference_analysis(self, reference, service, slot, ref_gid=None,
+                               reindex=True):
         """
         Creates a reference analysis in the destination slot (dest_slot) passed
         in, by using the reference and service_uid. If the analysis
@@ -603,6 +613,10 @@ class Worksheet(Container):
         :param service: the service object to create an analysis from
         :param slot: slot where the reference analysis must be stored
         :param ref_gid: the reference analyses group id to be set
+        :param reindex: whether to refresh all the metadata of this worksheet
+            after the reference analysis is added. Set it to False when adding
+            reference analyses in bulk and reindex the worksheet once, after
+            all of them are added
         :return: the reference analysis or None
         """
         if not reference or not service:
@@ -624,8 +638,9 @@ class Worksheet(Container):
         values = {"ReferenceAnalysesGroupID": gid, "Worksheet": self}
         ref_analysis = create_reference_analysis(reference, service, **values)
 
-        # Add the reference analysis into the worksheet
-        self.setAnalyses(self.getAnalyses() + [ref_analysis, ])
+        # Add the reference analysis into the worksheet. Note we deal with UIDs
+        # here, so we do not need to wake up all the analyses assigned
+        self.setAnalyses(self.getRawAnalyses() + [api.get_uid(ref_analysis)])
         self.addToLayout(ref_analysis, slot)
 
         # TODO This shuldn't be necessary, but `getWorksheetUID` relies on
@@ -639,7 +654,17 @@ class Worksheet(Container):
         ])
 
         # Reindex
-        self.reindexObject(idxs=["getAnalysesUIDs"])
+        if reindex:
+            # Note this refreshes all the metadata of this worksheet as well,
+            # cause `reindexObject` restricts the indexes, but not the columns
+            self.reindexObject(idxs=["getAnalysesUIDs"])
+        else:
+            # Keep the analyses UIDs in sync only. The rest of the metadata is
+            # refreshed when the caller reindexes this worksheet, once all the
+            # analyses are added
+            api.reindex(self, idxs=["getAnalysesUIDs"],
+                        cols=["getAnalysesUIDs"])
+
         return ref_analysis
 
     def nextRefAnalysesGroupID(self, reference):
@@ -678,13 +703,16 @@ class Worksheet(Container):
             suffix = str(_id + 1).zfill(2)
         return "%s%s" % (prefix, suffix)
 
-    def addDuplicateAnalyses(self, src_slot, dest_slot=None):
+    def addDuplicateAnalyses(self, src_slot, dest_slot=None, reindex=True):
         """ Creates and add duplicate analyses from the src_slot to
         the dest_slot. If no destination slot is defined, the most suitable
         slot will be used, typically a new slot at the end of
         the worksheet will be added.
         :param src_slot: slot that contains the analyses to duplicate
         :param dest_slot: slot where the duplicate analyses must be stored
+        :param reindex: whether to reindex this worksheet once the duplicate
+            analyses are added. Set it to False when the caller reindexes the
+            worksheet afterwards
         :return: the list of duplicate analyses added
         """
         # Duplicate analyses can only be added if the state of the ws is open
@@ -703,7 +731,8 @@ class Worksheet(Container):
         if not slot_to:
             # Find the suitable slot to add these duplicates
             slot_to = self.get_suitable_slot_for_duplicate(slot_from)
-            return self.addDuplicateAnalyses(src_slot, slot_to)
+            return self.addDuplicateAnalyses(src_slot, slot_to,
+                                             reindex=reindex)
 
         processed = map(lambda an: api.get_uid(an.getAnalysis()),
                         self.get_analyses_at(slot_to))
@@ -716,15 +745,27 @@ class Worksheet(Container):
         ref_gid = None
         duplicates = list()
         for analysis in src_analyses:
-            duplicate = self.add_duplicate_analysis(analysis, slot_to)
+            duplicate = self.add_duplicate_analysis(analysis, slot_to,
+                                                    reindex=False)
             if not duplicate:
                 continue
             # All duplicates from the same slot must have the same group id
             ref_gid = ref_gid or duplicate.getReferenceAnalysesGroupID()
             duplicates.append(duplicate)
+
+        if reindex and duplicates:
+            # reindex this worksheet once, after all the analyses are added
+            # Note duplicates are created inside this worksheet, so Dexterity's
+            # `reindexOnModify` subscriber reindexes it on every duplicate
+            # created, making this call redundant at the moment. We keep it
+            # anyway, so the record of this worksheet does not depend on an
+            # event fired somewhere else
+            self.reindexObject()
+
         return duplicates
 
-    def add_duplicate_analysis(self, src_analysis, destination_slot):
+    def add_duplicate_analysis(self, src_analysis, destination_slot,
+                               reindex=True):
         """
         Creates a duplicate of the src_analysis passed in. If the analysis
         passed in is not an IRoutineAnalysis, is retracted or has dependent
@@ -732,6 +773,10 @@ class Worksheet(Container):
         set, the value will be generated automatically.
         :param src_analysis: analysis to create a duplicate from
         :param destination_slot: slot where duplicate analysis must be stored
+        :param reindex: whether to refresh all the metadata of this worksheet
+            after the duplicate is added. Set it to False when adding duplicate
+            analyses in bulk and reindex the worksheet once, after all of them
+            are added
         :return: the duplicate analysis or None
         """
         if not src_analysis:
@@ -762,9 +807,10 @@ class Worksheet(Container):
         # Create the duplicate
         duplicate = create_duplicate(src_analysis)
 
-        # Add the duplicate into the worksheet
+        # Add the duplicate into the worksheet. Note we deal with UIDs here,
+        # so we do not need to wake up all the analyses assigned
         self.addToLayout(duplicate, destination_slot)
-        self.setAnalyses(self.getAnalyses() + [duplicate, ])
+        self.setAnalyses(self.getRawAnalyses() + [api.get_uid(duplicate)])
 
         # TODO This shuldn't be necessary, but `getWorksheetUID` relies on
         #      backreference, while it should be the other way round.
@@ -773,7 +819,17 @@ class Worksheet(Container):
         duplicate.reindexObject(idxs=["getWorksheetUID", "getAnalyst"])
 
         # Reindex
-        self.reindexObject(idxs=["getAnalysesUIDs"])
+        if reindex:
+            # Note this refreshes all the metadata of this worksheet as well,
+            # cause `reindexObject` restricts the indexes, but not the columns
+            self.reindexObject(idxs=["getAnalysesUIDs"])
+        else:
+            # Keep the analyses UIDs in sync only. The rest of the metadata is
+            # refreshed when the caller reindexes this worksheet, once all the
+            # analyses are added
+            api.reindex(self, idxs=["getAnalysesUIDs"],
+                        cols=["getAnalysesUIDs"])
+
         return duplicate
 
     def get_suitable_slot_for_duplicate(self, src_slot):
@@ -1324,7 +1380,7 @@ class Worksheet(Container):
             slot = reference["slot"]
             sample = reference["sample"]
             services = reference["supported_services"]
-            self.addReferenceAnalyses(sample, services, slot)
+            self.addReferenceAnalyses(sample, services, slot, reindex=False)
 
     def applyWorksheetTemplate(self, wst, analyses=None):
         """ Add analyses to worksheet according to wst's layout.
@@ -1345,11 +1401,11 @@ class Worksheet(Container):
             # do not rely on `reindexObject` here, cause it recomputes all the
             # metadata of this worksheet, and some of the columns are resolved
             # by waking up all the analyses assigned
-            api.reindex(self, idxs_cols=[
-                "getWorksheetTemplateTitle",
-                "getWorksheetTemplateUID",
-                "getWorksheetTemplateURL",
-            ])
+            api.reindex(self,
+                        idxs=["getWorksheetTemplateTitle"],
+                        cols=["getWorksheetTemplateTitle",
+                              "getWorksheetTemplateUID",
+                              "getWorksheetTemplateURL"])
             return
 
         try:
@@ -1402,7 +1458,7 @@ class Worksheet(Container):
             src_pos = to_int(row["dup"])
             dest_pos = to_int(row["pos"])
 
-            self.addDuplicateAnalyses(src_pos, dest_pos)
+            self.addDuplicateAnalyses(src_pos, dest_pos, reindex=False)
 
     def getAnalystName(self):
         """Returns the name of the currently assigned analyst

--- a/src/senaite/core/content/worksheet.py
+++ b/src/senaite/core/content/worksheet.py
@@ -41,6 +41,7 @@ from plone.autoform import directives
 from plone.supermodel import model
 from senaite.core import logger
 from senaite.core.catalog import ANALYSIS_CATALOG
+from senaite.core.catalog import SAMPLE_CATALOG
 from senaite.core.catalog import SENAITE_CATALOG
 from senaite.core.catalog import SETUP_CATALOG
 from senaite.core.catalog import WORKSHEET_CATALOG
@@ -61,6 +62,29 @@ from zope.interface import implementer
 
 ALL_ANALYSES_TYPES = "all"
 ALLOWED_ANALYSES_TYPES = ["a", "b", "c", "d"]
+
+
+def get_sample_id(analysis):
+    """Returns the ID of the sample the analysis passed-in belongs to
+
+    Supports both catalog brains and objects, so the sample can be resolved
+    without waking up the analysis object when a brain is passed-in.
+
+    Note `getRequestID` is only available for analyses that belong to a sample,
+    those that implement `IRequestAnalysis` (routine analyses and duplicates),
+    but not for reference analyses. Returns None when the sample cannot be
+    resolved, so this function is safe for any type of analysis.
+
+    :param analysis: analysis object or catalog brain
+    :returns: the ID of the sample the analysis belongs to, or None
+    """
+    sample_id = getattr(analysis, "getRequestID", None)
+    if callable(sample_id):
+        # an object was passed-in, not a catalog brain
+        sample_id = sample_id()
+    # might be Missing.Value when the brain of an analysis without sample is
+    # passed-in, cause the metadata column is shared by all analysis types
+    return sample_id or None
 
 
 def get_worksheet_layouts():
@@ -425,28 +449,41 @@ class Worksheet(Container):
         """Adds a collection of analyses to the Worksheet at once
         """
         for analysis in analyses:
-            self.addAnalysis(api.get_object(analysis))
+            self.addAnalysis(api.get_object(analysis), reindex=False)
 
-    def addAnalysis(self, analysis, position=None):
+        # reindex this worksheet once, after all the analyses are added
+        self.reindexObject()
+
+    def addAnalysis(self, analysis, position=None, reindex=True):
         """- add the analysis to self.Analyses().
            - position is overruled if a slot for this analysis' parent exists
            - if position is None, next available pos is used.
+
+        :param analysis: the analysis to add
+        :param position: the slot where the analysis has to be added
+        :param reindex: whether to reindex this worksheet after the analysis is
+            added. Set it to False when adding analyses in bulk and reindex the
+            worksheet once, after all of them are added
         """
+        uid = api.get_uid(analysis)
+
         # Cannot add an analysis if not open, unless a retest
         if api.get_review_status(self) not in ["open", "to_be_verified"]:
             retracted = analysis.getRetestOf()
-            if retracted not in self.getAnalyses():
+            retracted_uid = retracted and api.get_uid(retracted) or None
+            if retracted_uid not in self.getRawAnalyses():
                 return
 
         # Cannot add an analysis that is assigned already
         if analysis.getWorksheet():
             return
 
-        # Just in case
-        analyses = self.getAnalyses()
-        if analysis in analyses:
-            analyses = filter(lambda an: an != analysis, analyses)
-            self.setAnalyses(analyses)
+        # Just in case. Note we deal with UIDs here, so we do not need to wake
+        # up all the analyses assigned to this worksheet
+        uids = self.getRawAnalyses()
+        if uid in uids:
+            uids = filter(lambda u: u != uid, uids)
+            self.setAnalyses(uids)
             # ???
             # self.updateLayout()
 
@@ -476,8 +513,10 @@ class Worksheet(Container):
         analysis.setAnalyst(self.getAnalyst())
 
         # Transition analysis to "assigned"
+        # Note the sample the analysis belongs to (and its ancestors) are
+        # reindexed by the `after_assign` event of the analysis
         doActionFor(analysis, "assign")
-        self.setAnalyses(analyses + [analysis])
+        self.setAnalyses(uids + [uid])
         self.addToLayout(analysis, position)
 
         if api.get_review_status(self) != "open":
@@ -488,11 +527,8 @@ class Worksheet(Container):
         analysis.reindexObject()
 
         # Reindex Worksheet
-        self.reindexObject()
-
-        # Reindex Analysis Request, if any
-        if IRequestAnalysis.providedBy(analysis):
-            analysis.getRequest().reindexObject()
+        if reindex:
+            self.reindexObject()
 
     def removeAnalysis(self, analysis):
         """Unassigns the analysis passed in from the worksheet.
@@ -1089,10 +1125,23 @@ class Worksheet(Container):
 
         # Map existing sample uids with slots
         samples_slots = dict(self.get_containers_slots())
-        new_sample_uids = []
+
+        # Sample IDs that have a slot assigned in this worksheet. This allows
+        # us to discard analyses that cannot be assigned (no slot left for
+        # their sample) without waking up the object first
+        slotted_ids = self.get_slotted_sample_ids(samples_slots.keys())
+
         new_analyses = []
 
         for analysis in analyses:
+            sample_id = get_sample_id(analysis)
+
+            if not available_slots and sample_id not in slotted_ids:
+                # No slot left and this sample has no slot assigned. Maybe next
+                # analysis is from a sample with a slot assigned, but there is
+                # no need to wake this analysis up
+                continue
+
             analysis = api.get_object(analysis)
 
             if instrument and not analysis.isInstrumentAllowed(instrument):
@@ -1116,21 +1165,33 @@ class Worksheet(Container):
 
                 # Feed the samples_slots
                 samples_slots[sample_uid] = slot
-                new_sample_uids.append(sample_uid)
+                slotted_ids.add(sample_id)
 
             # Keep track of the analyses to add
             new_analyses.append((analysis, sample_uid))
 
-        # Re-sort slots for new samples to display them in natural order
-        new_slots = map(lambda s: samples_slots.get(s), new_sample_uids)
-        sorted_slots = zip(sorted(new_sample_uids), sorted(new_slots))
-        for sample_id, slot in sorted_slots:
-            samples_slots[sample_uid] = slot
-
-        # Add analyses to the worksheet
+        # Add analyses to the worksheet. Reindexing of the worksheet is done
+        # once, after the whole template is applied
         for analysis, sample_uid in new_analyses:
             slot = samples_slots[sample_uid]
-            self.addAnalysis(analysis, slot)
+            self.addAnalysis(analysis, slot, reindex=False)
+
+    def get_slotted_sample_ids(self, container_uids):
+        """Returns the IDs of the containers (samples) passed-in that have a
+        slot assigned in this worksheet
+
+        Resolution is done via catalog to avoid waking up objects.
+
+        :param container_uids: UIDs of the containers from the layout
+        :returns: set of container ids
+        """
+        uids = filter(api.is_uid, container_uids)
+        if not uids:
+            return set()
+
+        query = {"UID": list(uids)}
+        brains = api.search(query, SAMPLE_CATALOG)
+        return set([api.get_id(brain) for brain in brains])
 
     def _resolve_reference_sample(self, reference_samples=None,
                                   service_uids=None):
@@ -1195,6 +1256,15 @@ class Worksheet(Container):
         sc = api.get_tool(SENAITE_CATALOG)
         wst_type = type == "b" and "blank_ref" or "control_ref"
 
+        # We only want the reference samples that fit better with the type and
+        # with the analyses defined in the Template. Note the services are the
+        # same for all the slots, so they are resolved only once
+        services = wst.getRawServices()
+
+        # Cache of candidate reference samples per reference definition, cause
+        # the same definition is often used in more than one slot
+        candidates_by_definition = {}
+
         slots_sample = list()
         available_slots = self.resolve_available_slots(wst, type)
         wst_layout = wst.getTemplateLayout()
@@ -1209,21 +1279,21 @@ class Worksheet(Container):
                 # in worksheet templates
                 continue
 
-            samples = sc(portal_type="ReferenceSample",
-                         review_state="current",
-                         is_active=True,
-                         getReferenceDefinitionUID=ref_definition_uid)
+            candidates = candidates_by_definition.get(ref_definition_uid)
+            if candidates is None:
+                samples = sc(portal_type="ReferenceSample",
+                             review_state="current",
+                             is_active=True,
+                             getReferenceDefinitionUID=ref_definition_uid)
 
-            # We only want the reference samples that fit better with the type
-            # and with the analyses defined in the Template
-            services = wst.getServices()
-            services = [s.UID() for s in services]
-            candidates = list()
-            for sample in samples:
-                obj = api.get_object(sample)
-                if (type == "b" and obj.getBlank()) or \
-                        (type == "c" and not obj.getBlank()):
-                    candidates.append(obj)
+                candidates = list()
+                for sample in samples:
+                    obj = api.get_object(sample)
+                    if (type == "b" and obj.getBlank()) or \
+                            (type == "c" and not obj.getBlank()):
+                        candidates.append(obj)
+
+                candidates_by_definition[ref_definition_uid] = candidates
 
             sample, uids = self._resolve_reference_sample(candidates, services)
             if not sample:
@@ -1267,31 +1337,49 @@ class Worksheet(Container):
         """
         wst = api.get_object(wst, default=None)
 
-        # Store the Worksheet Template field and reindex it
+        # Store the Worksheet Template field
         self.setWorksheetTemplate(wst)
-        self.reindexObject(idxs=["getWorksheetTemplateTitle"])
 
         if not wst:
+            # Only the values that depend on the template are affected. Note we
+            # do not rely on `reindexObject` here, cause it recomputes all the
+            # metadata of this worksheet, and some of the columns are resolved
+            # by waking up all the analyses assigned
+            api.reindex(self, idxs_cols=[
+                "getWorksheetTemplateTitle",
+                "getWorksheetTemplateUID",
+                "getWorksheetTemplateURL",
+            ])
             return
 
-        # Apply the template for routine analyses
-        self._apply_worksheet_template_routine_analyses(wst, analyses=analyses)
+        try:
+            # Apply the template for routine analyses
+            self._apply_worksheet_template_routine_analyses(
+                wst, analyses=analyses)
 
-        # Apply the template for duplicate analyses
-        self._apply_worksheet_template_duplicate_analyses(wst)
+            # Apply the template for duplicate analyses
+            self._apply_worksheet_template_duplicate_analyses(wst)
 
-        # Apply the template for reference analyses (blanks and controls)
-        self._apply_worksheet_template_reference_analyses(wst)
+            # Apply the template for reference analyses (blanks and controls)
+            self._apply_worksheet_template_reference_analyses(wst)
 
-        # Assign the instrument
-        instrument = wst.getInstrument()
-        if instrument:
-            self.setInstrument(instrument, True)
+            # Assign the instrument
+            instrument = wst.getInstrument()
+            if instrument:
+                self.setInstrument(instrument, True)
 
-        # Assign the method
-        method = wst.getRestrictToMethod()
-        if method:
-            self.setMethod(method, True)
+            # Assign the method
+            method = wst.getRestrictToMethod()
+            if method:
+                self.setMethod(method, True)
+
+        finally:
+            # Reindex the worksheet once, instead of once per analysis added.
+            # Some of the metadata of this worksheet (e.g. the number of
+            # analyses and samples it contains) is resolved by waking up all
+            # the analyses assigned, so reindexing on every single analysis
+            # added makes the application of the template quadratic
+            self.reindexObject()
 
     def _apply_worksheet_template_duplicate_analyses(self, wst):
         """Add duplicate analyses to worksheet according to

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -2601,28 +2601,48 @@ title and its keyword:
     >>> brain.Title, brain.getKeyword
     ('Gold', 'Au')
 
-The update can also be restricted to some indexes and metadata columns, that is
-way cheaper for objects with expensive metadata:
+The reindexing can be restricted to some indexes, and the metadata can be left
+untouched by passing an empty list of columns:
 
     >>> copper.setTitle("Silver")
     >>> copper.setKeyword("Ag")
-    >>> api.reindex(copper, idxs_cols=["getKeyword"])
+    >>> api.reindex(copper, idxs=["getKeyword"], cols=[])
 
 The keyword index is up-to-date:
 
     >>> len(api.get_tool(SETUP_CATALOG)(getKeyword="Ag"))
     1
 
-And so is the keyword metadata column, while the title has not been touched:
+But no column was recomputed, so the metadata of the record is stale:
+
+    >>> brain = get_brain(copper, SETUP_CATALOG)
+    >>> brain.Title, brain.getKeyword
+    ('Gold', 'Au')
+
+Passing a list of columns recomputes only those, which is way cheaper for
+objects with expensive metadata:
+
+    >>> api.reindex(copper, idxs=["getKeyword"], cols=["getKeyword"])
 
     >>> brain = get_brain(copper, SETUP_CATALOG)
     >>> brain.Title, brain.getKeyword
     ('Gold', 'Ag')
 
-Indexes and columns that the catalogs of the object do not have are skipped:
+The title of the record is still stale, cause only the keyword column was
+recomputed. Reindexing without restrictions refreshes the whole record:
+
+    >>> api.reindex(copper)
+
+    >>> brain = get_brain(copper, SETUP_CATALOG)
+    >>> brain.Title, brain.getKeyword
+    ('Silver', 'Ag')
+
+Catalogs without any of the indexes passed-in are skipped, as well as the
+columns they do not have:
 
     >>> contact.setFirstname("Super")
-    >>> api.reindex(contact, idxs_cols=["getFullname", "getKeyword"])
+    >>> api.reindex(contact, idxs=["getFullname", "getKeyword"],
+    ...             cols=["getFullname", "getKeyword"])
     >>> get_brain(contact, CONTACT_CATALOG).getFullname
     'Super Mohale'
 
@@ -2634,7 +2654,7 @@ with the absolute path, so no duplicate record is left behind:
     >>> uc = api.get_tool(api.UID_CATALOG)
 
     >>> copper.setTitle("Bronze")
-    >>> api.reindex(copper, idxs_cols=["Title"])
+    >>> api.reindex(copper, idxs=["Title"], cols=["Title"])
     >>> len(uc(UID=api.get_uid(copper))) == 1
     True
 
@@ -2647,7 +2667,7 @@ with the absolute path, so no duplicate record is left behind:
 The same applies to Dexterity contents:
 
     >>> water.setTitle("Sea Water")
-    >>> api.reindex(water, idxs_cols=["Title"])
+    >>> api.reindex(water, idxs=["Title"], cols=["Title"])
     >>> len(uc(UID=api.get_uid(water))) == 1
     True
 

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -2554,6 +2554,110 @@ by its absolute path:
     True
 
 
+
+Reindexing an object
+....................
+
+This function reindexes an object in **all** the catalogs it is registered to.
+Objects from any content type are supported, no matter the catalogs they are
+mapped to:
+
+    >>> from senaite.core.catalog import CONTACT_CATALOG
+    >>> from senaite.core.catalog import SETUP_CATALOG
+
+    >>> water = api.create(portal.setup.sampletypes, "SampleType",
+    ...                    title="Pure Water", Prefix="PW")
+    >>> api.is_dexterity_content(water)
+    True
+
+    >>> api.get_catalogs_for(water)
+    [<SetupCatalog at /plone/senaite_catalog_setup>]
+
+    >>> contact = api.create(labcontacts, "LabContact", Firstname="Rita",
+    ...                      Surname="Mohale")
+    >>> api.is_at_content(contact)
+    True
+
+    >>> api.get_catalogs_for(contact)
+    [<ContactCatalog at /plone/senaite_catalog_contact>]
+
+A helper to look at the record a catalog keeps of an object:
+
+    >>> def get_brain(obj, catalog):
+    ...     brains = api.get_tool(catalog)(UID=api.get_uid(obj))
+    ...     return brains[0] if brains else None
+
+When no indexes are specified, the whole record is updated. Let's create an
+Archetypes content that is catalogued in the setup catalog and change both its
+title and its keyword:
+
+    >>> copper = api.create(services, "AnalysisService", title="Copper",
+    ...                     Keyword="Cu")
+    >>> copper.setTitle("Gold")
+    >>> copper.setKeyword("Au")
+    >>> api.reindex(copper)
+
+    >>> brain = get_brain(copper, SETUP_CATALOG)
+    >>> brain.Title, brain.getKeyword
+    ('Gold', 'Au')
+
+The update can also be restricted to some indexes and metadata columns, that is
+way cheaper for objects with expensive metadata:
+
+    >>> copper.setTitle("Silver")
+    >>> copper.setKeyword("Ag")
+    >>> api.reindex(copper, idxs_cols=["getKeyword"])
+
+The keyword index is up-to-date:
+
+    >>> len(api.get_tool(SETUP_CATALOG)(getKeyword="Ag"))
+    1
+
+And so is the keyword metadata column, while the title has not been touched:
+
+    >>> brain = get_brain(copper, SETUP_CATALOG)
+    >>> brain.Title, brain.getKeyword
+    ('Gold', 'Ag')
+
+Indexes and columns that the catalogs of the object do not have are skipped:
+
+    >>> contact.setFirstname("Super")
+    >>> api.reindex(contact, idxs_cols=["getFullname", "getKeyword"])
+    >>> get_brain(contact, CONTACT_CATALOG).getFullname
+    'Super Mohale'
+
+The `uid_catalog` is taken into account as well, but only when the names
+passed-in match its indexes or columns. Note it keeps the records of AT contents
+with a path relative to the portal root, while those of DX contents are kept
+with the absolute path, so no duplicate record is left behind:
+
+    >>> uc = api.get_tool(api.UID_CATALOG)
+
+    >>> copper.setTitle("Bronze")
+    >>> api.reindex(copper, idxs_cols=["Title"])
+    >>> len(uc(UID=api.get_uid(copper))) == 1
+    True
+
+    >>> get_brain(copper, api.UID_CATALOG).Title
+    'Bronze'
+
+    >>> "/".join(copper.getPhysicalPath()[2:]) in uc._catalog.uids
+    True
+
+The same applies to Dexterity contents:
+
+    >>> water.setTitle("Sea Water")
+    >>> api.reindex(water, idxs_cols=["Title"])
+    >>> len(uc(UID=api.get_uid(water))) == 1
+    True
+
+    >>> get_brain(water, api.UID_CATALOG).Title
+    'Sea Water'
+
+    >>> "/".join(water.getPhysicalPath()) in uc._catalog.uids
+    True
+
+
 Recursive (un)cataloging
 ........................
 

--- a/src/senaite/core/tests/doctests/WorksheetApplyTemplate.rst
+++ b/src/senaite/core/tests/doctests/WorksheetApplyTemplate.rst
@@ -874,3 +874,94 @@ Reject any remaining analyses awaiting for assignment:
     >>> query = {"portal_type": "Analysis", "review_state": "unassigned"}
     >>> objs = map(api.get_object, api.search(query, "senaite_catalog_analysis"))
     >>> success = map(lambda obj: doActionFor(obj, "reject"), objs)
+
+
+Worksheet metadata after applying a Worksheet Template
+......................................................
+
+The worksheet is reindexed once the whole template is applied, so the values the
+listings rely on are up-to-date. Create a template with two slots for routine
+analyses of `Cu`:
+
+    >>> from senaite.core.catalog import WORKSHEET_CATALOG
+
+    >>> layout = [
+    ...     {'pos': '1', 'type': 'a',
+    ...      'blank_ref': '', 'control_ref': '', 'dup': ''},
+    ...     {'pos': '2', 'type': 'a',
+    ...      'blank_ref': '', 'control_ref': '', 'dup': ''},
+    ... ]
+    >>> metadata_template = api.create(setup.worksheettemplates,
+    ...                               "WorksheetTemplate",
+    ...                               title="WS Template Metadata",
+    ...                               Layout=layout, Services=[Cu.UID()])
+
+Create two samples to fill the slots with and apply the template:
+
+    >>> samples = map(lambda i: create_analysisrequest(
+    ...     client, request, values, [Cu]), range(2))
+    >>> success = map(lambda s: doActionFor(s, "receive"), samples)
+
+    >>> worksheet = api.create(portal.worksheets, "Worksheet")
+    >>> worksheet.applyWorksheetTemplate(metadata_template)
+
+    >>> def get_brain(worksheet):
+    ...     query = dict(UID=api.get_uid(worksheet))
+    ...     return api.search(query, WORKSHEET_CATALOG)[0]
+
+The record of the worksheet knows about the template assigned, as well as about
+the analyses and samples it contains:
+
+    >>> brain = get_brain(worksheet)
+    >>> brain.getWorksheetTemplateTitle == metadata_template.Title()
+    True
+
+    >>> brain.getNumberOfRegularAnalyses
+    2
+
+    >>> brain.getNumberOfRegularSamples
+    2
+
+    >>> brain.getNumberOfQCAnalyses
+    0
+
+    >>> sorted(brain.getAnalysesUIDs) == sorted(worksheet.getRawAnalyses())
+    True
+
+The same applies when the analyses are added in bulk, without a template:
+
+    >>> sample = create_analysisrequest(client, request, values, [Cu, Fe])
+    >>> success = doActionFor(sample, "receive")
+
+    >>> worksheet = api.create(portal.worksheets, "Worksheet")
+    >>> worksheet.addAnalyses(sample.getAnalyses(full_objects=True))
+
+    >>> brain = get_brain(worksheet)
+    >>> brain.getNumberOfRegularAnalyses
+    2
+
+    >>> brain.getNumberOfRegularSamples
+    1
+
+    >>> sorted(brain.getAnalysesUIDs) == sorted(worksheet.getRawAnalyses())
+    True
+
+Adding duplicate or reference analyses in bulk reindexes the worksheet once they
+are added too, so the metadata of the record the listings rely on is up-to-date
+without reindexing on every single analysis created:
+
+    >>> dups = worksheet.addDuplicateAnalyses(1)
+    >>> brain = get_brain(worksheet)
+    >>> brain.getNumberOfQCAnalyses == worksheet.getNumberOfQCAnalyses() == len(dups) > 0
+    True
+
+    >>> sorted(brain.getAnalysesUIDs) == sorted(worksheet.getRawAnalyses())
+    True
+
+    >>> refs = worksheet.addReferenceAnalyses(control, [Cu.UID()])
+    >>> brain = get_brain(worksheet)
+    >>> brain.getNumberOfQCAnalyses == worksheet.getNumberOfQCAnalyses() == len(dups) + len(refs)
+    True
+
+    >>> sorted(brain.getAnalysesUIDs) == sorted(worksheet.getRawAnalyses())
+    True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Creating a worksheet from a worksheet template takes an unreasonable amount of time on big instances, specially with templates with a high number of slots. Four things are responsible for that.

**1. Every unassigned analysis of the system is woken up.** The search for candidates in `applyWorksheetTemplate` is unbounded, and the object is resolved before checking whether there is a slot left for its sample:

```python
analyses = api.search(query, ANALYSIS_CATALOG)   # all unassigned analyses
for analysis in analyses:
    analysis = api.get_object(analysis)          # <-- always woken up
    ...
    if len(available_slots) == 0:
        continue
```

With a backlog of a few thousand unassigned analyses matching the services of the template, thousands of objects are loaded from the database to fill a few dozen slots.

**2. The worksheet is fully reindexed once per analysis added.** Part of the metadata of a worksheet is resolved by walking through all the analyses assigned (`getNumberOfQCAnalyses`, `getNumberOfRegularAnalyses`, `getNumberOfRegularSamples`) and `getProgressPercentage` runs a catalog search. Reindexing on each `addAnalysis` makes the whole operation quadratic.

**3. The sample is fully reindexed twice per analysis added**, once by the `after_assign` event of the analysis and once explicitly by `addAnalysis`. A full reindex of a sample recomputes every index and metadata column, including the searchable text index and the columns resolved by walking through all its analyses, while `assigned_state` is the only value that actually changes.

**4. The QC analyses recompute the worksheet metadata one by one.** Both `add_reference_analysis` and `add_duplicate_analysis` end with `self.reindexObject(idxs=["getAnalysesUIDs"])`. That call restricts the **indexes**, but `update_metadata` defaults to 1 all the way down to `Products.ZCatalog`, so every metadata column of the worksheet is recomputed on every single control, blank and duplicate created. Same quadratic pattern as (2) on a different path, and templates with 64 positions reserve a good share of them for QC.

## Current behavior before PR

Measured on a test instance (tiny catalogs, everything in the ZODB cache, so the reindexing costs here are a fraction of what they are in production). The first scenario assigns 40 analyses, the second one 10:

| Backlog / routine slots | Sample reindexes | Worksheet reindexes | ZODB loads | Time  |
|-------------------------|------------------|---------------------|------------|-------|
| 60 samples / 20 slots   | 80 (full)        | 41                  | 1225       | 1.22s |
| 200 samples / 5 slots   | 20 (full)        | 11                  | 1499       | 0.42s |

For the QC analyses, the full recomputes of the worksheet metadata grow with the number of controls, blanks and duplicates created: 6 of them for a slot with 3 duplicates.

## Desired behavior after PR is merged

| Backlog / routine slots | Sample reindexes | Worksheet reindexes | ZODB loads | Time  |
|-------------------------|------------------|---------------------|------------|-------|
| 60 samples / 20 slots   | 41 (targeted)    | 1                   | 1176       | 0.84s |
| 200 samples / 5 slots   | 11 (targeted)    | 1                   | 914        | 0.32s |

- the sample of the analysis is resolved from the catalog metadata first, and the object is only woken up when it can actually be assigned. The number of objects loaded no longer grows with the size of the backlog, but with the number of analyses that are actually assigned
- the worksheet is reindexed once, when the template is applied. `addAnalysis` accepts a `reindex` parameter for that, and `addAnalyses` relies on it too, so adding a collection of analyses without a template benefits as well
- `addReferenceAnalyses`, `add_reference_analysis`, `addDuplicateAnalyses` and `add_duplicate_analysis` accept a `reindex` parameter as well. The plural ones reindex the worksheet once, when all the analyses are added, and the template application skips it, cause it reindexes the worksheet at the end anyway. The defaults preserve the current behavior, so the views that add blanks, controls and duplicates, as well as the retract event of a reference analysis (that calls `add_reference_analysis` directly), need no changes
- `after_assign` restricts the reindex of the sample (and of its ancestors) to `assigned_state`. The `idxs` parameter of `reindex_request` was silently ignored, it is honored now
- `getAnalyses` is no longer used to keep track of the analyses assigned, neither in `addAnalysis` nor when adding QC analyses, cause it wakes up all of them on every call. UIDs are enough
- the reference samples that suit each slot are resolved once per reference definition instead of once per slot, and the services of the template are no longer resolved to objects just to get their UIDs

This PR also adds a new function to the API, `api.reindex`, used by the changes above:

```python
api.reindex(obj)                                     # reindex everything
api.reindex(obj, idxs=["assigned_state"],            # this index and this
            cols=["assigned_state"])                 # column only
api.reindex(obj, idxs=["assigned_state"], cols=[])   # index only
```

Only the indexes named in `idxs` are reindexed (all of them when None), and catalogs without any of them are skipped. `cols` does the same for the metadata: all the columns are recomputed when None, only the named ones otherwise, and none at all when empty. Note this is not what `obj.reindexObject(idxs=[...])` does, that restricts the indexes but recomputes **all** the metadata columns. The `uid_catalog` is taken into account too, resolving its record with the path convention of the content type (relative to the portal root for AT contents, absolute for DX ones), so no duplicate record is left behind. The function is covered in `API.rst`.

The `WorksheetApplyTemplate` doctest asserts now the metadata of the worksheet record after applying a template, and after adding analyses, duplicates and reference analyses in bulk, which was not covered before.

Three notes for reviewers:

- **the modification date of a sample is no longer bumped** when one of its analyses is assigned to a worksheet, cause the sample object itself is not modified anymore. This also keeps the sample out of the write set of the transaction, reducing the chance of conflict errors
- the re-sort of the slots for new samples was a no-op that, because of a leaked loop variable (`samples_slots[sample_uid]` instead of the sorted `sample_id`), could assign the slot of one sample to a different one, ending up with two samples sharing a slot. It has been removed: slots keep the order in which the analyses are resolved, by priority
- duplicate analyses are created **inside** the worksheet, so Dexterity's `reindexOnModify` subscriber still reindexes it fully on every duplicate created. Traced with 3 duplicates, the full recomputes of the worksheet metadata go from 6 (one explicit and one implicit per duplicate) down to 4 (one implicit per duplicate plus the single explicit one at the end), so this path is improved, but not linear yet. Batching that event-driven reindex is out of the scope of this PR


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
