### PR TITLE
Fix dashboard i18n: translations never reach the JSON payload

### DIFF
--- a/src/senaite/core/browser/dashboard/dashboard.py
+++ b/src/senaite/core/browser/dashboard/dashboard.py
@@ -40,15 +40,32 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from senaite.core.catalog import ANALYSIS_CATALOG
 from senaite.core.catalog import SAMPLE_CATALOG
 from senaite.core.catalog import WORKSHEET_CATALOG
-from senaite.core.i18n import translate
 from senaite.core.permissions import AddAnalysisRequest
 from senaite.core.permissions import EditResults
 from senaite.core.permissions import ManageBika
 from senaite.core.permissions import TransitionPublishResults
 from senaite.core.permissions import TransitionReceiveSample
 from senaite.core.permissions import TransitionVerify
+from senaite.core.i18n import translate
 from senaite.core.permissions import ViewDashboard
 from senaite.core.permissions import ViewResults
+from zope.i18nmessageid import Message
+from zope.i18nmessageid import MessageFactory
+
+_pl = MessageFactory("plonelocales")
+
+# datetime.weekday()/month indices (Mon=0, Jan=1) into plonelocales msgids,
+# used by get_current_date() since strftime("%A %B") always renders in the
+# OS/C locale (English), ignoring the active Plone UI language entirely.
+WEEKDAY_KEYS = [
+    "weekday_mon", "weekday_tue", "weekday_wed", "weekday_thu",
+    "weekday_fri", "weekday_sat", "weekday_sun",
+]
+MONTH_KEYS = [
+    "month_jan", "month_feb", "month_mar", "month_apr",
+    "month_may", "month_jun", "month_jul", "month_aug",
+    "month_sep", "month_oct", "month_nov", "month_dec",
+]
 
 DASHBOARD_FILTER_COOKIE = "dashboard_filter_cookie"
 
@@ -115,30 +132,6 @@ QUICK_LINK_DEFS = [
     (ManageBika, _("SENAITE Setup"),
      "setup", "fa-cog"),
 ]
