### PR TITLE
Fix empty sticker template selection when printing stickers from a listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #3007 Fix empty sticker template selection when printing stickers from a listing
 - #3003 Fix colliding reference analyses group IDs within the same transaction
 - #3000 Validate inter-field limits from the instance when there is no form
 - #2999 Pin plone.jsonapi.core to 0.8.0 and add find-links for its sdist

--- a/src/senaite/core/browser/stickers/view.py
+++ b/src/senaite/core/browser/stickers/view.py
@@ -22,6 +22,7 @@ import os
 import os.path
 import tempfile
 import traceback
+from collections import OrderedDict
 
 from bika.lims import api
 from bika.lims import logger
@@ -154,14 +155,45 @@ class StickerView(BrowserView):
         return uids
 
     def get_sticker_template_adapters(self):
-        """Query context adapters for IGetStickerTemplate
+        """Query the adapters for IGetStickerTemplates
+
+        Stickers printed from a listing are rendered on the container (e.g. the
+        Samples folder), that has no adapter registered, while the items to
+        print do have one. Therefore, fall back to the adapters of the items
+        when the context itself provides none.
+
+        :returns: list of (name, adapter) tuples
+        """
+        adapters = self.query_sticker_template_adapters(self.context)
+        if adapters:
+            return adapters
+        return self.get_items_sticker_template_adapters()
+
+    def query_sticker_template_adapters(self, obj):
+        """Query the IGetStickerTemplates adapters registered for an object
+
+        :param obj: the object to look the adapters up for
+        :returns: list of (name, adapter) tuples
         """
         try:
-            return getAdapters((self.context, ), IGetStickerTemplates)
+            return list(getAdapters((obj, ), IGetStickerTemplates))
         except ComponentLookupError:
             logger.debug("No IGetStickerTemplates adapters found for %s."
-                         % api.get_path(self.context))
+                         % api.get_path(obj))
             return []
+
+    def get_items_sticker_template_adapters(self):
+        """Return the IGetStickerTemplates adapters of the items to print
+
+        :returns: list of (name, adapter) tuples
+        """
+        adapters = []
+        for uid in self.get_uids():
+            obj = api.get_object_by_uid(uid, default=None)
+            if obj is None:
+                continue
+            adapters.extend(self.query_sticker_template_adapters(obj))
+        return adapters
 
     def get_available_templates(self):
         """Returns a list of available sticker templates
@@ -178,16 +210,15 @@ class StickerView(BrowserView):
         """
         templates = []
 
-        # `getAdapters` yields a generator, so materialize it to tell "no
-        # adapter registered" apart from "adapter returned no templates".
-        adapters = list(self.get_sticker_template_adapters())
+        adapters = self.get_sticker_template_adapters()
         has_adapter = len(adapters) > 0
         # Gather all templates offered by the registered adapters
         for name, adapter in adapters:
             templates += adapter(self.request)
 
         if templates:
-            return templates
+            # several items can share the same adapter and templates
+            return self.uniquify_templates(templates)
 
         # A context with no sticker adapter at all must not be offered the
         # whole catalog: return nothing unless an explicit type filter narrows
@@ -205,6 +236,24 @@ class StickerView(BrowserView):
             templates.append(out)
 
         return templates
+
+    def uniquify_templates(self, templates):
+        """Remove duplicate template records, preserving the order
+
+        A template that is selected takes precedence over the same template
+        coming from another adapter without the selected flag set.
+
+        :param templates: list of template info records
+        :returns: list of template info records without duplicates
+        """
+        unique = OrderedDict()
+        for template in templates:
+            template_id = template.get("id")
+            existing = unique.get(template_id)
+            if existing and existing.get("selected"):
+                continue
+            unique[template_id] = template
+        return list(unique.values())
 
     def getSelectedTemplateCSS(self):
         """Looks for the CSS file from the selected template and return its

--- a/src/senaite/core/tests/doctests/Stickers.rst
+++ b/src/senaite/core/tests/doctests/Stickers.rst
@@ -193,6 +193,38 @@ entire sticker catalog. Without a type filter, no templates are available:
     []
 
 
+Stickers printed from a listing
+...............................
+
+When stickers are printed from a listing, the view is rendered on the
+container, that has no sticker adapter, and the items to print come in the
+`items` parameter. The templates of the items are offered nevertheless:
+
+    >>> request["items"] = api.get_uid(sample)
+    >>> view = api.get_view("sticker", context=portal.samples, request=request)
+    >>> template_ids = [t["id"] for t in view.get_available_templates()]
+    >>> SAMPLE_TYPE_SMALL_STICKER in template_ids
+    True
+
+Items sharing the same templates are not listed twice:
+
+    >>> other = new_sample([Cu], client, contact, sampletype)
+    >>> request["items"] = ",".join([api.get_uid(sample), api.get_uid(other)])
+    >>> view = api.get_view("sticker", context=portal.samples, request=request)
+    >>> template_ids = [t["id"] for t in view.get_available_templates()]
+    >>> len(template_ids) == len(set(template_ids))
+    True
+
+Items without a sticker adapter do not add any template:
+
+    >>> request["items"] = api.get_uid(batch)
+    >>> view = api.get_view("sticker", context=portal.samples, request=request)
+    >>> view.get_available_templates()
+    []
+
+    >>> request["items"] = ""
+
+
 Type filters
 ............
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Regression introduced by #2974. Printing stickers from a listing renders the sticker view on the container (e.g. the Samples folder), while the items to print come in the `items` request parameter. The `IGetStickerTemplates` adapter is only registered `for="bika.lims.interfaces.IAnalysisRequest"`, so the container provides no adapter and the guard added in #2974 returns an empty list:

```python
if not has_adapter and not self.filter_by_type:
    return templates
```

`get_selected_template` has no such guard and still falls back to the setup default, so a sticker is rendered while the template selection list stays empty.

## Current behavior before PR

Selecting samples in a listing and printing their stickers (`/senaite/samples/sticker?items=<uids>`) shows an empty Template dropdown. A sticker is rendered below it, but no template can be picked, so admitted sticker templates configured on the sample type are unreachable through this path. The same applies to any container context without its own sticker adapter.

## Desired behavior after PR is merged

When the context provides no sticker adapter, the adapters of the items to print are used instead. The templates of the selected samples are offered again, while the intent of #2974 is preserved: a context whose items have no adapter either (e.g. a Batch) is still offered no templates, and the `filter_by_type` path is unchanged.

Since several items can now contribute templates, duplicates are removed, so ten selected samples of the same sample type no longer list the same template ten times.

Covered by three new cases in `Stickers.rst`: templates offered from the container context, no duplicates across items sharing a sample type, and items without an adapter yielding nothing. The doctest fails without the `view.py` change and passes with it.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html