### PR TITLE
Filter sidebar root folders by permission instead of by catalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #3004 Filter sidebar root folders by permission instead of by catalog
 - #3003 Fix colliding reference analyses group IDs within the same transaction
 - #3000 Validate inter-field limits from the instance when there is no form
 - #2999 Pin plone.jsonapi.core to 0.8.0 and add find-links for its sdist

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- #3004 Filter sidebar root folders by permission instead of by catalog
+- #3008 Filter sidebar root folders by permission instead of by catalog
 - #3003 Fix colliding reference analyses group IDs within the same transaction
 - #3000 Validate inter-field limits from the instance when there is no form
 - #2999 Pin plone.jsonapi.core to 0.8.0 and add find-links for its sdist

--- a/src/senaite/core/browser/viewlets/sidebar.py
+++ b/src/senaite/core/browser/viewlets/sidebar.py
@@ -26,6 +26,7 @@ from bika.lims.api.security import check_permission
 from senaite.core.permissions import ViewNavigation
 from plone.app.viewletmanager.manager import OrderedViewletManager
 from plone.memoize.instance import memoize
+from Products.CMFCore.permissions import View
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from senaite.core import logger
@@ -34,7 +35,6 @@ from senaite.core.i18n import translate
 from senaite.core.interfaces.catalog import ISenaiteCatalogObject
 from zope.component import getMultiAdapter
 
-PORTAL_CATALOG = "portal_catalog"
 UID_CATALOG = "uid_catalog"
 
 
@@ -128,10 +128,10 @@ class SidebarNavigationAPI(BrowserView):
         """
         return self.setup.getSidebarFolders()
 
-    def get_catalog_for(self, parent_brain):
-        """Return the appropriate catalog for the given parent brain
+    def get_catalog_for(self, brain_or_object):
+        """Return the appropriate catalog for the given parent
         """
-        portal_type = api.get_portal_type(parent_brain)
+        portal_type = api.get_portal_type(brain_or_object)
 
         # Check cache first
         if portal_type in self._catalog_cache:
@@ -218,8 +218,9 @@ class SidebarNavigationAPI(BrowserView):
                     selected_folders=None, show_more=False):
         """Build navigation tree
 
-        Top-level folders are queried from portal_catalog by ID.
-        Children are queried recursively from uid_catalog.
+        Top-level folders are looked up by ID in the navigation root and
+        filtered by the View permission. Children are queried recursively
+        from the catalogs.
 
         If no folders are selected, returns an empty tree.
 
@@ -239,34 +240,41 @@ class SidebarNavigationAPI(BrowserView):
         if not selected_folders:
             return {"children": root_children}
 
-        # Get selected folders directly from portal_catalog by ID
-        portal_catalog = api.get_tool(PORTAL_CATALOG)
-        root_path = api.get_path(navigation_root)
-
         for folder_id in selected_folders:
-            # Query for folder by ID at root level
-            query = {
-                "path": {"query": root_path, "depth": 1},
-                "id": folder_id
-            }
-            brains = portal_catalog(**query)
+            # Get the selected folder directly from the navigation root
+            folder = navigation_root.get(folder_id)
 
-            if not brains:
+            if folder is None:
                 continue
 
-            parent_brain = brains[0]
+            # Filter by permission instead of by `allowedRolesAndUsers`.
+            #
+            # The `Client` role is granted dynamically by the local role
+            # providers in `senaite.core.security.clientrole`, and their
+            # `getAllRoles` deliberately returns nothing so that linking a
+            # contact does not force a catalog reindex. A role granted that
+            # way never reaches the `allowedRolesAndUsers` index, so a
+            # catalog query hides root folders the user can actually reach:
+            # the folder is traversable and editable, but absent from the
+            # navigation bar.
+            #
+            # The selected folders are an explicit, bounded setup value, so
+            # waking them up to ask the same question traversal asks is
+            # cheap and cannot disagree with what the user gets on click.
+            if not check_permission(View, folder):
+                continue
 
-            # Build folder item from brain
-            folder_item = self._create_item_from_brain(parent_brain, depth=1)
+            # Build folder item from the object
+            folder_item = self._create_item(folder, depth=1)
 
-            # Skip invalid/stale brain items
+            # Skip invalid items
             if folder_item is None:
                 continue
 
-            # Query children using uid_catalog if depth allows
+            # Query children using the catalogs if depth allows
             if navigation_depth > 1:
                 children_data = self._get_children_recursive(
-                    parent_brain,
+                    folder,
                     max_depth=navigation_depth,
                     current_depth=1,
                     skip_types=skip_types,
@@ -281,25 +289,28 @@ class SidebarNavigationAPI(BrowserView):
 
         return {"children": root_children}
 
-    def _create_item_from_brain(self, brain, depth):
-        """Create navigation item dict from catalog brain
+    def _create_item(self, brain_or_object, depth):
+        """Create navigation item dict from a catalog brain or an object
 
-        :param brain: Catalog brain
+        Root folders are passed as objects (they are filtered by permission,
+        not by catalog query), children as catalog brains.
+
+        :param brain_or_object: Catalog brain or content object
         :param depth: Depth level of the item
-        :returns: Dict with item data or None if brain is invalid
+        :returns: Dict with item data or None if the item is invalid
         """
         try:
             item = {
-                "id": api.get_id(brain),
-                "Title": api.get_title(brain),
-                "Description": api.get_description(brain),
-                "getURL": api.get_url(brain),
-                "portal_type": api.get_portal_type(brain),
-                "path": api.get_path(brain),
+                "id": api.get_id(brain_or_object),
+                "Title": api.get_title(brain_or_object),
+                "Description": api.get_description(brain_or_object),
+                "getURL": api.get_url(brain_or_object),
+                "portal_type": api.get_portal_type(brain_or_object),
+                "path": api.get_path(brain_or_object),
                 "depth": depth,
-                "review_state": api.get_review_status(brain),
+                "review_state": api.get_review_status(brain_or_object),
                 "show_children": True,
-                "item": brain,
+                "item": brain_or_object,
                 "children": []
             }
 