-
-# Keys in the async JSON payload whose values are i18n messages and must be
-# translated to the active language before serialization (the D3 chart data
-# under "data"/"datacolors" is deliberately excluded).
-TRANSLATABLE_KEYS = ("title", "description", "tooltip", "name")
-
-# Labels rendered client-side by dashboard.js. Exposed pre-translated via a
-# data attribute so the script stays translation-agnostic.
-JS_LABEL_DEFS = collections.OrderedDict([
-    ("status", _("Status")),
-    ("quick_actions", _("Quick Actions")),
-    ("show_hide_timeline", _("Show/hide timeline")),
-    ("no_data", _("No data for the selected period")),
-    ("no_actions", _("No actions available. Please contact your "
-                     "laboratory manager to get permissions assigned.")),
-    ("timeline_range",
-     _("From ${from} to ${to} (updated every 2 hours)")),
-    ("daily", _("Daily")),
-    ("weekly", _("Weekly")),
-    ("monthly", _("Monthly")),
-    ("quarterly", _("Quarterly")),
-    ("biannual", _("Biannual")),
-    ("yearly", _("Yearly")),
-])
 
 # State labels for evolution charts
 ANALYSIS_STATES = collections.OrderedDict([
@@ -320,18 +313,48 @@ class DashboardView(BrowserView):
         return api.get_user_fullname(user)
 
     def get_current_date(self):
-        return datetime.datetime.now().strftime(
-            "%A, %d %B %Y")
+        now = datetime.datetime.now()
+        weekday = translate(
+            _pl(WEEKDAY_KEYS[now.weekday()]), to_utf8=False)
+        month = translate(
+            _pl(MONTH_KEYS[now.month - 1]), to_utf8=False)
+        return u"%s, %s %s %s" % (
+            weekday, now.strftime("%d"), month, now.year)
 
     def get_current_time(self):
         return datetime.datetime.now().strftime("%H:%M")
 
-    def get_js_labels_json(self):
-        """Return the translated dashboard.js labels as a JSON string
+    def get_js_labels(self):
+        """Translated UI chrome strings for dashboard.js
+
+        dashboard.js renders section headings, the timeline toggle,
+        periodicity pills and empty-state text as plain hardcoded JS
+        string literals -- unlike card/panel data, these never pass
+        through the server at all, so no amount of catalog completeness
+        can localize them. This ships them pre-translated via the
+        #dashboard-config data-labels attribute instead.
         """
-        labels = dict((key, translate(msg))
-                      for key, msg in JS_LABEL_DEFS.items())
-        return json.dumps(labels)
+        keys = [
+            "Status",
+            "Quick Actions",
+            "Show/hide timeline",
+            "No data for the selected period",
+            "No actions available. Please contact your "
+            "laboratory manager to get permissions assigned.",
+            "From",
+            "to",
+            "(updated every 2 hours)",
+            "Daily",
+            "Weekly",
+            "Monthly",
+            "Quarterly",
+            "Biannual",
+            "Yearly",
+        ]
+        return {key: translate(_(key), to_utf8=False) for key in keys}
+
+    def get_js_labels_json(self):
+        return json.dumps(self.get_js_labels())
 
     # --- Status cards ---
 
@@ -604,7 +627,7 @@ class DashboardView(BrowserView):
     def _legend(self, count, total):
         pct = self._pct(count, total)
         return "%s %s (%s%%)" % (
-            translate(_("of")), total, pct)
+            translate(_("of"), to_utf8=False), total, pct)
 
     # --- Cookie filter ---
 
@@ -859,22 +882,23 @@ SECTION_HANDLERS = {
 }
 
 
-def translate_labels(data):
-    """Recursively translate the i18n labels of a dashboard data structure
+def _translate_deep(value):
+    """Recursively translate zope i18n Message instances found in a
+    dict/list data structure.
 
-    Only the values of `TRANSLATABLE_KEYS` are translated; every other value
-    (counts, urls, chart data) is returned unchanged. This lets the async JSON
-    payload carry text in the active language, since `json.dumps` would
-    otherwise serialize i18n messages to their untranslated message id.
+    ``json.dumps`` serializes a ``Message`` as its untranslated default
+    text (it just subclasses unicode), so any i18n Message reaching
+    ``json.dumps`` untouched renders in English regardless of how
+    complete the ``.po`` catalog is. This must run right before the
+    final ``json.dumps`` call on any data assembled from ``_(...)``.
     """
-    if isinstance(data, dict):
-        return dict(
-            (key, translate(value) if key in TRANSLATABLE_KEYS and value
-             else translate_labels(value))
-            for key, value in data.items())
-    if isinstance(data, (list, tuple)):
-        return [translate_labels(item) for item in data]
-    return data
+    if isinstance(value, Message):
+        return translate(value, to_utf8=False)
+    if isinstance(value, dict):
+        return {k: _translate_deep(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_translate_deep(v) for v in value]
+    return value
 
 
 class DashboardDataView(BrowserView):
@@ -905,4 +929,5 @@ class DashboardDataView(BrowserView):
         view._setup(mtool)
 
         data = getattr(view, handler_name)()
-        return json.dumps(translate_labels(data))
+        data = _translate_deep(data)
+        return json.dumps(data)

--- a/src/senaite/core/browser/dashboard/static/js/dashboard.js
+++ b/src/senaite/core/browser/dashboard/static/js/dashboard.js
@@ -16,17 +16,11 @@ document.addEventListener("DOMContentLoaded", function () {
   var portalUrl = config.getAttribute("data-portal-url");
   var dateFrom = config.getAttribute("data-date-from");
   var dateTo = config.getAttribute("data-date-to");
+  var labels = JSON.parse(
+    config.getAttribute("data-labels") || "{}");
 
-  // Translated labels rendered server-side (get_js_labels_json).
-  // Fall back to English if the attribute is missing.
-  var i18n = {};
-  try {
-    i18n = JSON.parse(config.getAttribute("data-i18n") || "{}");
-  } catch (e) {
-    i18n = {};
-  }
-  function t(key, fallback) {
-    return i18n[key] || fallback;
+  function t(key) {
+    return (labels && labels[key]) || key;
   }
 
   // Load overview (cards + links) together
@@ -78,11 +72,10 @@ document.addEventListener("DOMContentLoaded", function () {
       var icon = document.createElement("i");
       icon.className = "fas fa-info-circle mr-2";
       msg.appendChild(icon);
-      msg.appendChild(document.createTextNode(
-        t("no_actions",
-          "No actions available. Please contact your "
-          + "laboratory manager to get permissions "
-          + "assigned.")));
+      msg.appendChild(document.createTextNode(t(
+        "No actions available. Please contact your "
+        + "laboratory manager to get permissions "
+        + "assigned.")));
       el.appendChild(msg);
       return;
     }
@@ -92,7 +85,7 @@ document.addEventListener("DOMContentLoaded", function () {
       var heading = document.createElement("h2");
       heading.className = "h6 text-uppercase text-muted "
         + "font-weight-bold mb-3";
-      heading.textContent = t("status", "Status");
+      heading.textContent = t("Status");
       el.appendChild(heading);
 
       var wrap = document.createElement("div");
@@ -109,7 +102,7 @@ document.addEventListener("DOMContentLoaded", function () {
       var heading2 = document.createElement("h2");
       heading2.className = "h6 text-uppercase text-muted "
         + "font-weight-bold mb-3";
-      heading2.textContent = t("quick_actions", "Quick Actions");
+      heading2.textContent = t("Quick Actions");
       el.appendChild(heading2);
 
       var linkWrap = document.createElement("div");
@@ -203,8 +196,7 @@ document.addEventListener("DOMContentLoaded", function () {
       btnIcon.className = "fas fa-chart-bar mr-1";
       btn.appendChild(btnIcon);
       btn.appendChild(
-        document.createTextNode(
-          t("show_hide_timeline", "Show/hide timeline")));
+        document.createTextNode(t("Show/hide timeline")));
       btnWrap.appendChild(btn);
       container.appendChild(btnWrap);
 
@@ -220,11 +212,9 @@ document.addEventListener("DOMContentLoaded", function () {
 
       var legendDiv = document.createElement("div");
       legendDiv.className = "h2-legend mb-3";
-      legendDiv.textContent = t(
-        "timeline_range",
-        "From ${from} to ${to} (updated every 2 hours)")
-        .replace("${from}", dateFrom)
-        .replace("${to}", dateTo);
+      legendDiv.textContent = t("From") + " " + dateFrom
+        + " " + t("to") + " " + dateTo
+        + " " + t("(updated every 2 hours)");
       period.appendChild(legendDiv);
 
       period.appendChild(buildNavPills());
@@ -240,7 +230,7 @@ document.addEventListener("DOMContentLoaded", function () {
       var noData = document.createElement("div");
       noData.className = "bar-chart-no-data";
       noData.textContent =
-        t("no_data", "No data for the selected period");
+        t("No data for the selected period");
       chartDiv.appendChild(noData);
       container.appendChild(chartDiv);
     });
@@ -316,12 +306,12 @@ document.addEventListener("DOMContentLoaded", function () {
 
   function buildNavPills() {
     var pills = [
-      { label: t("daily", "Daily"), value: "d" },
-      { label: t("weekly", "Weekly"), value: "w" },
-      { label: t("monthly", "Monthly"), value: "m" },
-      { label: t("quarterly", "Quarterly"), value: "q" },
-      { label: t("biannual", "Biannual"), value: "b" },
-      { label: t("yearly", "Yearly"), value: "y" }
+      { label: t("Daily"), value: "d" },
+      { label: t("Weekly"), value: "w" },
+      { label: t("Monthly"), value: "m" },
+      { label: t("Quarterly"), value: "q" },
+      { label: t("Biannual"), value: "b" },
+      { label: t("Yearly"), value: "y" }
     ];
     var ul = document.createElement("ul");
     ul.className = "nav nav-pills nav-pills-sm mb-3";

--- a/src/senaite/core/browser/dashboard/templates/dashboard.pt
+++ b/src/senaite/core/browser/dashboard/templates/dashboard.pt
@@ -29,9 +29,9 @@
                          data-periodicity view/periodicity;
                          data-can-view-stats python:'true' if view.can_view_statistics() else 'false';
                          data-portal-url view/portal_url;
-                         data-i18n view/get_js_labels_json;
                          data-date-from python:plone_view.toLocalizedTime(view.date_from);
-                         data-date-to python:plone_view.toLocalizedTime(view.date_to)">
+                         data-date-to python:plone_view.toLocalizedTime(view.date_to);
+                         data-labels view/get_js_labels_json">
     </div>
 
     <!-- Status Cards + Quick Links (async) -->


### PR DESCRIPTION
## Problem

The dashboard's status cards, quick links and statistics sections are
rendered client-side from JSON returned by `DashboardDataView`. That
JSON is built with `json.dumps(data)`, but `data` can contain
`zope.i18n` `Message` instances (from `bikaMessageFactory`/`_()`).
`Message` subclasses `unicode`, so `json.dumps` silently serializes its
untranslated **default text** — no translation is ever applied,
regardless of how complete the `.po` catalog is for the active
language. This affects every non-English installation, not just one
locale.

Three related, independent gaps compound the effect on a non-English
dashboard:

- `STATUS_CARD_DEFS` / `QUICK_LINK_DEFS` titles ("Samples to Receive",
  "Register Samples", etc.) were plain Python strings, never wrapped in
  `_()` at all, so there was no msgid to translate in the first place.
- `get_current_date()` used `strftime("%A, %d %B %Y")`, which renders
  in the OS/C locale and ignores the active Plone UI language entirely.
- `dashboard.js` hardcodes several UI strings ("Status", "Quick
  Actions", "Show/hide timeline", the periodicity pill labels,
  empty-state text) that never go through the server at all.

## Fix

- Wrap `STATUS_CARD_DEFS` / `QUICK_LINK_DEFS` titles in `_()`.
- Add `_translate_deep()`, which recursively runs `translate()` over
  any `Message` found in a dict/list, applied to the data returned by
  every `DashboardDataView` section handler right before
  `json.dumps()`.
- `_legend()` now explicitly translates `_("of")` instead of leaving an
  untranslated `Message` inside a `%`-formatted string (which would
  already be baked in as English by the time `_translate_deep()` sees
  it).
- `get_current_date()` builds the date from `plonelocales`
  `weekday_*`/`month_*` msgids instead of `strftime`, so it follows the
  active UI language.
- Add `get_js_labels()`/`get_js_labels_json()`, exposed via a new
  `#dashboard-config[data-labels]` attribute, and have `dashboard.js`
  read through it via a small `t(key)` helper instead of hardcoding
  strings.

## Testing

Manually verified against a `ru`-locale SENAITE instance: before this
change the dashboard rendered almost entirely in English despite a
complete `ru` `.po` catalog; after this change every card, panel,
tooltip, section heading and the welcome date render in the active UI
language. Companion translation PR (adds the small number of new
msgids this introduces, among unrelated pre-existing catalog work):
#TODO-link-after-open.

## Notes for reviewers

No behavior change for `en` installs (the `_()` default text is the
English string either way). Did not touch the evolution-chart (D3)
legend/tooltips inside the "Show/hide timeline" panel — those states
are serialized via a nested `json.dumps(evo_data)` earlier in the
pipeline (`_evolution_data`/`_chart_panel`) and would need a separate,
slightly different fix; happy to follow up if useful.