@@ -312,19 +323,24 @@ class SidebarNavigationAPI(BrowserView):
             return item
 
         except Exception as e:
-            # Log and skip invalid brains (stale catalog entries)
-            logger.warning(
-                "Could not create item from brain: %s" % str(e))
+            # Log and skip invalid items (e.g. stale catalog entries)
+            logger.warning("Could not create item from %r: %s"
+                           % (brain_or_object, str(e)))
             return None
 
-    def _get_children_recursive(self, parent_brain, max_depth, current_depth,
+    def _get_children_recursive(self, parent, max_depth, current_depth,
                                 skip_types=None, show_more=False):
         """Recursively get children using catalog depth=1 query
 
         Uses a catalog query with depth=1 for optimal performance on large
-        databases. Does not wake up any objects.
+        databases. Does not wake up any of the children.
 
-        :param parent_brain: Parent catalog brain
+        Children stay catalog-filtered on purpose: they can be many, and
+        their `allowedRolesAndUsers` does carry the tokens client users are
+        queried with (`user:<id>` from local roles, `client:<uid>` from
+        `senaite.core.catalog.indexer.allowedrolesandusers`).
+
+        :param parent: Parent object or catalog brain
         :param max_depth: Maximum depth to query
         :param current_depth: Current depth level
         :param skip_types: Tuple of portal types to exclude
@@ -334,8 +350,8 @@ class SidebarNavigationAPI(BrowserView):
         if current_depth >= max_depth:
             return {"items": [], "has_more": False, "total_count": 0}
 
-        parent_path = api.get_path(parent_brain)
-        catalog = self.get_catalog_for(parent_brain)
+        parent_path = api.get_path(parent)
+        catalog = self.get_catalog_for(parent)
 
         # Query for immediate children only (depth=1)
         query = {
@@ -378,7 +394,7 @@ class SidebarNavigationAPI(BrowserView):
                 break
 
             # Create item from brain
-            item = self._create_item_from_brain(
+            item = self._create_item(
                 brain, depth=current_depth + 1)
 
             # Skip invalid items (stale catalog entries)

--- a/src/senaite/core/tests/doctests/SidebarNavigation.rst
+++ b/src/senaite/core/tests/doctests/SidebarNavigation.rst
@@ -329,7 +329,7 @@ Test creating navigation items from catalog brains using created client:
     >>> len(brains) > 0
     True
     >>> brain = brains[0]
-    >>> item = view._create_item_from_brain(brain, depth=1)
+    >>> item = view._create_item(brain, depth=1)
     >>> # Item should have required keys
     >>> "id" in item
     True
@@ -343,6 +343,17 @@ Test creating navigation items from catalog brains using created client:
     True
     >>> "children" in item
     True
+
+The same factory accepts a content object, which is how the root folders
+are built:
+
+    >>> item = view._create_item(client, depth=1)
+    >>> item["id"] == api.get_id(client)
+    True
+    >>> item["getURL"] == api.get_url(client)
+    True
+    >>> item["portal_type"]
+    'Client'
 
 
 Test navigation tree processing
@@ -426,6 +437,110 @@ Test the full JSON API response:
 
     >>> "count" in result
     True
+
+
+Root folders are filtered by permission, not by the catalog
+..........................................................
+
+Root folders are resolved from the navigation root and filtered with the
+`View` permission instead of with a `portal_catalog` query. The two do not
+always agree.
+
+The `Client` role is granted dynamically by the local role providers in
+`senaite.core.security.clientrole`, and those providers return nothing from
+`getAllRoles` on purpose, so that linking a contact to a user does not force
+a catalog reindex of the whole client tree. A role granted that way never
+reaches the `allowedRolesAndUsers` index, so a catalog-filtered sidebar hides
+root folders that the user can open by typing the URL.
+
+Imports and helpers for this section:
+
+    >>> from bika.lims.api.security import check_permission
+    >>> from plone import api as ploneapi
+    >>> from plone.app.testing import login
+    >>> from plone.app.testing import TEST_USER_NAME
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+
+Create a contact for our client and link it to a new user:
+
+    >>> contact = api.create(client, "Contact", "Contact-1")
+    >>> client_user = ploneapi.user.create(
+    ...     email="contact-1@example.com",
+    ...     username="client-user-1",
+    ...     password=TEST_USER_PASSWORD,
+    ...     properties=dict(fullname="Test Client User"))
+    >>> contact.setUser(client_user)
+    True
+
+The user does not hold the `Client` role globally:
+
+    >>> sorted(ploneapi.user.get_roles(user=client_user))
+    ['Authenticated', 'Member']
+
+It holds it in the context of the portal, granted by the site root role
+provider from the `linked_client_uid` member property:
+
+    >>> sorted(ploneapi.user.get_roles(user=client_user, obj=portal))
+    ['Authenticated', 'Client', 'Member']
+
+Grant a root folder to the `Client` role only. Note `allowedRolesAndUsers`
+is built from "Access contents information", while the navigation bar (and
+traversal) is governed by "View":
+
+    >>> batches.manage_permission(
+    ...     "Access contents information", ["Client", "Manager"], acquire=0)
+    >>> batches.manage_permission("View", ["Client", "Manager"], acquire=0)
+    >>> batches.reindexObjectSecurity()
+
+    >>> setup.setSidebarFolders(("batches", ))
+    >>> setup.setSidebarNavigationDepth(1)
+    >>> setup.setSidebarSkipTypes(())
+
+Now act as the client user:
+
+    >>> login(portal, "client-user-1")
+
+The folder is viewable:
+
+    >>> check_permission("View", batches)
+    True
+
+But the catalog does not return it, because none of the tokens the query
+carries for this user matches the `Client` role in the index:
+
+    >>> portal_catalog = api.get_tool("portal_catalog")
+    >>> query = {"path": {"query": api.get_path(portal), "depth": 1},
+    ...          "id": "batches"}
+    >>> len(portal_catalog(**query))
+    0
+
+The sidebar shows the folder nevertheless:
+
+    >>> view = api.get_view("sidebar-navigation-json", context=portal)
+    >>> [item["id"] for item in view.get_navigation_tree()]
+    ['batches']
+
+A folder the user cannot view is excluded. Revoke `View` again as the lab
+manager:
+
+    >>> login(portal, TEST_USER_NAME)
+    >>> batches.manage_permission("View", ["Manager"], acquire=0)
+    >>> batches.reindexObjectSecurity()
+
+    >>> login(portal, "client-user-1")
+    >>> check_permission("View", batches)
+    False
+
+    >>> view = api.get_view("sidebar-navigation-json", context=portal)
+    >>> view.get_navigation_tree()
+    []
+
+Restore the folder permissions:
+
+    >>> login(portal, TEST_USER_NAME)
+    >>> batches.manage_permission("Access contents information", (), acquire=1)
+    >>> batches.manage_permission("View", (), acquire=1)
+    >>> batches.reindexObjectSecurity()
 
 
 Cleanup


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

A lab-custom deployment grants the `senaite.patient` Patients root folder ("patients", type `PatientFolder`) to the `Client` role, so that client contacts can reach their own patients — patients are `IClientShareable`, so each client user only ever sees the ones shared with their client. The grant is applied through the folder's workflow: `View`, `Access contents information`, `Add portal content` and `senaite.patient: Add Patient` all list `Client`, and the role mappings are pushed onto the existing folder object.

The grant works everywhere except the navigation bar. A client user can open `<portal>/patients` by typing the URL, the listing renders, and the user can even create a patient there — but the "Patients" entry is missing from the sidebar, so in practice the feature is unreachable.

The folder is not stale in the catalog, and the permissions are not misconfigured. On the object:

    rolesForPermissionOn("View", patients)
    ['Client', 'LabClerk', 'LabManager', 'Manager', ...]
    rolesForPermissionOn("Access contents information", patients)
    ['Client', 'LabClerk', 'LabManager', 'Manager', ...]

and the index agrees:

    allowedRolesAndUsers on /<portal>/patients
    ['Client', 'LabClerk', 'LabManager', 'Manager']

The mismatch is on the querying side. A client contact never holds `Client` as a global role, so the tokens `CatalogTool._listAllowedRolesAndUsers` builds for them are:

    ['user:<contact-id>', 'Authenticated', 'user:AuthenticatedUsers',
     'user:Clients', 'Anonymous']

No intersection, so `portal_catalog` returns zero brains for a folder the same user can traverse, list and add to. `checkPermission` succeeds because it resolves roles in context; the catalog cannot, because `allowedRolesAndUsers` is computed from `rolesForPermissionOn` plus `acl_users._getAllLocalRoles(obj)`, and the dynamic providers feeding the latter report nothing (see below).

The sidebar is the only navigation surface that depends on this, because `SidebarNavigationAPI._build_tree` resolves its root folders with a `portal_catalog` query rather than with a permission check.

Then the two sections as before, with the mechanism spelled out:

## Current behavior before PR

`SidebarNavigationAPI._build_tree` issues one `portal_catalog` query per selected folder and drops the folder when the query returns nothing, so the sidebar's root level is filtered by `allowedRolesAndUsers`.

Since #2933 / #2938 the `Client` role is granted dynamically by the local role providers in `senaite.core.security.clientrole`, keyed off the `linked_client_uid` member property. `getAllRoles` returns an empty iterator there on purpose, so that linking or unlinking a contact does not force a catalog reindex of the whole client tree. A role granted that way is therefore structurally absent from `allowedRolesAndUsers`, and any permission expressed against the literal `Client` role is invisible to the catalog.

The replacement token, `client:<uid>`, does not close the gap for root folders: it is injected by `BaseCatalog._listAllowedRolesAndUsers`, and `portal_catalog` is the stock Plone `CatalogTool`, not a `BaseCatalog`. The token is also only attached to `IClient` / `IClientAwareMixin` content, and a root folder outside the client tree has no client UID to carry.

`GlobalClientRoleProvider` was added precisely so that site-root permission checks such as the sidebar's `View Navigation` pass for linked client users; `_build_tree` was left on the catalog.

## Desired behavior after PR is merged

Root folders are looked up by ID in the navigation root and filtered with `check_permission(View, folder)` — the same check traversal performs, so the navigation bar cannot disagree with what the user gets on click, in either direction. This also fixes the reverse mismatch, where a stale `allowedRolesAndUsers` advertises a link that then returns `Unauthorized`.

Children keep using the catalogs: they can be many, and their `allowedRolesAndUsers` does carry the tokens client users are queried with (`user:<id>` from local roles, `client:<uid>` from `senaite.core.catalog.indexer.allowedrolesandusers`).

The selected folders are an explicit, bounded setup value, so this replaces N catalog queries with N permission checks on top-level objects that are permanently resident in the ZODB cache.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
