### PR TITLE
Complete ru/ru_RU translation catalogs for senaite.core and plone domains

### DIFF
--- a/src/senaite/core/locales/ru/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ru/LC_MESSAGES/plone.po
@@ -5,23 +5,23 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 12:29+0000\n"
+"POT-Creation-Date: 2026-06-19 06:37+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: PavelFadeev, 2022\n"
 "Language-Team: Russian (https://app.transifex.com/senaite/teams/87045/ru/)\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Domain: DOMAIN\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: DOMAIN\n"
-"Language: ru\n"
 
 #: senaite/core/browser/user/templates/account-panel.pt:16
 msgid "${action/title}"
-msgstr ""
+msgstr "${action/title}"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:167
 msgid "Activated add-ons"
@@ -73,8 +73,13 @@ msgid "Go to parent folder"
 msgstr "Перейти в родительскую папку"
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:222
-msgid "Go to the folder where you want the rule to apply, or at the site root, click on 'rule' tab, and then locally setup the rules."
-msgstr "Перейдите в папку, к которой вы хотите применить правило, или в корень участка, перейдите на вкладку \"правила\", а затем локально настройте правила."
+msgid ""
+"Go to the folder where you want the rule to apply, or at the site root, "
+"click on 'rule' tab, and then locally setup the rules."
+msgstr ""
+"Перейдите в папку, к которой вы хотите применить правило, или в корень "
+"участка, перейдите на вкладку \"правила\", а затем локально настройте "
+"правила."
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:32
 msgid "Go to the upgrade page"
@@ -98,7 +103,7 @@ msgstr "Выйти"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/recordswidget.pt:275
 msgid "More"
-msgstr ""
+msgstr "Ещё"
 
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:79
 msgid "Move down"
@@ -130,11 +135,19 @@ msgstr "Относительный URL-адрес для логотипа пан
 
 #: senaite/core/browser/sharing/templates/client_sharing.pt:67
 msgid "Search for user or group"
-msgstr ""
+msgstr "Поиск пользователя или группы"
 
 #: senaite/core/profiles/default/registry.xml
-msgid "Select which formats are available for users as alternative to the default format. Note that if new formats are installed, they will be enabled for text fields by default unless explicitly turned off here or by the relevant installer."
-msgstr "Выберите, какие форматы доступны пользователям в качестве альтернативы формату по умолчанию. Обратите внимание, что если установлены новые форматы, они будут включены для текстовых полей по умолчанию, если они явно не отключены здесь или соответствующей программой установки."
+msgid ""
+"Select which formats are available for users as alternative to the default "
+"format. Note that if new formats are installed, they will be enabled for "
+"text fields by default unless explicitly turned off here or by the relevant "
+"installer."
+msgstr ""
+"Выберите, какие форматы доступны пользователям в качестве альтернативы "
+"формату по умолчанию. Обратите внимание, что если установлены новые форматы,"
+" они будут включены для текстовых полей по умолчанию, если они явно не "
+"отключены здесь или соответствующей программой установки."
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:148
 msgid "Server:"
@@ -151,20 +164,37 @@ msgid "Site title"
 msgstr "Заголовок сайта"
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:218
-msgid "The rule is enabled but will perform nothing since it is not assigned anywhere."
-msgstr "Правило включено, но оно ничего не будет выполнять, не будучи нигде назначенным."
+msgid ""
+"The rule is enabled but will perform nothing since it is not assigned "
+"anywhere."
+msgstr ""
+"Правило включено, но оно ничего не будет выполнять, не будучи нигде "
+"назначенным."
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:32
-msgid "The site configuration is outdated and needs to be upgraded. Please ${link_continue_with_the_upgrade}."
-msgstr "Конфигурация сайта устарела и нуждается в обновлении. Перейдите по ссылке ${link_continue_with_the_upgrade}."
+msgid ""
+"The site configuration is outdated and needs to be upgraded. Please "
+"${link_continue_with_the_upgrade}."
+msgstr ""
+"Конфигурация сайта устарела и нуждается в обновлении. Перейдите по ссылке "
+"${link_continue_with_the_upgrade}."
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:87
-msgid "There is no upgrade procedure defined for this addon. Please consult the addon documentation for upgrade information, or contact the addon author."
-msgstr "Для этого дополнения не определена процедура обновления. Пожалуйста, обратитесь к документации дополнения для получения информации об обновлении или свяжитесь с автором дополнения."
+msgid ""
+"There is no upgrade procedure defined for this addon. Please consult the "
+"addon documentation for upgrade information, or contact the addon author."
+msgstr ""
+"Для этого дополнения не определена процедура обновления. Пожалуйста, "
+"обратитесь к документации дополнения для получения информации об обновлении "
+"или свяжитесь с автором дополнения."
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:124
-msgid "There is not any action performed by this rule. Click on Add button to setup an action."
-msgstr "Это правило не выполняет никаких действий. Нажмите кнопку Добавить, чтобы установить действие."
+msgid ""
+"There is not any action performed by this rule. Click on Add button to setup"
+" an action."
+msgstr ""
+"Это правило не выполняет никаких действий. Нажмите кнопку Добавить, чтобы "
+"установить действие."
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:39
 msgid "There is not any additional condition checked on this rule."
@@ -179,8 +209,12 @@ msgid "This addon has been upgraded."
 msgstr "Это дополнение было обновлено."
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:23
-msgid "This is the Add-on configuration section, you can activate and deactivate add-ons in the lists below."
-msgstr "Это раздел настройки дополнений, вы можете активировать и деактивировать дополнения в списках ниже."
+msgid ""
+"This is the Add-on configuration section, you can activate and deactivate "
+"add-ons in the lists below."
+msgstr ""
+"Это раздел настройки дополнений, вы можете активировать и деактивировать "
+"дополнения в списках ниже."
 
 #: senaite/core/profiles/default/registry.xml
 msgid "This must be a URL relative to the site root."
@@ -224,75 +258,87 @@ msgid "WSGI:"
 msgstr "WSGI:"
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:53
-msgid "Whether or not content rules should be disabled globally. If this is selected, no rules will be executed anywhere in the portal."
-msgstr "Отключать ли правила содержания глобально или нет. Если этот параметр выбран, никакие правила не будут выполняться нигде в пределах портала."
+msgid ""
+"Whether or not content rules should be disabled globally. If this is "
+"selected, no rules will be executed anywhere in the portal."
+msgstr ""
+"Отключать ли правила содержания глобально или нет. Если этот параметр "
+"выбран, никакие правила не будут выполняться нигде в пределах портала."
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:40
 msgid "You are up to date. High fives."
 msgstr "Вы в курсе всех событий. Дай пять."
 
 #. convert them to new-style portlets."
-#. Default: "There are legacy portlets defined here. Click the button to convert them to new-style portlets."
+#. Default: "There are legacy portlets defined here. Click the button to
+#. convert them to new-style portlets."
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:69
 msgid "action_convert_legacy_portlets"
 msgstr ""
+"Здесь определены устаревшие портлеты. Нажмите кнопку, чтобы преобразовать их"
+" в портлеты нового типа."
 
 #. Default: "Next ${number} items"
 #: senaite/core/browser/batching/templates/batchnavigation.pt:85
 msgid "batch_next_x_items"
-msgstr ""
+msgstr "Следующие ${number} элементов"
 
 #. Default: "Previous ${number} items"
 #: senaite/core/browser/batching/templates/batchnavigation.pt:19
 msgid "batch_previous_x_items"
-msgstr ""
+msgstr "Предыдущие ${number} элементов"
 
 #. Default: "Add action"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:183
 msgid "contentrules_add_action"
-msgstr ""
+msgstr "Добавить действие"
 
 #. Default: "Add condition"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:91
 msgid "contentrules_add_condition"
-msgstr ""
+msgstr "Добавить условие"
 
 #. Default: "Shortcuts:"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:228
 msgid "contentrules_assignments_shortcuts"
-msgstr ""
+msgstr "Быстрые ссылки:"
 
 #. Default: "The actions executed by this rule can trigger other rules"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:305
 msgid "contentrules_description_cascading"
-msgstr ""
+msgstr "Действия, выполняемые этим правилом, могут запускать другие правила"
 
 #. Default: "Enter a short description of the rule and its purpose."
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:278
 msgid "contentrules_description_description"
-msgstr ""
+msgstr "Введите краткое описание правила и его назначения."
 
 #. only be invoked if all the rule's conditions are met. You can add new
 #. actions and conditions using the buttons below."
-#. Default: "Rules execute when a triggering event occurs. Rule actions will only be invoked if all the rule's conditions are met. You can add new actions and conditions using the buttons below."
+#. Default: "Rules execute when a triggering event occurs. Rule actions will
+#. only be invoked if all the rule's conditions are met. You can add new
+#. actions and conditions using the buttons below."
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:23
 msgid "contentrules_description_execution"
 msgstr ""
+"Правила выполняются при возникновении события-триггера. Действия правила "
+"выполняются только при соблюдении всех его условий. Новые действия и условия"
+" можно добавить с помощью кнопок ниже."
 
 #. Default: "Stop evaluating content rules after this rule completes"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:296
 msgid "contentrules_description_stop"
-msgstr ""
+msgstr "Прекратить обработку правил контента после выполнения этого правила"
 
 #. Default: "The rule will execute when the following event occurs."
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:287
 msgid "contentrules_description_trigger"
-msgstr ""
+msgstr "Правило будет выполнено при возникновении следующего события."
 
 #. Default: "Perform the following actions:"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:117
 msgid "contentrules_perform_actions"
-msgstr ""
+msgstr "Выполнить следующие действия:"
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:32
 msgid "continue with the upgrade"
@@ -301,275 +347,368 @@ msgstr "продолжить обновление"
 #. Default: "There is no group or user attached to this group."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:171
 msgid "decription_no_members_assigned"
-msgstr ""
+msgstr "К этой группе не привязаны группы или пользователи."
 
 #. Rules will automatically perform actions on content when certain triggers
 #. take place. After defining rules, you may want to go to a folder to assign
 #. them, using the \"rules\" item in the actions menu."
-#. Default: "Use the form below to define, change or remove content rules. Rules will automatically perform actions on content when certain triggers take place. After defining rules, you may want to go to a folder to assign them, using the \"rules\" item in the actions menu."
+#. Default: "Use the form below to define, change or remove content rules.
+#. Rules will automatically perform actions on content when certain triggers
+#. take place. After defining rules, you may want to go to a folder to assign
+#. them, using the \"rules\" item in the actions menu."
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:24
 msgid "description-contentrules-controlpanel"
 msgstr ""
+"Используйте форму ниже, чтобы определить, изменить или удалить правила "
+"контента. Правила автоматически выполняют действия над содержимым при "
+"определённых событиях. После определения правил перейдите в папку, чтобы "
+"назначить их, используя пункт \\\"правила\\\" в меню действий."
 
 #. Default: "The languages in which the site should be translatable."
 #: senaite/core/profiles/default/registry.xml
 msgid "description_available_languages"
-msgstr ""
+msgstr "Языки, на которые должен переводиться сайт."
 
 #. Default: "Please set a descriptive title for the rule."
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:266
 msgid "description_contentrule_title"
-msgstr ""
+msgstr "Задайте информативное название для правила."
 
 #. Default: "This rule is assigned to the following locations:"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:242
 msgid "description_contentrules_rule_assignments"
-msgstr ""
+msgstr "Это правило назначено следующим расположениям:"
 
 #. Default: "Configuration area for Plone and add-on Products."
 #: senaite/core/browser/controlpanel/templates/overview.pt:19
 msgid "description_control_panel"
-msgstr ""
+msgstr "Область настройки Plone и дополнительных продуктов."
 
 #. Default: "Required for the language selector viewlet to be rendered."
 #: senaite/core/profiles/default/registry.xml
 msgid "description_cookie_manual_override"
-msgstr ""
+msgstr "Требуется для отображения виджета выбора языка."
 
 #. sites that are under development. This allows many configuration changes to
 #. be immediately visible, but will make your site run more slowly. To turn
 #. off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg,
 #. re-run bin/buildout and then restart the server process."
-#. Default: "You are running in \"debug mode\". This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg, re-run bin/buildout and then restart the server process."
+#. Default: "You are running in \"debug mode\". This mode is intended for
+#. sites that are under development. This allows many configuration changes to
+#. be immediately visible, but will make your site run more slowly. To turn
+#. off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg,
+#. re-run bin/buildout and then restart the server process."
 #: senaite/core/browser/controlpanel/templates/overview.pt:167
 msgid "description_debug_mode"
 msgstr ""
+"Вы работаете в режиме \\\"отладки\\\". Этот режим предназначен для сайтов в "
+"разработке. Он позволяет сразу видеть многие изменения конфигурации, но "
+"замедляет работу сайта. Чтобы отключить режим отладки, остановите сервер, "
+"установите 'debug-mode=off' в buildout.cfg, повторно запустите bin/buildout "
+"и перезапустите сервер."
 
 #. here. Note that this doesn't actually delete the group or user, it is only
 #. removed from this group."
-#. Default: "You can add or remove groups and users from this particular group here. Note that this doesn't actually delete the group or user, it is only removed from this group."
+#. Default: "You can add or remove groups and users from this particular group
+#. here. Note that this doesn't actually delete the group or user, it is only
+#. removed from this group."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:78
 msgid "description_group_members_of"
 msgstr ""
+"Здесь можно добавлять или удалять группы и пользователей в этой группе. "
+"Обратите внимание: это не удаляет саму группу или пользователя, а только "
+"исключает их из этой группы."
 
 #. business units. Groups are not directly related to permissions on a global
 #. level, you normally use Roles for that - and let certain Groups have a
 #. particular role."
-#. Default: "Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role."
+#. Default: "Groups are logical collections of users, such as departments and
+#. business units. Groups are not directly related to permissions on a global
+#. level, you normally use Roles for that - and let certain Groups have a
+#. particular role."
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:55
 msgid "description_groups_management"
 msgstr ""
+"Группы — это логические объединения пользователей, например подразделения "
+"или бизнес-единицы. Группы напрямую не связаны с правами на глобальном "
+"уровне — для этого обычно используются роли, которые назначаются "
+"определённым группам."
 
 #. membership in another group."
-#. Default: "The symbol ${image_link_icon} indicates a role inherited from membership in another group."
+#. Default: "The symbol ${image_link_icon} indicates a role inherited from
+#. membership in another group."
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:66
 msgid "description_groups_management2"
 msgstr ""
+"Символ ${image_link_icon} обозначает роль, унаследованную от участия в "
+"другой группе."
 
 #. assigned in this context. Use the buttons on each portlet to move them up
 #. or down, delete or edit them. To add a new portlet, use the drop-down list
 #. at the top of the column."
-#. Default: "The portlet columns will first display portlets explicitly assigned in this context. Use the buttons on each portlet to move them up or down, delete or edit them. To add a new portlet, use the drop-down list at the top of the column."
+#. Default: "The portlet columns will first display portlets explicitly
+#. assigned in this context. Use the buttons on each portlet to move them up
+#. or down, delete or edit them. To add a new portlet, use the drop-down list
+#. at the top of the column."
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:52
 msgid "description_manage_contextual_portlets"
 msgstr ""
+"Столбцы портлетов сначала отображают портлеты, явно назначенные в этом "
+"контексте. Используйте кнопки на каждом портлете, чтобы переместить его "
+"вверх/вниз, удалить или отредактировать. Чтобы добавить новый портлет, "
+"используйте выпадающий список вверху столбца."
 
 #. listing of groups, so you may not see the groups defined by those plugins
 #. unless doing a specific search."
-#. Default: "Note: Some or all of your PAS groups source plugins do not allow listing of groups, so you may not see the groups defined by those plugins unless doing a specific search."
+#. Default: "Note: Some or all of your PAS groups source plugins do not allow
+#. listing of groups, so you may not see the groups defined by those plugins
+#. unless doing a specific search."
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:72
 msgid "description_pas_group_listing"
 msgstr ""
+"Примечание: некоторые или все источники групп PAS не позволяют выводить "
+"список групп, поэтому группы из этих источников могут быть не видны без "
+"конкретного поискового запроса."
 
 #. Default: "Show all search results"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:332
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:250
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:189
 msgid "description_pas_show_all_search_results"
-msgstr ""
+msgstr "Показать все результаты поиска"
 
 #. of users, so you may not see the users defined by those plugins unless
 #. doing a specific search."
-#. Default: "Some or all of your PAS user source plugins do not allow listing of users, so you may not see the users defined by those plugins unless doing a specific search."
+#. Default: "Some or all of your PAS user source plugins do not allow listing
+#. of users, so you may not see the users defined by those plugins unless
+#. doing a specific search."
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:57
 msgid "description_pas_users_listing"
 msgstr ""
+"Некоторые или все источники пользователей PAS не позволяют выводить список "
+"пользователей, поэтому пользователи из этих источников могут быть не видны "
+"без конкретного поискового запроса."
 
 #. you can do so using the drop-down boxes. Portlets that are included by
 #. these categories are shown below the selection box."
-#. Default: "If you wish to block or unblock certain categories of portlets, you can do so using the drop-down boxes. Portlets that are included by these categories are shown below the selection box."
+#. Default: "If you wish to block or unblock certain categories of portlets,
+#. you can do so using the drop-down boxes. Portlets that are included by
+#. these categories are shown below the selection box."
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:59
 msgid "description_portlets_block_unblock"
 msgstr ""
+"Чтобы заблокировать или разблокировать определённые категории портлетов, "
+"используйте выпадающие списки. Портлеты, входящие в эти категории, показаны "
+"ниже блока выбора."
 
 #. mode of operation for a live Plone site, but means that some configuration
 #. changes will not take effect until your server is restarted or a product
 #. refreshed. If this is a development instance, and you want to enable debug
 #. mode, stop the server, set 'debug-mode=on' in your buildout.cfg, re-run
 #. bin/buildout and then restart the server process."
-#. Default: "You are running in \"production mode\". This is the preferred mode of operation for a live Plone site, but means that some configuration changes will not take effect until your server is restarted or a product refreshed. If this is a development instance, and you want to enable debug mode, stop the server, set 'debug-mode=on' in your buildout.cfg, re-run bin/buildout and then restart the server process."
+#. Default: "You are running in \"production mode\". This is the preferred
+#. mode of operation for a live Plone site, but means that some configuration
+#. changes will not take effect until your server is restarted or a product
+#. refreshed. If this is a development instance, and you want to enable debug
+#. mode, stop the server, set 'debug-mode=on' in your buildout.cfg, re-run
+#. bin/buildout and then restart the server process."
 #: senaite/core/browser/controlpanel/templates/overview.pt:155
 msgid "description_production_mode"
 msgstr ""
+"Вы работаете в режиме \\\"production\\\". Это предпочтительный режим для "
+"рабочего сайта Plone, однако некоторые изменения конфигурации вступят в силу"
+" только после перезапуска сервера или обновления продукта. Если это среда "
+"разработки и нужен режим отладки, остановите сервер, установите 'debug-"
+"mode=on' в buildout.cfg, повторно запустите bin/buildout и перезапустите "
+"сервер."
 
 #. Access should be granted only to the client group below. <br /> Client
 #. contacts which are linked to a user account will be automatically added to
 #. this group and have therefore the same roles granted immediately. <br />
 #. Other granted access to users or groups will only affect new created
 #. contents. </div>"
-#. Default: "Grant access for users or groups <div class=\"font-italic\"> Access should be granted only to the client group below. <br /> Client contacts which are linked to a user account will be automatically added to this group and have therefore the same roles granted immediately. <br /> Other granted access to users or groups will only affect new created contents. </div>"
+#. Default: "Grant access for users or groups <div class=\"font-italic\">
+#. Access should be granted only to the client group below. <br /> Client
+#. contacts which are linked to a user account will be automatically added to
+#. this group and have therefore the same roles granted immediately. <br />
+#. Other granted access to users or groups will only affect new created
+#. contents. </div>"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:43
 msgid "description_sharing_control"
 msgstr ""
+"Предоставить доступ пользователям или группам <div class=\\\"font-"
+"italic\\\"> Доступ следует предоставлять только группе клиента ниже. <br /> "
+"Контакты клиента, связанные с учётной записью пользователя, будут "
+"автоматически добавлены в эту группу и сразу получат те же роли. <br /> "
+"Прочий предоставленный доступ пользователям или группам повлияет только на "
+"вновь создаваемое содержимое. </div>"
 
 #. log in."
-#. Default: "Cookies are not enabled. You must enable cookies before you can log in."
+#. Default: "Cookies are not enabled. You must enable cookies before you can
+#. log in."
 #: senaite/core/browser/login/templates/login.pt:20
 msgid "enable_cookies_message_before_login"
-msgstr ""
+msgstr "Cookie не включены. Для входа в систему необходимо включить cookie."
 
 #. Default: "File already uploaded:"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_input.pt:19
 msgid "file_already_uploaded"
-msgstr ""
+msgstr "Файл уже загружен:"
 
 #. Default: "Get help"
 #: senaite/core/browser/login/templates/login.pt:105
 msgid "footer_login_link_get_help"
-msgstr ""
+msgstr "Получить помощь"
 
 #. Default: "Sign up here"
 #: senaite/core/browser/login/templates/login.pt:110
 msgid "footer_login_link_signup"
-msgstr ""
+msgstr "Зарегистрироваться здесь"
 
 #. Default: "Up to rule management"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:16
 msgid "go_to_contentrules_management"
-msgstr ""
+msgstr "К управлению правилами"
 
 #. Default: "Add ${itemtype}"
 #: senaite/core/skins/senaite_templates/edit_macros.pt:24
 msgid "heading_add_item"
-msgstr ""
+msgstr "Добавить ${itemtype}"
 
 #. Default: "Assign to groups"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:111
 msgid "heading_assign_to_groups"
-msgstr ""
+msgstr "Назначить в группы"
 
 #. Default: "Available languages"
 #: senaite/core/profiles/default/registry.xml
 msgid "heading_available_languages"
-msgstr ""
+msgstr "Доступные языки"
 
 #. Default: "Use cookie for manual override"
 #: senaite/core/profiles/default/registry.xml
 msgid "heading_cookie_manual_override"
-msgstr ""
+msgstr "Использовать cookie для ручного переопределения"
 
 #. Default: "Create a Group"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:22
 msgid "heading_create_group"
-msgstr ""
+msgstr "Создать группу"
 
 #. Default: "Manage access for ${folder}"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:37
 msgid "heading_currently_assigned_shares"
-msgstr ""
+msgstr "Управление доступом для ${folder}"
 
 #. Default: "Group: ${groupname}"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:58
 msgid "heading_edit_groupproperties"
-msgstr ""
+msgstr "Группа: ${groupname}"
 
 #. Default: "Edit ${itemtype}"
 #: senaite/core/skins/senaite_templates/edit_macros.pt:34
 msgid "heading_edit_item"
-msgstr ""
+msgstr "Редактировать ${itemtype}"
 
 #. Default: "Group Members"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:27
 msgid "heading_group_members"
-msgstr ""
+msgstr "Участники группы"
 
 #. Default: "Group: ${groupname}"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:55
 msgid "heading_group_members_of"
-msgstr ""
+msgstr "Группа: ${groupname}"
 
 #. Default: "Current group members"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:91
 msgid "heading_groupmembers_current"
-msgstr ""
+msgstr "Текущие участники группы"
 
 #. Default: "Current group memberships"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:70
 msgid "heading_memberships_current"
-msgstr ""
+msgstr "Текущие членства в группах"
 
 #. Default: "Portlets assigned here"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:40
 msgid "heading_portlets_assigned_here"
-msgstr ""
+msgstr "Портлеты, назначенные здесь"
 
 #. Default: "Search for groups"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:110
 msgid "heading_search_groups"
-msgstr ""
+msgstr "Поиск групп"
 
 #. Default: "Search for new group members"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:184
 msgid "heading_search_newmembers"
-msgstr ""
+msgstr "Поиск новых участников группы"
 
 #. Default: "Version Overview"
 #: senaite/core/browser/controlpanel/templates/overview.pt:135
 msgid "heading_version_overview"
-msgstr ""
+msgstr "Обзор версий"
 
 #. and type the document as you usually do."
-#. Default: "If you are unsure of which format to use, just select Plain Text and type the document as you usually do."
+#. Default: "If you are unsure of which format to use, just select Plain Text
+#. and type the document as you usually do."
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:52
 msgid "help_format_wysiwyg"
 msgstr ""
+"Если не уверены, какой формат использовать, выберите обычный текст и вводите"
+" документ как обычно."
 
 #. creation."
-#. Default: "A unique identifier for the group. Can not be changed after creation."
+#. Default: "A unique identifier for the group. Can not be changed after
+#. creation."
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:34
 msgid "help_groupname"
 msgstr ""
+"Уникальный идентификатор группы. Не может быть изменён после создания."
 
 #. inherited. If you disable this, only the explicitly defined sharing
 #. permissions will be valid. In the overview, the symbol
 #. ${image_confirm_icon} indicates an inherited value. Similarly, the symbol
 #. ${image_link_icon} indicates a global role, which is managed by the site
 #. administrator."
-#. Default: "By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol ${image_confirm_icon} indicates an inherited value. Similarly, the symbol ${image_link_icon} indicates a global role, which is managed by the site administrator."
+#. Default: "By default, permissions from the container of this item are
+#. inherited. If you disable this, only the explicitly defined sharing
+#. permissions will be valid. In the overview, the symbol
+#. ${image_confirm_icon} indicates an inherited value. Similarly, the symbol
+#. ${image_link_icon} indicates a global role, which is managed by the site
+#. administrator."
 #: senaite/core/browser/sharing/templates/client_sharing.pt:191
 msgid "help_inherit_local_roles"
 msgstr ""
+"По умолчанию права наследуются от контейнера этого элемента. Если отключить "
+"это, будут действовать только явно заданные права общего доступа. В обзоре "
+"символ ${image_confirm_icon} обозначает унаследованное значение, а символ "
+"${image_link_icon} — глобальную роль, управляемую администратором сайта."
 
 #. Default: "go here"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:28
 msgid "help_sharing_go_here"
-msgstr ""
+msgstr "перейдите сюда"
 
 #. container. To adjust them for the entire container, ${go_here}."
-#. Default: "You are adjusting the sharing privileges for a default view in a container. To adjust them for the entire container, ${go_here}."
+#. Default: "You are adjusting the sharing privileges for a default view in a
+#. container. To adjust them for the entire container, ${go_here}."
 #: senaite/core/browser/sharing/templates/client_sharing.pt:28
 msgid "help_sharing_page_default_page"
 msgstr ""
+"Вы настраиваете права общего доступа для стандартного просмотра контейнера. "
+"Чтобы настроить их для всего контейнера, ${go_here}."
 
 #. Default: "HTML"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:73
 msgid "html"
-msgstr ""
+msgstr "HTML"
 
 #. Default: "If all of the following conditions are met:"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:31
 msgid "if_all_conditions_met"
-msgstr ""
+msgstr "Если выполнены все следующие условия:"
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:148
 msgid "inactive"
@@ -578,281 +717,284 @@ msgstr "неактивен"
 #. Default: "Add"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:105
 msgid "label_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Add New Group"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:83
 msgid "label_add_new_group"
-msgstr ""
+msgstr "Добавить новую группу"
 
 #. Default: "Add New User"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:66
 msgid "label_add_new_user"
-msgstr ""
+msgstr "Добавить нового пользователя"
 
 #. Default: "Add portlet"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:10
 msgid "label_add_portlet"
-msgstr ""
+msgstr "Добавить портлет"
 
 #. Default: "Add portlet…"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:17
 msgid "label_add_portlet_ellipsis"
-msgstr ""
+msgstr "Добавить портлет…"
 
 #. Default: "Add user to selected groups"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:204
 msgid "label_add_user_to_group"
-msgstr ""
+msgstr "Добавить пользователя в выбранные группы"
 
 #. Default: "Add selected groups and users to this group"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:339
 msgid "label_add_users_to_group"
-msgstr ""
+msgstr "Добавить выбранные группы и пользователей в эту группу"
 
 #. Default: "Cancel"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:198
 #: senaite/core/skins/senaite_templates/edit_macros.pt:262
 msgid "label_cancel"
-msgstr ""
+msgstr "Отмена"
 
 #. Default: "Add content rule"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:189
 msgid "label_contentrule_add"
-msgstr ""
+msgstr "Добавить правило контента"
 
 #. Default: "Assignments"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:209
 msgid "label_contentrules_rule_assignments"
-msgstr ""
+msgstr "Назначения"
 
 #. Default: "enabled"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:114
 msgid "label_contentrules_rule_enabled"
-msgstr ""
+msgstr "включено"
 
 #. Default: "event"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:113
 msgid "label_contentrules_rule_event"
-msgstr ""
+msgstr "событие"
 
 #. Default: "content rule"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:112
 msgid "label_contentrules_rule_listing"
-msgstr ""
+msgstr "правило контента"
 
 #. Default: "Convert portlets"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:77
 msgid "label_convert_portlets"
-msgstr ""
+msgstr "Преобразовать портлеты"
 
 #. Default: "Delete"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:175
 msgid "label_delete"
-msgstr ""
+msgstr "Удалить"
 
 #. Default: "Description"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:272
 msgid "label_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Disable"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:170
 msgid "label_disable"
-msgstr ""
+msgstr "Отключить"
 
 #. Default: "Edit"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:52
 msgid "label_edit"
-msgstr ""
+msgstr "Редактировать"
 
 #. Default: "Enable"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:165
 msgid "label_enable"
-msgstr ""
+msgstr "Включить"
 
 #. Default: "Find a group here"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:37
 msgid "label_find_group"
-msgstr ""
+msgstr "Найдите группу здесь"
 
 #. Default: "Format"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:50
 msgid "label_format"
-msgstr ""
+msgstr "Формат"
 
 #. Default: "Group Members"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:69
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:67
 msgid "label_group_members"
-msgstr ""
+msgstr "Участники группы"
 
 #. Default: "Group Memberships"
 #: senaite/core/browser/user/templates/account-configlet.pt:41
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:62
 msgid "label_group_memberships"
-msgstr ""
+msgstr "Членства в группах"
 
 #. Default: "Group Properties"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:71
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:70
 msgid "label_group_properties"
-msgstr ""
+msgstr "Свойства группы"
 
 #. Default: "Group Search"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:106
 msgid "label_group_search"
-msgstr ""
+msgstr "Поиск группы"
 
 #. Default: "Groups"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:45
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:42
 msgid "label_groups"
-msgstr ""
+msgstr "Группы"
 
 #. Default: "Hide"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:103
 msgid "label_hide_item"
-msgstr ""
+msgstr "Скрыть"
 
 #. Default: "Inherit permissions from higher levels"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:180
 msgid "label_inherit_local_roles"
-msgstr ""
+msgstr "Наследовать права с более высоких уровней"
 
 #. If you wanted to manage the portlets of the container itself, ${go_here}."
-#. Default: "You are managing the portlets of the default view of a container. If you wanted to manage the portlets of the container itself, ${go_here}."
+#. Default: "You are managing the portlets of the default view of a container.
+#. If you wanted to manage the portlets of the container itself, ${go_here}."
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:45
 msgid "label_manage_portlets_default_view_container"
 msgstr ""
+"Вы управляете портлетами стандартного просмотра контейнера. Если хотите "
+"управлять портлетами самого контейнера, ${go_here}."
 
 #. Default: "go here"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:45
 msgid "label_manage_portlets_default_view_container_go_here"
-msgstr ""
+msgstr "перейдите сюда"
 
 #. Default: "Name"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:102
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:28
 msgid "label_name"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Next"
 #: senaite/core/skins/senaite_templates/edit_macros.pt:247
 msgid "label_next"
-msgstr ""
+msgstr "Далее"
 
 #. Default: "No group was specified."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:35
 msgid "label_no_group_specified"
-msgstr ""
+msgstr "Группа не указана."
 
 #. Default: "No preference panels available."
 #: senaite/core/browser/controlpanel/templates/overview.pt:123
 msgid "label_no_prefs_panels_available"
-msgstr ""
+msgstr "Доступные панели настроек отсутствуют."
 
 #. Default: "Previous"
 #: senaite/core/skins/senaite_templates/edit_macros.pt:239
 msgid "label_previous"
-msgstr ""
+msgstr "Назад"
 
 #. Default: "This can be risky, are you sure you want to do this?"
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:104
 msgid "label_product_upgrade_all_action"
-msgstr ""
+msgstr "Это может быть рискованно, вы уверены, что хотите продолжить?"
 
 #. Default: "New profile version is ${version}."
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:81
 msgid "label_product_upgrade_new_profile_version"
-msgstr ""
+msgstr "Новая версия профиля: ${version}."
 
 #. Default: "Old profile version was ${version}."
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:78
 msgid "label_product_upgrade_old_profile_version"
-msgstr ""
+msgstr "Старая версия профиля была: ${version}."
 
 #. Default: "Old version was ${version}."
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:74
 msgid "label_product_upgrade_old_version"
-msgstr ""
+msgstr "Старая версия была: ${version}."
 
 #. Default: "Quick search"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:200
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:120
 msgid "label_quick_search"
-msgstr ""
+msgstr "Быстрый поиск"
 
 #. Default: "Remove"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:55
 msgid "label_remove"
-msgstr ""
+msgstr "Удалить"
 
 #. Default: "Remove from selected groups"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:103
 msgid "label_remove_selected_groups"
-msgstr ""
+msgstr "Удалить из выбранных групп"
 
 #. Default: "Remove selected groups / users"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:175
 msgid "label_remove_selected_users"
-msgstr ""
+msgstr "Удалить выбранные группы/пользователей"
 
 #. Default: "(Required)"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:30
 msgid "label_required"
-msgstr ""
+msgstr "(Обязательно)"
 
 #. Default: "Event trigger: ${trigger}"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:285
 msgid "label_rule_event_trigger"
-msgstr ""
+msgstr "Событие-триггер: ${trigger}"
 
 #. Default: "Search"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:78
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:214
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:120
 msgid "label_search"
-msgstr ""
+msgstr "Поиск"
 
 #. Default: "Show all"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:219
 msgid "label_search_large"
-msgstr ""
+msgstr "Показать все"
 
 #. Default: "Show"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:91
 msgid "label_show_item"
-msgstr ""
+msgstr "Показать"
 
 #. Default: "Show all"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:127
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:106
 msgid "label_showall"
-msgstr ""
+msgstr "Показать все"
 
 #. Default: "Up to Groups Overview"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:49
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:18
 msgid "label_up_to_groups_overview"
-msgstr ""
+msgstr "К обзору групп"
 
 #. Default: "Up to Users Overview"
 #: senaite/core/browser/user/templates/account-configlet.pt:13
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:36
 msgid "label_up_to_usersoverview"
-msgstr ""
+msgstr "К обзору пользователей"
 
 #. Default: "User Search"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:85
 msgid "label_user_search"
-msgstr ""
+msgstr "Поиск пользователя"
 
 #. Default: "Users"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:43
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:39
 msgid "label_users"
-msgstr ""
+msgstr "Пользователи"
 
 #. Default: "Content rules"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:73
@@ -862,184 +1004,196 @@ msgstr "правила содержания легенд"
 #. Default: "E-mail Address"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:114
 msgid "listingheader_email_address"
-msgstr ""
+msgstr "Email адрес"
 
 #. Default: "Group Name"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:146
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:79
 msgid "listingheader_group_name"
-msgstr ""
+msgstr "Название группы"
 
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:78
 msgid "listingheader_group_remove"
-msgstr ""
+msgstr "Удалить"
 
 #. Default: "Group/User name"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:242
 msgid "listingheader_group_user_name"
-msgstr ""
+msgstr "Имя группы/пользователя"
 
 #. Default: "Remove"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:159
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:123
 msgid "listingheader_remove"
-msgstr ""
+msgstr "Удалить"
 
 #. Default: "Reset Password"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:122
 msgid "listingheader_reset_password"
-msgstr ""
+msgstr "Сбросить пароль"
 
 #. Default: "User name"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:113
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:120
 msgid "listingheader_user_name"
-msgstr ""
+msgstr "Имя пользователя"
 
 #. Default: "Need an account?"
 #: senaite/core/browser/login/templates/login.pt:109
 msgid "need_an_account"
-msgstr ""
+msgstr "Нет учётной записи?"
 
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
-msgstr ""
-
-#. Default: "No image"
-#: senaite/core/z3cform/widgets/namedimage/display.pt:17
-msgid "no_image"
-msgstr ""
+msgstr "Нет файла"
 
 #. Default: "Plain Text"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:82
 msgid "plain_text"
-msgstr ""
+msgstr "Обычный текст"
 
 #. Default: "Return"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:22
 msgid "return_to_view"
-msgstr ""
+msgstr "Вернуться"
 
 #. Default: "Structured Text"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:64
 msgid "structured_text"
-msgstr ""
+msgstr "Структурированный текст"
 
 #. Default: "Current sharing permissions"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:92
 msgid "summary_assigned_roles"
-msgstr ""
+msgstr "Текущие права общего доступа"
 
 #. Default: "Select roles for each group"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:139
 msgid "summary_roles_for_groups"
-msgstr ""
+msgstr "Выберите роли для каждой группы"
 
 #. various features including contact forms, email notification and password
 #. reset will not work. Go to the ${label_mail_control_panel_link} to fix
 #. this."
-#. Default: "You have not configured a mail host or a site 'From' address, various features including contact forms, email notification and password reset will not work. Go to the ${label_mail_control_panel_link} to fix this."
+#. Default: "You have not configured a mail host or a site 'From' address,
+#. various features including contact forms, email notification and password
+#. reset will not work. Go to the ${label_mail_control_panel_link} to fix
+#. this."
 #: senaite/core/browser/controlpanel/templates/overview.pt:53
 msgid "text_no_mailhost_configured"
 msgstr ""
+"Вы не настроили почтовый сервер или адрес отправителя сайта — контактные "
+"формы, email-уведомления и сброс пароля работать не будут. Перейдите в "
+"${label_mail_control_panel_link}, чтобы это исправить."
 
 #. Default: "Mail control panel"
 #: senaite/core/browser/controlpanel/templates/overview.pt:54
 msgid "text_no_mailhost_configured_control_panel_link"
-msgstr ""
+msgstr "Панель управления почтой"
 
 #. Default: "PIL is not installed properly, image scaling will not work."
 #: senaite/core/browser/controlpanel/templates/overview.pt:90
 msgid "text_no_pil_installed"
 msgstr ""
+"PIL не установлена корректно, масштабирование изображений работать не будет."
 
 #. Default: "Enter a group or user name to search for or click 'Show All'."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:308
 msgid "text_no_searchstring"
 msgstr ""
+"Введите имя группы или пользователя для поиска либо нажмите 'Показать все'."
 
 #. Default: "Enter a group or user name to search for."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:302
 msgid "text_no_searchstring_large"
-msgstr ""
+msgstr "Введите имя группы или пользователя для поиска."
 
 #. work properly for timezone aware date/time values. Go to the
 #. ${label_mail_event_settings_link} to fix this."
-#. Default: "You have not set the portal timezone. Date/Time handling will not work properly for timezone aware date/time values. Go to the ${label_mail_event_settings_link} to fix this."
+#. Default: "You have not set the portal timezone. Date/Time handling will not
+#. work properly for timezone aware date/time values. Go to the
+#. ${label_mail_event_settings_link} to fix this."
 #: senaite/core/browser/controlpanel/templates/overview.pt:74
 msgid "text_no_timezone_configured"
 msgstr ""
+"Вы не задали часовой пояс портала. Обработка даты/времени будет работать "
+"некорректно для значений с учётом часового пояса. Перейдите в "
+"${label_mail_event_settings_link}, чтобы это исправить."
 
 #. Default: "Date and Time Settings control panel"
 #: senaite/core/browser/controlpanel/templates/overview.pt:75
 msgid "text_no_timezone_configured_control_panel_link"
-msgstr ""
+msgstr "Панель управления настройками даты и времени"
 
 #. Default: "Enter a username to search for"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:195
 msgid "text_no_user_searchstring"
-msgstr ""
+msgstr "Введите имя пользователя для поиска"
 
 #. Default: "Enter a username to search for, or click 'Show All'"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:201
 msgid "text_no_user_searchstring_largesite"
-msgstr ""
+msgstr "Введите имя пользователя для поиска либо нажмите 'Показать все'"
 
 #. Default: "No matches"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:297
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:231
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:191
 msgid "text_nomatches"
-msgstr ""
+msgstr "Совпадений не найдено"
 
 #. Default: "This user does not belong to any group."
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:102
 msgid "text_user_not_in_any_group"
-msgstr ""
+msgstr "Этот пользователь не состоит ни в одной группе."
 
 #. Default: "Edit content rule"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:13
 msgid "title_edit_contentrule"
-msgstr ""
+msgstr "Редактировать правило контента"
 
 #. Default: "Legacy portlets"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:67
 msgid "title_legacy_portlets"
-msgstr ""
+msgstr "Устаревшие портлеты"
 
 #. Default: "Content Rules"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:21
 msgid "title_manage_contentrules"
-msgstr ""
+msgstr "Правила контента"
 
 #. Default: "Manage portlets for ${context_title}"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:14
 msgid "title_manage_contextual_portlets"
-msgstr ""
+msgstr "Управление портлетами для ${context_title}"
 
 #. Default: "Personal Information"
 #: senaite/core/browser/user/templates/account-configlet.pt:33
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:58
 msgid "title_personal_information_form"
-msgstr ""
+msgstr "Личная информация"
 
 #. Default: "Send a mail to this user"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:158
 msgid "title_send_mail_to_user"
-msgstr ""
+msgstr "Отправить письмо этому пользователю"
 
 #. Default: "Trouble logging in?"
 #: senaite/core/browser/login/templates/login.pt:104
 msgid "trouble_logging_in"
-msgstr ""
+msgstr "Проблемы со входом?"
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:153
 msgid "unassigned"
 msgstr "неназначенный"
 
 #. ${image_link_icon} indicates a role inherited from membership in a group."
-#. Default: "Note that roles set here apply directly to a user. The symbol ${image_link_icon} indicates a role inherited from membership in a group."
+#. Default: "Note that roles set here apply directly to a user. The symbol
+#. ${image_link_icon} indicates a role inherited from membership in a group."
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:52
 msgid "user_roles_note"
 msgstr ""
+"Обратите внимание: роли, заданные здесь, применяются непосредственно к "
+"пользователю. Символ ${image_link_icon} обозначает роль, унаследованную от "
+"участия в группе."

--- a/src/senaite/core/locales/ru/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ru/LC_MESSAGES/senaite.core.po
@@ -10,37 +10,96 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 12:29+0000\n"
+"POT-Creation-Date: 2026-06-19 06:37+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: Ramon Bartl <rb@ridingbytes.com>, 2026\n"
 "Language-Team: Russian (https://app.transifex.com/senaite/teams/87045/ru/)\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Domain: DOMAIN\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: DOMAIN\n"
-"Language: ru\n"
 
-#: bika/lims/content/bikasetup.py:1135
-msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
+#: bika/lims/content/bikasetup.py:1134
+msgid ""
+" <p>The ID Server provides unique sequential IDs for objects such as Samples"
+" and Worksheets etc, based on a format specified for each content "
+"type.</p><p>The format is constructed similarly to the Python format syntax,"
+" using predefined variables per content type, and advancing the IDs through "
+"a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' "
+"for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs "
+"are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} "
+"produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For "
+"dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} "
+"can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, "
+"etc.</p><p>Variables that can be used include:<table><tr><th "
+"style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client "
+"ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample"
+" ID</td><td>{sampleId}</td></tr><tr><td>Sample "
+"Type</td><td>{sampleType}</td></tr><tr><td>Sampling "
+"Date</td><td>{samplingDate}</td></tr><tr><td>Date "
+"Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration "
+"Settings:<ul><li>format:<ul><li>a python format string constructed from "
+"predefined variables like sampleId, clientId, sampleType.</li><li>special "
+"variable 'seq' must be positioned last in theformat "
+"string</li></ul></li><li>sequence type: [generated|counter]</li><li>context:"
+" if type counter, provides context the counting function</li><li>counter "
+"type: [backreference|contained]</li><li>counter reference: a parameter to "
+"the counting function</li><li>prefix: default prefix if none provided in "
+"format string</li><li>split length: the number of parts to be included in "
+"the prefix</li></ul></p>"
 msgstr ""
+"<p>Сервер идентификаторов предоставляет уникальные последовательные ID для "
+"объектов, таких как образцы и рабочие листы, на основе формата, заданного "
+"для каждого типа содержимого.</p><p>Формат строится аналогично синтаксису "
+"форматирования Python, с использованием предопределённых переменных для "
+"каждого типа содержимого и продвижением ID через номер последовательности "
+"'seq' с заданным количеством цифр, например '03d' для последовательности от "
+"001 до 999.</p><p>Буквенно-числовые префиксы для ID включаются в формат как "
+"есть, например WS для рабочего листа в WS-{seq:03d} даёт последовательные "
+"ID: WS-001, WS-002, WS-003 и т.д.</p><p>Для динамической генерации буквенно-"
+"числовых последовательных ID можно использовать шаблон {alpha}. Например "
+"WS-{alpha:2a3d} даёт WS-AA001, WS-AA002, WS-AB034 и т.д.</p><p>Доступные "
+"переменные:<table><tr><th style='width:150px'>Тип "
+"содержимого</th><th>Переменные</th></tr><tr><td>ID "
+"клиента</td><td>{clientId}</td></tr><tr><td>Год</td><td>{year}</td></tr><tr><td>ID"
+" образца</td><td>{sampleId}</td></tr><tr><td>Тип "
+"образца</td><td>{sampleType}</td></tr><tr><td>Дата "
+"отбора</td><td>{samplingDate}</td></tr><tr><td>Дата отбора "
+"образца</td><td>{dateSampled}</td></tr></table></p><p>Параметры "
+"конфигурации:<ul><li>format:<ul><li>строка формата Python, построенная из "
+"предопределённых переменных, таких как sampleId, clientId, "
+"sampleType.</li><li>специальная переменная 'seq' должна быть последней в "
+"строке формата</li></ul></li><li>тип последовательности: "
+"[generated|counter]</li><li>context: для типа counter — контекст функции "
+"подсчёта</li><li>тип счётчика: [backreference|contained]</li><li>ссылка "
+"счётчика: параметр функции подсчёта</li><li>prefix: префикс по умолчанию, "
+"если не указан в строке формата</li><li>split length: количество частей "
+"формата, включаемых в префикс хранения</li></ul></p>"
 
 #: bika/lims/browser/publish/templates/email.pt:143
 msgid "${amount} attachments with a total size of ${total_size}"
 msgstr "${amount} вложений общим размером ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
-#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
 msgstr "${back_link} "
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:32
-msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
-msgstr "${contact_fullname} может войти в LIMS, используя ${contact_username} как имя пользователя. Предприятии | Контакты должны изменить свои пароли. Если пароль забыт пользователь может запросить новый пароль из формы входа в систему"
+msgid ""
+"${contact_fullname} can log into the LIMS by using ${contact_username} as "
+"username. Contacts must change their own passwords. If a password is "
+"forgotten a contact can request a new password from the login form."
+msgstr ""
+"${contact_fullname} может войти в LIMS, используя ${contact_username} как "
+"имя пользователя. Предприятии | Контакты должны изменить свои пароли. Если "
+"пароль забыт пользователь может запросить новый пароль из формы входа в "
+"систему"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:105
 msgid "${items} were successfully created."
@@ -59,7 +118,6 @@ msgid "%s has no '%s' column."
 msgstr "%s не содержит колонку '%s'"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
-#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
 msgstr "&larr; Назад"
@@ -71,7 +129,7 @@ msgstr "&larr; Назад к ${back_link} "
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:30
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:35
 msgid "&larr; Go back"
-msgstr ""
+msgstr "Назад"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:46
 msgid "&larr; Go back to see all samples"
@@ -91,19 +149,19 @@ msgstr "'Мин' значение должно быть числом"
 
 #: bika/lims/validators.py:898
 msgid "'Warn Max' value must be above 'Max' value"
-msgstr ""
+msgstr "Значение 'Предупр. максимум' должно быть больше значения 'Максимум'"
 
 #: bika/lims/validators.py:895
 msgid "'Warn Max' value must be numeric or empty"
-msgstr ""
+msgstr "Значение 'Предупр. максимум' должно быть числом или пустым"
 
 #: bika/lims/validators.py:891
 msgid "'Warn Min' value must be below 'Min' value"
-msgstr ""
+msgstr "Значение 'Предупр. минимум' должно быть меньше значения 'Минимум'"
 
 #: bika/lims/validators.py:888
 msgid "'Warn Min' value must be numeric or empty"
-msgstr ""
+msgstr "Значение 'Предупр. минимум' должно быть числом или пустым"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:255
 msgid "(Blank)"
@@ -122,20 +180,20 @@ msgid "(Required)"
 msgstr "(Требуется)"
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:26
-msgid "*** This is an automatically generated email, please do not reply to this message. ***"
-msgstr "*** Это автоматически сгенерированное сообщение, пожалуйста, не отвечайте на него. ***"
+msgid ""
+"*** This is an automatically generated email, please do not reply to this "
+"message. ***"
+msgstr ""
+"*** Это автоматически сгенерированное сообщение, пожалуйста, не отвечайте на"
+" него. ***"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:91
 msgid "+-"
 msgstr "±"
 
-# senaite.app.listing: Column-filter row — boolean select placeholder
-msgid "-- Select --"
-msgstr ""
-
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
-msgstr ""
+msgstr "... Выберите инструмент ..."
 
 #: bika/lims/browser/fields/resultrangefield.py:40
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:126
@@ -143,20 +201,133 @@ msgid "< Min"
 msgstr "< Мин."
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:61
-msgid "<i class=\"fas fa-link\" aria-hidden=\"true\" /> Go to worksheet template setup"
-msgstr "<i class=\"fas fa-link\" aria-hidden=\"true\" />Перейти к настройке шаблона рабочего листа"
+msgid ""
+"<i class=\"fas fa-link\" aria-hidden=\"true\" /> Go to worksheet template "
+"setup"
+msgstr ""
+"<i class=\"fas fa-link\" aria-hidden=\"true\" />Перейти к настройке шаблона "
+"рабочего листа"
 
 #: bika/lims/browser/templates/senaite-frontpage.pt:15
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
 msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> Добро пожаловать в SENAITE"
 
-#: senaite/core/content/senaitesetup.py:1204
-msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
+#: senaite/core/content/senaitesetup.py:1181
+msgid ""
+"<p>The ID Server provides unique sequential IDs for objects such as Samples "
+"and Worksheets etc, based on a format specified for each content type. The "
+"format is constructed similarly to the Python format syntax, e.g. "
+"<code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>,"
+" <code>WS-003</code> etc.</p><p>The current persistent counter values are "
+"managed in the <a href='ng'>Number Generator view</a>.</p><details class"
+"='id-server-cheatsheet'><summary>Available variables</summary><table "
+"class='table table-sm'><thead><tr><th "
+"style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code>"
+" / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-"
+"padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric "
+"counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, "
+"...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year "
+"(e.g. "
+"<code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current "
+"date as "
+"<code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client"
+" ID (samples "
+"only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type "
+"prefix.</td></tr><tr><td><code>{samplingDate}</code> / "
+"<code>{dateSampled}</code></td><td>Sample dates (Python "
+"<code>strftime</code> specs "
+"apply).</td></tr><tr><td><code>{parent_ar_id}</code> / "
+"<code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: "
+"the parent sample "
+"ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent "
+"partition counter.</td></tr><tr><td><code>{retest_count}</code> / "
+"<code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters "
+"for retests, secondaries, and total "
+"tests.</td></tr></tbody></table></details><details class='id-server-"
+"cheatsheet'><summary>Configuration "
+"fields</summary><ul><li><strong>Format</strong>: the ID "
+"template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the"
+" persistent number counter; <code>counter</code> uses the count of related "
+"objects.</li><li><strong>Context</strong>: only used by <code>counter</code>"
+" type; the named context the counter applies to.</li><li><strong>Counter "
+"Type</strong>: <code>backreference</code> (deprecated) or "
+"<code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship "
+"name (backreference) or meta type "
+"(contained).</li><li><strong>Prefix</strong>: default prefix if none in the "
+"format.</li><li><strong>Split Length</strong>: how many segments of the "
+"format become the storage key prefix. Determines how the counter is "
+"partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-"
+"server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { "
+"cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet"
+" table { margin-top: 0.5em; }</style>"
 msgstr ""
+"<p>Сервер идентификаторов предоставляет уникальные последовательные ID для "
+"объектов, таких как образцы и рабочие листы, на основе формата, заданного "
+"для каждого типа содержимого. Формат строится аналогично синтаксису "
+"форматирования Python, например <code>WS-{seq:03d}</code> даёт "
+"<code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> и "
+"т.д.</p><p>Текущие постоянные значения счётчиков управляются в <a "
+"href='ng'>просмотре генератора номеров</a>.</p><details class='id-server-"
+"cheatsheet'><summary>Доступные переменные</summary><table class='table "
+"table-sm'><thead><tr><th "
+"style='width:30%'>Переменная</th><th>Описание</th></tr></thead><tbody><tr><td><code>{seq}</code>"
+" / <code>{seq:04d}</code></td><td>Числовой номер последовательности, при "
+"необходимости с ведущими "
+"нулями.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Буквенно-числовой"
+" счётчик, например <code>{alpha:2a3d}</code> даёт AA001, AA002, ..., AB001, "
+"...</td></tr><tr><td><code>{year}</code></td><td>Двузначный текущий год "
+"(например, "
+"<code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Текущая "
+"дата в формате "
+"<code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>ID "
+"клиента (только для "
+"образцов).</td></tr><tr><td><code>{sampleType}</code></td><td>Префикс типа "
+"образца.</td></tr><tr><td><code>{samplingDate}</code> / "
+"<code>{dateSampled}</code></td><td>Даты образца (применяются спецификаторы "
+"<code>strftime</code> Python).</td></tr><tr><td><code>{parent_ar_id}</code> "
+"/ <code>{parent_base_id}</code></td><td>Для партиций/повторных "
+"тестов/вторичных образцов: ID родительского "
+"образца.</td></tr><tr><td><code>{partition_count}</code></td><td>Счётчик "
+"партиций на родителя.</td></tr><tr><td><code>{retest_count}</code> / "
+"<code>{secondary_count}</code> / <code>{test_count}</code></td><td>Счётчики "
+"повторных тестов, вторичных образцов и общего числа "
+"тестов.</td></tr></tbody></table></details><details class='id-server-"
+"cheatsheet'><summary>Поля "
+"конфигурации</summary><ul><li><strong>Format</strong>: шаблон "
+"ID.</li><li><strong>Seq Type</strong>: <code>generated</code> использует "
+"постоянный счётчик номеров; <code>counter</code> использует количество "
+"связанных объектов.</li><li><strong>Context</strong>: используется только "
+"для типа <code>counter</code> — именованный контекст, к которому применяется"
+" счётчик.</li><li><strong>Counter Type</strong>: <code>backreference</code> "
+"(устарел) или <code>contained</code>.</li><li><strong>Counter Ref</strong>: "
+"имя связи (backreference) или мета-тип "
+"(contained).</li><li><strong>Prefix</strong>: префикс по умолчанию, если не "
+"указан в формате.</li><li><strong>Split Length</strong>: сколько сегментов "
+"формата становятся префиксом ключа хранения. Определяет разбиение счётчика "
+"(например, по годам, по типу образца).</li></ul></details><style>.id-server-"
+"cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: "
+"pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table {"
+" margin-top: 0.5em; }</style>"
 
 #: bika/lims/content/calculation.py:133
-msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
-msgstr "<p>Формула, которую вы вводите здесь, будет вычисляться динамически при отображении анализа, использующего данный расчет.</p><p>Для построения формулы используйте стандартные математические операции, + - * / ( ), ключевые слова Аналитических Услуг и промежуточные поля,  доступные как переменные. Оборачивайте их в прямоугольные скобки []</p><p>Например, для расчета показателя Общей Жесткости воды, суммарное содержание ионов кальция и магния в воде, можно записать как [Ca] + [Mg], где Са и Mg являются ключевыми словами для этих двух Аналитических Услуг.</p>"
+msgid ""
+"<p>The formula you type here will be dynamically calculated when an analysis"
+" using this calculation is displayed.</p><p>To enter a Calculation, use "
+"standard maths operators,  + - * / ( ), and all keywords available, both "
+"from other Analysis Services and the Interim Fields specified here, as "
+"variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation "
+"for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in "
+"water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those"
+" two Analysis Services.</p>"
+msgstr ""
+"<p>Формула, которую вы вводите здесь, будет вычисляться динамически при "
+"отображении анализа, использующего данный расчет.</p><p>Для построения "
+"формулы используйте стандартные математические операции, + - * / ( ), "
+"ключевые слова Аналитических Услуг и промежуточные поля,  доступные как "
+"переменные. Оборачивайте их в прямоугольные скобки []</p><p>Например, для "
+"расчета показателя Общей Жесткости воды, суммарное содержание ионов кальция "
+"и магния в воде, можно записать как [Ca] + [Mg], где Са и Mg являются "
+"ключевыми словами для этих двух Аналитических Услуг.</p>"
 
 #: bika/lims/browser/fields/resultrangefield.py:41
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:131
@@ -165,23 +336,27 @@ msgstr "> Макс."
 
 #: senaite/core/profiles/default/types/Multifile.xml
 msgid "A Document/File attachment"
-msgstr ""
+msgstr "Вложение документа/файла"
 
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "A published results report"
-msgstr ""
+msgstr "Опубликованный отчёт с результатами"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:66
-msgid "A short title for the site. This will be shown in the title of the browser window on each page."
-msgstr "Краткое наименование сайта. Сокращенное наименование ображается в заголовке окна браузера на каждой странице."
+msgid ""
+"A short title for the site. This will be shown in the title of the browser "
+"window on each page."
+msgstr ""
+"Краткое наименование сайта. Сокращенное наименование ображается в заголовке "
+"окна браузера на каждой странице."
 
 #: senaite/core/profiles/default/types/SimpleFile.xml
 msgid "A simple file attachment"
-msgstr ""
+msgstr "Простое файловое вложение"
 
 #: senaite/core/profiles/default/types/SimpleImage.xml
 msgid "A simple image attachment"
-msgstr ""
+msgstr "Простое вложение изображения"
 
 #: bika/lims/profiles/default/types/ARTemplate.xml
 msgid "AR Template"
@@ -208,7 +383,7 @@ msgid "Account Type"
 msgstr "Тип счета"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1296
+#: senaite/core/content/senaitesetup.py:1273
 msgid "Accounting"
 msgstr "Учет"
 
@@ -240,8 +415,7 @@ msgstr "Заголовок страницы аккредитации"
 msgid "Accredited"
 msgstr "Аккредитованные"
 
-#: bika/lims/browser/auditlog.py:92
-#: bika/lims/controlpanel/auditlog.py:95
+#: bika/lims/browser/auditlog.py:92 bika/lims/controlpanel/auditlog.py:95
 msgid "Action"
 msgstr "Действие"
 
@@ -253,21 +427,21 @@ msgstr "Активировать"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:71
+#: senaite/core/browser/controlpanel/labels/view.py:70
 msgid "Active"
 msgstr "Активные"
 
-#: senaite/core/content/resultsreport.py:52
+#: senaite/core/content/resultsreport.py:51
 msgid "Actor"
 msgstr "Исполнитель"
 
-#: senaite/core/content/resultsreport.py:57
+#: senaite/core/content/resultsreport.py:56
 msgid "Actor Fullname"
-msgstr ""
+msgstr "Полное имя исполнителя"
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:46
+#: senaite/core/browser/controlpanel/labels/view.py:45
 msgid "Add"
 msgstr "Добавить"
 
@@ -295,21 +469,19 @@ msgstr "Добавить повторный"
 msgid "Add Samples"
 msgstr "Добавить образцы"
 
-#: senaite/core/api/remarks.py:492
-msgid "Add a remark..."
-msgstr ""
-
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:460
 msgid "Add a remarks field to all analyses"
 msgstr "Добавить замечания ко всем анализам"
 
-#: senaite/core/content/senaitesetup.py:321
+#: senaite/core/content/senaitesetup.py:320
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
-msgstr "Добавить пользовательские CSS стили для логотипа, например height:15px; width:150px;"
-
-#: senaite/core/browser/controlpanel/labels/view.py:53
-msgid "Add default selectable labels"
 msgstr ""
+"Добавить пользовательские CSS стили для логотипа, например height:15px; "
+"width:150px;"
+
+#: senaite/core/browser/controlpanel/labels/view.py:52
+msgid "Add default selectable labels"
+msgstr "Добавить стандартные метки для выбора"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:205
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:38
@@ -317,14 +489,15 @@ msgid "Add new Attachment"
 msgstr "Добавить вложение"
 
 #: bika/lims/content/analysisrequest.py:1026
-msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
+msgid ""
+"Add one or more attachments to describe the sample in this sample, or to "
+"specify your request."
 msgstr ""
+"Добавьте одно или несколько вложений, чтобы описать этот образец или "
+"уточнить запрос."
 
-#: senaite/core/browser/samples/view.py:879
-msgid "Add or remove labels on the selected samples"
-msgstr ""
-
-#: senaite/core/api/remarks.py:477
+#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
+#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
 msgid "Add remarks"
 msgstr "Добавить замечания"
 
@@ -342,7 +515,7 @@ msgstr "Дополнительный адрес электронной почт�
 
 #: bika/lims/content/analysisservice.py:117
 msgid "Additional result values"
-msgstr ""
+msgstr "Дополнительные значения результата"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:137
 #: senaite/core/z3cform/widgets/address.py:119
@@ -351,7 +524,7 @@ msgstr "Адрес"
 
 #: senaite/core/behaviors/configure.zcml:60
 msgid "Adds the ability to add/remove labels"
-msgstr ""
+msgstr "Добавляет возможность добавлять/удалять метки"
 
 #: senaite/core/behaviors/configure.zcml:49
 msgid "Adds the ability to share a content across clients"
@@ -359,11 +532,11 @@ msgstr "Добавляет возможность делиться контен�
 
 #: bika/lims/content/sampletype.py:231
 msgid "Admitted sticker templates"
-msgstr ""
+msgstr "Разрешённые шаблоны стикеров"
 
 #: bika/lims/content/sampletype.py:204
 msgid "Admitted stickers for the sample type"
-msgstr ""
+msgstr "Разрешённые стикеры для типа образца"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:138
 msgid "Advanced"
@@ -388,25 +561,17 @@ msgstr "Все аккредитованные услуги на анализ н�
 msgid "All Analyses of Service"
 msgstr "Все анализы по услугам"
 
-#: senaite/core/browser/samples/view.py:723
+#: senaite/core/browser/samples/view.py:585
 msgid "All analyses assigned"
 msgstr "Все назначенные анализы "
-
-# senaite.app.listing: Column config — empty state when no columns are visible
-msgid "All columns are hidden."
-msgstr ""
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
 msgstr "Разрешить ручной ввод определения лимитов"
 
-#: bika/lims/content/abstractbaseanalysis.py:728
-msgid "Allow Manual Entry"
-msgstr ""
-
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
-msgstr ""
+msgstr "Разрешить пустое значение"
 
 #: bika/lims/content/abstractbaseanalysis.py:685
 msgid "Allow manual uncertainty value input"
@@ -418,19 +583,25 @@ msgstr "Разрешить пользователю верифицировать
 
 #: senaite/core/vocabularies/setup.py:177
 msgid "Allow same user to verify multiple times, but not consecutively"
-msgstr "Разрешить пользователю верифицировать результаты несколько раз, но не последовательно"
+msgstr ""
+"Разрешить пользователю верифицировать результаты несколько раз, но не "
+"последовательно"
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:492
 msgid "Allow self-verification of results"
 msgstr "Разрешить самопроверку результатов"
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:189
 msgid "Allow submission of results for unassigned analyses"
-msgstr ""
+msgstr "Разрешить отправку результатов для неназначенных анализов"
 
 #: bika/lims/content/abstractbaseanalysis.py:336
-msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
+msgid ""
+"Allow the analyst to manually replace the default Detection Limits (LDL and "
+"UDL) on results entry views"
 msgstr ""
+"Разрешить аналитику вручную заменять стандартные пределы обнаружения (LDL и "
+"UDL) при вводе результатов"
 
 #: bika/lims/content/abstractbaseanalysis.py:686
 msgid "Allow the analyst to manually replace the default uncertainty value."
@@ -438,46 +609,30 @@ msgstr "Разрешить аналитику изменять величину 
 
 #: bika/lims/content/abstractbaseanalysis.py:379
 msgid "Allow to introduce analysis results manually"
-msgstr ""
+msgstr "Разрешить вводить результаты анализов вручную"
 
 #: senaite/core/exportimport/instruments/importer.py:371
 msgid "Allowed analysis states: {allowed_states}, "
-msgstr ""
+msgstr "Допустимые статусы анализа: {allowed_states}, "
 
 #: senaite/core/exportimport/instruments/importer.py:368
 msgid "Allowed sample states: {allowed_states}, "
-msgstr ""
+msgstr "Допустимые статусы образца: {allowed_states}, "
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:60
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:60
 msgid "Analysed by"
 msgstr "Анализ выполнен"
 
-#: senaite/core/browser/dashboard/dashboard.py:506
-#: senaite/core/browser/samples/view.py:248
+#: senaite/core/browser/dashboard/dashboard.py:459
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
+#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
 msgstr "Анализы"
 
-#: senaite/core/browser/dashboard/dashboard.py:485
-msgid "Analyses assigned to a worksheet, awaiting results"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:498
-msgid "Analyses included in a published report"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:480
-msgid "Analyses not yet assigned to a worksheet"
-msgstr ""
-
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:494
-msgid "Analyses that have been verified"
-msgstr ""
+msgstr "Запрошенные анализы"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
@@ -486,8 +641,12 @@ msgid "Analysis"
 msgstr "Анализ"
 
 #: senaite/core/exportimport/instruments/importer.py:657
-msgid "Analysis '{keyword}' of sample '{sid}' has the result '{result}' set, which is kept due to the selected override option"
+msgid ""
+"Analysis '{keyword}' of sample '{sid}' has the result '{result}' set, which "
+"is kept due to the selected override option"
 msgstr ""
+"Для анализа '{keyword}' образца '{sid}' установлен результат '{result}', "
+"который сохранён благодаря выбранной опции перезаписи"
 
 #: bika/lims/content/abstractbaseanalysis.py:362
 msgid "Analysis Keyword"
@@ -500,16 +659,16 @@ msgstr "Анализы: Профили"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:22
 msgid "Analysis Report"
-msgstr ""
+msgstr "Отчёт по анализу"
 
 #: bika/lims/browser/publish/reports_listing.py:55
 #: bika/lims/profiles/default/types/Client.xml
 msgid "Analysis Reports"
-msgstr ""
+msgstr "Отчёты по анализам"
 
 #: bika/lims/browser/publish/emailview.py:310
 msgid "Analysis Results for {}"
-msgstr ""
+msgstr "Результаты анализов для {}"
 
 #: bika/lims/browser/fields/referenceresultsfield.py:34
 #: bika/lims/browser/fields/resultrangefield.py:33
@@ -517,8 +676,7 @@ msgstr ""
 msgid "Analysis Service"
 msgstr "Услуга по анализам"
 
-#: bika/lims/config.py:61
-#: bika/lims/controlpanel/bika_analysisservices.py:149
+#: bika/lims/config.py:61 bika/lims/controlpanel/bika_analysisservices.py:149
 #: bika/lims/profiles/default/types/AnalysisServices.xml
 msgid "Analysis Services"
 msgstr "Анализы: Услуги"
@@ -526,7 +684,7 @@ msgstr "Анализы: Услуги"
 #: bika/lims/controlpanel/bika_analysisspecs.py:76
 #: bika/lims/profiles/default/types/AnalysisSpec.xml
 msgid "Analysis Specification"
-msgstr ""
+msgstr "Спецификация анализа"
 
 #: bika/lims/controlpanel/bika_analysisspecs.py:64
 #: bika/lims/profiles/default/types/AnalysisSpecs.xml
@@ -540,27 +698,27 @@ msgstr "Тип анализа"
 
 #: bika/lims/content/analysisservice.py:266
 msgid "Analysis conditions"
-msgstr ""
+msgstr "Условия анализа"
 
 #: senaite/core/browser/modals/conditions.py:165
 msgid "Analysis conditions updated: {}"
 msgstr "Обновление условий анализа: {}"
 
-#: bika/lims/content/bikasetup.py:412
+#: bika/lims/content/bikasetup.py:411
 msgid "Analysis specifications which are edited directly on the Sample."
-msgstr ""
+msgstr "Спецификации анализа, редактируемые непосредственно в образце."
 
 #: senaite/core/content/interpretationtemplate.py:59
 msgid "Analysis templates"
-msgstr ""
+msgstr "Шаблоны анализов"
 
 #: senaite/core/profiles/default/types/AnalysisCategories.xml
 msgid "AnalysisCategories"
-msgstr ""
+msgstr "Категории анализов"
 
 #: senaite/core/profiles/default/types/AnalysisCategory.xml
 msgid "AnalysisCategory"
-msgstr ""
+msgstr "Категория анализа"
 
 #: senaite/core/profiles/default/types/AnalysisProfile.xml
 msgid "AnalysisProfile"
@@ -568,7 +726,7 @@ msgstr "Набор анализов"
 
 #: senaite/core/profiles/default/types/AnalysisProfiles.xml
 msgid "AnalysisProfiles"
-msgstr ""
+msgstr "Профили анализов"
 
 #: senaite/core/browser/modals/analysis/schema.py:87
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:35
@@ -577,53 +735,53 @@ msgstr "Аналитик"
 
 #: bika/lims/browser/worksheet/views/add_worksheet.py:42
 msgid "Analyst must be specified."
-msgstr ""
+msgstr "Необходимо указать аналитика."
 
 #: bika/lims/browser/fields/partitionsetupfield.py:57
 msgid "Any"
 msgstr "Любое"
 
-#: senaite/core/content/senaitesetup.py:1345
+#: senaite/core/content/senaitesetup.py:1322
 msgid "Appearance"
-msgstr ""
+msgstr "Внешний вид"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:217
 msgid "Apply"
-msgstr ""
+msgstr "Применить"
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
 msgstr "Применить шаблон"
 
-# senaite.app.listing: Saved filter presets — apply button tooltip
-msgid "Apply this filter"
-msgstr ""
-
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
-msgstr ""
+msgstr "Применить ко всем"
 
 #: bika/lims/content/instrument.py:308
 msgid "Asset Number"
-msgstr ""
+msgstr "Инвентарный номер"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Assign"
 msgstr "Назначить"
 
-#: senaite/core/browser/dashboard/dashboard.py:147
-#: senaite/core/browser/samples/view.py:443
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
 msgstr "Назначен"
 
-#: bika/lims/browser/analyses/view.py:1666
+#: bika/lims/browser/analyses/view.py:1665
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
+msgstr "Назначено на: ${worksheet_id}"
+
+#: senaite/core/browser/dashboard/dashboard.py:122
+msgid "Assignment pending"
+msgstr "Назначение ожидается"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
-msgstr ""
+msgstr "Для поля выбора требуется минимум два варианта"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:244
 msgid "Attach to Sample"
@@ -631,25 +789,24 @@ msgstr "Приложить к Образцу"
 
 #: senaite/core/exportimport/instruments/importer.py:815
 msgid "Attached file '{filename}' to worksheet {worksheet}"
-msgstr ""
+msgstr "К рабочему листу {worksheet} прикреплён файл '{filename}'"
 
-#: senaite/core/extender/label.py:62
+#: senaite/core/extender/label.py:58
 msgid "Attached labels"
-msgstr ""
+msgstr "Прикреплённые метки"
 
 #: senaite/core/exportimport/instruments/importer.py:854
 msgid "Attaching '{attachment}' to Analysis '{analysis}'"
-msgstr ""
+msgstr "Прикрепление '{attachment}' к анализу '{analysis}'"
 
 #: bika/lims/content/analysisrequest.py:1025
-#: bika/lims/content/attachment.py:52
-#: bika/lims/content/samplepoint.py:133
+#: bika/lims/content/attachment.py:52 bika/lims/content/samplepoint.py:133
 msgid "Attachment"
 msgstr "Вложение"
 
 #: senaite/core/exportimport/instruments/importer.py:860
 msgid "Attachment '{attachment}' was already linked to analysis {analysis}"
-msgstr ""
+msgstr "Вложение '{attachment}' уже связано с анализом {analysis}"
 
 #: bika/lims/content/attachment.py:91
 msgid "Attachment Keys"
@@ -681,7 +838,7 @@ msgstr "Требуется вложение"
 
 #: bika/lims/content/abstractbaseanalysis.py:348
 msgid "Attachment required for verification"
-msgstr ""
+msgstr "Для верификации требуется вложение"
 
 #: senaite/core/browser/attachment/attachment.py:349
 msgid "Attachment(s) deleted"
@@ -703,7 +860,7 @@ msgstr "Журнал аудита"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:215
 msgid "Authorized by"
-msgstr ""
+msgstr "Утверждено"
 
 #: senaite/core/exportimport/import.pt:56
 msgid "Auto Import"
@@ -711,55 +868,55 @@ msgstr "Автоматический Импорт"
 
 #: bika/lims/browser/instrument.py:759
 msgid "Auto Import Logs of %s"
-msgstr ""
+msgstr "Журналы автоимпорта для %s"
 
 #: senaite/core/behaviors/configure.zcml:13
 msgid "Auto-Generate ID Behavior for Dexterity Contents"
-msgstr ""
+msgstr "Поведение автогенерации ID для содержимого Dexterity"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Auto-Import Logs"
 msgstr "Журналы автоматического импорта"
 
-# senaite.app.listing: Saved filter presets — star action tooltip
-msgid "Auto-apply on open"
-msgstr ""
-
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
-msgstr ""
+msgstr "Автоматическое разделение при приёме"
 
-#: senaite/core/content/senaitesetup.py:1030
+#: senaite/core/content/senaitesetup.py:1007
 msgid "Auto-receive samples"
-msgstr ""
+msgstr "Автоматический приём образцов"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:166
 msgid "Autofill"
 msgstr "Автозаполнение"
 
-#: senaite/core/content/senaitesetup.py:1130
+#: senaite/core/content/senaitesetup.py:1107
 msgid "Automatic Sticker Printing"
-msgstr ""
+msgstr "Автоматическая печать стикеров"
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:161
 msgid "Automatic log-off"
 msgstr "Автоматический выход"
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:475
 msgid "Automatic verification of samples"
-msgstr ""
+msgstr "Автоматическая верификация образцов"
 
 #: bika/lims/content/artemplate.py:242
-msgid "Automatically redirect the user to the partitions creation view when Sample is received."
+msgid ""
+"Automatically redirect the user to the partitions creation view when Sample "
+"is received."
 msgstr ""
+"Автоматически перенаправлять пользователя на создание партиций при приёме "
+"образца."
 
 #: bika/lims/content/analysisservice.py:76
 msgid "Available instruments based on the selected methods."
-msgstr ""
+msgstr "Доступные инструменты на основе выбранных методов."
 
 #: bika/lims/content/analysisservice.py:61
 msgid "Available methods to perform the test"
-msgstr ""
+msgstr "Доступные методы выполнения теста"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print.pt:119
 msgid "Available templates"
@@ -767,7 +924,7 @@ msgstr "Доступные шаблоны"
 
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:46
 msgid "Back"
-msgstr ""
+msgstr "Назад"
 
 #: bika/lims/content/organisation.py:154
 msgid "Bank branch"
@@ -784,19 +941,19 @@ msgstr "Основная конфигурация"
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:44
 #: bika/lims/browser/templates/referencesample_analyses.pt:42
 msgid "Basis"
-msgstr ""
+msgstr "Основание"
 
 #: bika/lims/browser/publish/reports_listing.py:76
 #: bika/lims/profiles/default/types/Batch.xml
 #: bika/lims/vocabularies/__init__.py:128
 msgid "Batch"
-msgstr ""
+msgstr "Партия"
 
 #: bika/lims/profiles/default/types/Batch.xml
 msgid "Batch Book"
 msgstr "Книга пачек"
 
-#: senaite/core/browser/samples/view.py:186
+#: senaite/core/browser/samples/view.py:174
 msgid "Batch ID"
 msgstr "ID Партии"
 
@@ -815,20 +972,25 @@ msgid "Batches"
 msgstr "Партии"
 
 #: bika/lims/browser/viewlets/templates/dynamic_specs_viewlet.pt:19
-msgid "Be aware that the ranges provided in the spreadsheet file from the dynamic specification might override the ranges defined in the Specifications list below."
+msgid ""
+"Be aware that the ranges provided in the spreadsheet file from the dynamic "
+"specification might override the ranges defined in the Specifications list "
+"below."
 msgstr ""
+"Обратите внимание: диапазоны из файла динамической спецификации могут "
+"переопределить диапазоны, указанные в списке спецификаций ниже."
 
 #: bika/lims/browser/viewlets/templates/sample_dynamic_specs_viewlet.pt:19
-msgid "Be aware that the ranges provided in the spreadsheet file from the dynamic specification might override the ranges manually defined in the list below."
+msgid ""
+"Be aware that the ranges provided in the spreadsheet file from the dynamic "
+"specification might override the ranges manually defined in the list below."
 msgstr ""
+"Обратите внимание: диапазоны из файла динамической спецификации могут "
+"переопределить диапазоны, заданные вручную в списке ниже."
 
 #: bika/lims/browser/fields/coordinatefield.py:39
 msgid "Bearing"
 msgstr "Подшипник"
-
-#: senaite/core/browser/dashboard/dashboard.py:139
-msgid "Biannual"
-msgstr ""
 
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
@@ -840,7 +1002,7 @@ msgstr "Бланк"
 
 #: bika/lims/config.py:88
 msgid "Blank QC analyses"
-msgstr ""
+msgstr "Анализы контроля качества (холостые пробы)"
 
 #: bika/lims/controlpanel/bika_instruments.py:80
 msgid "Brand"
@@ -848,12 +1010,11 @@ msgstr "Производитель(ТМ)"
 
 #: bika/lims/browser/clientfolder.py:90
 msgid "Bulk Discount"
-msgstr ""
+msgstr "Оптовая скидка"
 
-#: bika/lims/content/client.py:77
-#: bika/lims/content/pricelist.py:59
+#: bika/lims/content/client.py:75 bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
-msgstr ""
+msgstr "Применяется оптовая скидка"
 
 #: bika/lims/content/abstractbaseanalysis.py:561
 msgid "Bulk price (excluding VAT)"
@@ -868,38 +1029,37 @@ msgstr "Рабочий телефон "
 msgid "Business address"
 msgstr "Рабочий адрес"
 
-#: bika/lims/content/abstractbaseanalysis.py:759
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "By 'Display Value' ascending"
-msgstr ""
-
-#: bika/lims/content/abstractbaseanalysis.py:760
-msgid "By 'Display Value' descending"
-msgstr ""
+msgstr "По 'Отображаемому значению' по возрастанию"
 
 #: bika/lims/content/abstractbaseanalysis.py:757
-msgid "By 'Result Value' ascending"
-msgstr ""
+msgid "By 'Display Value' descending"
+msgstr "По 'Отображаемому значению' по убыванию"
 
-#: bika/lims/content/abstractbaseanalysis.py:758
+#: bika/lims/content/abstractbaseanalysis.py:754
+msgid "By 'Result Value' ascending"
+msgstr "По 'Значению результата' по возрастанию"
+
+#: bika/lims/content/abstractbaseanalysis.py:755
 msgid "By 'Result Value' descending"
-msgstr ""
+msgstr "По 'Значению результата' по убыванию"
 
 #: bika/lims/content/analysisrequest.py:348
 msgid "CBID"
-msgstr ""
+msgstr "CBID"
 
-#: bika/lims/content/client.py:133
+#: bika/lims/content/client.py:129
 msgid "CC Contacts"
-msgstr ""
+msgstr "Контакты для копии (CC)"
 
-#: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:166
+#: bika/lims/content/analysisrequest.py:236 bika/lims/content/client.py:162
 msgid "CC Emails"
 msgstr "Копия Emails"
 
 #: bika/lims/content/abstractbaseanalysis.py:663
 msgid "Calculate Precision from Uncertainties"
-msgstr ""
+msgstr "Рассчитать точность на основе неопределённостей"
 
 #: senaite/core/profiles/default/types/Calculation.xml
 msgid "Calculation"
@@ -920,7 +1080,7 @@ msgstr "Расчет временных полей"
 
 #: bika/lims/content/analysisservice.py:106
 msgid "Calculation to be assigned to this content."
-msgstr ""
+msgstr "Формула расчёта, назначаемая этому содержимому."
 
 #: senaite/core/profiles/default/types/Calculations.xml
 msgid "Calculations"
@@ -938,7 +1098,7 @@ msgstr "Сертификаты калибровки"
 
 #: bika/lims/content/instrumentcalibration.py:69
 msgid "Calibration report date"
-msgstr ""
+msgstr "Дата отчёта о калибровке"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Calibrations"
@@ -947,55 +1107,64 @@ msgstr "Калибровка"
 #: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentcalibration.py:96
 msgid "Calibrator"
-msgstr ""
+msgstr "Калибровщик"
 
-#: bika/lims/browser/analyses/view.py:1614
+#: bika/lims/browser/analyses/view.py:1613
 msgid "Can verify, but submitted by current user"
-msgstr ""
+msgstr "Можно верифицировать, но отправлено текущим пользователем"
 
-#: bika/lims/browser/analyses/view.py:1638
+#: bika/lims/browser/analyses/view.py:1637
 msgid "Can verify, but was already verified by current user"
-msgstr ""
+msgstr "Можно верифицировать, но уже верифицировано текущим пользователем"
 
-#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
+#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
 msgstr "Отменить"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/dispose_samples.py:70
-#: senaite/core/browser/samples/view.py:403
+#: senaite/core/browser/samples/view.py:373
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Cancelled"
 msgstr "Отменено"
 
 #: bika/lims/content/calculation.py:460
-msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
-msgstr "Не удается активировать расчет, так как следующие зависимости услуг являются неактивными: ${inactive_services}"
+msgid ""
+"Cannot activate calculation, because the following service dependencies are "
+"inactive: ${inactive_services}"
+msgstr ""
+"Не удается активировать расчет, так как следующие зависимости услуг являются"
+" неактивными: ${inactive_services}"
 
 #: bika/lims/content/calculation.py:480
-msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
-msgstr "Не удается отключить вычисление, так как он используется следующими услугами: ${calc_services}"
+msgid ""
+"Cannot deactivate calculation, because it is in use by the following "
+"services: ${calc_services}"
+msgstr ""
+"Не удается отключить вычисление, так как он используется следующими "
+"услугами: ${calc_services}"
 
 #: senaite/core/browser/samples/invalidate_samples.py:93
 msgid "Cannot invalidate ${sample_id}: ${error}"
-msgstr ""
+msgstr "Невозможно аннулировать ${sample_id}: ${error}"
 
 #: senaite/core/browser/samples/invalidate_samples.py:262
 msgid "Cannot send email for ${sample_id}: ${error}"
-msgstr ""
+msgstr "Невозможно отправить письмо для ${sample_id}: ${error}"
 
-#: bika/lims/browser/analyses/view.py:1644
+#: bika/lims/browser/analyses/view.py:1643
 msgid "Cannot verify, last verified by current user"
 msgstr ""
+"Нельзя верифицировать: последняя верификация выполнена текущим пользователем"
 
-#: bika/lims/browser/analyses/view.py:1620
+#: bika/lims/browser/analyses/view.py:1619
 msgid "Cannot verify, submitted by current user"
-msgstr ""
+msgstr "Нельзя верифицировать: отправлено текущим пользователем"
 
-#: bika/lims/browser/analyses/view.py:1629
+#: bika/lims/browser/analyses/view.py:1628
 msgid "Cannot verify, was verified by current user"
-msgstr ""
+msgstr "Нельзя верифицировать: уже верифицировано текущим пользователем"
 
 #: senaite/core/content/samplecontainer.py:78
 msgid "Capacity"
@@ -1003,23 +1172,23 @@ msgstr "Емкость"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:112
 msgid "Captured"
-msgstr ""
+msgstr "Зафиксировано"
 
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:45
 #: bika/lims/browser/templates/referencesample_analyses.pt:43
 msgid "Cardinal"
-msgstr ""
+msgstr "Кардинальное"
 
 #: senaite/core/behaviors/configure.zcml:26
 msgid "Catalog Dexterity contents in multiple catalogs"
-msgstr ""
+msgstr "Индексировать содержимое Dexterity в нескольких каталогах"
 
 #: bika/lims/browser/templates/referencesample_view.pt:57
 #: bika/lims/content/referencesample.py:151
 msgid "Catalogue Number"
 msgstr "Номер по каталогу"
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:354
 msgid "Categorise analysis services"
 msgstr "Категоризация аналитических услуг"
 
@@ -1031,31 +1200,31 @@ msgstr "Категория"
 
 #: bika/lims/content/analysiscategory.py:118
 msgid "Category cannot be deactivated because it contains Analysis Services"
-msgstr "Категория нельзя отключить, поскольку она содержит службы Analysis Services"
+msgstr ""
+"Категория нельзя отключить, поскольку она содержит службы Analysis Services"
 
 #: bika/lims/browser/instrument.py:659
 msgid "Cert. Num"
-msgstr ""
+msgstr "№ сертификата"
 
 #: bika/lims/content/instrumentcertification.py:209
 msgid "Certificate Code"
-msgstr ""
+msgstr "Код сертификата"
 
-#: bika/lims/browser/auditlog.py:96
-#: bika/lims/controlpanel/auditlog.py:103
+#: bika/lims/browser/auditlog.py:96 bika/lims/controlpanel/auditlog.py:103
 msgid "Changes"
-msgstr ""
+msgstr "Изменения"
 
 #: senaite/core/browser/viewlets/resultsinterpretation.py:64
 msgid "Changes Saved"
 msgstr "Изменения Сохранены"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:125
+#: senaite/core/browser/viewlets/sampleheader.py:114
 msgid "Changes saved."
 msgstr "Изменения сохранены."
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
 msgid "Changes will be propagated to partitions"
 msgstr "Изменения будут применены к субпробам"
 
@@ -1064,61 +1233,129 @@ msgid "Check if the method has been accredited"
 msgstr "Метод аккредитован"
 
 #: bika/lims/content/abstractbaseanalysis.py:495
-msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
-msgstr "Пометить этот квадрат, если анализ включен в список аккредитованных анализов лаборатории "
+msgid ""
+"Check this box if the analysis service is included in the laboratory's "
+"schedule of accredited analyses"
+msgstr ""
+"Пометить этот квадрат, если анализ включен в список аккредитованных анализов"
+" лаборатории "
 
 #: bika/lims/content/samplepoint.py:122
-msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
-msgstr "Установите этот флажок, если проб, взятых в данный момент «композиционных» и положить вместе с более чем одной суб выборки, например несколько поверхности образцов от плотины смешиваться быть репрезентативной для плотины. По умолчанию флажок не установлен, указывает захватить образцов"
+msgid ""
+"Check this box if the samples taken at this point are 'composite' and put "
+"together from more than one sub sample, e.g. several surface samples from a "
+"dam mixed together to be a representative sample for the dam. The default, "
+"unchecked, indicates 'grab' samples"
+msgstr ""
+"Установите этот флажок, если проб, взятых в данный момент «композиционных» и"
+" положить вместе с более чем одной суб выборки, например несколько "
+"поверхности образцов от плотины смешиваться быть репрезентативной для "
+"плотины. По умолчанию флажок не установлен, указывает захватить образцов"
 
 #: senaite/core/content/samplecontainer.py:86
-msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
-msgstr "Установите этот флажок, если этот контейнер уже сохранен. Установка этого флажка сократит рабочий процесс сохранения для разделов образцов, хранящихся в этом контейнере."
+msgid ""
+"Check this box if this container is already preserved.Setting this will "
+"short-circuit the preservation workflow for sample partitions stored in this"
+" container."
+msgstr ""
+"Установите этот флажок, если этот контейнер уже сохранен. Установка этого "
+"флажка сократит рабочий процесс сохранения для разделов образцов, хранящихся"
+" в этом контейнере."
 
 #: bika/lims/content/laboratory.py:112
 msgid "Check this box if your laboratory is accredited"
 msgstr "Этот флажок, если ваша лаборатория аккредитована"
 
 #: bika/lims/content/analysisservice.py:130
-msgid "Check this box to ensure a separate sample container is used for this analysis service"
+msgid ""
+"Check this box to ensure a separate sample container is used for this "
+"analysis service"
 msgstr ""
+"Отметьте, чтобы для этого анализа использовался отдельный контейнер образца"
 
 #: bika/lims/content/analysisservice.py:260
 msgid "Checkbox"
-msgstr ""
+msgstr "Флажок"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:55
 #: bika/lims/content/analysisservice.py:223
 msgid "Choices"
-msgstr ""
+msgstr "Варианты"
 
-#: senaite/core/content/senaitesetup.py:1174
-msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
+#: senaite/core/content/senaitesetup.py:1151
+msgid ""
+"Choose the default template for 'large' stickers. Note: Sample-specific "
+"'large' stickers are configured based on their sample type."
 msgstr ""
+"Выберите шаблон по умолчанию для 'больших' стикеров. Примечание: стикеры для"
+" конкретных образцов настраиваются по типу образца."
 
-#: bika/lims/content/bikasetup.py:1038
-msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
+#: bika/lims/content/bikasetup.py:1037
+msgid ""
+"Choose the default template for 'large' stickers.<br/><strong>Note:</strong>"
+" Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
+"Выберите шаблон по умолчанию для 'больших' "
+"стикеров.<br/><strong>Примечание:</strong> стикеры для конкретных образцов "
+"настраиваются по типу образца."
 
-#: senaite/core/content/senaitesetup.py:1162
-msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
+#: senaite/core/content/senaitesetup.py:1139
+msgid ""
+"Choose the default template for 'small' stickers. Note: Sample-specific "
+"'small' stickers are configured based on their sample type."
 msgstr ""
+"Выберите шаблон по умолчанию для 'малых' стикеров. Примечание: стикеры для "
+"конкретных образцов настраиваются по типу образца."
 
-#: bika/lims/content/bikasetup.py:1019
-msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
+#: bika/lims/content/bikasetup.py:1018
+msgid ""
+"Choose the default template for 'small' stickers.<br/><strong>Note:</strong>"
+" Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
+"Выберите шаблон по умолчанию для 'малых' "
+"стикеров.<br/><strong>Примечание:</strong> стикеры для конкретных образцов "
+"настраиваются по типу образца."
 
-#: bika/lims/content/bikasetup.py:530
-msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
+#: bika/lims/content/bikasetup.py:529
+msgid ""
+"Choose type of multiple verification for the same user.This setting can "
+"enable/disable verifying/consecutively verifyingmore than once for the same "
+"user."
 msgstr ""
+"Выберите тип многократной верификации для одного пользователя. Этот параметр"
+" включает/отключает повторную верификацию одним и тем же пользователем."
 
-#: bika/lims/content/bikasetup.py:977
-msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
+#: bika/lims/content/bikasetup.py:976
+msgid ""
+"Choose when stickers should be automatically "
+"printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  "
+"automatically when new samples are "
+"created.</li><li><strong>Receive:</strong> Stickers are printed  "
+"automatically when samples are received.</li><li><strong>None:</strong> "
+"Disables automatic sticker printing.</li></ul>"
 msgstr ""
+"Выберите, когда стикеры должны печататься "
+"автоматически:<br/><ul><li><strong>Регистрация:</strong> стикеры печатаются "
+"автоматически при создании новых образцов.</li><li><strong>Приём:</strong> "
+"стикеры печатаются автоматически при приёме "
+"образцов.</li><li><strong>Нет:</strong> отключает автоматическую печать "
+"стикеров.</li></ul>"
 
-#: senaite/core/content/senaitesetup.py:1131
-msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
+#: senaite/core/content/senaitesetup.py:1108
+msgid ""
+"Choose when stickers should be automatically "
+"printed:<br/><ul><li><strong>Register:</strong> Stickers are printed "
+"automatically when new samples are "
+"created.</li><li><strong>Receive:</strong> Stickers are printed "
+"automatically when samples are received.</li><li><strong>None:</strong> "
+"Disables automatic sticker printing.</li></ul>"
 msgstr ""
+"Выберите, когда стикеры должны печататься "
+"автоматически:<br/><ul><li><strong>Регистрация:</strong> стикеры печатаются "
+"автоматически при создании новых образцов.</li><li><strong>Приём:</strong> "
+"стикеры печатаются автоматически при приёме "
+"образцов.</li><li><strong>Нет:</strong> отключает автоматическую печать "
+"стикеров.</li></ul>"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:113
 #: senaite/core/z3cform/widgets/address.py:225
@@ -1129,58 +1366,44 @@ msgstr "Город"
 msgid "Classic"
 msgstr "Классический"
 
-# senaite.app.listing: Column-filter row — clear button tooltip
-msgid "Clear filter"
-msgstr ""
-
-# senaite.app.listing: Search box — undo button tooltip when only clearing
-# search
-msgid "Clear search"
-msgstr ""
-
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
 msgstr "Сбросить выделение"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
 msgid "Click to expand this category"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — release button tooltip on the
-# applied preset
-msgid "Click to release this filter"
-msgstr ""
+msgstr "Нажмите, чтобы развернуть эту категорию"
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
+"Нажмите, чтобы переключить видимость, или перетащите для изменения порядка"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:191
+#: senaite/core/browser/samples/view.py:179
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
 msgstr "Клиент"
 
-#: bika/lims/browser/batchfolder.py:84
-#: bika/lims/content/batch.py:101
+#: bika/lims/browser/batchfolder.py:84 bika/lims/content/batch.py:101
 msgid "Client Batch ID"
-msgstr ""
+msgstr "ID партии клиента"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:196
+#: senaite/core/browser/samples/view.py:184
 msgid "Client ID"
 msgstr "ID клиента"
 
 #: bika/lims/profiles/default/registry.xml
 msgid "Client Landing Page"
-msgstr ""
+msgstr "Стартовая страница клиента"
 
 #: senaite/core/behaviors/clientshareable.py:85
 msgid "Client Name"
-msgstr ""
+msgstr "Название клиента"
 
-#: senaite/core/browser/samples/view.py:144
+#: senaite/core/browser/samples/view.py:132
 msgid "Client Order"
 msgstr "Заказ клиента"
 
@@ -1188,9 +1411,9 @@ msgstr "Заказ клиента"
 #: bika/lims/browser/batch/batchbook.py:81
 #: bika/lims/content/analysisrequest.py:817
 msgid "Client Order Number"
-msgstr ""
+msgstr "Номер заказа клиента"
 
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:189
 msgid "Client Ref"
 msgstr "Ссылка Клиента"
 
@@ -1199,17 +1422,17 @@ msgstr "Ссылка Клиента"
 msgid "Client Reference"
 msgstr "Ссылка клиента "
 
-#: senaite/core/browser/samples/view.py:206
+#: senaite/core/browser/samples/view.py:194
 msgid "Client SID"
 msgstr "SID Клиента"
 
 #: bika/lims/content/analysisrequest.py:851
 msgid "Client Sample ID"
-msgstr ""
+msgstr "ID образца клиента"
 
 #: senaite/core/registry/schema.py:39
 msgid "Client Settings"
-msgstr ""
+msgstr "Настройки клиента"
 
 #: senaite/core/behaviors/configure.zcml:49
 msgid "ClientShareableBehavior"
@@ -1220,8 +1443,14 @@ msgid "Clients"
 msgstr "Клиенты"
 
 #: senaite/core/behaviors/clientshareable.py:59
-msgid "Clients with whom this content will be shared across. This content will become available on searches to users that belong to any of the selected clients thanks to the role 'ClientGuest'"
-msgstr "Клиенты, с которыми будет осуществляться обмен этим содержимым. Этот контент станет доступен при поиске для пользователей, принадлежащих к любому из выбранных клиентов, благодаря роли 'ClientGuest'."
+msgid ""
+"Clients with whom this content will be shared across. This content will "
+"become available on searches to users that belong to any of the selected "
+"clients thanks to the role 'ClientGuest'"
+msgstr ""
+"Клиенты, с которыми будет осуществляться обмен этим содержимым. Этот контент"
+" станет доступен при поиске для пользователей, принадлежащих к любому из "
+"выбранных клиентов, благодаря роли 'ClientGuest'."
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:13
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
@@ -1234,68 +1463,72 @@ msgstr "Закрытые"
 
 #: bika/lims/content/storagelocation.py:59
 msgid "Code for the location"
-msgstr ""
+msgstr "Код местоположения"
 
 #: bika/lims/content/storagelocation.py:44
 msgid "Code for the site"
-msgstr ""
+msgstr "Код площадки"
 
 #: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
-msgstr ""
+msgstr "Код стеллажа"
 
 #: senaite/core/registry/schema.py:133
 msgid "Collapse field analysis table"
-msgstr ""
+msgstr "Свернуть таблицу полевых анализов"
 
 #: senaite/core/registry/schema.py:134
 msgid "Collapse field analysis table in sample view"
-msgstr ""
+msgstr "Сворачивать таблицу полевых анализов в просмотре образца"
 
 #: senaite/core/registry/schema.py:140
 msgid "Collapse lab analysis table"
-msgstr ""
+msgstr "Свернуть таблицу лабораторных анализов"
 
 #: senaite/core/registry/schema.py:141
 msgid "Collapse lab analysis table in sample view"
-msgstr ""
+msgstr "Сворачивать таблицу лабораторных анализов в просмотре образца"
 
 #: senaite/core/registry/schema.py:147
 msgid "Collapse qc analysis table"
-msgstr ""
+msgstr "Свернуть таблицу анализов контроля качества"
 
 #: senaite/core/registry/schema.py:148
 msgid "Collapse qc analysis table in sample view"
-msgstr ""
+msgstr "Сворачивать таблицу анализов контроля качества в просмотре образца"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:117
 msgid "Collected"
-msgstr ""
+msgstr "Собрано"
 
 #: senaite/core/content/dynamicanalysisspec.py:94
 msgid "Column '{}' is missing"
-msgstr ""
+msgstr "Отсутствует столбец '{}'"
 
 #: senaite/core/content/dynamicanalysisspec.py:88
-msgid "Column {} of the header row has no name. Please remove empty columns from the spreadsheet and upload it again."
+msgid ""
+"Column {} of the header row has no name. Please remove empty columns from "
+"the spreadsheet and upload it again."
 msgstr ""
+"Столбец {} строки заголовка не имеет имени. Удалите пустые столбцы из "
+"таблицы и загрузите её снова."
 
 #: senaite/core/vocabularies/setup.py:114
 msgid "Comma (,)"
-msgstr ""
+msgstr "Запятая (,)"
 
 #: bika/lims/content/analysiscategory.py:51
 msgid "Comments"
-msgstr ""
+msgstr "Комментарии"
 
 #: bika/lims/content/analysisrequest.py:1368
 msgid "Comments or results interpretation"
-msgstr ""
+msgstr "Комментарии или интерпретация результатов"
 
-#: bika/lims/content/abstractbaseanalysis.py:856
+#: bika/lims/content/abstractbaseanalysis.py:853
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
-msgstr ""
+msgstr "Коммерческий ID"
 
 #: bika/lims/content/analysisrequest.py:957
 #: bika/lims/content/samplepoint.py:121
@@ -1304,11 +1537,20 @@ msgstr "Составной"
 
 #: bika/lims/content/artemplate.py:109
 msgid "Composite sample"
-msgstr ""
+msgstr "Составной образец"
 
 #: bika/lims/content/analysisservice.py:267
-msgid "Conditions to ask for this analysis on sample registration. For instance, laboratory may want the user to input the temperature, the ramp and flow when a thermogravimetric (TGA) analysis is selected on sample registration. The information provided will be later considered by the laboratory personnel when performing the test."
+msgid ""
+"Conditions to ask for this analysis on sample registration. For instance, "
+"laboratory may want the user to input the temperature, the ramp and flow "
+"when a thermogravimetric (TGA) analysis is selected on sample registration. "
+"The information provided will be later considered by the laboratory "
+"personnel when performing the test."
 msgstr ""
+"Условия, запрашиваемые для этого анализа при регистрации образца. Например, "
+"лаборатория может запросить у пользователя ввод температуры, скорости "
+"нагрева и потока при выборе термогравиметрического (ТГА) анализа. Указанная "
+"информация будет учтена персоналом лаборатории при выполнении теста."
 
 #: bika/lims/content/laboratory.py:99
 msgid "Confidence Level %"
@@ -1316,31 +1558,31 @@ msgstr "Доверительный интервал%"
 
 # senaite.app.listing: Configuration
 msgid "Configuration"
-msgstr ""
+msgstr "Конфигурация"
 
 #: senaite/core/registry/schema.py:227
 msgid "Configuration for Generic Setup"
-msgstr ""
+msgstr "Конфигурация для Generic Setup"
 
 #: senaite/core/registry/schema.py:161
 msgid "Configuration for the sample header information"
-msgstr ""
+msgstr "Конфигурация для информации в заголовке образца"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:119
 msgid "Configuration restored to default values."
-msgstr ""
-
-# senaite.app.listing: Column config — trigger button label
-msgid "Configure"
-msgstr ""
+msgstr "Конфигурация восстановлена к значениям по умолчанию."
 
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
-msgstr ""
+msgstr "Настроить столбцы таблицы"
 
 #: bika/lims/content/artemplate.py:173
-msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
+msgid ""
+"Configure the sample partitions and preservations for this template. Assign "
+"analyses to the different partitions on the template's Analyses tab"
 msgstr ""
+"Настройте партиции и способы сохранения образца для этого шаблона. Назначьте"
+" анализы разным партициям на вкладке 'Анализы' шаблона"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:253
 msgid "Confirm password"
@@ -1350,16 +1592,16 @@ msgstr "Подтверждение пароля"
 #: bika/lims/content/instrumentmaintenancetask.py:93
 #: bika/lims/content/instrumentscheduledtask.py:86
 msgid "Considerations"
-msgstr ""
+msgstr "Замечания"
 
-#: senaite/core/browser/samples/view.py:209
+#: senaite/core/browser/samples/view.py:197
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
 msgstr "Контакт"
 
 #: bika/lims/browser/analysisrequest/add2.py:2066
 msgid "Contact does not belong to the selected client"
-msgstr ""
+msgstr "Контакт не принадлежит выбранному клиенту"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:118
 msgid "Contact is deactivated. User cannot be unlinked."
@@ -1373,7 +1615,7 @@ msgstr "Контакты"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:72
 msgid "Contained Samples"
-msgstr ""
+msgstr "Содержащиеся образцы"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:175
 msgid "Container"
@@ -1394,11 +1636,11 @@ msgstr "Контейнеры"
 
 #: bika/lims/browser/dynamic_analysisspec.py:45
 msgid "Contents of the file {}"
-msgstr ""
+msgstr "Содержимое файла {}"
 
-#: senaite/core/content/senaitesetup.py:224
+#: senaite/core/content/senaitesetup.py:223
 msgid "Context"
-msgstr ""
+msgstr "Контекст"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:590
 msgid "Control"
@@ -1406,76 +1648,77 @@ msgstr "Контроль"
 
 #: bika/lims/config.py:89
 msgid "Control QC analyses"
-msgstr ""
+msgstr "Контрольные анализы контроля качества"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:56
 #: bika/lims/content/analysisservice.py:222
 msgid "Control type"
-msgstr ""
+msgstr "Тип контроля"
 
 #: bika/lims/validators.py:441
 msgid "Control type is not supported for empty choices"
-msgstr ""
+msgstr "Тип контроля не поддерживается для пустых вариантов выбора"
 
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:54
 msgid "Copy"
-msgstr ""
+msgstr "Копировать"
 
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:11
 msgid "Copy analysis services"
-msgstr ""
+msgstr "Копировать услуги анализа"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:49
 msgid "Copy from"
 msgstr "Копировать из"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
-msgid "Copy the currently displayed column value to the other columns on the right"
-msgstr ""
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+msgid ""
+"Copy the currently displayed column value to the other columns on the right"
+msgstr "Скопировать текущее значение столбца в остальные столбцы справа"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
 msgid "Copy the value of the first sample to the others"
-msgstr ""
+msgstr "Скопировать значение первого образца в остальные"
 
-#: senaite/core/browser/samples/view.py:901
+#: senaite/core/browser/samples/view.py:742
 msgid "Copy to new"
 msgstr "Копировать в новый"
 
 #: senaite/core/browser/idserver/view.py:131
 msgid "Could not convert {} value(s) to integer: {}"
-msgstr ""
+msgstr "Не удалось преобразовать значение(-я) {} в целое число: {}"
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
-msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgid ""
+"Could not create the following sample(s) due to transaction conflicts, "
+"please retry them: ${rows}"
 msgstr ""
-
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
-msgid "Could not link User: ${error}"
-msgstr ""
+"Не удалось создать следующие образцы из-за конфликтов транзакций, повторите "
+"попытку: ${rows}"
 
 #: bika/lims/browser/workflow/client.py:52
 msgid "Could not load PDF for sample {}"
-msgstr ""
+msgstr "Не удалось загрузить PDF для образца {}"
 
 #: bika/lims/browser/publish/emailview.py:558
 msgid "Could not send email to {0} ({1})"
-msgstr ""
+msgstr "Не удалось отправить письмо на {0} ({1})"
 
 #: bika/lims/browser/workflow/analysisrequest.py:217
 msgid "Could not transition samples to the sampled state"
-msgstr ""
+msgstr "Не удалось перевести образцы в статус 'отобрано'"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:103
 msgid "Counter <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Счётчик <span class=\"sort-indicator\" />"
 
-#: senaite/core/content/senaitesetup.py:236
+#: senaite/core/content/senaitesetup.py:235
 msgid "Counter Ref"
-msgstr ""
+msgstr "Ссылка счётчика"
 
-#: senaite/core/content/senaitesetup.py:229
+#: senaite/core/content/senaitesetup.py:228
 msgid "Counter Type"
-msgstr ""
+msgstr "Тип счётчика"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:28
 #: senaite/core/z3cform/widgets/address.py:222
@@ -1486,15 +1729,15 @@ msgstr "Страна"
 msgid "Create Invoice PDF"
 msgstr "Создать pdf-документ счета"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:264
+#: senaite/core/browser/samples/templates/partition_magic.pt:256
 msgid "Create Partitions"
-msgstr ""
+msgstr "Создать партиции"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:214
 msgid "Create SENAITE Site"
 msgstr "Создать сайт SENAITE"
 
-#: senaite/core/browser/samples/view.py:864
+#: senaite/core/browser/samples/view.py:716
 msgid "Create Worksheet"
 msgstr "Создать рабочий лист"
 
@@ -1506,13 +1749,13 @@ msgstr "Создать новый сайт SENAITE"
 msgid "Create a new User"
 msgstr "Ввести нового пользователя"
 
-#: senaite/core/browser/samples/view.py:868
+#: senaite/core/browser/samples/view.py:720
 msgid "Create a new worksheet for the selected samples"
 msgstr "Создайте новый рабочий лист для выбранных образцов"
 
 #: senaite/core/browser/worksheets/templates/view.pt:26
 msgid "Create new worksheet"
-msgstr ""
+msgstr "Создать новый рабочий лист"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Create partitions"
@@ -1520,32 +1763,32 @@ msgstr "Создать партиции"
 
 #: senaite/core/browser/clients/client/attachments/view.py:71
 msgid "Created"
-msgstr ""
+msgstr "Создано"
 
 #: bika/lims/browser/instrument.py:404
 msgid "Created by"
-msgstr ""
+msgstr "Создал(а)"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:46
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:46
 msgid "Created on"
-msgstr ""
+msgstr "Дата создания"
 
 #: senaite/core/browser/samples/partition_magic.py:113
 msgid "Created {} partitions: {}"
-msgstr ""
+msgstr "Создано партиций: {} ({})"
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:148
+#: senaite/core/browser/samples/view.py:136
 msgid "Creator"
 msgstr "Выполнено"
 
 #: bika/lims/browser/instrument.py:403
 #: bika/lims/content/instrumentscheduledtask.py:76
 msgid "Criteria"
-msgstr ""
+msgstr "Критерии"
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:253
 msgid "Currency"
 msgstr "Валюта"
 
@@ -1553,21 +1796,13 @@ msgstr "Валюта"
 msgid "Current"
 msgstr "Текущий"
 
-# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
-msgid "Current view differs from saved"
-msgstr ""
-
-#: bika/lims/content/client.py:241
+#: bika/lims/content/client.py:237
 msgid "Custom decimal mark"
-msgstr ""
+msgstr "Пользовательский десятичный разделитель"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:135
-msgid "Daily"
-msgstr ""
+msgstr "ПО"
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
@@ -1581,8 +1816,7 @@ msgstr "Настройки интерфейса данных"
 msgid "Data import successful"
 msgstr "Данные импортированы успешно"
 
-#: bika/lims/browser/batchfolder.py:76
-#: bika/lims/browser/instrument.py:661
+#: bika/lims/browser/batchfolder.py:76 bika/lims/browser/instrument.py:661
 #: bika/lims/content/abstractbaseanalysis.py:700
 msgid "Date"
 msgstr "Дата"
@@ -1603,10 +1837,9 @@ msgstr "Конечная дата"
 msgid "Date Loaded"
 msgstr "Дата загрузки"
 
-#: bika/lims/browser/auditlog.py:82
-#: bika/lims/controlpanel/auditlog.py:76
+#: bika/lims/browser/auditlog.py:82 bika/lims/controlpanel/auditlog.py:76
 msgid "Date Modified"
-msgstr ""
+msgstr "Дата изменения"
 
 #: bika/lims/browser/referencesample.py:364
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
@@ -1614,23 +1847,23 @@ msgstr ""
 msgid "Date Opened"
 msgstr "Дата открытия"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:155
 msgid "Date Preserved"
 msgstr "Дата Сохранения"
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:208
 msgid "Date Printed"
 msgstr "Напечатан"
 
-#: senaite/core/browser/samples/view.py:183
+#: senaite/core/browser/samples/view.py:171
 msgid "Date Published"
 msgstr "Дата публикации"
 
-#: senaite/core/browser/samples/view.py:173
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Received"
 msgstr "Дата получения"
 
-#: senaite/core/browser/samples/view.py:153
+#: senaite/core/browser/samples/view.py:141
 msgid "Date Registered"
 msgstr "Дата Регистрации"
 
@@ -1642,60 +1875,60 @@ msgstr "Дата запроса"
 msgid "Date Sample Received"
 msgstr "Получен"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:149
 msgid "Date Sampled"
 msgstr "Дата получения пробы"
 
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Verified"
 msgstr "Дата проверки"
 
 #: bika/lims/content/instrumentcalibration.py:79
 msgid "Date from which the instrument is under calibration"
-msgstr ""
+msgstr "Дата, с которой инструмент находится на калибровке"
 
 #: bika/lims/content/instrumentmaintenancetask.py:66
 msgid "Date from which the instrument is under maintenance"
-msgstr ""
+msgstr "Дата, с которой инструмент находится на обслуживании"
 
 #: bika/lims/content/instrumentvalidation.py:61
 msgid "Date from which the instrument is under validation"
-msgstr ""
+msgstr "Дата, с которой инструмент находится на валидации"
 
 #: bika/lims/content/instrumentcertification.py:100
 msgid "Date granted"
-msgstr ""
+msgstr "Дата выдачи"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:112
 msgid "Date received"
-msgstr ""
+msgstr "Дата получения"
 
 #: bika/lims/content/instrumentcertification.py:137
 msgid "Date until the certificate is valid"
-msgstr ""
+msgstr "Дата, до которой сертификат действителен"
 
 #: bika/lims/content/instrumentcalibration.py:89
 #: bika/lims/content/instrumentmaintenancetask.py:76
 #: bika/lims/content/instrumentvalidation.py:71
 msgid "Date until the instrument will not be available"
-msgstr ""
+msgstr "Дата, до которой инструмент будет недоступен"
 
 #: bika/lims/content/instrumentcertification.py:101
 msgid "Date when the calibration certificate was granted"
-msgstr ""
+msgstr "Дата выдачи сертификата калибровки"
 
 #: bika/lims/content/instrumentcertification.py:127
 msgid "Date when the certificate is valid"
-msgstr ""
+msgstr "Дата, на которую сертификат действителен"
 
-#: senaite/core/content/resultsreport.py:210
+#: senaite/core/content/resultsreport.py:209
 msgid "Date when the report was printed"
-msgstr ""
+msgstr "Дата печати отчёта"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:101
 #: bika/lims/content/abstractbaseanalysis.py:701
 msgid "Datetime"
-msgstr ""
+msgstr "Дата и время"
 
 #: bika/lims/browser/fields/durationfield.py:36
 msgid "Days"
@@ -1703,7 +1936,7 @@ msgstr "Дни"
 
 #: bika/lims/content/instrument.py:186
 msgid "De-activate until next calibration test"
-msgstr ""
+msgstr "Деактивировать до следующей калибровки"
 
 #: senaite/core/profiles/default/workflows/senaite_client_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_clientcontact_workflow/definition.xml
@@ -1711,176 +1944,203 @@ msgstr ""
 msgid "Deactivate"
 msgstr "Отключить"
 
-#: bika/lims/content/client.py:242
+#: bika/lims/content/client.py:238
 msgid "Decimal mark to use in the reports from this Client."
-msgstr ""
+msgstr "Десятичный разделитель, используемый в отчётах для этого клиента."
 
-#: bika/lims/content/client.py:134
-msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
+#: bika/lims/content/client.py:130
+msgid ""
+"Default CC contacts for new samples. If set, these contacts are "
+"automatically selected in the sample add form."
 msgstr ""
+"Контакты для копии (CC) по умолчанию для новых образцов. Если заданы, они "
+"автоматически выбираются в форме добавления образца."
 
 #: bika/lims/content/analysisservice.py:165
 msgid "Default Container"
-msgstr ""
+msgstr "Контейнер по умолчанию"
 
 #: bika/lims/controlpanel/bika_labcontacts.py:80
 msgid "Default Department"
-msgstr ""
+msgstr "Подразделение по умолчанию"
 
-#: bika/lims/content/client.py:167
+#: bika/lims/content/client.py:163
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
+"Email по умолчанию для копии всех опубликованных образцов этого клиента"
 
 #: bika/lims/content/abstractbaseanalysis.py:414
 msgid "Default Instrument"
-msgstr ""
+msgstr "Инструмент по умолчанию"
 
 #: bika/lims/content/abstractbaseanalysis.py:430
 msgid "Default Method"
-msgstr ""
+msgstr "Метод по умолчанию"
 
-#: senaite/core/content/senaitesetup.py:1185
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Default Number of Copies"
-msgstr ""
+msgstr "Количество копий по умолчанию"
 
 #: bika/lims/content/analysisservice.py:145
 msgid "Default Preservation"
-msgstr ""
+msgstr "Способ сохранения по умолчанию"
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1128
 msgid "Default Sticker Template"
-msgstr ""
+msgstr "Шаблон стикера по умолчанию"
 
-#: bika/lims/content/client.py:99
-msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
+#: bika/lims/content/client.py:95
+msgid ""
+"Default contact for new samples. If set, this contact is automatically "
+"selected in the sample add form."
 msgstr ""
+"Контакт по умолчанию для новых образцов. Если задан, он автоматически "
+"выбирается в форме добавления образца."
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1215
 msgid "Default count of Sample to add."
-msgstr ""
+msgstr "Количество образцов для добавления по умолчанию."
 
-#: bika/lims/content/bikasetup.py:312
-#: bika/lims/content/client.py:229
+#: bika/lims/content/bikasetup.py:311 bika/lims/content/client.py:225
 msgid "Default decimal mark"
-msgstr ""
+msgstr "Десятичный разделитель по умолчанию"
 
 #: bika/lims/content/abstractbaseanalysis.py:415
 msgid "Default instrument used for analyses of this type"
-msgstr ""
+msgstr "Инструмент по умолчанию для анализов этого типа"
 
 #: bika/lims/content/sampletype.py:208
 msgid "Default large sticker"
-msgstr ""
+msgstr "Большой стикер по умолчанию"
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:573
 msgid "Default layout in worksheet view"
-msgstr ""
+msgstr "Макет по умолчанию в просмотре рабочего листа"
 
 #: bika/lims/content/abstractbaseanalysis.py:431
 msgid "Default method used for analyses of this type"
-msgstr ""
+msgstr "Метод по умолчанию для анализов этого типа"
 
 #: senaite/core/registry/schema.py:110
 msgid "Default printing templates order for worksheet"
-msgstr ""
+msgstr "Порядок шаблонов печати по умолчанию для рабочего листа"
 
 #: bika/lims/content/analysisservice.py:195
 msgid "Default result"
-msgstr ""
+msgstr "Результат по умолчанию"
 
 #: bika/lims/validators.py:1379
 msgid "Default result is not a valid date"
-msgstr ""
+msgstr "Результат по умолчанию не является допустимой датой"
 
 #: bika/lims/validators.py:1383
 msgid "Default result is not numeric"
-msgstr ""
+msgstr "Результат по умолчанию не является числом"
 
 #: bika/lims/validators.py:1389
 msgid "Default result must be one of the following result options: {}"
-msgstr ""
+msgstr "Результат по умолчанию должен быть одним из следующих вариантов: {}"
 
 #: bika/lims/content/analysisservice.py:196
 msgid "Default result to display on result entry"
-msgstr ""
+msgstr "Результат по умолчанию для отображения при вводе результата"
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1050
 msgid "Default sample retention period"
 msgstr "Срок хранения образцов по умолчанию"
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:325
 msgid "Default scientific notation format for reports"
-msgstr ""
+msgstr "Формат научной нотации по умолчанию для отчётов"
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:559
 msgid "Default scientific notation format for results"
-msgstr ""
+msgstr "Формат научной нотации по умолчанию для результатов"
 
 #: bika/lims/content/sampletype.py:206
 msgid "Default small sticker"
-msgstr ""
+msgstr "Малый стикер по умолчанию"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:97
 msgid "Default timezone"
 msgstr "Часовой пояс по умолчанию"
 
-#: senaite/core/content/senaitesetup.py:1060
+#: senaite/core/content/senaitesetup.py:1037
 msgid "Default turnaround time for analyses."
-msgstr ""
+msgstr "Срок выполнения по умолчанию для анализов."
 
 #: bika/lims/browser/fields/interimfieldsfield.py:54
 #: bika/lims/content/analysisservice.py:224
 msgid "Default value"
 msgstr "Значение по умолчанию"
 
-#: bika/lims/content/bikasetup.py:1217
-msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
+#: bika/lims/content/bikasetup.py:1216
+msgid ""
+"Default value of the 'Sample count' when users click 'ADD' button to create "
+"new Samples"
 msgstr ""
+"Значение по умолчанию для 'Количество образцов' при нажатии кнопки "
+"'ДОБАВИТЬ'"
 
 #: bika/lims/content/method.py:57
 msgid "Define an identifier code for the method. It must be unique."
-msgstr ""
+msgstr "Задайте идентификационный код метода. Он должен быть уникальным."
 
 #: bika/lims/content/calculation.py:60
-msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
+msgid ""
+"Define interim fields such as vessel mass, dilution factors, should your "
+"calculation require them. The field title specified here will be used as "
+"column headers and field descriptors where the interim fields are displayed."
+" If 'Apply wide' is enabled the field will be shown in a selection box on "
+"the top of the worksheet, allowing to apply a specific value to all the "
+"corresponding fields on the sheet."
 msgstr ""
+"Определите промежуточные поля, например массу сосуда, коэффициенты "
+"разбавления, если это требуется для расчёта. Название поля, указанное здесь,"
+" будет использовано как заголовок столбца и описание поля. Если включена "
+"опция 'Применить ко всем', поле будет показано в блоке выбора вверху "
+"рабочего листа, позволяя применить значение ко всем соответствующим полям "
+"листа."
 
 #: bika/lims/content/abstractbaseanalysis.py:177
 msgid "Define the number of decimals to be used for this result."
-msgstr ""
+msgstr "Задайте количество десятичных знаков для этого результата."
 
 #: bika/lims/content/abstractbaseanalysis.py:191
-msgid "Define the precision when converting values to exponent notation.  The default is 7."
+msgid ""
+"Define the precision when converting values to exponent notation.  The "
+"default is 7."
 msgstr ""
+"Задайте точность при преобразовании значений в экспоненциальную нотацию. По "
+"умолчанию — 7."
 
 #: bika/lims/content/analysisrequest.py:494
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
+"Укажите пробоотборщика, который должен взять образец в запланированную дату"
 
-#: senaite/core/content/senaitesetup.py:1112
-msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
+#: senaite/core/content/senaitesetup.py:1089
+msgid ""
+"Define the template for the email body that will be automatically sent to "
+"primary contacts and laboratory managers when a sample is invalidated. The "
+"following placeholders are supported: $sample_id, $retest_id, $retest_link, "
+"$reason, $lab_address."
 msgstr ""
+"Задайте шаблон текста письма, автоматически отправляемого основным контактам"
+" и менеджерам лаборатории при аннулировании образца. Поддерживаются "
+"плейсхолдеры: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 
 #: bika/lims/content/sampletype.py:232
 msgid "Defines the stickers to use for this sample type."
-msgstr ""
+msgstr "Определяет стикеры, используемые для этого типа образца."
 
 #: bika/lims/browser/fields/coordinatefield.py:36
 msgid "Degrees"
 msgstr "Градусы"
 
-#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — row action tooltip
-msgid "Delete filter"
-msgstr ""
-
-#: senaite/core/api/remarks.py:484
-msgid "Delete this remark?"
-msgstr ""
+msgstr "Удалить"
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
 #: senaite/core/profiles/default/types/Department.xml
@@ -1889,7 +2149,7 @@ msgstr "Подразделение"
 
 #: senaite/core/browser/controlpanel/departments/view.py:68
 msgid "Department ID"
-msgstr ""
+msgstr "ID подразделения"
 
 #: senaite/core/content/department.py:134
 msgid "Department ID must be unique"
@@ -1908,27 +2168,27 @@ msgstr "Подразделения"
 msgid "Dependent Analyses"
 msgstr "Анализы подразделения"
 
-#: senaite/core/behaviors/label.py:119
+#: senaite/core/behaviors/label.py:111
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:63
+#: senaite/core/browser/controlpanel/labels/view.py:62
 msgid "Description"
 msgstr "Описание"
 
 #: bika/lims/content/instrumentcalibration.py:119
 msgid "Description of the actions made during the calibration"
-msgstr ""
+msgstr "Описание действий, выполненных во время калибровки"
 
 #: bika/lims/content/instrumentmaintenancetask.py:104
 msgid "Description of the actions made during the maintenance process"
-msgstr ""
+msgstr "Описание действий, выполненных в процессе обслуживания"
 
 #: bika/lims/content/instrumentvalidation.py:101
 msgid "Description of the actions made during the validation"
-msgstr ""
+msgstr "Описание действий, выполненных во время валидации"
 
 #: bika/lims/content/storagelocation.py:64
 msgid "Description of the location"
-msgstr ""
+msgstr "Описание местоположения"
 
 #: bika/lims/content/storagelocation.py:84
 msgid "Description of the shelf"
@@ -1936,10 +2196,10 @@ msgstr "Описание полки"
 
 #: bika/lims/content/storagelocation.py:49
 msgid "Description of the site"
-msgstr ""
+msgstr "Описание площадки"
 
 msgid "Deselect all"
-msgstr ""
+msgstr "Снять выделение со всех"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Detach"
@@ -1947,24 +2207,20 @@ msgstr "Отделить"
 
 #: senaite/core/browser/modals/analysis/schema.py:105
 msgid "Detection Limit"
-msgstr ""
+msgstr "Предел обнаружения"
 
 # senaite.app.listing: Disable auto fetch transitions
 msgid "Disable auto fetch transitions"
-msgstr ""
+msgstr "Отключить автоматическое получение переходов"
 
 #: senaite/core/vocabularies/setup.py:180
 msgid "Disable multi-verification for the same user"
-msgstr ""
+msgstr "Отключить многократную верификацию одним пользователем"
 
-# senaite.app.listing: Saved filter presets — Revert action tooltip
-msgid "Discard edits and restore preset"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
-msgstr ""
+msgstr "Скидка"
 
 #: bika/lims/content/pricelist.py:66
 msgid "Discount %"
@@ -1979,14 +2235,14 @@ msgstr "Отправить"
 msgid "Dispatch samples"
 msgstr "Отправить образцы"
 
-#: senaite/core/browser/samples/view.py:379
+#: senaite/core/browser/samples/view.py:361
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
 msgstr "Отправлено"
 
 # bika.lims.bikalisting.js
 msgid "Display Columns"
-msgstr ""
+msgstr "Отображаемые столбцы"
 
 #: bika/lims/content/abstractbaseanalysis.py:727
 msgid "Display Value"
@@ -1994,33 +2250,25 @@ msgstr "Отобразить значение"
 
 #: bika/lims/validators.py:675
 msgid "Display Value is required"
-msgstr ""
+msgstr "Отображаемое значение обязательно"
 
 #: bika/lims/validators.py:687
 msgid "Display Value must be unique"
-msgstr ""
+msgstr "Отображаемое значение должно быть уникальным"
 
 #: bika/lims/content/abstractbaseanalysis.py:316
 msgid "Display a Detection Limit selector"
-msgstr ""
+msgstr "Показывать селектор предела обнаружения"
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:721
 msgid "Display sample partitions to clients"
-msgstr ""
+msgstr "Показывать партиции образца клиентам"
 
-#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
 msgstr "Ликвидировать"
 
-#: senaite/core/browser/samples/templates/dispose_samples.pt:15
-msgid "Dispose samples"
-msgstr ""
-
-#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
 msgstr "Извлечено"
 
@@ -2029,30 +2277,25 @@ msgstr "Извлечено"
 msgid "District"
 msgstr "Район"
 
-#: bika/lims/browser/instrument.py:664
-#: bika/lims/content/multifile.py:47
+#: bika/lims/browser/instrument.py:664 bika/lims/content/multifile.py:47
 msgid "Document"
-msgstr ""
+msgstr "Документ"
 
-#: bika/lims/browser/instrument.py:809
-#: bika/lims/content/multifile.py:39
+#: bika/lims/browser/instrument.py:809 bika/lims/content/multifile.py:39
 msgid "Document ID"
-msgstr ""
+msgstr "ID документа"
 
-#: bika/lims/browser/instrument.py:812
-#: bika/lims/content/multifile.py:63
+#: bika/lims/browser/instrument.py:812 bika/lims/content/multifile.py:63
 msgid "Document Location"
-msgstr ""
+msgstr "Расположение документа"
 
-#: bika/lims/browser/instrument.py:813
-#: bika/lims/content/multifile.py:73
+#: bika/lims/browser/instrument.py:813 bika/lims/content/multifile.py:73
 msgid "Document Type"
-msgstr ""
+msgstr "Тип документа"
 
-#: bika/lims/browser/instrument.py:811
-#: bika/lims/content/multifile.py:55
+#: bika/lims/browser/instrument.py:811 bika/lims/content/multifile.py:55
 msgid "Document Version"
-msgstr ""
+msgstr "Версия документа"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Documents"
@@ -2060,52 +2303,48 @@ msgstr "Документы"
 
 #: senaite/core/exportimport/instruments/importer.py:375
 msgid "Don't override analysis results"
-msgstr ""
+msgstr "Не перезаписывать результаты анализов"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:79
 msgid "Done"
-msgstr ""
+msgstr "Готово"
 
 #: senaite/core/vocabularies/setup.py:113
 msgid "Dot (.)"
-msgstr ""
+msgstr "Точка (.)"
 
 #: bika/lims/browser/instrument.py:87
 msgid "Down from"
-msgstr ""
+msgstr "От"
 
 #: bika/lims/browser/instrument.py:88
 msgid "Down to"
-msgstr ""
+msgstr "До"
 
 #: bika/lims/browser/publish/reports_listing.py:150
 msgid "Download"
-msgstr ""
+msgstr "Скачать"
 
 #: bika/lims/browser/publish/reports_listing.py:80
 msgid "Download PDF"
-msgstr ""
+msgstr "Скачать PDF"
 
 #: bika/lims/browser/publish/reports_listing.py:145
 msgid "Download selected reports"
-msgstr ""
+msgstr "Скачать выбранные отчёты"
 
-# senaite.app.listing: Column config — drag handle tooltip / aria-label
-msgid "Drag to reorder"
-msgstr ""
-
-#: senaite/core/browser/samples/view.py:327
+#: senaite/core/browser/samples/view.py:309
 msgid "Due"
 msgstr "Ожидается"
 
-#: senaite/core/browser/samples/view.py:176
+#: senaite/core/browser/samples/view.py:164
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
 msgstr "Дата ожидания"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:199
 msgid "Dup Var"
-msgstr ""
+msgstr "Разброс дубликата"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:556
 msgid "Duplicate"
@@ -2115,9 +2354,13 @@ msgstr "Дублировать"
 msgid "Duplicate Analysis"
 msgstr "Повторный анализ"
 
-#: senaite/core/content/senaitesetup.py:1433
-msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
+#: senaite/core/content/senaitesetup.py:1406
+msgid ""
+"Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the "
+"first row is used; remove or merge the duplicate."
 msgstr ""
+"Повторяющийся формат ID для типа '${pt}' (строки ${a} и ${b}). Используется "
+"только первая строка; удалите или объедините дубликат."
 
 #: bika/lims/content/worksheettemplate.py:59
 msgid "Duplicate Of"
@@ -2125,202 +2368,206 @@ msgstr "Дубликат"
 
 #: bika/lims/config.py:90
 msgid "Duplicate QC analyses"
-msgstr ""
+msgstr "Дублирующие анализы контроля качества"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Duplicate Sample"
-msgstr ""
+msgstr "Дублировать образец"
 
 #: bika/lims/content/abstractbaseanalysis.py:479
 msgid "Duplicate Variation %"
-msgstr ""
+msgstr "Разброс дубликата, %"
 
 #: bika/lims/validators.py:461
 msgid "Duplicate keys in choices field"
-msgstr ""
+msgstr "Повторяющиеся ключи в поле выбора"
 
 #: bika/lims/browser/workflow/analysisrequest.py:443
 msgid "Duplicated samples: {}"
-msgstr ""
+msgstr "Дублированные образцы: {}"
 
 #: senaite/core/profiles/default/types/DynamicAnalysisSpec.xml
 msgid "Dynamic Analysis Specification"
-msgstr ""
+msgstr "Динамическая спецификация анализа"
 
 #: senaite/core/profiles/default/types/DynamicAnalysisSpecs.xml
 msgid "Dynamic Analysis Specifications"
-msgstr ""
+msgstr "Динамические спецификации анализа"
 
 #: bika/lims/controlpanel/bika_analysisspecs.py:82
 msgid "Dynamic Specification"
-msgstr ""
+msgstr "Динамическая спецификация"
 
 #: bika/lims/content/laboratory.py:122
 msgid "E.g. SANAS, APLAC, etc."
 msgstr "Например SANAS, APLAC и т.д."
 
 #: senaite/core/exportimport/import.pt:165
-msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
-msgstr "Каждый интерфейс импорта может определить папку, в которой система ищет файлы результатов при автоматическом импорте результатов при вызове представления <code>auto_import_results</code>"
+msgid ""
+"Each import interface can define a folder, where the system looks for the "
+"results files while automatically importing results when calling the "
+"<code>auto_import_results</code> view."
+msgstr ""
+"Каждый интерфейс импорта может определить папку, в которой система ищет "
+"файлы результатов при автоматическом импорте результатов при вызове "
+"представления <code>auto_import_results</code>"
 
-#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
 msgstr "Редактировать"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:15
 msgid "Edit Multiple Analyses Results"
-msgstr ""
+msgstr "Редактировать результаты нескольких анализов"
 
 #: bika/lims/content/samplepoint.py:74
 msgid "Elevation"
 msgstr "Высота"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
-#: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:147
+#: senaite/core/config/widgets.py:55 senaite/core/content/contact.py:115
 msgid "Email"
 msgstr "Отправить по электронной почте"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:115
+#: senaite/core/content/resultsreport.py:114
 msgid "Email Address"
 msgstr "Адрес электронной почты"
 
-#: senaite/core/content/resultsreport.py:89
+#: senaite/core/content/resultsreport.py:88
 msgid "Email Attachments"
-msgstr ""
+msgstr "Вложения письма"
 
-#: senaite/core/content/resultsreport.py:84
+#: senaite/core/content/resultsreport.py:83
 msgid "Email Body"
-msgstr ""
+msgstr "Текст письма"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:96
 msgid "Email Log"
-msgstr ""
+msgstr "Журнал писем"
 
-#: senaite/core/content/resultsreport.py:67
+#: senaite/core/content/resultsreport.py:66
 msgid "Email Recipients"
-msgstr ""
+msgstr "Получатели письма"
 
-#: senaite/core/content/resultsreport.py:73
+#: senaite/core/content/resultsreport.py:72
 msgid "Email Responsibles"
-msgstr ""
+msgstr "Ответственные по email"
 
-#: senaite/core/content/resultsreport.py:62
+#: senaite/core/content/resultsreport.py:61
 msgid "Email Send Date"
-msgstr ""
+msgstr "Дата отправки письма"
 
-#: senaite/core/content/resultsreport.py:79
+#: senaite/core/content/resultsreport.py:78
 msgid "Email Subject"
-msgstr ""
+msgstr "Тема письма"
 
-#: senaite/core/content/senaitesetup.py:1111
+#: senaite/core/content/senaitesetup.py:1088
 msgid "Email body for Sample Invalidation notifications"
-msgstr ""
+msgstr "Текст письма для уведомлений об аннулировании образца"
 
-#: senaite/core/content/senaitesetup.py:1095
+#: senaite/core/content/senaitesetup.py:1072
 msgid "Email body for Sample Rejection notifications"
-msgstr ""
+msgstr "Текст письма для уведомлений об отклонении образца"
 
 #: bika/lims/browser/publish/emailview.py:158
 msgid "Email cancelled"
-msgstr ""
+msgstr "Отправка письма отменена"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:126
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:129
 msgid "Email notification"
-msgstr ""
+msgstr "Уведомление по email"
 
-#: senaite/core/content/senaitesetup.py:1085
+#: senaite/core/content/senaitesetup.py:1062
 msgid "Email notification on Sample rejection"
-msgstr ""
+msgstr "Уведомление по email при отклонении образца"
 
-#: senaite/core/content/resultsreport.py:258
+#: senaite/core/content/resultsreport.py:257
 msgid "Email send log"
-msgstr ""
+msgstr "Журнал отправки писем"
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
-msgstr ""
-
-#: bika/lims/api/snapshot.py:585
-msgid "Empty"
-msgstr ""
+msgstr "Письмо отправлено"
 
 #: bika/lims/validators.py:456
 msgid "Empty keys are not supported"
-msgstr ""
+msgstr "Пустые ключи не поддерживаются"
 
 #: bika/lims/content/worksheettemplate.py:140
 msgid "Enable Multiple Use of Instrument in Worksheets."
-msgstr ""
+msgstr "Разрешить многократное использование инструмента в рабочих листах."
 
-#: senaite/core/content/senaitesetup.py:1040
+#: senaite/core/content/senaitesetup.py:1017
 msgid "Enable Sample Preservation"
-msgstr ""
+msgstr "Включить сохранение образца"
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:410
 msgid "Enable Sample Specifications"
-msgstr ""
+msgstr "Включить спецификации образца"
 
-#: senaite/core/content/senaitesetup.py:1012
+#: senaite/core/content/senaitesetup.py:989
 msgid "Enable Sampling"
-msgstr ""
+msgstr "Включить отбор проб"
 
-#: senaite/core/content/senaitesetup.py:1020
+#: senaite/core/content/senaitesetup.py:997
 msgid "Enable Sampling Scheduling"
-msgstr ""
+msgstr "Включить планирование отбора проб"
 
-#: bika/lims/content/bikasetup.py:224
+#: bika/lims/content/bikasetup.py:223
 msgid "Enable global Audit Log"
-msgstr ""
+msgstr "Включить глобальный журнал аудита"
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/content/senaitesetup.py:297
 msgid "Enable global Auditlog"
-msgstr ""
+msgstr "Включить глобальный журнал аудита"
 
 #: bika/lims/content/artemplate.py:119
 msgid "Enable sampling workflow for the created sample"
-msgstr ""
+msgstr "Включить процесс отбора проб для создаваемого образца"
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:979
 msgid "Enable the Results Report Printing workflow"
-msgstr ""
-
-#: senaite/core/content/senaitesetup.py:1000
-msgid "Enable the Sample Dispatch workflow"
-msgstr ""
-
-#: senaite/core/content/senaitesetup.py:990
-msgid "Enable the Sample Dispose workflow"
-msgstr ""
+msgstr "Включить процесс печати отчёта с результатами"
 
 #: bika/lims/browser/pricelist.py:68
 msgid "End Date"
-msgstr ""
+msgstr "Дата окончания"
 
 #: bika/lims/content/instrumentmaintenancetask.py:165
 #: bika/lims/content/instrumentscheduledtask.py:119
 msgid "Enhancement"
-msgstr ""
+msgstr "Улучшение"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:231
-msgid "Enter a user name, usually something like 'jsmith'. No spaces or special characters. Usernames and passwords are case sensitive, make sure the caps lock key is not enabled. This is the name used to log in."
-msgstr "Введите имя пользователя, обычно что-то вроде «jsmith». Без пробелов и специальных символов. Имена пользователей и пароли чувствительны к регистру, убедитесь, что клавиша caps lock не нажата. Это имя, используемое для входа в систему."
+msgid ""
+"Enter a user name, usually something like 'jsmith'. No spaces or special "
+"characters. Usernames and passwords are case sensitive, make sure the caps "
+"lock key is not enabled. This is the name used to log in."
+msgstr ""
+"Введите имя пользователя, обычно что-то вроде «jsmith». Без пробелов и "
+"специальных символов. Имена пользователей и пароли чувствительны к регистру,"
+" убедитесь, что клавиша caps lock не нажата. Это имя, используемое для входа"
+" в систему."
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:268
-msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
-msgstr "Введите адрес электронной почты. Это необходимо в случае утери пароля. Мы уважаем вашу частную жизнь и не будет передавать адреса третьим лицам."
+msgid ""
+"Enter an email address. This is necessary in case the password is lost. We "
+"respect your privacy, and will not give the address away to any third "
+"parties or expose it anywhere."
+msgstr ""
+"Введите адрес электронной почты. Это необходимо в случае утери пароля. Мы "
+"уважаем вашу частную жизнь и не будет передавать адреса третьим лицам."
 
 #: bika/lims/content/pricelist.py:67
 msgid "Enter discount percentage value"
 msgstr "Введите процентное значение скидки"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
 msgid "Enter individual values for this field per sample"
-msgstr ""
+msgstr "Введите отдельные значения этого поля для каждого образца"
 
 #: bika/lims/content/abstractbaseanalysis.py:576
 #: bika/lims/content/labproduct.py:48
@@ -2328,54 +2575,82 @@ msgid "Enter percentage value eg. 14.0"
 msgstr "Введите процентное значение напр. 14,0"
 
 #: bika/lims/content/analysisprofile.py:123
-msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
+msgid ""
+"Enter percentage value eg. 14.0. This percentage is applied on the Analysis "
+"Profile only, overriding the systems VAT"
 msgstr ""
+"Введите значение процента, например 14.0. Этот процент применяется только к "
+"профилю анализа, переопределяя системный НДС"
 
-#: bika/lims/content/bikasetup.py:298
-msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
-msgstr "Введите процентное значение напр. 14.0. Это процент всей прикладной системе но может быть переписан для отдельных элементов"
+#: bika/lims/content/bikasetup.py:297
+msgid ""
+"Enter percentage value eg. 14.0. This percentage is applied system wide but "
+"can be overwrittem on individual items"
+msgstr ""
+"Введите процентное значение напр. 14.0. Это процент всей прикладной системе "
+"но может быть переписан для отдельных элементов"
 
 #: bika/lims/content/analysisrequest.py:1120
 msgid "Enter percentage value eg. 33.0"
 msgstr "Введите значение  процента напр. 33,0"
 
 #: bika/lims/content/samplepoint.py:57
-msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
-msgstr "Введите Образец точки широты в 0-90 градусов, минут 0-59, секунд-0-59 и N/S индикатор"
+msgid ""
+"Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds "
+"0-59 and N/S indicator"
+msgstr ""
+"Введите Образец точки широты в 0-90 градусов, минут 0-59, секунд-0-59 и N/S "
+"индикатор"
 
 #: bika/lims/content/samplepoint.py:66
-msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
+msgid ""
+"Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds "
+"0-59 and E/W indicator"
 msgstr ""
+"Введите долготу точки отбора проб: градусы 0-180, минуты 0-59, секунды 0-59 "
+"и индикатор В/З"
 
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:18
 msgid "Enter the details of each of the analysis services you want to copy."
-msgstr ""
+msgstr "Введите данные каждой услуги анализа, которую хотите скопировать."
 
 #: bika/lims/content/laboratory.py:176
-msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
+msgid ""
+"Enter the details of your lab's service accreditations here. The following "
+"fields are available:  lab_is_accredited, lab_name, lab_country, confidence,"
+" accreditation_body_name, accreditation_standard, "
+"accreditation_reference<br/>"
 msgstr ""
+"Введите данные об аккредитации услуг вашей лаборатории. Доступны поля: "
+"lab_is_accredited, lab_name, lab_country, confidence, "
+"accreditation_body_name, accreditation_standard, "
+"accreditation_reference<br/>"
 
-#: bika/lims/browser/analyses/view.py:1097
-msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
+#: bika/lims/browser/analyses/view.py:1096
+msgid ""
+"Enter the result either in decimal or scientific notation, e.g. 0.00005 or "
+"1e-5, 10000 or 1e5"
 msgstr ""
+"Введите результат в десятичной или научной нотации, например 0.00005 или "
+"1e-5, 10000 или 1e5"
 
 #: bika/lims/content/analysisrequest.py:939
 msgid "Environmental conditions"
-msgstr ""
+msgstr "Условия окружающей среды"
 
 #: senaite/core/browser/samples/invalidate_samples.py:282
 msgid "Erroneous result publication: ${sample_id}"
-msgstr ""
+msgstr "Ошибочная публикация результата: ${sample_id}"
 
-#: senaite/core/browser/dashboard/dashboard.py:502
+#: senaite/core/browser/dashboard/dashboard.py:455
 msgid "Evolution of Analyses"
 msgstr "Продвижение анализов"
 
-#: senaite/core/browser/dashboard/dashboard.py:453
+#: senaite/core/browser/dashboard/dashboard.py:407
 msgid "Evolution of Samples"
 msgstr "Динамика образцов"
 
-#: senaite/core/browser/dashboard/dashboard.py:535
+#: senaite/core/browser/dashboard/dashboard.py:484
 msgid "Evolution of Worksheets"
 msgstr "Динамика рабочих листов"
 
@@ -2387,7 +2662,7 @@ msgstr "Пример Cronjob для выполнения автоматичес�
 msgid "Example content"
 msgstr "Пример содержания"
 
-#: senaite/core/browser/samples/view.py:739
+#: senaite/core/browser/samples/view.py:601
 msgid "Exclude from invoice"
 msgstr "Исключить из счета"
 
@@ -2397,13 +2672,13 @@ msgstr "Исключить из счета"
 msgid "Expected Result"
 msgstr "Ожидаемый результат"
 
-#: senaite/core/browser/samples/view.py:157
+#: senaite/core/browser/samples/view.py:145
 msgid "Expected Sampling Date"
 msgstr "Ожидаемая дата отбора проб"
 
 #: bika/lims/content/referencesample.py:214
 msgid "Expected Values"
-msgstr ""
+msgstr "Ожидаемые значения"
 
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
 msgid "Expire"
@@ -2421,30 +2696,31 @@ msgstr "Дата истечения срока действия"
 
 #: bika/lims/content/abstractbaseanalysis.py:190
 msgid "Exponential format precision"
-msgstr ""
+msgstr "Точность экспоненциального формата"
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:425
 msgid "Exponential format threshold"
-msgstr ""
+msgstr "Порог экспоненциального формата"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Export"
 msgstr "Экспорт"
 
-#: senaite/core/browser/stickers/view.py:283
+#: senaite/core/browser/stickers/view.py:273
 msgid "Failed to load sticker"
-msgstr ""
+msgstr "Не удалось загрузить стикер"
 
 #: bika/lims/browser/publish/emailview.py:150
 msgid "Failed to send Email(s)"
-msgstr ""
+msgstr "Не удалось отправить письмо(а)"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:101
-msgid "Failed to update registry records. Please check the server log for details."
+msgid ""
+"Failed to update registry records. Please check the server log for details."
 msgstr ""
+"Не удалось обновить записи реестра. Подробности см. в журнале сервера."
 
-#: bika/lims/browser/clientfolder.py:86
-#: bika/lims/content/organisation.py:66
+#: bika/lims/browser/clientfolder.py:86 bika/lims/content/organisation.py:66
 #: bika/lims/controlpanel/bika_labcontacts.py:89
 msgid "Fax"
 msgstr "Факс"
@@ -2459,7 +2735,7 @@ msgstr "Женский"
 
 # senaite.app.listing: Fetch transitions
 msgid "Fetch Transitions"
-msgstr ""
+msgstr "Получить переходы"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:191
 msgid "Field"
@@ -2467,7 +2743,7 @@ msgstr "Поле"
 
 #: bika/lims/browser/analysisrequest/add2.py:2122
 msgid "Field '{}' is required"
-msgstr ""
+msgstr "Поле '{}' обязательно"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:125
 #: senaite/core/browser/viewlets/sampleanalyses.py:69
@@ -2476,11 +2752,11 @@ msgstr "Анализы \"в поле\""
 
 #: senaite/core/registry/schema.py:214
 msgid "Field Name"
-msgstr ""
+msgstr "Название поля"
 
 #: bika/lims/config.py:56
 msgid "Field Preservation"
-msgstr ""
+msgstr "Полевое сохранение"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:53
 msgid "Field Title"
@@ -2488,11 +2764,11 @@ msgstr "Название поля"
 
 #: bika/lims/browser/analysisrequest/add2.py:1460
 msgid "Field flushed"
-msgstr ""
+msgstr "Поле очищено"
 
 #: senaite/core/registry/schema.py:212
 msgid "Field visibility"
-msgstr ""
+msgstr "Видимость поля"
 
 #: bika/lims/browser/instrument.py:814
 msgid "File"
@@ -2500,55 +2776,43 @@ msgstr "Файл"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:194
 msgid "File Deleted"
-msgstr ""
+msgstr "Файл удалён"
 
 #: bika/lims/content/analysisservice.py:262
 msgid "File upload"
-msgstr ""
+msgstr "Загрузка файла"
 
 #: bika/lims/content/multifile.py:48
 msgid "File upload "
-msgstr ""
+msgstr "Загрузка файла "
 
 #: senaite/core/browser/clients/client/attachments/view.py:59
 msgid "Filename"
-msgstr ""
+msgstr "Имя файла"
 
 #: bika/lims/browser/publish/reports_listing.py:82
 msgid "Filesize"
-msgstr ""
+msgstr "Размер файла"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
 msgid "Filter analyses by name..."
-msgstr ""
+msgstr "Фильтр анализов по названию..."
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:190
 msgid "Filter by template method"
-msgstr ""
+msgstr "Фильтр по методу шаблона"
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:175
 msgid "Filter by template services"
-msgstr ""
+msgstr "Фильтр по услугам шаблона"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — inline editor placeholder
-msgid "Filter name"
-msgstr ""
-
-#: senaite/core/browser/samples/view.py:601
-msgid "Filter samples by this analysis"
-msgstr ""
-
-# senaite.app.listing: Column-filter row — text-input placeholder
-msgid "Filter..."
-msgstr ""
+msgstr "Фильтр ключей (поддерживается regex)"
 
 #: senaite/core/content/dynamicanalysisspec.py:75
 msgid "First sheet does not contain a valid column definition"
-msgstr ""
+msgstr "Первый лист не содержит корректного определения столбцов"
 
 #: bika/lims/content/person.py:51
 msgid "Firstname"
@@ -2557,16 +2821,20 @@ msgstr "Имя"
 #: bika/lims/content/abstractbaseanalysis.py:83
 #: bika/lims/content/analysiscategory.py:83
 #: bika/lims/controlpanel/bika_analysisservices.py:207
-msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
+msgid ""
+"Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values "
+"are ordered alphabetically."
 msgstr ""
+"Число с плавающей точкой от 0.0 до 1000.0, задающее порядок сортировки. "
+"Повторяющиеся значения сортируются по алфавиту."
 
-#: senaite/core/content/senaitesetup.py:212
+#: senaite/core/content/senaitesetup.py:211
 msgid "Format"
-msgstr ""
+msgstr "Формат"
 
-#: senaite/core/content/senaitesetup.py:1203
+#: senaite/core/content/senaitesetup.py:1180
 msgid "Formatting Configuration"
-msgstr ""
+msgstr "Настройка форматирования"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:183
 #: bika/lims/controlpanel/bika_calculations.py:79
@@ -2575,11 +2843,11 @@ msgstr "Формула"
 
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:239
 msgid "Found Dynamic Analysis Specification for '{}' in '{}'"
-msgstr ""
+msgstr "Найдена динамическая спецификация анализа для '{}' в '{}'"
 
 #: senaite/core/vocabularies/setup.py:160
 msgid "Friday"
-msgstr ""
+msgstr "Пятница"
 
 #: bika/lims/browser/publish/templates/email.pt:47
 #: bika/lims/content/instrumentcalibration.py:78
@@ -2587,25 +2855,21 @@ msgstr ""
 msgid "From"
 msgstr "От"
 
-#: senaite/core/browser/dashboard/dashboard.py:134
-msgid "From ${from} to ${to} (updated every 2 hours)"
-msgstr ""
-
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
 msgstr "Полное имя"
 
-#: senaite/core/content/resultsreport.py:110
+#: senaite/core/content/resultsreport.py:109
 msgid "Fullname"
-msgstr ""
+msgstr "Полное имя"
 
 #: bika/lims/content/calculation.py:100
 msgid "Function"
-msgstr ""
+msgstr "Функция"
 
-#: senaite/core/browser/samples/view.py:736
+#: senaite/core/browser/samples/view.py:598
 msgid "Future dated sample"
 msgstr "Образец с будущей датой"
 
@@ -2616,19 +2880,19 @@ msgstr "Общее"
 
 #: senaite/core/behaviors/configure.zcml:13
 msgid "Generates an ID with the IDServer"
-msgstr ""
+msgstr "Генерирует ID с помощью сервера идентификаторов"
 
 #: senaite/core/registry/schema.py:226
 msgid "Generic Setup"
-msgstr ""
+msgstr "Generic Setup"
 
 #: senaite/core/browser/viewlets/templates/auditlog_disabled.pt:11
 msgid "Global Audit Log is disabled"
-msgstr ""
+msgstr "Глобальный журнал аудита отключён"
 
 #: senaite/core/profiles/default/types/Contacts.xml
 msgid "Global contacts container"
-msgstr ""
+msgstr "Глобальный контейнер контактов"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:44
 msgid "Go to your instance"
@@ -2638,13 +2902,17 @@ msgstr "Перейти к своему образцу"
 msgid "Greeting title eg. Mr, Mrs, Dr"
 msgstr "Приветствие напр. Г-Н, миссис, Dr"
 
-#: bika/lims/content/bikasetup.py:356
-msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
-msgstr "Группировка аналитических услуг в таблицах LIMS, полезно, когда список длинный"
+#: bika/lims/content/bikasetup.py:355
+msgid ""
+"Group analysis services by category in the LIMS tables, helpful when the "
+"list is long"
+msgstr ""
+"Группировка аналитических услуг в таблицах LIMS, полезно, когда список "
+"длинный"
 
 #: bika/lims/content/arreport.py:134
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: bika/lims/content/referencesample.py:105
 #: bika/lims/content/sampletype.py:127
@@ -2652,42 +2920,30 @@ msgid "Hazardous"
 msgstr "Опасные"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:84
+#: bika/lims/browser/analysisrequest/manage_analyses.py:81
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
-msgstr ""
+msgstr "Скрыто"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:60
 msgid "Hidden Field"
-msgstr ""
+msgstr "Скрытое поле"
 
 #: senaite/core/browser/modals/analysis/schema.py:114
 msgid "Hidden from report"
-msgstr ""
+msgstr "Скрыто из отчёта"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
 msgid "Hide additional fields"
-msgstr ""
-
-# senaite.app.listing: Column config — bulk action button
-msgid "Hide all"
-msgstr ""
-
-#: senaite/core/api/remarks.py:487
-msgid "Hide history"
-msgstr ""
-
-# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
-msgid "Hide this column"
-msgstr ""
+msgstr "Скрыть дополнительные поля"
 
 #: bika/lims/config.py:140
 msgid "High"
-msgstr ""
+msgstr "Высокий"
 
 #: bika/lims/config.py:139
 msgid "Highest"
-msgstr ""
+msgstr "Наивысший"
 
 #: bika/lims/browser/fields/durationfield.py:37
 msgid "Hours"
@@ -2695,133 +2951,226 @@ msgstr "Часы"
 
 #: bika/lims/content/supplier.py:75
 msgid "IBN"
-msgstr ""
+msgstr "IBN"
 
 #: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_view.pt:43
 msgid "ID"
 msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1407
+#: senaite/core/content/senaitesetup.py:1380
 msgid "ID Server"
-msgstr ""
+msgstr "Сервер идентификаторов"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:17
 msgid "ID Server Settings"
-msgstr ""
+msgstr "Настройки сервера идентификаторов"
 
-#: bika/lims/content/bikasetup.py:1189
+#: bika/lims/content/bikasetup.py:1188
 msgid "ID Server Values"
-msgstr ""
+msgstr "Значения сервера идентификаторов"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:113
 msgid "ID Template <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Шаблон ID <span class=\"sort-indicator\" />"
 
 #: bika/lims/content/samplepoint.py:84
-msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
+msgid ""
+"If a sample is taken periodically at this sample point, enter frequency "
+"here, e.g. weekly"
 msgstr ""
+"Если образец на этой точке отбирается периодически, укажите частоту, "
+"например еженедельно"
 
 #: bika/lims/content/abstractbaseanalysis.py:317
-msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
+msgid ""
+"If checked, a selection list will be displayed next to the analysis' result "
+"field in results entry views. By using this selector, the analyst will be "
+"able to set the value as a Detection Limit (LDL or UDL) instead of a regular"
+" result"
 msgstr ""
+"Если отмечено, рядом с полем результата анализа будет отображаться список "
+"выбора. С его помощью аналитик сможет установить значение как предел "
+"обнаружения (LDL или UDL) вместо обычного результата"
 
 #: bika/lims/content/instrument.py:187
-msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
+msgid ""
+"If checked, the instrument will be unavailable until the next valid "
+"calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
+"Если отмечено, инструмент будет недоступен до следующей действительной "
+"калибровки. Этот флажок будет снят автоматически."
 
-#: bika/lims/content/bikasetup.py:462
-msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
+#: bika/lims/content/bikasetup.py:461
+msgid ""
+"If enabled, a free text field will be displayed close to each analysis in "
+"results entry view"
 msgstr ""
+"Если включено, рядом с каждым анализом при вводе результатов будет "
+"отображаться поле свободного текста"
 
-#: bika/lims/content/abstractbaseanalysis.py:821
-msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
+#: bika/lims/content/abstractbaseanalysis.py:818
+msgid ""
+"If enabled, a user who submitted a result for this analysis will also be "
+"able to verify it. This setting take effect for those users with a role "
+"assigned that allows them to verify results (by default, managers, "
+"labmanagers and verifiers). The option set here has priority over the option"
+" set in Bika Setup"
 msgstr ""
+"Если включено, пользователь, отправивший результат этого анализа, также "
+"сможет его верифицировать. Действует для пользователей с ролью, позволяющей "
+"верифицировать результаты (по умолчанию — менеджеры, менеджеры лаборатории и"
+" верификаторы). Этот параметр имеет приоритет над настройкой в Bika Setup"
 
-#: bika/lims/content/bikasetup.py:494
-msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
+#: bika/lims/content/bikasetup.py:493
+msgid ""
+"If enabled, a user who submitted a result will also be able to verify it. "
+"This setting only take effect for those users with a role assigned that "
+"allows them to verify results (by default, managers, labmanagers and "
+"verifiers).This setting can be overrided for a given Analysis in Analysis "
+"Service edit view. By default, disabled."
 msgstr ""
+"Если включено, пользователь, отправивший результат, также сможет его "
+"верифицировать. Действует только для пользователей с ролью, позволяющей "
+"верифицировать результаты (по умолчанию — менеджеры, менеджеры лаборатории и"
+" верификаторы). Может быть переопределено для конкретного анализа в услуге "
+"анализа. По умолчанию отключено."
 
 #: bika/lims/content/abstractbaseanalysis.py:96
 msgid "If enabled, the name of the analysis will be written in italics."
-msgstr ""
+msgstr "Если включено, название анализа будет отображаться курсивом."
 
-#: bika/lims/content/abstractbaseanalysis.py:805
-msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
+#: bika/lims/content/abstractbaseanalysis.py:802
+msgid ""
+"If enabled, this analysis and its results will not be displayed by default "
+"in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
+"Если включено, этот анализ и его результаты по умолчанию не будут "
+"отображаться в отчётах. Может быть переопределено в профиле анализа и/или "
+"образце"
 
 #: bika/lims/content/batch.py:138
 msgid "If no Title value is entered, the Batch ID will be used."
-msgstr ""
+msgstr "Если название не указано, будет использован ID партии."
 
 #: bika/lims/content/batch.py:134
 msgid "If no value is entered, the Batch ID will be auto-generated."
-msgstr ""
+msgstr "Если значение не указано, ID партии будет сгенерирован автоматически."
 
 #: bika/lims/content/method.py:128
-msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
+msgid ""
+"If required, select a calculation for the The analysis services linked to "
+"this method. Calculations can be configured under the calculations item in "
+"the LIMS set-up"
 msgstr ""
+"При необходимости выберите формулу расчёта для услуг анализа, связанных с "
+"этим методом. Формулы расчёта настраиваются в разделе 'Расчёты' настроек "
+"LIMS"
 
 #: senaite/core/content/interpretationtemplate.py:72
-msgid "If set, this interpretation template will only be available for selection on samples from these types"
+msgid ""
+"If set, this interpretation template will only be available for selection on"
+" samples from these types"
 msgstr ""
+"Если задано, этот шаблон интерпретации будет доступен для выбора только для "
+"образцов этих типов"
 
 #: senaite/core/content/interpretationtemplate.py:60
-msgid "If set, this interpretation template will only be available for selection on samples that have assigned any of these analysis templates"
+msgid ""
+"If set, this interpretation template will only be available for selection on"
+" samples that have assigned any of these analysis templates"
 msgstr ""
+"Если задано, этот шаблон интерпретации будет доступен для выбора только для "
+"образцов с одним из этих шаблонов анализа"
 
 #: bika/lims/content/abstractbaseanalysis.py:69
-msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
+msgid ""
+"If text is entered here, it is used instead of the title when the service is"
+" listed in column headings. HTML formatting is allowed."
 msgstr ""
+"Если здесь указан текст, он используется вместо названия в заголовках "
+"столбцов списка услуг. HTML-разметка допускается."
 
 #: senaite/core/exportimport/import.pt:74
-msgid "If the system doesn't find any match (Sample, Reference Analysis or Duplicate), it will use the record's identifier to find matches for Reference Sample IDs. <br /> If a Reference Sample ID is found, the system will automatically create a Calibration Test (Reference Analysis) and will link it to the selected Instrument."
+msgid ""
+"If the system doesn't find any match (Sample, Reference Analysis or "
+"Duplicate), it will use the record's identifier to find matches for "
+"Reference Sample IDs. <br /> If a Reference Sample ID is found, the system "
+"will automatically create a Calibration Test (Reference Analysis) and will "
+"link it to the selected Instrument."
 msgstr ""
+"Если система не находит совпадений (образец, референс-анализ или дубликат), "
+"она использует идентификатор записи для поиска совпадений по ID референс-"
+"образцов. <br /> При обнаружении ID референс-образца система автоматически "
+"создаст калибровочный тест (референс-анализ) и свяжет его с выбранным "
+"инструментом."
 
 #: bika/lims/content/worksheettemplate.py:141
-msgid "If unchecked, Lab Managers won't be able to assign the same Instrument more than one Analyses while creating a Worksheet."
+msgid ""
+"If unchecked, Lab Managers won't be able to assign the same Instrument more "
+"than one Analyses while creating a Worksheet."
 msgstr ""
+"Если не отмечено, менеджеры лаборатории не смогут назначить один и тот же "
+"инструмент более чем одному анализу при создании рабочего листа."
 
 #: bika/lims/content/calculation.py:112
-msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
+msgid ""
+"If your formula needs a special function from an external Python library, "
+"you can import it here. E.g. if you want to use the 'floor' function from "
+"the Python 'math' module, you add 'math' to the Module field and 'floor' to "
+"the function field. The equivalent in Python would be 'from math import "
+"floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
+"Если вашей формуле нужна специальная функция из внешней библиотеки Python, "
+"импортируйте её здесь. Например, чтобы использовать функцию 'floor' из "
+"модуля Python 'math', добавьте 'math' в поле 'Модуль' и 'floor' в поле "
+"'Функция'. В Python это эквивалентно 'from math import floor'. В расчёте "
+"можно использовать 'floor([Ca] + [Mg])'."
 
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:328
 msgid "Immediate results entry"
-msgstr ""
+msgstr "Немедленный ввод результатов"
 
 #: senaite/core/exportimport/import.pt:14
 #: senaite/core/profiles/default/actions.xml
 msgid "Import"
-msgstr ""
+msgstr "Импорт"
 
 #: bika/lims/content/instrument.py:235
 msgid "Import Data Interface"
-msgstr ""
+msgstr "Интерфейс импорта данных"
 
 #: senaite/core/exportimport/instruments/importer.py:548
-msgid "Import finished successfully: {updated_ars} Samples and {updated_results} results updated"
+msgid ""
+"Import finished successfully: {updated_ars} Samples and {updated_results} "
+"results updated"
 msgstr ""
+"Импорт успешно завершён: обновлено образцов — {updated_ars}, результатов — "
+"{updated_results}"
 
 #: senaite/core/exportimport/instruments/importer.py:541
-msgid "Import finished successfully: {updated_ars} Samples, {updated_instruments} Instruments and {updated_results} results updated"
+msgid ""
+"Import finished successfully: {updated_ars} Samples, {updated_instruments} "
+"Instruments and {updated_results} results updated"
 msgstr ""
+"Импорт успешно завершён: обновлено образцов — {updated_ars}, инструментов — "
+"{updated_instruments}, результатов — {updated_results}"
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:59
 msgid "Imported File"
-msgstr ""
+msgstr "Импортированный файл"
 
 #: bika/lims/content/instrument.py:200
 msgid "In-lab calibration procedure"
-msgstr ""
+msgstr "Процедура калибровки в лаборатории"
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:76
+#: senaite/core/browser/controlpanel/labels/view.py:75
 msgid "Inactive"
 msgstr "Неактивные"
 
-#: bika/lims/content/bikasetup.py:241
+#: bika/lims/content/bikasetup.py:240
 msgid "Include and display pricing information"
 msgstr "Включить и отображать информацию о ценах"
 
@@ -2831,51 +3180,58 @@ msgstr "Включить описания"
 
 #: senaite/core/content/supplier.py:170
 msgid "Incorrect IBAN number: %s"
-msgstr ""
+msgstr "Неверный номер IBAN: %s"
 
 #: senaite/core/content/supplier.py:132
 msgid "Incorrect NIB number: %s"
-msgstr ""
+msgstr "Неверный номер NIB: %s"
 
 #: bika/lims/content/analysisrequest.py:1404
 msgid "Indicates if the last SampleReport is printed,"
-msgstr ""
+msgstr "Указывает, был ли распечатан последний отчёт по образцу,"
 
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:22
 msgid "Info"
-msgstr ""
+msgstr "Информация"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Initialize"
-msgstr ""
+msgstr "Инициализировать"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:13
 msgid "Install SENAITE LIMS"
-msgstr ""
+msgstr "Установить SENAITE LIMS"
 
 #: bika/lims/content/instrument.py:356
 msgid "Installation Certificate"
-msgstr ""
+msgstr "Сертификат установки"
 
 #: bika/lims/content/instrument.py:357
 msgid "Installation certificate upload"
-msgstr ""
+msgstr "Загрузка сертификата установки"
 
 #: bika/lims/content/instrument.py:347
 msgid "InstallationDate"
-msgstr ""
+msgstr "Дата установки"
 
 #: bika/lims/content/method.py:77
 msgid "Instructions"
-msgstr ""
+msgstr "Инструкции"
 
 #: bika/lims/content/instrument.py:201
-msgid "Instructions for in-lab regular calibration routines intended for analysts"
+msgid ""
+"Instructions for in-lab regular calibration routines intended for analysts"
 msgstr ""
+"Инструкции для регулярных процедур калибровки в лаборатории, предназначенные"
+" для аналитиков"
 
 #: bika/lims/content/instrument.py:213
-msgid "Instructions for regular preventive and maintenance routines intended for analysts"
+msgid ""
+"Instructions for regular preventive and maintenance routines intended for "
+"analysts"
 msgstr ""
+"Инструкции для регулярных профилактических работ и обслуживания, "
+"предназначенные для аналитиков"
 
 #: senaite/core/browser/modals/analysis/schema.py:78
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:107
@@ -2885,51 +3241,52 @@ msgstr "Инструмент"
 
 #: senaite/core/browser/form/adapters/method.py:74
 msgid "Instrument '{}' is used by service '{}'"
-msgstr ""
+msgstr "Инструмент '{}' используется услугой '{}'"
 
 #: bika/lims/browser/instrument.py:193
 msgid "Instrument Calibrations"
-msgstr ""
+msgstr "Калибровки инструмента"
 
 #: bika/lims/browser/instrument.py:791
 msgid "Instrument Files"
-msgstr ""
+msgstr "Файлы инструмента"
 
 #: senaite/core/exportimport/import.pt:37
 msgid "Instrument Import"
-msgstr ""
+msgstr "Импорт инструмента"
 
 #: senaite/core/profiles/default/types/InstrumentLocation.xml
 msgid "Instrument Location"
-msgstr ""
+msgstr "Расположение инструмента"
 
 #: senaite/core/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
-msgstr ""
+msgstr "Расположения инструментов"
 
 #: bika/lims/browser/instrument.py:65
 msgid "Instrument Maintenance"
-msgstr ""
+msgstr "Обслуживание инструмента"
 
 #: bika/lims/browser/instrument.py:382
 msgid "Instrument Scheduled Tasks"
-msgstr ""
+msgstr "Запланированные задачи инструмента"
 
 #: bika/lims/browser/instrument.py:290
 msgid "Instrument Validations"
-msgstr ""
+msgstr "Валидации инструмента"
 
 #: bika/lims/content/abstractbaseanalysis.py:392
 msgid "Instrument assignment is allowed"
-msgstr ""
+msgstr "Назначение инструмента разрешено"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:35
 msgid "Instrument disabled until successful calibration:"
-msgstr ""
+msgstr "Инструмент отключён до успешной калибровки:"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:54
 msgid "Instrument disposed until new calibration tests being done:"
 msgstr ""
+"Инструмент выведен из эксплуатации до проведения новых калибровочных тестов:"
 
 #: bika/lims/browser/worksheet/views/export.py:53
 msgid "Instrument exporter not found"
@@ -2937,27 +3294,27 @@ msgstr "Экспортер документ не найден"
 
 #: bika/lims/browser/workflow/analysis.py:141
 msgid "Instrument failed reference test"
-msgstr ""
+msgstr "Инструмент не прошёл референс-тест"
 
 #: bika/lims/browser/worksheet/views/export.py:40
 msgid "Instrument has no data interface selected"
-msgstr ""
+msgstr "У инструмента не выбран интерфейс данных"
 
 #: senaite/core/browser/form/adapters/data_import.py:96
 msgid "Instrument import finished"
-msgstr ""
+msgstr "Импорт инструмента завершён"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:92
 msgid "Instrument in calibration progress:"
-msgstr ""
+msgstr "Инструмент в процессе калибровки:"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:73
 msgid "Instrument in validation progress:"
-msgstr ""
+msgstr "Инструмент в процессе валидации:"
 
 #: senaite/core/exportimport/instruments/importer.py:402
 msgid "Instrument not found"
-msgstr ""
+msgstr "Инструмент не найден"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:16
 msgid "Instrument's calibration certificate expired:"
@@ -2965,11 +3322,11 @@ msgstr "Сертификат калибровки прибора истек:"
 
 #: senaite/core/profiles/default/types/InstrumentType.xml
 msgid "InstrumentType"
-msgstr ""
+msgstr "Тип инструмента"
 
 #: senaite/core/profiles/default/types/InstrumentTypes.xml
 msgid "InstrumentTypes"
-msgstr ""
+msgstr "Типы инструментов"
 
 #: senaite/core/profiles/default/types/InstrumentLocation.xml
 #: senaite/core/profiles/default/types/InstrumentType.xml
@@ -2978,92 +3335,101 @@ msgid "Instruments"
 msgstr "Оборудование"
 
 #: senaite/core/exportimport/import.pt:162
-msgid "Instruments can be configured with one or multiple import data interfaces."
+msgid ""
+"Instruments can be configured with one or multiple import data interfaces."
 msgstr ""
+"Для инструментов можно настроить один или несколько интерфейсов импорта "
+"данных."
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:39
 msgid "Instruments disabled until successful calibration:"
-msgstr ""
+msgstr "Инструменты отключены до успешной калибровки:"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:58
 msgid "Instruments disposed until new calibration tests being done:"
 msgstr ""
+"Инструменты выведены из эксплуатации до проведения новых калибровочных "
+"тестов:"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:96
 msgid "Instruments in calibration progress:"
-msgstr ""
+msgstr "Инструменты в процессе калибровки:"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:77
 msgid "Instruments in validation progress:"
-msgstr ""
+msgstr "Инструменты в процессе валидации:"
 
 #: bika/lims/content/method.py:103
 msgid "Instruments supporting this method"
-msgstr ""
+msgstr "Инструменты, поддерживающие этот метод"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:20
 msgid "Instruments' calibration certificates expired:"
-msgstr ""
+msgstr "Истёк срок сертификатов калибровки инструментов:"
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:55
 msgid "Interface"
-msgstr ""
+msgstr "Интерфейс"
 
 #: bika/lims/browser/instrument.py:494
 msgid "Internal Calibration Tests"
-msgstr ""
+msgstr "Внутренние калибровочные тесты"
 
 #: bika/lims/content/instrumentcertification.py:84
 msgid "Internal Certificate"
 msgstr "Внутренний сертификат "
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:746
+#: senaite/core/browser/samples/view.py:608
 msgid "Internal use"
-msgstr ""
+msgstr "Для внутреннего использования"
 
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:42
 #: bika/lims/browser/templates/referencesample_analyses.pt:40
 msgid "Interpolation"
-msgstr ""
+msgstr "Интерполяция"
 
 #: senaite/core/profiles/default/types/InterpretationTemplate.xml
 msgid "Interpretation Template"
-msgstr ""
+msgstr "Шаблон интерпретации"
 
 #: senaite/core/profiles/default/types/InterpretationTemplates.xml
 msgid "Interpretation Templates"
-msgstr ""
+msgstr "Шаблоны интерпретации"
 
 #: bika/lims/content/instrumentcertification.py:110
 msgid "Interval"
-msgstr ""
+msgstr "Интервал"
 
-#: senaite/core/browser/dashboard/dashboard.py:168
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:137
+#: senaite/core/browser/samples/view.py:383
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
 msgstr "Недействительный"
 
-#: senaite/core/content/senaitesetup.py:1444
+#: senaite/core/content/senaitesetup.py:1417
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
-msgstr ""
+msgstr "Неверный формат ID в строке ${i} ('${pt}'): ${err}"
 
 #: senaite/core/content/person.py:236
 msgid "Invalid email address"
-msgstr ""
+msgstr "Неверный адрес email"
 
 #: senaite/core/content/dynamicanalysisspec.py:65
-msgid "Invalid specifications file detected. Please upload an Excel spreadsheet with at least the following columns defined: '{}', "
+msgid ""
+"Invalid specifications file detected. Please upload an Excel spreadsheet "
+"with at least the following columns defined: '{}', "
 msgstr ""
+"Обнаружен неверный файл спецификаций. Загрузите таблицу Excel как минимум со"
+" следующими столбцами: '{}', "
 
 #: bika/lims/validators.py:1324
 msgid "Invalid value: Please enter a value without spaces."
-msgstr ""
+msgstr "Неверное значение: введите значение без пробелов."
 
 #: bika/lims/validators.py:528
 msgid "Invalid wildcards found: ${wildcards}"
-msgstr ""
+msgstr "Обнаружены неверные шаблоны подстановки: ${wildcards}"
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:152
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
@@ -3072,21 +3438,21 @@ msgstr "Недействительный"
 
 #: bika/lims/browser/workflow/analysisrequest.py:162
 msgid "Invalidated items: {}"
-msgstr ""
+msgstr "Аннулированные элементы: {}"
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:90
 msgid "Invalidation reason"
-msgstr ""
+msgstr "Причина аннулирования"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:18
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 #: bika/lims/profiles/default/types/Invoice.xml
 msgid "Invoice"
-msgstr ""
+msgstr "Счёт"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:55
 msgid "Invoice Date"
-msgstr ""
+msgstr "Дата счёта"
 
 #: bika/lims/content/analysisrequest.py:973
 msgid "Invoice Exclude"
@@ -3094,43 +3460,43 @@ msgstr "Исключить счета"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:44
 msgid "Invoice ID"
-msgstr ""
+msgstr "ID счёта"
 
 #: bika/lims/content/invoice.py:41
 msgid "Invoice PDF"
-msgstr ""
+msgstr "PDF счёта"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:35
 msgid "Invoice To"
-msgstr ""
+msgstr "Счёт для"
 
 #: bika/lims/browser/analysisrequest/invoice.py:187
 msgid "Invoice {} created"
-msgstr ""
+msgstr "Счёт {} создан"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2427
+#: senaite/core/exportimport/setupdata/__init__.py:2426
 msgid "InvoiceBatch has no End Date"
-msgstr ""
+msgstr "У пакета счетов не задана дата окончания"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2424
+#: senaite/core/exportimport/setupdata/__init__.py:2423
 msgid "InvoiceBatch has no Start Date"
-msgstr ""
+msgstr "У пакета счетов не задана дата начала"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2421
+#: senaite/core/exportimport/setupdata/__init__.py:2420
 msgid "InvoiceBatch has no Title"
-msgstr ""
+msgstr "У пакета счетов не задано название"
 
 #: senaite/core/config/widgets.py:60
 msgid "Job Title"
-msgstr ""
+msgstr "Должность"
 
 #: bika/lims/content/person.py:141
 msgid "Job title"
 msgstr "Название должности"
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:753
 msgid "Keep order above"
-msgstr ""
+msgstr "Сохранить порядок выше"
 
 #: bika/lims/content/instrument.py:287
 msgid "Key"
@@ -3138,40 +3504,37 @@ msgstr "Ключ"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:98
 msgid "Key <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Ключ <span class=\"sort-indicator\" />"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
 msgstr "Ключевое слово"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:51
 msgid "Keyword is used in active analyses and can not be changed anymore"
 msgstr ""
+"Ключевое слово используется в активных анализах и больше не может быть "
+"изменено"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:187
 msgid "Keyword required"
-msgstr ""
+msgstr "Требуется ключевое слово"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
 msgstr "Ключевые слова"
 
-#: senaite/core/browser/samples/view.py:249
-msgid "Keywords of the analyses contained in the sample"
-msgstr ""
-
 #: bika/lims/browser/templates/analysisservice_info.pt:100
-#: bika/lims/config.py:52
-#: bika/lims/content/analysisspec.py:142
+#: bika/lims/config.py:52 bika/lims/content/analysisspec.py:142
 msgid "Lab"
 msgstr "Лаборатория"
 
 #: bika/lims/content/supplier.py:98
 msgid "Lab Account Number"
-msgstr ""
+msgstr "Номер лабораторного счёта"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:134
 msgid "Lab Analyses"
@@ -3192,11 +3555,11 @@ msgstr "Лаборатория: Департаменты"
 
 #: bika/lims/config.py:57
 msgid "Lab Preservation"
-msgstr ""
+msgstr "Лабораторное сохранение"
 
 #: senaite/core/profiles/default/types/LabProduct.xml
 msgid "Lab Product"
-msgstr ""
+msgstr "Услуга лаборатории"
 
 #: senaite/core/profiles/default/types/LabProducts.xml
 msgid "Lab Products"
@@ -3206,33 +3569,32 @@ msgstr "Лаборатория: Расходные матриалы"
 msgid "Lab URL"
 msgstr "URL-адрес лаборатории"
 
-#: senaite/core/behaviors/label.py:115
-#: senaite/core/extender/label.py:80
+#: senaite/core/behaviors/label.py:107 senaite/core/extender/label.py:76
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
-msgstr ""
+msgstr "Метка"
 
 #: senaite/core/registry/schema.py:69
 msgid "Label configuration"
-msgstr ""
+msgstr "Настройка меток"
 
-#: senaite/core/content/label.py:93
+#: senaite/core/content/label.py:65
 msgid "Label names must be unique"
-msgstr ""
+msgstr "Названия меток должны быть уникальными"
 
 #: senaite/core/behaviors/configure.zcml:60
 msgid "Label schema extender"
-msgstr ""
+msgstr "Расширитель схемы меток"
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:50
 msgid "Labeled Objects"
-msgstr ""
+msgstr "Объекты с метками"
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
-#: senaite/core/browser/label/labeled_objects.py:66
-#: senaite/core/browser/samples/view.py:875
+#: senaite/core/browser/controlpanel/labels/view.py:51
+#: senaite/core/browser/label/labeled_objects.py:65
+#: senaite/core/extender/label.py:57
 msgid "Labels"
-msgstr ""
+msgstr "Метки"
 
 #: senaite/core/content/laboratory.py:244
 #: senaite/core/profiles/default/types/Laboratory.xml
@@ -3243,35 +3605,35 @@ msgstr "Лаборатория"
 msgid "Laboratory Accredited"
 msgstr "Аккредитованные лаборатории"
 
-#: senaite/core/content/senaitesetup.py:1046
+#: senaite/core/content/senaitesetup.py:1023
 msgid "Laboratory Workdays"
-msgstr ""
+msgstr "Рабочие дни лаборатории"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:74
 msgid "Language"
-msgstr ""
+msgstr "Язык"
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Large Sticker"
 msgstr "Большой стикер"
 
-#: senaite/core/content/senaitesetup.py:1173
+#: senaite/core/content/senaitesetup.py:1150
 msgid "Large Sticker Template"
-msgstr ""
+msgstr "Шаблон большого стикера"
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:42
 msgid "Last Auto-Import Logs"
-msgstr ""
+msgstr "Последние журналы автоимпорта"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:97
 msgid "Last Login Time"
-msgstr ""
+msgstr "Время последнего входа"
 
-#: senaite/core/browser/samples/view.py:469
+#: senaite/core/browser/samples/view.py:439
 msgid "Late"
 msgstr "Отложить"
 
-#: senaite/core/browser/samples/view.py:731
+#: senaite/core/browser/samples/view.py:593
 msgid "Late Analyses"
 msgstr "Отложенные анализы"
 
@@ -3285,49 +3647,61 @@ msgstr "Широта"
 
 #: senaite/core/schema/gpscoordinatesfield.py:103
 msgid "Latitude must be within -90 and 90 degrees"
-msgstr ""
+msgstr "Широта должна быть в пределах от -90 до 90 градусов"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:104
 msgid "Layout"
-msgstr ""
+msgstr "Макет"
 
 #: bika/lims/browser/worksheet/views/results.py:68
 msgid "Layout view '{}' not found. Set '{}' as layout view."
 msgstr ""
+"Представление макета '{}' не найдено. Установлено '{}' как представление "
+"макета."
 
 #: senaite/core/browser/viewlets/setup_legacy_link.py:63
 msgid "Legacy LIMS Setup"
-msgstr ""
+msgstr "Устаревшие настройки LIMS"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:153
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:120
-msgid "Legend: Results in <em>italic</em> font are pending, results in <strong>bold</strong> font are verified."
+msgid ""
+"Legend: Results in <em>italic</em> font are pending, results in "
+"<strong>bold</strong> font are verified."
 msgstr ""
+"Легенда: результаты <em>курсивом</em> — в ожидании, результаты "
+"<strong>жирным</strong> — верифицированы."
 
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:46
 #: bika/lims/browser/templates/referencesample_analyses.pt:44
 msgid "Linear"
-msgstr ""
+msgstr "Линейный"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:203
 msgid "Link User"
-msgstr ""
+msgstr "Связать пользователя"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:144
 msgid "Link an existing User"
-msgstr ""
+msgstr "Связать существующего пользователя"
 
-#: senaite/core/browser/label/labeled_objects.py:52
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "List all objects with labels"
-msgstr ""
+msgstr "Список всех объектов с метками"
 
-#: bika/lims/content/abstractbaseanalysis.py:739
-msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
+#: bika/lims/content/abstractbaseanalysis.py:736
+msgid ""
+"List of possible final results. When set, no custom result is allowed on "
+"results entry and user has to choose from these values"
 msgstr ""
+"Список возможных итоговых результатов. Если задан, произвольный результат "
+"при вводе не допускается — пользователь должен выбрать из этих значений"
 
-#: bika/lims/content/bikasetup.py:1203
+#: bika/lims/content/bikasetup.py:1202
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
+"Список предопределённых причин отклонения. Укажите по одной причине на "
+"строку."
 
 #: senaite/core/exportimport/import.pt:47
 msgid "Load Setup Data"
@@ -3339,52 +3713,44 @@ msgstr "Загрузить документы, описывающие метод
 
 #: senaite/core/exportimport/import.pt:121
 msgid "Load from file"
-msgstr ""
+msgstr "Загрузить из файла"
 
 #: bika/lims/content/instrumentcertification.py:195
 msgid "Load the certificate document here"
-msgstr ""
+msgstr "Загрузите документ сертификата здесь"
 
 # senaite.core: Sidebar loading state
 msgid "Loading navigation..."
-msgstr ""
+msgstr "Загрузка навигации..."
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:41
+#: senaite/core/browser/dashboard/templates/dashboard.pt:40
 msgid "Loading..."
-msgstr ""
+msgstr "Загрузка..."
 
 #: senaite/core/browser/clients/client/attachments/view.py:79
 #: senaite/core/browser/controlpanel/contacts/view.py:70
 msgid "Location"
-msgstr ""
+msgstr "Местоположение"
 
 #: bika/lims/content/storagelocation.py:58
 msgid "Location Code"
-msgstr ""
+msgstr "Код местоположения"
 
 #: bika/lims/content/storagelocation.py:63
 msgid "Location Description"
-msgstr ""
+msgstr "Описание местоположения"
 
 #: bika/lims/content/storagelocation.py:53
 msgid "Location Title"
-msgstr ""
+msgstr "Название местоположения"
 
 #: bika/lims/content/storagelocation.py:68
 msgid "Location Type"
-msgstr ""
+msgstr "Тип местоположения"
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
-msgstr ""
-
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-msgid "Lock"
-msgstr ""
-
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-msgid "Locked"
-msgstr ""
+msgstr "Место хранения комплекта документов"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
@@ -3401,7 +3767,7 @@ msgstr "Долгота"
 
 #: senaite/core/schema/gpscoordinatesfield.py:110
 msgid "Longitude must be within -180 and 180 degrees"
-msgstr ""
+msgstr "Долгота должна быть в пределах от -180 до 180 градусов"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:62
@@ -3411,11 +3777,11 @@ msgstr "Номер лота"
 
 #: bika/lims/config.py:142
 msgid "Low"
-msgstr ""
+msgstr "Низкий"
 
 #: bika/lims/config.py:143
 msgid "Lowest"
-msgstr ""
+msgstr "Наименьший"
 
 #: bika/lims/config.py:82
 msgid "Mailing address"
@@ -3424,7 +3790,7 @@ msgstr "Почтовый адрес"
 #: bika/lims/browser/instrument.py:89
 #: bika/lims/content/instrumentmaintenancetask.py:83
 msgid "Maintainer"
-msgstr ""
+msgstr "Ответственный за обслуживание"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Maintenance"
@@ -3433,11 +3799,11 @@ msgstr "Обслуживание"
 #. Default: "Type"
 #: bika/lims/content/instrumentmaintenancetask.py:55
 msgid "Maintenance type"
-msgstr ""
+msgstr "Тип"
 
 #: bika/lims/content/abstractbaseanalysis.py:349
 msgid "Make attachments mandatory for verification"
-msgstr ""
+msgstr "Сделать вложения обязательными для верификации"
 
 #: bika/lims/config.py:76
 msgid "Male"
@@ -3446,19 +3812,19 @@ msgstr "Мужской"
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:14
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Manage Analyses"
-msgstr ""
+msgstr "Управление анализами"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
 msgid "Manage Form Fields"
-msgstr ""
+msgstr "Управление полями формы"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:12
 msgid "Manage Number Generator"
-msgstr ""
+msgstr "Управление генератором номеров"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:21
 msgid "Manage Partitions"
-msgstr ""
+msgstr "Управление партициями"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Manage Results"
@@ -3466,23 +3832,27 @@ msgstr "Управление результатами"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:10
 msgid "Manage Sample Form Fields"
-msgstr ""
+msgstr "Управление полями формы образца"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:41
 msgid "Manage linked User"
-msgstr ""
+msgstr "Управление связанным пользователем"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
 msgid "Manage sample fields"
-msgstr ""
+msgstr "Управление полями образца"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add_manage.pt:38
-msgid "Manage the order and visibility of the fields displayed in analysis request add forms."
+msgid ""
+"Manage the order and visibility of the fields displayed in analysis request "
+"add forms."
 msgstr ""
+"Управление порядком и видимостью полей, отображаемых в формах добавления "
+"заявки на анализ."
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:16
 msgid "Manage the order and visibility of the sample fields."
-msgstr ""
+msgstr "Управление порядком и видимостью полей образца."
 
 #: senaite/core/browser/controlpanel/departments/view.py:75
 msgid "Manager"
@@ -3496,22 +3866,22 @@ msgstr "электронная почта менеджера"
 msgid "Manager Phone"
 msgstr "Телефон менеджера"
 
-#: bika/lims/browser/analyses/view.py:1163
+#: bika/lims/browser/analyses/view.py:1162
 msgid "Manual"
-msgstr ""
+msgstr "Вручную"
 
 #: bika/lims/content/abstractbaseanalysis.py:378
 #: bika/lims/content/method.py:148
 msgid "Manual entry of results"
-msgstr ""
+msgstr "Ручной ввод результатов"
 
 #: bika/lims/browser/publish/reports_listing.py:161
 msgid "Manually publish all contained samples of the selected reports."
-msgstr ""
+msgstr "Вручную опубликовать все образцы, содержащиеся в выбранных отчётах."
 
 #: senaite/core/exportimport/import.pt:192
 msgid "Manually trigger auto import"
-msgstr ""
+msgstr "Запустить автоимпорт вручную"
 
 #: senaite/core/profiles/default/types/Manufacturer.xml
 msgid "Manufacturer"
@@ -3522,10 +3892,14 @@ msgid "Manufacturers"
 msgstr "Производители"
 
 #: bika/lims/content/analysisrequest.py:1417
-msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
+msgid ""
+"Mark the sample for internal use only. This means it is only accessible to "
+"lab personnel and not to clients."
 msgstr ""
+"Отметить образец только для внутреннего использования. Это означает, что он "
+"доступен только персоналу лаборатории, но не клиентам."
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:97
+#: bika/lims/browser/analysisrequest/manage_analyses.py:94
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
@@ -3538,25 +3912,29 @@ msgstr "Максимальное время"
 #: bika/lims/browser/fields/resultrangefield.py:36
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:121
 msgid "Max operator"
-msgstr ""
+msgstr "Оператор максимума"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:95
+#: bika/lims/browser/analysisrequest/manage_analyses.py:92
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
-msgstr ""
+msgstr "Предупр. максимум"
 
 #: senaite/core/content/samplecontainer.py:79
 msgid "Maximum possible size or volume of samples"
-msgstr ""
+msgstr "Максимально возможный размер или объём образцов"
 
 #: bika/lims/content/container.py:75
 msgid "Maximum possible size or volume of samples."
 msgstr "Максимально возможный размер или количество образцов."
 
 #: bika/lims/content/abstractbaseanalysis.py:443
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgid ""
+"Maximum time allowed for completion of the analysis. A late analysis alert "
+"is raised when this period elapses"
 msgstr ""
+"Максимально допустимое время выполнения анализа. По истечении этого срока "
+"формируется предупреждение о просрочке"
 
 #: bika/lims/content/abstractbaseanalysis.py:442
 msgid "Maximum turn-around time"
@@ -3564,36 +3942,36 @@ msgstr "Максимальное время"
 
 #: bika/lims/config.py:141
 msgid "Medium"
-msgstr ""
+msgstr "Средний"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:153
 msgid "Meet the community, browse the code and get support on"
-msgstr ""
+msgstr "Познакомьтесь с сообществом, изучите код и получите поддержку на"
 
 #: bika/lims/browser/clientfolder.py:94
 msgid "Member Discount"
-msgstr ""
+msgstr "Скидка для участников"
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:281
 msgid "Member discount %"
 msgstr "Членская скидка %"
 
-#: bika/lims/content/client.py:87
+#: bika/lims/content/client.py:83
 msgid "Member discount applies"
 msgstr "Член скидка распространяется"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:329
+#: senaite/core/browser/clients/client/contacts/login_details.py:318
 msgid "Member registered and linked to the current Contact."
-msgstr ""
+msgstr "Участник зарегистрирован и связан с текущим контактом."
 
 #: bika/lims/browser/publish/emailview.py:146
 msgid "Message sent to {}, "
-msgstr ""
+msgstr "Сообщение отправлено на {}, "
 
-#: senaite/core/content/resultsreport.py:218
+#: senaite/core/content/resultsreport.py:217
 msgid "Metadata"
-msgstr ""
+msgstr "Метаданные"
 
 #: senaite/core/browser/modals/analysis/schema.py:69
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:103
@@ -3606,7 +3984,7 @@ msgstr "Документация к методу"
 
 #: bika/lims/content/method.py:56
 msgid "Method ID"
-msgstr ""
+msgstr "ID метода"
 
 #: bika/lims/browser/methodfolder.py:48
 #: bika/lims/browser/templates/analysisservice_info.pt:119
@@ -3616,28 +3994,28 @@ msgstr "Методы"
 
 #: bika/lims/content/person.py:59
 msgid "Middle initial"
-msgstr ""
+msgstr "Отчество (инициал)"
 
 #: bika/lims/content/person.py:67
 msgid "Middle name"
-msgstr ""
+msgstr "Отчество"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:93
+#: bika/lims/browser/analysisrequest/manage_analyses.py:90
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
-msgstr ""
+msgstr "Минимум"
 
 #: bika/lims/browser/fields/resultrangefield.py:34
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:106
 msgid "Min operator"
-msgstr ""
+msgstr "Оператор минимума"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:91
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
-msgstr ""
+msgstr "Предупр. минимум"
 
 #: bika/lims/browser/worksheet/views/folder.py:183
 msgid "Mine"
@@ -3649,11 +4027,12 @@ msgstr "Минимум 5 символов."
 
 #: bika/lims/content/sampletype.py:165
 msgid "Minimum Volume"
-msgstr ""
+msgstr "Минимальный объём"
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:339
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
+"Минимальное количество результатов для расчёта статистики контроля качества"
 
 #: bika/lims/browser/fields/coordinatefield.py:37
 #: bika/lims/browser/fields/durationfield.py:38
@@ -3667,7 +4046,7 @@ msgstr "Телефон мобильный"
 #: senaite/core/browser/clients/client/contacts/view.py:80
 #: senaite/core/browser/controlpanel/contacts/view.py:68
 msgid "MobilePhone"
-msgstr ""
+msgstr "Мобильный телефон"
 
 #: bika/lims/content/instrument.py:137
 #: bika/lims/controlpanel/bika_instruments.py:84
@@ -3676,347 +4055,346 @@ msgstr "Модель"
 
 #: bika/lims/content/calculation.py:100
 msgid "Module"
-msgstr ""
+msgstr "Модуль"
 
 #: senaite/core/vocabularies/setup.py:156
 msgid "Monday"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:137
-msgid "Monthly"
-msgstr ""
+msgstr "Понедельник"
 
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
-msgstr ""
+msgstr "Найдено более одного анализа для {sid} и ключевого слова '{keyword}'"
 
 #: senaite/core/behaviors/configure.zcml:26
 msgid "Multi Catalog Behavior for Dexterity Contents"
-msgstr ""
+msgstr "Поведение мультикаталога для содержимого Dexterity"
 
 #: senaite/core/browser/samples/multi_results_transposed.py:66
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Multi Results"
-msgstr ""
+msgstr "Несколько результатов"
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:528
 msgid "Multi Verification type"
-msgstr ""
+msgstr "Тип многократной верификации"
 
-#: bika/lims/browser/analyses/view.py:1586
+#: bika/lims/browser/analyses/view.py:1585
 msgid "Multi-verification required"
-msgstr ""
+msgstr "Требуется многократная верификация"
 
 #: senaite/core/profiles/default/types/Multifile.xml
 msgid "Multifile"
-msgstr ""
+msgstr "Мультифайл"
 
 #: senaite/core/config/vocabularies.py:60
 msgid "Multiple choices"
-msgstr ""
+msgstr "Множественный выбор"
 
 #: senaite/core/config/vocabularies.py:58
 msgid "Multiple selection"
-msgstr ""
+msgstr "Множественный выбор"
 
 #: senaite/core/config/vocabularies.py:59
 msgid "Multiple selection (with duplicates)"
-msgstr ""
+msgstr "Множественный выбор (с повторами)"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:108
 msgid "Multiple values"
-msgstr ""
+msgstr "Несколько значений"
 
 #: bika/lims/validators.py:469
 msgid "Multiple values control type is not supported for choices"
 msgstr ""
+"Тип контроля 'несколько значений' не поддерживается для вариантов выбора"
 
 #: senaite/core/profiles/default/actions.xml
 msgid "My Organization"
-msgstr ""
+msgstr "Моя организация"
 
 #: senaite/core/profiles/default/actions.xml
 msgid "My Profile"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — default name when saving
-msgid "My filter"
-msgstr ""
+msgstr "Мой профиль"
 
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
-msgstr ""
+msgstr "NIB"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
-#: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:146
+#: senaite/core/config/widgets.py:32 senaite/core/content/contact.py:114
 msgid "Name"
 msgstr "Имя"
 
 #: senaite/core/browser/viewlets/setup_legacy_link.py:67
 msgid "New LIMS Setup"
-msgstr ""
+msgstr "Новые настройки LIMS"
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
-msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgid ""
+"New ranges won't be applied to neither new nor current analyses. Re-assign "
+"the Specification if you want to apply latest changes."
 msgstr ""
-
-#: senaite/core/api/remarks.py:490
-msgid "Newest first"
-msgstr ""
+"Новые диапазоны не будут применены ни к новым, ни к текущим анализам. "
+"Переназначьте спецификацию, чтобы применить последние изменения."
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
 msgid "Next ID <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Следующий ID <span class=\"sort-indicator\" />"
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:168
 #: senaite/core/browser/widgets/services_widget.py:305
 #: senaite/core/skins/senaite_templates/senaite_widgets/rejectionwidget.pt:9
 msgid "No"
-msgstr ""
+msgstr "Нет"
 
 #: senaite/core/exportimport/instruments/eltra/cs/cs2000.py:51
 msgid "No Analysis Services defined"
-msgstr ""
+msgstr "Не определены услуги анализа"
 
 #: bika/lims/browser/publish/templates/email.pt:70
 msgid "No Email Address"
-msgstr ""
+msgstr "Нет адреса email"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:43
 msgid "No Method selected for this Service"
-msgstr ""
+msgstr "Для этой услуги не выбран метод"
 
 #: senaite/core/exportimport/instruments/importer.py:415
 msgid "No Sample found for {sid}"
-msgstr ""
+msgstr "Образец не найден для {sid}"
 
 #: senaite/core/exportimport/instruments/importer.py:403
-msgid "No Sample with '{allowed_ar_states}' statesfound, and no QC analyses found for {sid}, "
+msgid ""
+"No Sample with '{allowed_ar_states}' statesfound, and no QC analyses found "
+"for {sid}, "
 msgstr ""
+"Не найдено образцов со статусами '{allowed_ar_states}', а также анализов "
+"контроля качества для {sid}, "
 
 #: bika/lims/browser/analysisrequest/add2.py:2189
 msgid "No Samples could be created."
-msgstr ""
+msgstr "Не удалось создать образцы."
 
 #: bika/lims/browser/batch/batchbook.py:175
 msgid "No Subgroup"
-msgstr ""
+msgstr "Без подгруппы"
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:131
-msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
-msgstr ""
+msgstr "Действие не определено."
 
 #: senaite/core/exportimport/instruments/importer.py:458
 msgid "No analyses found for {sid} and keyword '{keyword}'"
-msgstr ""
+msgstr "Не найдено анализов для {sid} и ключевого слова '{keyword}'"
 
 #: senaite/core/exportimport/instruments/importer.py:434
 msgid "No analyses found for {sid} in the states '{allowed_sample_states}' , "
-msgstr ""
+msgstr "Не найдено анализов для {sid} в статусах '{allowed_sample_states}', "
 
 #: bika/lims/browser/worksheet/views/add_worksheet.py:75
 msgid "No analyses were added"
-msgstr ""
+msgstr "Анализы не были добавлены"
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:152
 msgid "No analyses were added to this worksheet."
-msgstr ""
+msgstr "В этот рабочий лист не были добавлены анализы."
 
 #: senaite/core/browser/attachment/attachment.py:219
 msgid "No analysis found for service '{}'"
-msgstr ""
+msgstr "Не найдено анализов для услуги '{}'"
 
 #: senaite/core/exportimport/instruments/biodrop/ulite/ulite.py:53
 #: senaite/core/exportimport/instruments/lifetechnologies/qubit/qubit.py:54
 msgid "No analysis selected"
-msgstr ""
+msgstr "Анализ не выбран"
 
 #: senaite/core/exportimport/instruments/thermoscientific/multiskan/go.py:51
 msgid "No analysis service selected"
-msgstr ""
+msgstr "Услуга анализа не выбрана"
 
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:27
 msgid "No analysis services were selected."
-msgstr ""
+msgstr "Услуги анализа не были выбраны."
 
 #: senaite/core/browser/idserver/view.py:135
 msgid "No changes"
-msgstr ""
+msgstr "Без изменений"
 
 #: senaite/core/browser/workflow/worksheet.py:50
 msgid "No changes made"
-msgstr ""
+msgstr "Изменения не внесены"
 
 #: bika/lims/browser/workflow/__init__.py:166
 #: bika/lims/browser/workflow/analysisrequest.py:94
 msgid "No changes made."
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:130
-msgid "No data for the selected period"
-msgstr ""
+msgstr "Изменения не внесены."
 
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
-msgstr ""
+msgstr "Дата не задана"
 
 #: bika/lims/browser/workflow/analysisrequest.py:435
 msgid "No duplicate created"
-msgstr ""
+msgstr "Дубликат не создан"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:135
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:138
 msgid "No email recipients available for this sample"
-msgstr ""
+msgstr "Нет доступных получателей email для этого образца"
 
 #: bika/lims/browser/publish/emailview.py:167
 msgid "No email recipients selected"
-msgstr ""
+msgstr "Не выбраны получатели email"
 
 #: senaite/core/exportimport/instruments/abaxis/vetscan/vs2.py:47
 #: senaite/core/exportimport/instruments/abbott/m2000rt/m2000rt.py:59
 #: senaite/core/exportimport/instruments/alere/pima/beads.py:47
 msgid "No file selected"
-msgstr ""
+msgstr "Файл не выбран"
 
 #: senaite/core/browser/form/adapters/data_import.py:81
 msgid "No importer not found for interface '{}'"
-msgstr ""
+msgstr "Не найден импортёр для интерфейса '{}'"
 
 #: senaite/core/browser/form/adapters/data_import.py:126
 msgid "No instrument import interfaces available for {}"
-msgstr ""
+msgstr "Нет доступных интерфейсов импорта инструмента для {}"
 
 #: bika/lims/browser/workflow/client.py:120
 msgid "No items published"
-msgstr ""
+msgstr "Ничего не опубликовано"
 
 #: senaite/core/browser/samples/partition_magic.py:64
 #: senaite/core/browser/samples/rejection/reject_samples.py:78
 msgid "No items selected"
-msgstr ""
+msgstr "Ничего не выбрано"
 
 #: bika/lims/browser/workflow/__init__.py:129
 msgid "No items selected."
-msgstr ""
-
-# senaite.app.listing: Column config — empty state for hidden section with
-# search
-msgid "No matches in hidden columns."
-msgstr ""
-
-# senaite.app.listing: Column config — empty state for visible section with
-# search
-msgid "No matches in visible columns."
-msgstr ""
+msgstr "Ничего не выбрано."
 
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
-msgstr ""
+msgstr "Новые элементы не были созданы."
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
-msgstr ""
-
-#: senaite/core/api/remarks.py:493
-msgid "No remarks yet"
-msgstr ""
+msgstr "Партиции не были созданы"
 
 #: bika/lims/browser/publish/emailview.py:176
 msgid "No reports found"
-msgstr ""
+msgstr "Отчёты не найдены"
 
 #: senaite/core/browser/samples/invalidate_samples.py:110
-msgid "No samples were invalidated. Please ensure samples are selected and meet the criteria for invalidation."
+msgid ""
+"No samples were invalidated. Please ensure samples are selected and meet the"
+" criteria for invalidation."
 msgstr ""
+"Образцы не были аннулированы. Убедитесь, что образцы выбраны и соответствуют"
+" критериям аннулирования."
 
 #: senaite/core/browser/samples/rejection/reject_samples.py:112
 msgid "No samples were rejected"
-msgstr ""
+msgstr "Образцы не были отклонены"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — empty state
-msgid "No saved filters yet."
-msgstr ""
+msgstr "Без процесса отбора проб"
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
-msgstr ""
+msgstr "Не найдено услуг для разобранных ключевых слов"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:133
-msgid "No user exists for ${contact_fullname} and they will not be able to log in. Fill in the form below to create one for them."
+msgid ""
+"No user exists for ${contact_fullname} and they will not be able to log in. "
+"Fill in the form below to create one for them."
 msgstr ""
+"Для ${contact_fullname} не существует пользователя, и вход в систему "
+"невозможен. Заполните форму ниже, чтобы создать его."
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:49
-msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
+msgid ""
+"No user profile could be found for the linked user. Please contact the lab "
+"administrator to get further support or try to relink the user."
 msgstr ""
+"Профиль связанного пользователя не найден. Обратитесь к администратору "
+"лаборатории за поддержкой или попробуйте пересвязать пользователя."
 
 #: bika/lims/browser/analysisrequest/add2.py:2057
 msgid "No valid contact"
-msgstr ""
+msgstr "Нет действительного контакта"
 
 #: bika/lims/validators.py:448
-msgid "No valid format in choices field. Supported format is: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
+msgid ""
+"No valid format in choices field. Supported format is: "
+"<value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 msgstr ""
+"Неверный формат поля выбора. Поддерживаемый формат: "
+"<value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:115
 msgid "No visible analyses for this sample"
-msgstr ""
+msgstr "Нет видимых анализов для этого образца"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1141
+#: senaite/core/content/senaitesetup.py:1118
 msgid "None"
-msgstr ""
+msgstr "Нет"
 
 #: bika/lims/browser/publish/emailview.py:216
-msgid "Not all contacts are equal for the selected Reports. Please manually select recipients for this email."
+msgid ""
+"Not all contacts are equal for the selected Reports. Please manually select "
+"recipients for this email."
 msgstr ""
+"Контакты для выбранных отчётов не совпадают. Выберите получателей для этого "
+"письма вручную."
 
 #: senaite/core/browser/modals/conditions.py:133
 msgid "Not allowed to update conditions: {}"
-msgstr ""
+msgstr "Обновление условий не разрешено: {}"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:86
 msgid "Not defined"
-msgstr ""
+msgstr "Не определено"
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:565
 msgid "Not printed"
-msgstr ""
+msgstr "Не напечатано"
 
-#: bika/lims/api/snapshot.py:611
+#: bika/lims/api/snapshot.py:433
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
-msgstr ""
+msgstr "Не задано"
 
 #: bika/lims/content/worksheet.py:291
 msgid "Not specified"
-msgstr ""
+msgstr "Не указано"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add_manage.pt:42
-msgid "Note: The settings apply to all Sample Add forms; Required fields can not be deselected."
+msgid ""
+"Note: The settings apply to all Sample Add forms; Required fields can not be"
+" deselected."
 msgstr ""
+"Примечание: настройки применяются ко всем формам добавления образца; "
+"обязательные поля нельзя снять с выбора."
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:19
 msgid "Note: The settings are global and apply to all sample views."
 msgstr ""
+"Примечание: настройки глобальны и применяются ко всем просмотрам образцов."
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:168
-msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
+msgid ""
+"Note: You can also drag and drop the attachment rows to change the order "
+"they appear in the report."
 msgstr ""
+"Примечание: вы также можете перетаскивать строки вложений, чтобы изменить "
+"порядок их отображения в отчёте."
 
-#: senaite/core/content/senaitesetup.py:1381
+#: senaite/core/content/senaitesetup.py:1354
 msgid "Notifications"
-msgstr ""
+msgstr "Уведомления"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print.pt:126
 msgid "Num columns"
@@ -4024,102 +4402,123 @@ msgstr "Кол-во столбцов"
 
 #: bika/lims/content/analysisservice.py:259
 msgid "Number"
-msgstr ""
+msgstr "Номер"
 
-#: senaite/core/browser/samples/view.py:242
+#: senaite/core/browser/samples/view.py:230
 msgid "Number of Analyses"
-msgstr ""
+msgstr "Количество анализов"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:82
 msgid "Number of Partitions to create"
-msgstr ""
+msgstr "Количество создаваемых партиций"
 
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:39
 msgid "Number of copies"
-msgstr ""
+msgstr "Количество копий"
 
 #: senaite/core/registry/schema.py:180
 msgid "Number of prominent columns"
-msgstr ""
+msgstr "Количество основных столбцов"
 
-#: bika/lims/content/abstractbaseanalysis.py:839
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/abstractbaseanalysis.py:836
+#: bika/lims/content/bikasetup.py:512
 msgid "Number of required verifications"
-msgstr ""
+msgstr "Требуемое количество верификаций"
 
-#: bika/lims/content/bikasetup.py:514
-msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
+#: bika/lims/content/bikasetup.py:513
+msgid ""
+"Number of required verifications before a given result being considered as "
+"'verified'. This setting can be overrided for any Analysis in Analysis "
+"Service edit view. By default, 1"
 msgstr ""
+"Требуемое количество верификаций, прежде чем результат будет считаться "
+"'верифицированным'. Может быть переопределено для конкретного анализа в "
+"услуге анализа. По умолчанию — 1"
 
-#: bika/lims/content/abstractbaseanalysis.py:840
-msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
+#: bika/lims/content/abstractbaseanalysis.py:837
+msgid ""
+"Number of required verifications from different users with enough privileges"
+" before a given result for this analysis being considered as 'verified'. The"
+" option set here has priority over the option set in Bika Setup"
 msgstr ""
+"Требуемое количество верификаций от разных пользователей с достаточными "
+"правами, прежде чем результат этого анализа будет считаться "
+"'верифицированным'. Имеет приоритет над настройкой в Bika Setup"
 
 #: senaite/core/registry/schema.py:189
 msgid "Number of standard columns"
-msgstr ""
+msgstr "Количество стандартных столбцов"
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
-msgstr ""
-
-#: senaite/core/api/remarks.py:491
-msgid "Oldest first"
-msgstr ""
+msgstr "Числовой"
 
 #: bika/lims/content/preservation.py:53
-msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
+msgid ""
+"Once preserved, the sample must be disposed of within this time period.  If "
+"not specified, the sample type retention period will be used."
 msgstr ""
+"После консервации образец должен быть утилизирован в течение этого периода. "
+"Если не указано, используется срок хранения типа образца."
 
 #: senaite/core/content/dynamicanalysisspec.py:51
 msgid "Only Excel files supported"
-msgstr ""
+msgstr "Поддерживаются только файлы Excel"
 
 #: bika/lims/content/attachment.py:81
 msgid "Only images can be rendered in the report directly"
-msgstr ""
+msgstr "В отчёте напрямую можно отобразить только изображения"
 
 #: senaite/core/exportimport/import.pt:95
-msgid "Only instruments that have an import interface configured are displayed"
-msgstr ""
+msgid ""
+"Only instruments that have an import interface configured are displayed"
+msgstr "Отображаются только инструменты с настроенным интерфейсом импорта"
 
-#: senaite/core/content/senaitesetup.py:1047
-msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
+#: senaite/core/content/senaitesetup.py:1024
+msgid ""
+"Only laboratory workdays are considered for the analysis turnaround time "
+"calculation."
 msgstr ""
+"Для расчёта срока выполнения анализа учитываются только рабочие дни "
+"лаборатории."
 
-#: bika/lims/content/bikasetup.py:754
-msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
+#: bika/lims/content/bikasetup.py:753
+msgid ""
+"Only laboratory workdays are considered for the analysis turnaround time "
+"calculation. "
 msgstr ""
+"Для расчёта срока выполнения анализа учитываются только рабочие дни "
+"лаборатории. "
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:216
 msgid "Only to empty or zero fields"
-msgstr ""
+msgstr "Только для пустых или нулевых полей"
 
-#: senaite/core/browser/samples/view.py:652
+#: senaite/core/browser/samples/view.py:525
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
 msgstr "Открытые"
 
-#: senaite/core/browser/samples/view.py:243
+#: senaite/core/browser/samples/view.py:231
 msgid "Open / To be verified / Verified / Total"
-msgstr ""
+msgstr "Открыто / Ожидает верификации / Верифицировано / Всего"
 
 #: bika/lims/profiles.zcml:15
 msgid "Open Source Web based Laboratory Information Management System"
-msgstr "Информационная система лаборатории с открытым исходным кодом на базе веб-технологий"
-
-#: senaite/core/browser/dashboard/dashboard.py:97
-msgid "Open Worksheets"
 msgstr ""
+"Информационная система лаборатории с открытым исходным кодом на базе веб-"
+"технологий"
 
 #: bika/lims/browser/publish/reports_listing.py:128
-msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgid ""
+"Open email form to send the selected reports to the recipients. This will "
+"also publish the contained samples of the reports after the email was "
+"successfully sent."
 msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:522
-msgid "Open worksheets with analyses awaiting results"
-msgstr ""
+"Открыть форму письма для отправки выбранных отчётов получателям. После "
+"успешной отправки письма также будут опубликованы образцы, содержащиеся в "
+"отчётах."
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
 msgid "Order"
@@ -4127,66 +4526,66 @@ msgstr "Заказ"
 
 #: bika/lims/content/instrumentcertification.py:93
 msgid "Organization responsible of granting the calibration certificate"
-msgstr ""
+msgstr "Организация, выдавшая сертификат калибровки"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:51
 msgid "Orientation"
-msgstr ""
+msgstr "Ориентация"
 
 #: senaite/core/z3cform/widgets/address.py:124
 msgid "Other address"
-msgstr ""
+msgstr "Другой адрес"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:100
 #: senaite/core/skins/senaite_templates/senaite_widgets/rejectionwidget.pt:70
 msgid "Other reasons"
-msgstr ""
+msgstr "Другие причины"
 
 #: bika/lims/browser/viewlets/templates/rejected_ar_viewlet.pt:22
 msgid "Other reasons:"
-msgstr ""
+msgstr "Другие причины:"
 
-#: senaite/core/browser/dashboard/dashboard.py:183
+#: senaite/core/browser/dashboard/dashboard.py:157
 msgid "Other status"
-msgstr ""
+msgstr "Другой статус"
 
 #: senaite/core/browser/widgets/selectotherwidget.py:114
 #: senaite/core/z3cform/widgets/selectother/widget.py:138
 msgid "Other..."
-msgstr ""
+msgstr "Другое..."
 
 #: bika/lims/browser/instrument.py:733
 #: bika/lims/controlpanel/bika_instruments.py:170
 msgid "Out of date"
-msgstr ""
+msgstr "Просрочено"
 
 #: senaite/core/exportimport/instruments/importer.py:377
 msgid "Override non-empty analysis results"
-msgstr ""
+msgstr "Перезаписывать непустые результаты анализов"
 
 #: senaite/core/exportimport/instruments/importer.py:379
 msgid "Override non-empty analysis results, also with empty"
-msgstr ""
+msgstr "Перезаписывать непустые результаты анализов, в том числе пустыми"
+
+#: senaite/core/content/resultsreport.py:197
+msgid "PDF"
+msgstr "PDF"
 
 #: senaite/core/content/resultsreport.py:198
-msgid "PDF"
-msgstr ""
-
-#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
-msgstr ""
+msgstr "PDF-файл отчёта"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:42
 msgid "Paperformat"
-msgstr ""
+msgstr "Формат бумаги"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:130
 msgid "Partition"
-msgstr ""
+msgstr "Партиция"
 
 #: senaite/core/browser/samples/partition_magic.py:120
 msgid "Partitioning canceled"
-msgstr ""
+msgstr "Разделение на партиции отменено"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:242
 msgid "Password"
@@ -4194,7 +4593,7 @@ msgstr "Пароль"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:50
 msgid "Path identifier"
-msgstr ""
+msgstr "Идентификатор пути"
 
 #: bika/lims/browser/fields/referenceresultsfield.py:36
 #: bika/lims/browser/referencesample.py:228
@@ -4203,8 +4602,14 @@ msgid "Permitted Error %"
 msgstr "Допустимое отклонение %"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:23
-msgid "Persistent counters used by the ID Server. Adjust a counter to change the next ID that will be issued for the matching prefix. Setting a counter to 0 removes the entry from the storage."
+msgid ""
+"Persistent counters used by the ID Server. Adjust a counter to change the "
+"next ID that will be issued for the matching prefix. Setting a counter to 0 "
+"removes the entry from the storage."
 msgstr ""
+"Постоянные счётчики, используемые сервером идентификаторов. Измените "
+"счётчик, чтобы изменить следующий выдаваемый ID для соответствующего "
+"префикса. Установка счётчика в 0 удаляет запись из хранилища."
 
 #: bika/lims/browser/clientfolder.py:81
 #: bika/lims/browser/templates/batch_publish.pt:68
@@ -4226,7 +4631,7 @@ msgstr "Телефон (моб.)"
 
 #: bika/lims/content/instrument.py:338
 msgid "Photo image file"
-msgstr ""
+msgstr "Файл фотографии"
 
 #: bika/lims/content/instrument.py:339
 msgid "Photo of the instrument"
@@ -4246,82 +4651,102 @@ msgid "Please add an email text"
 msgstr "Пожалуйста добавьте текст письма"
 
 #: senaite/core/browser/viewlets/sample/templates/not_sampled.pt:11
-msgid "Please check that the sample has been physically collected and the value for \"Sampled Date\" field has been set in accordance."
+msgid ""
+"Please check that the sample has been physically collected and the value for"
+" \"Sampled Date\" field has been set in accordance."
 msgstr ""
+"Убедитесь, что образец был физически отобран, и значение поля 'Дата отбора' "
+"установлено соответствующим образом."
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:165
 msgid "Please click the update button after your changes."
-msgstr ""
+msgstr "После внесения изменений нажмите кнопку обновления."
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:11
 msgid "Please find attached the analysis result(s) for ${client_name}"
-msgstr ""
+msgstr "Во вложении результат(ы) анализа для ${client_name}"
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:44
 msgid "Please follow the link to the retest ${retest_id}."
-msgstr ""
+msgstr "Перейдите по ссылке на повторный тест ${retest_id}."
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:95
-msgid "Please provide a comment explaining the reason for invalidating the sample. If the email notification option is selected, the sample contact will be informed, and this comment will be included in the email content."
+msgid ""
+"Please provide a comment explaining the reason for invalidating the sample. "
+"If the email notification option is selected, the sample contact will be "
+"informed, and this comment will be included in the email content."
 msgstr ""
+"Укажите комментарий с причиной аннулирования образца. Если выбрана опция "
+"уведомления по email, контакт образца будет проинформирован, и этот "
+"комментарий будет включён в текст письма."
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:109
 msgid "Please provide the reason for invalidating the sample."
-msgstr ""
+msgstr "Укажите причину аннулирования образца."
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:213
+#: senaite/core/browser/clients/client/contacts/login_details.py:222
 msgid "Please select a User from the list"
 msgstr "Пожалуйста выберите Пользователя из списка"
 
-#: senaite/core/browser/stickers/view.py:267
+#: senaite/core/browser/stickers/view.py:257
 msgid "Please select a sticker template"
-msgstr ""
+msgstr "Выберите шаблон стикера"
 
 #: senaite/core/browser/attachment/attachment.py:224
 msgid "Please select an analysis or service for the attachment"
-msgstr ""
+msgstr "Выберите анализ или услугу для вложения"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:111
-msgid "Please select number of partitions to create and press the preview button"
+msgid ""
+"Please select number of partitions to create and press the preview button"
 msgstr ""
+"Выберите количество создаваемых партиций и нажмите кнопку предпросмотра"
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
-#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
-msgstr ""
+msgstr "Укажите причину"
 
 #: bika/lims/content/analysisservice.py:183
-msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
+msgid ""
+"Please specify preservations that differ from the analysis service's default"
+" preservation per sample type here."
 msgstr ""
+"Укажите здесь способы сохранения, отличающиеся от способа по умолчанию для "
+"услуги анализа, по типам образца."
 
 #: bika/lims/content/laboratory.py:163
-msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
+msgid ""
+"Please upload the logo you are authorised to use on your website and results"
+" reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
+"Загрузите логотип, разрешённый к использованию на вашем сайте и в отчётах с "
+"результатами вашим органом по аккредитации. Максимальный размер — 175 x 175 "
+"пикселей."
 
 #: bika/lims/content/analysisservice.py:229
-msgid "Please use the following format for select options: key1:value1|key2:value2|...|keyN:valueN"
+msgid ""
+"Please use the following format for select options: "
+"key1:value1|key2:value2|...|keyN:valueN"
 msgstr ""
+"Используйте следующий формат для вариантов выбора: "
+"key1:value1|key2:value2|...|keyN:valueN"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:71
 msgid "Please write a comment where the listed sample(s) are dispatched"
-msgstr ""
-
-#: senaite/core/browser/samples/templates/dispose_samples.pt:73
-msgid "Please write a comment where the listed sample(s) are disposed"
-msgstr ""
+msgstr "Укажите комментарий о том, куда отправлены перечисленные образцы"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
 msgstr "Место отбора пробы"
 
-#: senaite/core/content/senaitesetup.py:207
+#: senaite/core/content/senaitesetup.py:206
 msgid "Portal Type"
-msgstr ""
+msgstr "Тип портала"
 
 #: bika/lims/content/identifiertype.py:39
 msgid "Portal Types"
-msgstr ""
+msgstr "Типы портала"
 
 #: senaite/core/browser/samples/multi_results_transposed.py:97
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:75
@@ -4340,55 +4765,76 @@ msgstr "Почтовый индекс"
 
 #: senaite/core/content/samplecontainer.py:85
 msgid "Pre-preserved"
-msgstr ""
+msgstr "Предварительно законсервирован"
 
 #: senaite/core/content/samplecontainer.py:100
 msgid "Pre-preserved containers must have a preservation selected"
 msgstr ""
+"У предварительно законсервированных контейнеров должен быть выбран способ "
+"сохранения"
 
 #: bika/lims/content/abstractbaseanalysis.py:176
 msgid "Precision as number of decimals"
-msgstr ""
+msgstr "Точность как количество десятичных знаков"
 
 #: bika/lims/content/abstractbaseanalysis.py:664
-msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
+msgid ""
+"Precision as the number of significant digits according to the uncertainty. "
+"The decimal position will be given by the first number different from zero "
+"in the uncertainty, at that position the system will round up the "
+"uncertainty and results. For example, with a result of 5.243 and an "
+"uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no "
+"uncertainty range is set for the result, the system will use the fixed "
+"precision set."
 msgstr ""
+"Точность как количество значащих цифр в соответствии с неопределённостью. "
+"Позиция десятичного знака определяется первой ненулевой цифрой "
+"неопределённости; на этой позиции система округлит неопределённость и "
+"результат. Например, для результата 5.243 с неопределённостью 0.22 система "
+"корректно отобразит 5.2±0.2. Если диапазон неопределённости для результата "
+"не задан, используется установленная фиксированная точность."
 
-#: bika/lims/content/abstractbaseanalysis.py:738
+#: bika/lims/content/abstractbaseanalysis.py:735
 msgid "Predefined results"
-msgstr ""
+msgstr "Предопределённые результаты"
 
-#: bika/lims/content/bikasetup.py:313
+#: bika/lims/content/bikasetup.py:312
 msgid "Preferred decimal mark for reports."
 msgstr "Предпочитаемый разделитель целой и дробной частей чисел в отчетах"
 
-#: bika/lims/content/bikasetup.py:547
+#: bika/lims/content/bikasetup.py:546
 msgid "Preferred decimal mark for results"
-msgstr ""
+msgstr "Предпочитаемый десятичный разделитель для результатов"
 
-#: bika/lims/content/bikasetup.py:575
-msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
+#: bika/lims/content/bikasetup.py:574
+msgid ""
+"Preferred layout of the results entry table in the Worksheet view. Classic "
+"layout displays the Samples in rows and the analyses in columns. Transposed "
+"layout displays the Samples in columns and the analyses in rows."
 msgstr ""
+"Предпочитаемый макет таблицы ввода результатов в просмотре рабочего листа. "
+"Классический макет отображает образцы в строках, а анализы в столбцах. "
+"Транспонированный макет отображает образцы в столбцах, а анализы в строках."
 
-#: bika/lims/content/bikasetup.py:327
+#: bika/lims/content/bikasetup.py:326
 msgid "Preferred scientific notation format for reports"
-msgstr ""
+msgstr "Предпочитаемый формат научной нотации для отчётов"
 
-#: bika/lims/content/bikasetup.py:561
+#: bika/lims/content/bikasetup.py:560
 msgid "Preferred scientific notation format for results"
-msgstr ""
+msgstr "Предпочитаемый формат научной нотации для результатов"
 
-#: senaite/core/content/senaitesetup.py:241
+#: senaite/core/content/senaitesetup.py:240
 msgid "Prefix"
-msgstr ""
+msgstr "Префикс"
 
 #: bika/lims/content/sampletype.py:157
 msgid "Prefixes can not contain spaces."
-msgstr ""
+msgstr "Префиксы не могут содержать пробелы."
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Prepublish"
-msgstr ""
+msgstr "Предварительная публикация"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:195
 #: senaite/core/content/samplecontainer.py:114
@@ -4397,42 +4843,42 @@ msgstr "Сохранение"
 
 #: bika/lims/content/preservation.py:45
 msgid "Preservation Category"
-msgstr ""
+msgstr "Категория сохранения"
 
 #: senaite/core/content/samplecontainer.py:117
 msgid "Preservation method of this container"
-msgstr ""
+msgstr "Способ сохранения этого контейнера"
 
 #: bika/lims/content/analysisservice.py:182
 msgid "Preservation per sample type"
-msgstr ""
+msgstr "Способ сохранения по типу образца"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Preserve"
-msgstr ""
+msgstr "Сохранить"
 
-#: senaite/core/browser/samples/view.py:234
+#: senaite/core/browser/samples/view.py:222
 msgid "Preserver"
-msgstr ""
+msgstr "Ответственный за сохранение"
 
 #: senaite/core/browser/viewlets/templates/toolbar.pt:44
 msgid "Press Ctrl+Space to trigger the Spotlight search"
-msgstr ""
+msgstr "Нажмите Ctrl+Space, чтобы запустить поиск Spotlight"
 
 #: bika/lims/content/instrumentmaintenancetask.py:163
 #: bika/lims/content/instrumentscheduledtask.py:120
 msgid "Preventive"
-msgstr ""
+msgstr "Профилактическое"
 
 #: bika/lims/content/instrument.py:212
 msgid "Preventive maintenance procedure"
-msgstr ""
+msgstr "Процедура профилактического обслуживания"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:258
+#: senaite/core/browser/samples/templates/partition_magic.pt:250
 msgid "Preview"
-msgstr ""
+msgstr "Предпросмотр"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:85
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
@@ -4460,20 +4906,20 @@ msgstr "Прейскурант для"
 msgid "Pricelists"
 msgstr "Прейскуранты"
 
-#: bika/lims/content/client.py:98
+#: bika/lims/content/client.py:94
 msgid "Primary Contact"
-msgstr ""
+msgstr "Основной контакт"
 
 #: bika/lims/browser/publish/reports_listing.py:73
 #: bika/lims/browser/templates/analysisreport_info.pt:60
 msgid "Primary Sample"
-msgstr ""
+msgstr "Основной образец"
 
-#: senaite/core/browser/samples/view.py:851
+#: senaite/core/browser/samples/view.py:703
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
-msgstr ""
+msgstr "Печать"
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Print Invoice"
@@ -4481,34 +4927,34 @@ msgstr "Напечатать счет"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:135
 msgid "Print Worksheet"
-msgstr ""
+msgstr "Печать рабочего листа"
 
 #: bika/lims/browser/templates/batch_publish.pt:124
 msgid "Print date:"
-msgstr ""
+msgstr "Дата печати:"
 
 #: bika/lims/profiles/default/types/Pricelist.xml
 msgid "Print pricelist"
 msgstr "Распечатать прейскурант"
 
-#: senaite/core/browser/samples/view.py:272
+#: senaite/core/browser/samples/view.py:254
 msgid "Print stickers"
-msgstr ""
+msgstr "Печать стикеров"
 
-#: senaite/core/browser/samples/view.py:259
+#: senaite/core/browser/samples/view.py:241
 msgid "Printed"
-msgstr ""
+msgstr "Напечатано"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:53
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:53
 msgid "Printed on"
-msgstr ""
+msgstr "Напечатано"
 
 #: bika/lims/content/analysisrequest.py:925
 msgid "Priority"
 msgstr "Приоритет"
 
-#: senaite/core/browser/samples/view.py:238
+#: senaite/core/browser/samples/view.py:226
 msgid "Profile"
 msgstr "Профиль"
 
@@ -4526,44 +4972,40 @@ msgstr "Ключевые слова профиля"
 
 #: bika/lims/content/analysisrequest.py:431
 msgid "Profile Name"
-msgstr ""
+msgstr "Название профиля"
 
 #: senaite/core/content/analysisprofile.py:216
 msgid "Profile keyword must be unique"
-msgstr ""
+msgstr "Ключевое слово профиля должно быть уникальным"
 
-#: senaite/core/browser/samples/view.py:134
+#: senaite/core/browser/samples/view.py:122
 msgid "Progress"
-msgstr ""
+msgstr "Прогресс"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:103
 #: senaite/core/registry/schema.py:198
 msgid "Prominent fields"
-msgstr ""
+msgstr "Основные поля"
 
-#: bika/lims/content/abstractbaseanalysis.py:868
+#: bika/lims/content/abstractbaseanalysis.py:865
 msgid "Protocol ID"
-msgstr ""
+msgstr "ID протокола"
 
 #: bika/lims/browser/clientfolder.py:75
 msgid "Province"
-msgstr ""
+msgstr "Область"
 
-#: senaite/core/content/resultsreport.py:120
+#: senaite/core/content/resultsreport.py:119
 msgid "Publication Modes"
-msgstr ""
+msgstr "Режимы публикации"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Publish"
-msgstr ""
+msgstr "Опубликовать"
 
-#: senaite/core/browser/dashboard/dashboard.py:112
-msgid "Publish Reports"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:150
-#: senaite/core/browser/samples/view.py:369
+#: senaite/core/browser/dashboard/dashboard.py:128
+#: senaite/core/browser/samples/view.py:351
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
 msgstr "Опубликовано"
@@ -4574,44 +5016,31 @@ msgstr "Опубликовано"
 
 #: bika/lims/browser/publish/reports_listing.py:84
 msgid "Published Date"
-msgstr ""
+msgstr "Дата публикации"
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
 msgstr "Опубликованные результаты"
 
-#: senaite/core/browser/dashboard/dashboard.py:448
-msgid "Published samples whose reports have not been printed yet"
-msgstr ""
-
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
-msgstr ""
+msgstr "Опубликовано {}, "
 
 #: senaite/core/browser/viewlets/sampleanalyses.py:76
 msgid "QC Analyses"
-msgstr ""
+msgstr "Анализы контроля качества"
 
 #: bika/lims/browser/referencesample.py:143
 msgid "QC Analysis ID"
-msgstr ""
+msgstr "ID анализа контроля качества"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "QC Results"
 msgstr "QC Результаты"
 
-#: bika/lims/browser/analyses/qc.py:55
-#: bika/lims/browser/instrument.py:554
+#: bika/lims/browser/analyses/qc.py:55 bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:138
-msgid "Quarterly"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:128
-msgid "Quick Actions"
-msgstr ""
+msgstr "ID образца контроля качества"
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
@@ -4623,11 +5052,12 @@ msgstr "Диапазон мин"
 
 #: bika/lims/browser/viewlets/templates/specification_non_compliant_viewlet.pt:18
 msgid "Ranges for some analyses are different from the Specification"
-msgstr ""
+msgstr "Диапазоны некоторых анализов отличаются от спецификации"
 
 #: bika/lims/browser/viewlets/templates/specification_non_compliant_viewlet.pt:29
 msgid "Re-assign the Specification if you want to restore analysis ranges."
 msgstr ""
+"Переназначьте спецификацию, если хотите восстановить диапазоны анализа."
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:256
 msgid "Re-enter the password. Make sure the passwords are identical."
@@ -4635,50 +5065,46 @@ msgstr "Повторно введите пароль. Убедитесь, что
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:145
 msgid "Reasons for rejection"
-msgstr ""
+msgstr "Причины отклонения"
 
-#: senaite/core/browser/worksheets/view.py:348
+#: senaite/core/browser/worksheets/view.py:344
 msgid "Reassign"
 msgstr "Переназначить"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:445
 msgid "Reassignable Slot"
-msgstr ""
+msgstr "Переназначаемый слот"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Reattach"
-msgstr ""
+msgstr "Прикрепить заново"
 
-#: bika/lims/browser/analyses/view.py:1171
+#: bika/lims/browser/analyses/view.py:1170
 msgid "Recalculate"
-msgstr ""
+msgstr "Пересчитать"
 
-#: senaite/core/content/senaitesetup.py:1144
+#: senaite/core/content/senaitesetup.py:1121
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
 msgstr "Получить"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:339
+#: senaite/core/browser/samples/view.py:321
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
 msgstr "Получено"
 
-#: senaite/core/browser/dashboard/dashboard.py:420
-msgid "Received samples with analyses awaiting results"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:160
+#: senaite/core/browser/dashboard/dashboard.py:135
 msgid "Reception pending"
 msgstr "Ожидают прием"
 
-#: senaite/core/content/resultsreport.py:245
+#: senaite/core/content/resultsreport.py:244
 msgid "Recipient"
-msgstr ""
+msgstr "Получатель"
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:241
 msgid "Recipients"
-msgstr ""
+msgstr "Получатели"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
 #: bika/lims/content/worksheettemplate.py:57
@@ -4687,11 +5113,11 @@ msgstr "Эталон"
 
 #: bika/lims/browser/referencesample.py:83
 msgid "Reference Analyses"
-msgstr ""
+msgstr "Референс-анализы"
 
 #: bika/lims/profiles/default/types/ReferenceAnalysis.xml
 msgid "Reference Analysis"
-msgstr ""
+msgstr "Референс-анализ"
 
 #: bika/lims/browser/referencesample.py:353
 #: bika/lims/browser/templates/referencesample_view.pt:67
@@ -4706,13 +5132,13 @@ msgstr "Эталон: Определения"
 
 #: bika/lims/content/referencesample.py:64
 msgid "Reference ID"
-msgstr ""
+msgstr "Референс-ID"
 
 #: bika/lims/browser/instrument.py:558
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:12
 #: bika/lims/browser/worksheet/views/referencesamples.py:72
 msgid "Reference Sample"
-msgstr ""
+msgstr "Референс-образец"
 
 #: senaite/core/profiles/default/types/Supplier.xml
 msgid "Reference Samples"
@@ -4721,37 +5147,33 @@ msgstr "Образцы эталона"
 #: bika/lims/browser/referencesample.py:202
 #: bika/lims/profiles/default/types/ReferenceSample.xml
 msgid "Reference Values"
-msgstr ""
+msgstr "Референсные значения"
 
 #: bika/lims/content/referencesample.py:98
 msgid "Reference sample values are zero or 'blank'"
 msgstr "Значения эталонного образца 0 или \"пусто\""
 
-#: senaite/core/content/senaitesetup.py:1143
+#: senaite/core/content/senaitesetup.py:1120
 msgid "Register"
 msgstr "Зарегистрировать"
 
-#: senaite/core/browser/dashboard/dashboard.py:105
-msgid "Register Samples"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:145
+#: senaite/core/browser/dashboard/dashboard.py:121
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
-msgstr ""
+msgstr "Зарегистрировано"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_cancellable_type_workflow/definition.xml
 msgid "Reinstate"
-msgstr ""
+msgstr "Восстановить"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:149
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Reject"
-msgstr ""
+msgstr "Отклонить"
 
 #: bika/lims/profiles/default/types/RejectAnalysis.xml
 msgid "Reject Analysis"
@@ -4759,41 +5181,41 @@ msgstr "Отклонить анализ"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:17
 msgid "Reject samples"
-msgstr ""
+msgstr "Отклонить образцы"
 
-#: senaite/core/browser/dashboard/dashboard.py:153
+#: senaite/core/browser/dashboard/dashboard.py:125
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:432
+#: senaite/core/browser/samples/view.py:402
 msgid "Rejected"
-msgstr ""
+msgstr "Отклонено"
 
 #: bika/lims/browser/workflow/analysisrequest.py:98
 msgid "Rejected items: {}"
-msgstr ""
+msgstr "Отклонённые элементы: {}"
 
 #: bika/lims/browser/viewlets/templates/rejected_ar_viewlet.pt:13
 msgid "Rejected sample"
-msgstr ""
+msgstr "Отклонённый образец"
 
 #: senaite/core/browser/samples/rejection/reject_samples.py:114
 msgid "Rejected {} samples: {}"
-msgstr ""
+msgstr "Отклонено образцов: {} ({})"
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1201
 msgid "Rejection Reasons"
-msgstr ""
+msgstr "Причины отклонения"
 
 #: senaite/core/browser/samples/rejection/reject_samples.py:121
 msgid "Rejection cancelled"
-msgstr ""
+msgstr "Отклонение отменено"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:84
 msgid "Rejection reasons"
-msgstr ""
+msgstr "Причины отклонения"
 
 #: senaite/core/browser/samples/rejection/reject_samples.py:70
 msgid "Rejection workflow is not enabled"
-msgstr ""
+msgstr "Процесс отклонения не включён"
 
 # senaite.app.listing: Reload
 msgid "Reload"
@@ -4807,63 +5229,54 @@ msgstr "Замечания"
 
 #: bika/lims/content/analysisrequest.py:1103
 msgid "Remarks and comments for this request"
-msgstr ""
+msgstr "Замечания и комментарии к этой заявке"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:672
 msgid "Remarks of {}"
-msgstr ""
+msgstr "Замечания к {}"
 
 #: bika/lims/content/instrumentcalibration.py:108
 msgid "Remarks to take into account before calibration"
-msgstr ""
+msgstr "Замечания, которые нужно учесть перед калибровкой"
 
 #: bika/lims/content/instrumentscheduledtask.py:87
 msgid "Remarks to take into account before performing the task"
-msgstr ""
+msgstr "Замечания, которые нужно учесть перед выполнением задачи"
 
 #: bika/lims/content/instrumentvalidation.py:90
 msgid "Remarks to take into account before validation"
-msgstr ""
+msgstr "Замечания, которые нужно учесть перед валидацией"
 
 #: bika/lims/content/instrumentmaintenancetask.py:94
 msgid "Remarks to take into account for maintenance process"
-msgstr ""
+msgstr "Замечания, которые нужно учесть в процессе обслуживания"
 
-#: bika/lims/browser/auditlog.py:90
-#: bika/lims/controlpanel/auditlog.py:92
+#: bika/lims/browser/auditlog.py:90 bika/lims/controlpanel/auditlog.py:92
 msgid "Remote IP"
-msgstr ""
+msgstr "IP-адрес"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:72
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Remove"
-msgstr ""
-
-#: senaite/core/browser/samples/view.py:597
-msgid "Remove this analysis from the filter"
-msgstr ""
+msgstr "Удалить"
 
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — row action tooltip
-msgid "Rename filter"
-msgstr ""
+msgstr "Удалено ключей: {} ({})"
 
 #: bika/lims/content/attachment.py:80
 msgid "Render attachment in report"
-msgstr ""
+msgstr "Отображать вложение в отчёте"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:68
 msgid "Render in Report"
-msgstr ""
+msgstr "Отображать в отчёте"
 
 #: bika/lims/content/instrumentmaintenancetask.py:164
 #: bika/lims/content/instrumentscheduledtask.py:121
 msgid "Repair"
-msgstr ""
+msgstr "Ремонт"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:59
 #: bika/lims/content/analysisservice.py:226
@@ -4873,44 +5286,44 @@ msgstr "Отчет"
 #: bika/lims/content/instrumentcalibration.py:68
 #: bika/lims/content/instrumentvalidation.py:50
 msgid "Report Date"
-msgstr ""
+msgstr "Дата отчёта"
 
 #: bika/lims/content/instrumentcalibration.py:150
 #: bika/lims/content/instrumentvalidation.py:132
 msgid "Report ID"
-msgstr ""
+msgstr "ID отчёта"
 
 #: bika/lims/content/instrumentcalibration.py:151
 #: bika/lims/content/instrumentvalidation.py:133
 msgid "Report identification number"
-msgstr ""
+msgstr "Идентификационный номер отчёта"
 
-#: senaite/core/content/resultsreport.py:230
+#: senaite/core/content/resultsreport.py:229
 msgid "Report metadata"
-msgstr ""
+msgstr "Метаданные отчёта"
 
-#: senaite/core/content/resultsreport.py:243
+#: senaite/core/content/resultsreport.py:242
 msgid "Report recipients"
-msgstr ""
+msgstr "Получатели отчёта"
 
 #: bika/lims/content/instrumentcertification.py:194
 msgid "Report upload"
-msgstr ""
+msgstr "Загрузка отчёта"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Republish"
-msgstr ""
+msgstr "Опубликовать повторно"
 
-#: senaite/core/browser/samples/view.py:712
+#: senaite/core/browser/samples/view.py:574
 msgid "Republished after last print"
-msgstr ""
+msgstr "Переопубликовано после последней печати"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:71
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:70
 msgid "Request ID"
 msgstr "ID Запроса"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
 msgid "Request new analyses"
 msgstr "Запросить новые анализы"
 
@@ -4924,41 +5337,28 @@ msgstr "Требуемый объем"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:198
 msgid "Reset"
-msgstr ""
-
-# senaite.app.listing: Reset-columns button tooltip
-msgid "Reset column visibility and order to the defaults"
-msgstr ""
+msgstr "Сбросить"
 
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
 msgstr "Сбросить"
 
-# senaite.app.listing: Column config — reset link tooltip
-msgid "Reset to default columns and order"
-msgstr ""
-
-# senaite.app.listing: Search box — undo / reset-view button tooltip
-msgid "Reset view"
-msgstr ""
-
 #: bika/lims/browser/publish/templates/email.pt:83
 #: bika/lims/browser/templates/analysisreport_info.pt:154
 msgid "Responsibles"
-msgstr ""
+msgstr "Ответственные"
 
-#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
-msgstr ""
+msgstr "Восстановить"
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:175
 msgid "Restrict worksheet access to assigned analysts"
-msgstr ""
+msgstr "Ограничить доступ к рабочему листу назначенными аналитиками"
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:206
 msgid "Restrict worksheet management to lab managers"
-msgstr ""
+msgstr "Ограничить управление рабочими листами менеджерами лаборатории"
 
 #: senaite/core/browser/modals/analysis/schema.py:53
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:86
@@ -4967,7 +5367,7 @@ msgstr "Результат"
 
 #: senaite/core/browser/modals/analysis/schema.py:130
 msgid "Result Capture Date"
-msgstr ""
+msgstr "Дата фиксации результата"
 
 #: bika/lims/content/abstractbaseanalysis.py:726
 msgid "Result Value"
@@ -4975,35 +5375,41 @@ msgstr "Значение результата"
 
 #: bika/lims/validators.py:642
 msgid "Result Value must be a number"
-msgstr ""
+msgstr "Значение результата должно быть числом"
 
 #: bika/lims/validators.py:657
 msgid "Result Value must be unique"
-msgstr ""
+msgstr "Значение результата должно быть уникальным"
 
-#: bika/lims/browser/analyses/view.py:1527
+#: bika/lims/browser/analyses/view.py:1526
 msgid "Result in shoulder range"
-msgstr ""
+msgstr "Результат в пограничном диапазоне"
 
-#: bika/lims/browser/analyses/view.py:1524
+#: bika/lims/browser/analyses/view.py:1523
 msgid "Result out of range"
 msgstr "Результат за пределами допустимого диапазона"
 
-#: bika/lims/browser/analyses/view.py:1546
+#: bika/lims/browser/analyses/view.py:1545
 msgid "Result range is different from Specification: {}"
-msgstr ""
+msgstr "Диапазон результата отличается от спецификации: {}"
 
 #: bika/lims/content/abstractbaseanalysis.py:711
 msgid "Result type"
-msgstr ""
+msgstr "Тип результата"
 
-#: bika/lims/content/bikasetup.py:427
-msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
+#: bika/lims/content/bikasetup.py:426
+msgid ""
+"Result values with at least this number of significant digits are displayed "
+"in scientific notation using the letter 'e' to indicate the exponent.  The "
+"precision can be configured in individual Analysis Services."
 msgstr ""
+"Значения результатов с числом значащих цифр не менее указанного отображаются"
+" в научной нотации с буквой 'e' для экспоненты. Точность можно настроить для"
+" отдельных услуг анализа."
 
 #: bika/lims/content/analysisservice.py:116
 msgid "Result variables"
-msgstr ""
+msgstr "Переменные результата"
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:63
 msgid "Results"
@@ -5011,42 +5417,37 @@ msgstr "Результаты"
 
 #: bika/lims/content/analysisrequest.py:1369
 msgid "Results Interpretation"
-msgstr ""
+msgstr "Интерпретация результатов"
 
-#: senaite/core/browser/dashboard/dashboard.py:85
-msgid "Results Pending"
-msgstr ""
-
-#: senaite/core/content/resultsreport.py:133
+#: senaite/core/content/resultsreport.py:132
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
-msgstr ""
+msgstr "Отчёт с результатами"
 
-#: senaite/core/content/senaitesetup.py:1308
+#: senaite/core/content/senaitesetup.py:1285
 msgid "Results Reports"
-msgstr ""
+msgstr "Отчёты с результатами"
 
-#: senaite/core/browser/samples/view.py:726
+#: senaite/core/browser/samples/view.py:588
 msgid "Results have been withdrawn"
-msgstr ""
+msgstr "Результаты были отозваны"
 
 #: senaite/core/browser/viewlets/resultsinterpretation.py:39
 msgid "Results interpretation"
-msgstr ""
+msgstr "Интерпретация результатов"
 
-#: senaite/core/browser/dashboard/dashboard.py:161
+#: senaite/core/browser/dashboard/dashboard.py:123
 msgid "Results pending"
 msgstr "Ожидают результатов"
 
 #: bika/lims/content/analysisrequest.py:660
-#: bika/lims/content/preservation.py:52
-#: bika/lims/content/sampletype.py:116
+#: bika/lims/content/preservation.py:52 bika/lims/content/sampletype.py:116
 msgid "Retention Period"
-msgstr ""
+msgstr "Срок хранения"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Retest"
-msgstr ""
+msgstr "Повторный тест"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:96
 msgid "Retested"
@@ -5056,90 +5457,84 @@ msgstr "Повторный анализ"
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Retract"
-msgstr ""
+msgstr "Отозвать"
 
-#: senaite/core/browser/dashboard/dashboard.py:152
+#: senaite/core/browser/dashboard/dashboard.py:126
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
-msgstr ""
+msgstr "Отозвано"
 
 #: bika/lims/browser/templates/analyses_retractedlist.pt:11
 msgid "Retracted analyses"
-msgstr ""
+msgstr "Отозванные анализы"
 
 #: bika/lims/browser/instrument.py:561
 msgid "Retractions"
-msgstr ""
+msgstr "Отзывы"
 
 #: bika/lims/browser/publish/reports_listing.py:78
 msgid "Review State"
-msgstr ""
+msgstr "Статус"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:171
 msgid "Reviewed by"
-msgstr ""
+msgstr "Проверено"
 
-#: bika/lims/browser/auditlog.py:88
-#: bika/lims/controlpanel/auditlog.py:88
+#: bika/lims/browser/auditlog.py:88 bika/lims/controlpanel/auditlog.py:88
 msgid "Roles"
-msgstr ""
+msgstr "Роли"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Rollback"
-msgstr ""
+msgstr "Откат"
 
 #: bika/lims/browser/worksheet/views/folder.py:110
 msgid "Routine Analyses"
-msgstr ""
-
-#: bika/lims/api/snapshot.py:555
-msgid "Row ${num}"
-msgstr ""
+msgstr "Плановые анализы"
 
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
-msgstr ""
+msgstr "SENAITE CORE"
 
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE Add-on"
-msgstr ""
+msgstr "Дополнение SENAITE CORE"
 
 #: bika/lims/profiles.zcml:15
 msgid "SENAITE Core 1.x (do not install)"
-msgstr ""
+msgstr "SENAITE Core 1.x (не устанавливать)"
 
 #: senaite/core/browser/frontpage/templates/frontpage.pt:6
 msgid "SENAITE LIMS"
-msgstr ""
+msgstr "SENAITE LIMS"
 
 #: senaite/core/browser/frontpage/configure.zcml:23
 msgid "SENAITE LIMS front-page"
-msgstr ""
+msgstr "Главная страница SENAITE LIMS"
 
 #: senaite/core/profiles/default/controlpanel.xml
 #: senaite/core/registry/controlpanel.py:81
 msgid "SENAITE Registry"
-msgstr ""
+msgstr "Реестр SENAITE"
 
-#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
-msgstr ""
+msgstr "Настройки SENAITE"
 
 #: senaite/core/browser/frontpage/configure.zcml:23
 msgid "SENAITE front-page"
-msgstr ""
+msgstr "Главная страница SENAITE"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:326
+#: senaite/core/browser/clients/client/contacts/login_details.py:315
 msgid "SMTP server disconnected. User creation aborted."
-msgstr ""
+msgstr "SMTP-сервер отключён. Создание пользователя прервано."
 
 #: bika/lims/content/supplier.py:87
 msgid "SWIFT code"
-msgstr ""
+msgstr "Код SWIFT"
 
 #: bika/lims/content/person.py:42
 msgid "Salutation"
@@ -5147,21 +5542,25 @@ msgstr "Приветствие"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:151
+#: senaite/core/content/resultsreport.py:150
 msgid "Sample"
 msgstr "Образец"
 
 #: bika/lims/browser/analysisrequest/add2.py:2195
 msgid "Sample ${AR} was successfully created."
-msgstr ""
+msgstr "Образец ${AR} успешно создан."
 
 #: senaite/core/browser/samples/invalidate_samples.py:149
 msgid "Sample ${sample_id} has been successfully invalidated."
-msgstr ""
+msgstr "Образец ${sample_id} успешно аннулирован."
 
 #: senaite/core/browser/samples/invalidate_samples.py:139
-msgid "Sample ${sample_id} was successfully invalidated, and a notification email has been sent to the following recipients: ${recipients}."
+msgid ""
+"Sample ${sample_id} was successfully invalidated, and a notification email "
+"has been sent to the following recipients: ${recipients}."
 msgstr ""
+"Образец ${sample_id} успешно аннулирован, уведомление отправлено следующим "
+"получателям: ${recipients}."
 
 #: senaite/core/profiles/default/types/SampleCondition.xml
 msgid "Sample Condition"
@@ -5173,24 +5572,24 @@ msgstr "Образец: Условия"
 
 #: senaite/core/profiles/default/types/SampleContainer.xml
 msgid "Sample Container"
-msgstr ""
+msgstr "Контейнер образца"
 
 #: senaite/core/profiles/default/types/SampleContainers.xml
 msgid "Sample Containers"
-msgstr ""
+msgstr "Контейнеры образцов"
 
 #: senaite/core/registry/schema.py:160
 msgid "Sample Header"
-msgstr ""
+msgstr "Заголовок образца"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:139
+#: senaite/core/browser/samples/view.py:127
 msgid "Sample ID"
 msgstr "Образец ID"
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:17
 msgid "Sample Invalidation"
-msgstr ""
+msgstr "Аннулирование образца"
 
 #: senaite/core/profiles/default/types/SampleMatrices.xml
 msgid "Sample Matrices"
@@ -5198,13 +5597,13 @@ msgstr "Образец: Матрицы"
 
 #: senaite/core/profiles/default/types/SampleMatrix.xml
 msgid "Sample Matrix"
-msgstr ""
+msgstr "Матрица образца"
 
 #: bika/lims/content/artemplate.py:172
 msgid "Sample Partitions"
-msgstr ""
+msgstr "Партиции образца"
 
-#: senaite/core/browser/samples/view.py:217
+#: senaite/core/browser/samples/view.py:205
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
@@ -5216,22 +5615,22 @@ msgstr "Образец: Места сбора"
 
 #: senaite/core/profiles/default/types/SamplePreservation.xml
 msgid "Sample Preservation"
-msgstr ""
+msgstr "Сохранение образца"
 
 #: senaite/core/profiles/default/types/SamplePreservations.xml
 msgid "Sample Preservations"
-msgstr ""
+msgstr "Способы сохранения образца"
 
 #: bika/lims/content/analysisrequest.py:671
 msgid "Sample Rejection"
-msgstr ""
+msgstr "Отклонение образца"
 
 #: bika/lims/profiles/default/types/Client.xml
 msgid "Sample Templates"
-msgstr ""
+msgstr "Шаблоны образцов"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:213
+#: senaite/core/browser/samples/view.py:201
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
 msgstr "Тип образца"
@@ -5242,97 +5641,94 @@ msgstr "Тип префикса образца"
 
 #: senaite/core/registry/schema.py:124
 msgid "Sample View"
-msgstr ""
+msgstr "Просмотр образца"
 
 #: bika/lims/content/artemplate.py:118
 msgid "Sample collected by the laboratory"
-msgstr ""
+msgstr "Образец отобран лабораторией"
 
 #: bika/lims/browser/analysisrequest/add2.py:1992
 msgid "Sample creation cancelled"
-msgstr ""
+msgstr "Создание образца отменено"
 
 #: bika/lims/browser/workflow/analysisrequest.py:248
 msgid "Sample date required for sample %s"
-msgstr ""
+msgstr "Требуется дата образца для образца %s"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Sample due"
 msgstr "Образец ожидается"
 
+#. Dynamically built in bika/lims/browser/publish/reports_listing.py
+#. from review_state.capitalize().replace("_", " ") for state "sample_received"
+msgid "Sample received"
+msgstr "Образец получен"
+
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:111
 msgid "Sample type"
-msgstr ""
+msgstr "Тип образца"
 
 #: senaite/core/content/interpretationtemplate.py:71
 msgid "Sample types"
-msgstr ""
+msgstr "Типы образца"
 
 #: senaite/core/registry/schema.py:125
 msgid "Sample view configuration"
-msgstr ""
+msgstr "Настройка просмотра образца"
 
 #: bika/lims/browser/viewlets/templates/primary_ar_viewlet.pt:15
 msgid "Sample with partitions"
-msgstr ""
+msgstr "Образец с партициями"
 
 #: senaite/core/profiles/default/types/SampleTemplate.xml
 msgid "SampleTemplate"
-msgstr ""
+msgstr "Шаблон образца"
 
 #: senaite/core/profiles/default/types/SampleTemplates.xml
 msgid "SampleTemplates"
-msgstr ""
+msgstr "Шаблоны образцов"
 
 #: senaite/core/profiles/default/types/SampleType.xml
 msgid "SampleType"
-msgstr ""
+msgstr "Тип образца"
 
 #: senaite/core/profiles/default/types/SampleTypes.xml
 msgid "SampleTypes"
-msgstr ""
+msgstr "Типы образцов"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:219
 msgid "Sampler"
 msgstr "Пробоотборщик"
 
 #: bika/lims/content/analysisrequest.py:497
 msgid "Sampler for scheduled sampling"
-msgstr ""
+msgstr "Пробоотборщик для запланированного отбора проб"
 
 #: bika/lims/browser/workflow/analysisrequest.py:241
 msgid "Sampler required for sample %s"
-msgstr ""
+msgstr "Требуется пробоотборщик для образца %s"
 
-#: senaite/core/browser/dashboard/dashboard.py:457
-#: senaite/core/browser/samples/view.py:112
+#: senaite/core/browser/dashboard/dashboard.py:411
+#: senaite/core/browser/samples/view.py:100
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
 msgstr "Образцы"
 
 #: bika/lims/browser/analysisrequest/add2.py:2192
 msgid "Samples ${ARs} were successfully created."
-msgstr ""
+msgstr "Образцы ${ARs} успешно созданы."
 
 #: senaite/core/browser/samples/invalidate_samples.py:155
-msgid "Samples ${sample_ids} were successfully invalidated, with notification emails sent for the following: ${notified_ids}."
+msgid ""
+"Samples ${sample_ids} were successfully invalidated, with notification "
+"emails sent for the following: ${notified_ids}."
 msgstr ""
+"Образцы ${sample_ids} успешно аннулированы, уведомления отправлены для: "
+"${notified_ids}."
 
 #: senaite/core/browser/samples/invalidate_samples.py:164
 msgid "Samples ${sample_ids} were successfully invalidated."
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:400
-msgid "Samples awaiting collection of the sample"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:404
-msgid "Samples awaiting preservation"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:416
-msgid "Samples awaiting reception at the laboratory"
-msgstr ""
+msgstr "Образцы ${sample_ids} успешно аннулированы."
 
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
@@ -5341,36 +5737,20 @@ msgstr "С образцами этого типа следует обращат�
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:67
 msgid "Samples rejection reporting form"
-msgstr ""
+msgstr "Форма отчёта об отклонении образцов"
 
-#: senaite/core/browser/dashboard/dashboard.py:81
-msgid "Samples to Receive"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:432
-msgid "Samples whose reports have been published"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:424
-msgid "Samples whose results are awaiting verification"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:409
-msgid "Samples with a scheduled sampling date"
-msgstr ""
-
-#: senaite/core/content/senaitesetup.py:1362
+#: senaite/core/content/senaitesetup.py:1337
 msgid "Sampling"
-msgstr ""
+msgstr "Отбор проб"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:106
 msgid "Sampling Date"
 msgstr "Дата отбора"
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:214
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
-msgstr ""
+msgstr "Отклонение при отборе проб"
 
 #: senaite/core/profiles/default/types/SamplingDeviations.xml
 msgid "Sampling Deviations"
@@ -5380,36 +5760,27 @@ msgstr "Отбор проб: Отклонения"
 msgid "Sampling Frequency"
 msgstr "Частота взятия образца"
 
-#: senaite/core/browser/dashboard/dashboard.py:159
+#: senaite/core/browser/dashboard/dashboard.py:134
 msgid "Sampling scheduled"
-msgstr ""
+msgstr "Отбор проб запланирован"
 
 #: senaite/core/vocabularies/setup.py:161
 msgid "Saturday"
-msgstr ""
+msgstr "Суббота"
 
-#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
+#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
 msgstr "Сохранить"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
 msgid "Save and Copy"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — footer button to save the
-# current view
-msgid "Save current view"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — toggle title + menu header
-msgid "Saved filters"
-msgstr ""
+msgstr "Сохранить и скопировать"
 
 #: bika/lims/browser/workflow/__init__.py:206
 msgid "Saved items: {}"
-msgstr ""
+msgstr "Сохранённые элементы: {}"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Schedule"
@@ -5417,92 +5788,99 @@ msgstr "Расписание"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Schedule sampling"
-msgstr ""
+msgstr "Запланировать отбор проб"
 
-#: senaite/core/browser/samples/view.py:317
+#: senaite/core/browser/samples/view.py:299
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
-msgstr ""
+msgstr "Запланированный отбор проб"
 
 #: bika/lims/browser/instrument.py:400
 msgid "Scheduled task"
-msgstr ""
+msgstr "Запланированная задача"
 
 #: bika/lims/content/abstractbaseanalysis.py:95
 msgid "Scientific name"
-msgstr ""
+msgstr "Научное название"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:154
 msgid "Search"
-msgstr ""
-
-# senaite.app.listing: Column config — search input placeholder
-msgid "Search columns…"
-msgstr ""
+msgstr "Поиск"
 
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
-msgstr ""
+msgstr "Поиск..."
 
 #: bika/lims/browser/fields/coordinatefield.py:38
 msgid "Seconds"
 msgstr "Секунд"
 
-#: senaite/core/content/senaitesetup.py:1284
+#: senaite/core/content/senaitesetup.py:1261
 msgid "Security"
-msgstr ""
+msgstr "Безопасность"
 
 #: bika/lims/content/container.py:118
 msgid "Security Seal Intact Y/N"
-msgstr ""
+msgstr "Пломба цела Да/Нет"
 
 #: senaite/core/content/samplecontainer.py:122
 msgid "Security seal intact"
-msgstr ""
+msgstr "Пломба цела"
 
 #: bika/lims/content/analysisservice.py:261
 msgid "Select"
-msgstr ""
+msgstr "Выбрать"
 
 #: senaite/core/exportimport/import.pt:100
 msgid "Select Import Interface"
-msgstr ""
+msgstr "Выберите интерфейс импорта"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:215
 msgid "Select Partition Analyses"
-msgstr ""
+msgstr "Выберите анализы для партиции"
 
 #: bika/lims/content/analysisservice.py:146
-msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
+msgid ""
+"Select a default preservation for this analysis service. If the preservation"
+" depends on the sample type combination, specify a preservation per sample "
+"type in the table below"
 msgstr ""
+"Выберите способ сохранения по умолчанию для этой услуги анализа. Если способ"
+" сохранения зависит от типа образца, укажите его для каждого типа образца в "
+"таблице ниже"
 
 # senaite.core.browser.modals.templates.create_worksheet.pt
 msgid "Select all"
-msgstr ""
+msgstr "Выбрать все"
 
 #: bika/lims/browser/publish/templates/email.pt:168
 msgid "Select all:"
-msgstr ""
+msgstr "Выбрать все:"
 
 #: bika/lims/content/instrument.py:223
 msgid "Select an Export interface for this instrument."
-msgstr ""
+msgstr "Выберите интерфейс экспорта для этого инструмента."
 
 #: bika/lims/content/instrument.py:236
 msgid "Select an Import interface for this instrument."
-msgstr ""
+msgstr "Выберите интерфейс импорта для этого инструмента."
 
 #: bika/lims/content/artemplate.py:288
 msgid "Select analyses to include in this template"
-msgstr ""
+msgstr "Выберите анализы для включения в этот шаблон"
 
 #: senaite/core/browser/worksheets/templates/view.pt:36
 msgid "Select analyst"
 msgstr "Выбор аналитика"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:203
-msgid "Select any add-ons you want to activate immediately. You can also activate add-ons after the site has been created using the Add-ons control panel."
+msgid ""
+"Select any add-ons you want to activate immediately. You can also activate "
+"add-ons after the site has been created using the Add-ons control panel."
 msgstr ""
+"Выберите дополнения, которые нужно активировать сразу. Вы также можете "
+"активировать дополнения после создания сайта в панели управления "
+"дополнениями."
 
 #: senaite/core/exportimport/import.pt:135
 msgid "Select existing file"
@@ -5510,19 +5888,31 @@ msgstr "Выберите существующий файл"
 
 #: bika/lims/content/instrumentcertification.py:85
 msgid "Select if is an in-house calibration certificate"
-msgstr ""
+msgstr "Отметьте, если это внутренний сертификат калибровки"
 
 #: bika/lims/content/analysisservice.py:88
-msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
+msgid ""
+"Select if the calculation to be used is the calculation set by default in "
+"the default method. If unselected, the calculation can be selected manually"
 msgstr ""
+"Отметьте, если нужно использовать формулу расчёта, заданную по умолчанию в "
+"методе по умолчанию. Если не отмечено, формулу можно выбрать вручную"
 
 #: bika/lims/content/pricelist.py:76
 msgid "Select if the descriptions should be included"
 msgstr "Выберите, если описания должны быть включены"
 
 #: bika/lims/content/abstractbaseanalysis.py:393
-msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
+msgid ""
+"Select if the results for tests of this type of analysis can be set by using"
+" an instrument. If disabled, no instruments will be available for tests of "
+"this type of analysis in manage results view, even though the method "
+"selected for the test has instruments assigned."
 msgstr ""
+"Отметьте, если результаты тестов этого типа анализа можно устанавливать с "
+"помощью инструмента. Если отключено, инструменты не будут доступны для "
+"тестов этого типа в просмотре управления результатами, даже если у "
+"выбранного метода есть назначенные инструменты."
 
 #: senaite/core/browser/worksheets/templates/view.pt:66
 msgid "Select instrument"
@@ -5530,7 +5920,7 @@ msgstr "Выбрать инструмент"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/rejectionwidget.pt:50
 msgid "Select reasons"
-msgstr ""
+msgstr "Выберите причины"
 
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:76
 #: senaite/core/browser/worksheets/templates/view.pt:51
@@ -5538,69 +5928,100 @@ msgstr ""
 msgid "Select template"
 msgstr "Выбрать шаблон"
 
-#: bika/lims/content/bikasetup.py:270
+#: bika/lims/content/bikasetup.py:269
 msgid "Select the country the site will show by default"
 msgstr "Выберите страну, сайт будет отображать по умолчанию"
 
-#: bika/lims/content/bikasetup.py:255
+#: bika/lims/content/bikasetup.py:254
 msgid "Select the currency the site will use to display prices."
 msgstr "Выберите валюту, сайт будет использовать для отображения цены."
 
 #: bika/lims/content/analysisservice.py:166
-msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
+msgid ""
+"Select the default container to be used for this analysis service. If the "
+"container to be used depends on the sample type and preservation "
+"combination, specify the container in the sample type table below"
 msgstr ""
+"Выберите контейнер по умолчанию для этой услуги анализа. Если контейнер "
+"зависит от сочетания типа образца и способа сохранения, укажите его в "
+"таблице типов образца ниже"
 
 #: bika/lims/profiles/default/registry.xml
-msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
+msgid ""
+"Select the default landing page. This is used when a Client user logs into "
+"the system, or when a client is selected from the client folder listing."
 msgstr ""
+"Выберите стартовую страницу по умолчанию. Она используется при входе "
+"пользователя-клиента в систему или при выборе клиента из списка папки "
+"клиентов."
 
-#: senaite/core/content/senaitesetup.py:1152
+#: senaite/core/content/senaitesetup.py:1129
 msgid "Select the default sticker template used for automatic printing."
-msgstr ""
+msgstr "Выберите шаблон стикера по умолчанию для автоматической печати."
 
-#: bika/lims/content/bikasetup.py:1001
+#: bika/lims/content/bikasetup.py:1000
 msgid "Select the default sticker template used for automatic printing.<br/>"
-msgstr ""
+msgstr "Выберите шаблон стикера по умолчанию для автоматической печати.<br/>"
 
 #: bika/lims/content/identifiertype.py:40
 msgid "Select the types that this ID is used to identify."
-msgstr ""
+msgstr "Выберите типы, которые идентифицирует этот ID."
 
-#: senaite/core/content/senaitesetup.py:1086
-msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
+#: senaite/core/content/senaitesetup.py:1063
+msgid ""
+"Select this to activate automatic notifications via email to the Client when"
+" a Sample is rejected."
 msgstr ""
+"Отметьте, чтобы активировать автоматические уведомления клиента по email при"
+" отклонении образца."
 
-#: bika/lims/content/bikasetup.py:593
+#: bika/lims/content/bikasetup.py:592
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
+"Отметьте, чтобы использовать панель управления как главную страницу по "
+"умолчанию."
 
-#: senaite/core/content/senaitesetup.py:1013
+#: senaite/core/content/senaitesetup.py:990
 msgid "Select this to activate the sample collection workflow steps."
-msgstr "Выберите эту опцию, чтобы активировать этапы рабочего процесса сбора образцов."
-
-#: senaite/core/content/senaitesetup.py:1021
-msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
+"Выберите эту опцию, чтобы активировать этапы рабочего процесса сбора "
+"образцов."
 
-#: senaite/core/content/senaitesetup.py:1001
-msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+#: senaite/core/content/senaitesetup.py:998
+msgid ""
+"Select this to allow a Sampling Coordinator to schedule a sampling. This "
+"functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
+"Отметьте, чтобы разрешить координатору отбора проб планировать отбор проб. "
+"Действует только при активном процессе отбора проб"
 
-#: senaite/core/content/senaitesetup.py:991
-msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+#: senaite/core/content/senaitesetup.py:980
+msgid ""
+"Select this to allow the user to set an additional 'Printed' status to those"
+" Analysis Requests that have been Published. Disabled by default."
 msgstr ""
+"Отметьте, чтобы разрешить пользователю устанавливать дополнительный статус "
+"'Напечатано' для опубликованных заявок на анализ. По умолчанию отключено."
 
-#: senaite/core/content/senaitesetup.py:981
-msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
+#: senaite/core/content/senaitesetup.py:1008
+msgid ""
+"Select to receive the samples automatically when created by lab personnel "
+"and sampling workflow is disabled. Samples created by client contacts won't "
+"be received automatically"
 msgstr ""
+"Отметьте, чтобы автоматически принимать образцы, созданные персоналом "
+"лаборатории, при отключённом процессе отбора проб. Образцы, созданные "
+"контактами клиента, автоматически приниматься не будут"
 
-#: senaite/core/content/senaitesetup.py:1031
-msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
+#: bika/lims/content/bikasetup.py:722
+msgid ""
+"Select to show sample partitions to client contacts. If deactivated, "
+"partitions won't be included in listings and no info message with links to "
+"the primary sample will be displayed to client contacts."
 msgstr ""
-
-#: bika/lims/content/bikasetup.py:723
-msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-msgstr ""
+"Отметьте, чтобы показывать партиции образца контактам клиента. Если "
+"отключено, партиции не будут включены в списки, и контактам клиента не будет"
+" показано информационное сообщение со ссылками на основной образец."
 
 #: bika/lims/content/worksheettemplate.py:82
 msgid "Select which Analyses should be included on the Worksheet"
@@ -5608,36 +6029,36 @@ msgstr "Выберете, какие анализы должны быть вкл
 
 #: senaite/core/config/vocabularies.py:57
 msgid "Selection list"
-msgstr ""
+msgstr "Список выбора"
 
-#: bika/lims/content/abstractbaseanalysis.py:820
+#: bika/lims/content/abstractbaseanalysis.py:817
 msgid "Self-verification of results"
 msgstr "Самопроверка результатов"
 
 #: bika/lims/browser/publish/templates/email.pt:208
 msgid "Send"
-msgstr ""
+msgstr "Отправить"
 
 #: bika/lims/browser/publish/templates/email.pt:23
 msgid "Send Analysis Reports via Email"
-msgstr ""
+msgstr "Отправить отчёты по анализам по email"
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:256
 msgid "Send Log"
-msgstr ""
+msgstr "Журнал отправки"
 
-#: senaite/core/content/resultsreport.py:260
+#: senaite/core/content/resultsreport.py:259
 msgid "Send Log Entry"
-msgstr ""
+msgstr "Запись журнала отправки"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:132
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:135
 msgid "Send an email notification to ${recipients}"
-msgstr ""
+msgstr "Отправить уведомление по email на ${recipients}"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:132
 msgid "Sender"
-msgstr ""
+msgstr "Отправитель"
 
 #: bika/lims/browser/publish/reports_listing.py:91
 msgid "Sent to"
@@ -5646,11 +6067,11 @@ msgstr "Отправлен"
 #: bika/lims/browser/fields/partitionsetupfield.py:115
 #: bika/lims/content/analysisservice.py:129
 msgid "Separate Container"
-msgstr ""
+msgstr "Отдельный контейнер"
 
-#: senaite/core/content/senaitesetup.py:217
+#: senaite/core/content/senaitesetup.py:216
 msgid "Seq Type"
-msgstr ""
+msgstr "Тип последовательности"
 
 #: bika/lims/content/instrument.py:145
 msgid "Serial No"
@@ -5662,41 +6083,52 @@ msgstr "Серийный номер"
 msgid "Service"
 msgstr "Услуга"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
-msgid "Service cannot be deselected. Please click the info button for further details"
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+msgid ""
+"Service cannot be deselected. Please click the info button for further "
+"details"
 msgstr ""
+"Услугу нельзя снять с выбора. Нажмите кнопку информации для подробностей"
 
 #: senaite/core/exportimport/instruments/importer.py:315
 msgid "Service keyword {analysis_keyword} not found"
-msgstr ""
+msgstr "Ключевое слово услуги {analysis_keyword} не найдено"
 
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:119
 msgid "Set Conditions"
-msgstr ""
+msgstr "Задать условия"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:167
 msgid "Set remarks"
-msgstr ""
+msgstr "Задать замечания"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:171
 msgid "Set remarks for selected analyses"
-msgstr ""
+msgstr "Задать замечания для выбранных анализов"
 
 #: bika/lims/content/analysisrequest.py:672
 msgid "Set the Sample Rejection workflow and the reasons"
-msgstr ""
+msgstr "Настройте процесс отклонения образца и причины"
 
 #: bika/lims/content/instrumentmaintenancetask.py:128
 msgid "Set the maintenance task as closed."
-msgstr ""
+msgstr "Отметить задачу обслуживания как закрытую."
 
-#: senaite/core/content/senaitesetup.py:1096
-msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
+#: senaite/core/content/senaitesetup.py:1073
+msgid ""
+"Set the text for the body of the email to be sent to the Sample's client "
+"contact if the option 'Email notification on Sample rejection' is enabled. "
+"You can use reserved keywords: $sample_id, $sample_link, $reasons, "
+"$lab_address"
 msgstr ""
+"Задайте текст письма, отправляемого контакту клиента образца, если включена "
+"опция 'Уведомление по email при отклонении образца'. Можно использовать "
+"зарезервированные ключевые слова: $sample_id, $sample_link, $reasons, "
+"$lab_address"
 
 #: senaite/core/registry/schema.py:40
 msgid "Settings for Clients"
-msgstr ""
+msgstr "Настройки клиентов"
 
 #: bika/lims/profiles/default/types/BikaSetup.xml
 msgid "Setup"
@@ -5704,75 +6136,72 @@ msgstr "Настройка"
 
 #: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
-msgstr ""
+msgstr "Код стеллажа"
 
 #: bika/lims/content/storagelocation.py:83
 msgid "Shelf Description"
-msgstr ""
+msgstr "Описание стеллажа"
 
 #: bika/lims/content/storagelocation.py:73
 msgid "Shelf Title"
-msgstr ""
+msgstr "Название стеллажа"
 
 #: bika/lims/config.py:84
 msgid "Shipping address"
 msgstr "Адрес доставки"
 
 #: bika/lims/content/client.py:61
-msgid "Short and unique identifier of this client. Besides fast searches by client in Samples listings, the purposes of this field depend on the laboratory needs. For instance, the Client ID can be included as part of the Sample identifier, so the lab can easily know the client a given sample belongs to by just looking to its ID."
+msgid ""
+"Short and unique identifier of this client. Besides fast searches by client "
+"in Samples listings, the purposes of this field depend on the laboratory "
+"needs. For instance, the Client ID can be included as part of the Sample "
+"identifier, so the lab can easily know the client a given sample belongs to "
+"by just looking to its ID."
 msgstr ""
+"Краткий уникальный идентификатор этого клиента. Помимо быстрого поиска по "
+"клиенту в списках образцов, назначение этого поля зависит от нужд "
+"лаборатории. Например, ID клиента может быть включён в идентификатор "
+"образца, чтобы лаборатория могла легко определить клиента по ID образца."
 
 #: bika/lims/content/method.py:160
 msgid "Short method description"
-msgstr ""
+msgstr "Краткое описание метода"
 
 #: bika/lims/content/abstractbaseanalysis.py:68
 msgid "Short title"
-msgstr ""
+msgstr "Краткое название"
 
 #: bika/lims/content/analysisrequest.py:974
 msgid "Should the analyses be excluded from the invoice?"
-msgstr ""
+msgstr "Исключать ли анализы из счёта?"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:127
 msgid "Should the default example content be added to the site?"
-msgstr ""
+msgstr "Добавить ли на сайт стандартный демонстрационный контент?"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
 msgid "Show additional fields"
-msgstr ""
+msgstr "Показать дополнительные поля"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
 msgid "Show all"
-msgstr ""
-
-#: senaite/core/api/remarks.py:486
-msgid "Show history"
-msgstr ""
+msgstr "Показать все"
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
-msgstr ""
+msgstr "Показать последние журналы автоимпорта"
 
-#: senaite/core/api/remarks.py:489
+#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
 msgid "Show less"
-msgstr ""
+msgstr "Показать меньше"
 
-#: senaite/core/api/remarks.py:488
+#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
 msgid "Show more"
-msgstr ""
+msgstr "Показать больше"
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
-msgstr ""
-
-# senaite.app.listing: Column config — plus button tooltip / aria-label
-msgid "Show this column"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:129
-msgid "Show/hide timeline"
-msgstr ""
+msgstr "Показать стандартные поля"
 
 #: bika/lims/content/labcontact.py:46
 msgid "Signature"
@@ -5780,31 +6209,31 @@ msgstr "Подпись"
 
 #: senaite/core/profiles/default/types/SimpleFile.xml
 msgid "Simple File"
-msgstr ""
+msgstr "Простой файл"
 
 #: senaite/core/profiles/default/types/SimpleImage.xml
 msgid "Simple Image"
-msgstr ""
+msgstr "Простое изображение"
 
 #: bika/lims/content/storagelocation.py:43
 msgid "Site Code"
-msgstr ""
+msgstr "Код площадки"
 
 #: bika/lims/content/storagelocation.py:48
 msgid "Site Description"
-msgstr ""
+msgstr "Описание площадки"
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:313
 msgid "Site Logo"
-msgstr ""
+msgstr "Логотип сайта"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:319
 msgid "Site Logo CSS"
-msgstr ""
+msgstr "CSS логотипа сайта"
 
 #: bika/lims/content/storagelocation.py:38
 msgid "Site Title"
-msgstr ""
+msgstr "Название площадки"
 
 #: senaite/core/browser/clients/client/attachments/view.py:67
 #: senaite/core/browser/viewlets/templates/attachments.pt:65
@@ -5812,79 +6241,88 @@ msgid "Size"
 msgstr "Размер"
 
 #: senaite/core/exportimport/instruments/importer.py:648
-msgid "Skipping result for analysis '{keyword}' of sample '{sid}' with calculation '{calculation}'"
+msgid ""
+"Skipping result for analysis '{keyword}' of sample '{sid}' with calculation "
+"'{calculation}'"
 msgstr ""
+"Пропуск результата для анализа '{keyword}' образца '{sid}' с формулой "
+"расчёта '{calculation}'"
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Small Sticker"
 msgstr "Мелкий стикер"
 
-#: senaite/core/content/senaitesetup.py:1161
+#: senaite/core/content/senaitesetup.py:1138
 msgid "Small Sticker Template"
-msgstr ""
+msgstr "Шаблон малого стикера"
 
 #: bika/lims/browser/auditlog.py:98
 msgid "Snapshot"
-msgstr ""
+msgstr "Снимок"
 
 #: bika/lims/browser/worksheet/views/results.py:190
-msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
+msgid ""
+"Some analyses use out-of-date or uncalibrated instruments. Results edition "
+"not allowed"
 msgstr ""
+"Некоторые анализы используют просроченные или неоткалиброванные инструменты."
+" Редактирование результатов запрещено"
 
 #: bika/lims/content/abstractbaseanalysis.py:82
-#: bika/lims/content/analysiscategory.py:82
-#: bika/lims/content/subgroup.py:38
+#: bika/lims/content/analysiscategory.py:82 bika/lims/content/subgroup.py:38
 msgid "Sort Key"
-msgstr ""
-
-# senaite.app.listing: Column header — sort arrow tooltip / aria-label
-msgid "Sort ascending"
-msgstr ""
-
-# senaite.app.listing: Column header — sort arrow tooltip / aria-label
-msgid "Sort descending"
-msgstr ""
+msgstr "Ключ сортировки"
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
-msgstr ""
+msgstr "Источник"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:93
 msgid "Specification"
-msgstr ""
+msgstr "Спецификация"
 
 #: senaite/core/content/dynamicanalysisspec.py:50
 msgid "Specification File"
-msgstr ""
+msgstr "Файл спецификации"
 
 #: bika/lims/content/analysisrequest.py:707
 msgid "Specification Name"
-msgstr ""
+msgstr "Название спецификации"
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:18
 msgid "Specification ranges have changed since they were assigned"
-msgstr ""
+msgstr "Диапазоны спецификации изменились с момента назначения"
 
 #: bika/lims/content/analysisspec.py:90
 msgid "Specifications"
-msgstr ""
+msgstr "Спецификации"
 
-#: senaite/core/content/senaitesetup.py:1186
+#: senaite/core/content/senaitesetup.py:1163
 msgid "Specify how many copies of each sticker should be printed by default."
-msgstr ""
+msgstr "Укажите количество копий каждого стикера для печати по умолчанию."
 
 #: bika/lims/content/worksheettemplate.py:63
-msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
+msgid ""
+"Specify the size of the Worksheet, e.g. corresponding to a specific "
+"instrument's tray size. Then select an Analysis 'type' per Worksheet "
+"position.Where QC samples are selected, also select which Reference Sample "
+"should be used.If a duplicate analysis is selected, indicate which sample "
+"position it should be a duplicate of"
 msgstr ""
+"Укажите размер рабочего листа, например, соответствующий размеру лотка "
+"конкретного инструмента. Затем выберите 'тип' анализа для каждой позиции "
+"рабочего листа. Если выбраны образцы контроля качества, также выберите "
+"используемый референс-образец. Если выбран дублирующий анализ, укажите, "
+"дубликатом какой позиции образца он является"
 
-#: senaite/core/content/senaitesetup.py:246
+#: senaite/core/content/senaitesetup.py:245
 msgid "Split Length"
-msgstr ""
+msgstr "Длина разбиения"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:149
 #: senaite/core/registry/schema.py:205
 msgid "Standard fields"
-msgstr ""
+msgstr "Стандартные поля"
 
 #: bika/lims/browser/pricelist.py:64
 msgid "Start Date"
@@ -5892,19 +6330,19 @@ msgstr "Дата начала действия"
 
 #: bika/lims/validators.py:237
 msgid "Start date must be before End Date"
-msgstr ""
+msgstr "Дата начала должна быть раньше даты окончания"
 
-#: senaite/core/browser/samples/view.py:264
+#: senaite/core/browser/samples/view.py:246
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
 msgstr "Статус"
 
-#: senaite/core/browser/dashboard/dashboard.py:127
+#: bika/lims/browser/analyses/view.py:200
 msgid "Status"
 msgstr "Статус"
 
-#: senaite/core/content/senaitesetup.py:1395
+#: senaite/core/content/senaitesetup.py:1368
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
 msgstr "Наклейка"
@@ -5913,14 +6351,10 @@ msgstr "Наклейка"
 msgid "Stickers preview"
 msgstr "Предварительный просмотр наклеек"
 
-# senaite.app.listing: Saved filter presets — star action tooltip when active
-msgid "Stop auto-applying"
-msgstr ""
-
-#: senaite/core/browser/samples/view.py:221
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
-msgstr ""
+msgstr "Место хранения"
 
 #: senaite/core/profiles/default/types/StorageLocations.xml
 msgid "Storage Locations"
@@ -5932,20 +6366,20 @@ msgstr "Строка"
 
 #: senaite/core/profiles/default/types/SubGroup.xml
 msgid "SubGroup"
-msgstr ""
+msgstr "Подгруппа"
 
 #: senaite/core/profiles/default/types/SubGroups.xml
 msgid "SubGroups"
-msgstr ""
+msgstr "Подгруппы"
 
 #: bika/lims/content/subgroup.py:39
 msgid "Subgroups are sorted with this key in group views"
-msgstr ""
+msgstr "Подгруппы сортируются по этому ключу в просмотрах группы"
 
 #: bika/lims/browser/publish/templates/email.pt:115
 #: bika/lims/browser/templates/analysisreport_info.pt:165
 msgid "Subject"
-msgstr ""
+msgstr "Тема"
 
 #: senaite/core/exportimport/import.pt:124
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
@@ -5954,29 +6388,28 @@ msgid "Submit"
 msgstr "Отправить"
 
 #: senaite/core/exportimport/import.pt:114
-msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
+msgid ""
+"Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
+"Для продолжения загрузите корректный файл Open XML (.XLSX) с записями "
+"настроек."
 
-#: senaite/core/browser/dashboard/dashboard.py:490
-msgid "Submitted analyses awaiting verification"
-msgstr ""
-
-#: bika/lims/browser/analyses/view.py:1571
+#: bika/lims/browser/analyses/view.py:1570
 msgid "Submitted and verified by the same user: {}"
-msgstr ""
+msgstr "Отправлено и верифицировано одним пользователем: {}"
 
 #: bika/lims/browser/analyses/view.py:181
 msgid "Submitter"
-msgstr ""
+msgstr "Отправитель"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
 msgstr "Итого"
 
 #: senaite/core/vocabularies/setup.py:162
 msgid "Sunday"
-msgstr ""
+msgstr "Воскресенье"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:600
 #: senaite/core/profiles/default/types/Supplier.xml
@@ -5989,11 +6422,11 @@ msgstr "Поставщики"
 
 #: bika/lims/browser/worksheet/views/referencesamples.py:75
 msgid "Supported Services"
-msgstr ""
+msgstr "Поддерживаемые услуги"
 
 #: bika/lims/content/method.py:116
 msgid "Supported calculations of this method"
-msgstr ""
+msgstr "Поддерживаемые формулы расчёта этого метода"
 
 #: bika/lims/content/person.py:75
 msgid "Surname"
@@ -6005,39 +6438,39 @@ msgstr "Переключить на стандартное представле�
 
 #: bika/lims/browser/templates/senaite-frontpage.pt:6
 msgid "Switch to dashboard"
-msgstr ""
+msgstr "Переключиться на панель управления"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:25
 msgid "Switch to transposed view"
 msgstr "Переключить на транспонированное представление"
 
-#: bika/lims/content/abstractbaseanalysis.py:1089
+#: bika/lims/content/abstractbaseanalysis.py:1086
 msgid "System default"
-msgstr ""
+msgstr "Системное значение по умолчанию"
 
 #: bika/lims/browser/instrument.py:84
 msgid "Task"
-msgstr ""
+msgstr "Задача"
 
 #: bika/lims/content/instrumentcertification.py:57
 msgid "Task ID"
-msgstr ""
+msgstr "ID задачи"
 
 #. Default: "Type"
 #: bika/lims/browser/instrument.py:86
 #: bika/lims/content/instrumentscheduledtask.py:66
 msgid "Task type"
-msgstr ""
+msgstr "Тип"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:217
 msgid "Taxes"
-msgstr ""
+msgstr "Налоги"
 
 #: bika/lims/content/method.py:78
 msgid "Technical description and instructions intended for analysts"
 msgstr "Техническое описание и инструкции, предназначенные для аналитиков"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:236
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
@@ -6045,31 +6478,39 @@ msgstr "Шаблон"
 
 #: bika/lims/content/calculation.py:156
 msgid "Test Parameters"
-msgstr ""
+msgstr "Параметры теста"
 
 #: bika/lims/content/calculation.py:170
 msgid "Test Result"
-msgstr ""
+msgstr "Результат теста"
 
 #: senaite/core/config/vocabularies.py:56
 msgid "Text"
-msgstr ""
+msgstr "Текст"
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:5
 msgid "Thank you for your analysis request."
-msgstr ""
+msgstr "Благодарим за заявку на анализ."
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:54
-msgid "The ID of the site. This ends up as part of the URL. No special characters or spaces are allowed."
+msgid ""
+"The ID of the site. This ends up as part of the URL. No special characters "
+"or spaces are allowed."
 msgstr ""
+"ID сайта. Становится частью URL. Специальные символы и пробелы не "
+"допускаются."
 
 #: bika/lims/content/laboratory.py:65
 msgid "The Laboratory's web address"
 msgstr "веб-адрес лаборатория "
 
 #: senaite/core/browser/form/adapters/referencesample.py:46
-msgid "The Reference Sample ID cannot be changed because it is already associated with other objects, such as QC analyses."
+msgid ""
+"The Reference Sample ID cannot be changed because it is already associated "
+"with other objects, such as QC analyses."
 msgstr ""
+"ID референс-образца нельзя изменить, поскольку он уже связан с другими "
+"объектами, например анализами контроля качества."
 
 #: bika/lims/content/laboratory.py:142
 msgid "The accreditation standard that applies, e.g. ISO 17025"
@@ -6081,116 +6522,166 @@ msgstr "Анализы, включенные в этот профиль, сгр�
 
 #: bika/lims/content/instrumentcalibration.py:97
 msgid "The analyst or agent responsible of the calibration"
-msgstr ""
+msgstr "Аналитик или ответственный за калибровку"
 
 #: bika/lims/content/instrumentmaintenancetask.py:84
 msgid "The analyst or agent responsible of the maintenance"
-msgstr ""
+msgstr "Аналитик или ответственный за обслуживание"
 
 #: bika/lims/content/instrumentvalidation.py:79
 msgid "The analyst responsible of the validation"
-msgstr ""
+msgstr "Аналитик, ответственный за валидацию"
 
 #: bika/lims/browser/batch/batchbook.py:38
-msgid "The batch book allows to introduce analysis results for all samples in this batch. Please note that submitting the results for verification is only possible within samples or worksheets, because additional information like e.g. the instrument or the method need to be set additionally."
+msgid ""
+"The batch book allows to introduce analysis results for all samples in this "
+"batch. Please note that submitting the results for verification is only "
+"possible within samples or worksheets, because additional information like "
+"e.g. the instrument or the method need to be set additionally."
 msgstr ""
+"Книга партии позволяет вносить результаты анализов для всех образцов этой "
+"партии. Обратите внимание: отправка результатов на верификацию возможна "
+"только в образцах или рабочих листах, поскольку требуется указать "
+"дополнительную информацию, например инструмент или метод."
 
 #: bika/lims/content/analysisrequest.py:852
 msgid "The client side identifier of the sample"
-msgstr ""
+msgstr "Идентификатор образца со стороны клиента"
 
 #: bika/lims/content/analysisrequest.py:818
 msgid "The client side order number for this request"
-msgstr ""
+msgstr "Номер заказа этой заявки со стороны клиента"
 
 #: bika/lims/content/analysisrequest.py:835
 msgid "The client side reference for this request"
-msgstr ""
+msgstr "Референс этой заявки со стороны клиента"
 
 #: bika/lims/content/instrument.py:348
 msgid "The date the instrument was installed"
-msgstr ""
+msgstr "Дата установки инструмента"
 
 #: bika/lims/content/analysisrequest.py:623
 msgid "The date when the sample was preserved"
-msgstr ""
+msgstr "Дата консервации образца"
 
 #: bika/lims/content/analysisrequest.py:1077
 msgid "The date when the sample was received"
-msgstr ""
+msgstr "Дата приёма образца"
 
-#: bika/lims/content/client.py:230
+#: bika/lims/content/client.py:226
 msgid "The decimal mark selected in Bika Setup will be used."
-msgstr ""
+msgstr "Будет использован десятичный разделитель, выбранный в Bika Setup."
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:113
-msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
+msgid ""
+"The default timezone setting of the portal. Users will be able to set their "
+"own timezone, if available timezones are defined in the date and time "
+"settings."
 msgstr ""
+"Часовой пояс портала по умолчанию. Пользователи смогут задать собственный "
+"часовой пояс, если доступные часовые пояса определены в настройках даты и "
+"времени."
 
-#: bika/lims/content/bikasetup.py:283
-msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-msgstr "Процент скидки введен здесь, применяется к ценам для клиентов с пометкой \"член\", как правило, кооператоров или партнеров, заслуживающих этой скидки"
+#: bika/lims/content/bikasetup.py:282
+msgid ""
+"The discount percentage entered here, is applied to the prices for clients "
+"flagged as 'members', normally co-operative members or associates deserving "
+"of this discount"
+msgstr ""
+"Процент скидки введен здесь, применяется к ценам для клиентов с пометкой "
+"\"член\", как правило, кооператоров или партнеров, заслуживающих этой скидки"
 
 #: bika/lims/browser/publish/emailview.py:179
-msgid "The email 'From' address is invalid. Please verify the \"Publication 'From' address\" in Setup > Notifications and/or the \"Site 'From' address\" in Site Setup > Mail."
+msgid ""
+"The email 'From' address is invalid. Please verify the \"Publication 'From' "
+"address\" in Setup > Notifications and/or the \"Site 'From' address\" in "
+"Site Setup > Mail."
 msgstr ""
+"Адрес отправителя письма недействителен. Проверьте \"Адрес отправителя "
+"публикации\" в Настройки > Уведомления и/или \"Адрес отправителя сайта\" в "
+"Настройки сайта > Почта."
 
 #: bika/lims/content/analysisrequest.py:940
 msgid "The environmental condition during sampling"
-msgstr ""
+msgstr "Условия окружающей среды при отборе проб"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:104
-msgid "The fields are always listed on top and can not be faded out. You can drag and drop any fields to the lower list to change thier visibility."
+msgid ""
+"The fields are always listed on top and can not be faded out. You can drag "
+"and drop any fields to the lower list to change thier visibility."
 msgstr ""
+"Эти поля всегда отображаются сверху и не могут быть скрыты. Вы можете "
+"перетащить любые поля в нижний список, чтобы изменить их видимость."
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:150
-msgid "The fields are listed below the promient fields and can be faded out. You can drag and drop any fields to the upper list to change their visibility."
+msgid ""
+"The fields are listed below the promient fields and can be faded out. You "
+"can drag and drop any fields to the upper list to change their visibility."
 msgstr ""
+"Эти поля отображаются под основными полями и могут быть скрыты. Вы можете "
+"перетащить любые поля в верхний список, чтобы изменить их видимость."
 
 #: bika/lims/browser/viewlets/templates/primary_ar_viewlet.pt:20
 msgid "The following partitions have been created from this Sample:"
-msgstr ""
+msgstr "Из этого образца были созданы следующие партиции:"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:47
 msgid "The following sample(s) will be dispatched"
-msgstr ""
+msgstr "Следующие образцы будут отправлены"
 
-#: senaite/core/browser/samples/templates/dispose_samples.pt:47
-msgid "The following sample(s) will be disposed"
+#: senaite/core/content/senaitesetup.py:298
+msgid ""
+"The global Auditlog shows all modifications of the system. When enabled, all"
+" entities will be indexed in a separate catalog. This will increase the time"
+" when objects are created or modified."
 msgstr ""
-
-#: senaite/core/content/senaitesetup.py:299
-msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
-msgstr ""
+"Глобальный журнал аудита показывает все изменения системы. При включении все"
+" сущности будут индексироваться в отдельном каталоге, что увеличит время "
+"создания и изменения объектов."
 
 #: bika/lims/content/samplepoint.py:75
 msgid "The height or depth at which the sample has to be taken"
-msgstr ""
+msgstr "Высота или глубина, на которой должен быть взят образец"
 
-#: bika/lims/browser/analyses/view.py:1846
-msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
+#: bika/lims/browser/analyses/view.py:1845
+msgid ""
+"The holding time for this sample and analysis has expired. Proceeding with "
+"the analysis may compromise the reliability of the results."
 msgstr ""
+"Срок хранения для этого образца и анализа истёк. Продолжение анализа может "
+"снизить достоверность результатов."
 
-#: bika/lims/browser/analyses/view.py:1858
-msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
+#: bika/lims/browser/analyses/view.py:1857
+msgid ""
+"The holding time for this sample and analysis is about to expire. Please "
+"complete the analysis as soon as possible to ensure data accuracy and "
+"reliability."
 msgstr ""
+"Срок хранения для этого образца и анализа скоро истечёт. Завершите анализ "
+"как можно скорее для обеспечения точности и достоверности данных."
 
 #: bika/lims/content/instrument.py:309
 #: bika/lims/content/instrumentcertification.py:58
 msgid "The instrument's ID in the lab's asset register"
-msgstr ""
+msgstr "ID инструмента в реестре активов лаборатории"
 
 #: bika/lims/content/instrument.py:138
 msgid "The instrument's model number"
 msgstr "Номер модели инструмента"
 
 #: bika/lims/content/instrumentcertification.py:111
-msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
+msgid ""
+"The interval is calculated from the 'From' field and defines when the "
+"certificate expires in days. Setting this inverval overwrites the 'To' field"
+" on save."
 msgstr ""
+"Интервал рассчитывается от поля 'С' и определяет, через сколько дней "
+"истекает срок действия сертификата. При сохранении интервал перезаписывает "
+"поле 'До'."
 
 #: senaite/core/browser/samples/invalidate_samples.py:121
 msgid "The invalidation process has been successfully cancelled."
-msgstr ""
+msgstr "Процесс аннулирования успешно отменён."
 
 #: bika/lims/browser/accreditation.py:71
 msgid "The lab is not accredited, or accreditation has not been configured. "
@@ -6198,303 +6689,403 @@ msgstr "Лаборатория не аккредитована, или аккр�
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:90
 msgid "The main language of the site."
-msgstr ""
+msgstr "Основной язык сайта."
 
 #: bika/lims/content/sampletype.py:166
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
+"Минимальный объём образца, необходимый для анализа, например '10 мл' или '1 "
+"кг'."
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:40
-msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
+msgid ""
+"The number generator storage is empty. Counters are seeded on the first ID "
+"generation for each prefix."
 msgstr ""
+"Хранилище генератора номеров пусто. Счётчики создаются при первой генерации "
+"ID для каждого префикса."
 
-#: senaite/core/content/senaitesetup.py:1074
-msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
-msgstr "Количество дней до того, как образец будет просрочен и не может быть проанализирован. Этот параметр может быть перезаписан каждый тип отдельных образцов в типы Установка образцов"
+#: senaite/core/content/senaitesetup.py:1051
+msgid ""
+"The number of days before a sample expires and cannot be analysed any more. "
+"This setting can be overwritten per individual sample type in the sample "
+"types setup"
+msgstr ""
+"Количество дней до того, как образец будет просрочен и не может быть "
+"проанализирован. Этот параметр может быть перезаписан каждый тип отдельных "
+"образцов в типы Установка образцов"
 
-#: bika/lims/content/bikasetup.py:163
-msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-msgstr "Количество минут до автоматического выхода пользователя . 0 отключает автоматический выход"
+#: bika/lims/content/bikasetup.py:162
+msgid ""
+"The number of minutes before a user is automatically logged off. 0 disables "
+"automatic log-off"
+msgstr ""
+"Количество минут до автоматического выхода пользователя . 0 отключает "
+"автоматический выход"
 
 #: bika/lims/content/sampletype.py:117
-msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
+msgid ""
+"The period for which un-preserved samples of this type can be kept before "
+"they expire and cannot be analysed any further"
 msgstr ""
+"Период, в течение которого неконсервированные образцы этого типа могут "
+"храниться до истечения срока годности"
 
 #: bika/lims/content/analysisrequest.py:644
 msgid "The person who preserved the sample"
-msgstr ""
+msgstr "Лицо, законсервировавшее образец"
 
 #: bika/lims/content/analysisrequest.py:477
 msgid "The person who took the sample"
-msgstr ""
+msgstr "Лицо, отобравшее образец"
 
 #: bika/lims/content/abstractbaseanalysis.py:562
-msgid "The price charged per analysis for clients who qualify for bulk discounts"
-msgstr ""
+msgid ""
+"The price charged per analysis for clients who qualify for bulk discounts"
+msgstr "Цена за анализ для клиентов, имеющих право на оптовую скидку"
 
 #: bika/lims/content/analysisprofile.py:92
 msgid "The profile's commercial ID for accounting purposes."
-msgstr ""
+msgstr "Коммерческий ID профиля для бухгалтерского учёта."
 
 #: bika/lims/content/analysisprofile.py:52
-msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
-msgstr "Профиль ключевое слово используется для уникальной идентификации в файлы импорта. Он должен быть уникальным, и он не может быть таким же, как поля Код любых временных вычислений."
+msgid ""
+"The profile's keyword is used to uniquely identify it in import files. It "
+"has to be unique, and it may not be the same as any Calculation Interim "
+"field ID."
+msgstr ""
+"Профиль ключевое слово используется для уникальной идентификации в файлы "
+"импорта. Он должен быть уникальным, и он не может быть таким же, как поля "
+"Код любых временных вычислений."
 
 #: bika/lims/browser/viewlets/templates/specification_non_compliant_viewlet.pt:23
-msgid "The ranges for the following analyses have been manually changed and they are no longer compliant with the ranges of the Specification:"
+msgid ""
+"The ranges for the following analyses have been manually changed and they "
+"are no longer compliant with the ranges of the Specification:"
 msgstr ""
+"Диапазоны следующих анализов были изменены вручную и больше не соответствуют"
+" диапазонам спецификации:"
 
 #: bika/lims/content/laboratory.py:153
 msgid "The reference code issued to the lab by the accreditation body"
 msgstr "Код ссылки, выданного органом аккредитации лаборатории"
 
 #: bika/lims/content/calculation.py:171
-msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
+msgid ""
+"The result after the calculation has taken place with test values.  You will"
+" need to save the calculation before this value will be calculated."
 msgstr ""
+"Результат после выполнения расчёта с тестовыми значениями. Перед расчётом "
+"этого значения нужно сохранить формулу."
 
-#: bika/lims/browser/analyses/view.py:1836
+#: bika/lims/browser/analyses/view.py:1835
 msgid "The result was captured past the holding time limit."
-msgstr ""
+msgstr "Результат был зафиксирован после истечения срока хранения."
 
 #: bika/lims/content/method.py:149
-msgid "The results for the Analysis Services that use this method can be set manually"
+msgid ""
+"The results for the Analysis Services that use this method can be set "
+"manually"
 msgstr ""
+"Результаты услуг анализа, использующих этот метод, можно устанавливать "
+"вручную"
 
 #: bika/lims/content/abstractbaseanalysis.py:514
-msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
-msgstr "Результаты анализов поля фиксируются во время отбора проб на контрольной точке, например температура образца воды в реке, где пробы отбирались. Лабораторные анализы проводятся в лаборатории"
+msgid ""
+"The results of field analyses are captured during sampling at the sample "
+"point, e.g. the temperature of a water sample in the river where it is "
+"sampled. Lab analyses are done in the laboratory"
+msgstr ""
+"Результаты анализов поля фиксируются во время отбора проб на контрольной "
+"точке, например температура образца воды в реке, где пробы отбирались. "
+"Лабораторные анализы проводятся в лаборатории"
 
 #: senaite/core/browser/viewlets/sample/templates/not_sampled.pt:8
 msgid "The sample cannot be received"
-msgstr ""
+msgstr "Образец не может быть принят"
 
 #: bika/lims/content/artemplate.py:110
 msgid "The sample is a mix of sub samples"
-msgstr ""
+msgstr "Образец является смесью суб-образцов"
 
 #: bika/lims/content/instrument.py:146
 msgid "The serial number that uniquely identifies the instrument"
 msgstr "Серийный номер, который однозначно идентифицирует инструмент"
 
-#: bika/lims/content/abstractbaseanalysis.py:869
+#: bika/lims/content/abstractbaseanalysis.py:866
 msgid "The service's analytical protocol ID"
-msgstr ""
+msgstr "ID аналитического протокола услуги"
 
-#: bika/lims/content/abstractbaseanalysis.py:857
+#: bika/lims/content/abstractbaseanalysis.py:854
 msgid "The service's commercial ID for accounting purposes"
-msgstr ""
+msgstr "Коммерческий ID услуги для бухгалтерского учёта"
 
 #: bika/lims/browser/viewlets/templates/sample_dynamic_specs_viewlet.pt:14
 msgid "The specification has a Dynamic Specification assigned"
-msgstr ""
+msgstr "У спецификации назначена динамическая спецификация"
 
 #: senaite/core/schema/emailfield.py:12
 msgid "The specified email is not valid."
-msgstr ""
+msgstr "Указанный email недействителен."
 
 #: bika/lims/content/referencesample.py:65
-msgid "The unique identifier for this reference sample. If specified, the system will use this value as the sample's ID instead of automatically generating one based on the formatting rules defined in the setup's ID server."
+msgid ""
+"The unique identifier for this reference sample. If specified, the system "
+"will use this value as the sample's ID instead of automatically generating "
+"one based on the formatting rules defined in the setup's ID server."
 msgstr ""
+"Уникальный идентификатор этого референс-образца. Если указан, система будет "
+"использовать это значение как ID образца вместо автоматической генерации по "
+"правилам форматирования сервера идентификаторов."
 
 #: bika/lims/content/abstractbaseanalysis.py:363
-msgid "The unique keyword used to identify the analysis service in import files of bulk Sample requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
+msgid ""
+"The unique keyword used to identify the analysis service in import files of "
+"bulk Sample requests and results imports from instruments. It is also used "
+"to identify dependent analysis services in user defined results calculations"
 msgstr ""
+"Уникальное ключевое слово для идентификации услуги анализа в файлах "
+"массового импорта заявок и импорта результатов из инструментов. Также "
+"используется для идентификации зависимых услуг анализа в пользовательских "
+"формулах расчёта результатов"
 
 #: bika/lims/browser/analysisrequest/add2.py:1461
 msgid "The value of field '%s' was emptied. Please select a new value."
-msgstr ""
+msgstr "Значение поля '%s' было очищено. Выберите новое значение."
 
 #: bika/lims/browser/publish/templates/email.pt:126
-msgid "The variable ${recipients} will be automatically replaced with the names and emails of the final selected recipients."
+msgid ""
+"The variable ${recipients} will be automatically replaced with the names and"
+" emails of the final selected recipients."
 msgstr ""
+"Переменная ${recipients} будет автоматически заменена именами и email "
+"итоговых выбранных получателей."
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:93
 msgid "There are no pre-defined conditions set"
-msgstr ""
+msgstr "Предопределённые условия не заданы"
 
 #: bika/lims/browser/viewlets/templates/dynamic_specs_viewlet.pt:14
 msgid "This Analysis Specification has a Dynamic Specification assigned"
-msgstr ""
+msgstr "У этой спецификации анализа назначена динамическая спецификация"
 
 #: bika/lims/browser/viewlets/templates/rejected_ar_viewlet.pt:15
 msgid "This Sample has been rejected due to the following reasons:"
-msgstr ""
+msgstr "Этот образец был отклонён по следующим причинам:"
 
 #: bika/lims/browser/viewlets/templates/partition_ar_viewlet.pt:14
 msgid "This is a Partition from Sample"
-msgstr ""
+msgstr "Это партиция образца"
 
 #: bika/lims/browser/viewlets/templates/secondary_ar_viewlet.pt:15
 msgid "This is a Secondary Sample of"
-msgstr ""
+msgstr "Это вторичный образец от"
 
 #: bika/lims/browser/viewlets/templates/detached_partition_viewlet.pt:15
 msgid "This is a detached partition from Sample"
-msgstr ""
+msgstr "Это отсоединённая партиция образца"
 
-#: bika/lims/content/bikasetup.py:769
-msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
+#: bika/lims/content/bikasetup.py:768
+msgid ""
+"This is the default maximum time allowed for performing analyses.  It is "
+"only used for analyses where the analysis service does not specify a "
+"turnaround time. Only laboratory workdays are considered."
 msgstr ""
+"Это максимальное время по умолчанию, допустимое для выполнения анализов. "
+"Используется только для анализов, у которых услуга анализа не определяет "
+"срок выполнения. Учитываются только рабочие дни лаборатории."
 
-#: senaite/core/content/senaitesetup.py:1061
-msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
+#: senaite/core/content/senaitesetup.py:1038
+msgid ""
+"This is the default maximum time allowed for performing analyses. It is only"
+" used for analyses where the analysis service does not specify a turnaround "
+"time. Only laboratory workdays are considered."
 msgstr ""
+"Это максимальное время по умолчанию, допустимое для выполнения анализов. "
+"Используется только для анализов, у которых услуга анализа не определяет "
+"срок выполнения. Учитываются только рабочие дни лаборатории."
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:134
-msgid "This operation can not be undone. Are you sure you want to reject the selected analyses?"
+msgid ""
+"This operation can not be undone. Are you sure you want to reject the "
+"selected analyses?"
 msgstr ""
+"Это действие нельзя отменить. Вы уверены, что хотите отклонить выбранные "
+"анализы?"
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:14
 msgid "This report was sent to the following contacts:"
-msgstr ""
+msgstr "Этот отчёт был отправлен следующим контактам:"
 
 #: bika/lims/browser/viewlets/templates/retest_ar_viewlet.pt:19
-msgid "This sample is a retest, automatically generated following the invalidation of sample ${invalidated_id}."
+msgid ""
+"This sample is a retest, automatically generated following the invalidation "
+"of sample ${invalidated_id}."
 msgstr ""
+"Этот образец является повторным тестом, автоматически созданным после "
+"аннулирования образца ${invalidated_id}."
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:28
-msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date} for the following reason(s): ${reason}."
+msgid ""
+"This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date} "
+"for the following reason(s): ${reason}."
 msgstr ""
+"Этот образец был аннулирован пользователем ${actor_fullname} (${actor_id}) "
+"${date} по следующей причине(-ам): ${reason}."
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:38
-msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
+msgid ""
+"This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
+"Этот образец был аннулирован пользователем ${actor_fullname} (${actor_id}) "
+"${date}."
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
-msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+msgid ""
+"This service cannot be selected to prevent the analysis from being conducted"
+" beyond the analytical holding time."
 msgstr ""
+"Эта услуга не может быть выбрана, чтобы предотвратить выполнение анализа "
+"после истечения срока хранения."
 
-#: senaite/core/content/senaitesetup.py:315
+#: senaite/core/content/senaitesetup.py:314
 msgid "This shows a custom logo on your SENAITE site."
-msgstr ""
+msgstr "Показывает пользовательский логотип на вашем сайте SENAITE."
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:57
 msgid "This site configuration is outdated and needs to be upgraded:"
-msgstr ""
+msgstr "Конфигурация сайта устарела и требует обновления:"
 
 #: bika/lims/content/laboratory.py:100
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
+msgstr "Это значение указывается внизу всех опубликованных результатов"
 
 #: bika/lims/browser/worksheet/tools.py:84
-msgid "This worksheet has been created to replace the rejected worksheet at ${ws_id}"
+msgid ""
+"This worksheet has been created to replace the rejected worksheet at "
+"${ws_id}"
 msgstr ""
+"Этот рабочий лист создан для замены отклонённого рабочего листа ${ws_id}"
 
 #: bika/lims/browser/worksheet/tools.py:77
-msgid "This worksheet has been rejected.  The replacement worksheet is ${ws_id}"
-msgstr ""
+msgid ""
+"This worksheet has been rejected.  The replacement worksheet is ${ws_id}"
+msgstr "Этот рабочий лист отклонён. Замещающий рабочий лист — ${ws_id}"
 
 #: senaite/core/vocabularies/setup.py:159
 msgid "Thursday"
-msgstr ""
+msgstr "Четверг"
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:47
 msgid "Time"
-msgstr ""
+msgstr "Время"
 
 #: senaite/core/exportimport/import.pt:129
-msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
+msgid ""
+"Tip. Attached documents will not be loaded unless they are present in the "
+"instance."
 msgstr ""
+"Совет. Прикреплённые документы не будут загружены, если они отсутствуют в "
+"инстансе."
 
-#: senaite/core/browser/controlpanel/labels/view.py:60
-#: senaite/core/browser/label/labeled_objects.py:59
+#: senaite/core/browser/controlpanel/labels/view.py:59
+#: senaite/core/browser/label/labeled_objects.py:58
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
 msgstr "Название"
 
 #: bika/lims/content/storagelocation.py:54
 msgid "Title of location"
-msgstr ""
+msgstr "Название местоположения"
 
 #: bika/lims/controlpanel/dynamic_analysisspecs.py:35
 msgid "Title of the Folder"
-msgstr ""
+msgstr "Название папки"
 
 #: bika/lims/content/storagelocation.py:74
 msgid "Title of the shelf"
-msgstr ""
+msgstr "Название стеллажа"
 
 #: bika/lims/content/storagelocation.py:39
 msgid "Title of the site"
-msgstr ""
+msgstr "Название площадки"
 
 #: bika/lims/content/instrumentcalibration.py:88
 #: bika/lims/content/instrumentmaintenancetask.py:75
 #: bika/lims/content/instrumentvalidation.py:70
 msgid "To"
-msgstr ""
+msgstr "До"
 
-#: senaite/core/browser/samples/view.py:307
+#: senaite/core/browser/samples/view.py:289
 msgid "To Be Preserved"
 msgstr "Должны быть сохранены"
 
-#: senaite/core/browser/samples/view.py:298
+#: senaite/core/browser/samples/view.py:280
 msgid "To Be Sampled"
 msgstr "Ожидаемый образец"
 
-#: senaite/core/browser/dashboard/dashboard.py:93
-msgid "To be Published"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:89
-msgid "To be Verified"
-msgstr ""
-
 #: bika/lims/content/analysiscategory.py:48
-msgid "To be displayed below each Analysis Category section on results reports."
+msgid ""
+"To be displayed below each Analysis Category section on results reports."
 msgstr ""
+"Отображается под каждым разделом категории анализа в отчётах с результатами."
 
-#: senaite/core/browser/dashboard/dashboard.py:158
+#: senaite/core/browser/dashboard/dashboard.py:133
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
 msgstr "Должны быть сохранены"
 
-#: senaite/core/browser/dashboard/dashboard.py:441
+#: senaite/core/browser/dashboard/dashboard.py:398
 msgid "To be printed"
-msgstr ""
+msgstr "К печати"
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:132
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
 msgstr "Ожидаемые образцы"
 
-#: senaite/core/browser/dashboard/dashboard.py:148
-#: senaite/core/browser/samples/view.py:349
+#: senaite/core/browser/dashboard/dashboard.py:124
+#: senaite/core/browser/samples/view.py:331
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
 msgstr "На проверку"
 
 #: bika/lims/content/calculation.py:157
-msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
+msgid ""
+"To test the calculation, enter values here for all calculation parameters.  "
+"This includes Interim fields defined above, as well as any services that "
+"this calculation depends on to calculate results."
 msgstr ""
+"Чтобы протестировать формулу расчёта, введите здесь значения всех параметров"
+" расчёта. Это включает промежуточные поля, определённые выше, а также любые "
+"услуги, от которых зависит расчёт результатов."
 
 #: senaite/core/registry/schema.py:174
 msgid "Toggle visibility of standard sample header fields"
-msgstr ""
+msgstr "Переключить видимость стандартных полей заголовка образца"
 
-#: senaite/core/browser/samples/view.py:650
+#: senaite/core/browser/samples/view.py:523
 msgid "Total"
 msgstr "Итого"
 
-#: bika/lims/content/analysisprofile.py:142
-#: bika/lims/content/labproduct.py:67
+#: bika/lims/content/analysisprofile.py:142 bika/lims/content/labproduct.py:67
 msgid "Total price"
 msgstr "Полная стоимость"
 
 #: bika/lims/browser/publish/emailview.py:202
 msgid "Total size of email exceeded {:.1f} MB ({:.2f} MB)"
-msgstr ""
+msgstr "Общий размер письма превысил {:.1f} МБ ({:.2f} МБ)"
 
 #: bika/lims/config.py:126
 msgid "Transposed"
-msgstr ""
+msgstr "Транспонировано"
 
 #: senaite/core/vocabularies/setup.py:157
 msgid "Tuesday"
-msgstr ""
+msgstr "Вторник"
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:62
+#: senaite/core/browser/label/labeled_objects.py:61
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
 msgstr "Тип"
@@ -6502,51 +7093,55 @@ msgstr "Тип"
 #: bika/lims/browser/fields/interimfieldsfield.py:64
 msgid "Type of control to be displayed on value entry when choices are set"
 msgstr ""
+"Тип контроля, отображаемый при вводе значения, если заданы варианты выбора"
 
 #: bika/lims/content/multifile.py:74
-msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
+msgid ""
+"Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
+"Тип документа (например, руководство пользователя, спецификации инструмента,"
+" изображение...)"
 
 #: bika/lims/content/storagelocation.py:69
 msgid "Type of location"
-msgstr ""
+msgstr "Тип местоположения"
 
 #: senaite/core/content/samplecontainer.py:73
 msgid "Type of the container"
-msgstr ""
+msgstr "Тип контейнера"
 
 #: senaite/core/browser/controlpanel/templates/setupview.pt:27
 msgid "Type to filter ..."
-msgstr ""
-
-# senaite.app.listing: Column-filter row — searchable-select placeholder
-msgid "Type to filter..."
-msgstr ""
+msgstr "Введите для фильтрации..."
 
 #: senaite/core/registry/schema.py:78
-msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
+msgid ""
+"Types that support labels directly.<br/>NOTE: In cluster setups, other "
+"instances need to be restarted manually for the changes to take place!"
 msgstr ""
+"Типы, непосредственно поддерживающие метки.<br/>ПРИМЕЧАНИЕ: в кластерных "
+"конфигурациях остальные инстансы нужно перезапустить вручную для применения "
+"изменений!"
 
 #: senaite/core/registry/schema.py:77
 msgid "Types with labels"
-msgstr ""
+msgstr "Типы с метками"
 
-#: senaite/core/content/resultsreport.py:100
+#: senaite/core/content/resultsreport.py:99
 msgid "UID"
-msgstr ""
+msgstr "UID"
 
 #: bika/lims/browser/worksheet/views/printview.py:151
 msgid "Unable to load the template"
-msgstr ""
+msgstr "Не удалось загрузить шаблон"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassign"
-msgstr ""
+msgstr "Отменить назначение"
 
-#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
-msgstr ""
+msgstr "Не назначено"
 
 #: senaite/core/browser/modals/analysis/schema.py:61
 msgid "Uncertainty"
@@ -6558,7 +7153,7 @@ msgstr "Величина неопределенности"
 
 #: bika/lims/content/department.py:45
 msgid "Unique Department ID that identifies the department"
-msgstr ""
+msgstr "Уникальный ID подразделения"
 
 #: senaite/core/browser/modals/analysis/schema.py:96
 msgid "Unit"
@@ -6566,81 +7161,84 @@ msgstr "Единица"
 
 #: senaite/core/browser/clients/client/attachments/view.py:125
 msgid "Unknown"
-msgstr ""
+msgstr "Неизвестно"
 
 #: senaite/core/content/supplier.py:156
 msgid "Unknown IBAN country %s"
-msgstr ""
+msgstr "Неизвестная страна IBAN %s"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:108
 msgid "Unlink User"
-msgstr ""
+msgstr "Отвязать пользователя"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:239
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
 msgid "Unlinked User"
-msgstr ""
-
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-msgid "Unlock"
-msgstr ""
+msgstr "Отвязанный пользователь"
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
 msgid "Unrecognized file format ${file_format}"
-msgstr ""
+msgstr "Нераспознанный формат файла ${file_format}"
 
 #: senaite/core/exportimport/instruments/abaxis/vetscan/vs2.py:51
 #: senaite/core/exportimport/instruments/abbott/m2000rt/m2000rt.py:63
 #: senaite/core/exportimport/instruments/alere/pima/beads.py:51
 msgid "Unrecognized file format ${fileformat}"
-msgstr ""
+msgstr "Нераспознанный формат файла ${fileformat}"
 
 #: senaite/core/exportimport/instruments/horiba/jobinyvon/icp.py:57
 msgid "Unrecognized file format ${format}"
-msgstr ""
+msgstr "Нераспознанный формат файла ${format}"
 
-#: senaite/core/browser/samples/view.py:455
+#: senaite/core/browser/samples/view.py:425
 msgid "Unsassigned"
-msgstr ""
+msgstr "Не назначено"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
 msgstr "Обновить вложения"
 
-# senaite.app.listing: Saved filter presets — Update preset action tooltip
-msgid "Update preset with current view"
-msgstr ""
-
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
-msgstr ""
+msgstr "Обновлено ключей: {} ({})"
 
 #: bika/lims/content/labcontact.py:47
-msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
+msgid ""
+"Upload a scanned signature to be used on printed analysis results reports. "
+"Ideal size is 250 pixels wide by 150 high"
 msgstr ""
+"Загрузите скан подписи для использования в печатных отчётах с результатами "
+"анализа. Оптимальный размер — 250x150 пикселей"
 
-#: bika/lims/content/client.py:254
-msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
+#: bika/lims/content/client.py:250
+msgid ""
+"Upload files and images for this client. Files will be stored in the client "
+"folder and can be downloaded later."
 msgstr ""
+"Загрузите файлы и изображения для этого клиента. Файлы будут храниться в "
+"папке клиента и доступны для скачивания позже."
 
 #: bika/lims/content/analysisprofile.py:101
 msgid "Use Analysis Profile Price"
-msgstr ""
+msgstr "Использовать цену профиля анализа"
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:591
 msgid "Use Dashboard as default front page"
-msgstr ""
+msgstr "Использовать панель управления как главную страницу по умолчанию"
 
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:84
 msgid "Use Template"
-msgstr ""
+msgstr "Использовать шаблон"
 
 #: bika/lims/content/analysisservice.py:87
 msgid "Use the Default Calculation of Method"
-msgstr ""
+msgstr "Использовать формулу расчёта метода по умолчанию"
 
 #: bika/lims/content/instrument.py:292
-msgid "Use this field to pass arbitrary parameters to the export/import modules."
-msgstr "Используйте это поле для передачи произвольных параметров для экспорта / импорта модулей."
+msgid ""
+"Use this field to pass arbitrary parameters to the export/import modules."
+msgstr ""
+"Используйте это поле для передачи произвольных параметров для экспорта / "
+"импорта модулей."
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:71
 #: senaite/core/browser/clients/client/contacts/view.py:74
@@ -6650,45 +7248,50 @@ msgstr "Имя пользователя"
 
 #: bika/lims/controlpanel/bika_labcontacts.py:101
 msgid "User groups"
-msgstr ""
+msgstr "Группы пользователей"
 
 #: senaite/core/browser/user/userdatapanel.py:181
 msgid "User is linked to lab contact '${fullname}'"
-msgstr ""
+msgstr "Пользователь связан с лабораторным контактом '${fullname}'"
 
 #: senaite/core/browser/user/userdatapanel.py:192
 msgid "User is linked to the contact '${fullname}'"
-msgstr ""
+msgstr "Пользователь связан с контактом '${fullname}'"
 
 #: senaite/core/browser/user/userdatapanel.py:189
 msgid "User is linked to the global contact '${fullname}'"
-msgstr ""
+msgstr "Пользователь связан с глобальным контактом '${fullname}'"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:233
+#: senaite/core/browser/clients/client/contacts/login_details.py:217
 msgid "User linked to this Contact"
-msgstr ""
+msgstr "Пользователь, связанный с этим контактом"
 
 #: bika/lims/controlpanel/bika_labcontacts.py:98
 msgid "User name"
-msgstr ""
+msgstr "Имя пользователя"
 
-#: senaite/core/content/resultsreport.py:105
+#: senaite/core/content/resultsreport.py:104
 msgid "Username"
-msgstr ""
+msgstr "Имя пользователя"
 
-#: bika/lims/content/bikasetup.py:341
-msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
+#: bika/lims/content/bikasetup.py:340
+msgid ""
+"Using too few data points does not make statistical sense. Set an acceptable"
+" minimum number of results before QC statistics will be calculated and "
+"plotted"
 msgstr ""
+"Использование слишком малого числа точек данных статистически некорректно. "
+"Установите допустимое минимальное количество результатов перед расчётом и "
+"построением статистики контроля качества"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
 msgstr "НДС"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
-#: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/analysisprofile.py:122 bika/lims/content/bikasetup.py:296
 msgid "VAT %"
 msgstr "% НДС"
 
@@ -6698,7 +7301,7 @@ msgstr "номер НДС"
 
 #: bika/lims/browser/analyses/view.py:223
 msgid "Valid"
-msgstr ""
+msgstr "Действителен"
 
 #: bika/lims/browser/instrument.py:662
 #: bika/lims/content/instrumentcertification.py:126
@@ -6716,27 +7319,31 @@ msgstr "Валидация (поверка)"
 
 #: senaite/core/z3cform/error.py:32
 msgid "Validation failed."
-msgstr ""
+msgstr "Проверка не пройдена."
 
 #: bika/lims/validators.py:346
 msgid "Validation failed: '${keyword}': duplicate keyword"
-msgstr ""
+msgstr "Проверка не пройдена: '${keyword}' — повторяющееся ключевое слово"
 
 #: bika/lims/validators.py:365
-msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
+msgid ""
+"Validation failed: '${title}': This keyword is already in use by service "
+"'${used_by}'"
 msgstr ""
+"Проверка не пройдена: '${title}' — это ключевое слово уже используется "
+"услугой '${used_by}'"
 
 #: bika/lims/validators.py:354
 msgid "Validation failed: '${title}': duplicate title"
-msgstr ""
+msgstr "Проверка не пройдена: '${title}' — повторяющееся название"
 
 #: bika/lims/validators.py:206
 msgid "Validation failed: '${value}' is not unique"
-msgstr ""
+msgstr "Проверка не пройдена: '${value}' не уникально"
 
 #: bika/lims/validators.py:1465
 msgid "Validation failed: '{}' is not numeric"
-msgstr ""
+msgstr "Проверка не пройдена: '{}' не является числом"
 
 #: bika/lims/validators.py:624
 msgid "Validation failed: Bearing must be E/W"
@@ -6748,59 +7355,79 @@ msgstr "Ошибка контроля данных: Bearing must be N/S"
 
 #: bika/lims/validators.py:1350
 msgid "Validation failed: Could not import module '%s'"
-msgstr ""
+msgstr "Проверка не пройдена: не удалось импортировать модуль '%s'"
 
 #: bika/lims/validators.py:966
 msgid "Validation failed: Error percentage must be between 0 and 100"
-msgstr ""
+msgstr "Проверка не пройдена: процент ошибки должен быть от 0 до 100"
 
 #: bika/lims/validators.py:982
 msgid "Validation failed: Error value must be 0 or greater"
-msgstr ""
+msgstr "Проверка не пройдена: значение ошибки должно быть 0 или больше"
 
 #: bika/lims/validators.py:959
 msgid "Validation failed: Error values must be numeric"
-msgstr ""
+msgstr "Проверка не пройдена: значения ошибки должны быть числами"
 
 #: bika/lims/validators.py:499
 msgid "Validation failed: Keyword '${keyword}' is invalid"
-msgstr ""
+msgstr "Проверка не пройдена: ключевое слово '${keyword}' недействительно"
 
 #: bika/lims/validators.py:974
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
+"Проверка не пройдена: значения максимума должны быть больше значений "
+"минимума"
 
 #: bika/lims/validators.py:944
 msgid "Validation failed: Max values must be numeric"
-msgstr ""
+msgstr "Проверка не пройдена: значения максимума должны быть числами"
 
 #: bika/lims/validators.py:937
 msgid "Validation failed: Min values must be numeric"
-msgstr ""
+msgstr "Проверка не пройдена: значения минимума должны быть числами"
 
 #: bika/lims/validators.py:1451
-msgid "Validation failed: Please set a default value when defining a required checkbox condition."
+msgid ""
+"Validation failed: Please set a default value when defining a required "
+"checkbox condition."
 msgstr ""
+"Проверка не пройдена: задайте значение по умолчанию при определении "
+"обязательного условия флажка."
 
 #: bika/lims/validators.py:1445
-msgid "Validation failed: Please use the character '|' to separate the available options in 'Choices' subfield"
+msgid ""
+"Validation failed: Please use the character '|' to separate the available "
+"options in 'Choices' subfield"
 msgstr ""
+"Проверка не пройдена: используйте символ '|' для разделения вариантов в "
+"подполе 'Варианты'"
 
 #: bika/lims/validators.py:770
-msgid "Validation failed: PrePreserved containers must have a preservation selected."
+msgid ""
+"Validation failed: PrePreserved containers must have a preservation "
+"selected."
 msgstr ""
+"Проверка не пройдена: у предварительно законсервированных контейнеров должен"
+" быть выбран способ сохранения."
 
 #: bika/lims/validators.py:728
-msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
+msgid ""
+"Validation failed: The selection requires the following categories to be "
+"selected: ${categories}"
 msgstr ""
+"Проверка не пройдена: необходимо выбрать следующие категории: ${categories}"
 
 #: bika/lims/validators.py:1014
 msgid "Validation failed: Values must be numbers"
-msgstr ""
+msgstr "Проверка не пройдена: значения должны быть числами"
 
 #: bika/lims/validators.py:393
-msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
+msgid ""
+"Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
+"Проверка не пройдена: заголовку столбца '${title}' должно соответствовать "
+"ключевое слово '${keyword}'"
 
 #: bika/lims/validators.py:615
 msgid "Validation failed: degrees is 180; minutes must be zero"
@@ -6808,19 +7435,21 @@ msgstr "Ошибка контроля данных: значение минут 
 
 #: bika/lims/validators.py:620
 msgid "Validation failed: degrees is 180; seconds must be zero"
-msgstr "Ошибка контроля данных: значение градусов равно 180; секунды должны быть равны нулю."
+msgstr ""
+"Ошибка контроля данных: значение градусов равно 180; секунды должны быть "
+"равны нулю."
 
 #: bika/lims/validators.py:596
 msgid "Validation failed: degrees is 90; minutes must be zero"
-msgstr ""
+msgstr "Проверка не пройдена: при 90 градусах минуты должны быть равны нулю"
 
 #: bika/lims/validators.py:601
 msgid "Validation failed: degrees is 90; seconds must be zero"
-msgstr ""
+msgstr "Проверка не пройдена: при 90 градусах секунды должны быть равны нулю"
 
 #: bika/lims/validators.py:610
 msgid "Validation failed: degrees must be 0 - 180"
-msgstr ""
+msgstr "Проверка не пройдена: градусы должны быть от 0 до 180"
 
 #: bika/lims/validators.py:591
 msgid "Validation failed: degrees must be 0 - 90"
@@ -6831,8 +7460,11 @@ msgid "Validation failed: degrees must be numeric"
 msgstr "Ошибка контроля данных: значение градусов должно быть числовым"
 
 #: bika/lims/validators.py:405
-msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
+msgid ""
+"Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
+"Проверка не пройдена: ключевому слову '${keyword}' должен соответствовать "
+"заголовок столбца '${title}'"
 
 #: senaite/core/api/analysisservice.py:172
 msgid "Validation failed: keyword contains invalid characters"
@@ -6840,16 +7472,17 @@ msgstr "Ошибка контроля данных: ключевое слово 
 
 #: senaite/core/api/analysisservice.py:177
 msgid "Validation failed: keyword is already in use"
-msgstr ""
+msgstr "Проверка не пройдена: ключевое слово уже используется"
 
 #: senaite/core/api/analysisservice.py:187
 msgid "Validation failed: keyword is already in use by calculation '{}'"
 msgstr ""
+"Проверка не пройдена: ключевое слово уже используется формулой расчёта '{}'"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:95
 #: bika/lims/validators.py:324
 msgid "Validation failed: keyword is required"
-msgstr ""
+msgstr "Проверка не пройдена: требуется ключевое слово"
 
 #: bika/lims/validators.py:580
 msgid "Validation failed: minutes must be 0 - 59"
@@ -6861,11 +7494,11 @@ msgstr "Ошибка контроля данных: значение минут 
 
 #: bika/lims/validators.py:1042
 msgid "Validation failed: percent values must be between 0 and 100"
-msgstr ""
+msgstr "Проверка не пройдена: значения процента должны быть от 0 до 100"
 
 #: bika/lims/validators.py:1038
 msgid "Validation failed: percent values must be numbers"
-msgstr ""
+msgstr "Проверка не пройдена: значения процента должны быть числами"
 
 #: bika/lims/validators.py:584
 msgid "Validation failed: seconds must be 0 - 59"
@@ -6878,29 +7511,37 @@ msgstr "Ошибка контроля данных: значение секун�
 #: bika/lims/controlpanel/bika_analysisservices.py:88
 #: bika/lims/validators.py:320
 msgid "Validation failed: title is required"
-msgstr ""
+msgstr "Проверка не пройдена: требуется название"
 
 #: bika/lims/validators.py:1456
-msgid "Validation failed: value for Choices subfield is only required for when the control type of choice is 'Select'"
+msgid ""
+"Validation failed: value for Choices subfield is only required for when the "
+"control type of choice is 'Select'"
 msgstr ""
+"Проверка не пройдена: значение подполя 'Варианты' требуется только когда тип"
+" контроля — 'Выбор'"
 
 #: bika/lims/validators.py:1438
-msgid "Validation failed: value for Choices subfield is required when the control type of choice is 'Select'"
+msgid ""
+"Validation failed: value for Choices subfield is required when the control "
+"type of choice is 'Select'"
 msgstr ""
+"Проверка не пройдена: значение подполя 'Варианты' требуется, когда тип "
+"контроля — 'Выбор'"
 
 #: senaite/core/content/analysiscategory.py:122
 #: senaite/core/content/subgroup.py:82
 msgid "Validation failed: value must be between 0 and 1000"
-msgstr ""
+msgstr "Проверка не пройдена: значение должно быть от 0 до 1000"
 
 #: senaite/core/content/analysiscategory.py:118
 #: senaite/core/content/subgroup.py:78
 msgid "Validation failed: value must be float"
-msgstr ""
+msgstr "Проверка не пройдена: значение должно быть числом с плавающей точкой"
 
 #: bika/lims/content/instrumentvalidation.py:51
 msgid "Validation report date"
-msgstr ""
+msgstr "Дата отчёта о валидации"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Validations"
@@ -6909,7 +7550,7 @@ msgstr "Проверки"
 #: bika/lims/browser/instrument.py:318
 #: bika/lims/content/instrumentvalidation.py:78
 msgid "Validator"
-msgstr ""
+msgstr "Проверяющий"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:206
 msgid "Value"
@@ -6917,47 +7558,43 @@ msgstr "Значение"
 
 #: senaite/core/schema/coordinatefield.py:109
 msgid "Value for degrees must be within 0 and 180"
-msgstr ""
+msgstr "Значение градусов должно быть от 0 до 180"
 
 #: senaite/core/schema/coordinatefield.py:93
 msgid "Value for degrees must be within 0 and 90"
-msgstr ""
+msgstr "Значение градусов должно быть от 0 до 90"
 
 #: senaite/core/schema/coordinatefield.py:68
 msgid "Value for minutes must be within 0 and 59"
-msgstr ""
+msgstr "Значение минут должно быть от 0 до 59"
 
 #: senaite/core/schema/coordinatefield.py:77
 msgid "Value for seconds must be within 0 and 59.9999"
-msgstr ""
+msgstr "Значение секунд должно быть от 0 до 59.9999"
 
 #: bika/lims/content/abstractanalysis.py:183
-msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
+msgid ""
+"Values can be entered here which will override the defaults specified in the"
+" Calculation Interim Fields."
 msgstr ""
+"Здесь можно ввести значения, которые переопределят значения по умолчанию, "
+"указанные в промежуточных полях расчёта."
 
-#: senaite/core/browser/dashboard/dashboard.py:149
-#: senaite/core/browser/samples/view.py:359
+#: senaite/core/browser/dashboard/dashboard.py:127
+#: senaite/core/browser/samples/view.py:341
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
 msgstr "Проверено"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:133
 msgid "Verified By"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:428
-msgid "Verified samples ready to be published"
-msgstr ""
+msgstr "Верифицировал(а)"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:109
-msgid "Verify Results"
-msgstr ""
+msgstr "Верифицировать"
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
@@ -6967,32 +7604,25 @@ msgstr "Версия"
 
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "View"
-msgstr ""
+msgstr "Просмотр"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
-msgstr ""
-
-# senaite.app.listing: Column config — visible-section header
-msgid "Visible"
-msgstr ""
-
-# senaite.app.listing: Column config — counter title attribute
-msgid "Visible / total columns"
-msgstr ""
+msgstr "Просмотреть ваш сайт SENAITE"
 
 #: senaite/core/registry/schema.py:213
 msgid "Visible fields"
-msgstr ""
+msgstr "Видимые поля"
 
 #: bika/lims/browser/viewlets/templates/dynamic_specs_viewlet.pt:24
 #: bika/lims/browser/viewlets/templates/sample_dynamic_specs_viewlet.pt:24
 msgid "Visit the Dynamic Specification for additional information:"
-msgstr ""
+msgstr "Перейдите к динамической спецификации для дополнительной информации:"
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:28
 msgid "Visit the Specification's changes history for additional information:"
 msgstr ""
+"Перейдите к истории изменений спецификации для дополнительной информации:"
 
 #: bika/lims/content/labproduct.py:36
 msgid "Volume"
@@ -7004,82 +7634,116 @@ msgstr "Предупреждение"
 
 #: bika/lims/content/laboratory.py:132
 msgid "Web address for the accreditation body"
-msgstr ""
+msgstr "Веб-адрес органа по аккредитации"
 
 #: bika/lims/content/supplier.py:52
 msgid "Website"
-msgstr ""
+msgstr "Веб-сайт"
 
 #: senaite/core/vocabularies/setup.py:158
 msgid "Wednesday"
 msgstr "Сре́да"
 
-#: senaite/core/browser/dashboard/dashboard.py:136
-msgid "Weekly"
-msgstr ""
-
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
-msgstr ""
+msgstr "Недель до истечения"
 
 #: senaite/core/browser/dashboard/templates/dashboard.pt:7
 msgid "Welcome"
-msgstr ""
+msgstr "Добро пожаловать"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:14
 msgid "Welcome to SENAITE"
-msgstr ""
+msgstr "Добро пожаловать в SENAITE"
 
-#: bika/lims/content/bikasetup.py:177
-msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
+#: bika/lims/content/bikasetup.py:176
+msgid ""
+"When enabled, analysts can only access worksheets to which they are "
+"assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
+"Если включено, аналитики могут получить доступ только к назначенным им "
+"рабочим листам. Если отключено, аналитики имеют доступ ко всем рабочим "
+"листам."
 
-#: bika/lims/content/bikasetup.py:208
-msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
+#: bika/lims/content/bikasetup.py:207
+msgid ""
+"When enabled, only lab managers can create and manage worksheets. When "
+"disabled, analysts and lab clerks can also manage worksheets. Note: This "
+"setting is automatically enabled and locked when worksheet access is "
+"restricted to assigned analysts."
 msgstr ""
+"Если включено, только менеджеры лаборатории могут создавать рабочие листы и "
+"управлять ими. Если отключено, аналитики и лаборанты также могут управлять "
+"рабочими листами. Примечание: этот параметр автоматически включается и "
+"блокируется, когда доступ к рабочим листам ограничен назначенными "
+"аналитиками."
 
-#: bika/lims/content/bikasetup.py:477
-msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
+#: bika/lims/content/bikasetup.py:476
+msgid ""
+"When enabled, the sample is automatically verified as soon as all results "
+"are verified. Otherwise, users with enough privileges have to manually "
+"verify the sample afterwards. Default: enabled"
 msgstr ""
+"Если включено, образец автоматически верифицируется, как только "
+"верифицированы все результаты. В противном случае пользователи с "
+"достаточными правами должны верифицировать образец вручную впоследствии. По "
+"умолчанию: включено"
 
-#: bika/lims/content/bikasetup.py:191
-msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
+#: bika/lims/content/bikasetup.py:190
+msgid ""
+"When enabled, users can submit results for analyses not assigned to them or "
+"for unassigned analyses. When disabled, users can only submit results for "
+"analyses assigned to themselves. This setting does not apply to users with "
+"role Lab Manager."
 msgstr ""
+"Если включено, пользователи могут отправлять результаты для анализов, не "
+"назначенных им, или для неназначенных анализов. Если отключено, пользователи"
+" могут отправлять результаты только для назначенных им анализов. Этот "
+"параметр не распространяется на пользователей с ролью 'Менеджер "
+"лаборатории'."
 
 #: bika/lims/content/analysisprofile.py:102
-msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
+msgid ""
+"When it's set, the system uses the analysis profile's price to quote and the"
+" system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
+"Если задано, система использует цену профиля анализа для расчёта, а "
+"системный НДС переопределяется НДС профиля анализа"
 
 #: bika/lims/content/abstractbaseanalysis.py:480
-msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
+msgid ""
+"When the results of duplicate analyses on worksheets, carried out on the "
+"same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
+"Если результаты дублирующих анализов на рабочих листах, выполненных на одном"
+" образце, отличаются больше чем на этот процент, формируется предупреждение"
 
 #: bika/lims/validators.py:518
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
+"Шаблоны подстановки для промежуточных полей не допускаются: ${wildcards}"
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:20
 msgid "With best regards"
-msgstr ""
+msgstr "С уважением"
 
 #: bika/lims/content/instrumentcalibration.py:118
 #: bika/lims/content/instrumentmaintenancetask.py:103
 #: bika/lims/content/instrumentvalidation.py:100
 msgid "Work Performed"
-msgstr ""
+msgstr "Выполненная работа"
 
-#: bika/lims/browser/auditlog.py:94
-#: bika/lims/controlpanel/auditlog.py:99
+#: bika/lims/browser/auditlog.py:94 bika/lims/controlpanel/auditlog.py:99
 msgid "Workflow State"
-msgstr ""
+msgstr "Статус процесса"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Worksheet"
-msgstr ""
+msgstr "Рабочий лист"
 
 #: bika/lims/content/worksheettemplate.py:62
 msgid "Worksheet Layout"
-msgstr ""
+msgstr "Макет рабочего листа"
 
 #: senaite/core/profiles/default/types/WorksheetTemplate.xml
 msgid "Worksheet Template"
@@ -7091,32 +7755,20 @@ msgstr "Рабочий лист: Шаблоны"
 
 #: senaite/core/registry/schema.py:109
 msgid "Worksheet printing templates order"
-msgstr ""
+msgstr "Порядок шаблонов печати рабочего листа"
 
-#: senaite/core/browser/dashboard/dashboard.py:107
+#: senaite/core/browser/dashboard/dashboard.py:489
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
 msgstr "Рабочие листы"
 
-#: senaite/core/browser/dashboard/dashboard.py:531
-msgid "Worksheets that have been verified"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:526
-msgid "Worksheets whose results are awaiting verification"
-msgstr ""
-
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
-msgstr ""
+msgstr "Неверная длина IBAN у %s: %s"
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
 msgstr "Неверная IBAN длина %s: %sсокращен до %i"
-
-#: senaite/core/browser/dashboard/dashboard.py:140
-msgid "Yearly"
-msgstr ""
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
@@ -7125,43 +7777,56 @@ msgstr "Да"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:124
 msgid "You can add another SENAITE site:"
-msgstr ""
+msgstr "Вы можете добавить ещё один сайт SENAITE:"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:109
-msgid "You can change the visibility of a field by selecting or unselecting the checkbox."
-msgstr ""
+msgid ""
+"You can change the visibility of a field by selecting or unselecting the "
+"checkbox."
+msgstr "Вы можете изменить видимость поля, установив или сняв флажок."
 
 #: senaite/core/browser/viewlets/templates/auditlog_disabled.pt:17
-msgid "You can enable the global Audit Log again in the <a href=\"${DYNAMIC_CONTENT}\">Setup</a>"
+msgid ""
+"You can enable the global Audit Log again in the <a "
+"href=\"${DYNAMIC_CONTENT}\">Setup</a>"
 msgstr ""
+"Вы можете снова включить глобальный журнал аудита в <a "
+"href=\"${DYNAMIC_CONTENT}\">Настройках</a>"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:294
 msgid "You can use the browse button to select and upload a new attachment."
-msgstr ""
+msgstr "Используйте кнопку обзора, чтобы выбрать и загрузить новое вложение."
 
 #: bika/lims/browser/worksheet/tools.py:42
-msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
+msgid ""
+"You do not have sufficient privileges to view the worksheet "
+"${worksheet_title}."
 msgstr ""
+"У вас недостаточно прав для просмотра рабочего листа ${worksheet_title}."
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:78
 msgid "You have multiple SENAITE sites:"
-msgstr ""
+msgstr "У вас несколько сайтов SENAITE:"
 
 #: bika/lims/browser/worksheet/views/export.py:33
 msgid "You must select an instrument"
 msgstr "Вы должны выбрать инструмент"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:159
-msgid "You normally don't need to change anything here unless you have specific reasons and know what you are doing."
+msgid ""
+"You normally don't need to change anything here unless you have specific "
+"reasons and know what you are doing."
 msgstr ""
+"Обычно здесь не требуется ничего менять, если у вас нет особых причин и вы "
+"точно понимаете, что делаете."
 
 #: senaite/core/exportimport/instruments/sysmex/xs/i500.py:77
 msgid "You should introduce a default result key."
-msgstr ""
+msgstr "Необходимо указать ключ результата по умолчанию."
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:121
 msgid "Your SENAITE site has not been added yet:"
-msgstr ""
+msgstr "Ваш сайт SENAITE ещё не добавлен:"
 
 #: bika/lims/browser/templates/referencesample_view.pt:134
 msgid "activate"
@@ -7170,41 +7835,37 @@ msgstr "активировать"
 #. Default: "Classic"
 #: senaite/core/config/worksheet.py:25
 msgid "analyses_classic_view_name"
-msgstr ""
+msgstr "Классический"
 
 #. Default: "Transposed"
 #: senaite/core/config/worksheet.py:29
 msgid "analyses_transposed_view_name"
-msgstr ""
+msgstr "Транспонировано"
 
 #. Default: "Analysis"
 #: senaite/core/config/vocabularies.py:35
 msgid "analysis_type_analysis"
-msgstr ""
+msgstr "Анализ"
 
 #. Default: "Blank"
 #: senaite/core/config/vocabularies.py:39
 msgid "analysis_type_blank"
-msgstr ""
+msgstr "Холостая проба"
 
 #. Default: "Control"
 #: senaite/core/config/vocabularies.py:43
 msgid "analysis_type_control"
-msgstr ""
+msgstr "Контроль"
 
 #. Default: "Duplicate"
 #: senaite/core/config/vocabularies.py:47
 msgid "analysis_type_duplicate"
-msgstr ""
+msgstr "Дубликат"
 
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — micro-tag on the default preset
-msgid "auto"
-msgstr ""
+msgstr "Необходимо указать аналитика."
 
 #: bika/lims/content/instrumentcertification.py:254
 msgid "biannually"
@@ -7213,60 +7874,69 @@ msgstr "раз в два года"
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:48
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:48
 msgid "by"
-msgstr ""
+msgstr "от"
 
 #. in '${calc}')"
-#. Default: "keyword '${keyword}' must have column title '${title}' (defined in '${calc}')"
+#. Default: "keyword '${keyword}' must have column title '${title}' (defined
+#. in '${calc}')"
 #: senaite/core/validators/interimfields.py:151
 msgid "calcs_interims_validator_dup_keyword_error"
 msgstr ""
+"ключевому слову '${keyword}' должен соответствовать заголовок столбца "
+"'${title}' (определён в '${calc}')"
 
 #. Default: "Changes saved."
 #: senaite/core/browser/worksheets/worksheet/manage_results.py:57
 msgid "change_worksheet_result_layout_message"
-msgstr ""
+msgstr "Изменения сохранены."
 
 #. Default: "Changes saved."
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:168
 msgid "changes_saved"
-msgstr ""
+msgstr "Изменения сохранены."
 
 #. Results edition not allowed: ${inv}"
-#. Default: "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed: ${inv}"
+#. Default: "Some analyses use out-of-date or uncalibrated instruments.
+#. Results edition not allowed: ${inv}"
 #: senaite/core/browser/worksheets/worksheet/manage_results.py:214
 msgid "check_instrument_validity_message"
 msgstr ""
+"Некоторые анализы используют просроченные или неоткалиброванные инструменты."
+" Редактирование результатов запрещено: ${inv}"
 
 #. <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
-#. Default: "No valid format in choices field. Supported format is: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
+#. Default: "No valid format in choices field. Supported format is:
+#. <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 #: senaite/core/validators/interimfields.py:211
 msgid "choice_syntax_validation_error"
 msgstr ""
+"Неверный формат поля выбора. Поддерживаемый формат: "
+"<value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 
 #. Default: "Control type is not supported for empty choices"
 #: senaite/core/validators/interimfields.py:111
 msgid "choices_and_restype_validator_no_choices_error"
-msgstr ""
+msgstr "Тип контроля не поддерживается для пустых вариантов выбора"
 
 #. Default: "Chosen control type not supporting choices"
 #: senaite/core/validators/interimfields.py:117
 msgid "choices_and_restype_validator_not_supported_choices_error"
-msgstr ""
+msgstr "Выбранный тип контроля не поддерживает варианты выбора"
 
 #. Default: "Empty keys are not supported"
 #: senaite/core/validators/interimfields.py:169
 msgid "choices_empty_keys_validator_error"
-msgstr ""
+msgstr "Пустые ключи не поддерживаются"
 
 #. Default: "At least, two options for choices field are required"
 #: senaite/core/validators/interimfields.py:195
 msgid "choices_min_items_validator_error"
-msgstr ""
+msgstr "Для поля выбора требуется минимум два варианта"
 
 #. Default: "Duplicate keys in choices field"
 #: senaite/core/validators/interimfields.py:183
 msgid "choices_unique_keys_validator_error"
-msgstr ""
+msgstr "Повторяющиеся ключи в поле выбора"
 
 #: bika/lims/content/instrumentcertification.py:250
 msgid "daily"
@@ -7281,7 +7951,7 @@ msgstr "ежедневно"
 #. ${b} ${d}, ${Y} ${I}:${M} ${p}
 #: ./TranslationServiceTool.py
 msgid "date_format_long"
-msgstr ""
+msgstr "${d}.${m}.${Y} ${I}:${M} ${p}"
 
 #. Default: "${Y}-${m}-${d}"
 #. The variables used here are the same as used in the strftime formating.
@@ -7292,80 +7962,82 @@ msgstr ""
 #. ${b} ${d}, ${Y}
 #: ./TranslationServiceTool.py
 msgid "date_format_short"
-msgstr ""
+msgstr "${d}.${m}.${Y}"
 
 #. Date format used with the datepicker jqueryui plugin.
 #. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
 #. Default: "mm/dd/yy"
 msgid "date_format_short_datepicker"
-msgstr ""
+msgstr "дд.мм.гг"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:285
 msgid "days"
-msgstr ""
+msgstr "дней"
 
 #: bika/lims/browser/templates/referencesample_view.pt:127
 msgid "deactivate"
 msgstr "отключить"
 
-#. Default: "Sample disposed after the retention period."
-#: senaite/core/browser/samples/templates/dispose_samples.pt:66
-msgid "default_dispose_reason"
-msgstr ""
-
-#: senaite/core/api/remarks.py:485
-msgid "deleted by {user} at {time}"
-msgstr ""
-
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:126
+#: senaite/core/behaviors/label.py:118
 msgid "description_Labels"
-msgstr ""
+msgstr "Прикреплённые метки"
 
 #. Default: "The accreditation standard that applies, e.g. ISO 17025"
 #: senaite/core/content/laboratory.py:174
 msgid "description_accreditation"
-msgstr ""
+msgstr "Применяемый стандарт аккредитации, например ISO 17025"
 
 #. Default: "E.g. SANAS, APLAC, etc."
 #: senaite/core/content/laboratory.py:153
 msgid "description_accreditation_body"
-msgstr ""
+msgstr "Например, SANAS, APLAC и т.д."
 
 #. and results reports by your accreditation body. Maximum size is 175 x 175
 #. pixels."
-#. Default: "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
+#. Default: "Please upload the logo you are authorised to use on your website
+#. and results reports by your accreditation body. Maximum size is 175 x 175
+#. pixels."
 #: senaite/core/content/laboratory.py:198
 msgid "description_accreditation_body_logo"
 msgstr ""
+"Загрузите логотип, разрешённый к использованию на вашем сайте и в отчётах с "
+"результатами вашим органом по аккредитации. Максимальный размер — 175 x 175 "
+"пикселей."
 
 #. Default: "Web address for the accreditation body"
 #: senaite/core/content/laboratory.py:163
 msgid "description_accreditation_body_url"
-msgstr ""
+msgstr "Веб-адрес органа по аккредитации"
 
 #. following fields are available: lab_is_accredited, lab_name, lab_country,
 #. confidence, accreditation_body_name, accreditation_standard,
 #. accreditation_reference"
-#. Default: "Enter the details of your lab's service accreditations here. The following fields are available: lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference"
+#. Default: "Enter the details of your lab's service accreditations here. The
+#. following fields are available: lab_is_accredited, lab_name, lab_country,
+#. confidence, accreditation_body_name, accreditation_standard,
+#. accreditation_reference"
 #: senaite/core/content/laboratory.py:220
 msgid "description_accreditation_page_header"
 msgstr ""
+"Введите данные об аккредитации услуг вашей лаборатории. Доступны поля: "
+"lab_is_accredited, lab_name, lab_country, confidence, "
+"accreditation_body_name, accreditation_standard, accreditation_reference"
 
 #. Default: "The reference code issued to the lab by the accreditation body"
 #: senaite/core/content/laboratory.py:186
 msgid "description_accreditation_reference"
-msgstr ""
+msgstr "Референсный код, выданный лаборатории органом по аккредитации"
 
 #. Default: "The category the analysis service belongs to"
 #: bika/lims/content/abstractbaseanalysis.py:533
 msgid "description_analysis_category"
-msgstr ""
+msgstr "Категория, к которой относится услуга анализа"
 
 #. Default: "Select the responsible department"
 #: bika/lims/content/abstractbaseanalysis.py:591
 msgid "description_analysis_department"
-msgstr ""
+msgstr "Выберите ответственное подразделение"
 
 #. registration form if the elapsed time since sample collection exceeds the
 #. holding time limit. Exceeding this time limit may result in unreliable or
@@ -7374,18 +8046,38 @@ msgstr ""
 #. reflect the sample's true composition, impacting data validity. Note: This
 #. setting does not affect the test's availability in the 'Manage Analyses'
 #. view."
-#. Default: "This service will not appear for selection on the sample registration form if the elapsed time since sample collection exceeds the holding time limit. Exceeding this time limit may result in unreliable or compromised data, as the integrity of the sample can degrade over time. Consequently, any results obtained after this period may not accurately reflect the sample's true composition, impacting data validity. Note: This setting does not affect the test's availability in the 'Manage Analyses' view."
+#. Default: "This service will not appear for selection on the sample
+#. registration form if the elapsed time since sample collection exceeds the
+#. holding time limit. Exceeding this time limit may result in unreliable or
+#. compromised data, as the integrity of the sample can degrade over time.
+#. Consequently, any results obtained after this period may not accurately
+#. reflect the sample's true composition, impacting data validity. Note: This
+#. setting does not affect the test's availability in the 'Manage Analyses'
+#. view."
 #: bika/lims/content/abstractbaseanalysis.py:457
 msgid "description_analysis_maxholdingtime"
 msgstr ""
+"Эта услуга не будет доступна для выбора в форме регистрации образца, если "
+"время с момента отбора превышает предельный срок хранения. Превышение этого "
+"срока может привести к недостоверным данным, поскольку целостность образца "
+"со временем может нарушаться. Соответственно, результаты, полученные после "
+"этого срока, могут неточно отражать истинный состав образца. Примечание: "
+"этот параметр не влияет на доступность теста в просмотре 'Управление "
+"анализами'."
 
 #. in results entry listings. Note this only applies to the options displayed
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
-#. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:773
+#. Default: "Criteria to use when result options are displayed for selection
+#. in results entry listings. Note this only applies to the options displayed
+#. in the selection list. It does not have any effect to the order in which
+#. results are displayed after being submitted"
+#: bika/lims/content/abstractbaseanalysis.py:770
 msgid "description_analysis_results_options_sorting"
 msgstr ""
+"Критерий, используемый при отображении вариантов результата для выбора при "
+"вводе результатов. Применяется только к отображаемому списку вариантов и не "
+"влияет на порядок отображения результатов после отправки"
 
 #. in a range with minimum of 0 and maximum of 10, where the uncertainty value
 #. is 0.5 - a result of 6.67 will be reported as 6.67 ± 0.5.<br/>You can also
@@ -7397,89 +8089,128 @@ msgstr ""
 #. 0 (or a value below 0) as the Uncertainty value.<br/>Please ensure
 #. successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 -
 #. 20.00, 20.01 - 30.00 etc."
-#. Default: "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 ± 0.5.<br/>You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2%, a result of 100 will be reported as 100 ± 2.<br/>If you don't want uncertainty to be displayed for a given range, set 0 (or a value below 0) as the Uncertainty value.<br/>Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30.00 etc."
+#. Default: "Specify the uncertainty value for a given range, e.g. for results
+#. in a range with minimum of 0 and maximum of 10, where the uncertainty value
+#. is 0.5 - a result of 6.67 will be reported as 6.67 ± 0.5.<br/>You can also
+#. specify the uncertainty value as a percentage of the result value, by
+#. adding a '%' to the value entered in the 'Uncertainty Value' column, e.g.
+#. for results in a range with minimum of 10.01 and a maximum of 100, where
+#. the uncertainty value is 2%, a result of 100 will be reported as 100 ±
+#. 2.<br/>If you don't want uncertainty to be displayed for a given range, set
+#. 0 (or a value below 0) as the Uncertainty value.<br/>Please ensure
+#. successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 -
+#. 20.00, 20.01 - 30.00 etc."
 #: bika/lims/content/abstractbaseanalysis.py:630
 msgid "description_analysis_uncertainty"
 msgstr ""
+"Укажите значение неопределённости для заданного диапазона. Например, для "
+"результатов в диапазоне от 0 до 10 с неопределённостью 0.5 результат 6.67 "
+"будет указан как 6.67 ± 0.5.<br/>Также можно указать неопределённость в "
+"процентах от значения результата, добавив '%' к значению в столбце 'Значение"
+" неопределённости'. Например, для диапазона от 10.01 до 100 с "
+"неопределённостью 2% результат 100 будет указан как 100 ± 2.<br/>Если не "
+"нужно отображать неопределённость для заданного диапазона, установите 0 (или"
+" значение меньше 0).<br/>Убедитесь, что последующие диапазоны непрерывны, "
+"например 0.00-10.00, затем 10.01-20.00, 20.01-30.00 и т.д."
 
 #. mg/l, ppm, dB, mV, etc."
-#. Default: "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
+#. Default: "The measurement units for this analysis service' results, e.g.
+#. mg/l, ppm, dB, mV, etc."
 #: bika/lims/content/abstractbaseanalysis.py:112
 msgid "description_analysis_unit"
 msgstr ""
+"Единицы измерения результатов этой услуги анализа, например мг/л, ppm, дБ, "
+"мВ и т.д."
 
 #. Ensure to include the default unit in this list"
-#. Default: "Provide a list of units that are suitable for the analysis. Ensure to include the default unit in this list"
+#. Default: "Provide a list of units that are suitable for the analysis.
+#. Ensure to include the default unit in this list"
 #: bika/lims/content/abstractbaseanalysis.py:162
 msgid "description_analysis_unitchoices"
 msgstr ""
+"Укажите список единиц измерения, подходящих для анализа. Убедитесь, что "
+"единица измерения по умолчанию включена в этот список"
 
 #. reports."
-#. Default: "To be displayed below each Analysis Category section on results reports."
+#. Default: "To be displayed below each Analysis Category section on results
+#. reports."
 #: senaite/core/content/analysiscategory.py:64
 msgid "description_analysiscategory_comments"
 msgstr ""
+"Отображается под каждым разделом категории анализа в отчётах с результатами."
 
 #. Default: "Select the responsible department"
 #: senaite/core/content/analysiscategory.py:85
 msgid "description_analysiscategory_department"
-msgstr ""
+msgstr "Выберите ответственное подразделение"
 
 #. Duplicate values are ordered alphabetically."
-#. Default: "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
+#. Default: "Float value from 0.0 - 1000.0 indicating the sort order.
+#. Duplicate values are ordered alphabetically."
 #: senaite/core/content/analysiscategory.py:99
 msgid "description_analysiscategory_sort_key"
 msgstr ""
+"Число с плавающей точкой от 0.0 до 1000.0, задающее порядок сортировки. "
+"Повторяющиеся значения сортируются по алфавиту."
 
 #. Default: "Commercial ID used for accounting"
 #: senaite/core/content/analysisprofile.py:125
 msgid "description_analysisprofile_commercial_id"
-msgstr ""
+msgstr "Коммерческий ID для бухгалтерского учёта"
 
 #. Default: "Please provide a unique profile keyword"
 #: senaite/core/content/analysisprofile.py:94
 msgid "description_analysisprofile_profile_key"
-msgstr ""
+msgstr "Укажите уникальное ключевое слово профиля"
 
 #. Default: "Please provide the price excluding VAT"
 #: senaite/core/content/analysisprofile.py:149
 msgid "description_analysisprofile_profile_price"
-msgstr ""
+msgstr "Укажите цену без учёта НДС"
 
 #. price"
-#. Default: "Please provide the VAT in percent that is added to the profile price"
+#. Default: "Please provide the VAT in percent that is added to the profile
+#. price"
 #: senaite/core/content/analysisprofile.py:161
 msgid "description_analysisprofile_profile_vat"
-msgstr ""
+msgstr "Укажите НДС в процентах, добавляемый к цене профиля"
 
 #. profile won't be available for selection in sample creation and edit forms
 #. unless the selected sample type is one of these. If no sample type is set
 #. here, this profile will always be available for selection, regardless of
 #. the sample type of the sample."
-#. Default: "Sample types for which this analysis profile is supported. This profile won't be available for selection in sample creation and edit forms unless the selected sample type is one of these. If no sample type is set here, this profile will always be available for selection, regardless of the sample type of the sample."
+#. Default: "Sample types for which this analysis profile is supported. This
+#. profile won't be available for selection in sample creation and edit forms
+#. unless the selected sample type is one of these. If no sample type is set
+#. here, this profile will always be available for selection, regardless of
+#. the sample type of the sample."
 #: senaite/core/content/analysisprofile.py:184
 msgid "description_analysisprofile_sampletypes"
 msgstr ""
+"Типы образца, для которых поддерживается этот профиль анализа. Профиль не "
+"будет доступен для выбора в формах создания и редактирования образца, если "
+"выбранный тип образца не входит в этот список. Если тип образца не задан, "
+"профиль всегда доступен для выбора независимо от типа образца."
 
 #. Default: "Select the included analyses for this profile"
 #: senaite/core/content/analysisprofile.py:110
 msgid "description_analysisprofile_services"
-msgstr ""
+msgstr "Выберите анализы, включённые в этот профиль"
 
 #. Default: "Use profile price instead of single analyses prices"
 #: senaite/core/content/analysisprofile.py:137
 msgid "description_analysisprofile_use_profile_price"
-msgstr ""
+msgstr "Использовать цену профиля вместо цен отдельных анализов"
 
 #. Default: "Number of samples to create with the information provided"
 #: bika/lims/content/analysisrequest.py:1441
 msgid "description_analysisrequest_numsamples"
-msgstr ""
+msgstr "Количество создаваемых образцов с указанной информацией"
 
 #. Default: "Link dynamic analysis specification"
 #: bika/lims/content/analysisspec.py:72
 msgid "description_analysisspec_dynamicspec"
-msgstr ""
+msgstr "Связать динамическую спецификацию анализа"
 
 #. outside this results range will raise an alert.<br/>'Min warn' and 'Max
 #. warn' values indicate a shoulder range. Any result outside the results
@@ -7488,110 +8219,151 @@ msgstr ""
 #. be displayed in lists and results reports instead of the real result. In
 #. such case, the value set for 'Out of range comment' will be displayed in
 #. results report as well"
-#. Default: "'Min' and 'Max' values indicate a valid results range. Any result outside this results range will raise an alert.<br/>'Min warn' and 'Max warn' values indicate a shoulder range. Any result outside the results range but within the shoulder range will raise a less severe alert.<br/>If the result is out of range, the value set for '&lt; Min' or '&gt; Max' will be displayed in lists and results reports instead of the real result. In such case, the value set for 'Out of range comment' will be displayed in results report as well"
+#. Default: "'Min' and 'Max' values indicate a valid results range. Any result
+#. outside this results range will raise an alert.<br/>'Min warn' and 'Max
+#. warn' values indicate a shoulder range. Any result outside the results
+#. range but within the shoulder range will raise a less severe alert.<br/>If
+#. the result is out of range, the value set for '&lt; Min' or '&gt; Max' will
+#. be displayed in lists and results reports instead of the real result. In
+#. such case, the value set for 'Out of range comment' will be displayed in
+#. results report as well"
 #: bika/lims/content/analysisspec.py:91
 msgid "description_analysisspec_resultsrange"
 msgstr ""
+"Значения 'Минимум' и 'Максимум' определяют допустимый диапазон результатов. "
+"Любой результат за пределами этого диапазона вызовет "
+"предупреждение.<br/>Значения 'Предупр. минимум' и 'Предупр. максимум' "
+"определяют пограничный диапазон. Любой результат за пределами диапазона "
+"результатов, но в пределах пограничного диапазона, вызовет менее серьёзное "
+"предупреждение.<br/>Если результат вне диапазона, вместо реального "
+"результата в списках и отчётах будет отображаться значение, заданное для "
+"'&lt; Минимум' или '&gt; Максимум'. В этом случае в отчёте также будет "
+"отображаться значение, заданное для 'Комментарий вне диапазона'"
 
 #. Default: "Select the sample type for this specification"
 #: bika/lims/content/analysisspec.py:52
 msgid "description_analysisspec_sampletype"
-msgstr ""
+msgstr "Выберите тип образца для этой спецификации"
 
 #. Default: "Contained samples in the PDF"
 #: bika/lims/content/arreport.py:82
 msgid "description_arreport_contained_samples"
-msgstr ""
+msgstr "Образцы, содержащиеся в PDF"
 
 #. Default: "The primary sample of the PDF"
 #: bika/lims/content/arreport.py:52
 msgid "description_arreport_sample"
-msgstr ""
+msgstr "Основной образец PDF"
 
 #. Default: "Select the analysis profile for this template"
 #: bika/lims/content/artemplate.py:257
 msgid "description_artemplate_profile"
-msgstr ""
+msgstr "Выберите профиль анализа для этого шаблона"
 
 #. Default: "Select the sample point for this template"
 #: bika/lims/content/artemplate.py:58
 msgid "description_artemplate_samplepoint"
-msgstr ""
+msgstr "Выберите точку отбора проб для этого шаблона"
 
 #. Default: "Select the sample type for this template"
 #: bika/lims/content/artemplate.py:89
 msgid "description_artemplate_sampletype"
-msgstr ""
+msgstr "Выберите тип образца для этого шаблона"
 
 #. Default: "Select the type of the attachment"
 #: bika/lims/content/attachment.py:64
 msgid "description_attachment_type"
-msgstr ""
+msgstr "Выберите тип вложения"
 
 #. Default: "Assign the instrument for this log"
 #: bika/lims/content/autoimportlog.py:53
 msgid "description_autoimportlog_instrument"
-msgstr ""
+msgstr "Назначьте инструмент для этого журнала"
 
 #. Default: "The date and time when the log was created"
 #: bika/lims/content/autoimportlog.py:90
 msgid "description_autoimportlog_logtime"
-msgstr ""
+msgstr "Дата и время создания журнала"
 
 #. Default: "The logged results"
 #: bika/lims/content/autoimportlog.py:77
 msgid "description_autoimportlog_results"
-msgstr ""
+msgstr "Зафиксированные результаты"
 
 #. Default: "Select the client of this batch"
 #: bika/lims/content/batch.py:81
 msgid "description_batch_client"
-msgstr ""
+msgstr "Выберите клиента этой партии"
 
 #. entered manually for analyses"
-#. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:397
+#. Default: "If this option is activated, the result capture date can be
+#. entered manually for analyses"
+#: bika/lims/content/bikasetup.py:396
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
+"Если этот параметр активирован, дату фиксации результата можно вводить "
+"вручную для анализов"
 
 #. departments will receive publication emails."
-#. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:854
+#. Default: "When selected, the responsible persons of all involved lab
+#. departments will receive publication emails."
+#: bika/lims/content/bikasetup.py:853
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
+"Если выбрано, ответственные лица всех задействованных подразделений "
+"лаборатории будут получать письма о публикации."
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:369
+#: bika/lims/content/bikasetup.py:368
 msgid "description_bikasetup_categorizesampleanalyses"
-msgstr ""
+msgstr "Группировать анализы по категориям для образцов"
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
-#. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:690
+#. Default: "Select this to make DateSampled field required on sample
+#. creation. This functionality only takes effect when 'Sampling workflow' is
+#. not active"
+#: bika/lims/content/bikasetup.py:689
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
+"Отметьте, чтобы сделать поле 'Дата отбора' обязательным при создании "
+"образца. Действует только когда процесс отбора проб не активен"
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
-#. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:830
+#. Default: "Set the email body text to be used by default when sending out
+#. result reports to the selected recipients. You can use reserved keywords:
+#. $client_name, $recipients, $lab_name, $lab_address"
+#: bika/lims/content/bikasetup.py:829
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
+"Задайте текст письма по умолчанию для отправки отчётов с результатами "
+"выбранным получателям. Можно использовать ключевые слова: $client_name, "
+"$recipients, $lab_name, $lab_address"
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
-#. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:806
+#. Default: "E-mail to use as the 'From' address for outgoing e-mails when
+#. publishing results reports. This address overrides the value set at
+#. portal's 'Mail settings'."
+#: bika/lims/content/bikasetup.py:805
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
+"Email для использования в качестве адреса отправителя исходящих писем при "
+"публикации отчётов с результатами. Переопределяет значение, заданное в "
+"настройках почты портала."
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
-#. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:444
+#. Default: "Allow the user to directly enter results after sample creation,
+#. e.g. to enter field results immediately, or lab results, when the automatic
+#. sample reception is activated."
+#: bika/lims/content/bikasetup.py:443
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
+"Разрешить пользователю сразу вводить результаты после создания образца, "
+"например для немедленного ввода полевых или лабораторных результатов при "
+"включённом автоматическом приёме образца."
 
 #. sent to primary contacts and laboratory managers when a sample is
 #. invalidated. The following placeholders are supported: <code title='The ID
@@ -7600,27 +8372,46 @@ msgstr ""
 #. retest'>$retest_link</code>, <code title='The reason(s) for
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
-#. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:947
+#. Default: "Define the template for the email body that will be automatically
+#. sent to primary contacts and laboratory managers when a sample is
+#. invalidated. The following placeholders are supported: <code title='The ID
+#. of the sample'>$sample_id</code>, <code title='The ID of the sample
+#. retest'>$retest_id</code>, <code title='The link to the
+#. retest'>$retest_link</code>, <code title='The reason(s) for
+#. invalidation'>$reason</code>, <code title='The address of the
+#. lab'>$lab_address</code>."
+#: bika/lims/content/bikasetup.py:946
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
+"Задайте шаблон текста письма, автоматически отправляемого основным контактам"
+" и менеджерам лаборатории при аннулировании образца. Поддерживаются "
+"плейсхолдеры: <code title='ID образца'>$sample_id</code>, <code title='ID "
+"повторного теста'>$retest_id</code>, <code title='Ссылка на повторный "
+"тест'>$retest_link</code>, <code title='Причина(-ы) "
+"аннулирования'>$reason</code>, <code title='Адрес "
+"лаборатории'>$lab_address</code>."
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
-#. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:914
+#. Default: "Specify whether providing a reason is mandatory when invalidating
+#. a sample. If enabled, the '$reason' placeholder in the sample invalidation
+#. notification email body will be replaced with the entered reason."
+#: bika/lims/content/bikasetup.py:913
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
+"Укажите, обязательно ли указание причины при аннулировании образца. Если "
+"включено, плейсхолдер '$reason' в тексте письма-уведомления об аннулировании"
+" образца будет заменён указанной причиной."
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:383
+#: bika/lims/content/bikasetup.py:382
 msgid "description_bikasetup_sampleanalysesrequired"
-msgstr ""
+msgstr "Анализы обязательны для регистрации образца"
 
 #. Default: "Dependent services of this calculation"
 #: bika/lims/content/calculation.py:84
 msgid "description_calculation_dependentservices"
-msgstr ""
+msgstr "Зависимые услуги этой формулы расчёта"
 
 #. dynamically calculated when an analysis using this calculation is
 #. displayed.</p><p>To enter a Calculation, use standard maths operators, + -
@@ -7629,255 +8420,299 @@ msgstr ""
 #. brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of
 #. Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg],
 #. where Ca and Mg are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators, + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and Mg are the keywords for those two Analysis Services.</p>"
+#. Default: "<p>The formula you type here will be dynamically calculated be
+#. dynamically calculated when an analysis using this calculation is
+#. displayed.</p><p>To enter a Calculation, use standard maths operators, + -
+#. * / ( ), and all keywords available, both from other Analysis Services and
+#. the Interim Fields specified here, as variables. Enclose them in square
+#. brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of
+#. Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg],
+#. where Ca and Mg are the keywords for those two Analysis Services.</p>"
 #: senaite/core/content/calculation.py:291
 msgid "description_calculation_formula"
 msgstr ""
-
-#. library, you can import it here. E.g. if you want to use the 'floor'
-#. function from the Python 'math' module, you add 'math' to the Module field
-#. and 'floor' to the function field. The equivalent in Python would be 'from
-#. math import floor'. In your calculation you could use then 'floor([Ca] +
-#. [Mg])'."
-#. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
-#: senaite/core/content/calculation.py:268
-msgid "description_calculation_imports"
-msgstr ""
+"<p>Введённая здесь формула будет динамически рассчитываться при отображении "
+"анализа, использующего эту формулу расчёта.</p><p>Для ввода формулы расчёта "
+"используйте стандартные математические операторы + - * / ( ) и все доступные"
+" ключевые слова — как из других услуг анализа, так и из промежуточных полей,"
+" указанных здесь, — в качестве переменных. Заключайте их в квадратные скобки"
+" [ ].</p><p>Например, формула общей жёсткости — суммы ионов кальция (ppm) и "
+"магния (ppm) в воде — вводится как [Ca] + [Mg], где Ca и Mg — ключевые слова"
+" этих двух услуг анализа.</p>"
 
 #. should your calculation require them. The field title specified here will
 #. be used as column headers and field descriptors where the interim fields
 #. are displayed. If 'Apply wide' is enabled the field will be shown in a
 #. selection box on the top of the worksheet, allowing to apply a specific
 #. value to all the corresponding fields on the sheet."
-#. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
+#. Default: "If your formula needs a special function from an external Python
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
+#: senaite/core/content/calculation.py:268
+msgid "description_calculation_imports"
+msgstr ""
+"Если вашей формуле нужна специальная функция из внешней библиотеки Python, "
+"импортируйте её здесь. Например, чтобы использовать функцию 'floor' из "
+"модуля Python 'math', добавьте 'math' в поле 'Модуль' и 'floor' в поле "
+"'Функция'. В Python это эквивалентно 'from math import floor'. В расчёте "
+"можно использовать 'floor([Ca] + [Mg])'."
+
+#. Default: "Define interim fields such as vessel mass, dilution factors,
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
 msgstr ""
+"Определите промежуточные поля, например массу сосуда, коэффициенты "
+"разбавления, если это требуется для расчёта. Название поля, указанное здесь,"
+" будет использовано как заголовок столбца и описание поля. Если включена "
+"опция 'Применить ко всем', поле будет показано в блоке выбора вверху "
+"рабочего листа, позволяя применить значение ко всем соответствующим полям "
+"листа."
 
 #. parameters.  This includes Interim fields defined above, as well as any
 #. services that this calculation depends on to calculate results."
-#. Default: "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
+#. Default: "To test the calculation, enter values here for all calculation
+#. parameters.  This includes Interim fields defined above, as well as any
+#. services that this calculation depends on to calculate results."
 #: senaite/core/content/calculation.py:321
 msgid "description_calculation_test_params"
 msgstr ""
+"Чтобы протестировать формулу расчёта, введите здесь значения всех параметров"
+" расчёта. Это включает промежуточные поля, определённые выше, а также любые "
+"услуги, от которых зависит расчёт результатов."
 
 #. values."
-#. Default: "The result after the calculation has taken place with test values."
+#. Default: "The result after the calculation has taken place with test
+#. values."
 #: senaite/core/content/calculation.py:345
 msgid "description_calculation_test_result"
-msgstr ""
+msgstr "Результат после выполнения расчёта с тестовыми значениями."
 
 #. Default: "Select the responsible department"
 #: bika/lims/content/analysiscategory.py:62
 msgid "description_category_department"
-msgstr ""
+msgstr "Выберите ответственное подразделение"
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:188
+#: bika/lims/content/client.py:184
 msgid "description_client_defaultcategories"
-msgstr ""
+msgstr "Всегда разворачивать выбранные категории"
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:212
+#: bika/lims/content/client.py:208
 msgid "description_client_restrictcategories"
-msgstr ""
+msgstr "Показывать только выбранные категории"
 
 #. Default: "This value is reported at the bottom of all published results"
 #: senaite/core/content/laboratory.py:127
 msgid "description_confidence_level"
-msgstr ""
+msgstr "Это значение указывается внизу всех опубликованных результатов"
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:155
+#: senaite/core/content/contact.py:123
 msgid "description_contact_cccontact"
-msgstr ""
+msgstr "Контакты для копии (CC) для новых образцов"
 
 #. could be selected here."
-#. Default: "If this container is pre-preserved, then the preservation method could be selected here."
+#. Default: "If this container is pre-preserved, then the preservation method
+#. could be selected here."
 #: bika/lims/content/container.py:100
 msgid "description_container_preservation"
 msgstr ""
+"Если этот контейнер предварительно законсервирован, здесь можно выбрать "
+"способ сохранения."
 
 #. Default: "Select the type of this container"
 #: bika/lims/content/container.py:57
 msgid "description_container_type"
-msgstr ""
+msgstr "Выберите тип этого контейнера"
 
 #. Default: "${copyright} 2017-${current_year} ${senaitelims}"
 #: senaite/core/browser/viewlets/templates/footer.pt:13
 msgid "description_copyright"
-msgstr ""
+msgstr "${copyright} 2017-${current_year} ${senaitelims}"
 
 #. Default: "Please provide a unique department identifier"
 #: senaite/core/content/department.py:80
 msgid "description_department_id"
-msgstr ""
+msgstr "Укажите уникальный идентификатор подразделения"
 
 #. the 'lab contacts' setup item. Departmental managers are referenced on
 #. analysis results reports containing analyses by their department."
-#. Default: "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
+#. Default: "Select a manager from the available personnel configured under
+#. the 'lab contacts' setup item. Departmental managers are referenced on
+#. analysis results reports containing analyses by their department."
 #: senaite/core/content/department.py:106
 msgid "description_department_manager"
 msgstr ""
+"Выберите менеджера из доступного персонала, настроенного в разделе "
+"'лабораторные контакты'. Менеджеры подразделений указываются в отчётах с "
+"результатами анализов, содержащих анализы этого подразделения."
 
 #. Default: "Name of the department"
 #: senaite/core/content/department.py:52
 msgid "description_department_title"
-msgstr ""
+msgstr "Название подразделения"
 
 #. Default: "Location where the instrument is installed"
 #: bika/lims/content/instrument.py:322
 msgid "description_instrument_instrumentlocation"
-msgstr ""
+msgstr "Место установки инструмента"
 
 #. Default: "Select the type of this instrument"
 #: bika/lims/content/instrument.py:82
 msgid "description_instrument_instrumenttype"
-msgstr ""
+msgstr "Выберите тип этого инструмента"
 
 #. Default: "Select the manufacturer of this instrument"
 #: bika/lims/content/instrument.py:102
 msgid "description_instrument_manufacturer"
-msgstr ""
+msgstr "Выберите производителя этого инструмента"
 
 #. Default: "Methods that are supported by this analytical instrument"
 #: bika/lims/content/instrument.py:174
 msgid "description_instrument_methods"
-msgstr ""
+msgstr "Методы, поддерживаемые этим аналитическим инструментом"
 
 #. where the system should look for the results files while automatically
 #. importing results. Having a folder for each Instrument and inside that
 #. folder creating different folders for each of its Interfaces can be a good
 #. approach. You can use Interface codes to be sure that folder names are
 #. unique."
-#. Default: "For each interface of this instrument, you can define a folder where the system should look for the results files while automatically importing results. Having a folder for each Instrument and inside that folder creating different folders for each of its Interfaces can be a good approach. You can use Interface codes to be sure that folder names are unique."
+#. Default: "For each interface of this instrument, you can define a folder
+#. where the system should look for the results files while automatically
+#. importing results. Having a folder for each Instrument and inside that
+#. folder creating different folders for each of its Interfaces can be a good
+#. approach. You can use Interface codes to be sure that folder names are
+#. unique."
 #: bika/lims/content/instrument.py:267
 msgid "description_instrument_result_file_folder"
 msgstr ""
+"Для каждого интерфейса этого инструмента можно задать папку, в которой "
+"система будет искать файлы результатов при автоматическом импорте. Хорошей "
+"практикой является создание отдельной папки для каждого инструмента, а "
+"внутри неё — папок для каждого интерфейса. Используйте коды интерфейсов, "
+"чтобы имена папок были уникальными."
 
 #. Default: "Select the supplier of this instrument"
 #: bika/lims/content/instrument.py:122
 msgid "description_instrument_supplier"
-msgstr ""
+msgstr "Выберите поставщика этого инструмента"
 
 #. Default: "The person who performed the task"
 #: bika/lims/content/instrumentcalibration.py:130
 msgid "description_instrumentcalibration_worker"
-msgstr ""
+msgstr "Лицо, выполнившее задачу"
 
 #. Default: "The person at the supplier who prepared the certificat"
 #: bika/lims/content/instrumentcertification.py:149
 msgid "description_instrumentcertification_preparator"
-msgstr ""
+msgstr "Лицо у поставщика, подготовившее сертификат"
 
 #. Default: "The person at the supplier who approved the certificate"
 #: bika/lims/content/instrumentcertification.py:173
 msgid "description_instrumentcertification_validator"
-msgstr ""
+msgstr "Лицо у поставщика, утвердившее сертификат"
 
 #. Default: "The person who performed the task"
 #: bika/lims/content/instrumentvalidation.py:112
 msgid "description_instrumentvalidation_worker"
-msgstr ""
+msgstr "Лицо, выполнившее задачу"
 
 #. selected departments."
-#. Default: "Select a default department for this contact from one of the selected departments."
+#. Default: "Select a default department for this contact from one of the
+#. selected departments."
 #: bika/lims/content/labcontact.py:89
 msgid "description_labcontact_default_department"
 msgstr ""
+"Выберите подразделение по умолчанию для этого контакта из выбранных "
+"подразделений."
 
 #. Default: "Assigned laboratory departments"
 #: bika/lims/content/labcontact.py:62
 msgid "description_labcontact_departments"
-msgstr ""
-
-#. the default style."
-#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
-#: senaite/core/content/label.py:72
-msgid "description_label_color"
-msgstr ""
-
-#. labeled content. The cascade runs in the same transaction as the save and
-#. may take a moment on large datasets."
-#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
-#: senaite/core/content/label.py:45
-msgid "description_label_title"
-msgstr ""
+msgstr "Назначенные подразделения лаборатории"
 
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
-msgstr ""
+msgstr "Отметьте, если ваша лаборатория аккредитована"
 
 #. Default: "The Laboratory's web address"
 #: senaite/core/content/laboratory.py:101
 msgid "description_laboratory_lab_url"
-msgstr ""
+msgstr "Веб-адрес лаборатории"
 
 #. Default: "Supervisor of the Lab"
 #: bika/lims/content/laboratory.py:78
 msgid "description_laboratory_suervisor"
-msgstr ""
+msgstr "Руководитель лаборатории"
 
 #. Default: "Supervisor of the Lab"
 #: senaite/core/content/laboratory.py:77
 msgid "description_laboratory_supervisor"
-msgstr ""
+msgstr "Руководитель лаборатории"
 
 #. Default: "Please provide the price excluding VAT"
 #: senaite/core/content/labproduct.py:89
 msgid "description_labproduct_price"
-msgstr ""
+msgstr "Укажите цену без учёта НДС"
 
 #. price"
-#. Default: "Please provide the VAT in percent that is added to the labproduct price"
+#. Default: "Please provide the VAT in percent that is added to the labproduct
+#. price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
-msgstr ""
-
-#. nested and positioned as they appear on the site. Use the controls to hide,
-#. show or reorder each viewlet."
-#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
-#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
-msgid "description_manage_viewlets"
-msgstr ""
+msgstr "Укажите НДС в процентах, добавляемый к цене товара лаборатории"
 
 #. Default: "Location where the document set is shelved"
 #: senaite/core/content/multifile.py:71
 msgid "description_multifile_document_location"
-msgstr ""
+msgstr "Место хранения комплекта документов"
 
 #. image, ...)"
-#. Default: "Type of document (e.g. user manual, instrument specifications, image, ...)"
+#. Default: "Type of document (e.g. user manual, instrument specifications,
+#. image, ...)"
 #: senaite/core/content/multifile.py:83
 msgid "description_multifile_document_type"
 msgstr ""
+"Тип документа (например, руководство пользователя, спецификации инструмента,"
+" изображение...)"
 
 #. Default: "File upload"
 #: senaite/core/content/multifile.py:51
 msgid "description_multifile_file"
-msgstr ""
+msgstr "Загрузка файла"
 
 #. Default: "Greeting title eg. Mr, Mrs, Dr"
 #: senaite/core/content/person.py:71
 msgid "description_person_salutation"
-msgstr ""
+msgstr "Обращение, например г-н, г-жа, д-р"
 
 #. Default: "Reference sample values are zero or 'blank'"
 #: bika/lims/content/referencedefinition.py:77
 msgid "description_referencedefinition_blank"
-msgstr ""
+msgstr "Значения референс-образца равны нулю или являются 'холостыми'"
 
 #. definition."
-#. Default: "Hazard categories that apply to samples of this reference definition."
+#. Default: "Hazard categories that apply to samples of this reference
+#. definition."
 #: bika/lims/content/referencedefinition.py:106
 msgid "description_referencedefinition_hazard_categories"
 msgstr ""
+"Категории опасности, применимые к образцам этого эталонного определения."
 
 #. Default: "Samples of this type should be treated as hazardous"
 #: bika/lims/content/referencedefinition.py:91
 msgid "description_referencedefinition_hazardous"
-msgstr ""
+msgstr "Образцы этого типа следует считать опасными"
 
 #. category. Enter minimum and maximum values to indicate a valid results
 #. range. Any result outside this range will raise an alert. The % Error field
@@ -7885,1090 +8720,1393 @@ msgstr ""
 #. against minimum and maximum values. A result out of range but still in
 #. range if the % error is taken into consideration, will raise a less severe
 #. alert."
-#. Default: "Click on Analysis Categories to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
+#. Default: "Click on Analysis Categories to see Analysis Services in each
+#. category. Enter minimum and maximum values to indicate a valid results
+#. range. Any result outside this range will raise an alert. The % Error field
+#. allows for an % uncertainty to be considered when evaluating results
+#. against minimum and maximum values. A result out of range but still in
+#. range if the % error is taken into consideration, will raise a less severe
+#. alert."
 #: bika/lims/content/referencedefinition.py:55
 msgid "description_referencedefinition_referencevalues"
 msgstr ""
+"Нажмите на категории анализа, чтобы увидеть услуги анализа в каждой "
+"категории. Введите минимальное и максимальное значения для допустимого "
+"диапазона результатов. Любой результат вне этого диапазона вызовет "
+"предупреждение. Поле '% ошибки' позволяет учитывать процент неопределённости"
+" при оценке результатов относительно минимума и максимума. Результат вне "
+"диапазона, но входящий в него с учётом % ошибки, вызовет менее серьёзное "
+"предупреждение."
 
 #. inherit from the reference definition."
-#. Default: "Hazard categories for this reference sample. Leave empty to inherit from the reference definition."
+#. Default: "Hazard categories for this reference sample. Leave empty to
+#. inherit from the reference definition."
 #: bika/lims/content/referencesample.py:118
 msgid "description_referencesample_hazard_categories"
 msgstr ""
+"Категории опасности для этого референс-образца. Оставьте пустым, чтобы "
+"наследовать от эталонного определения."
 
 #. Default: "Select the manufacturer for this sample"
 #: bika/lims/content/referencesample.py:136
 msgid "description_referencesample_manufacturer"
-msgstr ""
+msgstr "Выберите производителя для этого образца"
 
 #. Default: "Select the reference definition for this sample"
 #: bika/lims/content/referencesample.py:82
 msgid "description_referencesample_referencedefinition"
-msgstr ""
+msgstr "Выберите эталонное определение для этого образца"
 
 #. the paste popup in the sample add form. Please note that the paste button
 #. will only show for the fields listed here."
-#. Default: "Add all field names that support to enter multiple values using the paste popup in the sample add form. Please note that the paste button will only show for the fields listed here."
+#. Default: "Add all field names that support to enter multiple values using
+#. the paste popup in the sample add form. Please note that the paste button
+#. will only show for the fields listed here."
 #: senaite/core/registry/schema.py:375
 msgid "description_registry_allow_multi_paste"
 msgstr ""
+"Добавьте названия всех полей, поддерживающих ввод нескольких значений через "
+"всплывающее окно вставки в форме добавления образца. Кнопка вставки "
+"отображается только для перечисленных здесь полей."
 
 #. catalogs in which these portal types should be indexed, beyond the default
 #. catalogs. A restart is required for these changes to take effect."
-#. Default: "Define the relationship between portal types and the additional catalogs in which these portal types should be indexed, beyond the default catalogs. A restart is required for these changes to take effect."
+#. Default: "Define the relationship between portal types and the additional
+#. catalogs in which these portal types should be indexed, beyond the default
+#. catalogs. A restart is required for these changes to take effect."
 #: senaite/core/registry/schema.py:278
 msgid "description_registry_catalog_mappings"
 msgstr ""
+"Определите связь между типами портала и дополнительными каталогами, в "
+"которых эти типы должны индексироваться, помимо каталогов по умолчанию. Для "
+"применения изменений требуется перезапуск."
 
 #. logs into the system, or when a client is selected from the client folder
 #. listing"
-#. Default: "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing"
+#. Default: "Select the default landing page. This is used when a Client user
+#. logs into the system, or when a client is selected from the client folder
+#. listing"
 #: senaite/core/registry/schema.py:51
 msgid "description_registry_client_landing_page"
 msgstr ""
+"Выберите стартовую страницу по умолчанию. Она используется при входе "
+"пользователя-клиента в систему или при выборе клиента из списка папки "
+"клиентов"
 
 #. structure of the site via Generic Setup"
-#. Default: "List of portal types to be skipped when exporting the content structure of the site via Generic Setup"
+#. Default: "List of portal types to be skipped when exporting the content
+#. structure of the site via Generic Setup"
 #: senaite/core/registry/schema.py:238
 msgid "description_registry_generic_setup_skip_export_types"
 msgstr ""
+"Список типов портала, пропускаемых при экспорте структуры содержимого сайта "
+"через Generic Setup"
 
 #. Default: "Attach import file to all Worksheet assigned analyses"
 #: senaite/core/registry/schema.py:443
 msgid "description_registry_import_analysis_attach_attachment"
-msgstr ""
+msgstr "Прикреплять файл импорта ко всем анализам, назначенным рабочему листу"
 
 #. Default: "Automatically submit analyses upon import"
 #: senaite/core/registry/schema.py:456
 msgid "description_registry_import_analysis_submit"
-msgstr ""
+msgstr "Автоматически отправлять анализы при импорте"
 
 #. in its own ZODB transaction with a per-sample retry on conflict. This
 #. reduces the chance that ID-counter or container contention aborts the whole
 #. batch on instances with many concurrent users. When disabled, the whole
 #. batch is created in a single transaction (legacy behaviour)."
-#. Default: "When enabled, each sample created from the add form is committed in its own ZODB transaction with a per-sample retry on conflict. This reduces the chance that ID-counter or container contention aborts the whole batch on instances with many concurrent users. When disabled, the whole batch is created in a single transaction (legacy behaviour)."
+#. Default: "When enabled, each sample created from the add form is committed
+#. in its own ZODB transaction with a per-sample retry on conflict. This
+#. reduces the chance that ID-counter or container contention aborts the whole
+#. batch on instances with many concurrent users. When disabled, the whole
+#. batch is created in a single transaction (legacy behaviour)."
 #: senaite/core/registry/schema.py:391
 msgid "description_registry_sample_add_commit_per_sample"
 msgstr ""
+"Если включено, каждый образец, созданный из формы добавления, фиксируется в "
+"отдельной транзакции ZODB с повторной попыткой при конфликте. Это снижает "
+"вероятность прерывания всей партии из-за конфликта счётчика ID или "
+"контейнера при большом числе одновременных пользователей. Если отключено, "
+"вся партия создаётся в одной транзакции (прежнее поведение)."
 
 #. matching the source sample structure. Each partition will be created with
 #. the same configuration (sample type, container, preservation) and analyses
 #. as the source partition."
-#. Default: "When enabled, copying a sample will also create partitions matching the source sample structure. Each partition will be created with the same configuration (sample type, container, preservation) and analyses as the source partition."
+#. Default: "When enabled, copying a sample will also create partitions
+#. matching the source sample structure. Each partition will be created with
+#. the same configuration (sample type, container, preservation) and analyses
+#. as the source partition."
 #: senaite/core/registry/schema.py:328
 msgid "description_registry_sample_add_copy_partitions"
 msgstr ""
+"Если включено, при копировании образца также создаются партиции, "
+"соответствующие структуре исходного образца. Каждая партиция создаётся с той"
+" же конфигурацией (тип образца, контейнер, способ сохранения) и анализами, "
+"что и исходная партиция."
 
 #. copying analyses to a new sample in the sample add form."
-#. Default: "Add all analyses workflow states that should be skipped when copying analyses to a new sample in the sample add form."
+#. Default: "Add all analyses workflow states that should be skipped when
+#. copying analyses to a new sample in the sample add form."
 #: senaite/core/registry/schema.py:359
 msgid "description_registry_sample_add_skip_analyses_in_states"
 msgstr ""
+"Добавьте все статусы процесса анализа, которые нужно пропускать при "
+"копировании анализов в новый образец в форме добавления образца."
 
 #. copying a sample. Only analyses that directly belong to the source sample
 #. will be copied to the new sample."
-#. Default: "When enabled, analyses from partitions will be excluded when copying a sample. Only analyses that directly belong to the source sample will be copied to the new sample."
+#. Default: "When enabled, analyses from partitions will be excluded when
+#. copying a sample. Only analyses that directly belong to the source sample
+#. will be copied to the new sample."
 #: senaite/core/registry/schema.py:344
 msgid "description_registry_sample_add_skip_partition_analyses"
 msgstr ""
+"Если включено, анализы из партиций исключаются при копировании образца. В "
+"новый образец копируются только анализы, непосредственно принадлежащие "
+"исходному образцу."
 
 #. upon sample creation. This option is disabled by default, but certain add-
 #. ons may depend on it to operate correctly."
-#. Default: "When enabled, triggers “before” and “after” transition events upon sample creation. This option is disabled by default, but certain add-ons may depend on it to operate correctly."
+#. Default: "When enabled, triggers “before” and “after” transition events
+#. upon sample creation. This option is disabled by default, but certain add-
+#. ons may depend on it to operate correctly."
 #: senaite/core/registry/schema.py:410
 msgid "description_registry_trigger_events_on_sample_creation"
 msgstr ""
+"Если включено, при создании образца запускаются события перехода 'до' и "
+"'после'. По умолчанию отключено, но некоторые дополнения могут требовать "
+"этого для корректной работы."
 
 #. Default: "Worksheet view configuration"
 #: senaite/core/registry/schema.py:99
 msgid "description_registry_worksheet_settings"
-msgstr ""
+msgstr "Настройка просмотра рабочего листа"
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:187
+#: senaite/core/content/resultsreport.py:186
 msgid "description_resultsreport_contained_samples"
-msgstr ""
+msgstr "Образцы, содержащиеся в PDF"
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:159
+#: senaite/core/content/resultsreport.py:158
 msgid "description_resultsreport_sample"
-msgstr ""
+msgstr "Основной образец PDF"
 
 #. Default: "Assign sample to a batch"
 #: bika/lims/content/analysisrequest.py:331
 msgid "description_sample_batch"
-msgstr ""
+msgstr "Назначить образец партии"
 
 #. Default: "The contacts used in CC for email notifications"
 #: bika/lims/content/analysisrequest.py:200
 msgid "description_sample_cccontact"
-msgstr ""
+msgstr "Контакты, используемые в копии (CC) для email-уведомлений"
 
 #. Default: "Select the client for this sample"
 #: bika/lims/content/analysisrequest.py:258
 msgid "description_sample_client"
-msgstr ""
+msgstr "Выберите клиента для этого образца"
 
 #. Default: "Select the primary contact for this sample"
 #: bika/lims/content/analysisrequest.py:159
 msgid "description_sample_contact"
-msgstr ""
+msgstr "Выберите основной контакт для этого образца"
 
 #. Default: "Select a container for this sample"
 #: bika/lims/content/analysisrequest.py:569
 msgid "description_sample_container"
-msgstr ""
+msgstr "Выберите контейнер для этого образца"
 
 #. Default: "The date when the sample was taken"
 #: bika/lims/content/analysisrequest.py:453
 msgid "description_sample_datesampled"
-msgstr ""
+msgstr "Дата отбора образца"
 
 #. Default: "Reference to detached sample"
 #: bika/lims/content/analysisrequest.py:1311
 msgid "description_sample_detached_from"
-msgstr ""
+msgstr "Ссылка на отсоединённый образец"
 
 #. Default: "Reference to the source sample this sample was duplicated from"
 #: bika/lims/content/analysisrequest.py:1283
 msgid "description_sample_duplicated_from"
-msgstr ""
+msgstr "Ссылка на исходный образец, из которого был создан дубликат"
 
 #. Default: "Generated invoice for this sample"
 #: bika/lims/content/analysisrequest.py:1049
 msgid "description_sample_invoice"
-msgstr ""
+msgstr "Созданный счёт для этого образца"
 
 #. Default: "Reference to parent sample"
 #: bika/lims/content/analysisrequest.py:1255
 msgid "description_sample_parent_sample"
-msgstr ""
+msgstr "Ссылка на родительский образец"
 
 #. Default: "Select the needed preservation for this sample"
 #: bika/lims/content/analysisrequest.py:600
 msgid "description_sample_preservation"
-msgstr ""
+msgstr "Выберите необходимый способ сохранения для этого образца"
 
 #. Default: "Select a sample to create a secondary Sample"
 #: bika/lims/content/analysisrequest.py:295
 msgid "description_sample_primary"
-msgstr ""
+msgstr "Выберите образец для создания вторичного образца"
 
 #. Default: "Select an analysis profile for this sample"
 #: bika/lims/content/analysisrequest.py:421
 msgid "description_sample_profiles"
-msgstr ""
+msgstr "Выберите профиль анализа для этого образца"
 
 #. sample publication report"
-#. Default: "Select an analysis specification that should be used in the sample publication report"
+#. Default: "Select an analysis specification that should be used in the
+#. sample publication report"
 #: bika/lims/content/analysisrequest.py:737
 msgid "description_sample_publicationspecification"
 msgstr ""
+"Выберите спецификацию анализа для использования в отчёте публикации образца"
 
 #. Default: "Reference to retracted sample"
 #: bika/lims/content/analysisrequest.py:1339
 msgid "description_sample_retracted"
-msgstr ""
+msgstr "Ссылка на отозванный образец"
 
 #. Default: "The condition of the sample"
 #: bika/lims/content/analysisrequest.py:900
 msgid "description_sample_samplecondition"
-msgstr ""
+msgstr "Состояние образца"
 
 #. Default: "Location where the sample was taken"
 #: bika/lims/content/analysisrequest.py:770
 msgid "description_sample_samplepoint"
-msgstr ""
+msgstr "Место отбора образца"
 
 #. Default: "Select the sample type of this sample"
 #: bika/lims/content/analysisrequest.py:541
 msgid "description_sample_sampletype"
-msgstr ""
+msgstr "Выберите тип этого образца"
 
 #. Default: "The date when the sample will be taken"
 #: bika/lims/content/analysisrequest.py:516
 msgid "description_sample_samplingdate"
-msgstr ""
+msgstr "Дата, когда образец будет отобран"
 
 #. Default: "Deviation between the sample and how it was sampled"
 #: bika/lims/content/analysisrequest.py:872
 msgid "description_sample_samplingdeviation"
-msgstr ""
+msgstr "Отклонение между образцом и способом его отбора"
 
 #. Default: "Select an analysis specification for this sample"
 #: bika/lims/content/analysisrequest.py:693
 msgid "description_sample_specification"
-msgstr ""
+msgstr "Выберите спецификацию анализа для этого образца"
 
 #. Default: "Location where the sample is kept"
 #: bika/lims/content/analysisrequest.py:794
 msgid "description_sample_storagelocation"
-msgstr ""
+msgstr "Место хранения образца"
 
 #. Default: "The assigned batch sub group of this request"
 #: bika/lims/content/analysisrequest.py:366
 msgid "description_sample_subgroup"
-msgstr ""
+msgstr "Назначенная подгруппа партии этой заявки"
 
 #. Default: "Select an analysis template for this sample"
 #: bika/lims/content/analysisrequest.py:393
 msgid "description_sample_template"
-msgstr ""
+msgstr "Выберите шаблон анализа для этого образца"
 
 #. and put together from more than one sub sample, e.g. several surface
 #. samples from a dam mixed together to be a representative sample for the
 #. dam. The default, unchecked, indicates 'grab' samples"
-#. Default: "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
+#. Default: "Check this box if the samples taken at this point are 'composite'
+#. and put together from more than one sub sample, e.g. several surface
+#. samples from a dam mixed together to be a representative sample for the
+#. dam. The default, unchecked, indicates 'grab' samples"
 #: senaite/core/content/samplepoint.py:147
 msgid "description_samplepoint_composite"
 msgstr ""
+"Отметьте, если образцы, отобранные в этой точке, являются 'составными' и "
+"объединены из нескольких суб-образцов, например несколько поверхностных проб"
+" плотины, смешанных в один представительный образец. По умолчанию (не "
+"отмечено) — 'разовые' образцы"
 
 #. Default: "The height or depth at which the sample has to be taken"
 #: senaite/core/content/samplepoint.py:91
 msgid "description_samplepoint_elevation"
-msgstr ""
+msgstr "Высота или глубина, на которой должен быть взят образец"
 
 #. further analysis. It plays a pivotal role in research as it can
 #. significantly influence the results and conclusions drawn from the study."
-#. Default: "The geographical point or area from which samples are taken for further analysis. It plays a pivotal role in research as it can significantly influence the results and conclusions drawn from the study."
+#. Default: "The geographical point or area from which samples are taken for
+#. further analysis. It plays a pivotal role in research as it can
+#. significantly influence the results and conclusions drawn from the study."
 #: senaite/core/content/samplepoint.py:76
 msgid "description_samplepoint_location"
 msgstr ""
+"Географическая точка или область, из которой отбираются образцы для "
+"дальнейшего анализа. Играет ключевую роль в исследовании, так как может "
+"существенно влиять на результаты и выводы."
 
 #. point. The field for the selection of a sample point in sample creation and
 #. edit forms will be filtered in accordance. Still, sample points that do not
 #. have any sample type assigned will always be available for selection,
 #. regardless of the type."
-#. Default: "The list of sample types that can be collected at this sample point. The field for the selection of a sample point in sample creation and edit forms will be filtered in accordance. Still, sample points that do not have any sample type assigned will always be available for selection, regardless of the type."
+#. Default: "The list of sample types that can be collected at this sample
+#. point. The field for the selection of a sample point in sample creation and
+#. edit forms will be filtered in accordance. Still, sample points that do not
+#. have any sample type assigned will always be available for selection,
+#. regardless of the type."
 #: bika/lims/content/samplepoint.py:98
 msgid "description_samplepoint_sampletypes"
 msgstr ""
+"Список типов образца, которые можно отбирать в этой точке. Поле выбора точки"
+" отбора в формах создания и редактирования образца будет соответствующим "
+"образом отфильтровано. При этом точки без назначенного типа образца всегда "
+"доступны для выбора, независимо от типа."
 
 #. frequency here, e.g. weekly"
-#. Default: "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
+#. Default: "If a sample is taken periodically at this sample point, enter
+#. frequency here, e.g. weekly"
 #: senaite/core/content/samplepoint.py:103
 msgid "description_samplepoint_sampling_frequency"
 msgstr ""
+"Если образец на этой точке отбирается периодически, укажите частоту, "
+"например еженедельно"
 
 #. point. The field for the selection of a sample point in sample creation and
 #. edit forms will be filtered in accordance. Still, sample points that do not
 #. have any sample type assigned will always be available for selection,
 #. regardless of the type."
-#. Default: "The list of sample types that can be collected at this sample point. The field for the selection of a sample point in sample creation and edit forms will be filtered in accordance. Still, sample points that do not have any sample type assigned will always be available for selection, regardless of the type."
+#. Default: "The list of sample types that can be collected at this sample
+#. point. The field for the selection of a sample point in sample creation and
+#. edit forms will be filtered in accordance. Still, sample points that do not
+#. have any sample type assigned will always be available for selection,
+#. regardless of the type."
 #: senaite/core/content/samplepoint.py:126
 msgid "description_samplepoint_sampling_sample_types"
 msgstr ""
+"Список типов образца, которые можно отбирать в этой точке. Поле выбора точки"
+" отбора в формах создания и редактирования образца будет соответствующим "
+"образом отфильтровано. При этом точки без назначенного типа образца всегда "
+"доступны для выбора, независимо от типа."
 
 #. sample is received"
-#. Default: "Automatically redirect the user to the partitions view when the sample is received"
+#. Default: "Automatically redirect the user to the partitions view when the
+#. sample is received"
 #: senaite/core/content/sampletemplate.py:258
 msgid "description_sampletemplate_auto_partition"
 msgstr ""
+"Автоматически перенаправлять пользователя на просмотр партиций при приёме "
+"образца"
 
 #. Default: "Select if the sample is a mix of sub samples"
 #: senaite/core/content/sampletemplate.py:219
 msgid "description_sampletemplate_composite"
-msgstr ""
+msgstr "Отметьте, если образец является смесью суб-образцов"
 
 #. ID'"
-#. Default: "Each line defines a new partition identified by the 'Partition ID'"
+#. Default: "Each line defines a new partition identified by the 'Partition
+#. ID'"
 #: senaite/core/content/sampletemplate.py:245
 msgid "description_sampletemplate_partitions"
 msgstr ""
+"Каждая строка определяет новую партицию, идентифицируемую по 'ID партиции'"
 
 #. Default: "Select the sample point for this template"
 #: senaite/core/content/sampletemplate.py:187
 msgid "description_sampletemplate_samplepoint"
-msgstr ""
+msgstr "Выберите точку отбора проб для этого шаблона"
 
 #. Default: "Select the sample type for this template"
 #: senaite/core/content/sampletemplate.py:209
 msgid "description_sampletemplate_sampletype"
-msgstr ""
+msgstr "Выберите тип образца для этого шаблона"
 
 #. Default: "Enable sampling workflow for the created samples"
 #: senaite/core/content/sampletemplate.py:228
 msgid "description_sampletemplate_sampling_required"
-msgstr ""
+msgstr "Включить процесс отбора проб для создаваемых образцов"
 
 #. Default: "Select the services for this template"
 #: senaite/core/content/sampletemplate.py:273
 msgid "description_sampletemplate_services"
-msgstr ""
+msgstr "Выберите услуги для этого шаблона"
 
 #. Default: "Defines the stickers to use for this sample type."
 #: senaite/core/content/sampletype.py:281
 msgid "description_sampletype_admitted_stickers_templates"
-msgstr ""
+msgstr "Определяет стикеры, используемые для этого типа образца."
 
 #. automatically assigned a container of this type, unless it has been
 #. specified in more details per analysis service"
-#. Default: "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
+#. Default: "The default container type. New sample partitions are
+#. automatically assigned a container of this type, unless it has been
+#. specified in more details per analysis service"
 #: senaite/core/content/sampletype.py:258
 msgid "description_sampletype_containertype"
 msgstr ""
+"Тип контейнера по умолчанию. Новым партициям образца автоматически "
+"назначается контейнер этого типа, если иное не указано для конкретной услуги"
+" анализа"
 
 #. before they expire and cannot be analysed any further"
-#. Default: "The period for which unpreserved samples of this type can be kept before they expire and cannot be analysed any further"
+#. Default: "The period for which unpreserved samples of this type can be kept
+#. before they expire and cannot be analysed any further"
 #: senaite/core/content/sampletype.py:155
 msgid "description_sampletype_duration_period"
 msgstr ""
+"Период, в течение которого неконсервированные образцы этого типа могут "
+"храниться до истечения срока годности"
 
 #. display the appropriate pictograms in reports and lists."
-#. Default: "Hazard categories that apply to samples of this type. Used to display the appropriate pictograms in reports and lists."
+#. Default: "Hazard categories that apply to samples of this type. Used to
+#. display the appropriate pictograms in reports and lists."
 #: senaite/core/content/sampletype.py:180
 msgid "description_sampletype_hazard_categories"
 msgstr ""
+"Категории опасности, применимые к образцам этого типа. Используются для "
+"отображения соответствующих пиктограмм в отчётах и списках."
 
 #. Default: "Samples of this type should be treated as hazardous"
 #: senaite/core/content/sampletype.py:168
 msgid "description_sampletype_hazardous"
-msgstr ""
+msgstr "Образцы этого типа следует считать опасными"
 
 #. kg'."
-#. Default: "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
+#. Default: "The minimum sample volume required for analysis eg. '10 ml' or '1
+#. kg'."
 #: senaite/core/content/sampletype.py:235
 msgid "description_sampletype_min_volume"
 msgstr ""
+"Минимальный объём образца, необходимый для анализа, например '10 мл' или '1 "
+"кг'."
 
 #. Default: "Only ASCII characters without whitespaces are allowed."
 #: senaite/core/content/sampletype.py:222
 msgid "description_sampletype_prefix"
-msgstr ""
+msgstr "Допускаются только ASCII-символы без пробелов."
 
 #. Default: "Select the sample matrix for this sample type"
 #: senaite/core/content/sampletype.py:208
 msgid "description_sampletype_samplematrix"
-msgstr ""
+msgstr "Выберите матрицу образца для этого типа образца"
 
 #. entered manually for analyses"
-#. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:362
+#. Default: "If this option is activated, the result capture date can be
+#. entered manually for analyses"
+#: senaite/core/content/senaitesetup.py:361
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
+"Если этот параметр активирован, дату фиксации результата можно вводить "
+"вручную для анализов"
 
 #. to them or for unassigned analyses. When disabled, users can only submit
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
-#. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:456
+#. Default: "When enabled, users can submit results for analyses not assigned
+#. to them or for unassigned analyses. When disabled, users can only submit
+#. results for analyses assigned to themselves. This setting does not apply to
+#. users with role Lab Manager."
+#: senaite/core/content/senaitesetup.py:455
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
+"Если включено, пользователи могут отправлять результаты для анализов, не "
+"назначенных им, или для неназначенных анализов. Если отключено, пользователи"
+" могут отправлять результаты только для назначенных им анализов. Этот "
+"параметр не распространяется на пользователей с ролью 'Менеджер "
+"лаборатории'."
 
 #. departments will receive publication emails."
-#. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:289
+#. Default: "When selected, the responsible persons of all involved lab
+#. departments will receive publication emails."
+#: senaite/core/content/senaitesetup.py:288
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
+"Если выбрано, ответственные лица всех задействованных подразделений "
+"лаборатории будут получать письма о публикации."
 
 #. 0 disables automatic log-off"
-#. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:428
+#. Default: "The number of minutes before a user is automatically logged off.
+#. 0 disables automatic log-off"
+#: senaite/core/content/senaitesetup.py:427
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
+"Количество минут до автоматического выхода пользователя из системы. 0 "
+"отключает автоматический выход"
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
-#. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:655
+#. Default: "When enabled, the sample is automatically verified as soon as all
+#. results are verified. Otherwise, users with enough privileges have to
+#. manually verify the sample afterwards. Default: enabled"
+#: senaite/core/content/senaitesetup.py:654
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
+"Если включено, образец автоматически верифицируется, как только "
+"верифицированы все результаты. В противном случае пользователи с "
+"достаточными правами должны верифицировать образец вручную впоследствии. По "
+"умолчанию: включено"
 
 #. when the list is long"
-#. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:600
+#. Default: "Group analysis services by category in the LIMS tables, helpful
+#. when the list is long"
+#: senaite/core/content/senaitesetup.py:599
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
+"Группировать услуги анализа по категориям в таблицах LIMS — полезно при "
+"длинном списке"
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:341
+#: senaite/core/content/senaitesetup.py:340
 msgid "description_senaitesetup_categorizesampleanalyses"
-msgstr ""
+msgstr "Группировать анализы по категориям для образцов"
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:497
+#: senaite/core/content/senaitesetup.py:496
 msgid "description_senaitesetup_currency"
-msgstr ""
+msgstr "Выберите валюту, используемую сайтом для отображения цен."
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:862
+#: senaite/core/content/senaitesetup.py:861
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
+"Отметьте, чтобы использовать панель управления как главную страницу по "
+"умолчанию."
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
-#. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:387
+#. Default: "Select this to make DateSampled field required on sample
+#. creation. This functionality only takes effect when 'Sampling workflow' is
+#. not active"
+#: senaite/core/content/senaitesetup.py:386
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
+"Отметьте, чтобы сделать поле 'Дата отбора' обязательным при создании "
+"образца. Действует только когда процесс отбора проб не активен"
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:558
+#: senaite/core/content/senaitesetup.py:557
 msgid "description_senaitesetup_decimal_mark"
-msgstr ""
+msgstr "Предпочитаемый десятичный разделитель для отчётов."
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:511
+#: senaite/core/content/senaitesetup.py:510
 msgid "description_senaitesetup_default_country"
-msgstr ""
+msgstr "Выберите страну, отображаемую сайтом по умолчанию"
 
 #. to create new Samples"
-#. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:745
+#. Default: "Default value of the 'Sample count' when users click 'ADD' button
+#. to create new Samples"
+#: senaite/core/content/senaitesetup.py:744
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
+"Значение по умолчанию для 'Количество образцов' при нажатии кнопки "
+"'ДОБАВИТЬ'"
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
-#. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:261
+#. Default: "E-mail to use as the 'From' address for outgoing e-mails when
+#. publishing results reports. This address overrides the value set at
+#. portal's 'Mail settings'."
+#: senaite/core/content/senaitesetup.py:260
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
+"Email для использования в качестве адреса отправителя исходящих писем при "
+"публикации отчётов с результатами. Переопределяет значение, заданное в "
+"настройках почты портала."
 
 #. analysis in results entry view"
-#. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:642
+#. Default: "If enabled, a free text field will be displayed close to each
+#. analysis in results entry view"
+#: senaite/core/content/senaitesetup.py:641
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
+"Если включено, рядом с каждым анализом при вводе результатов будет "
+"отображаться поле свободного текста"
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:613
+#: senaite/core/content/senaitesetup.py:612
 msgid "description_senaitesetup_enable_ar_specs"
-msgstr ""
+msgstr "Спецификации анализа, редактируемые непосредственно в образце."
 
 #. 'Reject' option will be displayed in the actions menu."
-#. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:759
+#. Default: "Select this to activate the rejection workflow for Samples. A
+#. 'Reject' option will be displayed in the actions menu."
+#: senaite/core/content/senaitesetup.py:758
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
+"Отметьте, чтобы включить процесс отклонения образцов. В меню действий "
+"появится опция 'Отклонить'."
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
-#. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:626
+#. Default: "Result values with at least this number of significant digits are
+#. displayed in scientific notation using the letter 'e' to indicate the
+#. exponent. The precision can be configured in individual Analysis Services."
+#: senaite/core/content/senaitesetup.py:625
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
+"Значения результатов с числом значащих цифр не менее указанного отображаются"
+" в научной нотации с буквой 'e' для экспоненты. Точность можно настроить для"
+" отдельных услуг анализа."
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
-#. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:330
+#. Default: "Allow the user to directly enter results after sample creation,
+#. e.g. to enter field results immediately, or lab results, when the automatic
+#. sample reception is activated."
+#: senaite/core/content/senaitesetup.py:329
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
+"Разрешить пользователю сразу вводить результаты после создания образца, "
+"например для немедленного ввода полевых или лабораторных результатов при "
+"включённом автоматическом приёме образца."
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
-#. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:412
+#. Default: "Specify whether providing a reason is mandatory when invalidating
+#. a sample. If enabled, the '$reason' placeholder in the sample invalidation
+#. notification email body will be replaced with the entered reason."
+#: senaite/core/content/senaitesetup.py:411
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
+"Укажите, обязательно ли указание причины при аннулировании образца. Если "
+"включено, плейсхолдер '$reason' в тексте письма-уведомления об аннулировании"
+" образца будет заменён указанной причиной."
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
-#. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:875
+#. Default: "The landing page is shown for non-authenticated users if the
+#. Dashboard is not selected as the default front page. If no landing page is
+#. selected, the default frontpage is displayed."
+#: senaite/core/content/senaitesetup.py:874
 msgid "description_senaitesetup_landing_page"
 msgstr ""
+"Стартовая страница показывается неаутентифицированным пользователям, если "
+"панель управления не выбрана как главная страница по умолчанию. Если "
+"стартовая страница не выбрана, отображается страница по умолчанию."
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
-#. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:374
+#. Default: "Maximum number of samples that can be created in accordance with
+#. the value set for the field 'Number of samples' on the sample registration
+#. form"
+#: senaite/core/content/senaitesetup.py:373
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
+"Максимальное количество образцов, которые можно создать в соответствии со "
+"значением поля 'Количество образцов' формы регистрации"
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
-#. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:525
+#. Default: "The discount percentage entered here, is applied to the prices
+#. for clients flagged as 'members', normally co-operative members or
+#. associates deserving of this discount"
+#: senaite/core/content/senaitesetup.py:524
 msgid "description_senaitesetup_member_discount"
 msgstr ""
+"Указанный здесь процент скидки применяется к ценам для клиентов с отметкой "
+"'участник' — как правило, для членов кооперативов или партнёров, имеющих "
+"право на эту скидку"
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
-#. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:584
+#. Default: "Using too few data points does not make statistical sense. Set an
+#. acceptable minimum number of results before QC statistics will be
+#. calculated and plotted"
+#: senaite/core/content/senaitesetup.py:583
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
+"Использование слишком малого числа точек данных статистически некорректно. "
+"Установите допустимое минимальное количество результатов перед расчётом и "
+"построением статистики контроля качества"
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
-#. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:688
+#. Default: "Number of required verifications before a given result being
+#. considered as 'verified'. This setting can be overrided for any Analysis in
+#. Analysis Service edit view. By default, 1"
+#: senaite/core/content/senaitesetup.py:687
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
+"Требуемое количество верификаций, прежде чем результат будет считаться "
+"'верифицированным'. Может быть переопределено для конкретного анализа в "
+"услуге анализа. По умолчанию — 1"
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
-#. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:275
+#. Default: "Set the email body text to be used by default when sending out
+#. result reports to the selected recipients. You can use reserved keywords:
+#. $client_name, $recipients, $lab_name, $lab_address"
+#: senaite/core/content/senaitesetup.py:274
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
+"Задайте текст письма по умолчанию для отправки отчётов с результатами "
+"выбранным получателям. Можно использовать ключевые слова: $client_name, "
+"$recipients, $lab_name, $lab_address"
 
 #. rejecting a sample."
-#. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:774
+#. Default: "Enter the predefined rejection reasons that users can select when
+#. rejecting a sample."
+#: senaite/core/content/senaitesetup.py:773
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
+"Введите предопределённые причины отклонения, которые пользователи смогут "
+"выбрать при отклонении образца."
 
 #. When disabled, analysts and lab clerks can also manage worksheets. Note:
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
-#. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:472
+#. Default: "When enabled, only lab managers can create and manage worksheets.
+#. When disabled, analysts and lab clerks can also manage worksheets. Note:
+#. This setting is automatically enabled and locked when worksheet access is
+#. restricted to assigned analysts."
+#: senaite/core/content/senaitesetup.py:471
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
+"Если включено, только менеджеры лаборатории могут создавать рабочие листы и "
+"управлять ими. Если отключено, аналитики и лаборанты также могут управлять "
+"рабочими листами. Примечание: этот параметр автоматически включается и "
+"блокируется, когда доступ к рабочим листам ограничен назначенными "
+"аналитиками."
 
 #. are assigned. When disabled, analysts have access to all worksheets."
-#. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:442
+#. Default: "When enabled, analysts can only access worksheets to which they
+#. are assigned. When disabled, analysts have access to all worksheets."
+#: senaite/core/content/senaitesetup.py:441
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
+"Если включено, аналитики могут получить доступ только к назначенным им "
+"рабочим листам. Если отключено, аналитики имеют доступ ко всем рабочим "
+"листам."
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:719
+#: senaite/core/content/senaitesetup.py:718
 msgid "description_senaitesetup_results_decimal_mark"
-msgstr ""
+msgstr "Предпочитаемый десятичный разделитель для результатов"
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
-#. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:969
+#. Default: "If enabled, users with sufficient privileges can create a sibling
+#. sample directly from an existing one via the 'Duplicate' action in the
+#. samples listing. Enabled by default."
+#: senaite/core/content/senaitesetup.py:968
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
+"Если включено, пользователи с достаточными правами могут создать смежный "
+"образец напрямую из существующего через действие 'Дублировать' в списке "
+"образцов. По умолчанию включено."
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:351
+#: senaite/core/content/senaitesetup.py:350
 msgid "description_senaitesetup_sampleanalysesrequired"
-msgstr ""
+msgstr "Анализы обязательны для регистрации образца"
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
-#. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:805
+#. Default: "Select which columns to display in sample analysis listings. The
+#. order of selection determines the display order. Unselected columns are
+#. hidden. Leave empty to show all columns in default order."
+#: senaite/core/content/senaitesetup.py:804
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
+"Выберите столбцы для отображения в списках анализов образца. Порядок выбора "
+"определяет порядок отображения. Невыбранные столбцы скрыты. Оставьте пустым,"
+" чтобы показать все столбцы в порядке по умолчанию."
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:571
+#: senaite/core/content/senaitesetup.py:570
 msgid "description_senaitesetup_scientific_notation_report"
-msgstr ""
+msgstr "Предпочитаемый формат научной нотации для отчётов"
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:732
+#: senaite/core/content/senaitesetup.py:731
 msgid "description_senaitesetup_scientific_notation_results"
-msgstr ""
+msgstr "Предпочитаемый формат научной нотации для результатов"
 
 #. verify it. This setting only take effect for those users with a role
 #. assigned that allows them to verify results (by default, managers,
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
-#. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:670
+#. Default: "If enabled, a user who submitted a result will also be able to
+#. verify it. This setting only take effect for those users with a role
+#. assigned that allows them to verify results (by default, managers,
+#. labmanagers and verifiers). This setting can be overrided for a given
+#. Analysis in Analysis Service edit view. By default, disabled."
+#: senaite/core/content/senaitesetup.py:669
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
+"Если включено, пользователь, отправивший результат, также сможет его "
+"верифицировать. Действует только для пользователей с ролью, позволяющей "
+"верифицировать результаты (по умолчанию — менеджеры, менеджеры лаборатории и"
+" верификаторы). Может быть переопределено для конкретного анализа в услуге "
+"анализа. По умолчанию отключено."
 
 #. page, above the access credentials."
-#. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:400
+#. Default: "When selected, the laboratory name will be displayedin the login
+#. page, above the access credentials."
+#: senaite/core/content/senaitesetup.py:399
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
+"Если выбрано, название лаборатории будет отображаться на странице входа над "
+"полями учётных данных."
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
-#. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:899
+#. Default: "Select to show sample partitions to client contacts. If
+#. deactivated, partitions won't be included in listings and no info message
+#. with links to the primary sample will be displayed to client contacts."
+#: senaite/core/content/senaitesetup.py:898
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
+"Отметьте, чтобы показывать партиции образца контактам клиента. Если "
+"отключено, партиции не будут включены в списки, и контактам клиента не будет"
+" показано информационное сообщение со ссылками на основной образец."
 
 #. navigation. The order of selection determines the display order in the
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
-#. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:914
+#. Default: "Select which top-level folders should be displayed in the sidebar
+#. navigation. The order of selection determines the display order in the
+#. sidebar. If none are selected, all folders will be shown in the default
+#. order."
+#: senaite/core/content/senaitesetup.py:913
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
+"Выберите папки верхнего уровня для отображения в боковой навигации. Порядок "
+"выбора определяет порядок отображения. Если ничего не выбрано, отображаются "
+"все папки в порядке по умолчанию."
 
 #. top-level folders, level 2 includes their children, and so on."
-#. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:933
+#. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only
+#. top-level folders, level 2 includes their children, and so on."
+#: senaite/core/content/senaitesetup.py:932
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
+"Максимальная глубина дерева боковой навигации. Уровень 1 показывает только "
+"папки верхнего уровня, уровень 2 включает их дочерние элементы и т.д."
 
 #. navigation. If none are selected, all content types will be shown."
-#. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:950
+#. Default: "Select which content types should be excluded from the sidebar
+#. navigation. If none are selected, all content types will be shown."
+#: senaite/core/content/senaitesetup.py:949
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
+"Выберите типы содержимого, исключаемые из боковой навигации. Если ничего не "
+"выбрано, отображаются все типы."
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
-#. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:704
+#. Default: "Choose type of multiple verification for the same user. This
+#. setting can enable/disable verifying/consecutively verifying more than once
+#. for the same user."
+#: senaite/core/content/senaitesetup.py:703
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
+"Выберите тип многократной верификации для одного пользователя. Этот параметр"
+" включает/отключает повторную верификацию одним и тем же пользователем."
 
 #. system wide but can be overwritten on individual items"
-#. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:542
+#. Default: "Enter percentage value eg. 14.0. This percentage is applied
+#. system wide but can be overwritten on individual items"
+#: senaite/core/content/senaitesetup.py:541
 msgid "description_senaitesetup_vat"
 msgstr ""
+"Введите значение процента, например 14.0. Применяется во всей системе, но "
+"может быть переопределено для отдельных элементов"
 
 #. view. Classic layout displays the Samples in rows and the analyses in
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
-#. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:846
+#. Default: "Preferred layout of the results entry table in the Worksheet
+#. view. Classic layout displays the Samples in rows and the analyses in
+#. columns. Transposed layout displays the Samples in columns and the analyses
+#. in rows."
+#: senaite/core/content/senaitesetup.py:845
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
+"Предпочитаемый макет таблицы ввода результатов в просмотре рабочего листа. "
+"Классический макет отображает образцы в строках, а анализы в столбцах. "
+"Транспонированный макет отображает образцы в столбцах, а анализы в строках."
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
-#. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:825
+#. Default: "Select which columns to display in worksheet analysis listings.
+#. The order of selection determines the display order. Unselected columns are
+#. hidden. Leave empty to show all columns in default order."
+#: senaite/core/content/senaitesetup.py:824
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
+"Выберите столбцы для отображения в списках анализов рабочего листа. Порядок "
+"выбора определяет порядок отображения. Невыбранные столбцы скрыты. Оставьте "
+"пустым, чтобы показать все столбцы в порядке по умолчанию."
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
-#. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:617
+#. Default: "The landing page is shown for non-authenticated users if the
+#. Dashboard is not selected as the default front page. If no landing page is
+#. selected, the default frontpage is displayed."
+#: bika/lims/content/bikasetup.py:616
 msgid "description_setup_landingpage"
 msgstr ""
+"Стартовая страница показывается неаутентифицированным пользователям, если "
+"панель управления не выбрана как главная страница по умолчанию. Если "
+"стартовая страница не выбрана, отображается страница по умолчанию."
 
 #. Default: "Code for the location"
 #: senaite/core/content/storagelocation.py:106
 msgid "description_storagelocation_location_code"
-msgstr ""
+msgstr "Код местоположения"
 
 #. Default: "Description of the location"
 #: senaite/core/content/storagelocation.py:118
 msgid "description_storagelocation_location_description"
-msgstr ""
+msgstr "Описание местоположения"
 
 #. Default: "Title of location"
 #: senaite/core/content/storagelocation.py:94
 msgid "description_storagelocation_location_title"
-msgstr ""
+msgstr "Название местоположения"
 
 #. Default: "Type of location"
 #: senaite/core/content/storagelocation.py:130
 msgid "description_storagelocation_location_type"
-msgstr ""
+msgstr "Тип местоположения"
 
 #. Default: "Code the the shelf"
 #: senaite/core/content/storagelocation.py:154
 msgid "description_storagelocation_shelf_code"
-msgstr ""
+msgstr "Код стеллажа"
 
 #. Default: "Description of the shelf"
 #: senaite/core/content/storagelocation.py:166
 msgid "description_storagelocation_shelf_description"
-msgstr ""
+msgstr "Описание стеллажа"
 
 #. Default: "Title of the shelf"
 #: senaite/core/content/storagelocation.py:142
 msgid "description_storagelocation_shelf_title"
-msgstr ""
+msgstr "Название стеллажа"
 
 #. Default: "Code for the site"
 #: senaite/core/content/storagelocation.py:70
 msgid "description_storagelocation_site_code"
-msgstr ""
+msgstr "Код площадки"
 
 #. Default: "Description of the site"
 #: senaite/core/content/storagelocation.py:82
 msgid "description_storagelocation_site_description"
-msgstr ""
+msgstr "Описание площадки"
 
 #. Default: "Title of the site"
 #: senaite/core/content/storagelocation.py:58
 msgid "description_storagelocation_site_title"
-msgstr ""
+msgstr "Название площадки"
 
 #. Duplicate values are ordered alphabetically."
-#. Default: "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
+#. Default: "Float value from 0.0 - 1000.0 indicating the sort order.
+#. Duplicate values are ordered alphabetically."
 #: senaite/core/content/subgroup.py:60
 msgid "description_subgroup_sort_key"
 msgstr ""
+"Число с плавающей точкой от 0.0 до 1000.0, задающее порядок сортировки. "
+"Повторяющиеся значения сортируются по алфавиту."
 
 #. Default: "International Bank Account Number"
 #: senaite/core/content/supplier.py:100
 msgid "description_supplier_iban"
-msgstr ""
+msgstr "Международный номер банковского счёта (IBAN)"
 
 #. Default: "National Identification Bank Account Number"
 #: senaite/core/content/supplier.py:88
 msgid "description_supplier_nib"
-msgstr ""
+msgstr "Национальный идентификационный номер банковского счёта (NIB)"
 
 #. contact profile."
-#. Default: "User is linked to a contact. Please change your settings in the contact profile."
+#. Default: "User is linked to a contact. Please change your settings in the
+#. contact profile."
 #: senaite/core/browser/user/userdatapanel.py:82
 msgid "description_user_contact"
 msgstr ""
+"Пользователь связан с контактом. Измените настройки в профиле контакта."
 
 #. Default: "Select the preferred instrument"
 #: senaite/core/content/worksheettemplate.py:266
 msgid "description_worksheettemplate_instrument"
-msgstr ""
+msgstr "Выберите предпочитаемый инструмент"
 
 #. with the selected method.<br/>In order to apply this change to the services
 #. list, you should save the change first."
-#. Default: "Restrict the available analysis services and instruments to those with the selected method.<br/>In order to apply this change to the services list, you should save the change first."
+#. Default: "Restrict the available analysis services and instruments to those
+#. with the selected method.<br/>In order to apply this change to the services
+#. list, you should save the change first."
 #: senaite/core/content/worksheettemplate.py:240
 msgid "description_worksheettemplate_restrict_to_method"
 msgstr ""
+"Ограничить доступные услуги анализа и инструменты теми, что связаны с "
+"выбранным методом.<br/>Чтобы применить это изменение к списку услуг, сначала"
+" сохраните изменение."
 
 #. Default: "Select which Analyses should be included on the Worksheet"
 #: senaite/core/content/worksheettemplate.py:350
 msgid "description_worksheettemplate_services"
-msgstr ""
+msgstr "Выберите анализы, включаемые в рабочий лист"
 
 #. specific instrument's tray size. Then select an Analysis 'type' per
 #. Worksheet position. Where QC samples are selected, also select which
 #. Reference Sample should be used. If a duplicate analysis is selected,
 #. indicate which sample position it should be a duplicate of"
-#. Default: "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
+#. Default: "Specify the size of the Worksheet, e.g. corresponding to a
+#. specific instrument's tray size. Then select an Analysis 'type' per
+#. Worksheet position. Where QC samples are selected, also select which
+#. Reference Sample should be used. If a duplicate analysis is selected,
+#. indicate which sample position it should be a duplicate of"
 #: senaite/core/content/worksheettemplate.py:315
 msgid "description_worksheettemplate_template_layout"
 msgstr ""
+"Укажите размер рабочего листа, например, соответствующий размеру лотка "
+"конкретного инструмента. Затем выберите 'тип' анализа для каждой позиции "
+"рабочего листа. Если выбраны образцы контроля качества, также выберите "
+"используемый референс-образец. Если выбран дублирующий анализ, укажите, "
+"дубликатом какой позиции образца он является"
 
 #. Default: "Not found Analysis position for duplicate."
 #: senaite/core/browser/form/adapters/worksheettemplate.py:114
 msgid "duplicate_reference_not_found"
-msgstr ""
+msgstr "Не найдена позиция анализа для дубликата."
 
 #. routine analysis."
-#. Default: "Duplicate in position ${dup} references this, so it must be a routine analysis."
+#. Default: "Duplicate in position ${dup} references this, so it must be a
+#. routine analysis."
 #: senaite/core/browser/form/adapters/worksheettemplate.py:164
 msgid "duplicate_reference_this_position"
 msgstr ""
+"Дубликат в позиции ${dup} ссылается на это, поэтому это должен быть плановый"
+" анализ."
 
 #. Default: "${days} days"
 #: senaite/core/z3cform/widgets/duration/display.pt:19
 msgid "duration_widget_days_number"
-msgstr ""
+msgstr "${days} дн."
 
 #. Default: "${hours} hours"
 #: senaite/core/z3cform/widgets/duration/display.pt:24
 msgid "duration_widget_hours_number"
-msgstr ""
+msgstr "${hours} ч."
 
 #. Default: "Days"
 #: senaite/core/z3cform/widgets/duration/input.pt:20
 msgid "duration_widget_label_days"
-msgstr ""
+msgstr "Дни"
 
 #. Default: "Hours"
 #: senaite/core/z3cform/widgets/duration/input.pt:30
 msgid "duration_widget_label_hours"
-msgstr ""
+msgstr "Часы"
 
 #. Default: "Minutes"
 #: senaite/core/z3cform/widgets/duration/input.pt:40
 msgid "duration_widget_label_minutes"
-msgstr ""
+msgstr "Минуты"
 
 #. Default: "Seconds"
 #: senaite/core/z3cform/widgets/duration/input.pt:50
 msgid "duration_widget_label_seconds"
-msgstr ""
+msgstr "Секунды"
 
 #. Default: "${minutes} minutes"
 #: senaite/core/z3cform/widgets/duration/display.pt:29
 msgid "duration_widget_minutes_number"
-msgstr ""
+msgstr "${minutes} мин."
 
 #. Default: "${seconds} seconds"
 #: senaite/core/z3cform/widgets/duration/display.pt:34
 msgid "duration_widget_seconds_number"
-msgstr ""
+msgstr "${seconds} сек."
 
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
-msgstr ""
-
-#: senaite/core/api/remarks.py:481
-msgid "edited"
-msgstr ""
+msgstr "Содержимое файла"
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
-#. Default: "The number of samples to create for the record 'Sample ${record_index}' (${num_samples}) is above ${max_num_samples}"
+#. Default: "The number of samples to create for the record 'Sample
+#. ${record_index}' (${num_samples}) is above ${max_num_samples}"
 #: bika/lims/browser/analysisrequest/add2.py:2081
 msgid "error_analyssirequest_numsamples_above_max"
 msgstr ""
+"Количество создаваемых образцов для записи 'Образец ${record_index}' "
+"(${num_samples}) превышает ${max_num_samples}"
 
 #. Default: "${name} is after ${max_date}, please correct."
 #: senaite/core/browser/fields/datetime.py:120
 msgid "error_datetime_after_max"
-msgstr ""
+msgstr "${name} позже ${max_date}, исправьте."
 
 #. Default: "${name} is before ${min_date}, please correct."
 #: senaite/core/browser/fields/datetime.py:94
 msgid "error_datetime_before_min"
-msgstr ""
+msgstr "${name} раньше ${min_date}, исправьте."
 
 #. Default: "Unable to load the template"
 #: senaite/core/browser/worksheets/worksheet/printview.py:155
 msgid "error_load_template_worksheet"
-msgstr ""
+msgstr "Не удалось загрузить шаблон"
 
 #. Default: "Location"
 #: senaite/core/content/samplepoint.py:48
 msgid "fieldset_samplepoint_location"
-msgstr ""
+msgstr "Местоположение"
 
 #. Default: "Analyses"
 #: senaite/core/content/sampletemplate.py:152
 msgid "fieldset_sampletemplate_analyses"
-msgstr ""
+msgstr "Анализы"
 
 #. Default: "Partitions"
 #: senaite/core/content/sampletemplate.py:141
 msgid "fieldset_sampletemplate_partitions"
-msgstr ""
+msgstr "Партиции"
 
 #. Default: "Validation chain internal error: ${error}"
 #: senaite/core/validators/formula.py:121
 msgid "formula_validation_chain_error"
-msgstr ""
+msgstr "Внутренняя ошибка цепочки проверки: ${error}"
 
 #. Default: "cryogenic / inert gas"
 #: senaite/core/vocabularies/hazard_categories.py:167
 msgid "hazard_ASPH01_common"
-msgstr ""
+msgstr "криогенный / инертный газ"
 
 #. Default: "Asphyxiating atmosphere"
 #: senaite/core/vocabularies/hazard_categories.py:165
 msgid "hazard_ASPH01_name"
-msgstr ""
+msgstr "Удушающая атмосфера"
 
 #. Default: "infectious / biological"
 #: senaite/core/vocabularies/hazard_categories.py:104
 msgid "hazard_BIO01_common"
-msgstr ""
+msgstr "инфекционный / биологический"
 
 #. Default: "Biohazard"
 #: senaite/core/vocabularies/hazard_categories.py:103
 msgid "hazard_BIO01_name"
-msgstr ""
+msgstr "Биологическая опасность"
 
 #. Default: "freezing / cold storage"
 #: senaite/core/vocabularies/hazard_categories.py:158
 msgid "hazard_COLD01_common"
-msgstr ""
+msgstr "заморозка / холодное хранение"
 
 #. Default: "Low temperature"
 #: senaite/core/vocabularies/hazard_categories.py:157
 msgid "hazard_COLD01_name"
-msgstr ""
+msgstr "Низкая температура"
 
 #. Default: "electric shock"
 #: senaite/core/vocabularies/hazard_categories.py:132
 msgid "hazard_ELEC01_common"
-msgstr ""
+msgstr "поражение электрическим током"
 
 #. Default: "Electricity"
 #: senaite/core/vocabularies/hazard_categories.py:131
 msgid "hazard_ELEC01_name"
-msgstr ""
+msgstr "Электричество"
 
 #. Default: "explosive"
 #: senaite/core/vocabularies/hazard_categories.py:48
 msgid "hazard_GHS01_common"
-msgstr ""
+msgstr "взрывоопасно"
 
 #. Default: "Explosive"
 #: senaite/core/vocabularies/hazard_categories.py:47
 msgid "hazard_GHS01_name"
-msgstr ""
+msgstr "Взрывчатое вещество"
 
 #. Default: "flammable"
 #: senaite/core/vocabularies/hazard_categories.py:54
 msgid "hazard_GHS02_common"
-msgstr ""
+msgstr "легковоспламеняющееся"
 
 #. Default: "Flammable"
 #: senaite/core/vocabularies/hazard_categories.py:53
 msgid "hazard_GHS02_name"
-msgstr ""
+msgstr "Легковоспламеняющееся"
 
 #. Default: "oxidizing"
 #: senaite/core/vocabularies/hazard_categories.py:60
 msgid "hazard_GHS03_common"
-msgstr ""
+msgstr "окисляющее"
 
 #. Default: "Oxidizing"
 #: senaite/core/vocabularies/hazard_categories.py:59
 msgid "hazard_GHS03_name"
-msgstr ""
+msgstr "Окисляющее вещество"
 
 #. Default: "pressurised gas"
 #: senaite/core/vocabularies/hazard_categories.py:66
 msgid "hazard_GHS04_common"
-msgstr ""
+msgstr "газ под давлением"
 
 #. Default: "Compressed gas"
 #: senaite/core/vocabularies/hazard_categories.py:65
 msgid "hazard_GHS04_name"
-msgstr ""
+msgstr "Сжатый газ"
 
 #. Default: "acid / caustic"
 #: senaite/core/vocabularies/hazard_categories.py:72
 msgid "hazard_GHS05_common"
-msgstr ""
+msgstr "кислота / едкое вещество"
 
 #. Default: "Corrosive"
 #: senaite/core/vocabularies/hazard_categories.py:71
 msgid "hazard_GHS05_name"
-msgstr ""
+msgstr "Коррозийное вещество"
 
 #. Default: "poisonous"
 #: senaite/core/vocabularies/hazard_categories.py:78
 msgid "hazard_GHS06_common"
-msgstr ""
+msgstr "ядовитое"
 
 #. Default: "Acute toxicity"
 #: senaite/core/vocabularies/hazard_categories.py:77
 msgid "hazard_GHS06_name"
-msgstr ""
+msgstr "Острая токсичность"
 
 #. Default: "harmful / irritant"
 #: senaite/core/vocabularies/hazard_categories.py:84
 msgid "hazard_GHS07_common"
-msgstr ""
+msgstr "вредное / раздражающее"
 
 #. Default: "Health hazard"
 #: senaite/core/vocabularies/hazard_categories.py:83
 msgid "hazard_GHS07_name"
-msgstr ""
+msgstr "Опасно для здоровья"
 
 #. Default: "carcinogenic / mutagenic"
 #: senaite/core/vocabularies/hazard_categories.py:90
 msgid "hazard_GHS08_common"
-msgstr ""
+msgstr "канцерогенное / мутагенное"
 
 #. Default: "Serious health hazard"
 #: senaite/core/vocabularies/hazard_categories.py:89
 msgid "hazard_GHS08_name"
-msgstr ""
+msgstr "Серьёзная опасность для здоровья"
 
 #. Default: "environmentally hazardous"
 #: senaite/core/vocabularies/hazard_categories.py:97
 msgid "hazard_GHS09_common"
-msgstr ""
+msgstr "опасно для окружающей среды"
 
 #. Default: "Environmental hazard"
 #: senaite/core/vocabularies/hazard_categories.py:96
 msgid "hazard_GHS09_name"
-msgstr ""
+msgstr "Экологическая опасность"
 
 #. Default: "heated material"
 #: senaite/core/vocabularies/hazard_categories.py:145
 msgid "hazard_HOT01_common"
-msgstr ""
+msgstr "нагретый материал"
 
 #. Default: "Hot content"
 #: senaite/core/vocabularies/hazard_categories.py:144
 msgid "hazard_HOT01_name"
-msgstr ""
+msgstr "Горячее содержимое"
 
 #. Default: "hot to touch"
 #: senaite/core/vocabularies/hazard_categories.py:139
 msgid "hazard_HSURF01_common"
-msgstr ""
+msgstr "горячо на ощупь"
 
 #. Default: "Hot surface"
 #: senaite/core/vocabularies/hazard_categories.py:138
 msgid "hazard_HSURF01_name"
-msgstr ""
+msgstr "Горячая поверхность"
 
 #. Default: "NMR / MRI"
 #: senaite/core/vocabularies/hazard_categories.py:125
 msgid "hazard_MAG01_common"
-msgstr ""
+msgstr "ЯМР / МРТ"
 
 #. Default: "Magnetic field"
 #: senaite/core/vocabularies/hazard_categories.py:124
 msgid "hazard_MAG01_name"
-msgstr ""
+msgstr "Магнитное поле"
 
 #. Default: "UV / laser / RF"
 #: senaite/core/vocabularies/hazard_categories.py:118
 msgid "hazard_NIR01_common"
-msgstr ""
+msgstr "УФ / лазер / РЧ"
 
 #. Default: "Non-ionising radiation"
 #: senaite/core/vocabularies/hazard_categories.py:117
 msgid "hazard_NIR01_name"
-msgstr ""
+msgstr "Неионизирующее излучение"
 
 #. Default: "ionising radiation"
 #: senaite/core/vocabularies/hazard_categories.py:112
 msgid "hazard_RAD01_common"
-msgstr ""
+msgstr "ионизирующее излучение"
 
 #. Default: "Radioactive"
 #: senaite/core/vocabularies/hazard_categories.py:111
 msgid "hazard_RAD01_name"
-msgstr ""
+msgstr "Радиоактивно"
 
 #. Default: "autoclave / sterilisation"
 #: senaite/core/vocabularies/hazard_categories.py:151
 msgid "hazard_STEAM01_common"
-msgstr ""
+msgstr "автоклав / стерилизация"
 
 #. Default: "Hot steam"
 #: senaite/core/vocabularies/hazard_categories.py:150
 msgid "hazard_STEAM01_name"
-msgstr ""
+msgstr "Горячий пар"
 
 #. Default: "Hazardous"
 #: senaite/core/api/hazard.py:37
 msgid "hazard_warning_label"
-msgstr ""
+msgstr "Опасно"
 
 #. Default: "Legacy Setup"
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:16
 msgid "heading_legacy_setup"
-msgstr ""
+msgstr "Устаревшие настройки"
 
 #. Default: "Re-enter the password. Make sure the passwords are identical."
 #: senaite/core/browser/user/passwordpanel.py:44
 msgid "help_confirm_password"
-msgstr ""
+msgstr "Введите пароль повторно. Убедитесь, что пароли совпадают."
 
 #. Default: "Enter full name, e.g. John Smith."
 #: senaite/core/browser/user/userdatapanel.py:65
 msgid "help_full_name_creation"
-msgstr ""
+msgstr "Введите полное имя, например Иван Иванов."
 
 #. Default: "Enter your new password."
 #: senaite/core/browser/user/passwordpanel.py:37
 msgid "help_new_password"
-msgstr ""
+msgstr "Введите новый пароль."
 
 #. Default: "Your time zone"
 #: senaite/core/browser/user/personalpreferences.py:39
 msgid "help_timezone"
-msgstr ""
+msgstr "Ваш часовой пояс"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:285
 msgid "hours"
-msgstr ""
+msgstr "часов"
 
 #. Default: "'${function}' not found in module '${module}'"
 #: senaite/core/validators/imports.py:66
 msgid "importable_function_error"
-msgstr ""
+msgstr "'${function}' не найдена в модуле '${module}'"
 
 #. Default: "Could not import module '${module}'"
 #: senaite/core/validators/imports.py:49
 msgid "importable_module_error"
-msgstr ""
+msgstr "Не удалось импортировать модуль '${module}'"
 
 #: bika/lims/browser/publish/templates/email.pt:189
 msgid "in"
@@ -8977,72 +10115,82 @@ msgstr "в"
 #. Default: "Instrument exporter not found"
 #: senaite/core/browser/worksheets/worksheet/export.py:66
 msgid "instrument_exporter_not_found_message"
-msgstr ""
+msgstr "Экспортёр инструмента не найден"
 
 #. Default: "Interim field ${row_num}: ${message}"
 #: senaite/core/validators/interimfields.py:299
 msgid "interim_field_error"
-msgstr ""
+msgstr "Промежуточное поле ${row_num}: ${message}"
 
 #. Default: "Validation chain internal error: ${error}"
 #: senaite/core/validators/interimfields.py:278
 msgid "interims_validation_chain_error"
-msgstr ""
+msgstr "Внутренняя ошибка цепочки проверки: ${error}"
 
 #. Default: "'${field_name}' contains invalid characters"
 #: senaite/core/validators/interimfields.py:68
 msgid "invalid_characters_validator_error"
-msgstr ""
+msgstr "'${field_name}' содержит недопустимые символы"
 
 #. Default: "AnalysesServices not found for keywords: ${keywords}"
 #: senaite/core/validators/formula.py:92
 msgid "invalid_keyword_error"
-msgstr ""
+msgstr "Не найдены услуги анализа для ключевых слов: ${keywords}"
 
 #. Default: "Invalid wildcards found: ${wildcards}"
 #: senaite/core/validators/formula.py:71
 msgid "invalid_wildcards_check_error"
-msgstr ""
+msgstr "Обнаружены неверные шаблоны подстановки: ${wildcards}"
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:125
+#: senaite/core/behaviors/label.py:117
 msgid "label_Labels"
-msgstr ""
+msgstr "Метки"
 
 #. Default: "Add to the following groups:"
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:276
 msgid "label_add_to_groups"
-msgstr ""
+msgstr "Добавить в следующие группы:"
 
 #. Default: "Address"
 #: senaite/core/content/person.py:197
 msgid "label_address"
-msgstr ""
+msgstr "Адрес"
 
 #. Default: "Analysis Category"
 #: bika/lims/content/abstractbaseanalysis.py:530
 msgid "label_analysis_category"
-msgstr ""
+msgstr "Категория анализа"
 
 #. Default: "Department"
 #: bika/lims/content/abstractbaseanalysis.py:588
 msgid "label_analysis_department"
-msgstr ""
+msgstr "Подразделение"
 
 #. of a parameter that can be reliably detected by a specified testing
 #. methodology with a defined level of confidence. Results below this
 #. threshold are typically reported as '< LLOD' (or 'Not Detected'),
 #. indicating that the parameter's concentration, if present, is below the
 #. detection capability of the method at a reliable level."
-#. Default: "The Lower Limit of Detection (LLOD) is the lowest concentration of a parameter that can be reliably detected by a specified testing methodology with a defined level of confidence. Results below this threshold are typically reported as '< LLOD' (or 'Not Detected'), indicating that the parameter's concentration, if present, is below the detection capability of the method at a reliable level."
+#. Default: "The Lower Limit of Detection (LLOD) is the lowest concentration
+#. of a parameter that can be reliably detected by a specified testing
+#. methodology with a defined level of confidence. Results below this
+#. threshold are typically reported as '< LLOD' (or 'Not Detected'),
+#. indicating that the parameter's concentration, if present, is below the
+#. detection capability of the method at a reliable level."
 #: bika/lims/content/abstractbaseanalysis.py:207
 msgid "label_analysis_lower_limit_of_detection_description"
 msgstr ""
+"Нижний предел обнаружения (LLOD) — минимальная концентрация параметра, "
+"которая может быть достоверно обнаружена указанной методикой испытания с "
+"определённым уровнем доверия. Результаты ниже этого порога обычно "
+"указываются как '< LLOD' (или 'Не обнаружено'), означая, что концентрация "
+"параметра, если она присутствует, ниже надёжного предела обнаружения метода."
 
 #. Default: "Lower Limit of Detection (LLOD)"
 #: bika/lims/content/abstractbaseanalysis.py:203
 msgid "label_analysis_lower_limit_of_detection_title"
-msgstr ""
+msgstr "Нижний предел обнаружения (LLOD)"
 
 #. concentration of a parameter that can be reliably and accurately measured
 #. using the specified testing methodology, with acceptable levels of
@@ -9050,35 +10198,46 @@ msgstr ""
 #. confidence and are typically reported as '< LOQ' (or 'Detected but < LOQ'),
 #. indicating that while the parameter may be present, its exact concentration
 #. cannot be determined reliably."
-#. Default: "The Lower Limit of Quantification (LLOQ) is the lowest concentration of a parameter that can be reliably and accurately measured using the specified testing methodology, with acceptable levels of precision and accuracy. Results below this value cannot be quantified with confidence and are typically reported as '< LOQ' (or 'Detected but < LOQ'), indicating that while the parameter may be present, its exact concentration cannot be determined reliably."
+#. Default: "The Lower Limit of Quantification (LLOQ) is the lowest
+#. concentration of a parameter that can be reliably and accurately measured
+#. using the specified testing methodology, with acceptable levels of
+#. precision and accuracy. Results below this value cannot be quantified with
+#. confidence and are typically reported as '< LOQ' (or 'Detected but < LOQ'),
+#. indicating that while the parameter may be present, its exact concentration
+#. cannot be determined reliably."
 #: bika/lims/content/abstractbaseanalysis.py:231
 msgid "label_analysis_lower_limit_of_quantification_description"
 msgstr ""
+"Нижний предел количественного определения (LLOQ) — минимальная концентрация "
+"параметра, которая может быть достоверно и точно измерена указанной "
+"методикой с приемлемой точностью. Результаты ниже этого значения не могут "
+"быть достоверно определены количественно и обычно указываются как '< LOQ' "
+"(или 'Обнаружено, но < LOQ')."
 
 #. Default: "Lower Limit Of Quantification (LLOQ)"
 #: bika/lims/content/abstractbaseanalysis.py:227
 msgid "label_analysis_lower_limit_of_quantification_title"
-msgstr ""
+msgstr "Нижний предел количественного определения (LLOQ)"
 
 #. Default: "Maximum holding time"
 #: bika/lims/content/abstractbaseanalysis.py:453
 msgid "label_analysis_maxholdingtime"
-msgstr ""
+msgstr "Максимальный срок хранения"
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:769
+#: bika/lims/content/abstractbaseanalysis.py:766
 msgid "label_analysis_results_options_sorting"
-msgstr ""
+msgstr "Критерий сортировки"
 
 #. Default: "Default Unit"
 #: bika/lims/content/abstractbaseanalysis.py:108
 msgid "label_analysis_unit"
-msgstr ""
+msgstr "Единица измерения по умолчанию"
 
 #. Default: "Units for Selection"
 #: bika/lims/content/abstractbaseanalysis.py:158
 msgid "label_analysis_unitchoices"
-msgstr ""
+msgstr "Единицы измерения для выбора"
 
 #. of a parameter that can be reliably measured using a specified testing
 #. methodology. Beyond this limit, results may no longer be accurate or valid
@@ -9086,2270 +10245,2272 @@ msgstr ""
 #. exceeding this threshold are typically reported as '> ULOD', indicating
 #. that the parameter's concentration is above the reliable detection range of
 #. the method."
-#. Default: "The Upper Limit of Detection (ULOD) is the highest concentration of a parameter that can be reliably measured using a specified testing methodology. Beyond this limit, results may no longer be accurate or valid due to instrument saturation or methodological limitations. Results exceeding this threshold are typically reported as '> ULOD', indicating that the parameter's concentration is above the reliable detection range of the method."
+#. Default: "The Upper Limit of Detection (ULOD) is the highest concentration
+#. of a parameter that can be reliably measured using a specified testing
+#. methodology. Beyond this limit, results may no longer be accurate or valid
+#. due to instrument saturation or methodological limitations. Results
+#. exceeding this threshold are typically reported as '> ULOD', indicating
+#. that the parameter's concentration is above the reliable detection range of
+#. the method."
 #: bika/lims/content/abstractbaseanalysis.py:277
 msgid "label_analysis_upper_limit_of_detection_description"
 msgstr ""
+"Верхний предел обнаружения (ULOD) — максимальная концентрация параметра, "
+"которая может быть достоверно измерена указанной методикой. Выше этого "
+"предела результаты могут быть неточными из-за насыщения прибора или "
+"методологических ограничений. Результаты, превышающие этот порог, обычно "
+"указываются как '> ULOD'."
 
 #. Default: "Upper Limit of Detection (ULOD)"
 #: bika/lims/content/abstractbaseanalysis.py:274
 msgid "label_analysis_upper_limit_of_detection_title"
-msgstr ""
+msgstr "Верхний предел обнаружения (ULOD)"
 
 #. concentration of a parameter that can be reliably and accurately measured
 #. using the specified testing methodology, with acceptable levels of
 #. precision and accuracy. Results above this value cannot be quantified with
 #. confidence and are typically reported as '> ULOQ', indicating that its
 #. exact concentration cannot be determined reliably."
-#. Default: "The Upper Limit of Quantification (ULOQ) is the highest concentration of a parameter that can be reliably and accurately measured using the specified testing methodology, with acceptable levels of precision and accuracy. Results above this value cannot be quantified with confidence and are typically reported as '> ULOQ', indicating that its exact concentration cannot be determined reliably."
+#. Default: "The Upper Limit of Quantification (ULOQ) is the highest
+#. concentration of a parameter that can be reliably and accurately measured
+#. using the specified testing methodology, with acceptable levels of
+#. precision and accuracy. Results above this value cannot be quantified with
+#. confidence and are typically reported as '> ULOQ', indicating that its
+#. exact concentration cannot be determined reliably."
 #: bika/lims/content/abstractbaseanalysis.py:255
 msgid "label_analysis_upper_limit_of_quantification_description"
 msgstr ""
+"Верхний предел количественного определения (ULOQ) — максимальная "
+"концентрация параметра, которая может быть достоверно и точно измерена "
+"указанной методикой. Результаты выше этого значения не могут быть достоверно"
+" определены количественно и обычно указываются как '> ULOQ'."
 
 #. Default: "Upper Limit Of Quantification (ULOQ)"
 #: bika/lims/content/abstractbaseanalysis.py:252
 msgid "label_analysis_upper_limit_of_quantification_title"
-msgstr ""
+msgstr "Верхний предел количественного определения (ULOQ)"
 
 #. Default: "Sample types"
 #: senaite/core/content/analysisprofile.py:180
 msgid "label_analysisprofile_sampletypes"
-msgstr ""
+msgstr "Типы образца"
 
 #. Default: "Number of samples"
 #: bika/lims/content/analysisrequest.py:1437
 msgid "label_analysisrequest_numsamples"
-msgstr ""
+msgstr "Количество образцов"
 
 #. Default: "Dynamic Analysis Specification"
 #: bika/lims/content/analysisspec.py:69
 msgid "label_analysisspec_dynamicspec"
-msgstr ""
+msgstr "Динамическая спецификация анализа"
 
 #. Default: "Sample Type"
 #: bika/lims/content/analysisspec.py:49
 msgid "label_analysisspec_sampletype"
-msgstr ""
+msgstr "Тип образца"
 
 #. Default: "Contained Samples"
 #: bika/lims/content/arreport.py:79
 msgid "label_arreport_contained_samples"
-msgstr ""
+msgstr "Содержащиеся образцы"
 
 #. Default: "Primary Sample"
 #: bika/lims/content/arreport.py:49
 msgid "label_arreport_sample"
-msgstr ""
+msgstr "Основной образец"
 
 #. Default: "Analysis Profile"
 #: bika/lims/content/artemplate.py:254
 msgid "label_artemplate_profile"
-msgstr ""
+msgstr "Профиль анализа"
 
 #. Default: "Sample Point"
 #: bika/lims/content/artemplate.py:55
 msgid "label_artemplate_samplepoint"
-msgstr ""
+msgstr "Точка отбора проб"
 
 #. Default: "Sample Type"
 #: bika/lims/content/artemplate.py:86
 msgid "label_artemplate_sampletype"
-msgstr ""
+msgstr "Тип образца"
 
 #. Default: "Attachment Type"
 #: bika/lims/content/attachment.py:61
 msgid "label_attachment_type"
-msgstr ""
+msgstr "Тип вложения"
 
 #. Default: "Instrument"
 #: bika/lims/content/autoimportlog.py:50
 msgid "label_autoimportlog_instrument"
-msgstr ""
+msgstr "Инструмент"
 
 #. Default: "Log Time"
 #: bika/lims/content/autoimportlog.py:87
 msgid "label_autoimportlog_logtime"
-msgstr ""
+msgstr "Время журнала"
 
 #. Default: "Results"
 #: bika/lims/content/autoimportlog.py:74
 msgid "label_autoimportlog_results"
-msgstr ""
+msgstr "Результаты"
 
 #. Default: "Client"
 #: bika/lims/content/batch.py:78
 msgid "label_batch_client"
-msgstr ""
+msgstr "Клиент"
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:395
+#: bika/lims/content/bikasetup.py:394
 msgid "label_bikasetup_allow_manual_result_capture_date"
-msgstr ""
+msgstr "Разрешить устанавливать дату фиксации результата"
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:851
+#: bika/lims/content/bikasetup.py:850
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
-msgstr ""
+msgstr "Всегда отправлять письмо о публикации ответственным"
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:367
+#: bika/lims/content/bikasetup.py:366
 msgid "label_bikasetup_categorizesampleanalyses"
-msgstr ""
+msgstr "Категоризировать анализы образца"
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:686
+#: bika/lims/content/bikasetup.py:685
 msgid "label_bikasetup_date_sampled_required"
-msgstr ""
+msgstr "Дата отбора обязательна"
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:827
+#: bika/lims/content/bikasetup.py:826
 msgid "label_bikasetup_email_body_sample_publication"
-msgstr ""
+msgstr "Текст письма для уведомлений о публикации образца"
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:802
+#: bika/lims/content/bikasetup.py:801
 msgid "label_bikasetup_email_from_sample_publication"
-msgstr ""
+msgstr "Адрес отправителя публикации"
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:442
+#: bika/lims/content/bikasetup.py:441
 msgid "label_bikasetup_immediateresultsentry"
-msgstr ""
+msgstr "Немедленный ввод результатов"
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:943
+#: bika/lims/content/bikasetup.py:942
 msgid "label_bikasetup_invalidation_email_body"
-msgstr ""
+msgstr "Текст письма для уведомлений об аннулировании образца"
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:910
+#: bika/lims/content/bikasetup.py:909
 msgid "label_bikasetup_invalidation_reason_required"
-msgstr ""
+msgstr "Причина аннулирования обязательна"
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:381
+#: bika/lims/content/bikasetup.py:380
 msgid "label_bikasetup_sampleanalysesrequired"
-msgstr ""
+msgstr "Требовать анализы образца"
 
 #. Default: "DependentServices"
 #: senaite/core/content/calculation.py:352
 msgid "label_calculation_dependent_services"
-msgstr ""
+msgstr "Зависимые услуги"
 
 #. Default: "Dependent services"
 #: bika/lims/content/calculation.py:81
 msgid "label_calculation_dependentservices"
-msgstr ""
+msgstr "Зависимые услуги"
 
 #. Default: "Calculation Formula"
 #: senaite/core/content/calculation.py:287
 msgid "label_calculation_formula"
-msgstr ""
+msgstr "Формула расчёта"
 
 #. Default: "Function"
 #: senaite/core/content/calculation.py:185
 msgid "label_calculation_import_function_name"
-msgstr ""
+msgstr "Функция"
 
 #. Default: "Module"
 #: senaite/core/content/calculation.py:179
 msgid "label_calculation_import_module_name"
-msgstr ""
+msgstr "Модуль"
 
 #. Default: "Additional Python Libraries"
 #: senaite/core/content/calculation.py:266
 msgid "label_calculation_imports"
-msgstr ""
+msgstr "Дополнительные библиотеки Python"
 
 #. Default: "Calculation Interim Fields"
 #: senaite/core/content/calculation.py:243
 msgid "label_calculation_interims"
-msgstr ""
+msgstr "Промежуточные поля расчёта"
 
 #. Default: "Raw Test Result"
 #: senaite/core/content/calculation.py:336
 msgid "label_calculation_raw_test_keywords"
-msgstr ""
+msgstr "Необработанный результат теста"
 
 #. Default: "Keyword"
 #: senaite/core/content/calculation.py:198
 msgid "label_calculation_test_param_keyword"
-msgstr ""
+msgstr "Ключевое слово"
 
 #. Default: "Value"
 #: senaite/core/content/calculation.py:207
 msgid "label_calculation_test_param_value"
-msgstr ""
+msgstr "Значение"
 
 #. Default: "Test Parameters"
 #: senaite/core/content/calculation.py:317
 msgid "label_calculation_test_params"
-msgstr ""
+msgstr "Параметры теста"
 
 #. Default: "Test Result"
 #: senaite/core/content/calculation.py:343
 msgid "label_calculation_test_result"
-msgstr ""
+msgstr "Результат теста"
 
 #. Default: "Department"
 #: bika/lims/content/analysiscategory.py:59
 msgid "label_category_department"
-msgstr ""
+msgstr "Подразделение"
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:185
+#: bika/lims/content/client.py:181
 msgid "label_client_defaultcategories"
-msgstr ""
+msgstr "Категории по умолчанию"
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:209
+#: bika/lims/content/client.py:205
 msgid "label_client_restrictcategories"
-msgstr ""
+msgstr "Ограничить категории"
 
 #. Default: "Confirm password"
 #: senaite/core/browser/user/passwordpanel.py:43
 msgid "label_confirm_password"
-msgstr ""
+msgstr "Подтвердите пароль"
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:151
+#: senaite/core/content/contact.py:119
 msgid "label_contact_cccontact"
-msgstr ""
+msgstr "Контакты для копии (CC)"
 
 #. Default: "Email Telephone Fax"
 #: senaite/core/content/person.py:137
 msgid "label_contact_information"
-msgstr ""
+msgstr "Email Телефон Факс"
 
 #. Default: "Preservation"
 #: bika/lims/content/container.py:97
 msgid "label_container_preservation"
-msgstr ""
+msgstr "Сохранение"
 
 #. Default: "Container Type"
 #: bika/lims/content/container.py:54
 msgid "label_container_type"
-msgstr ""
+msgstr "Тип контейнера"
 
 #. Default: "Manager"
 #: senaite/core/content/department.py:102
 msgid "label_department_manager"
-msgstr ""
+msgstr "Менеджер"
 
 #. edit the container itself, ${go_here}."
-#. Default: "You are editing the default view of a container. If you wanted to edit the container itself, ${go_here}."
+#. Default: "You are editing the default view of a container. If you wanted to
+#. edit the container itself, ${go_here}."
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:28
 msgid "label_edit_default_view_container"
 msgstr ""
+"Вы редактируете стандартный просмотр контейнера. Если хотите отредактировать"
+" сам контейнер, ${go_here}."
 
 #. Default: "go here"
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:28
 msgid "label_edit_default_view_container_go_here"
-msgstr ""
+msgstr "перейдите сюда"
 
 #. Default: "Bank Details"
 #: senaite/core/content/supplier.py:72
 msgid "label_fieldset_supplier_bank_details"
-msgstr ""
+msgstr "Банковские реквизиты"
 
 #. Default: "Analyses"
 #: senaite/core/content/worksheettemplate.py:332
 msgid "label_fieldset_worksheettemplate_analyses"
-msgstr ""
+msgstr "Анализы"
 
 #. Default: "Layout"
 #: senaite/core/content/worksheettemplate.py:275
 msgid "label_fieldset_worksheettemplate_layout"
-msgstr ""
+msgstr "Макет"
 
 #. Default: "Include client contacts"
 #: senaite/core/browser/controlpanel/contacts/templates/contacts_filter.pt:10
 msgid "label_include_client_contacts"
-msgstr ""
+msgstr "Включить контакты клиента"
 
 #. Default: "Location"
 #: bika/lims/content/instrument.py:319
 msgid "label_instrument_instrumentlocation"
-msgstr ""
+msgstr "Местоположение"
 
 #. Default: "Instrument type"
 #: bika/lims/content/instrument.py:79
 msgid "label_instrument_instrumenttype"
-msgstr ""
+msgstr "Тип инструмента"
 
 #. Default: "Manufacturer"
 #: bika/lims/content/instrument.py:99
 msgid "label_instrument_manufacturer"
-msgstr ""
+msgstr "Производитель"
 
 #. Default: "Supported methods"
 #: bika/lims/content/instrument.py:172
 msgid "label_instrument_methods"
-msgstr ""
+msgstr "Поддерживаемые методы"
 
 #. Default: "Result files folders"
 #: bika/lims/content/instrument.py:265
 msgid "label_instrument_result_file_folder"
-msgstr ""
+msgstr "Папки файлов результатов"
 
 #. Default: "Supplier"
 #: bika/lims/content/instrument.py:119
 msgid "label_instrument_supplier"
-msgstr ""
+msgstr "Поставщик"
 
 #. Default: "Performed by"
 #: bika/lims/content/instrumentcalibration.py:127
 msgid "label_instrumentcalibration_worker"
-msgstr ""
+msgstr "Выполнил(а)"
 
 #. Default: "Prepared by"
 #: bika/lims/content/instrumentcertification.py:146
 msgid "label_instrumentcertification_preparator"
-msgstr ""
+msgstr "Подготовил(а)"
 
 #. Default: "Approved by"
 #: bika/lims/content/instrumentcertification.py:170
 msgid "label_instrumentcertification_validator"
-msgstr ""
+msgstr "Утвердил(а)"
 
 #. Default: "Performed by"
 #: bika/lims/content/instrumentvalidation.py:109
 msgid "label_instrumentvalidation_worker"
-msgstr ""
+msgstr "Выполнил(а)"
 
 #. Default: "Allow empty"
 #: senaite/core/schema/interimfields.py:87
 msgid "label_interim_allow_empty"
-msgstr ""
+msgstr "Разрешить пустое значение"
 
 #. Default: "Apply wide"
 #: senaite/core/schema/interimfields.py:127
 msgid "label_interim_apply_wide"
-msgstr ""
+msgstr "Применить ко всем"
 
 #. Default: "Choices"
 #: senaite/core/schema/interimfields.py:67
 msgid "label_interim_choices"
-msgstr ""
+msgstr "Варианты"
 
 #. Default: "Default value"
 #: senaite/core/schema/interimfields.py:57
 msgid "label_interim_default_value"
-msgstr ""
+msgstr "Значение по умолчанию"
 
 #. Default: "Hidden"
 #: senaite/core/schema/interimfields.py:117
 msgid "label_interim_hidden"
-msgstr ""
+msgstr "Скрыто"
 
 #. Default: "Keyword"
 #: senaite/core/schema/interimfields.py:37
 msgid "label_interim_keyword"
-msgstr ""
+msgstr "Ключевое слово"
 
 #. Default: "Report"
 #: senaite/core/schema/interimfields.py:107
 msgid "label_interim_report"
-msgstr ""
+msgstr "Отчёт"
 
 #. Default: "Result type"
 #: senaite/core/schema/interimfields.py:76
 msgid "label_interim_result_type"
-msgstr ""
+msgstr "Тип результата"
 
 #. Default: "Field title"
 #: senaite/core/schema/interimfields.py:47
 msgid "label_interim_title"
-msgstr ""
+msgstr "Название поля"
 
 #. Default: "Unit"
 #: senaite/core/schema/interimfields.py:97
 msgid "label_interim_unit"
-msgstr ""
+msgstr "Единица измерения"
 
 #. Default: "Default Department"
 #: bika/lims/content/labcontact.py:86
 msgid "label_labcontact_default_department"
-msgstr ""
+msgstr "Подразделение по умолчанию"
 
 #. Default: "Departments"
 #: bika/lims/content/labcontact.py:59
 msgid "label_labcontact_departments"
-msgstr ""
+msgstr "Подразделения"
 
 #. Default: "Supervisor"
 #: senaite/core/content/laboratory.py:73
 msgid "label_laboratory_supervisor"
-msgstr ""
+msgstr "Руководитель"
 
 #. Default: "Document ID"
 #: senaite/core/content/multifile.py:39
 msgid "label_multifile_document_id"
-msgstr ""
+msgstr "ID документа"
 
 #. Default: "Document Location"
 #: senaite/core/content/multifile.py:67
 msgid "label_multifile_document_location"
-msgstr ""
+msgstr "Расположение документа"
 
 #. Default: "Document Type"
 #: senaite/core/content/multifile.py:79
 msgid "label_multifile_document_type"
-msgstr ""
+msgstr "Тип документа"
 
 #. Default: "Document Version"
 #: senaite/core/content/multifile.py:59
 msgid "label_multifile_document_version"
-msgstr ""
+msgstr "Версия документа"
 
 #. Default: "Document"
 #: senaite/core/content/multifile.py:47
 msgid "label_multifile_file"
-msgstr ""
+msgstr "Документ"
 
 #. Default: "New password"
 #: senaite/core/browser/user/passwordpanel.py:36
 msgid "label_new_password"
-msgstr ""
+msgstr "Новый пароль"
 
 #. Default: "Fax (business)"
 #: senaite/core/content/person.py:169
 msgid "label_person_business_fax"
-msgstr ""
+msgstr "Факс (рабочий)"
 
 #. Default: "Phone (business)"
 #: senaite/core/content/person.py:160
 msgid "label_person_business_phone"
-msgstr ""
+msgstr "Телефон (рабочий)"
 
 #. Default: "Department"
 #: senaite/core/content/person.py:119
 msgid "label_person_department"
-msgstr ""
+msgstr "Подразделение"
 
 #. Default: "Description"
 #: senaite/core/content/person.py:59
 msgid "label_person_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Email Address"
 #: senaite/core/content/person.py:151
 msgid "label_person_email_address"
-msgstr ""
+msgstr "Email адрес"
 
 #. Default: "Firstname"
 #: senaite/core/content/person.py:79
 msgid "label_person_firstname"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Phone (home)"
 #: senaite/core/content/person.py:178
 msgid "label_person_home_phone"
-msgstr ""
+msgstr "Телефон (домашний)"
 
 #. Default: "Job title"
 #: senaite/core/content/person.py:111
 msgid "label_person_job_title"
-msgstr ""
+msgstr "Должность"
 
 #. Default: "Middle initial"
 #: senaite/core/content/person.py:87
 msgid "label_person_middleinitial"
-msgstr ""
+msgstr "Отчество (инициал)"
 
 #. Default: "Middle name"
 #: senaite/core/content/person.py:95
 msgid "label_person_middlename"
-msgstr ""
+msgstr "Отчество"
 
 #. Default: "Phone (mobile)"
 #: senaite/core/content/person.py:187
 msgid "label_person_mobile_phone"
-msgstr ""
+msgstr "Телефон (мобильный)"
 
 #. Default: "Physical address"
 #: senaite/core/content/person.py:210
 msgid "label_person_physical_address"
-msgstr ""
+msgstr "Физический адрес"
 
 #. Default: "Postal address"
 #: senaite/core/content/person.py:219
 msgid "label_person_postal_address"
-msgstr ""
+msgstr "Почтовый адрес"
 
 #. Default: "Salutation"
 #: senaite/core/content/person.py:67
 msgid "label_person_salutation"
-msgstr ""
+msgstr "Обращение"
 
 #. Default: "Surname"
 #: senaite/core/content/person.py:103
 msgid "label_person_surname"
-msgstr ""
+msgstr "Фамилия"
 
 #. Default: "Title"
 #: senaite/core/content/person.py:51
 msgid "label_person_title"
-msgstr ""
+msgstr "Название"
 
 #. Default: "Username"
 #: senaite/core/content/person.py:127
 msgid "label_person_username"
-msgstr ""
+msgstr "Имя пользователя"
 
 #. Default: "SENAITE is powered by"
 #: senaite/core/browser/viewlets/templates/colophon.pt:11
 msgid "label_powered_by"
-msgstr ""
+msgstr "SENAITE работает на"
 
 #. Default: "Plone & Python"
 #: senaite/core/browser/viewlets/templates/colophon.pt:12
 msgid "label_powered_by_plone"
-msgstr ""
+msgstr "Plone и Python"
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:131
+#: senaite/core/content/contact.py:99
 msgid "label_publication_preference"
-msgstr ""
+msgstr "Предпочтение публикации"
 
 #. Default: "Blank"
 #: bika/lims/content/referencedefinition.py:75
 msgid "label_referencedefinition_blank"
-msgstr ""
+msgstr "Холостая проба"
 
 #. Default: "Hazard categories"
 #: bika/lims/content/referencedefinition.py:104
 msgid "label_referencedefinition_hazard_categories"
-msgstr ""
+msgstr "Категории опасности"
 
 #. Default: "Hazardous"
 #: bika/lims/content/referencedefinition.py:89
 msgid "label_referencedefinition_hazardous"
-msgstr ""
+msgstr "Опасно"
 
 #. Default: "Reference Values"
 #: bika/lims/content/referencedefinition.py:53
 msgid "label_referencedefinition_referencevalues"
-msgstr ""
+msgstr "Референсные значения"
 
 #. Default: "Hazard categories"
 #: bika/lims/content/referencesample.py:116
 msgid "label_referencesample_hazard_categories"
-msgstr ""
+msgstr "Категории опасности"
 
 #. Default: "Manufacturer"
 #: bika/lims/content/referencesample.py:133
 msgid "label_referencesample_manufacturer"
-msgstr ""
+msgstr "Производитель"
 
 #. Default: "Reference Definition"
 #: bika/lims/content/referencesample.py:79
 msgid "label_referencesample_referencedefinition"
-msgstr ""
+msgstr "Эталонное определение"
 
 #. Default: "Catalog mappings"
 #: senaite/core/registry/schema.py:274
 msgid "label_registry_catalog_mappings"
-msgstr ""
+msgstr "Сопоставления каталогов"
 
 #. Default: "Portal type"
 #: senaite/core/registry/schema.py:286
 msgid "label_registry_catalog_mappings_key"
-msgstr ""
+msgstr "Тип портала"
 
 #. Default: "Catalogs"
 #: senaite/core/registry/schema.py:293
 msgid "label_registry_catalog_mappings_value"
-msgstr ""
+msgstr "Каталоги"
 
 #. Default: "Catalogs"
 #: senaite/core/registry/schema.py:265
 msgid "label_registry_catalogs_fieldset"
-msgstr ""
+msgstr "Каталоги"
 
 #. Default: "Client landing page"
 #: senaite/core/registry/schema.py:47
 msgid "label_registry_client_landing_page"
-msgstr ""
+msgstr "Стартовая страница клиента"
 
 #. Default: "Portal types to skip on content structure export"
 #: senaite/core/registry/schema.py:234
 msgid "label_registry_generic_setup_skip_export_types"
-msgstr ""
+msgstr "Типы портала, пропускаемые при экспорте структуры содержимого"
 
 #. Default: "Import"
 #: senaite/core/registry/schema.py:428
 msgid "label_registry_import"
-msgstr ""
+msgstr "Импорт"
 
 #. Default: "Attach import file to Analyses"
 #: senaite/core/registry/schema.py:439
 msgid "label_registry_import_analysis_attach_attachment"
-msgstr ""
+msgstr "Прикреплять файл импорта к анализам"
 
 #. Default: "Submit Analyses upon import"
 #: senaite/core/registry/schema.py:452
 msgid "label_registry_import_analysis_submit"
-msgstr ""
+msgstr "Отправлять анализы при импорте"
 
 #. Default: "Allow multi paste"
 #: senaite/core/registry/schema.py:371
 msgid "label_registry_sample_add_allow_multi_paste_fields"
-msgstr ""
+msgstr "Разрешить массовую вставку"
 
 #. Default: "Commit each sample in its own transaction"
 #: senaite/core/registry/schema.py:387
 msgid "label_registry_sample_add_commit_per_sample"
-msgstr ""
+msgstr "Фиксировать каждый образец в отдельной транзакции"
 
 #. Default: "Copy sample structure with partitions"
 #: senaite/core/registry/schema.py:324
 msgid "label_registry_sample_add_copy_partitions"
-msgstr ""
+msgstr "Копировать структуру образца с партициями"
 
 #. Default: "Skip analyses workflow states on copy"
 #: senaite/core/registry/schema.py:355
 msgid "label_registry_sample_add_skip_analyses_in_states"
-msgstr ""
+msgstr "Пропускать статусы процесса анализа при копировании"
 
 #. Default: "Skip partition analyses on copy"
 #: senaite/core/registry/schema.py:340
 msgid "label_registry_sample_add_skip_partition_analyses"
-msgstr ""
+msgstr "Пропускать анализы партиций при копировании"
 
 #. Default: "Samples"
 #: senaite/core/registry/schema.py:309
 msgid "label_registry_samples"
-msgstr ""
+msgstr "Образцы"
 
 #. Default: "Trigger events on sample creation"
 #: senaite/core/registry/schema.py:406
 msgid "label_registry_trigger_events_on_sample_creation"
-msgstr ""
+msgstr "Запускать события при создании образца"
 
 #. Default: "Worksheet"
 #: senaite/core/registry/schema.py:95
 msgid "label_registry_worksheet_settings"
-msgstr ""
+msgstr "Рабочий лист"
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:184
+#: senaite/core/content/resultsreport.py:183
 msgid "label_resultsreport_contained_samples"
-msgstr ""
+msgstr "Содержащиеся образцы"
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:156
+#: senaite/core/content/resultsreport.py:155
 msgid "label_resultsreport_sample"
-msgstr ""
+msgstr "Основной образец"
 
 #. Default: "Batch"
 #: bika/lims/content/analysisrequest.py:328
 msgid "label_sample_batch"
-msgstr ""
+msgstr "Партия"
 
 #. Default: "CC Contact"
 #: bika/lims/content/analysisrequest.py:197
 msgid "label_sample_cccontact"
-msgstr ""
+msgstr "Контакт для копии (CC)"
 
 #. Default: "Client"
 #: bika/lims/content/analysisrequest.py:255
 msgid "label_sample_client"
-msgstr ""
+msgstr "Клиент"
 
 #. Default: "Contact"
 #: bika/lims/content/analysisrequest.py:156
 msgid "label_sample_contact"
-msgstr ""
+msgstr "Контакт"
 
 #. Default: "Container"
 #: bika/lims/content/analysisrequest.py:566
 msgid "label_sample_container"
-msgstr ""
+msgstr "Контейнер"
 
 #. Default: "Date Sampled"
 #: bika/lims/content/analysisrequest.py:449
 msgid "label_sample_datesampled"
-msgstr ""
+msgstr "Дата отбора"
 
 #. Default: "Detached from sample"
 #: bika/lims/content/analysisrequest.py:1308
 msgid "label_sample_detached_from"
-msgstr ""
+msgstr "Отсоединён от образца"
 
 #. Default: "Duplicated from sample"
 #: bika/lims/content/analysisrequest.py:1280
 msgid "label_sample_duplicated_from"
-msgstr ""
+msgstr "Дублирован из образца"
 
 #. Default: "Invoice"
 #: bika/lims/content/analysisrequest.py:1046
 msgid "label_sample_invoice"
-msgstr ""
+msgstr "Счёт"
 
 #. Default: "Parent sample"
 #: bika/lims/content/analysisrequest.py:1252
 msgid "label_sample_parent_sample"
-msgstr ""
+msgstr "Родительский образец"
 
 #. Default: "Preservation"
 #: bika/lims/content/analysisrequest.py:597
 msgid "label_sample_preservation"
-msgstr ""
+msgstr "Сохранение"
 
 #. Default: "Primary Sample"
 #: bika/lims/content/analysisrequest.py:292
 msgid "label_sample_primary"
-msgstr ""
+msgstr "Основной образец"
 
 #. Default: "Analysis Profiles"
 #: bika/lims/content/analysisrequest.py:418
 msgid "label_sample_profiles"
-msgstr ""
+msgstr "Профили анализов"
 
 #. Default: "Publication Specification"
 #: bika/lims/content/analysisrequest.py:734
 msgid "label_sample_publicationspecification"
-msgstr ""
+msgstr "Спецификация публикации"
 
 #. Default: "Retest from sample"
 #: bika/lims/content/analysisrequest.py:1336
 msgid "label_sample_retracted"
-msgstr ""
+msgstr "Повторный тест из образца"
 
 #. Default: "Sample Condition"
 #: bika/lims/content/analysisrequest.py:897
 msgid "label_sample_samplecondition"
-msgstr ""
+msgstr "Состояние образца"
 
 #. Default: "Sample Point"
 #: bika/lims/content/analysisrequest.py:767
 msgid "label_sample_samplepoint"
-msgstr ""
+msgstr "Точка отбора проб"
 
 #. Default: "Sample Type"
 #: bika/lims/content/analysisrequest.py:538
 msgid "label_sample_sampletype"
-msgstr ""
+msgstr "Тип образца"
 
 #. Default: "Expected Sampling Date"
 #: bika/lims/content/analysisrequest.py:512
 msgid "label_sample_samplingdate"
-msgstr ""
+msgstr "Ожидаемая дата отбора"
 
 #. Default: "Sampling Deviation"
 #: bika/lims/content/analysisrequest.py:869
 msgid "label_sample_samplingdeviation"
-msgstr ""
+msgstr "Отклонение при отборе проб"
 
 #. Default: "Analysis Specification"
 #: bika/lims/content/analysisrequest.py:690
 msgid "label_sample_specification"
-msgstr ""
+msgstr "Спецификация анализа"
 
 #. Default: "Storage Location"
 #: bika/lims/content/analysisrequest.py:791
 msgid "label_sample_storagelocation"
-msgstr ""
+msgstr "Место хранения"
 
 #. Default: "Batch Sub-group"
 #: bika/lims/content/analysisrequest.py:363
 msgid "label_sample_subgroup"
-msgstr ""
+msgstr "Подгруппа партии"
 
 #. Default: "Sample Template"
 #: bika/lims/content/analysisrequest.py:390
 msgid "label_sample_template"
-msgstr ""
+msgstr "Шаблон образца"
 
 #. Default: "Sample Types"
 #: bika/lims/content/samplepoint.py:95
 msgid "label_samplepoint_sampletypes"
-msgstr ""
+msgstr "Типы образца"
 
 #. Default: "Category"
 #: senaite/core/content/samplepreservation.py:55
 msgid "label_samplepreservation_category"
-msgstr ""
+msgstr "Категория"
 
 #. Default: "Container"
 #: senaite/core/content/sampletemplate.py:81
 msgid "label_sampletemplate_partition_container"
-msgstr ""
+msgstr "Контейнер"
 
 #. Default: "Partition ID"
 #: senaite/core/content/sampletemplate.py:60
 msgid "label_sampletemplate_partition_part_id"
-msgstr ""
+msgstr "ID партиции"
 
 #. Default: "Preservation"
 #: senaite/core/content/sampletemplate.py:103
 msgid "label_sampletemplate_partition_preservation"
-msgstr ""
+msgstr "Сохранение"
 
 #. Default: "Sample Type"
 #: senaite/core/content/sampletemplate.py:125
 msgid "label_sampletemplate_partition_sampletype"
-msgstr ""
+msgstr "Тип образца"
 
 #. Default: "Partitions"
 #: senaite/core/content/sampletemplate.py:243
 msgid "label_sampletemplate_partitions"
-msgstr ""
+msgstr "Партиции"
 
 #. Default: "Sample Point"
 #: senaite/core/content/sampletemplate.py:185
 msgid "label_sampletemplate_samplepoint"
-msgstr ""
+msgstr "Точка отбора проб"
 
 #. Default: "Sample Type"
 #: senaite/core/content/sampletemplate.py:207
 msgid "label_sampletemplate_sampletype"
-msgstr ""
+msgstr "Тип образца"
 
 #. Default: "Admitted stickers for the sample type"
 #: senaite/core/content/sampletype.py:100
 msgid "label_sampletype_admitted"
-msgstr ""
+msgstr "Разрешённые стикеры для типа образца"
 
 #. Default: "Admitted sticker templates"
 #: senaite/core/content/sampletype.py:279
 msgid "label_sampletype_admitted_stickers_templates"
-msgstr ""
+msgstr "Разрешённые шаблоны стикеров"
 
 #. Default: "Default Container Type"
 #: senaite/core/content/sampletype.py:254
 msgid "label_sampletype_containertype"
-msgstr ""
+msgstr "Тип контейнера по умолчанию"
 
 #. Default: "Description"
 #: senaite/core/content/sampletype.py:142
 msgid "label_sampletype_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Default large sticker"
 #: senaite/core/content/sampletype.py:120
 msgid "label_sampletype_large_default"
-msgstr ""
+msgstr "Большой стикер по умолчанию"
 
 #. Default: "Sample Matrix"
 #: senaite/core/content/sampletype.py:204
 msgid "label_sampletype_samplematrix"
-msgstr ""
+msgstr "Матрица образца"
 
 #. Default: "Default small sticker"
 #: senaite/core/content/sampletype.py:111
 msgid "label_sampletype_small_default"
-msgstr ""
+msgstr "Малый стикер по умолчанию"
 
 #. Default: "Name"
 #: senaite/core/content/sampletype.py:134
 msgid "label_sampletype_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
 msgid "label_save"
-msgstr ""
+msgstr "Сохранить"
 
 #. Default: "SENAITE LIMS"
 #: senaite/core/browser/viewlets/templates/footer.pt:14
 msgid "label_senaite"
-msgstr ""
+msgstr "SENAITE LIMS"
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:369
+#: senaite/core/content/senaitesetup.py:368
 msgid "label_senaitesetup_maxnumberofsamplesadd"
-msgstr ""
+msgstr "Максимальное значение поля 'Количество образцов' при регистрации"
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:614
+#: bika/lims/content/bikasetup.py:613
 msgid "label_setup_landingpage"
-msgstr ""
+msgstr "Стартовая страница"
 
 #. Default: "Item"
 #: senaite/core/browser/controlpanel/templates/setupview.pt:78
 msgid "label_setupview_item"
-msgstr ""
+msgstr "Элемент"
 
 #. Default: "Items"
 #: senaite/core/browser/controlpanel/templates/setupview.pt:81
 msgid "label_setupview_items"
-msgstr ""
+msgstr "Элементы"
 
 #. Default: "Out of range comment"
 #: bika/lims/browser/fields/resultrangefield.py:42
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:136
 msgid "label_specs_rangecomment"
-msgstr ""
+msgstr "Комментарий вне диапазона"
 
 #. Default: "Time zone"
 #: senaite/core/browser/user/personalpreferences.py:38
 msgid "label_timezone"
-msgstr ""
+msgstr "Часовой пояс"
 
 #. Default: "Title"
 #: senaite/core/browser/install/templates/senaite-addsite.pt:62
 msgid "label_title"
-msgstr ""
+msgstr "Название"
 
 #. Default: "Upgrade…"
 #: senaite/core/browser/install/templates/senaite-overview.pt:67
 msgid "label_upgrade_hellip"
-msgstr ""
+msgstr "Обновление…"
 
 #. Default: "Contact"
 #: senaite/core/browser/user/userdatapanel.py:81
 msgid "label_user_contact"
-msgstr ""
+msgstr "Контакт"
 
 #. Default: "Email"
 #: senaite/core/browser/user/userdatapanel.py:70
 msgid "label_user_email"
-msgstr ""
+msgstr "Email"
 
 #. Default: "Full Name"
 #: senaite/core/browser/user/userdatapanel.py:64
 msgid "label_user_full_name"
-msgstr ""
+msgstr "Полное имя"
 
 #. Default: "Preferred instrument"
 #: senaite/core/content/worksheettemplate.py:262
 msgid "label_worksheettemplate_instrument"
-msgstr ""
+msgstr "Предпочитаемый инструмент"
 
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
-msgstr ""
-
-#. Default: "Added ${count} label(s) to ${affected} sample(s)"
-#: senaite/core/browser/modals/manage_labels.py:185
-msgid "labels_added"
-msgstr ""
-
-#. sample(s)"
-#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
-#: senaite/core/browser/modals/manage_labels.py:174
-msgid "labels_changed"
-msgstr ""
-
-#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
-#: senaite/core/browser/modals/manage_labels.py:194
-msgid "labels_removed"
-msgstr ""
+msgstr "Ограничить методом"
 
 #. Default: "Category"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:119
 msgid "listing_add_analyses_column_category_title"
-msgstr ""
+msgstr "Категория"
 
 #. Default: "Client"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:93
 msgid "listing_add_analyses_column_client"
-msgstr ""
+msgstr "Клиент"
 
 #. Default: "Order"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:102
 msgid "listing_add_analyses_column_client_order_number"
-msgstr ""
+msgstr "Заказ"
 
 #. Default: "Date Received"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:132
 msgid "listing_add_analyses_column_date_received"
-msgstr ""
+msgstr "Дата получения"
 
 #. Default: "Due Date"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:139
 msgid "listing_add_analyses_column_due_date"
-msgstr ""
+msgstr "Срок выполнения"
 
 #. Default: "Request ID"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:110
 msgid "listing_add_analyses_column_request_id"
-msgstr ""
+msgstr "ID заявки"
 
 #. Default: "Analysis"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:125
 msgid "listing_add_analyses_column_title"
-msgstr ""
+msgstr "Анализ"
 
 #. Default: "All"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:150
 msgid "listing_add_analyses_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Filter by template method"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:221
 msgid "listing_add_analyses_state_restrict_to_method"
-msgstr ""
+msgstr "Фильтр по методу шаблона"
 
 #. Default: "Filter by template services"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:203
 msgid "listing_add_analyses_state_restrict_to_services"
-msgstr ""
+msgstr "Фильтр по услугам шаблона"
 
 #. Default: "Add Analyses"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:74
 msgid "listing_add_analyses_title"
-msgstr ""
+msgstr "Добавить анализы"
 
 #. Default: "Add Blank Reference"
 #: senaite/core/browser/worksheets/worksheet/add_blank.py:44
 msgid "listing_add_blank_title"
-msgstr ""
+msgstr "Добавить холостую пробу"
 
 #. Default: "Add Control Reference"
 #: senaite/core/browser/worksheets/worksheet/add_control.py:43
 msgid "listing_add_control_title"
-msgstr ""
+msgstr "Добавить контрольный образец"
 
 #. Default: "All"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:99
 msgid "listing_add_duplicate_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Add Duplicate"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:51
 msgid "listing_add_duplicate_title"
-msgstr ""
+msgstr "Добавить дубликат"
 
 #. Default: "Client"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:81
 msgid "listing_add_duplication_column_client"
-msgstr ""
+msgstr "Клиент"
 
 #. Default: "Date Requested"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:88
 msgid "listing_add_duplication_column_created"
-msgstr ""
+msgstr "Дата запроса"
 
 #. Default: "Request ID"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:74
 msgid "listing_add_duplication_column_request_id"
-msgstr ""
+msgstr "ID заявки"
 
 #. Default: "Position"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:67
 msgid "listing_add_duplication_column_title"
-msgstr ""
+msgstr "Позиция"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:50
 msgid "listing_analysiscategories_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Department"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:80
 msgid "listing_analysiscategories_column_department"
-msgstr ""
+msgstr "Подразделение"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:72
 msgid "listing_analysiscategories_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sort Key"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:87
 msgid "listing_analysiscategories_column_sort_key"
-msgstr ""
+msgstr "Ключ сортировки"
 
 #. Default: "Category"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:66
 msgid "listing_analysiscategories_column_title"
-msgstr ""
+msgstr "Категория"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:98
 msgid "listing_analysiscategories_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:114
 msgid "listing_analysiscategories_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:106
 msgid "listing_analysiscategories_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Analysis Categories"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:57
 msgid "listing_analysiscategories_title"
-msgstr ""
+msgstr "Категории анализа"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:54
 msgid "listing_analysisprofiles_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:76
 msgid "listing_analysisprofiles_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Profile Key"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:83
 msgid "listing_analysisprofiles_column_profilekey"
-msgstr ""
+msgstr "Ключ профиля"
 
 #. Default: "Sample Types"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:91
 msgid "listing_analysisprofiles_column_sampletypes"
-msgstr ""
+msgstr "Типы образца"
 
 #. Default: "Profile"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:69
 msgid "listing_analysisprofiles_column_title"
-msgstr ""
+msgstr "Профиль"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:103
 msgid "listing_analysisprofiles_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:119
 msgid "listing_analysisprofiles_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:111
 msgid "listing_analysisprofiles_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Analysis Profiles"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:61
 msgid "listing_analysisprofiles_title"
-msgstr ""
+msgstr "Профили анализов"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:50
 msgid "listing_attachmenttypes_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:73
 msgid "listing_attachmenttypes_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:67
 msgid "listing_attachmenttypes_column_title"
-msgstr ""
+msgstr "Название"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:83
 msgid "listing_attachmenttypes_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:99
 msgid "listing_attachmenttypes_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:91
 msgid "listing_attachmenttypes_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Attachment Types"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:57
 msgid "listing_attachmenttypes_title"
-msgstr ""
+msgstr "Типы вложений"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:50
 msgid "listing_batchlabels_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:67
 msgid "listing_batchlabels_column_title"
-msgstr ""
+msgstr "Название"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:77
 msgid "listing_batchlabels_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:93
 msgid "listing_batchlabels_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:85
 msgid "listing_batchlabels_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Batch Labels"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:57
 msgid "listing_batchlabels_title"
-msgstr ""
+msgstr "Метки партии"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/calculations/view.py:51
 msgid "listing_calculation_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/calculations/view.py:75
 msgid "listing_calculation_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Formula"
 #: senaite/core/browser/controlpanel/calculations/view.py:82
 msgid "listing_calculation_formula"
-msgstr ""
+msgstr "Формула"
 
 #. Default: "Calculation"
 #: senaite/core/browser/controlpanel/calculations/view.py:68
 msgid "listing_calculation_title"
-msgstr ""
+msgstr "Формула расчёта"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/calculations/view.py:93
 msgid "listing_calculations_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/calculations/view.py:111
 msgid "listing_calculations_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/calculations/view.py:102
 msgid "listing_calculations_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Calculations"
 #: senaite/core/browser/controlpanel/calculations/view.py:58
 msgid "listing_calculations_title"
-msgstr ""
+msgstr "Формулы расчёта"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/containertypes/view.py:51
 msgid "listing_containertypes_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/containertypes/view.py:72
 msgid "listing_containertypes_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/containertypes/view.py:66
 msgid "listing_containertypes_column_title"
-msgstr ""
+msgstr "Название"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/containertypes/view.py:82
 msgid "listing_containertypes_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/containertypes/view.py:98
 msgid "listing_containertypes_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/containertypes/view.py:90
 msgid "listing_containertypes_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Container Types"
 #: senaite/core/browser/controlpanel/containertypes/view.py:58
 msgid "listing_containertypes_title"
-msgstr ""
+msgstr "Типы контейнеров"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:52
 msgid "listing_dynamic_analysisspec_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:61
 msgid "listing_dynamic_analysisspec_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:76
 msgid "listing_dynamic_analysisspecs_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:70
 msgid "listing_dynamic_analysisspecs_column_title"
-msgstr ""
+msgstr "Название"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:86
 msgid "listing_dynamic_analysisspecs_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:102
 msgid "listing_dynamic_analysisspecs_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:94
 msgid "listing_dynamic_analysisspecs_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Dynamic Analysis Specifications"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:61
 msgid "listing_dynamic_analysisspecs_title"
-msgstr ""
+msgstr "Динамические спецификации анализа"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:52
 msgid "listing_instrumentlocations_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:74
 msgid "listing_instrumentlocations_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Location"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:67
 msgid "listing_instrumentlocations_column_title"
-msgstr ""
+msgstr "Местоположение"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:94
 msgid "listing_instrumentlocations_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:86
 msgid "listing_instrumentlocations_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:102
 msgid "listing_instrumentlocations_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Instrument Locations"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:58
 msgid "listing_instrumentlocations_title"
-msgstr ""
+msgstr "Расположения инструментов"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:49
 msgid "listing_instrumenttypes_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:72
 msgid "listing_instrumenttypes_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:65
 msgid "listing_instrumenttypes_column_title"
-msgstr ""
+msgstr "Название"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:83
 msgid "listing_instrumenttypes_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:101
 msgid "listing_instrumenttypes_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:92
 msgid "listing_instrumenttypes_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Instrument Types"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:56
 msgid "listing_instrumenttypes_title"
-msgstr ""
+msgstr "Типы инструментов"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:52
 msgid "listing_interpretationtemplates_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:75
 msgid "listing_interpretationtemplates_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sample Types"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:81
 msgid "listing_interpretationtemplates_column_sampletypes"
-msgstr ""
+msgstr "Типы образца"
 
 #. Default: "Text"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:88
 msgid "listing_interpretationtemplates_column_text"
-msgstr ""
+msgstr "Текст"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:68
 msgid "listing_interpretationtemplates_column_title"
-msgstr ""
+msgstr "Название"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:99
 msgid "listing_interpretationtemplates_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:115
 msgid "listing_interpretationtemplates_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:107
 msgid "listing_interpretationtemplates_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Interpretation Templates"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:58
 msgid "listing_interpretationtemplates_title"
-msgstr ""
+msgstr "Шаблоны интерпретации"
 
 #. Default: "Add"
 #: view.py:49
 msgid "listing_labproduct_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Price"
 #: view.py:87
 msgid "listing_labproducts_column_price"
-msgstr ""
+msgstr "Цена"
 
 #. Default: "Product"
 #: view.py:66
 msgid "listing_labproducts_column_title"
-msgstr ""
+msgstr "Услуга"
 
 #. Default: "Total Price"
 #: view.py:102
 msgid "listing_labproducts_column_total_price"
-msgstr ""
+msgstr "Общая цена"
 
 #. Default: "Unit"
 #: view.py:80
 msgid "listing_labproducts_column_unit"
-msgstr ""
+msgstr "Единица измерения"
 
 #. Default: "VAT Amount"
 #: view.py:95
 msgid "listing_labproducts_column_vatamount"
-msgstr ""
+msgstr "Сумма НДС"
 
 #. Default: "Volume"
 #: view.py:73
 msgid "listing_labproducts_column_volume"
-msgstr ""
+msgstr "Объём"
 
 #. Default: "Active"
 #: view.py:114
 msgid "listing_labproducts_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: view.py:132
 msgid "listing_labproducts_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: view.py:123
 msgid "listing_labproducts_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Lab Products"
 #: view.py:56
 msgid "listing_labproducts_title"
-msgstr ""
+msgstr "Услуги лаборатории"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:51
 msgid "listing_manufacturers_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:80
 msgid "listing_manufacturers_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:74
 msgid "listing_manufacturers_column_title"
-msgstr ""
+msgstr "Название"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:91
 msgid "listing_manufacturers_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:107
 msgid "listing_manufacturers_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:99
 msgid "listing_manufacturers_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Manufacturers"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:58
 msgid "listing_manufacturers_title"
-msgstr ""
+msgstr "Производители"
 
 #. Default: "Position"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:87
 msgid "listing_reference_samples_column_position"
-msgstr ""
+msgstr "Позиция"
 
 #. Default: "Supported Services"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:79
 msgid "listing_reference_samples_column_supported_services"
-msgstr ""
+msgstr "Поддерживаемые услуги"
 
 #. Default: "Reference Sample"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:72
 msgid "listing_reference_samples_column_title"
-msgstr ""
+msgstr "Референс-образец"
 
 #. Default: "All"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:98
 msgid "listing_reference_samples_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Add Control Reference"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:54
 msgid "listing_reference_samples_title"
-msgstr ""
+msgstr "Добавить контрольный образец"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/suppliers/referencesamples.py:36
 msgid "listing_referencesamples_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:51
 msgid "listing_sampleconatiners_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Capacity"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:86
 msgid "listing_sampleconatiners_column_capacity"
-msgstr ""
+msgstr "Ёмкость"
 
 #. Default: "Container Type"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:79
 msgid "listing_sampleconatiners_column_containertype"
-msgstr ""
+msgstr "Тип контейнера"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:72
 msgid "listing_sampleconatiners_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Pre-preserved"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:93
 msgid "listing_sampleconatiners_column_pre_preserved"
-msgstr ""
+msgstr "Предварительно законсервирован"
 
 #. Default: "Security seal intact"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:100
 msgid "listing_sampleconatiners_column_security_seal_intact"
-msgstr ""
+msgstr "Пломба цела"
 
 #. Default: "Container"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:65
 msgid "listing_sampleconatiners_column_title"
-msgstr ""
+msgstr "Контейнер"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:111
 msgid "listing_sampleconatiners_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:127
 msgid "listing_sampleconatiners_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:119
 msgid "listing_sampleconatiners_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Sample Containers"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:56
 msgid "listing_sampleconatiners_title"
-msgstr ""
+msgstr "Контейнеры образцов"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:47
 msgid "listing_sampleconditions_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:68
 msgid "listing_sampleconditions_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sample Condition"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:62
 msgid "listing_sampleconditions_column_title"
-msgstr ""
+msgstr "Состояние образца"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:78
 msgid "listing_sampleconditions_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:96
 msgid "listing_sampleconditions_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:87
 msgid "listing_sampleconditions_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Sample Conditions"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:54
 msgid "listing_sampleconditions_title"
-msgstr ""
+msgstr "Состояния образца"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:47
 msgid "listing_samplematrices_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:68
 msgid "listing_samplematrices_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sample Matrix"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:62
 msgid "listing_samplematrices_column_title"
-msgstr ""
+msgstr "Матрица образца"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:78
 msgid "listing_samplematrices_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:94
 msgid "listing_samplematrices_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:86
 msgid "listing_samplematrices_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Sample Matrices"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:54
 msgid "listing_samplematrices_title"
-msgstr ""
+msgstr "Матрицы образца"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:51
 msgid "listing_samplepoints_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:73
 msgid "listing_samplepoints_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sample Types"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:80
 msgid "listing_samplepoints_column_sampletypes"
-msgstr ""
+msgstr "Типы образца"
 
 #. Default: "Sample Point"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:66
 msgid "listing_samplepoints_column_title"
-msgstr ""
+msgstr "Точка отбора проб"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:92
 msgid "listing_samplepoints_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:108
 msgid "listing_samplepoints_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:100
 msgid "listing_samplepoints_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Sample Points"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:58
 msgid "listing_samplepoints_title"
-msgstr ""
+msgstr "Точки отбора проб"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:47
 msgid "listing_samplepreservations_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:68
 msgid "listing_samplepreservations_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sample Preservation"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:62
 msgid "listing_samplepreservations_column_title"
-msgstr ""
+msgstr "Сохранение образца"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:78
 msgid "listing_samplepreservations_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:96
 msgid "listing_samplepreservations_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:87
 msgid "listing_samplepreservations_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Sample Preservations"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:54
 msgid "listing_samplepreservations_title"
-msgstr ""
+msgstr "Способы сохранения образца"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:52
 msgid "listing_sampletemplates_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:73
 msgid "listing_sampletemplates_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sample Template"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:67
 msgid "listing_sampletemplates_column_title"
-msgstr ""
+msgstr "Шаблон образца"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:83
 msgid "listing_sampletemplates_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:99
 msgid "listing_sampletemplates_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:91
 msgid "listing_sampletemplates_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Sample Templates"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:59
 msgid "listing_sampletemplates_title"
-msgstr ""
+msgstr "Шаблоны образцов"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:52
 msgid "listing_sampletypes_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Default Container"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:109
 msgid "listing_sampletypes_column_default_container"
-msgstr ""
+msgstr "Контейнер по умолчанию"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:72
 msgid "listing_sampletypes_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Hazardous"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:79
 msgid "listing_sampletypes_column_hazardous"
-msgstr ""
+msgstr "Опасно"
 
 #. Default: "Minimum Volume"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:91
 msgid "listing_sampletypes_column_min_vol"
-msgstr ""
+msgstr "Минимальный объём"
 
 #. Default: "Prefix"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:85
 msgid "listing_sampletypes_column_prefix"
-msgstr ""
+msgstr "Префикс"
 
 #. Default: "Retention Period"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:97
 msgid "listing_sampletypes_column_retention_period"
-msgstr ""
+msgstr "Срок хранения"
 
 #. Default: "SampleMatrix"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:103
 msgid "listing_sampletypes_column_sample_matrix"
-msgstr ""
+msgstr "Матрица образца"
 
 #. Default: "Sample Type"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:66
 msgid "listing_sampletypes_column_title"
-msgstr ""
+msgstr "Тип образца"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:119
 msgid "listing_sampletypes_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:135
 msgid "listing_sampletypes_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:127
 msgid "listing_sampletypes_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Sample Types"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:58
 msgid "listing_sampletypes_title"
-msgstr ""
+msgstr "Типы образца"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:49
 msgid "listing_samplingdeviations_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:72
 msgid "listing_samplingdeviations_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sampling Deviation"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:65
 msgid "listing_samplingdeviations_column_title"
-msgstr ""
+msgstr "Отклонение при отборе проб"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:92
 msgid "listing_samplingdeviations_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:84
 msgid "listing_samplingdeviations_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:100
 msgid "listing_samplingdeviations_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Sampling Deviations"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:56
 msgid "listing_samplingdeviations_title"
-msgstr ""
+msgstr "Отклонения при отборе проб"
 
 #. Default: "Calculation"
 #: senaite/core/browser/widgets/worksheettemplate_services_widget.py:70
 msgid "listing_services_column_calculation"
-msgstr ""
+msgstr "Формула расчёта"
 
 #. Default: "Hidden"
 #: senaite/core/browser/widgets/services_widget.py:112
 msgid "listing_services_column_hidden"
-msgstr ""
+msgstr "Скрыто"
 
 #. Default: "Keyword"
 #: senaite/core/browser/widgets/services_widget.py:84
 #: senaite/core/browser/widgets/worksheettemplate_services_widget.py:56
 msgid "listing_services_column_keyword"
-msgstr ""
+msgstr "Ключевое слово"
 
 #. Default: "Methods"
 #: senaite/core/browser/widgets/services_widget.py:91
 #: senaite/core/browser/widgets/worksheettemplate_services_widget.py:63
 msgid "listing_services_column_methods"
-msgstr ""
+msgstr "Методы"
 
 #. Default: "Partition"
 #: senaite/core/browser/widgets/sampletemplate_services_widget.py:51
 msgid "listing_services_column_partition"
-msgstr ""
+msgstr "Партиция"
 
 #. Default: "Price"
 #: senaite/core/browser/widgets/services_widget.py:105
 msgid "listing_services_column_price"
-msgstr ""
+msgstr "Цена"
 
 #. Default: "Service"
 #: senaite/core/browser/widgets/services_widget.py:76
 #: senaite/core/browser/widgets/worksheettemplate_services_widget.py:48
 msgid "listing_services_column_title"
-msgstr ""
+msgstr "Услуга"
 
 #. Default: "Unit"
 #: senaite/core/browser/widgets/services_widget.py:98
 msgid "listing_services_column_unit"
-msgstr ""
+msgstr "Единица измерения"
 
 #. Default: "All"
 #: senaite/core/browser/widgets/services_widget.py:127
 msgid "listing_services_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:49
 msgid "listing_storagelocations_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:75
 msgid "listing_storagelocations_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Location Code"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:104
 msgid "listing_storagelocations_column_location_code"
-msgstr ""
+msgstr "Код местоположения"
 
 #. Default: "Location Title"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:97
 msgid "listing_storagelocations_column_location_title"
-msgstr ""
+msgstr "Название местоположения"
 
 #. Default: "Shelf Code"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:118
 msgid "listing_storagelocations_column_shelf_code"
-msgstr ""
+msgstr "Код стеллажа"
 
 #. Default: "Shelf Title"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:111
 msgid "listing_storagelocations_column_shelf_title"
-msgstr ""
+msgstr "Название стеллажа"
 
 #. Default: "Site Code"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:90
 msgid "listing_storagelocations_column_site_code"
-msgstr ""
+msgstr "Код площадки"
 
 #. Default: "Site Title"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:83
 msgid "listing_storagelocations_column_site_title"
-msgstr ""
+msgstr "Название площадки"
 
 #. Default: "Storage Location"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:68
 msgid "listing_storagelocations_column_title"
-msgstr ""
+msgstr "Место хранения"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:129
 msgid "listing_storagelocations_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:147
 msgid "listing_storagelocations_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:138
 msgid "listing_storagelocations_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Storage Locations"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:55
 msgid "listing_storagelocations_title"
-msgstr ""
+msgstr "Места хранения"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/subgroups/view.py:51
 msgid "listing_subgroup_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/subgroups/view.py:73
 msgid "listing_subgroups_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sort Key"
 #: senaite/core/browser/controlpanel/subgroups/view.py:80
 msgid "listing_subgroups_column_sortkey"
-msgstr ""
+msgstr "Ключ сортировки"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/subgroups/view.py:67
 msgid "listing_subgroups_column_title"
-msgstr ""
+msgstr "Название"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/subgroups/view.py:91
 msgid "listing_subgroups_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/subgroups/view.py:109
 msgid "listing_subgroups_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/subgroups/view.py:100
 msgid "listing_subgroups_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Sub-Groups"
 #: senaite/core/browser/controlpanel/subgroups/view.py:58
 msgid "listing_subgroups_title"
-msgstr ""
+msgstr "Подгруппы"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:51
 msgid "listing_suppliercontacts_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Business Phone"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:79
 msgid "listing_suppliercontacts_column_businessphone"
-msgstr ""
+msgstr "Рабочий телефон"
 
 #. Default: "Email Address"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:73
 msgid "listing_suppliercontacts_column_emailaddress"
-msgstr ""
+msgstr "Email адрес"
 
 #. Default: "Fax"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:91
 msgid "listing_suppliercontacts_column_fax"
-msgstr ""
+msgstr "Факс"
 
 #. Default: "FullName"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:67
 msgid "listing_suppliercontacts_column_fullname"
-msgstr ""
+msgstr "Полное имя"
 
 #. Default: "Mobile Phone"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:85
 msgid "listing_suppliercontacts_column_mobilephone"
-msgstr ""
+msgstr "Мобильный телефон"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:101
 msgid "listing_suppliercontacts_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Contacts"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:58
 msgid "listing_suppliercontacts_title"
-msgstr ""
+msgstr "Контакты"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/suppliers/view.py:54
 msgid "listing_suppliers_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Email"
 #: senaite/core/browser/controlpanel/suppliers/view.py:77
 msgid "listing_suppliers_column_email"
-msgstr ""
+msgstr "Email"
 
 #. Default: "Fax"
 #: senaite/core/browser/controlpanel/suppliers/view.py:91
 msgid "listing_suppliers_column_fax"
-msgstr ""
+msgstr "Факс"
 
 #. Default: "Name"
 #: senaite/core/browser/controlpanel/suppliers/view.py:70
 msgid "listing_suppliers_column_name"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Phone"
 #: senaite/core/browser/controlpanel/suppliers/view.py:84
 msgid "listing_suppliers_column_phone"
-msgstr ""
+msgstr "Телефон"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/suppliers/view.py:102
 msgid "listing_suppliers_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/suppliers/view.py:118
 msgid "listing_suppliers_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/suppliers/view.py:110
 msgid "listing_suppliers_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Suppliers"
 #: senaite/core/browser/controlpanel/suppliers/view.py:61
 msgid "listing_suppliers_title"
-msgstr ""
+msgstr "Поставщики"
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:67
+#: senaite/core/browser/worksheets/view.py:63
 msgid "listing_worksheets_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:118
+#: senaite/core/browser/worksheets/view.py:114
 msgid "listing_worksheets_column_analyst"
-msgstr ""
+msgstr "Аналитик"
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:150
+#: senaite/core/browser/worksheets/view.py:146
 msgid "listing_worksheets_column_created"
-msgstr ""
+msgstr "Создано"
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:144
+#: senaite/core/browser/worksheets/view.py:140
 msgid "listing_worksheets_column_number_analyses"
-msgstr ""
+msgstr "Плановые анализы"
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:138
+#: senaite/core/browser/worksheets/view.py:134
 msgid "listing_worksheets_column_number_qc_analyses"
-msgstr ""
+msgstr "Анализы контроля качества"
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:132
+#: senaite/core/browser/worksheets/view.py:128
 msgid "listing_worksheets_column_number_samples"
-msgstr ""
+msgstr "Образцы"
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:105
+#: senaite/core/browser/worksheets/view.py:101
 msgid "listing_worksheets_column_progress"
-msgstr ""
+msgstr "Прогресс"
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:157
+#: senaite/core/browser/worksheets/view.py:153
 msgid "listing_worksheets_column_state_title"
-msgstr ""
+msgstr "Статус"
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:125
+#: senaite/core/browser/worksheets/view.py:121
 msgid "listing_worksheets_column_template_title"
-msgstr ""
+msgstr "Шаблон"
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:111
+#: senaite/core/browser/worksheets/view.py:107
 msgid "listing_worksheets_column_title"
-msgstr ""
+msgstr "Рабочий лист"
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:168
+#: senaite/core/browser/worksheets/view.py:164
 msgid "listing_worksheets_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:227
+#: senaite/core/browser/worksheets/view.py:223
 msgid "listing_worksheets_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:248
+#: senaite/core/browser/worksheets/view.py:244
 msgid "listing_worksheets_state_mine"
-msgstr ""
+msgstr "Мои"
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:185
+#: senaite/core/browser/worksheets/view.py:181
 msgid "listing_worksheets_state_open"
-msgstr ""
+msgstr "Открыто"
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:199
+#: senaite/core/browser/worksheets/view.py:195
 msgid "listing_worksheets_state_to_be_verified"
-msgstr ""
+msgstr "Ожидает верификации"
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:213
+#: senaite/core/browser/worksheets/view.py:209
 msgid "listing_worksheets_state_verified"
-msgstr ""
+msgstr "Верифицировано"
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:75
+#: senaite/core/browser/worksheets/view.py:71
 msgid "listing_worksheets_title"
-msgstr ""
+msgstr "Рабочие листы"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:54
 msgid "listing_worksheettemplates_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:77
 msgid "listing_worksheettemplates_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Instrument"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:91
 msgid "listing_worksheettemplates_column_instrument"
-msgstr ""
+msgstr "Инструмент"
 
 #. Default: "Method"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:84
 msgid "listing_worksheettemplates_column_method"
-msgstr ""
+msgstr "Метод"
 
 #. Default: "Name"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:70
 msgid "listing_worksheettemplates_column_name"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:103
 msgid "listing_worksheettemplates_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:119
 msgid "listing_worksheettemplates_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:111
 msgid "listing_worksheettemplates_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Worksheet Templates"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:61
 msgid "listing_worksheettemplates_title"
-msgstr ""
+msgstr "Шаблоны рабочих листов"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:285
 msgid "minutes"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — dirty indicator on the applied
-# preset
-msgid "modified"
-msgstr ""
+msgstr "минут"
 
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
@@ -11358,64 +12519,59 @@ msgstr "ежемесячно"
 #. Default: "No analyses added to this worksheet."
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:177
 msgid "no_analyses_added_to_this_worksheet"
-msgstr ""
+msgstr "В этот рабочий лист не были добавлены анализы."
 
 #. Default: "No analyses were added"
 #: senaite/core/browser/worksheets/worksheet/view.py:39
 msgid "no_analyses_were_added_message"
-msgstr ""
+msgstr "Анализы не были добавлены"
 
 #. Default: "Instrument has no data interface selected"
 #: senaite/core/browser/worksheets/worksheet/export.py:47
 msgid "no_data_instrument_message"
-msgstr ""
+msgstr "У инструмента не выбран интерфейс данных"
 
 #. Default: "Keyword '${duplicate}' duplicate found for a Analysis Service"
 #: senaite/core/validators/interimfields.py:97
 msgid "no_dup_service_keyword_validator_error"
-msgstr ""
+msgstr "Найден дубликат ключевого слова '${duplicate}' для услуги анализа"
 
 #. Default: "'${duplicate}' duplicates found"
 #: senaite/core/validators/interimfields.py:83
 msgid "no_dups_values_validator_error"
-msgstr ""
+msgstr "Найдены дубликаты '${duplicate}'"
 
 #. Default: "Wildcards for  are not allowed: ${wildcards}"
 #: senaite/core/validators/formula.py:45
 msgid "no_wildcards__error"
-msgstr ""
+msgstr "Шаблоны подстановки не допускаются: ${wildcards}"
 
 #. Default: "'${field_name}' is required"
 #: senaite/core/validators/interimfields.py:54
 msgid "non_blank_validator_error"
-msgstr ""
+msgstr "'${field_name}' обязательно"
 
 #. view."
-#. Default: "Layout view '${view}' not found. Set '${default}' as layout view."
+#. Default: "Layout view '${view}' not found. Set '${default}' as layout
+#. view."
 #: senaite/core/browser/worksheets/worksheet/manage_results.py:66
 msgid "not_found_worksheet_layout_message"
 msgstr ""
+"Представление макета '${view}' не найдено. Установлено '${default}' как "
+"представление макета."
 
 #. Default: "Set"
 #: senaite/core/browser/form/adapters/worksheettemplate.py:239
 msgid "num_of_positions_button_title"
-msgstr ""
+msgstr "Задать"
 
-#: senaite/core/browser/dashboard/dashboard.py:607
+#: senaite/core/browser/dashboard/dashboard.py:544
 msgid "of"
 msgstr "из"
-
-#: senaite/core/api/remarks.py:494
-msgid "original"
-msgstr ""
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
 msgstr "обзор"
-
-# senaite.app.listing: Saved filter presets — menu subtitle
-msgid "per listing"
-msgstr ""
 
 #: bika/lims/content/instrumentcertification.py:253
 msgid "quarterly"
@@ -11423,7 +12579,7 @@ msgstr "ежеквартально"
 
 #: bika/lims/content/instrumentscheduledtask.py:137
 msgid "repeating every"
-msgstr ""
+msgstr "повторять каждые"
 
 #: bika/lims/content/instrumentscheduledtask.py:138
 msgid "repeatperiod"
@@ -11432,72 +12588,67 @@ msgstr "Интервал повторений"
 #. Default: "Not detected"
 #: bika/lims/content/abstractanalysis.py:1120
 msgid "result_below_llod"
-msgstr ""
+msgstr "Не обнаружено"
 
 #. Default: "Detected but < ${LLOQ}"
 #: bika/lims/content/abstractanalysis.py:1131
 msgid "result_below_lloq"
-msgstr ""
+msgstr "Обнаружено, но < ${LLOQ}"
 
 #. Default: "Field Preservation"
 #: senaite/core/config/vocabularies.py:24
 msgid "sample_preservation_category_vocab_field"
-msgstr ""
+msgstr "Полевое сохранение"
 
 #. Default: "Lab Preservation"
 #: senaite/core/config/vocabularies.py:28
 msgid "sample_preservation_category_vocab_lab"
-msgstr ""
+msgstr "Лабораторное сохранение"
 
 #. Default: "Only ASCII characters in prefix allowed"
 #: senaite/core/content/sampletype.py:88
 msgid "sampletype_prefix_ascii_validator_message"
-msgstr ""
+msgstr "В префиксе допускаются только символы ASCII"
 
 #. Default: "No whitespaces in prefix allowed"
 #: senaite/core/content/sampletype.py:81
 msgid "sampletype_prefix_no_whitespace_validator_message"
-msgstr ""
+msgstr "В префиксе не допускаются пробелы"
 
 #. Default: "You must select an instrument"
 #: senaite/core/browser/worksheets/worksheet/export.py:37
 msgid "select_instrument_message"
-msgstr ""
+msgstr "Необходимо выбрать инструмент"
 
 #. Default: "Condition"
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:35
 msgid "set_analysis_conditions_colname_condition"
-msgstr ""
+msgstr "Условие"
 
 #. Default: "Show in report"
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:37
 msgid "set_analysis_conditions_colname_report"
-msgstr ""
+msgstr "Показывать в отчёте"
 
 #. Default: "Value"
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:36
 msgid "set_analysis_conditions_colname_value"
-msgstr ""
+msgstr "Значение"
 
 #. Default: "Folder to import the instrument results from"
 #: bika/lims/content/instrument.py:250
 msgid "subfield_label_instrument_import_folder"
-msgstr ""
+msgstr "Папка для импорта результатов инструмента"
 
 #. Default: "Interface Code"
 #: bika/lims/content/instrument.py:248
 msgid "subfield_label_instrument_interface_name"
-msgstr ""
+msgstr "Код интерфейса"
 
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
-msgstr ""
-
-#. Default: "This sample has been disposed by ${actor} on ${date}"
-#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
-msgid "this_sample_has_been_disposed_by"
-msgstr ""
+msgstr "Этот образец был отправлен пользователем ${actor} ${date}"
 
 #. Default: "${I}:${M} ${p}"
 #. The variables used here are the same as used in the strftime formating.
@@ -11508,1047 +12659,1056 @@ msgstr ""
 #. ${I}:${M} ${p}
 #: ./TranslationServiceTool.py
 msgid "time_format"
-msgstr ""
+msgstr "${I}:${M} ${p}"
 
 #. Default: "Accreditation"
 #: senaite/core/content/laboratory.py:170
 msgid "title_accreditation"
-msgstr ""
+msgstr "Аккредитация"
 
 #. Default: "Accreditation Body Abbreviation"
 #: senaite/core/content/laboratory.py:149
 msgid "title_accreditation_body"
-msgstr ""
+msgstr "Сокращение органа аккредитации"
 
 #. Default: "Accreditation Logo"
 #: senaite/core/content/laboratory.py:195
 msgid "title_accreditation_body_logo"
-msgstr ""
+msgstr "Логотип аккредитации"
 
 #. Default: "Accreditation Body URL"
 #: senaite/core/content/laboratory.py:160
 msgid "title_accreditation_body_url"
-msgstr ""
+msgstr "URL органа аккредитации"
 
 #. Default: "Accreditation page header"
 #: senaite/core/content/laboratory.py:216
 msgid "title_accreditation_page_header"
-msgstr ""
+msgstr "Заголовок страницы аккредитации"
 
 #. Default: "Accreditation Reference"
 #: senaite/core/content/laboratory.py:182
 msgid "title_accreditation_reference"
-msgstr ""
+msgstr "Референс аккредитации"
 
 #. Default: "Address"
 #: senaite/core/content/laboratory.py:88
 #: senaite/core/content/organization.py:82
 msgid "title_addresses_tab"
-msgstr ""
+msgstr "Адрес"
 
 #. Default: "Comments"
 #: senaite/core/content/analysiscategory.py:60
 msgid "title_analysiscategory_comments"
-msgstr ""
+msgstr "Комментарии"
 
 #. Default: "Department"
 #: senaite/core/content/analysiscategory.py:81
 msgid "title_analysiscategory_department"
-msgstr ""
+msgstr "Подразделение"
 
 #. Default: "Description"
 #: senaite/core/content/analysiscategory.py:52
 msgid "title_analysiscategory_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sort Key"
 #: senaite/core/content/analysiscategory.py:95
 msgid "title_analysiscategory_sort_key"
-msgstr ""
+msgstr "Ключ сортировки"
 
 #. Default: "Name"
 #: senaite/core/content/analysiscategory.py:44
 msgid "title_analysiscategory_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Commercial ID"
 #: senaite/core/content/analysisprofile.py:121
 msgid "title_analysisprofile_commercial_id"
-msgstr ""
+msgstr "Коммерческий ID"
 
 #. Default: "Description"
 #: senaite/core/content/analysisprofile.py:82
 msgid "title_analysisprofile_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Profile Keyword"
 #: senaite/core/content/analysisprofile.py:90
 msgid "title_analysisprofile_profile_key"
-msgstr ""
+msgstr "Ключевое слово профиля"
 
 #. Default: "Price (excluding VAT)"
 #: senaite/core/content/analysisprofile.py:145
 msgid "title_analysisprofile_profile_price"
-msgstr ""
+msgstr "Цена (без НДС)"
 
 #. Default: "VAT %"
 #: senaite/core/content/analysisprofile.py:157
 msgid "title_analysisprofile_profile_vat"
-msgstr ""
+msgstr "НДС, %"
 
 #. Default: "Profile Analyses"
 #: senaite/core/content/analysisprofile.py:106
 msgid "title_analysisprofile_services"
-msgstr ""
+msgstr "Анализы профиля"
 
 #. Default: "Name"
 #: senaite/core/content/analysisprofile.py:74
 msgid "title_analysisprofile_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Use analysis profile price"
 #: senaite/core/content/analysisprofile.py:133
 msgid "title_analysisprofile_use_profile_price"
-msgstr ""
+msgstr "Использовать цену профиля анализа"
 
 #. Default: "Analyst"
 #: senaite/core/permissions/localroles.py:30
 msgid "title_analyst_role"
-msgstr ""
+msgstr "Аналитик"
 
 #. Default: "Description"
 #: senaite/core/content/attachmenttype.py:44
 msgid "title_attachmenttype_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/attachmenttype.py:36
 msgid "title_attachmenttype_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Bank Details"
 #: senaite/core/content/organization.py:110
 msgid "title_bank_details_tab"
-msgstr ""
+msgstr "Банковские реквизиты"
 
 #. Default: "Name"
 #: senaite/core/content/batchlabel.py:36
 msgid "title_batchlabel_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "This site was built using the Plone Open Source CMS/WCM."
 #: senaite/core/browser/viewlets/templates/colophon.pt:12
 msgid "title_built_with_plone"
 msgstr ""
+"Этот сайт создан с использованием Plone — CMS/WCM с открытым исходным кодом."
 
 #. Default: "Description"
 #: senaite/core/content/calculation.py:228
 msgid "title_calculation_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/calculation.py:220
 msgid "title_calculation_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Confidence Level %"
 #: senaite/core/content/laboratory.py:123
 msgid "title_confidence_level"
-msgstr ""
+msgstr "Уровень доверия, %"
 
 #. Default: "Description"
 #: senaite/core/content/containertype.py:44
 msgid "title_containertype_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/containertype.py:36
 msgid "title_containertype_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Copyright"
 #: senaite/core/browser/viewlets/templates/footer.pt:11
 msgid "title_copyright"
-msgstr ""
+msgstr "Авторские права"
 
 #. Default: "Description"
 #: senaite/core/content/department.py:60
 msgid "title_department_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Department ID"
 #: senaite/core/content/department.py:76
 msgid "title_department_id"
-msgstr ""
+msgstr "ID подразделения"
 
 #. Default: "Name"
 #: senaite/core/content/department.py:48
 msgid "title_department_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "No instrument"
 #: senaite/core/vocabularies/instruments.py:43
 msgid "title_instrument_no_instrument"
-msgstr ""
+msgstr "Без инструмента"
 
 #. Default: "Description"
 #: senaite/core/content/instrumentlocation.py:44
 msgid "title_instrumentlocation_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/instrumentlocation.py:36
 msgid "title_instrumentlocation_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Description"
 #: senaite/core/content/instrumenttype.py:44
 msgid "title_instrumenttype_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/instrumenttype.py:36
 msgid "title_instrumenttype_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Description"
 #: senaite/core/content/interpretationtemplate.py:51
 msgid "title_interpretationtemplate_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/interpretationtemplate.py:43
 msgid "title_interpretationtemplate_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Lab Clerk"
 #: senaite/core/permissions/localroles.py:44
 msgid "title_lab_clerk_role"
-msgstr ""
+msgstr "Лаборант"
 
 #. Default: "Lab Manager"
 #: senaite/core/permissions/localroles.py:79
 msgid "title_lab_manager_role"
-msgstr ""
-
-#. Default: "Color"
-#: senaite/core/content/label.py:68
-msgid "title_label_color"
-msgstr ""
+msgstr "Менеджер лаборатории"
 
 #. Default: "Description"
-#: senaite/core/content/label.py:56
+#: senaite/core/content/label.py:46
 msgid "title_label_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
-#: senaite/core/content/label.py:41
+#: senaite/core/content/label.py:38
 msgid "title_label_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Laboratory Accredited"
 #: senaite/core/content/laboratory.py:136
 msgid "title_laboratory_accredited"
-msgstr ""
+msgstr "Лаборатория аккредитована"
 
 #. Default: "Lab URL"
 #: senaite/core/content/laboratory.py:98
 msgid "title_laboratory_lab_url"
-msgstr ""
+msgstr "URL лаборатории"
 
 #. Default: "Description"
 #: senaite/core/content/labproduct.py:60
 msgid "title_labproduct_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Price (excluding VAT)"
 #: senaite/core/content/labproduct.py:85
 msgid "title_labproduct_price"
-msgstr ""
+msgstr "Цена (без НДС)"
 
 #. Default: "Name"
 #: senaite/core/content/labproduct.py:52
 msgid "title_labproduct_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Total Price"
 #: senaite/core/content/labproduct.py:123
 msgid "title_labproduct_total_price"
-msgstr ""
+msgstr "Общая цена"
 
 #. Default: "Unit"
 #: senaite/core/content/labproduct.py:76
 msgid "title_labproduct_unit"
-msgstr ""
+msgstr "Единица измерения"
 
 #. Default: "VAT %"
 #: senaite/core/content/labproduct.py:98
 msgid "title_labproduct_vat"
-msgstr ""
+msgstr "НДС, %"
 
 #. Default: "VAT"
 #: senaite/core/content/labproduct.py:114
 msgid "title_labproduct_vat_amount"
-msgstr ""
+msgstr "НДС"
 
 #. Default: "Volume"
 #: senaite/core/content/labproduct.py:68
 msgid "title_labproduct_volume"
-msgstr ""
+msgstr "Объём"
 
 #. Default: "Blank Reference"
 #: senaite/core/content/worksheettemplate.py:132
 msgid "title_layout_record_blank_ref"
-msgstr ""
+msgstr "Холостая проба"
 
 #. Default: "Control Reference"
 #: senaite/core/content/worksheettemplate.py:158
 msgid "title_layout_record_control_ref"
-msgstr ""
+msgstr "Контрольный образец"
 
 #. Default: "Duplicate Of"
 #: senaite/core/content/worksheettemplate.py:191
 msgid "title_layout_record_dup"
-msgstr ""
+msgstr "Дубликат от"
 
 #. Default: "Duplicate Of"
 #: senaite/core/content/worksheettemplate.py:180
 msgid "title_layout_record_dup_proxy"
-msgstr ""
+msgstr "Дубликат от"
 
 #. Default: "Position"
 #: senaite/core/content/worksheettemplate.py:96
 msgid "title_layout_record_pos"
-msgstr ""
+msgstr "Позиция"
 
 #. Default: "Reference"
 #: senaite/core/content/worksheettemplate.py:169
 msgid "title_layout_record_reference_proxy"
-msgstr ""
+msgstr "Референс"
 
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
-msgstr ""
-
-#. Default: "Manage Viewlets"
-#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
-msgid "title_manage_viewlets"
-msgstr ""
+msgstr "Тип анализа"
 
 #. Default: "Manager"
 #: senaite/core/permissions/localroles.py:86
 msgid "title_manager_role"
-msgstr ""
+msgstr "Менеджер"
 
 #. Default: "Description"
 #: senaite/core/content/manufacturer.py:44
 msgid "title_manufacturer_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/manufacturer.py:36
 msgid "title_manufacturer_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Not specified"
 #: senaite/core/vocabularies/methods.py:43
 msgid "title_method_not_specified"
-msgstr ""
+msgstr "Не указано"
 
 #. Default: "Bank Branch"
 #: senaite/core/content/organization.py:156
 msgid "title_organization_account_bank_branch"
-msgstr ""
+msgstr "Отделение банка"
 
 #. Default: "Bank Name"
 #: senaite/core/content/organization.py:148
 msgid "title_organization_account_bank_name"
-msgstr ""
+msgstr "Название банка"
 
 #. Default: "Account Name"
 #: senaite/core/content/organization.py:132
 msgid "title_organization_account_name"
-msgstr ""
+msgstr "Название счёта"
 
 #. Default: "Account Number"
 #: senaite/core/content/organization.py:140
 msgid "title_organization_account_number"
-msgstr ""
+msgstr "Номер счёта"
 
 #. Default: "Account Type"
 #: senaite/core/content/organization.py:124
 msgid "title_organization_account_type"
-msgstr ""
+msgstr "Тип счёта"
 
 #. Default: "Email"
 #: senaite/core/content/organization.py:93
 msgid "title_organization_email"
-msgstr ""
+msgstr "Email"
 
 #. Default: "Fax"
 #: senaite/core/content/organization.py:73
 msgid "title_organization_fax"
-msgstr ""
+msgstr "Факс"
 
 #. Default: "Name"
 #: senaite/core/content/organization.py:47
 msgid "title_organization_name"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Phone"
 #: senaite/core/content/organization.py:64
 msgid "title_organization_phone"
-msgstr ""
+msgstr "Телефон"
 
 #. Default: "VAT number"
 #: senaite/core/content/organization.py:55
 msgid "title_organization_tax_number"
-msgstr ""
+msgstr "Номер НДС"
 
 #. Default: "Owner"
 #: senaite/core/permissions/localroles.py:37
 msgid "title_owner_role"
-msgstr ""
+msgstr "Владелец"
 
 #. Default: "Preserver"
 #: senaite/core/permissions/localroles.py:51
 msgid "title_preserver_role"
-msgstr ""
+msgstr "Ответственный за сохранение"
 
 #. Default: "Publisher"
 #: senaite/core/permissions/localroles.py:58
 msgid "title_publisher_role"
-msgstr ""
+msgstr "Публикатор"
 
 #. Default: "Required"
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:47
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:91
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:137
 msgid "title_required"
-msgstr ""
+msgstr "Обязательно"
 
 #. Default: "Description"
 #: senaite/core/content/samplecondition.py:44
 msgid "title_samplecondition_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/samplecondition.py:36
 msgid "title_samplecondition_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Description"
 #: senaite/core/content/samplecontainer.py:52
 msgid "title_samplecontainer_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/samplecontainer.py:44
 msgid "title_samplecontainer_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Description"
 #: senaite/core/content/samplematrix.py:44
 msgid "title_samplematrix_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/samplematrix.py:36
 msgid "title_samplematrix_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Attachment"
 #: senaite/core/content/samplepoint.py:159
 msgid "title_samplepoint_attachment_file"
-msgstr ""
+msgstr "Вложение"
 
 #. Default: "Composite"
 #: senaite/core/content/samplepoint.py:143
 msgid "title_samplepoint_composite"
-msgstr ""
+msgstr "Составной"
 
 #. Default: "Description"
 #: senaite/core/content/samplepoint.py:64
 msgid "title_samplepoint_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Elevation"
 #: senaite/core/content/samplepoint.py:87
 msgid "title_samplepoint_elevation"
-msgstr ""
+msgstr "Высота"
 
 #. Default: "Location"
 #: senaite/core/content/samplepoint.py:72
 msgid "title_samplepoint_location"
-msgstr ""
+msgstr "Местоположение"
 
 #. Default: "Sampling Frequency"
 #: senaite/core/content/samplepoint.py:99
 msgid "title_samplepoint_sampling_frequency"
-msgstr ""
+msgstr "Частота отбора проб"
 
 #. Default: "Sample Types"
 #: senaite/core/content/samplepoint.py:122
 msgid "title_samplepoint_sampling_sample_types"
-msgstr ""
+msgstr "Типы образца"
 
 #. Default: "Name"
 #: senaite/core/content/samplepoint.py:56
 msgid "title_samplepoint_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Description"
 #: senaite/core/content/samplepreservation.py:47
 msgid "title_samplepreservation_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/samplepreservation.py:39
 msgid "title_samplepreservation_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Sampler"
 #: senaite/core/permissions/localroles.py:65
 msgid "title_sampler_role"
-msgstr ""
+msgstr "Пробоотборщик"
 
 #. Default: "Auto-partition on sample reception"
 #: senaite/core/content/sampletemplate.py:256
 msgid "title_sampletemplate_auto_partition"
-msgstr ""
+msgstr "Автоматическое разделение при приёме образца"
 
 #. Default: "Composite"
 #: senaite/core/content/sampletemplate.py:217
 msgid "title_sampletemplate_composite"
-msgstr ""
+msgstr "Составной"
 
 #. Default: "Description"
 #: senaite/core/content/sampletemplate.py:167
 msgid "title_sampletemplate_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sample collected by the laboratory"
 #: senaite/core/content/sampletemplate.py:226
 msgid "title_sampletemplate_sampling_required"
-msgstr ""
+msgstr "Образец отобран лабораторией"
 
 #. Default: "Services"
 #: senaite/core/content/sampletemplate.py:269
 msgid "title_sampletemplate_services"
-msgstr ""
+msgstr "Услуги"
 
 #. Default: "Name"
 #: senaite/core/content/sampletemplate.py:161
 msgid "title_sampletemplate_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Retention Period"
 #: senaite/core/content/sampletype.py:151
 msgid "title_sampletype_duration_period"
-msgstr ""
+msgstr "Срок хранения"
 
 #. Default: "Hazard categories"
 #: senaite/core/content/sampletype.py:178
 msgid "title_sampletype_hazard_categories"
-msgstr ""
+msgstr "Категории опасности"
 
 #. Default: "Hazardous"
 #: senaite/core/content/sampletype.py:166
 msgid "title_sampletype_hazardous"
-msgstr ""
+msgstr "Опасно"
 
 #. Default: "Minimum Volume"
 #: senaite/core/content/sampletype.py:231
 msgid "title_sampletype_min_volume"
-msgstr ""
+msgstr "Минимальный объём"
 
 #. Default: "Sample Type Prefix"
 #: senaite/core/content/sampletype.py:218
 msgid "title_sampletype_prefix"
-msgstr ""
+msgstr "Префикс типа образца"
 
 #. Default: "Description"
 #: senaite/core/content/samplingdeviation.py:44
 msgid "title_samplingdeviation_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/samplingdeviation.py:36
 msgid "title_samplingdeviation_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:360
+#: senaite/core/content/senaitesetup.py:359
 msgid "title_senaitesetup_allow_manual_result_capture_date"
-msgstr ""
+msgstr "Разрешить устанавливать дату фиксации результата"
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:452
+#: senaite/core/content/senaitesetup.py:451
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
-msgstr ""
+msgstr "Разрешить отправку результатов для неназначенных анализов"
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:286
+#: senaite/core/content/senaitesetup.py:285
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
-msgstr ""
+msgstr "Всегда отправлять письмо о публикации ответственным"
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:424
+#: senaite/core/content/senaitesetup.py:423
 msgid "title_senaitesetup_auto_log_off"
-msgstr ""
+msgstr "Автоматический выход из системы"
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:651
+#: senaite/core/content/senaitesetup.py:650
 msgid "title_senaitesetup_auto_verify_samples"
-msgstr ""
+msgstr "Автоматическая верификация образцов"
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:596
+#: senaite/core/content/senaitesetup.py:595
 msgid "title_senaitesetup_categorise_analysis_services"
-msgstr ""
+msgstr "Категоризировать услуги анализа"
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:339
+#: senaite/core/content/senaitesetup.py:338
 msgid "title_senaitesetup_categorizesampleanalyses"
-msgstr ""
+msgstr "Категоризировать анализы образца"
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:493
+#: senaite/core/content/senaitesetup.py:492
 msgid "title_senaitesetup_currency"
-msgstr ""
+msgstr "Валюта"
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:858
+#: senaite/core/content/senaitesetup.py:857
 msgid "title_senaitesetup_dashboard_by_default"
-msgstr ""
+msgstr "Использовать панель управления как главную страницу по умолчанию"
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:384
+#: senaite/core/content/senaitesetup.py:383
 msgid "title_senaitesetup_date_sampled_required"
-msgstr ""
+msgstr "Дата отбора обязательна"
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:554
+#: senaite/core/content/senaitesetup.py:553
 msgid "title_senaitesetup_decimal_mark"
-msgstr ""
+msgstr "Десятичный разделитель по умолчанию"
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:507
+#: senaite/core/content/senaitesetup.py:506
 msgid "title_senaitesetup_default_country"
-msgstr ""
+msgstr "Страна"
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:741
+#: senaite/core/content/senaitesetup.py:740
 msgid "title_senaitesetup_default_number_of_ars_to_add"
-msgstr ""
+msgstr "Количество образцов для добавления по умолчанию."
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:257
+#: senaite/core/content/senaitesetup.py:256
 msgid "title_senaitesetup_email_from_sample_publication"
-msgstr ""
+msgstr "Адрес отправителя публикации"
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:638
+#: senaite/core/content/senaitesetup.py:637
 msgid "title_senaitesetup_enable_analysis_remarks"
-msgstr ""
+msgstr "Добавить поле замечаний ко всем анализам"
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:609
+#: senaite/core/content/senaitesetup.py:608
 msgid "title_senaitesetup_enable_ar_specs"
-msgstr ""
+msgstr "Включить спецификации образца"
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:755
+#: senaite/core/content/senaitesetup.py:754
 msgid "title_senaitesetup_enable_rejection_workflow"
-msgstr ""
+msgstr "Включить процесс отклонения"
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:622
+#: senaite/core/content/senaitesetup.py:621
 msgid "title_senaitesetup_exponential_format_threshold"
-msgstr ""
+msgstr "Порог экспоненциального формата"
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:409
+#: senaite/core/content/senaitesetup.py:408
 msgid "title_senaitesetup_invalidation_reason_required"
-msgstr ""
+msgstr "Причина аннулирования обязательна"
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:871
+#: senaite/core/content/senaitesetup.py:870
 msgid "title_senaitesetup_landing_page"
-msgstr ""
+msgstr "Стартовая страница"
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:521
+#: senaite/core/content/senaitesetup.py:520
 msgid "title_senaitesetup_member_discount"
-msgstr ""
+msgstr "Скидка для участников, %"
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:580
+#: senaite/core/content/senaitesetup.py:579
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
+"Минимальное количество результатов для расчёта статистики контроля качества"
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:684
+#: senaite/core/content/senaitesetup.py:683
 msgid "title_senaitesetup_number_of_required_verifications"
-msgstr ""
+msgstr "Требуемое количество верификаций"
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:273
+#: senaite/core/content/senaitesetup.py:272
 msgid "title_senaitesetup_publication_email_text"
-msgstr ""
+msgstr "Текст письма публикации"
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:770
+#: senaite/core/content/senaitesetup.py:769
 msgid "title_senaitesetup_rejection_reasons"
-msgstr ""
+msgstr "Причины отклонения"
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:468
+#: senaite/core/content/senaitesetup.py:467
 msgid "title_senaitesetup_restrict_worksheet_management"
-msgstr ""
+msgstr "Ограничить управление рабочими листами менеджерами лаборатории"
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:438
+#: senaite/core/content/senaitesetup.py:437
 msgid "title_senaitesetup_restrict_worksheet_users_access"
-msgstr ""
+msgstr "Ограничить доступ к рабочему листу назначенными аналитиками"
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:715
+#: senaite/core/content/senaitesetup.py:714
 msgid "title_senaitesetup_results_decimal_mark"
-msgstr ""
+msgstr "Десятичный разделитель по умолчанию"
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:965
+#: senaite/core/content/senaitesetup.py:964
 msgid "title_senaitesetup_sample_duplicate_enabled"
-msgstr ""
+msgstr "Разрешить дублирование образца"
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:349
+#: senaite/core/content/senaitesetup.py:348
 msgid "title_senaitesetup_sampleanalysesrequired"
-msgstr ""
+msgstr "Требовать анализы образца"
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:801
+#: senaite/core/content/senaitesetup.py:800
 msgid "title_senaitesetup_sampleview_columns_order"
-msgstr ""
+msgstr "Столбцы анализа в просмотре образца"
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:567
+#: senaite/core/content/senaitesetup.py:566
 msgid "title_senaitesetup_scientific_notation_report"
-msgstr ""
+msgstr "Формат научной нотации по умолчанию для отчётов"
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:728
+#: senaite/core/content/senaitesetup.py:727
 msgid "title_senaitesetup_scientific_notation_results"
-msgstr ""
+msgstr "Формат научной нотации по умолчанию для результатов"
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:666
+#: senaite/core/content/senaitesetup.py:665
 msgid "title_senaitesetup_self_verification_enabled"
-msgstr ""
+msgstr "Разрешить самоверификацию результатов"
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:397
+#: senaite/core/content/senaitesetup.py:396
 msgid "title_senaitesetup_show_lab_name_in_login"
-msgstr ""
+msgstr "Показывать название лаборатории на странице входа"
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:895
+#: senaite/core/content/senaitesetup.py:894
 msgid "title_senaitesetup_show_partitions"
-msgstr ""
+msgstr "Показывать партиции образца клиентам"
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:485
+#: senaite/core/content/senaitesetup.py:484
 msgid "title_senaitesetup_show_prices"
-msgstr ""
+msgstr "Включить и отображать информацию о ценах"
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:910
+#: senaite/core/content/senaitesetup.py:909
 msgid "title_senaitesetup_sidebar_folders"
-msgstr ""
+msgstr "Папки боковой навигации"
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:929
+#: senaite/core/content/senaitesetup.py:928
 msgid "title_senaitesetup_sidebar_navigation_depth"
-msgstr ""
+msgstr "Глубина боковой навигации"
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:946
+#: senaite/core/content/senaitesetup.py:945
 msgid "title_senaitesetup_sidebar_skip_types"
-msgstr ""
+msgstr "Типы портала, пропускаемые в боковой навигации"
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:700
+#: senaite/core/content/senaitesetup.py:699
 msgid "title_senaitesetup_type_of_multi_verification"
-msgstr ""
+msgstr "Тип многократной верификации"
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:538
+#: senaite/core/content/senaitesetup.py:537
 msgid "title_senaitesetup_vat"
-msgstr ""
+msgstr "НДС, %"
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:842
+#: senaite/core/content/senaitesetup.py:841
 msgid "title_senaitesetup_worksheet_layout"
-msgstr ""
+msgstr "Макет по умолчанию в просмотре рабочего листа"
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:821
+#: senaite/core/content/senaitesetup.py:820
 msgid "title_senaitesetup_wsview_columns_order"
-msgstr ""
+msgstr "Столбцы анализа в просмотре рабочего листа"
 
 #. Default: "Service UID"
 #: senaite/core/content/worksheettemplate.py:86
 msgid "title_service_uid"
-msgstr ""
+msgstr "UID услуги"
 
 #. Default: "Description"
 #: senaite/core/content/storagelocation.py:46
 msgid "title_storagelocation_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Location Code"
 #: senaite/core/content/storagelocation.py:102
 msgid "title_storagelocation_location_code"
-msgstr ""
+msgstr "Код местоположения"
 
 #. Default: "Location Description"
 #: senaite/core/content/storagelocation.py:114
 msgid "title_storagelocation_location_description"
-msgstr ""
+msgstr "Описание местоположения"
 
 #. Default: "Location Title"
 #: senaite/core/content/storagelocation.py:90
 msgid "title_storagelocation_location_title"
-msgstr ""
+msgstr "Название местоположения"
 
 #. Default: "Location Type"
 #: senaite/core/content/storagelocation.py:126
 msgid "title_storagelocation_location_type"
-msgstr ""
+msgstr "Тип местоположения"
 
 #. Default: "Shelf Code"
 #: senaite/core/content/storagelocation.py:150
 msgid "title_storagelocation_shelf_code"
-msgstr ""
+msgstr "Код стеллажа"
 
 #. Default: "Shelf Description"
 #: senaite/core/content/storagelocation.py:162
 msgid "title_storagelocation_shelf_description"
-msgstr ""
+msgstr "Описание стеллажа"
 
 #. Default: "Shelf Title"
 #: senaite/core/content/storagelocation.py:138
 msgid "title_storagelocation_shelf_title"
-msgstr ""
+msgstr "Название стеллажа"
 
 #. Default: "Site Code"
 #: senaite/core/content/storagelocation.py:66
 msgid "title_storagelocation_site_code"
-msgstr ""
+msgstr "Код площадки"
 
 #. Default: "Site Description"
 #: senaite/core/content/storagelocation.py:78
 msgid "title_storagelocation_site_description"
-msgstr ""
+msgstr "Описание площадки"
 
 #. Default: "Site Title"
 #: senaite/core/content/storagelocation.py:54
 msgid "title_storagelocation_site_title"
-msgstr ""
+msgstr "Название площадки"
 
 #. Default: "Address"
 #: senaite/core/content/storagelocation.py:38
 msgid "title_storagelocation_title"
-msgstr ""
+msgstr "Адрес"
 
 #. Default: "Description"
 #: senaite/core/content/subgroup.py:48
 msgid "title_subgroup_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sort Key"
 #: senaite/core/content/subgroup.py:56
 msgid "title_subgroup_sort_key"
-msgstr ""
+msgstr "Ключ сортировки"
 
 #. Default: "Name"
 #: senaite/core/content/subgroup.py:40
 msgid "title_subgroup_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "IBAN"
 #: senaite/core/content/supplier.py:96
 msgid "title_supplier_iban"
-msgstr ""
+msgstr "IBAN"
 
 #. Default: "Lab Account Number"
 #: senaite/core/content/supplier.py:47
 msgid "title_supplier_lab_contact_number"
-msgstr ""
+msgstr "Номер лабораторного счёта"
 
 #. Default: "NIB"
 #: senaite/core/content/supplier.py:84
 msgid "title_supplier_nib"
-msgstr ""
+msgstr "NIB"
 
 #. Default: "Remarks"
 #: senaite/core/content/supplier.py:55
 msgid "title_supplier_remarks"
-msgstr ""
+msgstr "Замечания"
 
 #. Default: "SWIFT code"
 #: senaite/core/content/supplier.py:108
 msgid "title_supplier_swift_code"
-msgstr ""
+msgstr "Код SWIFT"
 
 #. Default: "Website"
 #: senaite/core/content/supplier.py:63
 msgid "title_supplier_website"
-msgstr ""
+msgstr "Веб-сайт"
 
 #. Default: "Verifier"
 #: senaite/core/permissions/localroles.py:72
 msgid "title_verifier_role"
-msgstr ""
+msgstr "Верификатор"
 
 #. Default: "Analyses"
 #: senaite/core/content/worksheet.py:165
 msgid "title_worksheet_analyses"
-msgstr ""
+msgstr "Анализы"
 
 #. Default: "Analyst"
 #: senaite/core/content/worksheet.py:187
 msgid "title_worksheet_analyst"
-msgstr ""
+msgstr "Аналитик"
 
 #. Default: "Description"
 #: senaite/core/content/worksheet.py:136
 msgid "title_worksheet_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Instrument"
 #: senaite/core/content/worksheet.py:197
 msgid "title_worksheet_instrument"
-msgstr ""
+msgstr "Инструмент"
 
 #. Default: "Layout"
 #: senaite/core/content/worksheet.py:154
 msgid "title_worksheet_layout"
-msgstr ""
+msgstr "Макет"
 
 #. Default: "Analysis"
 #: senaite/core/content/worksheet.py:110
 msgid "title_worksheet_layout_analysis"
-msgstr ""
+msgstr "Анализ"
 
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheet.py:90
 msgid "title_worksheet_layout_analysis_type"
-msgstr ""
+msgstr "Тип анализа"
 
 #. Default: "Container"
 #: senaite/core/content/worksheet.py:100
 msgid "title_worksheet_layout_container"
-msgstr ""
+msgstr "Контейнер"
 
 #. Default: "Position"
 #: senaite/core/content/worksheet.py:81
 msgid "title_worksheet_layout_position"
-msgstr ""
+msgstr "Позиция"
 
 #. Default: "Method"
 #: senaite/core/content/worksheet.py:176
 msgid "title_worksheet_method"
-msgstr ""
+msgstr "Метод"
 
 #. Default: "Remarks"
 #: senaite/core/content/worksheet.py:209
 msgid "title_worksheet_remarks"
-msgstr ""
+msgstr "Замечания"
 
 #. Default: "Results Layout"
 #: senaite/core/content/worksheet.py:217
 msgid "title_worksheet_results_layout"
-msgstr ""
+msgstr "Макет результатов"
 
 #. Default: "Name"
 #: senaite/core/content/worksheet.py:127
 msgid "title_worksheet_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Worksheet Template"
 #: senaite/core/content/worksheet.py:144
 msgid "title_worksheet_worksheettemplate"
-msgstr ""
+msgstr "Шаблон рабочего листа"
 
 #. Default: "Description"
 #: senaite/core/content/worksheettemplate.py:213
 msgid "title_worksheettemplate_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Number of Positions"
 #: senaite/core/content/worksheettemplate.py:290
 msgid "title_worksheettemplate_num_of_positions"
-msgstr ""
+msgstr "Количество позиций"
 
 #. Default: "Analysis Services"
 #: senaite/core/content/worksheettemplate.py:346
 msgid "title_worksheettemplate_services"
-msgstr ""
+msgstr "Услуги анализа"
 
 #. Default: "Worksheet Layout"
 #: senaite/core/content/worksheettemplate.py:311
 msgid "title_worksheettemplate_template_layout"
-msgstr ""
+msgstr "Макет рабочего листа"
 
 #. Default: "Name"
 #: senaite/core/content/worksheettemplate.py:205
 msgid "title_worksheettemplate_title"
-msgstr ""
+msgstr "Имя"
 
 #: bika/lims/content/instrumentscheduledtask.py:140
 msgid "until"
 msgstr "пока не"
 
 #. Lower Limit of Quantification (LLOQ)."
-#. Default: "The Lower Limit of Detection (LLOD) cannot be greater than the Lower Limit of Quantification (LLOQ)."
+#. Default: "The Lower Limit of Detection (LLOD) cannot be greater than the
+#. Lower Limit of Quantification (LLOQ)."
 #: bika/lims/validators.py:1491
 msgid "validator_llod_above_lloq"
 msgstr ""
+"Нижний предел обнаружения (LLOD) не может быть больше нижнего предела "
+"количественного определения (LLOQ)."
 
 #. or equal to the Upper Limit of Quantification (ULOQ)."
-#. Default: "The Lower Limit of Quantification (LLOQ) cannot be greater than or equal to the Upper Limit of Quantification (ULOQ)."
+#. Default: "The Lower Limit of Quantification (LLOQ) cannot be greater than
+#. or equal to the Upper Limit of Quantification (ULOQ)."
 #: bika/lims/validators.py:1519
 msgid "validator_lloq_above_uloq"
 msgstr ""
+"Нижний предел количественного определения (LLOQ) не может быть больше или "
+"равен верхнему пределу количественного определения (ULOQ)."
 
 #. associated with other objects, such as QC analyses."
-#. Default: "The Reference Sample ID cannot be changed because it is already associated with other objects, such as QC analyses."
+#. Default: "The Reference Sample ID cannot be changed because it is already
+#. associated with other objects, such as QC analyses."
 #: bika/lims/validators.py:1586
 msgid "validator_referencesample_id_children"
 msgstr ""
+"ID референс-образца нельзя изменить, поскольку он уже связан с другими "
+"объектами, например анализами контроля качества."
 
 #. Default: "A Reference Sample with the ID '%s' already exists."
 #: bika/lims/validators.py:1601
 msgid "validator_referencesample_id_exists"
-msgstr ""
+msgstr "Референс-образец с ID '%s' уже существует."
 
 #. letters, numbers, underscores ('_'), or hyphens ('-'), and verify that no
 #. other Reference Sample with the same ID already exists."
-#. Default: "The Reference Sample ID is invalid. Ensure it contains only letters, numbers, underscores ('_'), or hyphens ('-'), and verify that no other Reference Sample with the same ID already exists."
+#. Default: "The Reference Sample ID is invalid. Ensure it contains only
+#. letters, numbers, underscores ('_'), or hyphens ('-'), and verify that no
+#. other Reference Sample with the same ID already exists."
 #: bika/lims/validators.py:1576
 msgid "validator_referencesample_id_invalid"
 msgstr ""
+"ID референс-образца недействителен. Убедитесь, что он содержит только буквы,"
+" цифры, знаки подчёркивания ('_') или дефисы ('-'), и проверьте, что другой "
+"референс-образец с таким же ID не существует."
 
 #. the Upper Limit of Detection (ULOD)."
-#. Default: "The Upper Limit of Quantification (LLOQ) cannot be greater than the Upper Limit of Detection (ULOD)."
+#. Default: "The Upper Limit of Quantification (LLOQ) cannot be greater than
+#. the Upper Limit of Detection (ULOD)."
 #: bika/lims/validators.py:1547
 msgid "validator_uloq_above_ulod"
 msgstr ""
+"Верхний предел количественного определения (LLOQ) не может быть больше "
+"верхнего предела обнаружения (ULOD)."
 
-#: bika/lims/browser/analyses/view.py:1588
+#: bika/lims/browser/analyses/view.py:1587
 msgid "verification(s) pending"
 msgstr "проверка(и) в ожидании"
 
@@ -12560,41 +13720,194 @@ msgstr "еженедельно"
 #: senaite/core/browser/modals/sample.py:67
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:63
 msgid "worksheet_created"
-msgstr ""
+msgstr "Создан рабочий лист ${ws_id}"
 
 #. Default: "Worksheet not created."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:56
 msgid "worksheet_not_created"
-msgstr ""
+msgstr "Рабочий лист не создан."
 
 #: bika/lims/content/instrumentcertification.py:255
 msgid "yearly"
 msgstr "ежегодно"
 
 #: senaite/core/exportimport/instruments/importer.py:783
-msgid "{request_id}: calculated result for '{analysis_keyword}': '{analysis_result}'"
+msgid ""
+"{request_id}: calculated result for '{analysis_keyword}': "
+"'{analysis_result}'"
 msgstr ""
+"{request_id}: рассчитан результат для '{analysis_keyword}': "
+"'{analysis_result}'"
 
 #: senaite/core/exportimport/instruments/importer.py:532
 msgid "{request_id}: {keywords} imported sucessfully"
-msgstr ""
+msgstr "{request_id}: {keywords} успешно импортированы"
 
 #: senaite/core/exportimport/instruments/importer.py:731
 msgid "{sid} Updated field '{field}' with '{value}'"
-msgstr ""
+msgstr "{sid}: поле '{field}' обновлено значением '{value}'"
 
 #: senaite/core/exportimport/instruments/importer.py:613
 msgid "{sid} result for '{analysis_keyword}:{interim_keyword}': '{value}'"
 msgstr ""
+"{sid}: результат для '{analysis_keyword}:{interim_keyword}': '{value}'"
 
 #: senaite/core/exportimport/instruments/importer.py:680
 msgid "{sid} result for '{keyword}': '{result}'"
-msgstr ""
+msgstr "{sid}: результат для '{keyword}': '{result}'"
 
-#: bika/lims/browser/analyses/view.py:628
+#: bika/lims/browser/analyses/view.py:627
 msgid "{} (Out of date)"
-msgstr ""
+msgstr "{} (просрочено)"
 
 #: bika/lims/controlpanel/bika_instruments.py:173
 msgid "{} weeks and {} day(s)"
 msgstr "{} недели и {} день"
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Samples to Receive"
+msgstr "Образцы к приёму"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Results Pending"
+msgstr "Ожидают результатов"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "To be Verified"
+msgstr "На проверку"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "To be Published"
+msgstr "К публикации"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Open Worksheets"
+msgstr "Открытые рабочие листы"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Register Samples"
+msgstr "Регистрация образцов"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Verify Results"
+msgstr "Проверить результаты"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Publish Reports"
+msgstr "Опубликовать отчёты"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Samples awaiting collection of the sample"
+msgstr "Образцы, ожидающие отбора пробы"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Samples awaiting preservation"
+msgstr "Образцы, ожидающие консервации"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Samples with a scheduled sampling date"
+msgstr "Образцы с запланированной датой отбора"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Samples awaiting reception at the laboratory"
+msgstr "Образцы, ожидающие приёма в лаборатории"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Received samples with analyses awaiting results"
+msgstr "Полученные образцы с анализами, ожидающими результатов"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Samples whose results are awaiting verification"
+msgstr "Образцы, результаты которых ожидают проверки"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Verified samples ready to be published"
+msgstr "Проверенные образцы, готовые к публикации"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Samples whose reports have been published"
+msgstr "Образцы, отчёты по которым опубликованы"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Published samples whose reports have not been printed yet"
+msgstr "Опубликованные образцы, отчёты которых ещё не распечатаны"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Analyses not yet assigned to a worksheet"
+msgstr "Анализы, ещё не назначенные в рабочий лист"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr "Анализы, назначенные в рабочий лист, ожидают результатов"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Submitted analyses awaiting verification"
+msgstr "Отправленные анализы, ожидающие проверки"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Analyses that have been verified"
+msgstr "Проверенные анализы"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Analyses included in a published report"
+msgstr "Анализы, включённые в опубликованный отчёт"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Open worksheets with analyses awaiting results"
+msgstr "Открытые рабочие листы с анализами, ожидающими результатов"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Worksheets whose results are awaiting verification"
+msgstr "Рабочие листы, результаты которых ожидают проверки"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Worksheets that have been verified"
+msgstr "Проверенные рабочие листы"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "Quick Actions"
+msgstr "Быстрые действия"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "No data for the selected period"
+msgstr "Нет данных за выбранный период"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
+msgstr "Нет доступных действий. Обратитесь к руководителю лаборатории для назначения прав доступа."
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "to"
+msgstr "по"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "(updated every 2 hours)"
+msgstr "(обновляется каждые 2 часа)"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "Daily"
+msgstr "Ежедневно"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "Weekly"
+msgstr "Еженедельно"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "Monthly"
+msgstr "Ежемесячно"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "Quarterly"
+msgstr "Ежеквартально"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "Biannual"
+msgstr "Раз в полгода"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "Yearly"
+msgstr "Ежегодно"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "Show/hide timeline"
+msgstr "Показать/скрыть таймлайн"
+

--- a/src/senaite/core/locales/ru_RU/LC_MESSAGES/plone.po
+++ b/src/senaite/core/locales/ru_RU/LC_MESSAGES/plone.po
@@ -2,1041 +2,1195 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 12:29+0000\n"
+"POT-Creation-Date: 2026-06-19 06:37+0000\n"
 "PO-Revision-Date: 2018-06-01 18:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Russian (Russia) (https://app.transifex.com/senaite/teams/87045/ru_RU/)\n"
+"Language: ru_RU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Domain: DOMAIN\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: DOMAIN\n"
-"Language: ru_RU\n"
 
 #: senaite/core/browser/user/templates/account-panel.pt:16
 msgid "${action/title}"
-msgstr ""
+msgstr "${action/title}"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:167
 msgid "Activated add-ons"
-msgstr ""
+msgstr "Активированные дополнения"
 
 #: senaite/core/profiles/default/registry.xml
 msgid "Alternative formats"
-msgstr ""
+msgstr "Альтернативные форматы"
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:229
 msgid "Apply rule on the whole site"
-msgstr ""
+msgstr "Применить правило для всего участка"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:123
 msgid "Available add-ons"
-msgstr ""
+msgstr "Доступные дополнения"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:212
 msgid "Broken add-ons"
-msgstr ""
+msgstr "Неработающие дополнения"
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:256
 msgid "Configure rule"
-msgstr ""
+msgstr "Настроить содержимое "
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:35
 msgid "Content rule settings updated."
-msgstr ""
+msgstr "Обновлены настройки содержимого."
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:52
 msgid "Disable globally"
-msgstr ""
+msgstr "Выключить глобально"
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:314
 msgid "Enabled"
-msgstr ""
+msgstr "Включено"
 
 #: senaite/core/browser/dexterity/templates/macros.pt:20
 #: senaite/core/browser/login/templates/login.pt:17
 msgid "Error"
-msgstr ""
+msgstr "Ошибка"
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:78
 msgid "Filter:"
-msgstr ""
+msgstr "Фильтр:"
 
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:28
 msgid "Go to parent folder"
-msgstr ""
+msgstr "Перейти в родительскую папку"
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:222
-msgid "Go to the folder where you want the rule to apply, or at the site root, click on 'rule' tab, and then locally setup the rules."
+msgid ""
+"Go to the folder where you want the rule to apply, or at the site root, "
+"click on 'rule' tab, and then locally setup the rules."
 msgstr ""
+"Перейдите в папку, к которой вы хотите применить правило, или в корень "
+"участка, перейдите на вкладку \"правила\", а затем локально настройте "
+"правила."
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:32
 msgid "Go to the upgrade page"
-msgstr ""
+msgstr "Перейдите на страницу обновления"
 
 #: senaite/core/browser/viewlets/templates/path_bar.pt:9
 msgid "Home"
-msgstr ""
+msgstr "Главная страница"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:132
 msgid "Install"
-msgstr ""
+msgstr "Установить"
 
 #: senaite/core/profiles/default/actions.xml
 msgid "Log in"
-msgstr ""
+msgstr "Войти"
 
 #: senaite/core/profiles/default/actions.xml
 msgid "Log out"
-msgstr ""
+msgstr "Выйти"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/recordswidget.pt:275
 msgid "More"
-msgstr ""
+msgstr "Ещё"
 
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:79
 msgid "Move down"
-msgstr ""
+msgstr "Переместиться вниз"
 
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:67
 msgid "Move up"
-msgstr ""
+msgstr "Двигайтесь вверх"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:39
 msgid "No upgrades in this corner"
-msgstr ""
+msgstr "Обновление в этом углу не предусмотрено"
 
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:56
 msgid "Note"
-msgstr ""
+msgstr "Примечание"
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:145
 msgid "Off"
-msgstr ""
+msgstr "Выкл."
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:144
 msgid "On"
-msgstr ""
+msgstr "Вкл."
 
 #: senaite/core/profiles/default/registry.xml
 msgid "Relative URL for the SENAITE toolbar logo"
-msgstr ""
+msgstr "Относительный URL-адрес для логотипа панели инструментов SENAITE"
 
 #: senaite/core/browser/sharing/templates/client_sharing.pt:67
 msgid "Search for user or group"
-msgstr ""
+msgstr "Поиск пользователя или группы"
 
 #: senaite/core/profiles/default/registry.xml
-msgid "Select which formats are available for users as alternative to the default format. Note that if new formats are installed, they will be enabled for text fields by default unless explicitly turned off here or by the relevant installer."
+msgid ""
+"Select which formats are available for users as alternative to the default "
+"format. Note that if new formats are installed, they will be enabled for "
+"text fields by default unless explicitly turned off here or by the relevant "
+"installer."
 msgstr ""
+"Выберите, какие форматы доступны пользователям в качестве альтернативы "
+"формату по умолчанию. Обратите внимание, что если установлены новые форматы,"
+" они будут включены для текстовых полей по умолчанию, если они явно не "
+"отключены здесь или соответствующей программой установки."
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:148
 msgid "Server:"
-msgstr ""
+msgstr "Сервер:"
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:15
 #: senaite/core/browser/controlpanel/templates/overview.pt:16
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:13
 msgid "Site Setup"
-msgstr ""
+msgstr "Настройка сайта"
 
 #: senaite/core/profiles/default/registry.xml
 msgid "Site title"
-msgstr ""
+msgstr "Заголовок сайта"
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:218
-msgid "The rule is enabled but will perform nothing since it is not assigned anywhere."
+msgid ""
+"The rule is enabled but will perform nothing since it is not assigned "
+"anywhere."
 msgstr ""
+"Правило включено, но оно ничего не будет выполнять, не будучи нигде "
+"назначенным."
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:32
-msgid "The site configuration is outdated and needs to be upgraded. Please ${link_continue_with_the_upgrade}."
+msgid ""
+"The site configuration is outdated and needs to be upgraded. Please "
+"${link_continue_with_the_upgrade}."
 msgstr ""
+"Конфигурация сайта устарела и нуждается в обновлении. Перейдите по ссылке "
+"${link_continue_with_the_upgrade}."
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:87
-msgid "There is no upgrade procedure defined for this addon. Please consult the addon documentation for upgrade information, or contact the addon author."
+msgid ""
+"There is no upgrade procedure defined for this addon. Please consult the "
+"addon documentation for upgrade information, or contact the addon author."
 msgstr ""
+"Для этого дополнения не определена процедура обновления. Пожалуйста, "
+"обратитесь к документации дополнения для получения информации об обновлении "
+"или свяжитесь с автором дополнения."
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:124
-msgid "There is not any action performed by this rule. Click on Add button to setup an action."
+msgid ""
+"There is not any action performed by this rule. Click on Add button to setup"
+" an action."
 msgstr ""
+"Это правило не выполняет никаких действий. Нажмите кнопку Добавить, чтобы "
+"установить действие."
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:39
 msgid "There is not any additional condition checked on this rule."
-msgstr ""
+msgstr "В этом правиле не проверяется никакое дополнительное условие."
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:32
 msgid "There was an error saving content rules."
-msgstr ""
+msgstr "Произошла ошибка при сохранении правил содержимого."
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:69
 msgid "This addon has been upgraded."
-msgstr ""
+msgstr "Это дополнение было обновлено."
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:23
-msgid "This is the Add-on configuration section, you can activate and deactivate add-ons in the lists below."
+msgid ""
+"This is the Add-on configuration section, you can activate and deactivate "
+"add-ons in the lists below."
 msgstr ""
+"Это раздел настройки дополнений, вы можете активировать и деактивировать "
+"дополнения в списках ниже."
 
 #: senaite/core/profiles/default/registry.xml
 msgid "This must be a URL relative to the site root."
-msgstr ""
+msgstr "Это должен быть URL относительно корня сайта."
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:154
 msgid "This product cannot be uninstalled!"
-msgstr ""
+msgstr "Этот продукт не может быть деинсталлирован!"
 
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:215
 msgid "This rule is not assigned to any location"
-msgstr ""
+msgstr "Это правило не назначено ни одному объекту"
 
 #: senaite/core/profiles/default/registry.xml
 msgid "This shows up in the title bar of browsers and in syndication feeds."
-msgstr ""
+msgstr "Это отображается в строке заголовка браузеров и в лентах синдикации."
 
 #: senaite/core/browser/portlets/templates/navigation.pt:5
 msgid "Toggle sidebar visibility"
-msgstr ""
+msgstr "Переключение видимости боковой панели"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:176
 msgid "Uninstall"
-msgstr ""
+msgstr "Удалить"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:105
 msgid "Upgrade them ALL!"
-msgstr ""
+msgstr "Обновите их ВСЕ!"
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:36
 msgid "Upgrades"
-msgstr ""
+msgstr "Обновления"
 
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:32
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:28
 msgid "Users and Groups"
-msgstr ""
+msgstr "Пользователи и группы"
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:143
 msgid "WSGI:"
-msgstr ""
+msgstr "WSGI:"
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:53
-msgid "Whether or not content rules should be disabled globally. If this is selected, no rules will be executed anywhere in the portal."
+msgid ""
+"Whether or not content rules should be disabled globally. If this is "
+"selected, no rules will be executed anywhere in the portal."
 msgstr ""
+"Отключать ли правила содержания глобально или нет. Если этот параметр "
+"выбран, никакие правила не будут выполняться нигде в пределах портала."
 
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:40
 msgid "You are up to date. High fives."
-msgstr ""
+msgstr "Вы в курсе всех событий. Дай пять."
 
 #. convert them to new-style portlets."
-#. Default: "There are legacy portlets defined here. Click the button to convert them to new-style portlets."
+#. Default: "There are legacy portlets defined here. Click the button to
+#. convert them to new-style portlets."
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:69
 msgid "action_convert_legacy_portlets"
 msgstr ""
+"Здесь определены устаревшие портлеты. Нажмите кнопку, чтобы преобразовать их"
+" в портлеты нового типа."
 
 #. Default: "Next ${number} items"
 #: senaite/core/browser/batching/templates/batchnavigation.pt:85
 msgid "batch_next_x_items"
-msgstr ""
+msgstr "Следующие ${number} элементов"
 
 #. Default: "Previous ${number} items"
 #: senaite/core/browser/batching/templates/batchnavigation.pt:19
 msgid "batch_previous_x_items"
-msgstr ""
+msgstr "Предыдущие ${number} элементов"
 
 #. Default: "Add action"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:183
 msgid "contentrules_add_action"
-msgstr ""
+msgstr "Добавить действие"
 
 #. Default: "Add condition"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:91
 msgid "contentrules_add_condition"
-msgstr ""
+msgstr "Добавить условие"
 
 #. Default: "Shortcuts:"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:228
 msgid "contentrules_assignments_shortcuts"
-msgstr ""
+msgstr "Быстрые ссылки:"
 
 #. Default: "The actions executed by this rule can trigger other rules"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:305
 msgid "contentrules_description_cascading"
-msgstr ""
+msgstr "Действия, выполняемые этим правилом, могут запускать другие правила"
 
 #. Default: "Enter a short description of the rule and its purpose."
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:278
 msgid "contentrules_description_description"
-msgstr ""
+msgstr "Введите краткое описание правила и его назначения."
 
 #. only be invoked if all the rule's conditions are met. You can add new
 #. actions and conditions using the buttons below."
-#. Default: "Rules execute when a triggering event occurs. Rule actions will only be invoked if all the rule's conditions are met. You can add new actions and conditions using the buttons below."
+#. Default: "Rules execute when a triggering event occurs. Rule actions will
+#. only be invoked if all the rule's conditions are met. You can add new
+#. actions and conditions using the buttons below."
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:23
 msgid "contentrules_description_execution"
 msgstr ""
+"Правила выполняются при возникновении события-триггера. Действия правила "
+"выполняются только при соблюдении всех его условий. Новые действия и условия"
+" можно добавить с помощью кнопок ниже."
 
 #. Default: "Stop evaluating content rules after this rule completes"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:296
 msgid "contentrules_description_stop"
-msgstr ""
+msgstr "Прекратить обработку правил контента после выполнения этого правила"
 
 #. Default: "The rule will execute when the following event occurs."
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:287
 msgid "contentrules_description_trigger"
-msgstr ""
+msgstr "Правило будет выполнено при возникновении следующего события."
 
 #. Default: "Perform the following actions:"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:117
 msgid "contentrules_perform_actions"
-msgstr ""
+msgstr "Выполнить следующие действия:"
 
 #: senaite/core/browser/controlpanel/templates/overview.pt:32
 msgid "continue with the upgrade"
-msgstr ""
+msgstr "продолжить обновление"
 
 #. Default: "There is no group or user attached to this group."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:171
 msgid "decription_no_members_assigned"
-msgstr ""
+msgstr "К этой группе не привязаны группы или пользователи."
 
 #. Rules will automatically perform actions on content when certain triggers
 #. take place. After defining rules, you may want to go to a folder to assign
 #. them, using the \"rules\" item in the actions menu."
-#. Default: "Use the form below to define, change or remove content rules. Rules will automatically perform actions on content when certain triggers take place. After defining rules, you may want to go to a folder to assign them, using the \"rules\" item in the actions menu."
+#. Default: "Use the form below to define, change or remove content rules.
+#. Rules will automatically perform actions on content when certain triggers
+#. take place. After defining rules, you may want to go to a folder to assign
+#. them, using the \"rules\" item in the actions menu."
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:24
 msgid "description-contentrules-controlpanel"
 msgstr ""
+"Используйте форму ниже, чтобы определить, изменить или удалить правила "
+"контента. Правила автоматически выполняют действия над содержимым при "
+"определённых событиях. После определения правил перейдите в папку, чтобы "
+"назначить их, используя пункт \\\"правила\\\" в меню действий."
 
 #. Default: "The languages in which the site should be translatable."
 #: senaite/core/profiles/default/registry.xml
 msgid "description_available_languages"
-msgstr ""
+msgstr "Языки, на которые должен переводиться сайт."
 
 #. Default: "Please set a descriptive title for the rule."
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:266
 msgid "description_contentrule_title"
-msgstr ""
+msgstr "Задайте информативное название для правила."
 
 #. Default: "This rule is assigned to the following locations:"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:242
 msgid "description_contentrules_rule_assignments"
-msgstr ""
+msgstr "Это правило назначено следующим расположениям:"
 
 #. Default: "Configuration area for Plone and add-on Products."
 #: senaite/core/browser/controlpanel/templates/overview.pt:19
 msgid "description_control_panel"
-msgstr ""
+msgstr "Область настройки Plone и дополнительных продуктов."
 
 #. Default: "Required for the language selector viewlet to be rendered."
 #: senaite/core/profiles/default/registry.xml
 msgid "description_cookie_manual_override"
-msgstr ""
+msgstr "Требуется для отображения виджета выбора языка."
 
 #. sites that are under development. This allows many configuration changes to
 #. be immediately visible, but will make your site run more slowly. To turn
 #. off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg,
 #. re-run bin/buildout and then restart the server process."
-#. Default: "You are running in \"debug mode\". This mode is intended for sites that are under development. This allows many configuration changes to be immediately visible, but will make your site run more slowly. To turn off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg, re-run bin/buildout and then restart the server process."
+#. Default: "You are running in \"debug mode\". This mode is intended for
+#. sites that are under development. This allows many configuration changes to
+#. be immediately visible, but will make your site run more slowly. To turn
+#. off debug mode, stop the server, set 'debug-mode=off' in your buildout.cfg,
+#. re-run bin/buildout and then restart the server process."
 #: senaite/core/browser/controlpanel/templates/overview.pt:167
 msgid "description_debug_mode"
 msgstr ""
+"Вы работаете в режиме \\\"отладки\\\". Этот режим предназначен для сайтов в "
+"разработке. Он позволяет сразу видеть многие изменения конфигурации, но "
+"замедляет работу сайта. Чтобы отключить режим отладки, остановите сервер, "
+"установите 'debug-mode=off' в buildout.cfg, повторно запустите bin/buildout "
+"и перезапустите сервер."
 
 #. here. Note that this doesn't actually delete the group or user, it is only
 #. removed from this group."
-#. Default: "You can add or remove groups and users from this particular group here. Note that this doesn't actually delete the group or user, it is only removed from this group."
+#. Default: "You can add or remove groups and users from this particular group
+#. here. Note that this doesn't actually delete the group or user, it is only
+#. removed from this group."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:78
 msgid "description_group_members_of"
 msgstr ""
+"Здесь можно добавлять или удалять группы и пользователей в этой группе. "
+"Обратите внимание: это не удаляет саму группу или пользователя, а только "
+"исключает их из этой группы."
 
 #. business units. Groups are not directly related to permissions on a global
 #. level, you normally use Roles for that - and let certain Groups have a
 #. particular role."
-#. Default: "Groups are logical collections of users, such as departments and business units. Groups are not directly related to permissions on a global level, you normally use Roles for that - and let certain Groups have a particular role."
+#. Default: "Groups are logical collections of users, such as departments and
+#. business units. Groups are not directly related to permissions on a global
+#. level, you normally use Roles for that - and let certain Groups have a
+#. particular role."
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:55
 msgid "description_groups_management"
 msgstr ""
+"Группы — это логические объединения пользователей, например подразделения "
+"или бизнес-единицы. Группы напрямую не связаны с правами на глобальном "
+"уровне — для этого обычно используются роли, которые назначаются "
+"определённым группам."
 
 #. membership in another group."
-#. Default: "The symbol ${image_link_icon} indicates a role inherited from membership in another group."
+#. Default: "The symbol ${image_link_icon} indicates a role inherited from
+#. membership in another group."
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:66
 msgid "description_groups_management2"
 msgstr ""
+"Символ ${image_link_icon} обозначает роль, унаследованную от участия в "
+"другой группе."
 
 #. assigned in this context. Use the buttons on each portlet to move them up
 #. or down, delete or edit them. To add a new portlet, use the drop-down list
 #. at the top of the column."
-#. Default: "The portlet columns will first display portlets explicitly assigned in this context. Use the buttons on each portlet to move them up or down, delete or edit them. To add a new portlet, use the drop-down list at the top of the column."
+#. Default: "The portlet columns will first display portlets explicitly
+#. assigned in this context. Use the buttons on each portlet to move them up
+#. or down, delete or edit them. To add a new portlet, use the drop-down list
+#. at the top of the column."
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:52
 msgid "description_manage_contextual_portlets"
 msgstr ""
+"Столбцы портлетов сначала отображают портлеты, явно назначенные в этом "
+"контексте. Используйте кнопки на каждом портлете, чтобы переместить его "
+"вверх/вниз, удалить или отредактировать. Чтобы добавить новый портлет, "
+"используйте выпадающий список вверху столбца."
 
 #. listing of groups, so you may not see the groups defined by those plugins
 #. unless doing a specific search."
-#. Default: "Note: Some or all of your PAS groups source plugins do not allow listing of groups, so you may not see the groups defined by those plugins unless doing a specific search."
+#. Default: "Note: Some or all of your PAS groups source plugins do not allow
+#. listing of groups, so you may not see the groups defined by those plugins
+#. unless doing a specific search."
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:72
 msgid "description_pas_group_listing"
 msgstr ""
+"Примечание: некоторые или все источники групп PAS не позволяют выводить "
+"список групп, поэтому группы из этих источников могут быть не видны без "
+"конкретного поискового запроса."
 
 #. Default: "Show all search results"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:332
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:250
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:189
 msgid "description_pas_show_all_search_results"
-msgstr ""
+msgstr "Показать все результаты поиска"
 
 #. of users, so you may not see the users defined by those plugins unless
 #. doing a specific search."
-#. Default: "Some or all of your PAS user source plugins do not allow listing of users, so you may not see the users defined by those plugins unless doing a specific search."
+#. Default: "Some or all of your PAS user source plugins do not allow listing
+#. of users, so you may not see the users defined by those plugins unless
+#. doing a specific search."
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:57
 msgid "description_pas_users_listing"
 msgstr ""
+"Некоторые или все источники пользователей PAS не позволяют выводить список "
+"пользователей, поэтому пользователи из этих источников могут быть не видны "
+"без конкретного поискового запроса."
 
 #. you can do so using the drop-down boxes. Portlets that are included by
 #. these categories are shown below the selection box."
-#. Default: "If you wish to block or unblock certain categories of portlets, you can do so using the drop-down boxes. Portlets that are included by these categories are shown below the selection box."
+#. Default: "If you wish to block or unblock certain categories of portlets,
+#. you can do so using the drop-down boxes. Portlets that are included by
+#. these categories are shown below the selection box."
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:59
 msgid "description_portlets_block_unblock"
 msgstr ""
+"Чтобы заблокировать или разблокировать определённые категории портлетов, "
+"используйте выпадающие списки. Портлеты, входящие в эти категории, показаны "
+"ниже блока выбора."
 
 #. mode of operation for a live Plone site, but means that some configuration
 #. changes will not take effect until your server is restarted or a product
 #. refreshed. If this is a development instance, and you want to enable debug
 #. mode, stop the server, set 'debug-mode=on' in your buildout.cfg, re-run
 #. bin/buildout and then restart the server process."
-#. Default: "You are running in \"production mode\". This is the preferred mode of operation for a live Plone site, but means that some configuration changes will not take effect until your server is restarted or a product refreshed. If this is a development instance, and you want to enable debug mode, stop the server, set 'debug-mode=on' in your buildout.cfg, re-run bin/buildout and then restart the server process."
+#. Default: "You are running in \"production mode\". This is the preferred
+#. mode of operation for a live Plone site, but means that some configuration
+#. changes will not take effect until your server is restarted or a product
+#. refreshed. If this is a development instance, and you want to enable debug
+#. mode, stop the server, set 'debug-mode=on' in your buildout.cfg, re-run
+#. bin/buildout and then restart the server process."
 #: senaite/core/browser/controlpanel/templates/overview.pt:155
 msgid "description_production_mode"
 msgstr ""
+"Вы работаете в режиме \\\"production\\\". Это предпочтительный режим для "
+"рабочего сайта Plone, однако некоторые изменения конфигурации вступят в силу"
+" только после перезапуска сервера или обновления продукта. Если это среда "
+"разработки и нужен режим отладки, остановите сервер, установите 'debug-"
+"mode=on' в buildout.cfg, повторно запустите bin/buildout и перезапустите "
+"сервер."
 
 #. Access should be granted only to the client group below. <br /> Client
 #. contacts which are linked to a user account will be automatically added to
 #. this group and have therefore the same roles granted immediately. <br />
 #. Other granted access to users or groups will only affect new created
 #. contents. </div>"
-#. Default: "Grant access for users or groups <div class=\"font-italic\"> Access should be granted only to the client group below. <br /> Client contacts which are linked to a user account will be automatically added to this group and have therefore the same roles granted immediately. <br /> Other granted access to users or groups will only affect new created contents. </div>"
+#. Default: "Grant access for users or groups <div class=\"font-italic\">
+#. Access should be granted only to the client group below. <br /> Client
+#. contacts which are linked to a user account will be automatically added to
+#. this group and have therefore the same roles granted immediately. <br />
+#. Other granted access to users or groups will only affect new created
+#. contents. </div>"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:43
 msgid "description_sharing_control"
 msgstr ""
+"Предоставить доступ пользователям или группам <div class=\\\"font-"
+"italic\\\"> Доступ следует предоставлять только группе клиента ниже. <br /> "
+"Контакты клиента, связанные с учётной записью пользователя, будут "
+"автоматически добавлены в эту группу и сразу получат те же роли. <br /> "
+"Прочий предоставленный доступ пользователям или группам повлияет только на "
+"вновь создаваемое содержимое. </div>"
 
 #. log in."
-#. Default: "Cookies are not enabled. You must enable cookies before you can log in."
+#. Default: "Cookies are not enabled. You must enable cookies before you can
+#. log in."
 #: senaite/core/browser/login/templates/login.pt:20
 msgid "enable_cookies_message_before_login"
-msgstr ""
+msgstr "Cookie не включены. Для входа в систему необходимо включить cookie."
 
 #. Default: "File already uploaded:"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_input.pt:19
 msgid "file_already_uploaded"
-msgstr ""
+msgstr "Файл уже загружен:"
 
 #. Default: "Get help"
 #: senaite/core/browser/login/templates/login.pt:105
 msgid "footer_login_link_get_help"
-msgstr ""
+msgstr "Получить помощь"
 
 #. Default: "Sign up here"
 #: senaite/core/browser/login/templates/login.pt:110
 msgid "footer_login_link_signup"
-msgstr ""
+msgstr "Зарегистрироваться здесь"
 
 #. Default: "Up to rule management"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:16
 msgid "go_to_contentrules_management"
-msgstr ""
+msgstr "К управлению правилами"
 
 #. Default: "Add ${itemtype}"
 #: senaite/core/skins/senaite_templates/edit_macros.pt:24
 msgid "heading_add_item"
-msgstr ""
+msgstr "Добавить ${itemtype}"
 
 #. Default: "Assign to groups"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:111
 msgid "heading_assign_to_groups"
-msgstr ""
+msgstr "Назначить в группы"
 
 #. Default: "Available languages"
 #: senaite/core/profiles/default/registry.xml
 msgid "heading_available_languages"
-msgstr ""
+msgstr "Доступные языки"
 
 #. Default: "Use cookie for manual override"
 #: senaite/core/profiles/default/registry.xml
 msgid "heading_cookie_manual_override"
-msgstr ""
+msgstr "Использовать cookie для ручного переопределения"
 
 #. Default: "Create a Group"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:22
 msgid "heading_create_group"
-msgstr ""
+msgstr "Создать группу"
 
 #. Default: "Manage access for ${folder}"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:37
 msgid "heading_currently_assigned_shares"
-msgstr ""
+msgstr "Управление доступом для ${folder}"
 
 #. Default: "Group: ${groupname}"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:58
 msgid "heading_edit_groupproperties"
-msgstr ""
+msgstr "Группа: ${groupname}"
 
 #. Default: "Edit ${itemtype}"
 #: senaite/core/skins/senaite_templates/edit_macros.pt:34
 msgid "heading_edit_item"
-msgstr ""
+msgstr "Редактировать ${itemtype}"
 
 #. Default: "Group Members"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:27
 msgid "heading_group_members"
-msgstr ""
+msgstr "Участники группы"
 
 #. Default: "Group: ${groupname}"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:55
 msgid "heading_group_members_of"
-msgstr ""
+msgstr "Группа: ${groupname}"
 
 #. Default: "Current group members"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:91
 msgid "heading_groupmembers_current"
-msgstr ""
+msgstr "Текущие участники группы"
 
 #. Default: "Current group memberships"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:70
 msgid "heading_memberships_current"
-msgstr ""
+msgstr "Текущие членства в группах"
 
 #. Default: "Portlets assigned here"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:40
 msgid "heading_portlets_assigned_here"
-msgstr ""
+msgstr "Портлеты, назначенные здесь"
 
 #. Default: "Search for groups"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:110
 msgid "heading_search_groups"
-msgstr ""
+msgstr "Поиск групп"
 
 #. Default: "Search for new group members"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:184
 msgid "heading_search_newmembers"
-msgstr ""
+msgstr "Поиск новых участников группы"
 
 #. Default: "Version Overview"
 #: senaite/core/browser/controlpanel/templates/overview.pt:135
 msgid "heading_version_overview"
-msgstr ""
+msgstr "Обзор версий"
 
 #. and type the document as you usually do."
-#. Default: "If you are unsure of which format to use, just select Plain Text and type the document as you usually do."
+#. Default: "If you are unsure of which format to use, just select Plain Text
+#. and type the document as you usually do."
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:52
 msgid "help_format_wysiwyg"
 msgstr ""
+"Если не уверены, какой формат использовать, выберите обычный текст и вводите"
+" документ как обычно."
 
 #. creation."
-#. Default: "A unique identifier for the group. Can not be changed after creation."
+#. Default: "A unique identifier for the group. Can not be changed after
+#. creation."
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:34
 msgid "help_groupname"
 msgstr ""
+"Уникальный идентификатор группы. Не может быть изменён после создания."
 
 #. inherited. If you disable this, only the explicitly defined sharing
 #. permissions will be valid. In the overview, the symbol
 #. ${image_confirm_icon} indicates an inherited value. Similarly, the symbol
 #. ${image_link_icon} indicates a global role, which is managed by the site
 #. administrator."
-#. Default: "By default, permissions from the container of this item are inherited. If you disable this, only the explicitly defined sharing permissions will be valid. In the overview, the symbol ${image_confirm_icon} indicates an inherited value. Similarly, the symbol ${image_link_icon} indicates a global role, which is managed by the site administrator."
+#. Default: "By default, permissions from the container of this item are
+#. inherited. If you disable this, only the explicitly defined sharing
+#. permissions will be valid. In the overview, the symbol
+#. ${image_confirm_icon} indicates an inherited value. Similarly, the symbol
+#. ${image_link_icon} indicates a global role, which is managed by the site
+#. administrator."
 #: senaite/core/browser/sharing/templates/client_sharing.pt:191
 msgid "help_inherit_local_roles"
 msgstr ""
+"По умолчанию права наследуются от контейнера этого элемента. Если отключить "
+"это, будут действовать только явно заданные права общего доступа. В обзоре "
+"символ ${image_confirm_icon} обозначает унаследованное значение, а символ "
+"${image_link_icon} — глобальную роль, управляемую администратором сайта."
 
 #. Default: "go here"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:28
 msgid "help_sharing_go_here"
-msgstr ""
+msgstr "перейдите сюда"
 
 #. container. To adjust them for the entire container, ${go_here}."
-#. Default: "You are adjusting the sharing privileges for a default view in a container. To adjust them for the entire container, ${go_here}."
+#. Default: "You are adjusting the sharing privileges for a default view in a
+#. container. To adjust them for the entire container, ${go_here}."
 #: senaite/core/browser/sharing/templates/client_sharing.pt:28
 msgid "help_sharing_page_default_page"
 msgstr ""
+"Вы настраиваете права общего доступа для стандартного просмотра контейнера. "
+"Чтобы настроить их для всего контейнера, ${go_here}."
 
 #. Default: "HTML"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:73
 msgid "html"
-msgstr ""
+msgstr "HTML"
 
 #. Default: "If all of the following conditions are met:"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:31
 msgid "if_all_conditions_met"
-msgstr ""
+msgstr "Если выполнены все следующие условия:"
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:148
 msgid "inactive"
-msgstr ""
+msgstr "неактивен"
 
 #. Default: "Add"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:105
 msgid "label_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Add New Group"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:83
 msgid "label_add_new_group"
-msgstr ""
+msgstr "Добавить новую группу"
 
 #. Default: "Add New User"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:66
 msgid "label_add_new_user"
-msgstr ""
+msgstr "Добавить нового пользователя"
 
 #. Default: "Add portlet"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:10
 msgid "label_add_portlet"
-msgstr ""
+msgstr "Добавить портлет"
 
 #. Default: "Add portlet…"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:17
 msgid "label_add_portlet_ellipsis"
-msgstr ""
+msgstr "Добавить портлет…"
 
 #. Default: "Add user to selected groups"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:204
 msgid "label_add_user_to_group"
-msgstr ""
+msgstr "Добавить пользователя в выбранные группы"
 
 #. Default: "Add selected groups and users to this group"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:339
 msgid "label_add_users_to_group"
-msgstr ""
+msgstr "Добавить выбранные группы и пользователей в эту группу"
 
 #. Default: "Cancel"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:198
 #: senaite/core/skins/senaite_templates/edit_macros.pt:262
 msgid "label_cancel"
-msgstr ""
+msgstr "Отмена"
 
 #. Default: "Add content rule"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:189
 msgid "label_contentrule_add"
-msgstr ""
+msgstr "Добавить правило контента"
 
 #. Default: "Assignments"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:209
 msgid "label_contentrules_rule_assignments"
-msgstr ""
+msgstr "Назначения"
 
 #. Default: "enabled"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:114
 msgid "label_contentrules_rule_enabled"
-msgstr ""
+msgstr "включено"
 
 #. Default: "event"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:113
 msgid "label_contentrules_rule_event"
-msgstr ""
+msgstr "событие"
 
 #. Default: "content rule"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:112
 msgid "label_contentrules_rule_listing"
-msgstr ""
+msgstr "правило контента"
 
 #. Default: "Convert portlets"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:77
 msgid "label_convert_portlets"
-msgstr ""
+msgstr "Преобразовать портлеты"
 
 #. Default: "Delete"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:175
 msgid "label_delete"
-msgstr ""
+msgstr "Удалить"
 
 #. Default: "Description"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:272
 msgid "label_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Disable"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:170
 msgid "label_disable"
-msgstr ""
+msgstr "Отключить"
 
 #. Default: "Edit"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:52
 msgid "label_edit"
-msgstr ""
+msgstr "Редактировать"
 
 #. Default: "Enable"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:165
 msgid "label_enable"
-msgstr ""
+msgstr "Включить"
 
 #. Default: "Find a group here"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:37
 msgid "label_find_group"
-msgstr ""
+msgstr "Найдите группу здесь"
 
 #. Default: "Format"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:50
 msgid "label_format"
-msgstr ""
+msgstr "Формат"
 
 #. Default: "Group Members"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:69
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:67
 msgid "label_group_members"
-msgstr ""
+msgstr "Участники группы"
 
 #. Default: "Group Memberships"
 #: senaite/core/browser/user/templates/account-configlet.pt:41
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:62
 msgid "label_group_memberships"
-msgstr ""
+msgstr "Членства в группах"
 
 #. Default: "Group Properties"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:71
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:70
 msgid "label_group_properties"
-msgstr ""
+msgstr "Свойства группы"
 
 #. Default: "Group Search"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:106
 msgid "label_group_search"
-msgstr ""
+msgstr "Поиск группы"
 
 #. Default: "Groups"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:45
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:42
 msgid "label_groups"
-msgstr ""
+msgstr "Группы"
 
 #. Default: "Hide"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:103
 msgid "label_hide_item"
-msgstr ""
+msgstr "Скрыть"
 
 #. Default: "Inherit permissions from higher levels"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:180
 msgid "label_inherit_local_roles"
-msgstr ""
+msgstr "Наследовать права с более высоких уровней"
 
 #. If you wanted to manage the portlets of the container itself, ${go_here}."
-#. Default: "You are managing the portlets of the default view of a container. If you wanted to manage the portlets of the container itself, ${go_here}."
+#. Default: "You are managing the portlets of the default view of a container.
+#. If you wanted to manage the portlets of the container itself, ${go_here}."
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:45
 msgid "label_manage_portlets_default_view_container"
 msgstr ""
+"Вы управляете портлетами стандартного просмотра контейнера. Если хотите "
+"управлять портлетами самого контейнера, ${go_here}."
 
 #. Default: "go here"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:45
 msgid "label_manage_portlets_default_view_container_go_here"
-msgstr ""
+msgstr "перейдите сюда"
 
 #. Default: "Name"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:102
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:28
 msgid "label_name"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Next"
 #: senaite/core/skins/senaite_templates/edit_macros.pt:247
 msgid "label_next"
-msgstr ""
+msgstr "Далее"
 
 #. Default: "No group was specified."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:35
 msgid "label_no_group_specified"
-msgstr ""
+msgstr "Группа не указана."
 
 #. Default: "No preference panels available."
 #: senaite/core/browser/controlpanel/templates/overview.pt:123
 msgid "label_no_prefs_panels_available"
-msgstr ""
+msgstr "Доступные панели настроек отсутствуют."
 
 #. Default: "Previous"
 #: senaite/core/skins/senaite_templates/edit_macros.pt:239
 msgid "label_previous"
-msgstr ""
+msgstr "Назад"
 
 #. Default: "This can be risky, are you sure you want to do this?"
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:104
 msgid "label_product_upgrade_all_action"
-msgstr ""
+msgstr "Это может быть рискованно, вы уверены, что хотите продолжить?"
 
 #. Default: "New profile version is ${version}."
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:81
 msgid "label_product_upgrade_new_profile_version"
-msgstr ""
+msgstr "Новая версия профиля: ${version}."
 
 #. Default: "Old profile version was ${version}."
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:78
 msgid "label_product_upgrade_old_profile_version"
-msgstr ""
+msgstr "Старая версия профиля была: ${version}."
 
 #. Default: "Old version was ${version}."
 #: senaite/core/browser/quickinstaller/templates/quickinstaller.pt:74
 msgid "label_product_upgrade_old_version"
-msgstr ""
+msgstr "Старая версия была: ${version}."
 
 #. Default: "Quick search"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:200
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:120
 msgid "label_quick_search"
-msgstr ""
+msgstr "Быстрый поиск"
 
 #. Default: "Remove"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:55
 msgid "label_remove"
-msgstr ""
+msgstr "Удалить"
 
 #. Default: "Remove from selected groups"
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:103
 msgid "label_remove_selected_groups"
-msgstr ""
+msgstr "Удалить из выбранных групп"
 
 #. Default: "Remove selected groups / users"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:175
 msgid "label_remove_selected_users"
-msgstr ""
+msgstr "Удалить выбранные группы/пользователей"
 
 #. Default: "(Required)"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:30
 msgid "label_required"
-msgstr ""
+msgstr "(Обязательно)"
 
 #. Default: "Event trigger: ${trigger}"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:285
 msgid "label_rule_event_trigger"
-msgstr ""
+msgstr "Событие-триггер: ${trigger}"
 
 #. Default: "Search"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:78
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:214
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:120
 msgid "label_search"
-msgstr ""
+msgstr "Поиск"
 
 #. Default: "Show all"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:219
 msgid "label_search_large"
-msgstr ""
+msgstr "Показать все"
 
 #. Default: "Show"
 #: senaite/core/browser/portlets/templates/edit-manager-macros.pt:91
 msgid "label_show_item"
-msgstr ""
+msgstr "Показать"
 
 #. Default: "Show all"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:127
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:106
 msgid "label_showall"
-msgstr ""
+msgstr "Показать все"
 
 #. Default: "Up to Groups Overview"
 #: senaite/core/browser/usergroup/templates/usergroups_groupdetails.pt:49
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:18
 msgid "label_up_to_groups_overview"
-msgstr ""
+msgstr "К обзору групп"
 
 #. Default: "Up to Users Overview"
 #: senaite/core/browser/user/templates/account-configlet.pt:13
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:36
 msgid "label_up_to_usersoverview"
-msgstr ""
+msgstr "К обзору пользователей"
 
 #. Default: "User Search"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:85
 msgid "label_user_search"
-msgstr ""
+msgstr "Поиск пользователя"
 
 #. Default: "Users"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:43
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:39
 msgid "label_users"
-msgstr ""
+msgstr "Пользователи"
 
 #. Default: "Content rules"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:73
 msgid "legend-contentrules"
-msgstr ""
+msgstr "правила содержания легенд"
 
 #. Default: "E-mail Address"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:114
 msgid "listingheader_email_address"
-msgstr ""
+msgstr "Email адрес"
 
 #. Default: "Group Name"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:146
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:79
 msgid "listingheader_group_name"
-msgstr ""
+msgstr "Название группы"
 
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:78
 msgid "listingheader_group_remove"
-msgstr ""
+msgstr "Удалить"
 
 #. Default: "Group/User name"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:242
 msgid "listingheader_group_user_name"
-msgstr ""
+msgstr "Имя группы/пользователя"
 
 #. Default: "Remove"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:159
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:123
 msgid "listingheader_remove"
-msgstr ""
+msgstr "Удалить"
 
 #. Default: "Reset Password"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:122
 msgid "listingheader_reset_password"
-msgstr ""
+msgstr "Сбросить пароль"
 
 #. Default: "User name"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:113
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:120
 msgid "listingheader_user_name"
-msgstr ""
+msgstr "Имя пользователя"
 
 #. Default: "Need an account?"
 #: senaite/core/browser/login/templates/login.pt:109
 msgid "need_an_account"
-msgstr ""
+msgstr "Нет учётной записи?"
 
 #. Default: "No file"
 #: senaite/core/z3cform/widgets/datagrid/datagridrow_file_display.pt:27
 msgid "no_file"
-msgstr ""
-
-#. Default: "No image"
-#: senaite/core/z3cform/widgets/namedimage/display.pt:17
-msgid "no_image"
-msgstr ""
+msgstr "Нет файла"
 
 #. Default: "Plain Text"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:82
 msgid "plain_text"
-msgstr ""
+msgstr "Обычный текст"
 
 #. Default: "Return"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:22
 msgid "return_to_view"
-msgstr ""
+msgstr "Вернуться"
 
 #. Default: "Structured Text"
 #: senaite/core/skins/senaite_templates/tinymce_wysiwyg_support.pt:64
 msgid "structured_text"
-msgstr ""
+msgstr "Структурированный текст"
 
 #. Default: "Current sharing permissions"
 #: senaite/core/browser/sharing/templates/client_sharing.pt:92
 msgid "summary_assigned_roles"
-msgstr ""
+msgstr "Текущие права общего доступа"
 
 #. Default: "Select roles for each group"
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:139
 msgid "summary_roles_for_groups"
-msgstr ""
+msgstr "Выберите роли для каждой группы"
 
 #. various features including contact forms, email notification and password
 #. reset will not work. Go to the ${label_mail_control_panel_link} to fix
 #. this."
-#. Default: "You have not configured a mail host or a site 'From' address, various features including contact forms, email notification and password reset will not work. Go to the ${label_mail_control_panel_link} to fix this."
+#. Default: "You have not configured a mail host or a site 'From' address,
+#. various features including contact forms, email notification and password
+#. reset will not work. Go to the ${label_mail_control_panel_link} to fix
+#. this."
 #: senaite/core/browser/controlpanel/templates/overview.pt:53
 msgid "text_no_mailhost_configured"
 msgstr ""
+"Вы не настроили почтовый сервер или адрес отправителя сайта — контактные "
+"формы, email-уведомления и сброс пароля работать не будут. Перейдите в "
+"${label_mail_control_panel_link}, чтобы это исправить."
 
 #. Default: "Mail control panel"
 #: senaite/core/browser/controlpanel/templates/overview.pt:54
 msgid "text_no_mailhost_configured_control_panel_link"
-msgstr ""
+msgstr "Панель управления почтой"
 
 #. Default: "PIL is not installed properly, image scaling will not work."
 #: senaite/core/browser/controlpanel/templates/overview.pt:90
 msgid "text_no_pil_installed"
 msgstr ""
+"PIL не установлена корректно, масштабирование изображений работать не будет."
 
 #. Default: "Enter a group or user name to search for or click 'Show All'."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:308
 msgid "text_no_searchstring"
 msgstr ""
+"Введите имя группы или пользователя для поиска либо нажмите 'Показать все'."
 
 #. Default: "Enter a group or user name to search for."
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:302
 msgid "text_no_searchstring_large"
-msgstr ""
+msgstr "Введите имя группы или пользователя для поиска."
 
 #. work properly for timezone aware date/time values. Go to the
 #. ${label_mail_event_settings_link} to fix this."
-#. Default: "You have not set the portal timezone. Date/Time handling will not work properly for timezone aware date/time values. Go to the ${label_mail_event_settings_link} to fix this."
+#. Default: "You have not set the portal timezone. Date/Time handling will not
+#. work properly for timezone aware date/time values. Go to the
+#. ${label_mail_event_settings_link} to fix this."
 #: senaite/core/browser/controlpanel/templates/overview.pt:74
 msgid "text_no_timezone_configured"
 msgstr ""
+"Вы не задали часовой пояс портала. Обработка даты/времени будет работать "
+"некорректно для значений с учётом часового пояса. Перейдите в "
+"${label_mail_event_settings_link}, чтобы это исправить."
 
 #. Default: "Date and Time Settings control panel"
 #: senaite/core/browser/controlpanel/templates/overview.pt:75
 msgid "text_no_timezone_configured_control_panel_link"
-msgstr ""
+msgstr "Панель управления настройками даты и времени"
 
 #. Default: "Enter a username to search for"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:195
 msgid "text_no_user_searchstring"
-msgstr ""
+msgstr "Введите имя пользователя для поиска"
 
 #. Default: "Enter a username to search for, or click 'Show All'"
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:201
 msgid "text_no_user_searchstring_largesite"
-msgstr ""
+msgstr "Введите имя пользователя для поиска либо нажмите 'Показать все'"
 
 #. Default: "No matches"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:297
 #: senaite/core/browser/usergroup/templates/usergroups_groupsoverview.pt:231
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:191
 msgid "text_nomatches"
-msgstr ""
+msgstr "Совпадений не найдено"
 
 #. Default: "This user does not belong to any group."
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:102
 msgid "text_user_not_in_any_group"
-msgstr ""
+msgstr "Этот пользователь не состоит ни в одной группе."
 
 #. Default: "Edit content rule"
 #: senaite/core/browser/contentrules/templates/manage-elements.pt:13
 msgid "title_edit_contentrule"
-msgstr ""
+msgstr "Редактировать правило контента"
 
 #. Default: "Legacy portlets"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:67
 msgid "title_legacy_portlets"
-msgstr ""
+msgstr "Устаревшие портлеты"
 
 #. Default: "Content Rules"
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:21
 msgid "title_manage_contentrules"
-msgstr ""
+msgstr "Правила контента"
 
 #. Default: "Manage portlets for ${context_title}"
 #: senaite/core/browser/portlets/templates/manage-contextual.pt:14
 msgid "title_manage_contextual_portlets"
-msgstr ""
+msgstr "Управление портлетами для ${context_title}"
 
 #. Default: "Personal Information"
 #: senaite/core/browser/user/templates/account-configlet.pt:33
 #: senaite/core/browser/usergroup/templates/usergroups_usermembership.pt:58
 msgid "title_personal_information_form"
-msgstr ""
+msgstr "Личная информация"
 
 #. Default: "Send a mail to this user"
 #: senaite/core/browser/usergroup/templates/usergroups_groupmembership.pt:158
 msgid "title_send_mail_to_user"
-msgstr ""
+msgstr "Отправить письмо этому пользователю"
 
 #. Default: "Trouble logging in?"
 #: senaite/core/browser/login/templates/login.pt:104
 msgid "trouble_logging_in"
-msgstr ""
+msgstr "Проблемы со входом?"
 
 #: senaite/core/browser/contentrules/templates/controlpanel.pt:153
 msgid "unassigned"
-msgstr ""
+msgstr "неназначенный"
 
 #. ${image_link_icon} indicates a role inherited from membership in a group."
-#. Default: "Note that roles set here apply directly to a user. The symbol ${image_link_icon} indicates a role inherited from membership in a group."
+#. Default: "Note that roles set here apply directly to a user. The symbol
+#. ${image_link_icon} indicates a role inherited from membership in a group."
 #: senaite/core/browser/usergroup/templates/usergroups_usersoverview.pt:52
 msgid "user_roles_note"
 msgstr ""
+"Обратите внимание: роли, заданные здесь, применяются непосредственно к "
+"пользователю. Символ ${image_link_icon} обозначает роль, унаследованную от "
+"участия в группе."

--- a/src/senaite/core/locales/ru_RU/LC_MESSAGES/senaite.core.po
+++ b/src/senaite/core/locales/ru_RU/LC_MESSAGES/senaite.core.po
@@ -2,7267 +2,7937 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-07-19 12:29+0000\n"
+"POT-Creation-Date: 2026-06-19 06:37+0000\n"
 "PO-Revision-Date: 2018-06-01 18:44+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Russian (Russia) (https://app.transifex.com/senaite/teams/87045/ru_RU/)\n"
+"Language: ru_RU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Domain: DOMAIN\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: DOMAIN\n"
-"Language: ru_RU\n"
 
-#: bika/lims/content/bikasetup.py:1135
-msgid " <p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p><p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, etc.</p><p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample ID</td><td>{sampleId}</td></tr><tr><td>Sample Type</td><td>{sampleType}</td></tr><tr><td>Sampling Date</td><td>{samplingDate}</td></tr><tr><td>Date Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration Settings:<ul><li>format:<ul><li>a python format string constructed from predefined variables like sampleId, clientId, sampleType.</li><li>special variable 'seq' must be positioned last in theformat string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>"
+#: bika/lims/content/bikasetup.py:1134
+msgid ""
+" <p>The ID Server provides unique sequential IDs for objects such as Samples"
+" and Worksheets etc, based on a format specified for each content "
+"type.</p><p>The format is constructed similarly to the Python format syntax,"
+" using predefined variables per content type, and advancing the IDs through "
+"a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' "
+"for a sequence of IDs from 001 to 999.</p><p>Alphanumeric prefixes for IDs "
+"are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} "
+"produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p><p>For "
+"dynamic generation of alphanumeric and sequential IDs, the wildcard {alpha} "
+"can be used. E.g WS-{alpha:2a3d} produces WS-AA001, WS-AA002, WS-AB034, "
+"etc.</p><p>Variables that can be used include:<table><tr><th "
+"style='width:150px'>Content Type</th><th>Variables</th></tr><tr><td>Client "
+"ID</td><td>{clientId}</td></tr><tr><td>Year</td><td>{year}</td></tr><tr><td>Sample"
+" ID</td><td>{sampleId}</td></tr><tr><td>Sample "
+"Type</td><td>{sampleType}</td></tr><tr><td>Sampling "
+"Date</td><td>{samplingDate}</td></tr><tr><td>Date "
+"Sampled</td><td>{dateSampled}</td></tr></table></p><p>Configuration "
+"Settings:<ul><li>format:<ul><li>a python format string constructed from "
+"predefined variables like sampleId, clientId, sampleType.</li><li>special "
+"variable 'seq' must be positioned last in theformat "
+"string</li></ul></li><li>sequence type: [generated|counter]</li><li>context:"
+" if type counter, provides context the counting function</li><li>counter "
+"type: [backreference|contained]</li><li>counter reference: a parameter to "
+"the counting function</li><li>prefix: default prefix if none provided in "
+"format string</li><li>split length: the number of parts to be included in "
+"the prefix</li></ul></p>"
 msgstr ""
+"<p>Сервер идентификаторов предоставляет уникальные последовательные ID для "
+"объектов, таких как образцы и рабочие листы, на основе формата, заданного "
+"для каждого типа содержимого.</p><p>Формат строится аналогично синтаксису "
+"форматирования Python, с использованием предопределённых переменных для "
+"каждого типа содержимого и продвижением ID через номер последовательности "
+"'seq' с заданным количеством цифр, например '03d' для последовательности от "
+"001 до 999.</p><p>Буквенно-числовые префиксы для ID включаются в формат как "
+"есть, например WS для рабочего листа в WS-{seq:03d} даёт последовательные "
+"ID: WS-001, WS-002, WS-003 и т.д.</p><p>Для динамической генерации буквенно-"
+"числовых последовательных ID можно использовать шаблон {alpha}. Например "
+"WS-{alpha:2a3d} даёт WS-AA001, WS-AA002, WS-AB034 и т.д.</p><p>Доступные "
+"переменные:<table><tr><th style='width:150px'>Тип "
+"содержимого</th><th>Переменные</th></tr><tr><td>ID "
+"клиента</td><td>{clientId}</td></tr><tr><td>Год</td><td>{year}</td></tr><tr><td>ID"
+" образца</td><td>{sampleId}</td></tr><tr><td>Тип "
+"образца</td><td>{sampleType}</td></tr><tr><td>Дата "
+"отбора</td><td>{samplingDate}</td></tr><tr><td>Дата отбора "
+"образца</td><td>{dateSampled}</td></tr></table></p><p>Параметры "
+"конфигурации:<ul><li>format:<ul><li>строка формата Python, построенная из "
+"предопределённых переменных, таких как sampleId, clientId, "
+"sampleType.</li><li>специальная переменная 'seq' должна быть последней в "
+"строке формата</li></ul></li><li>тип последовательности: "
+"[generated|counter]</li><li>context: для типа counter — контекст функции "
+"подсчёта</li><li>тип счётчика: [backreference|contained]</li><li>ссылка "
+"счётчика: параметр функции подсчёта</li><li>prefix: префикс по умолчанию, "
+"если не указан в строке формата</li><li>split length: количество частей "
+"формата, включаемых в префикс хранения</li></ul></p>"
 
 #: bika/lims/browser/publish/templates/email.pt:143
 msgid "${amount} attachments with a total size of ${total_size}"
-msgstr ""
+msgstr "${amount} вложений общим размером ${total_size}"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
-#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "${back_link}"
-msgstr ""
+msgstr "${back_link} "
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:32
-msgid "${contact_fullname} can log into the LIMS by using ${contact_username} as username. Contacts must change their own passwords. If a password is forgotten a contact can request a new password from the login form."
+msgid ""
+"${contact_fullname} can log into the LIMS by using ${contact_username} as "
+"username. Contacts must change their own passwords. If a password is "
+"forgotten a contact can request a new password from the login form."
 msgstr ""
+"${contact_fullname} может войти в LIMS, используя ${contact_username} как "
+"имя пользователя. Предприятии | Контакты должны изменить свои пароли. Если "
+"пароль забыт пользователь может запросить новый пароль из формы входа в "
+"систему"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:105
 msgid "${items} were successfully created."
-msgstr ""
+msgstr "${items} успешно созданы."
 
 #: bika/lims/controlpanel/bika_analysisservices.py:110
 msgid "${item} was successfully created."
-msgstr ""
+msgstr "${item} успешно создан."
 
 #: bika/lims/utils/analysisrequest.py:885
 msgid "%s has been rejected"
-msgstr ""
+msgstr "%s отклонено"
 
 #: senaite/core/exportimport/setupdata/__init__.py:89
 msgid "%s has no '%s' column."
-msgstr ""
+msgstr "%s не содержит колонку '%s'"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:23
-#: senaite/core/browser/samples/templates/dispose_samples.pt:23
 #: senaite/core/browser/samples/templates/partition_magic.pt:29
 msgid "&larr; Back"
-msgstr ""
+msgstr "&larr; Назад"
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "&larr; Back to the ${back_link}"
-msgstr ""
+msgstr "&larr; Назад к ${back_link} "
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:30
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:35
 msgid "&larr; Go back"
-msgstr ""
+msgstr "Назад"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:46
 msgid "&larr; Go back to see all samples"
-msgstr ""
+msgstr "&larr; Назад к списку образцов"
 
 #: bika/lims/validators.py:884
 msgid "'Max' value must be above 'Min' value"
-msgstr ""
+msgstr "'Макс' значение должно быть больше 'Мин'"
 
 #: bika/lims/validators.py:879
 msgid "'Max' value must be numeric"
-msgstr ""
+msgstr "'Макс' значение должно быть числом"
 
 #: bika/lims/validators.py:877
 msgid "'Min' value must be numeric"
-msgstr ""
+msgstr "'Мин' значение должно быть числом"
 
 #: bika/lims/validators.py:898
 msgid "'Warn Max' value must be above 'Max' value"
-msgstr ""
+msgstr "Значение 'Предупр. максимум' должно быть больше значения 'Максимум'"
 
 #: bika/lims/validators.py:895
 msgid "'Warn Max' value must be numeric or empty"
-msgstr ""
+msgstr "Значение 'Предупр. максимум' должно быть числом или пустым"
 
 #: bika/lims/validators.py:891
 msgid "'Warn Min' value must be below 'Min' value"
-msgstr ""
+msgstr "Значение 'Предупр. минимум' должно быть меньше значения 'Минимум'"
 
 #: bika/lims/validators.py:888
 msgid "'Warn Min' value must be numeric or empty"
-msgstr ""
+msgstr "Значение 'Предупр. минимум' должно быть числом или пустым"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:255
 msgid "(Blank)"
-msgstr ""
+msgstr "(Пусто)"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:262
 msgid "(Control)"
-msgstr ""
+msgstr "(Контроль)"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:269
 msgid "(Duplicate)"
-msgstr ""
+msgstr "(Повторно)"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:227
 msgid "(Required)"
-msgstr ""
+msgstr "(Требуется)"
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:26
-msgid "*** This is an automatically generated email, please do not reply to this message. ***"
+msgid ""
+"*** This is an automatically generated email, please do not reply to this "
+"message. ***"
 msgstr ""
+"*** Это автоматически сгенерированное сообщение, пожалуйста, не отвечайте на"
+" него. ***"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:91
 msgid "+-"
-msgstr ""
-
-# senaite.app.listing: Column-filter row — boolean select placeholder
-msgid "-- Select --"
-msgstr ""
+msgstr "±"
 
 #: senaite/core/exportimport/dataimport.py:139
 msgid "... Choose an Instrument ..."
-msgstr ""
+msgstr "... Выберите инструмент ..."
 
 #: bika/lims/browser/fields/resultrangefield.py:40
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:126
 msgid "< Min"
-msgstr ""
+msgstr "< Мин."
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:61
-msgid "<i class=\"fas fa-link\" aria-hidden=\"true\" /> Go to worksheet template setup"
+msgid ""
+"<i class=\"fas fa-link\" aria-hidden=\"true\" /> Go to worksheet template "
+"setup"
 msgstr ""
+"<i class=\"fas fa-link\" aria-hidden=\"true\" />Перейти к настройке шаблона "
+"рабочего листа"
 
 #: bika/lims/browser/templates/senaite-frontpage.pt:15
 msgid "<img src=\"${DYNAMIC_CONTENT}\" /> Welcome to SENAITE"
-msgstr ""
+msgstr "<img src=\"${DYNAMIC_CONTENT}\" /> Добро пожаловать в SENAITE"
 
-#: senaite/core/content/senaitesetup.py:1204
-msgid "<p>The ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type. The format is constructed similarly to the Python format syntax, e.g. <code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> etc.</p><p>The current persistent counter values are managed in the <a href='ng'>Number Generator view</a>.</p><details class='id-server-cheatsheet'><summary>Available variables</summary><table class='table table-sm'><thead><tr><th style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code> / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, ...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year (e.g. <code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current date as <code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client ID (samples only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type prefix.</td></tr><tr><td><code>{samplingDate}</code> / <code>{dateSampled}</code></td><td>Sample dates (Python <code>strftime</code> specs apply).</td></tr><tr><td><code>{parent_ar_id}</code> / <code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: the parent sample ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent partition counter.</td></tr><tr><td><code>{retest_count}</code> / <code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters for retests, secondaries, and total tests.</td></tr></tbody></table></details><details class='id-server-cheatsheet'><summary>Configuration fields</summary><ul><li><strong>Format</strong>: the ID template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the persistent number counter; <code>counter</code> uses the count of related objects.</li><li><strong>Context</strong>: only used by <code>counter</code> type; the named context the counter applies to.</li><li><strong>Counter Type</strong>: <code>backreference</code> (deprecated) or <code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship name (backreference) or meta type (contained).</li><li><strong>Prefix</strong>: default prefix if none in the format.</li><li><strong>Split Length</strong>: how many segments of the format become the storage key prefix. Determines how the counter is partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table { margin-top: 0.5em; }</style>"
+#: senaite/core/content/senaitesetup.py:1181
+msgid ""
+"<p>The ID Server provides unique sequential IDs for objects such as Samples "
+"and Worksheets etc, based on a format specified for each content type. The "
+"format is constructed similarly to the Python format syntax, e.g. "
+"<code>WS-{seq:03d}</code> produces <code>WS-001</code>, <code>WS-002</code>,"
+" <code>WS-003</code> etc.</p><p>The current persistent counter values are "
+"managed in the <a href='ng'>Number Generator view</a>.</p><details class"
+"='id-server-cheatsheet'><summary>Available variables</summary><table "
+"class='table table-sm'><thead><tr><th "
+"style='width:30%'>Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>{seq}</code>"
+" / <code>{seq:04d}</code></td><td>Numeric sequence number, optionally zero-"
+"padded.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Alphanumeric "
+"counter, e.g. <code>{alpha:2a3d}</code> yields AA001, AA002, ..., AB001, "
+"...</td></tr><tr><td><code>{year}</code></td><td>Two-digit current year "
+"(e.g. "
+"<code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Current "
+"date as "
+"<code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>Client"
+" ID (samples "
+"only).</td></tr><tr><td><code>{sampleType}</code></td><td>Sample type "
+"prefix.</td></tr><tr><td><code>{samplingDate}</code> / "
+"<code>{dateSampled}</code></td><td>Sample dates (Python "
+"<code>strftime</code> specs "
+"apply).</td></tr><tr><td><code>{parent_ar_id}</code> / "
+"<code>{parent_base_id}</code></td><td>For partitions/retests/secondaries: "
+"the parent sample "
+"ID.</td></tr><tr><td><code>{partition_count}</code></td><td>Per-parent "
+"partition counter.</td></tr><tr><td><code>{retest_count}</code> / "
+"<code>{secondary_count}</code> / <code>{test_count}</code></td><td>Counters "
+"for retests, secondaries, and total "
+"tests.</td></tr></tbody></table></details><details class='id-server-"
+"cheatsheet'><summary>Configuration "
+"fields</summary><ul><li><strong>Format</strong>: the ID "
+"template.</li><li><strong>Seq Type</strong>: <code>generated</code> uses the"
+" persistent number counter; <code>counter</code> uses the count of related "
+"objects.</li><li><strong>Context</strong>: only used by <code>counter</code>"
+" type; the named context the counter applies to.</li><li><strong>Counter "
+"Type</strong>: <code>backreference</code> (deprecated) or "
+"<code>contained</code>.</li><li><strong>Counter Ref</strong>: relationship "
+"name (backreference) or meta type "
+"(contained).</li><li><strong>Prefix</strong>: default prefix if none in the "
+"format.</li><li><strong>Split Length</strong>: how many segments of the "
+"format become the storage key prefix. Determines how the counter is "
+"partitioned (e.g. per year, per sample type).</li></ul></details><style>.id-"
+"server-cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { "
+"cursor: pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet"
+" table { margin-top: 0.5em; }</style>"
 msgstr ""
+"<p>Сервер идентификаторов предоставляет уникальные последовательные ID для "
+"объектов, таких как образцы и рабочие листы, на основе формата, заданного "
+"для каждого типа содержимого. Формат строится аналогично синтаксису "
+"форматирования Python, например <code>WS-{seq:03d}</code> даёт "
+"<code>WS-001</code>, <code>WS-002</code>, <code>WS-003</code> и "
+"т.д.</p><p>Текущие постоянные значения счётчиков управляются в <a "
+"href='ng'>просмотре генератора номеров</a>.</p><details class='id-server-"
+"cheatsheet'><summary>Доступные переменные</summary><table class='table "
+"table-sm'><thead><tr><th "
+"style='width:30%'>Переменная</th><th>Описание</th></tr></thead><tbody><tr><td><code>{seq}</code>"
+" / <code>{seq:04d}</code></td><td>Числовой номер последовательности, при "
+"необходимости с ведущими "
+"нулями.</td></tr><tr><td><code>{alpha:NaNd}</code></td><td>Буквенно-числовой"
+" счётчик, например <code>{alpha:2a3d}</code> даёт AA001, AA002, ..., AB001, "
+"...</td></tr><tr><td><code>{year}</code></td><td>Двузначный текущий год "
+"(например, "
+"<code>26</code>).</td></tr><tr><td><code>{yymmdd}</code></td><td>Текущая "
+"дата в формате "
+"<code>yymmdd</code>.</td></tr><tr><td><code>{clientId}</code></td><td>ID "
+"клиента (только для "
+"образцов).</td></tr><tr><td><code>{sampleType}</code></td><td>Префикс типа "
+"образца.</td></tr><tr><td><code>{samplingDate}</code> / "
+"<code>{dateSampled}</code></td><td>Даты образца (применяются спецификаторы "
+"<code>strftime</code> Python).</td></tr><tr><td><code>{parent_ar_id}</code> "
+"/ <code>{parent_base_id}</code></td><td>Для партиций/повторных "
+"тестов/вторичных образцов: ID родительского "
+"образца.</td></tr><tr><td><code>{partition_count}</code></td><td>Счётчик "
+"партиций на родителя.</td></tr><tr><td><code>{retest_count}</code> / "
+"<code>{secondary_count}</code> / <code>{test_count}</code></td><td>Счётчики "
+"повторных тестов, вторичных образцов и общего числа "
+"тестов.</td></tr></tbody></table></details><details class='id-server-"
+"cheatsheet'><summary>Поля "
+"конфигурации</summary><ul><li><strong>Format</strong>: шаблон "
+"ID.</li><li><strong>Seq Type</strong>: <code>generated</code> использует "
+"постоянный счётчик номеров; <code>counter</code> использует количество "
+"связанных объектов.</li><li><strong>Context</strong>: используется только "
+"для типа <code>counter</code> — именованный контекст, к которому применяется"
+" счётчик.</li><li><strong>Counter Type</strong>: <code>backreference</code> "
+"(устарел) или <code>contained</code>.</li><li><strong>Counter Ref</strong>: "
+"имя связи (backreference) или мета-тип "
+"(contained).</li><li><strong>Prefix</strong>: префикс по умолчанию, если не "
+"указан в формате.</li><li><strong>Split Length</strong>: сколько сегментов "
+"формата становятся префиксом ключа хранения. Определяет разбиение счётчика "
+"(например, по годам, по типу образца).</li></ul></details><style>.id-server-"
+"cheatsheet { margin: 0.5em 0; }.id-server-cheatsheet > summary { cursor: "
+"pointer; font-weight: 600; padding: 0.25em 0; }.id-server-cheatsheet table {"
+" margin-top: 0.5em; }</style>"
 
 #: bika/lims/content/calculation.py:133
-msgid "<p>The formula you type here will be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators,  + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those two Analysis Services.</p>"
+msgid ""
+"<p>The formula you type here will be dynamically calculated when an analysis"
+" using this calculation is displayed.</p><p>To enter a Calculation, use "
+"standard maths operators,  + - * / ( ), and all keywords available, both "
+"from other Analysis Services and the Interim Fields specified here, as "
+"variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation "
+"for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in "
+"water, is entered as [Ca] + [Mg], where Ca and MG are the keywords for those"
+" two Analysis Services.</p>"
 msgstr ""
+"<p>Формула, которую вы вводите здесь, будет вычисляться динамически при "
+"отображении анализа, использующего данный расчет.</p><p>Для построения "
+"формулы используйте стандартные математические операции, + - * / ( ), "
+"ключевые слова Аналитических Услуг и промежуточные поля,  доступные как "
+"переменные. Оборачивайте их в прямоугольные скобки []</p><p>Например, для "
+"расчета показателя Общей Жесткости воды, суммарное содержание ионов кальция "
+"и магния в воде, можно записать как [Ca] + [Mg], где Са и Mg являются "
+"ключевыми словами для этих двух Аналитических Услуг.</p>"
 
 #: bika/lims/browser/fields/resultrangefield.py:41
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:131
 msgid "> Max"
-msgstr ""
+msgstr "> Макс."
 
 #: senaite/core/profiles/default/types/Multifile.xml
 msgid "A Document/File attachment"
-msgstr ""
+msgstr "Вложение документа/файла"
 
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "A published results report"
-msgstr ""
+msgstr "Опубликованный отчёт с результатами"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:66
-msgid "A short title for the site. This will be shown in the title of the browser window on each page."
+msgid ""
+"A short title for the site. This will be shown in the title of the browser "
+"window on each page."
 msgstr ""
+"Краткое наименование сайта. Сокращенное наименование ображается в заголовке "
+"окна браузера на каждой странице."
 
 #: senaite/core/profiles/default/types/SimpleFile.xml
 msgid "A simple file attachment"
-msgstr ""
+msgstr "Простое файловое вложение"
 
 #: senaite/core/profiles/default/types/SimpleImage.xml
 msgid "A simple image attachment"
-msgstr ""
+msgstr "Простое вложение изображения"
 
 #: bika/lims/profiles/default/types/ARTemplate.xml
 msgid "AR Template"
-msgstr ""
+msgstr "Шаблон ЗА"
 
 #: bika/lims/profiles/default/types/ARTemplates.xml
 msgid "AR Templates"
-msgstr ""
+msgstr "ЗА: Шаблоны"
 
 #: bika/lims/profiles/default/types/ARReport.xml
 msgid "ARReport"
-msgstr ""
+msgstr "Отчет ЗА"
 
 #: bika/lims/content/organisation.py:130
 msgid "Account Name"
-msgstr ""
+msgstr "Имя учетной записи"
 
 #: bika/lims/content/organisation.py:138
 msgid "Account Number"
-msgstr ""
+msgstr "Номер счета"
 
 #: bika/lims/content/organisation.py:122
 msgid "Account Type"
-msgstr ""
+msgstr "Тип счета"
 
 #: senaite/core/content/analysisprofile.py:64
-#: senaite/core/content/senaitesetup.py:1296
+#: senaite/core/content/senaitesetup.py:1273
 msgid "Accounting"
-msgstr ""
+msgstr "Учет"
 
 #: senaite/core/content/laboratory.py:109
 msgid "Accreditation"
-msgstr ""
+msgstr "Аккредитация"
 
 #: bika/lims/content/laboratory.py:121
 msgid "Accreditation Body Abbreviation"
-msgstr ""
+msgstr "Аббревиатура органа аккредитации"
 
 #: bika/lims/content/laboratory.py:131
 msgid "Accreditation Body URL"
-msgstr ""
+msgstr "URL-адрес органа аккредитации"
 
 #: bika/lims/content/laboratory.py:162
 msgid "Accreditation Logo"
-msgstr ""
+msgstr "Аккредитация логотип"
 
 #: bika/lims/content/laboratory.py:152
 msgid "Accreditation Reference"
-msgstr ""
+msgstr "Сылка на аккредитацию"
 
 #: bika/lims/content/laboratory.py:175
 msgid "Accreditation page header"
-msgstr ""
+msgstr "Заголовок страницы аккредитации"
 
 #: senaite/core/browser/widgets/services_widget.py:323
 msgid "Accredited"
-msgstr ""
+msgstr "Аккредитованные"
 
-#: bika/lims/browser/auditlog.py:92
-#: bika/lims/controlpanel/auditlog.py:95
+#: bika/lims/browser/auditlog.py:92 bika/lims/controlpanel/auditlog.py:95
 msgid "Action"
-msgstr ""
+msgstr "Действие"
 
 #: senaite/core/profiles/default/workflows/senaite_client_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_clientcontact_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_deactivable_type_workflow/definition.xml
 msgid "Activate"
-msgstr ""
+msgstr "Активировать"
 
 #: senaite/core/browser/clients/client/contacts/view.py:85
 #: senaite/core/browser/controlpanel/departments/view.py:88
-#: senaite/core/browser/controlpanel/labels/view.py:71
+#: senaite/core/browser/controlpanel/labels/view.py:70
 msgid "Active"
-msgstr ""
+msgstr "Активные"
 
-#: senaite/core/content/resultsreport.py:52
+#: senaite/core/content/resultsreport.py:51
 msgid "Actor"
-msgstr ""
+msgstr "Исполнитель"
 
-#: senaite/core/content/resultsreport.py:57
+#: senaite/core/content/resultsreport.py:56
 msgid "Actor Fullname"
-msgstr ""
+msgstr "Полное имя исполнителя"
 
 #: senaite/core/browser/clients/client/contacts/view.py:53
 #: senaite/core/browser/controlpanel/departments/view.py:51
-#: senaite/core/browser/controlpanel/labels/view.py:46
+#: senaite/core/browser/controlpanel/labels/view.py:45
 msgid "Add"
-msgstr ""
+msgstr "Добавить"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Add Analyses"
-msgstr ""
+msgstr "Добавить анализ"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:301
 msgid "Add Attachment"
-msgstr ""
+msgstr "Добавить вложение"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Add Blank Reference"
-msgstr ""
+msgstr "Добавление ссылки на бланк"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Add Control Reference"
-msgstr ""
+msgstr "Добавление ссылки на контроль"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Add Duplicate"
-msgstr ""
+msgstr "Добавить повторный"
 
 #: senaite/core/browser/viewlets/templates/add_samples.pt:22
 msgid "Add Samples"
-msgstr ""
+msgstr "Добавить образцы"
 
-#: senaite/core/api/remarks.py:492
-msgid "Add a remark..."
-msgstr ""
-
-#: bika/lims/content/bikasetup.py:461
+#: bika/lims/content/bikasetup.py:460
 msgid "Add a remarks field to all analyses"
-msgstr ""
+msgstr "Добавить замечания ко всем анализам"
 
-#: senaite/core/content/senaitesetup.py:321
+#: senaite/core/content/senaitesetup.py:320
 msgid "Add custom CSS rules for the Logo, e.g. height:15px; width:150px;"
 msgstr ""
+"Добавить пользовательские CSS стили для логотипа, например height:15px; "
+"width:150px;"
 
-#: senaite/core/browser/controlpanel/labels/view.py:53
+#: senaite/core/browser/controlpanel/labels/view.py:52
 msgid "Add default selectable labels"
-msgstr ""
+msgstr "Добавить стандартные метки для выбора"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:205
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:38
 msgid "Add new Attachment"
-msgstr ""
+msgstr "Добавить вложение"
 
 #: bika/lims/content/analysisrequest.py:1026
-msgid "Add one or more attachments to describe the sample in this sample, or to specify your request."
+msgid ""
+"Add one or more attachments to describe the sample in this sample, or to "
+"specify your request."
 msgstr ""
+"Добавьте одно или несколько вложений, чтобы описать этот образец или "
+"уточнить запрос."
 
-#: senaite/core/browser/samples/view.py:879
-msgid "Add or remove labels on the selected samples"
-msgstr ""
-
-#: senaite/core/api/remarks.py:477
+#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:50
+#: senaite/core/z3cform/widgets/remarks/display-input.pt:51
 msgid "Add remarks"
-msgstr ""
+msgstr "Добавить замечания"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:169
 msgid "Add-ons"
-msgstr ""
+msgstr "Дополнения"
 
 #: bika/lims/content/calculation.py:111
 msgid "Additional Python Libraries"
-msgstr ""
+msgstr "Дополнительные библиотеки Python"
 
 #: bika/lims/content/analysisrequest.py:237
 msgid "Additional email addresses to be notified"
-msgstr ""
+msgstr "Дополнительный адрес электронной почты для уведомлений"
 
 #: bika/lims/content/analysisservice.py:117
 msgid "Additional result values"
-msgstr ""
+msgstr "Дополнительные значения результата"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:137
 #: senaite/core/z3cform/widgets/address.py:119
 msgid "Address"
-msgstr ""
+msgstr "Адрес"
 
 #: senaite/core/behaviors/configure.zcml:60
 msgid "Adds the ability to add/remove labels"
-msgstr ""
+msgstr "Добавляет возможность добавлять/удалять метки"
 
 #: senaite/core/behaviors/configure.zcml:49
 msgid "Adds the ability to share a content across clients"
-msgstr ""
+msgstr "Добавляет возможность делиться контентом между клиентами"
 
 #: bika/lims/content/sampletype.py:231
 msgid "Admitted sticker templates"
-msgstr ""
+msgstr "Разрешённые шаблоны стикеров"
 
 #: bika/lims/content/sampletype.py:204
 msgid "Admitted stickers for the sample type"
-msgstr ""
+msgstr "Разрешённые стикеры для типа образца"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:138
 msgid "Advanced"
-msgstr ""
+msgstr "Дополнительно"
 
 #: bika/lims/browser/instrument.py:660
 #: bika/lims/content/instrumentcertification.py:92
 msgid "Agency"
-msgstr ""
+msgstr "Агентство"
 
 #: senaite/core/browser/clients/client/attachments/view.py:87
 #: senaite/core/browser/clients/client/contacts/view.py:95
 #: senaite/core/browser/controlpanel/departments/view.py:98
 msgid "All"
-msgstr ""
+msgstr "Все"
 
 #: bika/lims/browser/accreditation.py:75
 msgid "All Accredited analysis services are listed here."
-msgstr ""
+msgstr "Все аккредитованные услуги на анализ находятся здесь."
 
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:41
 msgid "All Analyses of Service"
-msgstr ""
+msgstr "Все анализы по услугам"
 
-#: senaite/core/browser/samples/view.py:723
+#: senaite/core/browser/samples/view.py:585
 msgid "All analyses assigned"
-msgstr ""
-
-# senaite.app.listing: Column config — empty state when no columns are visible
-msgid "All columns are hidden."
-msgstr ""
+msgstr "Все назначенные анализы "
 
 #: bika/lims/content/abstractbaseanalysis.py:335
 msgid "Allow Manual Detection Limit input"
-msgstr ""
-
-#: bika/lims/content/abstractbaseanalysis.py:728
-msgid "Allow Manual Entry"
-msgstr ""
+msgstr "Разрешить ручной ввод определения лимитов"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:57
 msgid "Allow empty"
-msgstr ""
+msgstr "Разрешить пустое значение"
 
 #: bika/lims/content/abstractbaseanalysis.py:685
 msgid "Allow manual uncertainty value input"
-msgstr ""
+msgstr "Разрешить ручной ввод величины неопределенности"
 
 #: senaite/core/vocabularies/setup.py:175
 msgid "Allow same user to verify multiple times"
-msgstr ""
+msgstr "Разрешить пользователю верифицировать результаты несколько раз"
 
 #: senaite/core/vocabularies/setup.py:177
 msgid "Allow same user to verify multiple times, but not consecutively"
 msgstr ""
+"Разрешить пользователю верифицировать результаты несколько раз, но не "
+"последовательно"
 
-#: bika/lims/content/bikasetup.py:493
+#: bika/lims/content/bikasetup.py:492
 msgid "Allow self-verification of results"
-msgstr ""
+msgstr "Разрешить самопроверку результатов"
 
-#: bika/lims/content/bikasetup.py:190
+#: bika/lims/content/bikasetup.py:189
 msgid "Allow submission of results for unassigned analyses"
-msgstr ""
+msgstr "Разрешить отправку результатов для неназначенных анализов"
 
 #: bika/lims/content/abstractbaseanalysis.py:336
-msgid "Allow the analyst to manually replace the default Detection Limits (LDL and UDL) on results entry views"
+msgid ""
+"Allow the analyst to manually replace the default Detection Limits (LDL and "
+"UDL) on results entry views"
 msgstr ""
+"Разрешить аналитику вручную заменять стандартные пределы обнаружения (LDL и "
+"UDL) при вводе результатов"
 
 #: bika/lims/content/abstractbaseanalysis.py:686
 msgid "Allow the analyst to manually replace the default uncertainty value."
-msgstr ""
+msgstr "Разрешить аналитику изменять величину неопределености вручную."
 
 #: bika/lims/content/abstractbaseanalysis.py:379
 msgid "Allow to introduce analysis results manually"
-msgstr ""
+msgstr "Разрешить вводить результаты анализов вручную"
 
 #: senaite/core/exportimport/instruments/importer.py:371
 msgid "Allowed analysis states: {allowed_states}, "
-msgstr ""
+msgstr "Допустимые статусы анализа: {allowed_states}, "
 
 #: senaite/core/exportimport/instruments/importer.py:368
 msgid "Allowed sample states: {allowed_states}, "
-msgstr ""
+msgstr "Допустимые статусы образца: {allowed_states}, "
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:60
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:60
 msgid "Analysed by"
-msgstr ""
+msgstr "Анализ выполнен"
 
-#: senaite/core/browser/dashboard/dashboard.py:506
-#: senaite/core/browser/samples/view.py:248
+#: senaite/core/browser/dashboard/dashboard.py:459
 #: senaite/core/browser/viewlets/sampleanalyses.py:33
+#: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:118
 msgid "Analyses"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:485
-msgid "Analyses assigned to a worksheet, awaiting results"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:498
-msgid "Analyses included in a published report"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:480
-msgid "Analyses not yet assigned to a worksheet"
-msgstr ""
+msgstr "Анализы"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:132
 msgid "Analyses requested"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:494
-msgid "Analyses that have been verified"
-msgstr ""
+msgstr "Запрошенные анализы"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:66
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:40
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:78
 msgid "Analysis"
-msgstr ""
+msgstr "Анализ"
 
 #: senaite/core/exportimport/instruments/importer.py:657
-msgid "Analysis '{keyword}' of sample '{sid}' has the result '{result}' set, which is kept due to the selected override option"
+msgid ""
+"Analysis '{keyword}' of sample '{sid}' has the result '{result}' set, which "
+"is kept due to the selected override option"
 msgstr ""
+"Для анализа '{keyword}' образца '{sid}' установлен результат '{result}', "
+"который сохранён благодаря выбранной опции перезаписи"
 
 #: bika/lims/content/abstractbaseanalysis.py:362
 msgid "Analysis Keyword"
-msgstr ""
+msgstr "Ключевые слова исследования"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:93
 #: bika/lims/profiles/default/types/Client.xml
 msgid "Analysis Profiles"
-msgstr ""
+msgstr "Анализы: Профили"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:22
 msgid "Analysis Report"
-msgstr ""
+msgstr "Отчёт по анализу"
 
 #: bika/lims/browser/publish/reports_listing.py:55
 #: bika/lims/profiles/default/types/Client.xml
 msgid "Analysis Reports"
-msgstr ""
+msgstr "Отчёты по анализам"
 
 #: bika/lims/browser/publish/emailview.py:310
 msgid "Analysis Results for {}"
-msgstr ""
+msgstr "Результаты анализов для {}"
 
 #: bika/lims/browser/fields/referenceresultsfield.py:34
 #: bika/lims/browser/fields/resultrangefield.py:33
 #: bika/lims/browser/referencesample.py:222
 msgid "Analysis Service"
-msgstr ""
+msgstr "Услуга по анализам"
 
-#: bika/lims/config.py:61
-#: bika/lims/controlpanel/bika_analysisservices.py:149
+#: bika/lims/config.py:61 bika/lims/controlpanel/bika_analysisservices.py:149
 #: bika/lims/profiles/default/types/AnalysisServices.xml
 msgid "Analysis Services"
-msgstr ""
+msgstr "Анализы: Услуги"
 
 #: bika/lims/controlpanel/bika_analysisspecs.py:76
 #: bika/lims/profiles/default/types/AnalysisSpec.xml
 msgid "Analysis Specification"
-msgstr ""
+msgstr "Спецификация анализа"
 
 #: bika/lims/controlpanel/bika_analysisspecs.py:64
 #: bika/lims/profiles/default/types/AnalysisSpecs.xml
 #: bika/lims/profiles/default/types/Client.xml
 msgid "Analysis Specifications"
-msgstr ""
+msgstr "Анализы: Спецификации"
 
 #: bika/lims/content/worksheettemplate.py:56
 msgid "Analysis Type"
-msgstr ""
+msgstr "Тип анализа"
 
 #: bika/lims/content/analysisservice.py:266
 msgid "Analysis conditions"
-msgstr ""
+msgstr "Условия анализа"
 
 #: senaite/core/browser/modals/conditions.py:165
 msgid "Analysis conditions updated: {}"
-msgstr ""
+msgstr "Обновление условий анализа: {}"
 
-#: bika/lims/content/bikasetup.py:412
+#: bika/lims/content/bikasetup.py:411
 msgid "Analysis specifications which are edited directly on the Sample."
-msgstr ""
+msgstr "Спецификации анализа, редактируемые непосредственно в образце."
 
 #: senaite/core/content/interpretationtemplate.py:59
 msgid "Analysis templates"
-msgstr ""
+msgstr "Шаблоны анализов"
 
 #: senaite/core/profiles/default/types/AnalysisCategories.xml
 msgid "AnalysisCategories"
-msgstr ""
+msgstr "Категории анализов"
 
 #: senaite/core/profiles/default/types/AnalysisCategory.xml
 msgid "AnalysisCategory"
-msgstr ""
+msgstr "Категория анализа"
 
 #: senaite/core/profiles/default/types/AnalysisProfile.xml
 msgid "AnalysisProfile"
-msgstr ""
+msgstr "Набор анализов"
 
 #: senaite/core/profiles/default/types/AnalysisProfiles.xml
 msgid "AnalysisProfiles"
-msgstr ""
+msgstr "Профили анализов"
 
 #: senaite/core/browser/modals/analysis/schema.py:87
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:35
 msgid "Analyst"
-msgstr ""
+msgstr "Аналитик"
 
 #: bika/lims/browser/worksheet/views/add_worksheet.py:42
 msgid "Analyst must be specified."
-msgstr ""
+msgstr "Необходимо указать аналитика."
 
 #: bika/lims/browser/fields/partitionsetupfield.py:57
 msgid "Any"
-msgstr ""
+msgstr "Любое"
 
-#: senaite/core/content/senaitesetup.py:1345
+#: senaite/core/content/senaitesetup.py:1322
 msgid "Appearance"
-msgstr ""
+msgstr "Внешний вид"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:217
 msgid "Apply"
-msgstr ""
+msgstr "Применить"
 
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:52
 msgid "Apply template"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — apply button tooltip
-msgid "Apply this filter"
-msgstr ""
+msgstr "Применить шаблон"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:61
 msgid "Apply wide"
-msgstr ""
+msgstr "Применить ко всем"
 
 #: bika/lims/content/instrument.py:308
 msgid "Asset Number"
-msgstr ""
+msgstr "Инвентарный номер"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Assign"
-msgstr ""
+msgstr "Назначить"
 
-#: senaite/core/browser/dashboard/dashboard.py:147
-#: senaite/core/browser/samples/view.py:443
+#: senaite/core/browser/samples/view.py:413
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
+#: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Assigned"
-msgstr ""
+msgstr "Назначен"
 
-#: bika/lims/browser/analyses/view.py:1666
+#: bika/lims/browser/analyses/view.py:1665
 msgid "Assigned to: ${worksheet_id}"
-msgstr ""
+msgstr "Назначено на: ${worksheet_id}"
+
+#: senaite/core/browser/dashboard/dashboard.py:122
+msgid "Assignment pending"
+msgstr "Назначение ожидается"
 
 #: bika/lims/validators.py:465
 msgid "At least, two options for choices field are required"
-msgstr ""
+msgstr "Для поля выбора требуется минимум два варианта"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:244
 msgid "Attach to Sample"
-msgstr ""
+msgstr "Приложить к Образцу"
 
 #: senaite/core/exportimport/instruments/importer.py:815
 msgid "Attached file '{filename}' to worksheet {worksheet}"
-msgstr ""
+msgstr "К рабочему листу {worksheet} прикреплён файл '{filename}'"
 
-#: senaite/core/extender/label.py:62
+#: senaite/core/extender/label.py:58
 msgid "Attached labels"
-msgstr ""
+msgstr "Прикреплённые метки"
 
 #: senaite/core/exportimport/instruments/importer.py:854
 msgid "Attaching '{attachment}' to Analysis '{analysis}'"
-msgstr ""
+msgstr "Прикрепление '{attachment}' к анализу '{analysis}'"
 
 #: bika/lims/content/analysisrequest.py:1025
-#: bika/lims/content/attachment.py:52
-#: bika/lims/content/samplepoint.py:133
+#: bika/lims/content/attachment.py:52 bika/lims/content/samplepoint.py:133
 msgid "Attachment"
-msgstr ""
+msgstr "Вложение"
 
 #: senaite/core/exportimport/instruments/importer.py:860
 msgid "Attachment '{attachment}' was already linked to analysis {analysis}"
-msgstr ""
+msgstr "Вложение '{attachment}' уже связано с анализом {analysis}"
 
 #: bika/lims/content/attachment.py:91
 msgid "Attachment Keys"
-msgstr ""
+msgstr "Кличи вложения"
 
 #: senaite/core/profiles/default/types/AttachmentType.xml
 msgid "Attachment Type"
-msgstr ""
+msgstr "Тип вложения"
 
 #: senaite/core/profiles/default/types/AttachmentTypes.xml
 msgid "Attachment Types"
-msgstr ""
+msgstr "Типы вложений"
 
 #: senaite/core/browser/attachment/attachment.py:215
 msgid "Attachment added to all '{}' analyses"
-msgstr ""
+msgstr "Приложение добавлено ко всем '{}' анализам "
 
 #: senaite/core/browser/attachment/attachment.py:182
 msgid "Attachment added to analysis '{}'"
-msgstr ""
+msgstr "Приложение добавлено к анализу '{}'"
 
 #: senaite/core/browser/attachment/attachment.py:281
 msgid "Attachment added to the current sample"
-msgstr ""
+msgstr "Приложение добавлено к текущему образцу"
 
 #: senaite/core/browser/widgets/services_widget.py:326
 msgid "Attachment required"
-msgstr ""
+msgstr "Требуется вложение"
 
 #: bika/lims/content/abstractbaseanalysis.py:348
 msgid "Attachment required for verification"
-msgstr ""
+msgstr "Для верификации требуется вложение"
 
 #: senaite/core/browser/attachment/attachment.py:349
 msgid "Attachment(s) deleted"
-msgstr ""
+msgstr "Приложение(я) удалено"
 
 #: senaite/core/browser/attachment/attachment.py:138
 msgid "Attachment(s) updated"
-msgstr ""
+msgstr "Приложение(я) обновлено"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:10
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:10
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:110
 msgid "Attachments"
-msgstr ""
+msgstr "Вложения"
 
 #: senaite/core/profiles/default/actions.xml
 msgid "Audit Log"
-msgstr ""
+msgstr "Журнал аудита"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:215
 msgid "Authorized by"
-msgstr ""
+msgstr "Утверждено"
 
 #: senaite/core/exportimport/import.pt:56
 msgid "Auto Import"
-msgstr ""
+msgstr "Автоматический Импорт"
 
 #: bika/lims/browser/instrument.py:759
 msgid "Auto Import Logs of %s"
-msgstr ""
+msgstr "Журналы автоимпорта для %s"
 
 #: senaite/core/behaviors/configure.zcml:13
 msgid "Auto-Generate ID Behavior for Dexterity Contents"
-msgstr ""
+msgstr "Поведение автогенерации ID для содержимого Dexterity"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Auto-Import Logs"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — star action tooltip
-msgid "Auto-apply on open"
-msgstr ""
+msgstr "Журналы автоматического импорта"
 
 #: bika/lims/content/artemplate.py:241
 msgid "Auto-partition on receive"
-msgstr ""
+msgstr "Автоматическое разделение при приёме"
 
-#: senaite/core/content/senaitesetup.py:1030
+#: senaite/core/content/senaitesetup.py:1007
 msgid "Auto-receive samples"
-msgstr ""
+msgstr "Автоматический приём образцов"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:166
 msgid "Autofill"
-msgstr ""
+msgstr "Автозаполнение"
 
-#: senaite/core/content/senaitesetup.py:1130
+#: senaite/core/content/senaitesetup.py:1107
 msgid "Automatic Sticker Printing"
-msgstr ""
+msgstr "Автоматическая печать стикеров"
 
-#: bika/lims/content/bikasetup.py:162
+#: bika/lims/content/bikasetup.py:161
 msgid "Automatic log-off"
-msgstr ""
+msgstr "Автоматический выход"
 
-#: bika/lims/content/bikasetup.py:476
+#: bika/lims/content/bikasetup.py:475
 msgid "Automatic verification of samples"
-msgstr ""
+msgstr "Автоматическая верификация образцов"
 
 #: bika/lims/content/artemplate.py:242
-msgid "Automatically redirect the user to the partitions creation view when Sample is received."
+msgid ""
+"Automatically redirect the user to the partitions creation view when Sample "
+"is received."
 msgstr ""
+"Автоматически перенаправлять пользователя на создание партиций при приёме "
+"образца."
 
 #: bika/lims/content/analysisservice.py:76
 msgid "Available instruments based on the selected methods."
-msgstr ""
+msgstr "Доступные инструменты на основе выбранных методов."
 
 #: bika/lims/content/analysisservice.py:61
 msgid "Available methods to perform the test"
-msgstr ""
+msgstr "Доступные методы выполнения теста"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print.pt:119
 msgid "Available templates"
-msgstr ""
+msgstr "Доступные шаблоны"
 
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:46
 msgid "Back"
-msgstr ""
+msgstr "Назад"
 
 #: bika/lims/content/organisation.py:154
 msgid "Bank branch"
-msgstr ""
+msgstr "Отделение банка"
 
 #: bika/lims/content/organisation.py:146
 msgid "Bank name"
-msgstr ""
+msgstr "Название банка"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:138
 msgid "Base configuration"
-msgstr ""
+msgstr "Основная конфигурация"
 
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:44
 #: bika/lims/browser/templates/referencesample_analyses.pt:42
 msgid "Basis"
-msgstr ""
+msgstr "Основание"
 
 #: bika/lims/browser/publish/reports_listing.py:76
 #: bika/lims/profiles/default/types/Batch.xml
 #: bika/lims/vocabularies/__init__.py:128
 msgid "Batch"
-msgstr ""
+msgstr "Партия"
 
 #: bika/lims/profiles/default/types/Batch.xml
 msgid "Batch Book"
-msgstr ""
+msgstr "Книга пачек"
 
-#: senaite/core/browser/samples/view.py:186
+#: senaite/core/browser/samples/view.py:174
 msgid "Batch ID"
-msgstr ""
+msgstr "ID Партии"
 
 #: senaite/core/profiles/default/types/BatchLabel.xml
 msgid "Batch Label"
-msgstr ""
+msgstr "Этикетка кейса"
 
 #: senaite/core/profiles/default/types/BatchLabels.xml
 msgid "Batch Labels"
-msgstr ""
+msgstr "Пачка: Этикетки"
 
 #: bika/lims/browser/batchfolder.py:49
 #: bika/lims/profiles/default/types/BatchFolder.xml
 #: bika/lims/profiles/default/types/Client.xml
 msgid "Batches"
-msgstr ""
+msgstr "Партии"
 
 #: bika/lims/browser/viewlets/templates/dynamic_specs_viewlet.pt:19
-msgid "Be aware that the ranges provided in the spreadsheet file from the dynamic specification might override the ranges defined in the Specifications list below."
+msgid ""
+"Be aware that the ranges provided in the spreadsheet file from the dynamic "
+"specification might override the ranges defined in the Specifications list "
+"below."
 msgstr ""
+"Обратите внимание: диапазоны из файла динамической спецификации могут "
+"переопределить диапазоны, указанные в списке спецификаций ниже."
 
 #: bika/lims/browser/viewlets/templates/sample_dynamic_specs_viewlet.pt:19
-msgid "Be aware that the ranges provided in the spreadsheet file from the dynamic specification might override the ranges manually defined in the list below."
+msgid ""
+"Be aware that the ranges provided in the spreadsheet file from the dynamic "
+"specification might override the ranges manually defined in the list below."
 msgstr ""
+"Обратите внимание: диапазоны из файла динамической спецификации могут "
+"переопределить диапазоны, заданные вручную в списке ниже."
 
 #: bika/lims/browser/fields/coordinatefield.py:39
 msgid "Bearing"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:139
-msgid "Biannual"
-msgstr ""
+msgstr "Подшипник"
 
 #: senaite/core/z3cform/widgets/address.py:122
 msgid "Billing address"
-msgstr ""
+msgstr "Адрес для выставления счета"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:593
 msgid "Blank"
-msgstr ""
+msgstr "Бланк"
 
 #: bika/lims/config.py:88
 msgid "Blank QC analyses"
-msgstr ""
+msgstr "Анализы контроля качества (холостые пробы)"
 
 #: bika/lims/controlpanel/bika_instruments.py:80
 msgid "Brand"
-msgstr ""
+msgstr "Производитель(ТМ)"
 
 #: bika/lims/browser/clientfolder.py:90
 msgid "Bulk Discount"
-msgstr ""
+msgstr "Оптовая скидка"
 
-#: bika/lims/content/client.py:77
-#: bika/lims/content/pricelist.py:59
+#: bika/lims/content/client.py:75 bika/lims/content/pricelist.py:59
 msgid "Bulk discount applies"
-msgstr ""
+msgstr "Применяется оптовая скидка"
 
 #: bika/lims/content/abstractbaseanalysis.py:561
 msgid "Bulk price (excluding VAT)"
-msgstr ""
+msgstr "Основная цена (без НДС)"
 
 #: senaite/core/browser/clients/client/contacts/view.py:78
 #: senaite/core/browser/controlpanel/contacts/view.py:66
 msgid "Business Phone"
-msgstr ""
+msgstr "Рабочий телефон "
 
 #: senaite/core/z3cform/widgets/address.py:123
 msgid "Business address"
-msgstr ""
+msgstr "Рабочий адрес"
 
-#: bika/lims/content/abstractbaseanalysis.py:759
+#: bika/lims/content/abstractbaseanalysis.py:756
 msgid "By 'Display Value' ascending"
-msgstr ""
-
-#: bika/lims/content/abstractbaseanalysis.py:760
-msgid "By 'Display Value' descending"
-msgstr ""
+msgstr "По 'Отображаемому значению' по возрастанию"
 
 #: bika/lims/content/abstractbaseanalysis.py:757
-msgid "By 'Result Value' ascending"
-msgstr ""
+msgid "By 'Display Value' descending"
+msgstr "По 'Отображаемому значению' по убыванию"
 
-#: bika/lims/content/abstractbaseanalysis.py:758
+#: bika/lims/content/abstractbaseanalysis.py:754
+msgid "By 'Result Value' ascending"
+msgstr "По 'Значению результата' по возрастанию"
+
+#: bika/lims/content/abstractbaseanalysis.py:755
 msgid "By 'Result Value' descending"
-msgstr ""
+msgstr "По 'Значению результата' по убыванию"
 
 #: bika/lims/content/analysisrequest.py:348
 msgid "CBID"
-msgstr ""
+msgstr "CBID"
 
-#: bika/lims/content/client.py:133
+#: bika/lims/content/client.py:129
 msgid "CC Contacts"
-msgstr ""
+msgstr "Контакты для копии (CC)"
 
-#: bika/lims/content/analysisrequest.py:236
-#: bika/lims/content/client.py:166
+#: bika/lims/content/analysisrequest.py:236 bika/lims/content/client.py:162
 msgid "CC Emails"
-msgstr ""
+msgstr "Копия Emails"
 
 #: bika/lims/content/abstractbaseanalysis.py:663
 msgid "Calculate Precision from Uncertainties"
-msgstr ""
+msgstr "Рассчитать точность на основе неопределённостей"
 
 #: senaite/core/profiles/default/types/Calculation.xml
 msgid "Calculation"
-msgstr ""
+msgstr "Калькуляция"
 
 #: senaite/core/browser/form/adapters/method.py:100
 msgid "Calculation '{}' is used by service '{}'"
-msgstr ""
+msgstr "Калькуляция '{}' используется службой '{}'"
 
 #: bika/lims/content/calculation.py:132
 msgid "Calculation Formula"
-msgstr ""
+msgstr "Формула вычисления"
 
 #: bika/lims/content/abstractanalysis.py:182
 #: bika/lims/content/calculation.py:59
 msgid "Calculation Interim Fields"
-msgstr ""
+msgstr "Расчет временных полей"
 
 #: bika/lims/content/analysisservice.py:106
 msgid "Calculation to be assigned to this content."
-msgstr ""
+msgstr "Формула расчёта, назначаемая этому содержимому."
 
 #: senaite/core/profiles/default/types/Calculations.xml
 msgid "Calculations"
-msgstr ""
+msgstr "Вычисления"
 
 #: bika/lims/content/instrumentscheduledtask.py:118
 msgid "Calibration"
-msgstr ""
+msgstr "Калибровка"
 
 #: bika/lims/browser/instrument.py:637
 #: bika/lims/browser/templates/instrument_certifications.pt:40
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Calibration Certificates"
-msgstr ""
+msgstr "Сертификаты калибровки"
 
 #: bika/lims/content/instrumentcalibration.py:69
 msgid "Calibration report date"
-msgstr ""
+msgstr "Дата отчёта о калибровке"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Calibrations"
-msgstr ""
+msgstr "Калибровка"
 
 #: bika/lims/browser/instrument.py:221
 #: bika/lims/content/instrumentcalibration.py:96
 msgid "Calibrator"
-msgstr ""
+msgstr "Калибровщик"
 
-#: bika/lims/browser/analyses/view.py:1614
+#: bika/lims/browser/analyses/view.py:1613
 msgid "Can verify, but submitted by current user"
-msgstr ""
+msgstr "Можно верифицировать, но отправлено текущим пользователем"
 
-#: bika/lims/browser/analyses/view.py:1638
+#: bika/lims/browser/analyses/view.py:1637
 msgid "Can verify, but was already verified by current user"
-msgstr ""
+msgstr "Можно верифицировать, но уже верифицировано текущим пользователем"
 
-#: senaite/core/api/remarks.py:479
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:155
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:83
+#: senaite/core/browser/samples/templates/invalidate_samples.pt:158
 msgid "Cancel"
-msgstr ""
+msgstr "Отменить"
 
 #: senaite/core/browser/samples/dispatch_samples.py:70
-#: senaite/core/browser/samples/dispose_samples.py:70
-#: senaite/core/browser/samples/view.py:403
+#: senaite/core/browser/samples/view.py:373
+#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Cancelled"
-msgstr ""
+msgstr "Отменено"
 
 #: bika/lims/content/calculation.py:460
-msgid "Cannot activate calculation, because the following service dependencies are inactive: ${inactive_services}"
+msgid ""
+"Cannot activate calculation, because the following service dependencies are "
+"inactive: ${inactive_services}"
 msgstr ""
+"Не удается активировать расчет, так как следующие зависимости услуг являются"
+" неактивными: ${inactive_services}"
 
 #: bika/lims/content/calculation.py:480
-msgid "Cannot deactivate calculation, because it is in use by the following services: ${calc_services}"
+msgid ""
+"Cannot deactivate calculation, because it is in use by the following "
+"services: ${calc_services}"
 msgstr ""
+"Не удается отключить вычисление, так как он используется следующими "
+"услугами: ${calc_services}"
 
 #: senaite/core/browser/samples/invalidate_samples.py:93
 msgid "Cannot invalidate ${sample_id}: ${error}"
-msgstr ""
+msgstr "Невозможно аннулировать ${sample_id}: ${error}"
 
 #: senaite/core/browser/samples/invalidate_samples.py:262
 msgid "Cannot send email for ${sample_id}: ${error}"
-msgstr ""
+msgstr "Невозможно отправить письмо для ${sample_id}: ${error}"
 
-#: bika/lims/browser/analyses/view.py:1644
+#: bika/lims/browser/analyses/view.py:1643
 msgid "Cannot verify, last verified by current user"
 msgstr ""
+"Нельзя верифицировать: последняя верификация выполнена текущим пользователем"
 
-#: bika/lims/browser/analyses/view.py:1620
+#: bika/lims/browser/analyses/view.py:1619
 msgid "Cannot verify, submitted by current user"
-msgstr ""
+msgstr "Нельзя верифицировать: отправлено текущим пользователем"
 
-#: bika/lims/browser/analyses/view.py:1629
+#: bika/lims/browser/analyses/view.py:1628
 msgid "Cannot verify, was verified by current user"
-msgstr ""
+msgstr "Нельзя верифицировать: уже верифицировано текущим пользователем"
 
 #: senaite/core/content/samplecontainer.py:78
 msgid "Capacity"
-msgstr ""
+msgstr "Емкость"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:112
 msgid "Captured"
-msgstr ""
+msgstr "Зафиксировано"
 
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:45
 #: bika/lims/browser/templates/referencesample_analyses.pt:43
 msgid "Cardinal"
-msgstr ""
+msgstr "Кардинальное"
 
 #: senaite/core/behaviors/configure.zcml:26
 msgid "Catalog Dexterity contents in multiple catalogs"
-msgstr ""
+msgstr "Индексировать содержимое Dexterity в нескольких каталогах"
 
 #: bika/lims/browser/templates/referencesample_view.pt:57
 #: bika/lims/content/referencesample.py:151
 msgid "Catalogue Number"
-msgstr ""
+msgstr "Номер по каталогу"
 
-#: bika/lims/content/bikasetup.py:355
+#: bika/lims/content/bikasetup.py:354
 msgid "Categorise analysis services"
-msgstr ""
+msgstr "Категоризация аналитических услуг"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:59
 #: bika/lims/browser/worksheet/views/add_analyses.py:107
 #: bika/lims/controlpanel/bika_analysisservices.py:179
 msgid "Category"
-msgstr ""
+msgstr "Категория"
 
 #: bika/lims/content/analysiscategory.py:118
 msgid "Category cannot be deactivated because it contains Analysis Services"
 msgstr ""
+"Категория нельзя отключить, поскольку она содержит службы Analysis Services"
 
 #: bika/lims/browser/instrument.py:659
 msgid "Cert. Num"
-msgstr ""
+msgstr "№ сертификата"
 
 #: bika/lims/content/instrumentcertification.py:209
 msgid "Certificate Code"
-msgstr ""
+msgstr "Код сертификата"
 
-#: bika/lims/browser/auditlog.py:96
-#: bika/lims/controlpanel/auditlog.py:103
+#: bika/lims/browser/auditlog.py:96 bika/lims/controlpanel/auditlog.py:103
 msgid "Changes"
-msgstr ""
+msgstr "Изменения"
 
 #: senaite/core/browser/viewlets/resultsinterpretation.py:64
 msgid "Changes Saved"
-msgstr ""
+msgstr "Изменения Сохранены"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:104
-#: senaite/core/browser/viewlets/sampleheader.py:125
+#: senaite/core/browser/viewlets/sampleheader.py:114
 msgid "Changes saved."
-msgstr ""
+msgstr "Изменения сохранены."
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:100
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:99
 msgid "Changes will be propagated to partitions"
-msgstr ""
+msgstr "Изменения будут применены к субпробам"
 
 #: bika/lims/content/method.py:67
 msgid "Check if the method has been accredited"
-msgstr ""
+msgstr "Метод аккредитован"
 
 #: bika/lims/content/abstractbaseanalysis.py:495
-msgid "Check this box if the analysis service is included in the laboratory's schedule of accredited analyses"
+msgid ""
+"Check this box if the analysis service is included in the laboratory's "
+"schedule of accredited analyses"
 msgstr ""
+"Пометить этот квадрат, если анализ включен в список аккредитованных анализов"
+" лаборатории "
 
 #: bika/lims/content/samplepoint.py:122
-msgid "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
+msgid ""
+"Check this box if the samples taken at this point are 'composite' and put "
+"together from more than one sub sample, e.g. several surface samples from a "
+"dam mixed together to be a representative sample for the dam. The default, "
+"unchecked, indicates 'grab' samples"
 msgstr ""
+"Установите этот флажок, если проб, взятых в данный момент «композиционных» и"
+" положить вместе с более чем одной суб выборки, например несколько "
+"поверхности образцов от плотины смешиваться быть репрезентативной для "
+"плотины. По умолчанию флажок не установлен, указывает захватить образцов"
 
 #: senaite/core/content/samplecontainer.py:86
-msgid "Check this box if this container is already preserved.Setting this will short-circuit the preservation workflow for sample partitions stored in this container."
+msgid ""
+"Check this box if this container is already preserved.Setting this will "
+"short-circuit the preservation workflow for sample partitions stored in this"
+" container."
 msgstr ""
+"Установите этот флажок, если этот контейнер уже сохранен. Установка этого "
+"флажка сократит рабочий процесс сохранения для разделов образцов, хранящихся"
+" в этом контейнере."
 
 #: bika/lims/content/laboratory.py:112
 msgid "Check this box if your laboratory is accredited"
-msgstr ""
+msgstr "Этот флажок, если ваша лаборатория аккредитована"
 
 #: bika/lims/content/analysisservice.py:130
-msgid "Check this box to ensure a separate sample container is used for this analysis service"
+msgid ""
+"Check this box to ensure a separate sample container is used for this "
+"analysis service"
 msgstr ""
+"Отметьте, чтобы для этого анализа использовался отдельный контейнер образца"
 
 #: bika/lims/content/analysisservice.py:260
 msgid "Checkbox"
-msgstr ""
+msgstr "Флажок"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:55
 #: bika/lims/content/analysisservice.py:223
 msgid "Choices"
-msgstr ""
+msgstr "Варианты"
 
-#: senaite/core/content/senaitesetup.py:1174
-msgid "Choose the default template for 'large' stickers. Note: Sample-specific 'large' stickers are configured based on their sample type."
+#: senaite/core/content/senaitesetup.py:1151
+msgid ""
+"Choose the default template for 'large' stickers. Note: Sample-specific "
+"'large' stickers are configured based on their sample type."
 msgstr ""
+"Выберите шаблон по умолчанию для 'больших' стикеров. Примечание: стикеры для"
+" конкретных образцов настраиваются по типу образца."
 
-#: bika/lims/content/bikasetup.py:1038
-msgid "Choose the default template for 'large' stickers.<br/><strong>Note:</strong> Sample-specific 'large' stickers are configured based on their sample type."
+#: bika/lims/content/bikasetup.py:1037
+msgid ""
+"Choose the default template for 'large' stickers.<br/><strong>Note:</strong>"
+" Sample-specific 'large' stickers are configured based on their sample type."
 msgstr ""
+"Выберите шаблон по умолчанию для 'больших' "
+"стикеров.<br/><strong>Примечание:</strong> стикеры для конкретных образцов "
+"настраиваются по типу образца."
 
-#: senaite/core/content/senaitesetup.py:1162
-msgid "Choose the default template for 'small' stickers. Note: Sample-specific 'small' stickers are configured based on their sample type."
+#: senaite/core/content/senaitesetup.py:1139
+msgid ""
+"Choose the default template for 'small' stickers. Note: Sample-specific "
+"'small' stickers are configured based on their sample type."
 msgstr ""
+"Выберите шаблон по умолчанию для 'малых' стикеров. Примечание: стикеры для "
+"конкретных образцов настраиваются по типу образца."
 
-#: bika/lims/content/bikasetup.py:1019
-msgid "Choose the default template for 'small' stickers.<br/><strong>Note:</strong> Sample-specific 'small' stickers are configured based on their sample type."
+#: bika/lims/content/bikasetup.py:1018
+msgid ""
+"Choose the default template for 'small' stickers.<br/><strong>Note:</strong>"
+" Sample-specific 'small' stickers are configured based on their sample type."
 msgstr ""
+"Выберите шаблон по умолчанию для 'малых' "
+"стикеров.<br/><strong>Примечание:</strong> стикеры для конкретных образцов "
+"настраиваются по типу образца."
 
-#: bika/lims/content/bikasetup.py:530
-msgid "Choose type of multiple verification for the same user.This setting can enable/disable verifying/consecutively verifyingmore than once for the same user."
+#: bika/lims/content/bikasetup.py:529
+msgid ""
+"Choose type of multiple verification for the same user.This setting can "
+"enable/disable verifying/consecutively verifyingmore than once for the same "
+"user."
 msgstr ""
+"Выберите тип многократной верификации для одного пользователя. Этот параметр"
+" включает/отключает повторную верификацию одним и тем же пользователем."
 
-#: bika/lims/content/bikasetup.py:977
-msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed  automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
+#: bika/lims/content/bikasetup.py:976
+msgid ""
+"Choose when stickers should be automatically "
+"printed:<br/><ul><li><strong>Register:</strong> Stickers are printed  "
+"automatically when new samples are "
+"created.</li><li><strong>Receive:</strong> Stickers are printed  "
+"automatically when samples are received.</li><li><strong>None:</strong> "
+"Disables automatic sticker printing.</li></ul>"
 msgstr ""
+"Выберите, когда стикеры должны печататься "
+"автоматически:<br/><ul><li><strong>Регистрация:</strong> стикеры печатаются "
+"автоматически при создании новых образцов.</li><li><strong>Приём:</strong> "
+"стикеры печатаются автоматически при приёме "
+"образцов.</li><li><strong>Нет:</strong> отключает автоматическую печать "
+"стикеров.</li></ul>"
 
-#: senaite/core/content/senaitesetup.py:1131
-msgid "Choose when stickers should be automatically printed:<br/><ul><li><strong>Register:</strong> Stickers are printed automatically when new samples are created.</li><li><strong>Receive:</strong> Stickers are printed automatically when samples are received.</li><li><strong>None:</strong> Disables automatic sticker printing.</li></ul>"
+#: senaite/core/content/senaitesetup.py:1108
+msgid ""
+"Choose when stickers should be automatically "
+"printed:<br/><ul><li><strong>Register:</strong> Stickers are printed "
+"automatically when new samples are "
+"created.</li><li><strong>Receive:</strong> Stickers are printed "
+"automatically when samples are received.</li><li><strong>None:</strong> "
+"Disables automatic sticker printing.</li></ul>"
 msgstr ""
+"Выберите, когда стикеры должны печататься "
+"автоматически:<br/><ul><li><strong>Регистрация:</strong> стикеры печатаются "
+"автоматически при создании новых образцов.</li><li><strong>Приём:</strong> "
+"стикеры печатаются автоматически при приёме "
+"образцов.</li><li><strong>Нет:</strong> отключает автоматическую печать "
+"стикеров.</li></ul>"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:113
 #: senaite/core/z3cform/widgets/address.py:225
 msgid "City"
-msgstr ""
+msgstr "Город"
 
 #: bika/lims/config.py:125
 msgid "Classic"
-msgstr ""
-
-# senaite.app.listing: Column-filter row — clear button tooltip
-msgid "Clear filter"
-msgstr ""
-
-# senaite.app.listing: Search box — undo button tooltip when only clearing
-# search
-msgid "Clear search"
-msgstr ""
+msgstr "Классический"
 
 # senaite.app.listing: ButtonBar
 msgid "Clear selection"
-msgstr ""
+msgstr "Сбросить выделение"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:542
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:533
 msgid "Click to expand this category"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — release button tooltip on the
-# applied preset
-msgid "Click to release this filter"
-msgstr ""
+msgstr "Нажмите, чтобы развернуть эту категорию"
 
 # senaite.app.listing: TableColumnConfig
 msgid "Click to toggle the visibility or drag&drop to change the order"
 msgstr ""
+"Нажмите, чтобы переключить видимость, или перетащите для изменения порядка"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:79
-#: senaite/core/browser/samples/view.py:191
+#: senaite/core/browser/samples/view.py:179
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:566
 msgid "Client"
-msgstr ""
+msgstr "Клиент"
 
-#: bika/lims/browser/batchfolder.py:84
-#: bika/lims/content/batch.py:101
+#: bika/lims/browser/batchfolder.py:84 bika/lims/content/batch.py:101
 msgid "Client Batch ID"
-msgstr ""
+msgstr "ID партии клиента"
 
 #: senaite/core/behaviors/clientshareable.py:90
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:83
-#: senaite/core/browser/samples/view.py:196
+#: senaite/core/browser/samples/view.py:184
 msgid "Client ID"
-msgstr ""
+msgstr "ID клиента"
 
 #: bika/lims/profiles/default/registry.xml
 msgid "Client Landing Page"
-msgstr ""
+msgstr "Стартовая страница клиента"
 
 #: senaite/core/behaviors/clientshareable.py:85
 msgid "Client Name"
-msgstr ""
+msgstr "Название клиента"
 
-#: senaite/core/browser/samples/view.py:144
+#: senaite/core/browser/samples/view.py:132
 msgid "Client Order"
-msgstr ""
+msgstr "Заказ клиента"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:115
 #: bika/lims/browser/batch/batchbook.py:81
 #: bika/lims/content/analysisrequest.py:817
 msgid "Client Order Number"
-msgstr ""
+msgstr "Номер заказа клиента"
 
-#: senaite/core/browser/samples/view.py:201
+#: senaite/core/browser/samples/view.py:189
 msgid "Client Ref"
-msgstr ""
+msgstr "Ссылка Клиента"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:66
 #: bika/lims/content/analysisrequest.py:834
 msgid "Client Reference"
-msgstr ""
+msgstr "Ссылка клиента "
 
-#: senaite/core/browser/samples/view.py:206
+#: senaite/core/browser/samples/view.py:194
 msgid "Client SID"
-msgstr ""
+msgstr "SID Клиента"
 
 #: bika/lims/content/analysisrequest.py:851
 msgid "Client Sample ID"
-msgstr ""
+msgstr "ID образца клиента"
 
 #: senaite/core/registry/schema.py:39
 msgid "Client Settings"
-msgstr ""
+msgstr "Настройки клиента"
 
 #: senaite/core/behaviors/configure.zcml:49
 msgid "ClientShareableBehavior"
-msgstr ""
+msgstr "ClientShareableBehavior"
 
 #: senaite/core/behaviors/clientshareable.py:58
 msgid "Clients"
-msgstr ""
+msgstr "Клиенты"
 
 #: senaite/core/behaviors/clientshareable.py:59
-msgid "Clients with whom this content will be shared across. This content will become available on searches to users that belong to any of the selected clients thanks to the role 'ClientGuest'"
+msgid ""
+"Clients with whom this content will be shared across. This content will "
+"become available on searches to users that belong to any of the selected "
+"clients thanks to the role 'ClientGuest'"
 msgstr ""
+"Клиенты, с которыми будет осуществляться обмен этим содержимым. Этот контент"
+" станет доступен при поиске для пользователей, принадлежащих к любому из "
+"выбранных клиентов, благодаря роли 'ClientGuest'."
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:13
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 msgid "Close"
-msgstr ""
+msgstr "Закрыть"
 
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 msgid "Closed"
-msgstr ""
+msgstr "Закрытые"
 
 #: bika/lims/content/storagelocation.py:59
 msgid "Code for the location"
-msgstr ""
+msgstr "Код местоположения"
 
 #: bika/lims/content/storagelocation.py:44
 msgid "Code for the site"
-msgstr ""
+msgstr "Код площадки"
 
 #: bika/lims/content/storagelocation.py:79
 msgid "Code the the shelf"
-msgstr ""
+msgstr "Код стеллажа"
 
 #: senaite/core/registry/schema.py:133
 msgid "Collapse field analysis table"
-msgstr ""
+msgstr "Свернуть таблицу полевых анализов"
 
 #: senaite/core/registry/schema.py:134
 msgid "Collapse field analysis table in sample view"
-msgstr ""
+msgstr "Сворачивать таблицу полевых анализов в просмотре образца"
 
 #: senaite/core/registry/schema.py:140
 msgid "Collapse lab analysis table"
-msgstr ""
+msgstr "Свернуть таблицу лабораторных анализов"
 
 #: senaite/core/registry/schema.py:141
 msgid "Collapse lab analysis table in sample view"
-msgstr ""
+msgstr "Сворачивать таблицу лабораторных анализов в просмотре образца"
 
 #: senaite/core/registry/schema.py:147
 msgid "Collapse qc analysis table"
-msgstr ""
+msgstr "Свернуть таблицу анализов контроля качества"
 
 #: senaite/core/registry/schema.py:148
 msgid "Collapse qc analysis table in sample view"
-msgstr ""
+msgstr "Сворачивать таблицу анализов контроля качества в просмотре образца"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:117
 msgid "Collected"
-msgstr ""
+msgstr "Собрано"
 
 #: senaite/core/content/dynamicanalysisspec.py:94
 msgid "Column '{}' is missing"
-msgstr ""
+msgstr "Отсутствует столбец '{}'"
 
 #: senaite/core/content/dynamicanalysisspec.py:88
-msgid "Column {} of the header row has no name. Please remove empty columns from the spreadsheet and upload it again."
+msgid ""
+"Column {} of the header row has no name. Please remove empty columns from "
+"the spreadsheet and upload it again."
 msgstr ""
+"Столбец {} строки заголовка не имеет имени. Удалите пустые столбцы из "
+"таблицы и загрузите её снова."
 
 #: senaite/core/vocabularies/setup.py:114
 msgid "Comma (,)"
-msgstr ""
+msgstr "Запятая (,)"
 
 #: bika/lims/content/analysiscategory.py:51
 msgid "Comments"
-msgstr ""
+msgstr "Комментарии"
 
 #: bika/lims/content/analysisrequest.py:1368
 msgid "Comments or results interpretation"
-msgstr ""
+msgstr "Комментарии или интерпретация результатов"
 
-#: bika/lims/content/abstractbaseanalysis.py:856
+#: bika/lims/content/abstractbaseanalysis.py:853
 #: bika/lims/content/analysisprofile.py:91
 msgid "Commercial ID"
-msgstr ""
+msgstr "Коммерческий ID"
 
 #: bika/lims/content/analysisrequest.py:957
 #: bika/lims/content/samplepoint.py:121
 msgid "Composite"
-msgstr ""
+msgstr "Составной"
 
 #: bika/lims/content/artemplate.py:109
 msgid "Composite sample"
-msgstr ""
+msgstr "Составной образец"
 
 #: bika/lims/content/analysisservice.py:267
-msgid "Conditions to ask for this analysis on sample registration. For instance, laboratory may want the user to input the temperature, the ramp and flow when a thermogravimetric (TGA) analysis is selected on sample registration. The information provided will be later considered by the laboratory personnel when performing the test."
+msgid ""
+"Conditions to ask for this analysis on sample registration. For instance, "
+"laboratory may want the user to input the temperature, the ramp and flow "
+"when a thermogravimetric (TGA) analysis is selected on sample registration. "
+"The information provided will be later considered by the laboratory "
+"personnel when performing the test."
 msgstr ""
+"Условия, запрашиваемые для этого анализа при регистрации образца. Например, "
+"лаборатория может запросить у пользователя ввод температуры, скорости "
+"нагрева и потока при выборе термогравиметрического (ТГА) анализа. Указанная "
+"информация будет учтена персоналом лаборатории при выполнении теста."
 
 #: bika/lims/content/laboratory.py:99
 msgid "Confidence Level %"
-msgstr ""
+msgstr "Доверительный интервал%"
 
 # senaite.app.listing: Configuration
 msgid "Configuration"
-msgstr ""
+msgstr "Конфигурация"
 
 #: senaite/core/registry/schema.py:227
 msgid "Configuration for Generic Setup"
-msgstr ""
+msgstr "Конфигурация для Generic Setup"
 
 #: senaite/core/registry/schema.py:161
 msgid "Configuration for the sample header information"
-msgstr ""
+msgstr "Конфигурация для информации в заголовке образца"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:119
 msgid "Configuration restored to default values."
-msgstr ""
-
-# senaite.app.listing: Column config — trigger button label
-msgid "Configure"
-msgstr ""
+msgstr "Конфигурация восстановлена к значениям по умолчанию."
 
 # senaite.app.listing: TableColumnConfig
 msgid "Configure Table Columns"
-msgstr ""
+msgstr "Настроить столбцы таблицы"
 
 #: bika/lims/content/artemplate.py:173
-msgid "Configure the sample partitions and preservations for this template. Assign analyses to the different partitions on the template's Analyses tab"
+msgid ""
+"Configure the sample partitions and preservations for this template. Assign "
+"analyses to the different partitions on the template's Analyses tab"
 msgstr ""
+"Настройте партиции и способы сохранения образца для этого шаблона. Назначьте"
+" анализы разным партициям на вкладке 'Анализы' шаблона"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:253
 msgid "Confirm password"
-msgstr ""
+msgstr "Подтверждение пароля"
 
 #: bika/lims/content/instrumentcalibration.py:107
 #: bika/lims/content/instrumentmaintenancetask.py:93
 #: bika/lims/content/instrumentscheduledtask.py:86
 msgid "Considerations"
-msgstr ""
+msgstr "Замечания"
 
-#: senaite/core/browser/samples/view.py:209
+#: senaite/core/browser/samples/view.py:197
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Contact"
-msgstr ""
+msgstr "Контакт"
 
 #: bika/lims/browser/analysisrequest/add2.py:2066
 msgid "Contact does not belong to the selected client"
-msgstr ""
+msgstr "Контакт не принадлежит выбранному клиенту"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:118
 msgid "Contact is deactivated. User cannot be unlinked."
-msgstr ""
+msgstr "Контакт деактивирован. Пользователь не может быть несвязанными."
 
 #: senaite/core/browser/clients/client/contacts/view.py:65
 #: senaite/core/profiles/default/types/Contacts.xml
 #: senaite/core/profiles/default/types/Supplier.xml
 msgid "Contacts"
-msgstr ""
+msgstr "Контакты"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:72
 msgid "Contained Samples"
-msgstr ""
+msgstr "Содержащиеся образцы"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:175
 msgid "Container"
-msgstr ""
+msgstr "Контейнер"
 
 #: senaite/core/content/samplecontainer.py:70
 #: senaite/core/profiles/default/types/ContainerType.xml
 msgid "Container Type"
-msgstr ""
+msgstr "Тип контейнера"
 
 #: senaite/core/profiles/default/types/ContainerTypes.xml
 msgid "Container Types"
-msgstr ""
+msgstr "Контейнеры: Типы"
 
 #: bika/lims/controlpanel/bika_containers.py:58
 msgid "Containers"
-msgstr ""
+msgstr "Контейнеры"
 
 #: bika/lims/browser/dynamic_analysisspec.py:45
 msgid "Contents of the file {}"
-msgstr ""
+msgstr "Содержимое файла {}"
 
-#: senaite/core/content/senaitesetup.py:224
+#: senaite/core/content/senaitesetup.py:223
 msgid "Context"
-msgstr ""
+msgstr "Контекст"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:590
 msgid "Control"
-msgstr ""
+msgstr "Контроль"
 
 #: bika/lims/config.py:89
 msgid "Control QC analyses"
-msgstr ""
+msgstr "Контрольные анализы контроля качества"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:56
 #: bika/lims/content/analysisservice.py:222
 msgid "Control type"
-msgstr ""
+msgstr "Тип контроля"
 
 #: bika/lims/validators.py:441
 msgid "Control type is not supported for empty choices"
-msgstr ""
+msgstr "Тип контроля не поддерживается для пустых вариантов выбора"
 
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:54
 msgid "Copy"
-msgstr ""
+msgstr "Копировать"
 
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:11
 msgid "Copy analysis services"
-msgstr ""
+msgstr "Копировать услуги анализа"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:49
 msgid "Copy from"
-msgstr ""
+msgstr "Копировать из"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:585
-msgid "Copy the currently displayed column value to the other columns on the right"
-msgstr ""
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:575
+msgid ""
+"Copy the currently displayed column value to the other columns on the right"
+msgstr "Скопировать текущее значение столбца в остальные столбцы справа"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:443
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:434
 msgid "Copy the value of the first sample to the others"
-msgstr ""
+msgstr "Скопировать значение первого образца в остальные"
 
-#: senaite/core/browser/samples/view.py:901
+#: senaite/core/browser/samples/view.py:742
 msgid "Copy to new"
-msgstr ""
+msgstr "Копировать в новый"
 
 #: senaite/core/browser/idserver/view.py:131
 msgid "Could not convert {} value(s) to integer: {}"
-msgstr ""
+msgstr "Не удалось преобразовать значение(-я) {} в целое число: {}"
 
 #: bika/lims/browser/analysisrequest/add2.py:2368
-msgid "Could not create the following sample(s) due to transaction conflicts, please retry them: ${rows}"
+msgid ""
+"Could not create the following sample(s) due to transaction conflicts, "
+"please retry them: ${rows}"
 msgstr ""
-
-#: senaite/core/browser/clients/client/contacts/login_details.py:228
-msgid "Could not link User: ${error}"
-msgstr ""
+"Не удалось создать следующие образцы из-за конфликтов транзакций, повторите "
+"попытку: ${rows}"
 
 #: bika/lims/browser/workflow/client.py:52
 msgid "Could not load PDF for sample {}"
-msgstr ""
+msgstr "Не удалось загрузить PDF для образца {}"
 
 #: bika/lims/browser/publish/emailview.py:558
 msgid "Could not send email to {0} ({1})"
-msgstr ""
+msgstr "Не удалось отправить письмо на {0} ({1})"
 
 #: bika/lims/browser/workflow/analysisrequest.py:217
 msgid "Could not transition samples to the sampled state"
-msgstr ""
+msgstr "Не удалось перевести образцы в статус 'отобрано'"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:103
 msgid "Counter <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Счётчик <span class=\"sort-indicator\" />"
 
-#: senaite/core/content/senaitesetup.py:236
+#: senaite/core/content/senaitesetup.py:235
 msgid "Counter Ref"
-msgstr ""
+msgstr "Ссылка счётчика"
 
-#: senaite/core/content/senaitesetup.py:229
+#: senaite/core/content/senaitesetup.py:228
 msgid "Counter Type"
-msgstr ""
+msgstr "Тип счётчика"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:28
 #: senaite/core/z3cform/widgets/address.py:222
 msgid "Country"
-msgstr ""
+msgstr "Страна"
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Create Invoice PDF"
-msgstr ""
+msgstr "Создать pdf-документ счета"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:264
+#: senaite/core/browser/samples/templates/partition_magic.pt:256
 msgid "Create Partitions"
-msgstr ""
+msgstr "Создать партиции"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:214
 msgid "Create SENAITE Site"
-msgstr ""
+msgstr "Создать сайт SENAITE"
 
-#: senaite/core/browser/samples/view.py:864
+#: senaite/core/browser/samples/view.py:716
 msgid "Create Worksheet"
-msgstr ""
+msgstr "Создать рабочий лист"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:134
 msgid "Create a new SENAITE site"
-msgstr ""
+msgstr "Создать новый сайт SENAITE"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:215
 msgid "Create a new User"
-msgstr ""
+msgstr "Ввести нового пользователя"
 
-#: senaite/core/browser/samples/view.py:868
+#: senaite/core/browser/samples/view.py:720
 msgid "Create a new worksheet for the selected samples"
-msgstr ""
+msgstr "Создайте новый рабочий лист для выбранных образцов"
 
 #: senaite/core/browser/worksheets/templates/view.pt:26
 msgid "Create new worksheet"
-msgstr ""
+msgstr "Создать новый рабочий лист"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Create partitions"
-msgstr ""
+msgstr "Создать партиции"
 
 #: senaite/core/browser/clients/client/attachments/view.py:71
 msgid "Created"
-msgstr ""
+msgstr "Создано"
 
 #: bika/lims/browser/instrument.py:404
 msgid "Created by"
-msgstr ""
+msgstr "Создал(а)"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:46
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:46
 msgid "Created on"
-msgstr ""
+msgstr "Дата создания"
 
 #: senaite/core/browser/samples/partition_magic.py:113
 msgid "Created {} partitions: {}"
-msgstr ""
+msgstr "Создано партиций: {} ({})"
 
 #: senaite/core/browser/clients/client/attachments/view.py:75
-#: senaite/core/browser/samples/view.py:148
+#: senaite/core/browser/samples/view.py:136
 msgid "Creator"
-msgstr ""
+msgstr "Выполнено"
 
 #: bika/lims/browser/instrument.py:403
 #: bika/lims/content/instrumentscheduledtask.py:76
 msgid "Criteria"
-msgstr ""
+msgstr "Критерии"
 
-#: bika/lims/content/bikasetup.py:254
+#: bika/lims/content/bikasetup.py:253
 msgid "Currency"
-msgstr ""
+msgstr "Валюта"
 
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
 msgid "Current"
-msgstr ""
+msgstr "Текущий"
 
-# senaite.app.listing: Saved filter presets — dirty tag hover tooltip
-msgid "Current view differs from saved"
-msgstr ""
-
-#: bika/lims/content/client.py:241
+#: bika/lims/content/client.py:237
 msgid "Custom decimal mark"
-msgstr ""
+msgstr "Пользовательский десятичный разделитель"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:80
 msgid "DL"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:135
-msgid "Daily"
-msgstr ""
+msgstr "ПО"
 
 #: bika/lims/content/instrument.py:222
 msgid "Data Interface"
-msgstr ""
+msgstr "Интерфейс данных"
 
 #: bika/lims/content/instrument.py:291
 msgid "Data Interface Options"
-msgstr ""
+msgstr "Настройки интерфейса данных"
 
 #: senaite/core/browser/form/adapters/data_import.py:72
 msgid "Data import successful"
-msgstr ""
+msgstr "Данные импортированы успешно"
 
-#: bika/lims/browser/batchfolder.py:76
-#: bika/lims/browser/instrument.py:661
+#: bika/lims/browser/batchfolder.py:76 bika/lims/browser/instrument.py:661
 #: bika/lims/content/abstractbaseanalysis.py:700
 msgid "Date"
-msgstr ""
+msgstr "Дата"
 
 #: bika/lims/browser/analyses/view.py:126
 msgid "Date Created"
-msgstr ""
+msgstr "Создан"
 
 #: bika/lims/content/referencesample.py:204
 msgid "Date Disposed"
-msgstr ""
+msgstr "Дата удаления"
 
 #: bika/lims/content/referencesample.py:197
 msgid "Date Expired"
-msgstr ""
+msgstr "Конечная дата"
 
 #: bika/lims/content/attachment.py:100
 msgid "Date Loaded"
-msgstr ""
+msgstr "Дата загрузки"
 
-#: bika/lims/browser/auditlog.py:82
-#: bika/lims/controlpanel/auditlog.py:76
+#: bika/lims/browser/auditlog.py:82 bika/lims/controlpanel/auditlog.py:76
 msgid "Date Modified"
-msgstr ""
+msgstr "Дата изменения"
 
 #: bika/lims/browser/referencesample.py:364
 #: bika/lims/browser/templates/referencesample_sticker.pt:71
 #: bika/lims/browser/templates/referencesample_view.pt:98
 msgid "Date Opened"
-msgstr ""
+msgstr "Дата открытия"
 
-#: senaite/core/browser/samples/view.py:167
+#: senaite/core/browser/samples/view.py:155
 msgid "Date Preserved"
-msgstr ""
+msgstr "Дата Сохранения"
 
-#: senaite/core/content/resultsreport.py:209
+#: senaite/core/content/resultsreport.py:208
 msgid "Date Printed"
-msgstr ""
+msgstr "Напечатан"
 
-#: senaite/core/browser/samples/view.py:183
+#: senaite/core/browser/samples/view.py:171
 msgid "Date Published"
-msgstr ""
+msgstr "Дата публикации"
 
-#: senaite/core/browser/samples/view.py:173
+#: senaite/core/browser/samples/view.py:161
 msgid "Date Received"
-msgstr ""
+msgstr "Дата получения"
 
-#: senaite/core/browser/samples/view.py:153
+#: senaite/core/browser/samples/view.py:141
 msgid "Date Registered"
-msgstr ""
+msgstr "Дата Регистрации"
 
 #: bika/lims/browser/worksheet/views/add_duplicate.py:76
 msgid "Date Requested"
-msgstr ""
+msgstr "Дата запроса"
 
 #: bika/lims/content/analysisrequest.py:1075
 msgid "Date Sample Received"
-msgstr ""
+msgstr "Получен"
 
-#: senaite/core/browser/samples/view.py:161
+#: senaite/core/browser/samples/view.py:149
 msgid "Date Sampled"
-msgstr ""
+msgstr "Дата получения пробы"
 
-#: senaite/core/browser/samples/view.py:179
+#: senaite/core/browser/samples/view.py:167
 msgid "Date Verified"
-msgstr ""
+msgstr "Дата проверки"
 
 #: bika/lims/content/instrumentcalibration.py:79
 msgid "Date from which the instrument is under calibration"
-msgstr ""
+msgstr "Дата, с которой инструмент находится на калибровке"
 
 #: bika/lims/content/instrumentmaintenancetask.py:66
 msgid "Date from which the instrument is under maintenance"
-msgstr ""
+msgstr "Дата, с которой инструмент находится на обслуживании"
 
 #: bika/lims/content/instrumentvalidation.py:61
 msgid "Date from which the instrument is under validation"
-msgstr ""
+msgstr "Дата, с которой инструмент находится на валидации"
 
 #: bika/lims/content/instrumentcertification.py:100
 msgid "Date granted"
-msgstr ""
+msgstr "Дата выдачи"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:112
 msgid "Date received"
-msgstr ""
+msgstr "Дата получения"
 
 #: bika/lims/content/instrumentcertification.py:137
 msgid "Date until the certificate is valid"
-msgstr ""
+msgstr "Дата, до которой сертификат действителен"
 
 #: bika/lims/content/instrumentcalibration.py:89
 #: bika/lims/content/instrumentmaintenancetask.py:76
 #: bika/lims/content/instrumentvalidation.py:71
 msgid "Date until the instrument will not be available"
-msgstr ""
+msgstr "Дата, до которой инструмент будет недоступен"
 
 #: bika/lims/content/instrumentcertification.py:101
 msgid "Date when the calibration certificate was granted"
-msgstr ""
+msgstr "Дата выдачи сертификата калибровки"
 
 #: bika/lims/content/instrumentcertification.py:127
 msgid "Date when the certificate is valid"
-msgstr ""
+msgstr "Дата, на которую сертификат действителен"
 
-#: senaite/core/content/resultsreport.py:210
+#: senaite/core/content/resultsreport.py:209
 msgid "Date when the report was printed"
-msgstr ""
+msgstr "Дата печати отчёта"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:101
 #: bika/lims/content/abstractbaseanalysis.py:701
 msgid "Datetime"
-msgstr ""
+msgstr "Дата и время"
 
 #: bika/lims/browser/fields/durationfield.py:36
 msgid "Days"
-msgstr ""
+msgstr "Дни"
 
 #: bika/lims/content/instrument.py:186
 msgid "De-activate until next calibration test"
-msgstr ""
+msgstr "Деактивировать до следующей калибровки"
 
 #: senaite/core/profiles/default/workflows/senaite_client_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_clientcontact_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_deactivable_type_workflow/definition.xml
 msgid "Deactivate"
-msgstr ""
+msgstr "Отключить"
 
-#: bika/lims/content/client.py:242
+#: bika/lims/content/client.py:238
 msgid "Decimal mark to use in the reports from this Client."
-msgstr ""
+msgstr "Десятичный разделитель, используемый в отчётах для этого клиента."
 
-#: bika/lims/content/client.py:134
-msgid "Default CC contacts for new samples. If set, these contacts are automatically selected in the sample add form."
+#: bika/lims/content/client.py:130
+msgid ""
+"Default CC contacts for new samples. If set, these contacts are "
+"automatically selected in the sample add form."
 msgstr ""
+"Контакты для копии (CC) по умолчанию для новых образцов. Если заданы, они "
+"автоматически выбираются в форме добавления образца."
 
 #: bika/lims/content/analysisservice.py:165
 msgid "Default Container"
-msgstr ""
+msgstr "Контейнер по умолчанию"
 
 #: bika/lims/controlpanel/bika_labcontacts.py:80
 msgid "Default Department"
-msgstr ""
+msgstr "Подразделение по умолчанию"
 
-#: bika/lims/content/client.py:167
+#: bika/lims/content/client.py:163
 msgid "Default Emails to CC all published Samples for this client"
 msgstr ""
+"Email по умолчанию для копии всех опубликованных образцов этого клиента"
 
 #: bika/lims/content/abstractbaseanalysis.py:414
 msgid "Default Instrument"
-msgstr ""
+msgstr "Инструмент по умолчанию"
 
 #: bika/lims/content/abstractbaseanalysis.py:430
 msgid "Default Method"
-msgstr ""
+msgstr "Метод по умолчанию"
 
-#: senaite/core/content/senaitesetup.py:1185
+#: senaite/core/content/senaitesetup.py:1162
 msgid "Default Number of Copies"
-msgstr ""
+msgstr "Количество копий по умолчанию"
 
 #: bika/lims/content/analysisservice.py:145
 msgid "Default Preservation"
-msgstr ""
+msgstr "Способ сохранения по умолчанию"
 
-#: senaite/core/content/senaitesetup.py:1151
+#: senaite/core/content/senaitesetup.py:1128
 msgid "Default Sticker Template"
-msgstr ""
+msgstr "Шаблон стикера по умолчанию"
 
-#: bika/lims/content/client.py:99
-msgid "Default contact for new samples. If set, this contact is automatically selected in the sample add form."
+#: bika/lims/content/client.py:95
+msgid ""
+"Default contact for new samples. If set, this contact is automatically "
+"selected in the sample add form."
 msgstr ""
+"Контакт по умолчанию для новых образцов. Если задан, он автоматически "
+"выбирается в форме добавления образца."
 
-#: bika/lims/content/bikasetup.py:1216
+#: bika/lims/content/bikasetup.py:1215
 msgid "Default count of Sample to add."
-msgstr ""
+msgstr "Количество образцов для добавления по умолчанию."
 
-#: bika/lims/content/bikasetup.py:312
-#: bika/lims/content/client.py:229
+#: bika/lims/content/bikasetup.py:311 bika/lims/content/client.py:225
 msgid "Default decimal mark"
-msgstr ""
+msgstr "Десятичный разделитель по умолчанию"
 
 #: bika/lims/content/abstractbaseanalysis.py:415
 msgid "Default instrument used for analyses of this type"
-msgstr ""
+msgstr "Инструмент по умолчанию для анализов этого типа"
 
 #: bika/lims/content/sampletype.py:208
 msgid "Default large sticker"
-msgstr ""
+msgstr "Большой стикер по умолчанию"
 
-#: bika/lims/content/bikasetup.py:574
+#: bika/lims/content/bikasetup.py:573
 msgid "Default layout in worksheet view"
-msgstr ""
+msgstr "Макет по умолчанию в просмотре рабочего листа"
 
 #: bika/lims/content/abstractbaseanalysis.py:431
 msgid "Default method used for analyses of this type"
-msgstr ""
+msgstr "Метод по умолчанию для анализов этого типа"
 
 #: senaite/core/registry/schema.py:110
 msgid "Default printing templates order for worksheet"
-msgstr ""
+msgstr "Порядок шаблонов печати по умолчанию для рабочего листа"
 
 #: bika/lims/content/analysisservice.py:195
 msgid "Default result"
-msgstr ""
+msgstr "Результат по умолчанию"
 
 #: bika/lims/validators.py:1379
 msgid "Default result is not a valid date"
-msgstr ""
+msgstr "Результат по умолчанию не является допустимой датой"
 
 #: bika/lims/validators.py:1383
 msgid "Default result is not numeric"
-msgstr ""
+msgstr "Результат по умолчанию не является числом"
 
 #: bika/lims/validators.py:1389
 msgid "Default result must be one of the following result options: {}"
-msgstr ""
+msgstr "Результат по умолчанию должен быть одним из следующих вариантов: {}"
 
 #: bika/lims/content/analysisservice.py:196
 msgid "Default result to display on result entry"
-msgstr ""
+msgstr "Результат по умолчанию для отображения при вводе результата"
 
-#: senaite/core/content/senaitesetup.py:1073
+#: senaite/core/content/senaitesetup.py:1050
 msgid "Default sample retention period"
-msgstr ""
+msgstr "Срок хранения образцов по умолчанию"
 
-#: bika/lims/content/bikasetup.py:326
+#: bika/lims/content/bikasetup.py:325
 msgid "Default scientific notation format for reports"
-msgstr ""
+msgstr "Формат научной нотации по умолчанию для отчётов"
 
-#: bika/lims/content/bikasetup.py:560
+#: bika/lims/content/bikasetup.py:559
 msgid "Default scientific notation format for results"
-msgstr ""
+msgstr "Формат научной нотации по умолчанию для результатов"
 
 #: bika/lims/content/sampletype.py:206
 msgid "Default small sticker"
-msgstr ""
+msgstr "Малый стикер по умолчанию"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:97
 msgid "Default timezone"
-msgstr ""
+msgstr "Часовой пояс по умолчанию"
 
-#: senaite/core/content/senaitesetup.py:1060
+#: senaite/core/content/senaitesetup.py:1037
 msgid "Default turnaround time for analyses."
-msgstr ""
+msgstr "Срок выполнения по умолчанию для анализов."
 
 #: bika/lims/browser/fields/interimfieldsfield.py:54
 #: bika/lims/content/analysisservice.py:224
 msgid "Default value"
-msgstr ""
+msgstr "Значение по умолчанию"
 
-#: bika/lims/content/bikasetup.py:1217
-msgid "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
+#: bika/lims/content/bikasetup.py:1216
+msgid ""
+"Default value of the 'Sample count' when users click 'ADD' button to create "
+"new Samples"
 msgstr ""
+"Значение по умолчанию для 'Количество образцов' при нажатии кнопки "
+"'ДОБАВИТЬ'"
 
 #: bika/lims/content/method.py:57
 msgid "Define an identifier code for the method. It must be unique."
-msgstr ""
+msgstr "Задайте идентификационный код метода. Он должен быть уникальным."
 
 #: bika/lims/content/calculation.py:60
-msgid "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
+msgid ""
+"Define interim fields such as vessel mass, dilution factors, should your "
+"calculation require them. The field title specified here will be used as "
+"column headers and field descriptors where the interim fields are displayed."
+" If 'Apply wide' is enabled the field will be shown in a selection box on "
+"the top of the worksheet, allowing to apply a specific value to all the "
+"corresponding fields on the sheet."
 msgstr ""
+"Определите промежуточные поля, например массу сосуда, коэффициенты "
+"разбавления, если это требуется для расчёта. Название поля, указанное здесь,"
+" будет использовано как заголовок столбца и описание поля. Если включена "
+"опция 'Применить ко всем', поле будет показано в блоке выбора вверху "
+"рабочего листа, позволяя применить значение ко всем соответствующим полям "
+"листа."
 
 #: bika/lims/content/abstractbaseanalysis.py:177
 msgid "Define the number of decimals to be used for this result."
-msgstr ""
+msgstr "Задайте количество десятичных знаков для этого результата."
 
 #: bika/lims/content/abstractbaseanalysis.py:191
-msgid "Define the precision when converting values to exponent notation.  The default is 7."
+msgid ""
+"Define the precision when converting values to exponent notation.  The "
+"default is 7."
 msgstr ""
+"Задайте точность при преобразовании значений в экспоненциальную нотацию. По "
+"умолчанию — 7."
 
 #: bika/lims/content/analysisrequest.py:494
 msgid "Define the sampler supposed to do the sample in the scheduled date"
 msgstr ""
+"Укажите пробоотборщика, который должен взять образец в запланированную дату"
 
-#: senaite/core/content/senaitesetup.py:1112
-msgid "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
+#: senaite/core/content/senaitesetup.py:1089
+msgid ""
+"Define the template for the email body that will be automatically sent to "
+"primary contacts and laboratory managers when a sample is invalidated. The "
+"following placeholders are supported: $sample_id, $retest_id, $retest_link, "
+"$reason, $lab_address."
 msgstr ""
+"Задайте шаблон текста письма, автоматически отправляемого основным контактам"
+" и менеджерам лаборатории при аннулировании образца. Поддерживаются "
+"плейсхолдеры: $sample_id, $retest_id, $retest_link, $reason, $lab_address."
 
 #: bika/lims/content/sampletype.py:232
 msgid "Defines the stickers to use for this sample type."
-msgstr ""
+msgstr "Определяет стикеры, используемые для этого типа образца."
 
 #: bika/lims/browser/fields/coordinatefield.py:36
 msgid "Degrees"
-msgstr ""
+msgstr "Градусы"
 
-#: senaite/core/api/remarks.py:482
 #: senaite/core/browser/clients/client/attachments/view.py:94
 msgid "Delete"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — row action tooltip
-msgid "Delete filter"
-msgstr ""
-
-#: senaite/core/api/remarks.py:484
-msgid "Delete this remark?"
-msgstr ""
+msgstr "Удалить"
 
 #: senaite/core/browser/controlpanel/departments/view.py:65
 #: senaite/core/profiles/default/types/Department.xml
 msgid "Department"
-msgstr ""
+msgstr "Подразделение"
 
 #: senaite/core/browser/controlpanel/departments/view.py:68
 msgid "Department ID"
-msgstr ""
+msgstr "ID подразделения"
 
 #: senaite/core/content/department.py:134
 msgid "Department ID must be unique"
-msgstr ""
+msgstr "ID подразделения должен быть уникальным"
 
 #: bika/lims/content/abstractbaseanalysis.py:601
 #: bika/lims/content/analysiscategory.py:72
 msgid "Department Name"
-msgstr ""
+msgstr "Наименование подразделения"
 
 #: senaite/core/profiles/default/types/Departments.xml
 msgid "Departments"
-msgstr ""
+msgstr "Подразделения"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:201
 msgid "Dependent Analyses"
-msgstr ""
+msgstr "Анализы подразделения"
 
-#: senaite/core/behaviors/label.py:119
+#: senaite/core/behaviors/label.py:111
 #: senaite/core/browser/controlpanel/departments/view.py:72
-#: senaite/core/browser/controlpanel/labels/view.py:63
+#: senaite/core/browser/controlpanel/labels/view.py:62
 msgid "Description"
-msgstr ""
+msgstr "Описание"
 
 #: bika/lims/content/instrumentcalibration.py:119
 msgid "Description of the actions made during the calibration"
-msgstr ""
+msgstr "Описание действий, выполненных во время калибровки"
 
 #: bika/lims/content/instrumentmaintenancetask.py:104
 msgid "Description of the actions made during the maintenance process"
-msgstr ""
+msgstr "Описание действий, выполненных в процессе обслуживания"
 
 #: bika/lims/content/instrumentvalidation.py:101
 msgid "Description of the actions made during the validation"
-msgstr ""
+msgstr "Описание действий, выполненных во время валидации"
 
 #: bika/lims/content/storagelocation.py:64
 msgid "Description of the location"
-msgstr ""
+msgstr "Описание местоположения"
 
 #: bika/lims/content/storagelocation.py:84
 msgid "Description of the shelf"
-msgstr ""
+msgstr "Описание полки"
 
 #: bika/lims/content/storagelocation.py:49
 msgid "Description of the site"
-msgstr ""
+msgstr "Описание площадки"
 
 msgid "Deselect all"
-msgstr ""
+msgstr "Снять выделение со всех"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Detach"
-msgstr ""
+msgstr "Отделить"
 
 #: senaite/core/browser/modals/analysis/schema.py:105
 msgid "Detection Limit"
-msgstr ""
+msgstr "Предел обнаружения"
 
 # senaite.app.listing: Disable auto fetch transitions
 msgid "Disable auto fetch transitions"
-msgstr ""
+msgstr "Отключить автоматическое получение переходов"
 
 #: senaite/core/vocabularies/setup.py:180
 msgid "Disable multi-verification for the same user"
-msgstr ""
+msgstr "Отключить многократную верификацию одним пользователем"
 
-# senaite.app.listing: Saved filter presets — Revert action tooltip
-msgid "Discard edits and restore preset"
-msgstr ""
-
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:673
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:663
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:207
 msgid "Discount"
-msgstr ""
+msgstr "Скидка"
 
 #: bika/lims/content/pricelist.py:66
 msgid "Discount %"
-msgstr ""
+msgstr "% скидки"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:78
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatch"
-msgstr ""
+msgstr "Отправить"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:15
 msgid "Dispatch samples"
-msgstr ""
+msgstr "Отправить образцы"
 
-#: senaite/core/browser/samples/view.py:379
+#: senaite/core/browser/samples/view.py:361
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispatched"
-msgstr ""
+msgstr "Отправлено"
 
 # bika.lims.bikalisting.js
 msgid "Display Columns"
-msgstr ""
+msgstr "Отображаемые столбцы"
 
 #: bika/lims/content/abstractbaseanalysis.py:727
 msgid "Display Value"
-msgstr ""
+msgstr "Отобразить значение"
 
 #: bika/lims/validators.py:675
 msgid "Display Value is required"
-msgstr ""
+msgstr "Отображаемое значение обязательно"
 
 #: bika/lims/validators.py:687
 msgid "Display Value must be unique"
-msgstr ""
+msgstr "Отображаемое значение должно быть уникальным"
 
 #: bika/lims/content/abstractbaseanalysis.py:316
 msgid "Display a Detection Limit selector"
-msgstr ""
+msgstr "Показывать селектор предела обнаружения"
 
-#: bika/lims/content/bikasetup.py:722
+#: bika/lims/content/bikasetup.py:721
 msgid "Display sample partitions to clients"
-msgstr ""
+msgstr "Показывать партиции образца клиентам"
 
-#: senaite/core/browser/samples/templates/dispose_samples.pt:80
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Dispose"
-msgstr ""
+msgstr "Ликвидировать"
 
-#: senaite/core/browser/samples/templates/dispose_samples.pt:15
-msgid "Dispose samples"
-msgstr ""
-
-#: senaite/core/browser/samples/view.py:391
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
-#: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Disposed"
-msgstr ""
+msgstr "Извлечено"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:87
 #: senaite/core/z3cform/widgets/address.py:224
 msgid "District"
-msgstr ""
+msgstr "Район"
 
-#: bika/lims/browser/instrument.py:664
-#: bika/lims/content/multifile.py:47
+#: bika/lims/browser/instrument.py:664 bika/lims/content/multifile.py:47
 msgid "Document"
-msgstr ""
+msgstr "Документ"
 
-#: bika/lims/browser/instrument.py:809
-#: bika/lims/content/multifile.py:39
+#: bika/lims/browser/instrument.py:809 bika/lims/content/multifile.py:39
 msgid "Document ID"
-msgstr ""
+msgstr "ID документа"
 
-#: bika/lims/browser/instrument.py:812
-#: bika/lims/content/multifile.py:63
+#: bika/lims/browser/instrument.py:812 bika/lims/content/multifile.py:63
 msgid "Document Location"
-msgstr ""
+msgstr "Расположение документа"
 
-#: bika/lims/browser/instrument.py:813
-#: bika/lims/content/multifile.py:73
+#: bika/lims/browser/instrument.py:813 bika/lims/content/multifile.py:73
 msgid "Document Type"
-msgstr ""
+msgstr "Тип документа"
 
-#: bika/lims/browser/instrument.py:811
-#: bika/lims/content/multifile.py:55
+#: bika/lims/browser/instrument.py:811 bika/lims/content/multifile.py:55
 msgid "Document Version"
-msgstr ""
+msgstr "Версия документа"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Documents"
-msgstr ""
+msgstr "Документы"
 
 #: senaite/core/exportimport/instruments/importer.py:375
 msgid "Don't override analysis results"
-msgstr ""
+msgstr "Не перезаписывать результаты анализов"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:79
 msgid "Done"
-msgstr ""
+msgstr "Готово"
 
 #: senaite/core/vocabularies/setup.py:113
 msgid "Dot (.)"
-msgstr ""
+msgstr "Точка (.)"
 
 #: bika/lims/browser/instrument.py:87
 msgid "Down from"
-msgstr ""
+msgstr "От"
 
 #: bika/lims/browser/instrument.py:88
 msgid "Down to"
-msgstr ""
+msgstr "До"
 
 #: bika/lims/browser/publish/reports_listing.py:150
 msgid "Download"
-msgstr ""
+msgstr "Скачать"
 
 #: bika/lims/browser/publish/reports_listing.py:80
 msgid "Download PDF"
-msgstr ""
+msgstr "Скачать PDF"
 
 #: bika/lims/browser/publish/reports_listing.py:145
 msgid "Download selected reports"
-msgstr ""
+msgstr "Скачать выбранные отчёты"
 
-# senaite.app.listing: Column config — drag handle tooltip / aria-label
-msgid "Drag to reorder"
-msgstr ""
-
-#: senaite/core/browser/samples/view.py:327
+#: senaite/core/browser/samples/view.py:309
 msgid "Due"
-msgstr ""
+msgstr "Ожидается"
 
-#: senaite/core/browser/samples/view.py:176
+#: senaite/core/browser/samples/view.py:164
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:120
 msgid "Due Date"
-msgstr ""
+msgstr "Дата ожидания"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:199
 msgid "Dup Var"
-msgstr ""
+msgstr "Разброс дубликата"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:556
 msgid "Duplicate"
-msgstr ""
+msgstr "Дублировать"
 
 #: bika/lims/profiles/default/types/DuplicateAnalysis.xml
 msgid "Duplicate Analysis"
-msgstr ""
+msgstr "Повторный анализ"
 
-#: senaite/core/content/senaitesetup.py:1433
-msgid "Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the first row is used; remove or merge the duplicate."
+#: senaite/core/content/senaitesetup.py:1406
+msgid ""
+"Duplicate ID format for portal type '${pt}' (rows ${a} and ${b}). Only the "
+"first row is used; remove or merge the duplicate."
 msgstr ""
+"Повторяющийся формат ID для типа '${pt}' (строки ${a} и ${b}). Используется "
+"только первая строка; удалите или объедините дубликат."
 
 #: bika/lims/content/worksheettemplate.py:59
 msgid "Duplicate Of"
-msgstr ""
+msgstr "Дубликат"
 
 #: bika/lims/config.py:90
 msgid "Duplicate QC analyses"
-msgstr ""
+msgstr "Дублирующие анализы контроля качества"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Duplicate Sample"
-msgstr ""
+msgstr "Дублировать образец"
 
 #: bika/lims/content/abstractbaseanalysis.py:479
 msgid "Duplicate Variation %"
-msgstr ""
+msgstr "Разброс дубликата, %"
 
 #: bika/lims/validators.py:461
 msgid "Duplicate keys in choices field"
-msgstr ""
+msgstr "Повторяющиеся ключи в поле выбора"
 
 #: bika/lims/browser/workflow/analysisrequest.py:443
 msgid "Duplicated samples: {}"
-msgstr ""
+msgstr "Дублированные образцы: {}"
 
 #: senaite/core/profiles/default/types/DynamicAnalysisSpec.xml
 msgid "Dynamic Analysis Specification"
-msgstr ""
+msgstr "Динамическая спецификация анализа"
 
 #: senaite/core/profiles/default/types/DynamicAnalysisSpecs.xml
 msgid "Dynamic Analysis Specifications"
-msgstr ""
+msgstr "Динамические спецификации анализа"
 
 #: bika/lims/controlpanel/bika_analysisspecs.py:82
 msgid "Dynamic Specification"
-msgstr ""
+msgstr "Динамическая спецификация"
 
 #: bika/lims/content/laboratory.py:122
 msgid "E.g. SANAS, APLAC, etc."
-msgstr ""
+msgstr "Например SANAS, APLAC и т.д."
 
 #: senaite/core/exportimport/import.pt:165
-msgid "Each import interface can define a folder, where the system looks for the results files while automatically importing results when calling the <code>auto_import_results</code> view."
+msgid ""
+"Each import interface can define a folder, where the system looks for the "
+"results files while automatically importing results when calling the "
+"<code>auto_import_results</code> view."
 msgstr ""
+"Каждый интерфейс импорта может определить папку, в которой система ищет "
+"файлы результатов при автоматическом импорте результатов при вызове "
+"представления <code>auto_import_results</code>"
 
-#: senaite/core/api/remarks.py:480
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Edit"
-msgstr ""
+msgstr "Редактировать"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:15
 msgid "Edit Multiple Analyses Results"
-msgstr ""
+msgstr "Редактировать результаты нескольких анализов"
 
 #: bika/lims/content/samplepoint.py:74
 msgid "Elevation"
-msgstr ""
+msgstr "Высота"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:87
-#: senaite/core/config/widgets.py:55
-#: senaite/core/content/contact.py:147
+#: senaite/core/config/widgets.py:55 senaite/core/content/contact.py:115
 msgid "Email"
-msgstr ""
+msgstr "Отправить по электронной почте"
 
 #: senaite/core/browser/clients/client/contacts/view.py:76
 #: senaite/core/browser/controlpanel/contacts/view.py:64
-#: senaite/core/content/resultsreport.py:115
+#: senaite/core/content/resultsreport.py:114
 msgid "Email Address"
-msgstr ""
+msgstr "Адрес электронной почты"
 
-#: senaite/core/content/resultsreport.py:89
+#: senaite/core/content/resultsreport.py:88
 msgid "Email Attachments"
-msgstr ""
+msgstr "Вложения письма"
 
-#: senaite/core/content/resultsreport.py:84
+#: senaite/core/content/resultsreport.py:83
 msgid "Email Body"
-msgstr ""
+msgstr "Текст письма"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:96
 msgid "Email Log"
-msgstr ""
+msgstr "Журнал писем"
 
-#: senaite/core/content/resultsreport.py:67
+#: senaite/core/content/resultsreport.py:66
 msgid "Email Recipients"
-msgstr ""
+msgstr "Получатели письма"
 
-#: senaite/core/content/resultsreport.py:73
+#: senaite/core/content/resultsreport.py:72
 msgid "Email Responsibles"
-msgstr ""
+msgstr "Ответственные по email"
 
-#: senaite/core/content/resultsreport.py:62
+#: senaite/core/content/resultsreport.py:61
 msgid "Email Send Date"
-msgstr ""
+msgstr "Дата отправки письма"
 
-#: senaite/core/content/resultsreport.py:79
+#: senaite/core/content/resultsreport.py:78
 msgid "Email Subject"
-msgstr ""
+msgstr "Тема письма"
 
-#: senaite/core/content/senaitesetup.py:1111
+#: senaite/core/content/senaitesetup.py:1088
 msgid "Email body for Sample Invalidation notifications"
-msgstr ""
+msgstr "Текст письма для уведомлений об аннулировании образца"
 
-#: senaite/core/content/senaitesetup.py:1095
+#: senaite/core/content/senaitesetup.py:1072
 msgid "Email body for Sample Rejection notifications"
-msgstr ""
+msgstr "Текст письма для уведомлений об отклонении образца"
 
 #: bika/lims/browser/publish/emailview.py:158
 msgid "Email cancelled"
-msgstr ""
+msgstr "Отправка письма отменена"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:126
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:129
 msgid "Email notification"
-msgstr ""
+msgstr "Уведомление по email"
 
-#: senaite/core/content/senaitesetup.py:1085
+#: senaite/core/content/senaitesetup.py:1062
 msgid "Email notification on Sample rejection"
-msgstr ""
+msgstr "Уведомление по email при отклонении образца"
 
-#: senaite/core/content/resultsreport.py:258
+#: senaite/core/content/resultsreport.py:257
 msgid "Email send log"
-msgstr ""
+msgstr "Журнал отправки писем"
 
 #: bika/lims/browser/publish/reports_listing.py:88
 msgid "Email sent"
-msgstr ""
-
-#: bika/lims/api/snapshot.py:585
-msgid "Empty"
-msgstr ""
+msgstr "Письмо отправлено"
 
 #: bika/lims/validators.py:456
 msgid "Empty keys are not supported"
-msgstr ""
+msgstr "Пустые ключи не поддерживаются"
 
 #: bika/lims/content/worksheettemplate.py:140
 msgid "Enable Multiple Use of Instrument in Worksheets."
-msgstr ""
+msgstr "Разрешить многократное использование инструмента в рабочих листах."
 
-#: senaite/core/content/senaitesetup.py:1040
+#: senaite/core/content/senaitesetup.py:1017
 msgid "Enable Sample Preservation"
-msgstr ""
+msgstr "Включить сохранение образца"
 
-#: bika/lims/content/bikasetup.py:411
+#: bika/lims/content/bikasetup.py:410
 msgid "Enable Sample Specifications"
-msgstr ""
+msgstr "Включить спецификации образца"
 
-#: senaite/core/content/senaitesetup.py:1012
+#: senaite/core/content/senaitesetup.py:989
 msgid "Enable Sampling"
-msgstr ""
+msgstr "Включить отбор проб"
 
-#: senaite/core/content/senaitesetup.py:1020
+#: senaite/core/content/senaitesetup.py:997
 msgid "Enable Sampling Scheduling"
-msgstr ""
+msgstr "Включить планирование отбора проб"
 
-#: bika/lims/content/bikasetup.py:224
+#: bika/lims/content/bikasetup.py:223
 msgid "Enable global Audit Log"
-msgstr ""
+msgstr "Включить глобальный журнал аудита"
 
-#: senaite/core/content/senaitesetup.py:298
+#: senaite/core/content/senaitesetup.py:297
 msgid "Enable global Auditlog"
-msgstr ""
+msgstr "Включить глобальный журнал аудита"
 
 #: bika/lims/content/artemplate.py:119
 msgid "Enable sampling workflow for the created sample"
-msgstr ""
+msgstr "Включить процесс отбора проб для создаваемого образца"
 
-#: senaite/core/content/senaitesetup.py:980
+#: senaite/core/content/senaitesetup.py:979
 msgid "Enable the Results Report Printing workflow"
-msgstr ""
-
-#: senaite/core/content/senaitesetup.py:1000
-msgid "Enable the Sample Dispatch workflow"
-msgstr ""
-
-#: senaite/core/content/senaitesetup.py:990
-msgid "Enable the Sample Dispose workflow"
-msgstr ""
+msgstr "Включить процесс печати отчёта с результатами"
 
 #: bika/lims/browser/pricelist.py:68
 msgid "End Date"
-msgstr ""
+msgstr "Дата окончания"
 
 #: bika/lims/content/instrumentmaintenancetask.py:165
 #: bika/lims/content/instrumentscheduledtask.py:119
 msgid "Enhancement"
-msgstr ""
+msgstr "Улучшение"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:231
-msgid "Enter a user name, usually something like 'jsmith'. No spaces or special characters. Usernames and passwords are case sensitive, make sure the caps lock key is not enabled. This is the name used to log in."
+msgid ""
+"Enter a user name, usually something like 'jsmith'. No spaces or special "
+"characters. Usernames and passwords are case sensitive, make sure the caps "
+"lock key is not enabled. This is the name used to log in."
 msgstr ""
+"Введите имя пользователя, обычно что-то вроде «jsmith». Без пробелов и "
+"специальных символов. Имена пользователей и пароли чувствительны к регистру,"
+" убедитесь, что клавиша caps lock не нажата. Это имя, используемое для входа"
+" в систему."
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:268
-msgid "Enter an email address. This is necessary in case the password is lost. We respect your privacy, and will not give the address away to any third parties or expose it anywhere."
+msgid ""
+"Enter an email address. This is necessary in case the password is lost. We "
+"respect your privacy, and will not give the address away to any third "
+"parties or expose it anywhere."
 msgstr ""
+"Введите адрес электронной почты. Это необходимо в случае утери пароля. Мы "
+"уважаем вашу частную жизнь и не будет передавать адреса третьим лицам."
 
 #: bika/lims/content/pricelist.py:67
 msgid "Enter discount percentage value"
-msgstr ""
+msgstr "Введите процентное значение скидки"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:453
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:444
 msgid "Enter individual values for this field per sample"
-msgstr ""
+msgstr "Введите отдельные значения этого поля для каждого образца"
 
 #: bika/lims/content/abstractbaseanalysis.py:576
 #: bika/lims/content/labproduct.py:48
 msgid "Enter percentage value eg. 14.0"
-msgstr ""
+msgstr "Введите процентное значение напр. 14,0"
 
 #: bika/lims/content/analysisprofile.py:123
-msgid "Enter percentage value eg. 14.0. This percentage is applied on the Analysis Profile only, overriding the systems VAT"
+msgid ""
+"Enter percentage value eg. 14.0. This percentage is applied on the Analysis "
+"Profile only, overriding the systems VAT"
 msgstr ""
+"Введите значение процента, например 14.0. Этот процент применяется только к "
+"профилю анализа, переопределяя системный НДС"
 
-#: bika/lims/content/bikasetup.py:298
-msgid "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwrittem on individual items"
+#: bika/lims/content/bikasetup.py:297
+msgid ""
+"Enter percentage value eg. 14.0. This percentage is applied system wide but "
+"can be overwrittem on individual items"
 msgstr ""
+"Введите процентное значение напр. 14.0. Это процент всей прикладной системе "
+"но может быть переписан для отдельных элементов"
 
 #: bika/lims/content/analysisrequest.py:1120
 msgid "Enter percentage value eg. 33.0"
-msgstr ""
+msgstr "Введите значение  процента напр. 33,0"
 
 #: bika/lims/content/samplepoint.py:57
-msgid "Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds 0-59 and N/S indicator"
+msgid ""
+"Enter the Sample Point's latitude in degrees 0-90, minutes 0-59, seconds "
+"0-59 and N/S indicator"
 msgstr ""
+"Введите Образец точки широты в 0-90 градусов, минут 0-59, секунд-0-59 и N/S "
+"индикатор"
 
 #: bika/lims/content/samplepoint.py:66
-msgid "Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds 0-59 and E/W indicator"
+msgid ""
+"Enter the Sample Point's longitude in degrees 0-180, minutes 0-59, seconds "
+"0-59 and E/W indicator"
 msgstr ""
+"Введите долготу точки отбора проб: градусы 0-180, минуты 0-59, секунды 0-59 "
+"и индикатор В/З"
 
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:18
 msgid "Enter the details of each of the analysis services you want to copy."
-msgstr ""
+msgstr "Введите данные каждой услуги анализа, которую хотите скопировать."
 
 #: bika/lims/content/laboratory.py:176
-msgid "Enter the details of your lab's service accreditations here. The following fields are available:  lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference<br/>"
+msgid ""
+"Enter the details of your lab's service accreditations here. The following "
+"fields are available:  lab_is_accredited, lab_name, lab_country, confidence,"
+" accreditation_body_name, accreditation_standard, "
+"accreditation_reference<br/>"
 msgstr ""
+"Введите данные об аккредитации услуг вашей лаборатории. Доступны поля: "
+"lab_is_accredited, lab_name, lab_country, confidence, "
+"accreditation_body_name, accreditation_standard, "
+"accreditation_reference<br/>"
 
-#: bika/lims/browser/analyses/view.py:1097
-msgid "Enter the result either in decimal or scientific notation, e.g. 0.00005 or 1e-5, 10000 or 1e5"
+#: bika/lims/browser/analyses/view.py:1096
+msgid ""
+"Enter the result either in decimal or scientific notation, e.g. 0.00005 or "
+"1e-5, 10000 or 1e5"
 msgstr ""
+"Введите результат в десятичной или научной нотации, например 0.00005 или "
+"1e-5, 10000 или 1e5"
 
 #: bika/lims/content/analysisrequest.py:939
 msgid "Environmental conditions"
-msgstr ""
+msgstr "Условия окружающей среды"
 
 #: senaite/core/browser/samples/invalidate_samples.py:282
 msgid "Erroneous result publication: ${sample_id}"
-msgstr ""
+msgstr "Ошибочная публикация результата: ${sample_id}"
 
-#: senaite/core/browser/dashboard/dashboard.py:502
+#: senaite/core/browser/dashboard/dashboard.py:455
 msgid "Evolution of Analyses"
-msgstr ""
+msgstr "Продвижение анализов"
 
-#: senaite/core/browser/dashboard/dashboard.py:453
+#: senaite/core/browser/dashboard/dashboard.py:407
 msgid "Evolution of Samples"
-msgstr ""
+msgstr "Динамика образцов"
 
-#: senaite/core/browser/dashboard/dashboard.py:535
+#: senaite/core/browser/dashboard/dashboard.py:484
 msgid "Evolution of Worksheets"
-msgstr ""
+msgstr "Динамика рабочих листов"
 
 #: senaite/core/exportimport/import.pt:172
 msgid "Example Cronjob to execute the auto import every 10 minutes"
-msgstr ""
+msgstr "Пример Cronjob для выполнения автоматического импорта каждые 10 минут"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:125
 msgid "Example content"
-msgstr ""
+msgstr "Пример содержания"
 
-#: senaite/core/browser/samples/view.py:739
+#: senaite/core/browser/samples/view.py:601
 msgid "Exclude from invoice"
-msgstr ""
+msgstr "Исключить из счета"
 
 #: bika/lims/browser/fields/referenceresultsfield.py:35
 #: bika/lims/browser/referencesample.py:225
 #: bika/lims/browser/widgets/referenceresultswidget.py:68
 msgid "Expected Result"
-msgstr ""
+msgstr "Ожидаемый результат"
 
-#: senaite/core/browser/samples/view.py:157
+#: senaite/core/browser/samples/view.py:145
 msgid "Expected Sampling Date"
-msgstr ""
+msgstr "Ожидаемая дата отбора проб"
 
 #: bika/lims/content/referencesample.py:214
 msgid "Expected Values"
-msgstr ""
+msgstr "Ожидаемые значения"
 
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
 msgid "Expire"
-msgstr ""
+msgstr "Просрочен"
 
 #: senaite/core/profiles/default/workflows/senaite_referencesample_workflow/definition.xml
 msgid "Expired"
-msgstr ""
+msgstr "Срок действия истек"
 
 #: bika/lims/browser/referencesample.py:367
 #: bika/lims/browser/templates/referencesample_sticker.pt:81
 #: bika/lims/browser/templates/referencesample_view.pt:111
 msgid "Expiry Date"
-msgstr ""
+msgstr "Дата истечения срока действия"
 
 #: bika/lims/content/abstractbaseanalysis.py:190
 msgid "Exponential format precision"
-msgstr ""
+msgstr "Точность экспоненциального формата"
 
-#: bika/lims/content/bikasetup.py:426
+#: bika/lims/content/bikasetup.py:425
 msgid "Exponential format threshold"
-msgstr ""
+msgstr "Порог экспоненциального формата"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Export"
-msgstr ""
+msgstr "Экспорт"
 
-#: senaite/core/browser/stickers/view.py:283
+#: senaite/core/browser/stickers/view.py:273
 msgid "Failed to load sticker"
-msgstr ""
+msgstr "Не удалось загрузить стикер"
 
 #: bika/lims/browser/publish/emailview.py:150
 msgid "Failed to send Email(s)"
-msgstr ""
+msgstr "Не удалось отправить письмо(а)"
 
 #: senaite/core/browser/samples/manage_sample_fields.py:101
-msgid "Failed to update registry records. Please check the server log for details."
+msgid ""
+"Failed to update registry records. Please check the server log for details."
 msgstr ""
+"Не удалось обновить записи реестра. Подробности см. в журнале сервера."
 
-#: bika/lims/browser/clientfolder.py:86
-#: bika/lims/content/organisation.py:66
+#: bika/lims/browser/clientfolder.py:86 bika/lims/content/organisation.py:66
 #: bika/lims/controlpanel/bika_labcontacts.py:89
 msgid "Fax"
-msgstr ""
+msgstr "Факс"
 
 #: bika/lims/content/person.py:118
 msgid "Fax (business)"
-msgstr ""
+msgstr "Факс (рабочий)"
 
 #: bika/lims/config.py:77
 msgid "Female"
-msgstr ""
+msgstr "Женский"
 
 # senaite.app.listing: Fetch transitions
 msgid "Fetch Transitions"
-msgstr ""
+msgstr "Получить переходы"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:191
 msgid "Field"
-msgstr ""
+msgstr "Поле"
 
 #: bika/lims/browser/analysisrequest/add2.py:2122
 msgid "Field '{}' is required"
-msgstr ""
+msgstr "Поле '{}' обязательно"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:125
 #: senaite/core/browser/viewlets/sampleanalyses.py:69
 msgid "Field Analyses"
-msgstr ""
+msgstr "Анализы \"в поле\""
 
 #: senaite/core/registry/schema.py:214
 msgid "Field Name"
-msgstr ""
+msgstr "Название поля"
 
 #: bika/lims/config.py:56
 msgid "Field Preservation"
-msgstr ""
+msgstr "Полевое сохранение"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:53
 msgid "Field Title"
-msgstr ""
+msgstr "Название поля"
 
 #: bika/lims/browser/analysisrequest/add2.py:1460
 msgid "Field flushed"
-msgstr ""
+msgstr "Поле очищено"
 
 #: senaite/core/registry/schema.py:212
 msgid "Field visibility"
-msgstr ""
+msgstr "Видимость поля"
 
 #: bika/lims/browser/instrument.py:814
 msgid "File"
-msgstr ""
+msgstr "Файл"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:194
 msgid "File Deleted"
-msgstr ""
+msgstr "Файл удалён"
 
 #: bika/lims/content/analysisservice.py:262
 msgid "File upload"
-msgstr ""
+msgstr "Загрузка файла"
 
 #: bika/lims/content/multifile.py:48
 msgid "File upload "
-msgstr ""
+msgstr "Загрузка файла "
 
 #: senaite/core/browser/clients/client/attachments/view.py:59
 msgid "Filename"
-msgstr ""
+msgstr "Имя файла"
 
 #: bika/lims/browser/publish/reports_listing.py:82
 msgid "Filesize"
-msgstr ""
+msgstr "Размер файла"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:525
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:516
 msgid "Filter analyses by name..."
-msgstr ""
+msgstr "Фильтр анализов по названию..."
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:190
 msgid "Filter by template method"
-msgstr ""
+msgstr "Фильтр по методу шаблона"
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:175
 msgid "Filter by template services"
-msgstr ""
+msgstr "Фильтр по услугам шаблона"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:49
 msgid "Filter keys (regex supported)"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — inline editor placeholder
-msgid "Filter name"
-msgstr ""
-
-#: senaite/core/browser/samples/view.py:601
-msgid "Filter samples by this analysis"
-msgstr ""
-
-# senaite.app.listing: Column-filter row — text-input placeholder
-msgid "Filter..."
-msgstr ""
+msgstr "Фильтр ключей (поддерживается regex)"
 
 #: senaite/core/content/dynamicanalysisspec.py:75
 msgid "First sheet does not contain a valid column definition"
-msgstr ""
+msgstr "Первый лист не содержит корректного определения столбцов"
 
 #: bika/lims/content/person.py:51
 msgid "Firstname"
-msgstr ""
+msgstr "Имя"
 
 #: bika/lims/content/abstractbaseanalysis.py:83
 #: bika/lims/content/analysiscategory.py:83
 #: bika/lims/controlpanel/bika_analysisservices.py:207
-msgid "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
+msgid ""
+"Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values "
+"are ordered alphabetically."
 msgstr ""
+"Число с плавающей точкой от 0.0 до 1000.0, задающее порядок сортировки. "
+"Повторяющиеся значения сортируются по алфавиту."
 
-#: senaite/core/content/senaitesetup.py:212
+#: senaite/core/content/senaitesetup.py:211
 msgid "Format"
-msgstr ""
+msgstr "Формат"
 
-#: senaite/core/content/senaitesetup.py:1203
+#: senaite/core/content/senaitesetup.py:1180
 msgid "Formatting Configuration"
-msgstr ""
+msgstr "Настройка форматирования"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:183
 #: bika/lims/controlpanel/bika_calculations.py:79
 msgid "Formula"
-msgstr ""
+msgstr "Формула"
 
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:239
 msgid "Found Dynamic Analysis Specification for '{}' in '{}'"
-msgstr ""
+msgstr "Найдена динамическая спецификация анализа для '{}' в '{}'"
 
 #: senaite/core/vocabularies/setup.py:160
 msgid "Friday"
-msgstr ""
+msgstr "Пятница"
 
 #: bika/lims/browser/publish/templates/email.pt:47
 #: bika/lims/content/instrumentcalibration.py:78
 #: bika/lims/content/instrumentmaintenancetask.py:65
 msgid "From"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:134
-msgid "From ${from} to ${to} (updated every 2 hours)"
-msgstr ""
+msgstr "От"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:63
 #: senaite/core/browser/clients/client/contacts/view.py:70
 #: senaite/core/browser/controlpanel/contacts/view.py:58
 msgid "Full Name"
-msgstr ""
+msgstr "Полное имя"
 
-#: senaite/core/content/resultsreport.py:110
+#: senaite/core/content/resultsreport.py:109
 msgid "Fullname"
-msgstr ""
+msgstr "Полное имя"
 
 #: bika/lims/content/calculation.py:100
 msgid "Function"
-msgstr ""
+msgstr "Функция"
 
-#: senaite/core/browser/samples/view.py:736
+#: senaite/core/browser/samples/view.py:598
 msgid "Future dated sample"
-msgstr ""
+msgstr "Образец с будущей датой"
 
 #: senaite/core/browser/dexterity/views.py:206
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:27
 msgid "General"
-msgstr ""
+msgstr "Общее"
 
 #: senaite/core/behaviors/configure.zcml:13
 msgid "Generates an ID with the IDServer"
-msgstr ""
+msgstr "Генерирует ID с помощью сервера идентификаторов"
 
 #: senaite/core/registry/schema.py:226
 msgid "Generic Setup"
-msgstr ""
+msgstr "Generic Setup"
 
 #: senaite/core/browser/viewlets/templates/auditlog_disabled.pt:11
 msgid "Global Audit Log is disabled"
-msgstr ""
+msgstr "Глобальный журнал аудита отключён"
 
 #: senaite/core/profiles/default/types/Contacts.xml
 msgid "Global contacts container"
-msgstr ""
+msgstr "Глобальный контейнер контактов"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:44
 msgid "Go to your instance"
-msgstr ""
+msgstr "Перейти к своему образцу"
 
 #: bika/lims/content/person.py:43
 msgid "Greeting title eg. Mr, Mrs, Dr"
-msgstr ""
+msgstr "Приветствие напр. Г-Н, миссис, Dr"
 
-#: bika/lims/content/bikasetup.py:356
-msgid "Group analysis services by category in the LIMS tables, helpful when the list is long"
+#: bika/lims/content/bikasetup.py:355
+msgid ""
+"Group analysis services by category in the LIMS tables, helpful when the "
+"list is long"
 msgstr ""
+"Группировка аналитических услуг в таблицах LIMS, полезно, когда список "
+"длинный"
 
 #: bika/lims/content/arreport.py:134
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: bika/lims/content/referencesample.py:105
 #: bika/lims/content/sampletype.py:127
 msgid "Hazardous"
-msgstr ""
+msgstr "Опасные"
 
 #: bika/lims/browser/analyses/view.py:203
-#: bika/lims/browser/analysisrequest/manage_analyses.py:84
+#: bika/lims/browser/analysisrequest/manage_analyses.py:81
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:90
 msgid "Hidden"
-msgstr ""
+msgstr "Скрыто"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:60
 msgid "Hidden Field"
-msgstr ""
+msgstr "Скрытое поле"
 
 #: senaite/core/browser/modals/analysis/schema.py:114
 msgid "Hidden from report"
-msgstr ""
+msgstr "Скрыто из отчёта"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:55
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:54
 msgid "Hide additional fields"
-msgstr ""
-
-# senaite.app.listing: Column config — bulk action button
-msgid "Hide all"
-msgstr ""
-
-#: senaite/core/api/remarks.py:487
-msgid "Hide history"
-msgstr ""
-
-# senaite.app.listing: Column config — eye-slash button tooltip / aria-label
-msgid "Hide this column"
-msgstr ""
+msgstr "Скрыть дополнительные поля"
 
 #: bika/lims/config.py:140
 msgid "High"
-msgstr ""
+msgstr "Высокий"
 
 #: bika/lims/config.py:139
 msgid "Highest"
-msgstr ""
+msgstr "Наивысший"
 
 #: bika/lims/browser/fields/durationfield.py:37
 msgid "Hours"
-msgstr ""
+msgstr "Часы"
 
 #: bika/lims/content/supplier.py:75
 msgid "IBN"
-msgstr ""
+msgstr "IBN"
 
 #: bika/lims/browser/referencesample.py:340
 #: bika/lims/browser/templates/referencesample_view.pt:43
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
-#: senaite/core/content/senaitesetup.py:1407
+#: senaite/core/content/senaitesetup.py:1380
 msgid "ID Server"
-msgstr ""
+msgstr "Сервер идентификаторов"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:17
 msgid "ID Server Settings"
-msgstr ""
+msgstr "Настройки сервера идентификаторов"
 
-#: bika/lims/content/bikasetup.py:1189
+#: bika/lims/content/bikasetup.py:1188
 msgid "ID Server Values"
-msgstr ""
+msgstr "Значения сервера идентификаторов"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:113
 msgid "ID Template <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Шаблон ID <span class=\"sort-indicator\" />"
 
 #: bika/lims/content/samplepoint.py:84
-msgid "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
+msgid ""
+"If a sample is taken periodically at this sample point, enter frequency "
+"here, e.g. weekly"
 msgstr ""
+"Если образец на этой точке отбирается периодически, укажите частоту, "
+"например еженедельно"
 
 #: bika/lims/content/abstractbaseanalysis.py:317
-msgid "If checked, a selection list will be displayed next to the analysis' result field in results entry views. By using this selector, the analyst will be able to set the value as a Detection Limit (LDL or UDL) instead of a regular result"
+msgid ""
+"If checked, a selection list will be displayed next to the analysis' result "
+"field in results entry views. By using this selector, the analyst will be "
+"able to set the value as a Detection Limit (LDL or UDL) instead of a regular"
+" result"
 msgstr ""
+"Если отмечено, рядом с полем результата анализа будет отображаться список "
+"выбора. С его помощью аналитик сможет установить значение как предел "
+"обнаружения (LDL или UDL) вместо обычного результата"
 
 #: bika/lims/content/instrument.py:187
-msgid "If checked, the instrument will be unavailable until the next valid calibration was performed. This checkbox will automatically be unchecked."
+msgid ""
+"If checked, the instrument will be unavailable until the next valid "
+"calibration was performed. This checkbox will automatically be unchecked."
 msgstr ""
+"Если отмечено, инструмент будет недоступен до следующей действительной "
+"калибровки. Этот флажок будет снят автоматически."
 
-#: bika/lims/content/bikasetup.py:462
-msgid "If enabled, a free text field will be displayed close to each analysis in results entry view"
+#: bika/lims/content/bikasetup.py:461
+msgid ""
+"If enabled, a free text field will be displayed close to each analysis in "
+"results entry view"
 msgstr ""
+"Если включено, рядом с каждым анализом при вводе результатов будет "
+"отображаться поле свободного текста"
 
-#: bika/lims/content/abstractbaseanalysis.py:821
-msgid "If enabled, a user who submitted a result for this analysis will also be able to verify it. This setting take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). The option set here has priority over the option set in Bika Setup"
+#: bika/lims/content/abstractbaseanalysis.py:818
+msgid ""
+"If enabled, a user who submitted a result for this analysis will also be "
+"able to verify it. This setting take effect for those users with a role "
+"assigned that allows them to verify results (by default, managers, "
+"labmanagers and verifiers). The option set here has priority over the option"
+" set in Bika Setup"
 msgstr ""
+"Если включено, пользователь, отправивший результат этого анализа, также "
+"сможет его верифицировать. Действует для пользователей с ролью, позволяющей "
+"верифицировать результаты (по умолчанию — менеджеры, менеджеры лаборатории и"
+" верификаторы). Этот параметр имеет приоритет над настройкой в Bika Setup"
 
-#: bika/lims/content/bikasetup.py:494
-msgid "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers).This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
+#: bika/lims/content/bikasetup.py:493
+msgid ""
+"If enabled, a user who submitted a result will also be able to verify it. "
+"This setting only take effect for those users with a role assigned that "
+"allows them to verify results (by default, managers, labmanagers and "
+"verifiers).This setting can be overrided for a given Analysis in Analysis "
+"Service edit view. By default, disabled."
 msgstr ""
+"Если включено, пользователь, отправивший результат, также сможет его "
+"верифицировать. Действует только для пользователей с ролью, позволяющей "
+"верифицировать результаты (по умолчанию — менеджеры, менеджеры лаборатории и"
+" верификаторы). Может быть переопределено для конкретного анализа в услуге "
+"анализа. По умолчанию отключено."
 
 #: bika/lims/content/abstractbaseanalysis.py:96
 msgid "If enabled, the name of the analysis will be written in italics."
-msgstr ""
+msgstr "Если включено, название анализа будет отображаться курсивом."
 
-#: bika/lims/content/abstractbaseanalysis.py:805
-msgid "If enabled, this analysis and its results will not be displayed by default in reports. This setting can be overrided in Analysis Profile and/or Sample"
+#: bika/lims/content/abstractbaseanalysis.py:802
+msgid ""
+"If enabled, this analysis and its results will not be displayed by default "
+"in reports. This setting can be overrided in Analysis Profile and/or Sample"
 msgstr ""
+"Если включено, этот анализ и его результаты по умолчанию не будут "
+"отображаться в отчётах. Может быть переопределено в профиле анализа и/или "
+"образце"
 
 #: bika/lims/content/batch.py:138
 msgid "If no Title value is entered, the Batch ID will be used."
-msgstr ""
+msgstr "Если название не указано, будет использован ID партии."
 
 #: bika/lims/content/batch.py:134
 msgid "If no value is entered, the Batch ID will be auto-generated."
-msgstr ""
+msgstr "Если значение не указано, ID партии будет сгенерирован автоматически."
 
 #: bika/lims/content/method.py:128
-msgid "If required, select a calculation for the The analysis services linked to this method. Calculations can be configured under the calculations item in the LIMS set-up"
+msgid ""
+"If required, select a calculation for the The analysis services linked to "
+"this method. Calculations can be configured under the calculations item in "
+"the LIMS set-up"
 msgstr ""
+"При необходимости выберите формулу расчёта для услуг анализа, связанных с "
+"этим методом. Формулы расчёта настраиваются в разделе 'Расчёты' настроек "
+"LIMS"
 
 #: senaite/core/content/interpretationtemplate.py:72
-msgid "If set, this interpretation template will only be available for selection on samples from these types"
+msgid ""
+"If set, this interpretation template will only be available for selection on"
+" samples from these types"
 msgstr ""
+"Если задано, этот шаблон интерпретации будет доступен для выбора только для "
+"образцов этих типов"
 
 #: senaite/core/content/interpretationtemplate.py:60
-msgid "If set, this interpretation template will only be available for selection on samples that have assigned any of these analysis templates"
+msgid ""
+"If set, this interpretation template will only be available for selection on"
+" samples that have assigned any of these analysis templates"
 msgstr ""
+"Если задано, этот шаблон интерпретации будет доступен для выбора только для "
+"образцов с одним из этих шаблонов анализа"
 
 #: bika/lims/content/abstractbaseanalysis.py:69
-msgid "If text is entered here, it is used instead of the title when the service is listed in column headings. HTML formatting is allowed."
+msgid ""
+"If text is entered here, it is used instead of the title when the service is"
+" listed in column headings. HTML formatting is allowed."
 msgstr ""
+"Если здесь указан текст, он используется вместо названия в заголовках "
+"столбцов списка услуг. HTML-разметка допускается."
 
 #: senaite/core/exportimport/import.pt:74
-msgid "If the system doesn't find any match (Sample, Reference Analysis or Duplicate), it will use the record's identifier to find matches for Reference Sample IDs. <br /> If a Reference Sample ID is found, the system will automatically create a Calibration Test (Reference Analysis) and will link it to the selected Instrument."
+msgid ""
+"If the system doesn't find any match (Sample, Reference Analysis or "
+"Duplicate), it will use the record's identifier to find matches for "
+"Reference Sample IDs. <br /> If a Reference Sample ID is found, the system "
+"will automatically create a Calibration Test (Reference Analysis) and will "
+"link it to the selected Instrument."
 msgstr ""
+"Если система не находит совпадений (образец, референс-анализ или дубликат), "
+"она использует идентификатор записи для поиска совпадений по ID референс-"
+"образцов. <br /> При обнаружении ID референс-образца система автоматически "
+"создаст калибровочный тест (референс-анализ) и свяжет его с выбранным "
+"инструментом."
 
 #: bika/lims/content/worksheettemplate.py:141
-msgid "If unchecked, Lab Managers won't be able to assign the same Instrument more than one Analyses while creating a Worksheet."
+msgid ""
+"If unchecked, Lab Managers won't be able to assign the same Instrument more "
+"than one Analyses while creating a Worksheet."
 msgstr ""
+"Если не отмечено, менеджеры лаборатории не смогут назначить один и тот же "
+"инструмент более чем одному анализу при создании рабочего листа."
 
 #: bika/lims/content/calculation.py:112
-msgid "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
+msgid ""
+"If your formula needs a special function from an external Python library, "
+"you can import it here. E.g. if you want to use the 'floor' function from "
+"the Python 'math' module, you add 'math' to the Module field and 'floor' to "
+"the function field. The equivalent in Python would be 'from math import "
+"floor'. In your calculation you could use then 'floor([Ca] + [Mg])'. "
 msgstr ""
+"Если вашей формуле нужна специальная функция из внешней библиотеки Python, "
+"импортируйте её здесь. Например, чтобы использовать функцию 'floor' из "
+"модуля Python 'math', добавьте 'math' в поле 'Модуль' и 'floor' в поле "
+"'Функция'. В Python это эквивалентно 'from math import floor'. В расчёте "
+"можно использовать 'floor([Ca] + [Mg])'."
 
-#: senaite/core/content/senaitesetup.py:329
+#: senaite/core/content/senaitesetup.py:328
 msgid "Immediate results entry"
-msgstr ""
+msgstr "Немедленный ввод результатов"
 
 #: senaite/core/exportimport/import.pt:14
 #: senaite/core/profiles/default/actions.xml
 msgid "Import"
-msgstr ""
+msgstr "Импорт"
 
 #: bika/lims/content/instrument.py:235
 msgid "Import Data Interface"
-msgstr ""
+msgstr "Интерфейс импорта данных"
 
 #: senaite/core/exportimport/instruments/importer.py:548
-msgid "Import finished successfully: {updated_ars} Samples and {updated_results} results updated"
+msgid ""
+"Import finished successfully: {updated_ars} Samples and {updated_results} "
+"results updated"
 msgstr ""
+"Импорт успешно завершён: обновлено образцов — {updated_ars}, результатов — "
+"{updated_results}"
 
 #: senaite/core/exportimport/instruments/importer.py:541
-msgid "Import finished successfully: {updated_ars} Samples, {updated_instruments} Instruments and {updated_results} results updated"
+msgid ""
+"Import finished successfully: {updated_ars} Samples, {updated_instruments} "
+"Instruments and {updated_results} results updated"
 msgstr ""
+"Импорт успешно завершён: обновлено образцов — {updated_ars}, инструментов — "
+"{updated_instruments}, результатов — {updated_results}"
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:59
 msgid "Imported File"
-msgstr ""
+msgstr "Импортированный файл"
 
 #: bika/lims/content/instrument.py:200
 msgid "In-lab calibration procedure"
-msgstr ""
+msgstr "Процедура калибровки в лаборатории"
 
 #: senaite/core/browser/clients/client/contacts/view.py:90
 #: senaite/core/browser/controlpanel/departments/view.py:93
-#: senaite/core/browser/controlpanel/labels/view.py:76
+#: senaite/core/browser/controlpanel/labels/view.py:75
 msgid "Inactive"
-msgstr ""
+msgstr "Неактивные"
 
-#: bika/lims/content/bikasetup.py:241
+#: bika/lims/content/bikasetup.py:240
 msgid "Include and display pricing information"
-msgstr ""
+msgstr "Включить и отображать информацию о ценах"
 
 #: bika/lims/content/pricelist.py:75
 msgid "Include descriptions"
-msgstr ""
+msgstr "Включить описания"
 
 #: senaite/core/content/supplier.py:170
 msgid "Incorrect IBAN number: %s"
-msgstr ""
+msgstr "Неверный номер IBAN: %s"
 
 #: senaite/core/content/supplier.py:132
 msgid "Incorrect NIB number: %s"
-msgstr ""
+msgstr "Неверный номер NIB: %s"
 
 #: bika/lims/content/analysisrequest.py:1404
 msgid "Indicates if the last SampleReport is printed,"
-msgstr ""
+msgstr "Указывает, был ли распечатан последний отчёт по образцу,"
 
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:22
 msgid "Info"
-msgstr ""
+msgstr "Информация"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Initialize"
-msgstr ""
+msgstr "Инициализировать"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:13
 msgid "Install SENAITE LIMS"
-msgstr ""
+msgstr "Установить SENAITE LIMS"
 
 #: bika/lims/content/instrument.py:356
 msgid "Installation Certificate"
-msgstr ""
+msgstr "Сертификат установки"
 
 #: bika/lims/content/instrument.py:357
 msgid "Installation certificate upload"
-msgstr ""
+msgstr "Загрузка сертификата установки"
 
 #: bika/lims/content/instrument.py:347
 msgid "InstallationDate"
-msgstr ""
+msgstr "Дата установки"
 
 #: bika/lims/content/method.py:77
 msgid "Instructions"
-msgstr ""
+msgstr "Инструкции"
 
 #: bika/lims/content/instrument.py:201
-msgid "Instructions for in-lab regular calibration routines intended for analysts"
+msgid ""
+"Instructions for in-lab regular calibration routines intended for analysts"
 msgstr ""
+"Инструкции для регулярных процедур калибровки в лаборатории, предназначенные"
+" для аналитиков"
 
 #: bika/lims/content/instrument.py:213
-msgid "Instructions for regular preventive and maintenance routines intended for analysts"
+msgid ""
+"Instructions for regular preventive and maintenance routines intended for "
+"analysts"
 msgstr ""
+"Инструкции для регулярных профилактических работ и обслуживания, "
+"предназначенные для аналитиков"
 
 #: senaite/core/browser/modals/analysis/schema.py:78
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:107
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:64
 msgid "Instrument"
-msgstr ""
+msgstr "Инструмент"
 
 #: senaite/core/browser/form/adapters/method.py:74
 msgid "Instrument '{}' is used by service '{}'"
-msgstr ""
+msgstr "Инструмент '{}' используется услугой '{}'"
 
 #: bika/lims/browser/instrument.py:193
 msgid "Instrument Calibrations"
-msgstr ""
+msgstr "Калибровки инструмента"
 
 #: bika/lims/browser/instrument.py:791
 msgid "Instrument Files"
-msgstr ""
+msgstr "Файлы инструмента"
 
 #: senaite/core/exportimport/import.pt:37
 msgid "Instrument Import"
-msgstr ""
+msgstr "Импорт инструмента"
 
 #: senaite/core/profiles/default/types/InstrumentLocation.xml
 msgid "Instrument Location"
-msgstr ""
+msgstr "Расположение инструмента"
 
 #: senaite/core/profiles/default/types/InstrumentLocations.xml
 msgid "Instrument Locations"
-msgstr ""
+msgstr "Расположения инструментов"
 
 #: bika/lims/browser/instrument.py:65
 msgid "Instrument Maintenance"
-msgstr ""
+msgstr "Обслуживание инструмента"
 
 #: bika/lims/browser/instrument.py:382
 msgid "Instrument Scheduled Tasks"
-msgstr ""
+msgstr "Запланированные задачи инструмента"
 
 #: bika/lims/browser/instrument.py:290
 msgid "Instrument Validations"
-msgstr ""
+msgstr "Валидации инструмента"
 
 #: bika/lims/content/abstractbaseanalysis.py:392
 msgid "Instrument assignment is allowed"
-msgstr ""
+msgstr "Назначение инструмента разрешено"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:35
 msgid "Instrument disabled until successful calibration:"
-msgstr ""
+msgstr "Инструмент отключён до успешной калибровки:"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:54
 msgid "Instrument disposed until new calibration tests being done:"
 msgstr ""
+"Инструмент выведен из эксплуатации до проведения новых калибровочных тестов:"
 
 #: bika/lims/browser/worksheet/views/export.py:53
 msgid "Instrument exporter not found"
-msgstr ""
+msgstr "Экспортер документ не найден"
 
 #: bika/lims/browser/workflow/analysis.py:141
 msgid "Instrument failed reference test"
-msgstr ""
+msgstr "Инструмент не прошёл референс-тест"
 
 #: bika/lims/browser/worksheet/views/export.py:40
 msgid "Instrument has no data interface selected"
-msgstr ""
+msgstr "У инструмента не выбран интерфейс данных"
 
 #: senaite/core/browser/form/adapters/data_import.py:96
 msgid "Instrument import finished"
-msgstr ""
+msgstr "Импорт инструмента завершён"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:92
 msgid "Instrument in calibration progress:"
-msgstr ""
+msgstr "Инструмент в процессе калибровки:"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:73
 msgid "Instrument in validation progress:"
-msgstr ""
+msgstr "Инструмент в процессе валидации:"
 
 #: senaite/core/exportimport/instruments/importer.py:402
 msgid "Instrument not found"
-msgstr ""
+msgstr "Инструмент не найден"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:16
 msgid "Instrument's calibration certificate expired:"
-msgstr ""
+msgstr "Сертификат калибровки прибора истек:"
 
 #: senaite/core/profiles/default/types/InstrumentType.xml
 msgid "InstrumentType"
-msgstr ""
+msgstr "Тип инструмента"
 
 #: senaite/core/profiles/default/types/InstrumentTypes.xml
 msgid "InstrumentTypes"
-msgstr ""
+msgstr "Типы инструментов"
 
 #: senaite/core/profiles/default/types/InstrumentLocation.xml
 #: senaite/core/profiles/default/types/InstrumentType.xml
 #: senaite/core/profiles/default/types/Manufacturer.xml
 msgid "Instruments"
-msgstr ""
+msgstr "Оборудование"
 
 #: senaite/core/exportimport/import.pt:162
-msgid "Instruments can be configured with one or multiple import data interfaces."
+msgid ""
+"Instruments can be configured with one or multiple import data interfaces."
 msgstr ""
+"Для инструментов можно настроить один или несколько интерфейсов импорта "
+"данных."
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:39
 msgid "Instruments disabled until successful calibration:"
-msgstr ""
+msgstr "Инструменты отключены до успешной калибровки:"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:58
 msgid "Instruments disposed until new calibration tests being done:"
 msgstr ""
+"Инструменты выведены из эксплуатации до проведения новых калибровочных "
+"тестов:"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:96
 msgid "Instruments in calibration progress:"
-msgstr ""
+msgstr "Инструменты в процессе калибровки:"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:77
 msgid "Instruments in validation progress:"
-msgstr ""
+msgstr "Инструменты в процессе валидации:"
 
 #: bika/lims/content/method.py:103
 msgid "Instruments supporting this method"
-msgstr ""
+msgstr "Инструменты, поддерживающие этот метод"
 
 #: bika/lims/browser/viewlets/templates/instrument_qc_failures_viewlet.pt:20
 msgid "Instruments' calibration certificates expired:"
-msgstr ""
+msgstr "Истёк срок сертификатов калибровки инструментов:"
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:55
 msgid "Interface"
-msgstr ""
+msgstr "Интерфейс"
 
 #: bika/lims/browser/instrument.py:494
 msgid "Internal Calibration Tests"
-msgstr ""
+msgstr "Внутренние калибровочные тесты"
 
 #: bika/lims/content/instrumentcertification.py:84
 msgid "Internal Certificate"
-msgstr ""
+msgstr "Внутренний сертификат "
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:145
-#: senaite/core/browser/samples/view.py:746
+#: senaite/core/browser/samples/view.py:608
 msgid "Internal use"
-msgstr ""
+msgstr "Для внутреннего использования"
 
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:42
 #: bika/lims/browser/templates/referencesample_analyses.pt:40
 msgid "Interpolation"
-msgstr ""
+msgstr "Интерполяция"
 
 #: senaite/core/profiles/default/types/InterpretationTemplate.xml
 msgid "Interpretation Template"
-msgstr ""
+msgstr "Шаблон интерпретации"
 
 #: senaite/core/profiles/default/types/InterpretationTemplates.xml
 msgid "Interpretation Templates"
-msgstr ""
+msgstr "Шаблоны интерпретации"
 
 #: bika/lims/content/instrumentcertification.py:110
 msgid "Interval"
-msgstr ""
+msgstr "Интервал"
 
-#: senaite/core/browser/dashboard/dashboard.py:168
-#: senaite/core/browser/samples/view.py:413
+#: senaite/core/browser/dashboard/dashboard.py:137
+#: senaite/core/browser/samples/view.py:383
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalid"
-msgstr ""
+msgstr "Недействительный"
 
-#: senaite/core/content/senaitesetup.py:1444
+#: senaite/core/content/senaitesetup.py:1417
 msgid "Invalid ID format on row ${i} ('${pt}'): ${err}"
-msgstr ""
+msgstr "Неверный формат ID в строке ${i} ('${pt}'): ${err}"
 
 #: senaite/core/content/person.py:236
 msgid "Invalid email address"
-msgstr ""
+msgstr "Неверный адрес email"
 
 #: senaite/core/content/dynamicanalysisspec.py:65
-msgid "Invalid specifications file detected. Please upload an Excel spreadsheet with at least the following columns defined: '{}', "
+msgid ""
+"Invalid specifications file detected. Please upload an Excel spreadsheet "
+"with at least the following columns defined: '{}', "
 msgstr ""
+"Обнаружен неверный файл спецификаций. Загрузите таблицу Excel как минимум со"
+" следующими столбцами: '{}', "
 
 #: bika/lims/validators.py:1324
 msgid "Invalid value: Please enter a value without spaces."
-msgstr ""
+msgstr "Неверное значение: введите значение без пробелов."
 
 #: bika/lims/validators.py:528
 msgid "Invalid wildcards found: ${wildcards}"
-msgstr ""
+msgstr "Обнаружены неверные шаблоны подстановки: ${wildcards}"
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:152
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Invalidate"
-msgstr ""
+msgstr "Недействительный"
 
 #: bika/lims/browser/workflow/analysisrequest.py:162
 msgid "Invalidated items: {}"
-msgstr ""
+msgstr "Аннулированные элементы: {}"
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:90
 msgid "Invalidation reason"
-msgstr ""
+msgstr "Причина аннулирования"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:18
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 #: bika/lims/profiles/default/types/Invoice.xml
 msgid "Invoice"
-msgstr ""
+msgstr "Счёт"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:55
 msgid "Invoice Date"
-msgstr ""
+msgstr "Дата счёта"
 
 #: bika/lims/content/analysisrequest.py:973
 msgid "Invoice Exclude"
-msgstr ""
+msgstr "Исключить счета"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:44
 msgid "Invoice ID"
-msgstr ""
+msgstr "ID счёта"
 
 #: bika/lims/content/invoice.py:41
 msgid "Invoice PDF"
-msgstr ""
+msgstr "PDF счёта"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:35
 msgid "Invoice To"
-msgstr ""
+msgstr "Счёт для"
 
 #: bika/lims/browser/analysisrequest/invoice.py:187
 msgid "Invoice {} created"
-msgstr ""
+msgstr "Счёт {} создан"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2427
+#: senaite/core/exportimport/setupdata/__init__.py:2426
 msgid "InvoiceBatch has no End Date"
-msgstr ""
+msgstr "У пакета счетов не задана дата окончания"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2424
+#: senaite/core/exportimport/setupdata/__init__.py:2423
 msgid "InvoiceBatch has no Start Date"
-msgstr ""
+msgstr "У пакета счетов не задана дата начала"
 
-#: senaite/core/exportimport/setupdata/__init__.py:2421
+#: senaite/core/exportimport/setupdata/__init__.py:2420
 msgid "InvoiceBatch has no Title"
-msgstr ""
+msgstr "У пакета счетов не задано название"
 
 #: senaite/core/config/widgets.py:60
 msgid "Job Title"
-msgstr ""
+msgstr "Должность"
 
 #: bika/lims/content/person.py:141
 msgid "Job title"
-msgstr ""
+msgstr "Название должности"
 
-#: bika/lims/content/abstractbaseanalysis.py:756
+#: bika/lims/content/abstractbaseanalysis.py:753
 msgid "Keep order above"
-msgstr ""
+msgstr "Сохранить порядок выше"
 
 #: bika/lims/content/instrument.py:287
 msgid "Key"
-msgstr ""
+msgstr "Ключ"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:98
 msgid "Key <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Ключ <span class=\"sort-indicator\" />"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:78
 #: bika/lims/browser/fields/interimfieldsfield.py:52
 #: bika/lims/browser/templates/analysisservice_info.pt:80
+#: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:77
 msgid "Keyword"
-msgstr ""
+msgstr "Ключевое слово"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:51
 msgid "Keyword is used in active analyses and can not be changed anymore"
 msgstr ""
+"Ключевое слово используется в активных анализах и больше не может быть "
+"изменено"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:187
 msgid "Keyword required"
-msgstr ""
+msgstr "Требуется ключевое слово"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:67
 #: senaite/core/browser/viewlets/templates/worksheet_attachments.pt:42
 msgid "Keywords"
-msgstr ""
-
-#: senaite/core/browser/samples/view.py:249
-msgid "Keywords of the analyses contained in the sample"
-msgstr ""
+msgstr "Ключевые слова"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:100
-#: bika/lims/config.py:52
-#: bika/lims/content/analysisspec.py:142
+#: bika/lims/config.py:52 bika/lims/content/analysisspec.py:142
 msgid "Lab"
-msgstr ""
+msgstr "Лаборатория"
 
 #: bika/lims/content/supplier.py:98
 msgid "Lab Account Number"
-msgstr ""
+msgstr "Номер лабораторного счёта"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:134
 msgid "Lab Analyses"
-msgstr ""
+msgstr "Лабораторные анализы"
 
 #: bika/lims/profiles/default/types/LabContact.xml
 msgid "Lab Contact"
-msgstr ""
+msgstr "Контакт лаборатории"
 
 #: bika/lims/controlpanel/bika_labcontacts.py:65
 #: bika/lims/profiles/default/types/LabContacts.xml
 msgid "Lab Contacts"
-msgstr ""
+msgstr "Лаборатория: Контакты"
 
 #: senaite/core/browser/controlpanel/departments/view.py:57
 msgid "Lab Departments"
-msgstr ""
+msgstr "Лаборатория: Департаменты"
 
 #: bika/lims/config.py:57
 msgid "Lab Preservation"
-msgstr ""
+msgstr "Лабораторное сохранение"
 
 #: senaite/core/profiles/default/types/LabProduct.xml
 msgid "Lab Product"
-msgstr ""
+msgstr "Услуга лаборатории"
 
 #: senaite/core/profiles/default/types/LabProducts.xml
 msgid "Lab Products"
-msgstr ""
+msgstr "Лаборатория: Расходные матриалы"
 
 #: bika/lims/content/laboratory.py:64
 msgid "Lab URL"
-msgstr ""
+msgstr "URL-адрес лаборатории"
 
-#: senaite/core/behaviors/label.py:115
-#: senaite/core/extender/label.py:80
+#: senaite/core/behaviors/label.py:107 senaite/core/extender/label.py:76
 #: senaite/core/profiles/default/types/Label.xml
 msgid "Label"
-msgstr ""
+msgstr "Метка"
 
 #: senaite/core/registry/schema.py:69
 msgid "Label configuration"
-msgstr ""
+msgstr "Настройка меток"
 
-#: senaite/core/content/label.py:93
+#: senaite/core/content/label.py:65
 msgid "Label names must be unique"
-msgstr ""
+msgstr "Названия меток должны быть уникальными"
 
 #: senaite/core/behaviors/configure.zcml:60
 msgid "Label schema extender"
-msgstr ""
+msgstr "Расширитель схемы меток"
 
-#: senaite/core/browser/label/labeled_objects.py:51
+#: senaite/core/browser/label/labeled_objects.py:50
 msgid "Labeled Objects"
-msgstr ""
+msgstr "Объекты с метками"
 
-#: senaite/core/browser/controlpanel/labels/view.py:52
-#: senaite/core/browser/label/labeled_objects.py:66
-#: senaite/core/browser/samples/view.py:875
+#: senaite/core/browser/controlpanel/labels/view.py:51
+#: senaite/core/browser/label/labeled_objects.py:65
+#: senaite/core/extender/label.py:57
 msgid "Labels"
-msgstr ""
+msgstr "Метки"
 
 #: senaite/core/content/laboratory.py:244
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "Laboratory"
-msgstr ""
+msgstr "Лаборатория"
 
 #: bika/lims/content/laboratory.py:111
 msgid "Laboratory Accredited"
-msgstr ""
+msgstr "Аккредитованные лаборатории"
 
-#: senaite/core/content/senaitesetup.py:1046
+#: senaite/core/content/senaitesetup.py:1023
 msgid "Laboratory Workdays"
-msgstr ""
+msgstr "Рабочие дни лаборатории"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:74
 msgid "Language"
-msgstr ""
+msgstr "Язык"
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Large Sticker"
-msgstr ""
+msgstr "Большой стикер"
 
-#: senaite/core/content/senaitesetup.py:1173
+#: senaite/core/content/senaitesetup.py:1150
 msgid "Large Sticker Template"
-msgstr ""
+msgstr "Шаблон большого стикера"
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:42
 msgid "Last Auto-Import Logs"
-msgstr ""
+msgstr "Последние журналы автоимпорта"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:97
 msgid "Last Login Time"
-msgstr ""
+msgstr "Время последнего входа"
 
-#: senaite/core/browser/samples/view.py:469
+#: senaite/core/browser/samples/view.py:439
 msgid "Late"
-msgstr ""
+msgstr "Отложить"
 
-#: senaite/core/browser/samples/view.py:731
+#: senaite/core/browser/samples/view.py:593
 msgid "Late Analyses"
-msgstr ""
+msgstr "Отложенные анализы"
 
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:307
 msgid "Late Analysis"
-msgstr ""
+msgstr "Отложенный анализ"
 
 #: bika/lims/content/samplepoint.py:56
 msgid "Latitude"
-msgstr ""
+msgstr "Широта"
 
 #: senaite/core/schema/gpscoordinatesfield.py:103
 msgid "Latitude must be within -90 and 90 degrees"
-msgstr ""
+msgstr "Широта должна быть в пределах от -90 до 90 градусов"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:104
 msgid "Layout"
-msgstr ""
+msgstr "Макет"
 
 #: bika/lims/browser/worksheet/views/results.py:68
 msgid "Layout view '{}' not found. Set '{}' as layout view."
 msgstr ""
+"Представление макета '{}' не найдено. Установлено '{}' как представление "
+"макета."
 
 #: senaite/core/browser/viewlets/setup_legacy_link.py:63
 msgid "Legacy LIMS Setup"
-msgstr ""
+msgstr "Устаревшие настройки LIMS"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:153
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:120
-msgid "Legend: Results in <em>italic</em> font are pending, results in <strong>bold</strong> font are verified."
+msgid ""
+"Legend: Results in <em>italic</em> font are pending, results in "
+"<strong>bold</strong> font are verified."
 msgstr ""
+"Легенда: результаты <em>курсивом</em> — в ожидании, результаты "
+"<strong>жирным</strong> — верифицированы."
 
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:46
 #: bika/lims/browser/templates/referencesample_analyses.pt:44
 msgid "Linear"
-msgstr ""
+msgstr "Линейный"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:203
 msgid "Link User"
-msgstr ""
+msgstr "Связать пользователя"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:144
 msgid "Link an existing User"
-msgstr ""
+msgstr "Связать существующего пользователя"
 
-#: senaite/core/browser/label/labeled_objects.py:52
+#: senaite/core/browser/label/labeled_objects.py:51
 msgid "List all objects with labels"
-msgstr ""
+msgstr "Список всех объектов с метками"
 
-#: bika/lims/content/abstractbaseanalysis.py:739
-msgid "List of possible final results. When set, no custom result is allowed on results entry and user has to choose from these values"
+#: bika/lims/content/abstractbaseanalysis.py:736
+msgid ""
+"List of possible final results. When set, no custom result is allowed on "
+"results entry and user has to choose from these values"
 msgstr ""
+"Список возможных итоговых результатов. Если задан, произвольный результат "
+"при вводе не допускается — пользователь должен выбрать из этих значений"
 
-#: bika/lims/content/bikasetup.py:1203
+#: bika/lims/content/bikasetup.py:1202
 msgid "List of predefined rejection reasons. Enter one reason per line."
 msgstr ""
+"Список предопределённых причин отклонения. Укажите по одной причине на "
+"строку."
 
 #: senaite/core/exportimport/import.pt:47
 msgid "Load Setup Data"
-msgstr ""
+msgstr "Данные настройки загрузки"
 
 #: bika/lims/content/method.py:89
 msgid "Load documents describing the method here"
-msgstr ""
+msgstr "Загрузить документы, описывающие метод "
 
 #: senaite/core/exportimport/import.pt:121
 msgid "Load from file"
-msgstr ""
+msgstr "Загрузить из файла"
 
 #: bika/lims/content/instrumentcertification.py:195
 msgid "Load the certificate document here"
-msgstr ""
+msgstr "Загрузите документ сертификата здесь"
 
 # senaite.core: Sidebar loading state
 msgid "Loading navigation..."
-msgstr ""
+msgstr "Загрузка навигации..."
 
-#: senaite/core/browser/dashboard/templates/dashboard.pt:41
+#: senaite/core/browser/dashboard/templates/dashboard.pt:40
 msgid "Loading..."
-msgstr ""
+msgstr "Загрузка..."
 
 #: senaite/core/browser/clients/client/attachments/view.py:79
 #: senaite/core/browser/controlpanel/contacts/view.py:70
 msgid "Location"
-msgstr ""
+msgstr "Местоположение"
 
 #: bika/lims/content/storagelocation.py:58
 msgid "Location Code"
-msgstr ""
+msgstr "Код местоположения"
 
 #: bika/lims/content/storagelocation.py:63
 msgid "Location Description"
-msgstr ""
+msgstr "Описание местоположения"
 
 #: bika/lims/content/storagelocation.py:53
 msgid "Location Title"
-msgstr ""
+msgstr "Название местоположения"
 
 #: bika/lims/content/storagelocation.py:68
 msgid "Location Type"
-msgstr ""
+msgstr "Тип местоположения"
 
 #: bika/lims/content/multifile.py:64
 msgid "Location where the document set is shelved"
-msgstr ""
-
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-msgid "Lock"
-msgstr ""
-
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-msgid "Locked"
-msgstr ""
+msgstr "Место хранения комплекта документов"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:252
 msgid "Log"
-msgstr ""
+msgstr "Журнал"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:11
 #: senaite/core/profiles/default/types/Contact.xml
 msgid "Login details"
-msgstr ""
+msgstr "Регистрационные данные"
 
 #: bika/lims/content/samplepoint.py:65
 msgid "Longitude"
-msgstr ""
+msgstr "Долгота"
 
 #: senaite/core/schema/gpscoordinatesfield.py:110
 msgid "Longitude must be within -180 and 180 degrees"
-msgstr ""
+msgstr "Долгота должна быть в пределах от -180 до 180 градусов"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:56
 #: bika/lims/browser/templates/referencesample_view.pt:62
 #: bika/lims/content/referencesample.py:157
 msgid "Lot Number"
-msgstr ""
+msgstr "Номер лота"
 
 #: bika/lims/config.py:142
 msgid "Low"
-msgstr ""
+msgstr "Низкий"
 
 #: bika/lims/config.py:143
 msgid "Lowest"
-msgstr ""
+msgstr "Наименьший"
 
 #: bika/lims/config.py:82
 msgid "Mailing address"
-msgstr ""
+msgstr "Почтовый адрес"
 
 #: bika/lims/browser/instrument.py:89
 #: bika/lims/content/instrumentmaintenancetask.py:83
 msgid "Maintainer"
-msgstr ""
+msgstr "Ответственный за обслуживание"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Maintenance"
-msgstr ""
+msgstr "Обслуживание"
 
 #. Default: "Type"
 #: bika/lims/content/instrumentmaintenancetask.py:55
 msgid "Maintenance type"
-msgstr ""
+msgstr "Тип"
 
 #: bika/lims/content/abstractbaseanalysis.py:349
 msgid "Make attachments mandatory for verification"
-msgstr ""
+msgstr "Сделать вложения обязательными для верификации"
 
 #: bika/lims/config.py:76
 msgid "Male"
-msgstr ""
+msgstr "Мужской"
 
 #: bika/lims/browser/analysisrequest/templates/analysisrequest_analyses.pt:14
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Manage Analyses"
-msgstr ""
+msgstr "Управление анализами"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:398
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:389
 msgid "Manage Form Fields"
-msgstr ""
+msgstr "Управление полями формы"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:12
 msgid "Manage Number Generator"
-msgstr ""
+msgstr "Управление генератором номеров"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:21
 msgid "Manage Partitions"
-msgstr ""
+msgstr "Управление партициями"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Manage Results"
-msgstr ""
+msgstr "Управление результатами"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:10
 msgid "Manage Sample Form Fields"
-msgstr ""
+msgstr "Управление полями формы образца"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:41
 msgid "Manage linked User"
-msgstr ""
+msgstr "Управление связанным пользователем"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:41
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:40
 msgid "Manage sample fields"
-msgstr ""
+msgstr "Управление полями образца"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add_manage.pt:38
-msgid "Manage the order and visibility of the fields displayed in analysis request add forms."
+msgid ""
+"Manage the order and visibility of the fields displayed in analysis request "
+"add forms."
 msgstr ""
+"Управление порядком и видимостью полей, отображаемых в формах добавления "
+"заявки на анализ."
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:16
 msgid "Manage the order and visibility of the sample fields."
-msgstr ""
+msgstr "Управление порядком и видимостью полей образца."
 
 #: senaite/core/browser/controlpanel/departments/view.py:75
 msgid "Manager"
-msgstr ""
+msgstr "Менеджер"
 
 #: senaite/core/browser/controlpanel/departments/view.py:81
 msgid "Manager Email"
-msgstr ""
+msgstr "электронная почта менеджера"
 
 #: senaite/core/browser/controlpanel/departments/view.py:78
 msgid "Manager Phone"
-msgstr ""
+msgstr "Телефон менеджера"
 
-#: bika/lims/browser/analyses/view.py:1163
+#: bika/lims/browser/analyses/view.py:1162
 msgid "Manual"
-msgstr ""
+msgstr "Вручную"
 
 #: bika/lims/content/abstractbaseanalysis.py:378
 #: bika/lims/content/method.py:148
 msgid "Manual entry of results"
-msgstr ""
+msgstr "Ручной ввод результатов"
 
 #: bika/lims/browser/publish/reports_listing.py:161
 msgid "Manually publish all contained samples of the selected reports."
-msgstr ""
+msgstr "Вручную опубликовать все образцы, содержащиеся в выбранных отчётах."
 
 #: senaite/core/exportimport/import.pt:192
 msgid "Manually trigger auto import"
-msgstr ""
+msgstr "Запустить автоимпорт вручную"
 
 #: senaite/core/profiles/default/types/Manufacturer.xml
 msgid "Manufacturer"
-msgstr ""
+msgstr "Производитель"
 
 #: senaite/core/profiles/default/types/Manufacturers.xml
 msgid "Manufacturers"
-msgstr ""
+msgstr "Производители"
 
 #: bika/lims/content/analysisrequest.py:1417
-msgid "Mark the sample for internal use only. This means it is only accessible to lab personnel and not to clients."
+msgid ""
+"Mark the sample for internal use only. This means it is only accessible to "
+"lab personnel and not to clients."
 msgstr ""
+"Отметить образец только для внутреннего использования. Это означает, что он "
+"доступен только персоналу лаборатории, но не клиентам."
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:97
+#: bika/lims/browser/analysisrequest/manage_analyses.py:94
 #: bika/lims/browser/fields/referenceresultsfield.py:38
 #: bika/lims/browser/fields/resultrangefield.py:37
 msgid "Max"
-msgstr ""
+msgstr "Макс"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:195
 msgid "Max Time"
-msgstr ""
+msgstr "Максимальное время"
 
 #: bika/lims/browser/fields/resultrangefield.py:36
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:121
 msgid "Max operator"
-msgstr ""
+msgstr "Оператор максимума"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:95
+#: bika/lims/browser/analysisrequest/manage_analyses.py:92
 #: bika/lims/browser/fields/resultrangefield.py:39
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:116
 msgid "Max warn"
-msgstr ""
+msgstr "Предупр. максимум"
 
 #: senaite/core/content/samplecontainer.py:79
 msgid "Maximum possible size or volume of samples"
-msgstr ""
+msgstr "Максимально возможный размер или объём образцов"
 
 #: bika/lims/content/container.py:75
 msgid "Maximum possible size or volume of samples."
-msgstr ""
+msgstr "Максимально возможный размер или количество образцов."
 
 #: bika/lims/content/abstractbaseanalysis.py:443
-msgid "Maximum time allowed for completion of the analysis. A late analysis alert is raised when this period elapses"
+msgid ""
+"Maximum time allowed for completion of the analysis. A late analysis alert "
+"is raised when this period elapses"
 msgstr ""
+"Максимально допустимое время выполнения анализа. По истечении этого срока "
+"формируется предупреждение о просрочке"
 
 #: bika/lims/content/abstractbaseanalysis.py:442
 msgid "Maximum turn-around time"
-msgstr ""
+msgstr "Максимальное время"
 
 #: bika/lims/config.py:141
 msgid "Medium"
-msgstr ""
+msgstr "Средний"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:153
 msgid "Meet the community, browse the code and get support on"
-msgstr ""
+msgstr "Познакомьтесь с сообществом, изучите код и получите поддержку на"
 
 #: bika/lims/browser/clientfolder.py:94
 msgid "Member Discount"
-msgstr ""
+msgstr "Скидка для участников"
 
 #: bika/lims/content/analysisrequest.py:1119
-#: bika/lims/content/bikasetup.py:282
+#: bika/lims/content/bikasetup.py:281
 msgid "Member discount %"
-msgstr ""
+msgstr "Членская скидка %"
 
-#: bika/lims/content/client.py:87
+#: bika/lims/content/client.py:83
 msgid "Member discount applies"
-msgstr ""
+msgstr "Член скидка распространяется"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:329
+#: senaite/core/browser/clients/client/contacts/login_details.py:318
 msgid "Member registered and linked to the current Contact."
-msgstr ""
+msgstr "Участник зарегистрирован и связан с текущим контактом."
 
 #: bika/lims/browser/publish/emailview.py:146
 msgid "Message sent to {}, "
-msgstr ""
+msgstr "Сообщение отправлено на {}, "
 
-#: senaite/core/content/resultsreport.py:218
+#: senaite/core/content/resultsreport.py:217
 msgid "Metadata"
-msgstr ""
+msgstr "Метаданные"
 
 #: senaite/core/browser/modals/analysis/schema.py:69
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:103
 msgid "Method"
-msgstr ""
+msgstr "Метод"
 
 #: bika/lims/content/method.py:88
 msgid "Method Document"
-msgstr ""
+msgstr "Документация к методу"
 
 #: bika/lims/content/method.py:56
 msgid "Method ID"
-msgstr ""
+msgstr "ID метода"
 
 #: bika/lims/browser/methodfolder.py:48
 #: bika/lims/browser/templates/analysisservice_info.pt:119
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:80
 msgid "Methods"
-msgstr ""
+msgstr "Методы"
 
 #: bika/lims/content/person.py:59
 msgid "Middle initial"
-msgstr ""
+msgstr "Отчество (инициал)"
 
 #: bika/lims/content/person.py:67
 msgid "Middle name"
-msgstr ""
+msgstr "Отчество"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:93
+#: bika/lims/browser/analysisrequest/manage_analyses.py:90
 #: bika/lims/browser/fields/referenceresultsfield.py:37
 #: bika/lims/browser/fields/resultrangefield.py:35
 msgid "Min"
-msgstr ""
+msgstr "Минимум"
 
 #: bika/lims/browser/fields/resultrangefield.py:34
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:106
 msgid "Min operator"
-msgstr ""
+msgstr "Оператор минимума"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:91
+#: bika/lims/browser/analysisrequest/manage_analyses.py:88
 #: bika/lims/browser/fields/resultrangefield.py:38
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:96
 msgid "Min warn"
-msgstr ""
+msgstr "Предупр. минимум"
 
 #: bika/lims/browser/worksheet/views/folder.py:183
 msgid "Mine"
-msgstr ""
+msgstr "Мои"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:245
 msgid "Minimum 5 characters."
-msgstr ""
+msgstr "Минимум 5 символов."
 
 #: bika/lims/content/sampletype.py:165
 msgid "Minimum Volume"
-msgstr ""
+msgstr "Минимальный объём"
 
-#: bika/lims/content/bikasetup.py:340
+#: bika/lims/content/bikasetup.py:339
 msgid "Minimum number of results for QC stats calculations"
 msgstr ""
+"Минимальное количество результатов для расчёта статистики контроля качества"
 
 #: bika/lims/browser/fields/coordinatefield.py:37
 #: bika/lims/browser/fields/durationfield.py:38
 msgid "Minutes"
-msgstr ""
+msgstr "Минуты"
 
 #: bika/lims/controlpanel/bika_labcontacts.py:92
 msgid "Mobile Phone"
-msgstr ""
+msgstr "Телефон мобильный"
 
 #: senaite/core/browser/clients/client/contacts/view.py:80
 #: senaite/core/browser/controlpanel/contacts/view.py:68
 msgid "MobilePhone"
-msgstr ""
+msgstr "Мобильный телефон"
 
 #: bika/lims/content/instrument.py:137
 #: bika/lims/controlpanel/bika_instruments.py:84
 msgid "Model"
-msgstr ""
+msgstr "Модель"
 
 #: bika/lims/content/calculation.py:100
 msgid "Module"
-msgstr ""
+msgstr "Модуль"
 
 #: senaite/core/vocabularies/setup.py:156
 msgid "Monday"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:137
-msgid "Monthly"
-msgstr ""
+msgstr "Понедельник"
 
 #: senaite/core/exportimport/instruments/importer.py:464
 msgid "More than one analysis found for {sid} and keyword '{keyword}'"
-msgstr ""
+msgstr "Найдено более одного анализа для {sid} и ключевого слова '{keyword}'"
 
 #: senaite/core/behaviors/configure.zcml:26
 msgid "Multi Catalog Behavior for Dexterity Contents"
-msgstr ""
+msgstr "Поведение мультикаталога для содержимого Dexterity"
 
 #: senaite/core/browser/samples/multi_results_transposed.py:66
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Multi Results"
-msgstr ""
+msgstr "Несколько результатов"
 
-#: bika/lims/content/bikasetup.py:529
+#: bika/lims/content/bikasetup.py:528
 msgid "Multi Verification type"
-msgstr ""
+msgstr "Тип многократной верификации"
 
-#: bika/lims/browser/analyses/view.py:1586
+#: bika/lims/browser/analyses/view.py:1585
 msgid "Multi-verification required"
-msgstr ""
+msgstr "Требуется многократная верификация"
 
 #: senaite/core/profiles/default/types/Multifile.xml
 msgid "Multifile"
-msgstr ""
+msgstr "Мультифайл"
 
 #: senaite/core/config/vocabularies.py:60
 msgid "Multiple choices"
-msgstr ""
+msgstr "Множественный выбор"
 
 #: senaite/core/config/vocabularies.py:58
 msgid "Multiple selection"
-msgstr ""
+msgstr "Множественный выбор"
 
 #: senaite/core/config/vocabularies.py:59
 msgid "Multiple selection (with duplicates)"
-msgstr ""
+msgstr "Множественный выбор (с повторами)"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:108
 msgid "Multiple values"
-msgstr ""
+msgstr "Несколько значений"
 
 #: bika/lims/validators.py:469
 msgid "Multiple values control type is not supported for choices"
 msgstr ""
+"Тип контроля 'несколько значений' не поддерживается для вариантов выбора"
 
 #: senaite/core/profiles/default/actions.xml
 msgid "My Organization"
-msgstr ""
+msgstr "Моя организация"
 
 #: senaite/core/profiles/default/actions.xml
 msgid "My Profile"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — default name when saving
-msgid "My filter"
-msgstr ""
+msgstr "Мой профиль"
 
 #: bika/lims/content/supplier.py:63
 msgid "NIB"
-msgstr ""
+msgstr "NIB"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:63
-#: senaite/core/config/widgets.py:32
-#: senaite/core/content/contact.py:146
+#: senaite/core/config/widgets.py:32 senaite/core/content/contact.py:114
 msgid "Name"
-msgstr ""
+msgstr "Имя"
 
 #: senaite/core/browser/viewlets/setup_legacy_link.py:67
 msgid "New LIMS Setup"
-msgstr ""
+msgstr "Новые настройки LIMS"
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:23
-msgid "New ranges won't be applied to neither new nor current analyses. Re-assign the Specification if you want to apply latest changes."
+msgid ""
+"New ranges won't be applied to neither new nor current analyses. Re-assign "
+"the Specification if you want to apply latest changes."
 msgstr ""
-
-#: senaite/core/api/remarks.py:490
-msgid "Newest first"
-msgstr ""
+"Новые диапазоны не будут применены ни к новым, ни к текущим анализам. "
+"Переназначьте спецификацию, чтобы применить последние изменения."
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:108
 msgid "Next ID <span class=\"sort-indicator\" />"
-msgstr ""
+msgstr "Следующий ID <span class=\"sort-indicator\" />"
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:168
 #: senaite/core/browser/widgets/services_widget.py:305
 #: senaite/core/skins/senaite_templates/senaite_widgets/rejectionwidget.pt:9
 msgid "No"
-msgstr ""
+msgstr "Нет"
 
 #: senaite/core/exportimport/instruments/eltra/cs/cs2000.py:51
 msgid "No Analysis Services defined"
-msgstr ""
+msgstr "Не определены услуги анализа"
 
 #: bika/lims/browser/publish/templates/email.pt:70
 msgid "No Email Address"
-msgstr ""
+msgstr "Нет адреса email"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:43
 msgid "No Method selected for this Service"
-msgstr ""
+msgstr "Для этой услуги не выбран метод"
 
 #: senaite/core/exportimport/instruments/importer.py:415
 msgid "No Sample found for {sid}"
-msgstr ""
+msgstr "Образец не найден для {sid}"
 
 #: senaite/core/exportimport/instruments/importer.py:403
-msgid "No Sample with '{allowed_ar_states}' statesfound, and no QC analyses found for {sid}, "
+msgid ""
+"No Sample with '{allowed_ar_states}' statesfound, and no QC analyses found "
+"for {sid}, "
 msgstr ""
+"Не найдено образцов со статусами '{allowed_ar_states}', а также анализов "
+"контроля качества для {sid}, "
 
 #: bika/lims/browser/analysisrequest/add2.py:2189
 msgid "No Samples could be created."
-msgstr ""
+msgstr "Не удалось создать образцы."
 
 #: bika/lims/browser/batch/batchbook.py:175
 msgid "No Subgroup"
-msgstr ""
+msgstr "Без подгруппы"
 
 #: bika/lims/browser/workflow/__init__.py:124
 msgid "No action defined."
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:131
-msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
-msgstr ""
+msgstr "Действие не определено."
 
 #: senaite/core/exportimport/instruments/importer.py:458
 msgid "No analyses found for {sid} and keyword '{keyword}'"
-msgstr ""
+msgstr "Не найдено анализов для {sid} и ключевого слова '{keyword}'"
 
 #: senaite/core/exportimport/instruments/importer.py:434
 msgid "No analyses found for {sid} in the states '{allowed_sample_states}' , "
-msgstr ""
+msgstr "Не найдено анализов для {sid} в статусах '{allowed_sample_states}', "
 
 #: bika/lims/browser/worksheet/views/add_worksheet.py:75
 msgid "No analyses were added"
-msgstr ""
+msgstr "Анализы не были добавлены"
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:152
 msgid "No analyses were added to this worksheet."
-msgstr ""
+msgstr "В этот рабочий лист не были добавлены анализы."
 
 #: senaite/core/browser/attachment/attachment.py:219
 msgid "No analysis found for service '{}'"
-msgstr ""
+msgstr "Не найдено анализов для услуги '{}'"
 
 #: senaite/core/exportimport/instruments/biodrop/ulite/ulite.py:53
 #: senaite/core/exportimport/instruments/lifetechnologies/qubit/qubit.py:54
 msgid "No analysis selected"
-msgstr ""
+msgstr "Анализ не выбран"
 
 #: senaite/core/exportimport/instruments/thermoscientific/multiskan/go.py:51
 msgid "No analysis service selected"
-msgstr ""
+msgstr "Услуга анализа не выбрана"
 
 #: bika/lims/controlpanel/templates/analysisservice_copy.pt:27
 msgid "No analysis services were selected."
-msgstr ""
+msgstr "Услуги анализа не были выбраны."
 
 #: senaite/core/browser/idserver/view.py:135
 msgid "No changes"
-msgstr ""
+msgstr "Без изменений"
 
 #: senaite/core/browser/workflow/worksheet.py:50
 msgid "No changes made"
-msgstr ""
+msgstr "Изменения не внесены"
 
 #: bika/lims/browser/workflow/__init__.py:166
 #: bika/lims/browser/workflow/analysisrequest.py:94
 msgid "No changes made."
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:130
-msgid "No data for the selected period"
-msgstr ""
+msgstr "Изменения не внесены."
 
 #: bika/lims/controlpanel/bika_instruments.py:164
 msgid "No date set"
-msgstr ""
+msgstr "Дата не задана"
 
 #: bika/lims/browser/workflow/analysisrequest.py:435
 msgid "No duplicate created"
-msgstr ""
+msgstr "Дубликат не создан"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:135
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:138
 msgid "No email recipients available for this sample"
-msgstr ""
+msgstr "Нет доступных получателей email для этого образца"
 
 #: bika/lims/browser/publish/emailview.py:167
 msgid "No email recipients selected"
-msgstr ""
+msgstr "Не выбраны получатели email"
 
 #: senaite/core/exportimport/instruments/abaxis/vetscan/vs2.py:47
 #: senaite/core/exportimport/instruments/abbott/m2000rt/m2000rt.py:59
 #: senaite/core/exportimport/instruments/alere/pima/beads.py:47
 msgid "No file selected"
-msgstr ""
+msgstr "Файл не выбран"
 
 #: senaite/core/browser/form/adapters/data_import.py:81
 msgid "No importer not found for interface '{}'"
-msgstr ""
+msgstr "Не найден импортёр для интерфейса '{}'"
 
 #: senaite/core/browser/form/adapters/data_import.py:126
 msgid "No instrument import interfaces available for {}"
-msgstr ""
+msgstr "Нет доступных интерфейсов импорта инструмента для {}"
 
 #: bika/lims/browser/workflow/client.py:120
 msgid "No items published"
-msgstr ""
+msgstr "Ничего не опубликовано"
 
 #: senaite/core/browser/samples/partition_magic.py:64
 #: senaite/core/browser/samples/rejection/reject_samples.py:78
 msgid "No items selected"
-msgstr ""
+msgstr "Ничего не выбрано"
 
 #: bika/lims/browser/workflow/__init__.py:129
 msgid "No items selected."
-msgstr ""
-
-# senaite.app.listing: Column config — empty state for hidden section with
-# search
-msgid "No matches in hidden columns."
-msgstr ""
-
-# senaite.app.listing: Column config — empty state for visible section with
-# search
-msgid "No matches in visible columns."
-msgstr ""
+msgstr "Ничего не выбрано."
 
 #: bika/lims/controlpanel/bika_analysisservices.py:114
 msgid "No new items were created."
-msgstr ""
+msgstr "Новые элементы не были созданы."
 
 #: senaite/core/browser/samples/partition_magic.py:111
 msgid "No partitions were created"
-msgstr ""
-
-#: senaite/core/api/remarks.py:493
-msgid "No remarks yet"
-msgstr ""
+msgstr "Партиции не были созданы"
 
 #: bika/lims/browser/publish/emailview.py:176
 msgid "No reports found"
-msgstr ""
+msgstr "Отчёты не найдены"
 
 #: senaite/core/browser/samples/invalidate_samples.py:110
-msgid "No samples were invalidated. Please ensure samples are selected and meet the criteria for invalidation."
+msgid ""
+"No samples were invalidated. Please ensure samples are selected and meet the"
+" criteria for invalidation."
 msgstr ""
+"Образцы не были аннулированы. Убедитесь, что образцы выбраны и соответствуют"
+" критериям аннулирования."
 
 #: senaite/core/browser/samples/rejection/reject_samples.py:112
 msgid "No samples were rejected"
-msgstr ""
+msgstr "Образцы не были отклонены"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "No sampling workflow"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — empty state
-msgid "No saved filters yet."
-msgstr ""
+msgstr "Без процесса отбора проб"
 
 #: senaite/core/exportimport/instruments/importer.py:322
 msgid "No services could be found for parsed keywords"
-msgstr ""
+msgstr "Не найдено услуг для разобранных ключевых слов"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:133
-msgid "No user exists for ${contact_fullname} and they will not be able to log in. Fill in the form below to create one for them."
+msgid ""
+"No user exists for ${contact_fullname} and they will not be able to log in. "
+"Fill in the form below to create one for them."
 msgstr ""
+"Для ${contact_fullname} не существует пользователя, и вход в систему "
+"невозможен. Заполните форму ниже, чтобы создать его."
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:49
-msgid "No user profile could be found for the linked user. Please contact the lab administrator to get further support or try to relink the user."
+msgid ""
+"No user profile could be found for the linked user. Please contact the lab "
+"administrator to get further support or try to relink the user."
 msgstr ""
+"Профиль связанного пользователя не найден. Обратитесь к администратору "
+"лаборатории за поддержкой или попробуйте пересвязать пользователя."
 
 #: bika/lims/browser/analysisrequest/add2.py:2057
 msgid "No valid contact"
-msgstr ""
+msgstr "Нет действительного контакта"
 
 #: bika/lims/validators.py:448
-msgid "No valid format in choices field. Supported format is: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
+msgid ""
+"No valid format in choices field. Supported format is: "
+"<value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 msgstr ""
+"Неверный формат поля выбора. Поддерживаемый формат: "
+"<value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:115
 msgid "No visible analyses for this sample"
-msgstr ""
+msgstr "Нет видимых анализов для этого образца"
 
 #: senaite/core/browser/form/adapters/analysisservice.py:70
 #: senaite/core/browser/modals/analysis/vocabularies.py:53
-#: senaite/core/content/senaitesetup.py:1141
+#: senaite/core/content/senaitesetup.py:1118
 msgid "None"
-msgstr ""
+msgstr "Нет"
 
 #: bika/lims/browser/publish/emailview.py:216
-msgid "Not all contacts are equal for the selected Reports. Please manually select recipients for this email."
+msgid ""
+"Not all contacts are equal for the selected Reports. Please manually select "
+"recipients for this email."
 msgstr ""
+"Контакты для выбранных отчётов не совпадают. Выберите получателей для этого "
+"письма вручную."
 
 #: senaite/core/browser/modals/conditions.py:133
 msgid "Not allowed to update conditions: {}"
-msgstr ""
+msgstr "Обновление условий не разрешено: {}"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:86
 msgid "Not defined"
-msgstr ""
+msgstr "Не определено"
 
-#: senaite/core/browser/samples/view.py:703
+#: senaite/core/browser/samples/view.py:565
 msgid "Not printed"
-msgstr ""
+msgstr "Не напечатано"
 
-#: bika/lims/api/snapshot.py:611
+#: bika/lims/api/snapshot.py:433
 #: bika/lims/content/instrumentcertification.py:249
 msgid "Not set"
-msgstr ""
+msgstr "Не задано"
 
 #: bika/lims/content/worksheet.py:291
 msgid "Not specified"
-msgstr ""
+msgstr "Не указано"
 
 #: bika/lims/browser/analysisrequest/templates/ar_add_manage.pt:42
-msgid "Note: The settings apply to all Sample Add forms; Required fields can not be deselected."
+msgid ""
+"Note: The settings apply to all Sample Add forms; Required fields can not be"
+" deselected."
 msgstr ""
+"Примечание: настройки применяются ко всем формам добавления образца; "
+"обязательные поля нельзя снять с выбора."
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:19
 msgid "Note: The settings are global and apply to all sample views."
 msgstr ""
+"Примечание: настройки глобальны и применяются ко всем просмотрам образцов."
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:168
-msgid "Note: You can also drag and drop the attachment rows to change the order they appear in the report."
+msgid ""
+"Note: You can also drag and drop the attachment rows to change the order "
+"they appear in the report."
 msgstr ""
+"Примечание: вы также можете перетаскивать строки вложений, чтобы изменить "
+"порядок их отображения в отчёте."
 
-#: senaite/core/content/senaitesetup.py:1381
+#: senaite/core/content/senaitesetup.py:1354
 msgid "Notifications"
-msgstr ""
+msgstr "Уведомления"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print.pt:126
 msgid "Num columns"
-msgstr ""
+msgstr "Кол-во столбцов"
 
 #: bika/lims/content/analysisservice.py:259
 msgid "Number"
-msgstr ""
+msgstr "Номер"
 
-#: senaite/core/browser/samples/view.py:242
+#: senaite/core/browser/samples/view.py:230
 msgid "Number of Analyses"
-msgstr ""
+msgstr "Количество анализов"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:82
 msgid "Number of Partitions to create"
-msgstr ""
+msgstr "Количество создаваемых партиций"
 
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:39
 msgid "Number of copies"
-msgstr ""
+msgstr "Количество копий"
 
 #: senaite/core/registry/schema.py:180
 msgid "Number of prominent columns"
-msgstr ""
+msgstr "Количество основных столбцов"
 
-#: bika/lims/content/abstractbaseanalysis.py:839
-#: bika/lims/content/bikasetup.py:513
+#: bika/lims/content/abstractbaseanalysis.py:836
+#: bika/lims/content/bikasetup.py:512
 msgid "Number of required verifications"
-msgstr ""
+msgstr "Требуемое количество верификаций"
 
-#: bika/lims/content/bikasetup.py:514
-msgid "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
+#: bika/lims/content/bikasetup.py:513
+msgid ""
+"Number of required verifications before a given result being considered as "
+"'verified'. This setting can be overrided for any Analysis in Analysis "
+"Service edit view. By default, 1"
 msgstr ""
+"Требуемое количество верификаций, прежде чем результат будет считаться "
+"'верифицированным'. Может быть переопределено для конкретного анализа в "
+"услуге анализа. По умолчанию — 1"
 
-#: bika/lims/content/abstractbaseanalysis.py:840
-msgid "Number of required verifications from different users with enough privileges before a given result for this analysis being considered as 'verified'. The option set here has priority over the option set in Bika Setup"
+#: bika/lims/content/abstractbaseanalysis.py:837
+msgid ""
+"Number of required verifications from different users with enough privileges"
+" before a given result for this analysis being considered as 'verified'. The"
+" option set here has priority over the option set in Bika Setup"
 msgstr ""
+"Требуемое количество верификаций от разных пользователей с достаточными "
+"правами, прежде чем результат этого анализа будет считаться "
+"'верифицированным'. Имеет приоритет над настройкой в Bika Setup"
 
 #: senaite/core/registry/schema.py:189
 msgid "Number of standard columns"
-msgstr ""
+msgstr "Количество стандартных столбцов"
 
 #: senaite/core/config/vocabularies.py:54
 msgid "Numeric"
-msgstr ""
-
-#: senaite/core/api/remarks.py:491
-msgid "Oldest first"
-msgstr ""
+msgstr "Числовой"
 
 #: bika/lims/content/preservation.py:53
-msgid "Once preserved, the sample must be disposed of within this time period.  If not specified, the sample type retention period will be used."
+msgid ""
+"Once preserved, the sample must be disposed of within this time period.  If "
+"not specified, the sample type retention period will be used."
 msgstr ""
+"После консервации образец должен быть утилизирован в течение этого периода. "
+"Если не указано, используется срок хранения типа образца."
 
 #: senaite/core/content/dynamicanalysisspec.py:51
 msgid "Only Excel files supported"
-msgstr ""
+msgstr "Поддерживаются только файлы Excel"
 
 #: bika/lims/content/attachment.py:81
 msgid "Only images can be rendered in the report directly"
-msgstr ""
+msgstr "В отчёте напрямую можно отобразить только изображения"
 
 #: senaite/core/exportimport/import.pt:95
-msgid "Only instruments that have an import interface configured are displayed"
-msgstr ""
+msgid ""
+"Only instruments that have an import interface configured are displayed"
+msgstr "Отображаются только инструменты с настроенным интерфейсом импорта"
 
-#: senaite/core/content/senaitesetup.py:1047
-msgid "Only laboratory workdays are considered for the analysis turnaround time calculation."
+#: senaite/core/content/senaitesetup.py:1024
+msgid ""
+"Only laboratory workdays are considered for the analysis turnaround time "
+"calculation."
 msgstr ""
+"Для расчёта срока выполнения анализа учитываются только рабочие дни "
+"лаборатории."
 
-#: bika/lims/content/bikasetup.py:754
-msgid "Only laboratory workdays are considered for the analysis turnaround time calculation. "
+#: bika/lims/content/bikasetup.py:753
+msgid ""
+"Only laboratory workdays are considered for the analysis turnaround time "
+"calculation. "
 msgstr ""
+"Для расчёта срока выполнения анализа учитываются только рабочие дни "
+"лаборатории. "
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:216
 msgid "Only to empty or zero fields"
-msgstr ""
+msgstr "Только для пустых или нулевых полей"
 
-#: senaite/core/browser/samples/view.py:652
+#: senaite/core/browser/samples/view.py:525
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Open"
-msgstr ""
+msgstr "Открытые"
 
-#: senaite/core/browser/samples/view.py:243
+#: senaite/core/browser/samples/view.py:231
 msgid "Open / To be verified / Verified / Total"
-msgstr ""
+msgstr "Открыто / Ожидает верификации / Верифицировано / Всего"
 
 #: bika/lims/profiles.zcml:15
 msgid "Open Source Web based Laboratory Information Management System"
 msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:97
-msgid "Open Worksheets"
-msgstr ""
+"Информационная система лаборатории с открытым исходным кодом на базе веб-"
+"технологий"
 
 #: bika/lims/browser/publish/reports_listing.py:128
-msgid "Open email form to send the selected reports to the recipients. This will also publish the contained samples of the reports after the email was successfully sent."
+msgid ""
+"Open email form to send the selected reports to the recipients. This will "
+"also publish the contained samples of the reports after the email was "
+"successfully sent."
 msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:522
-msgid "Open worksheets with analyses awaiting results"
-msgstr ""
+"Открыть форму письма для отправки выбранных отчётов получателям. После "
+"успешной отправки письма также будут опубликованы образцы, содержащиеся в "
+"отчётах."
 
 #: bika/lims/browser/worksheet/views/add_analyses.py:98
 msgid "Order"
-msgstr ""
+msgstr "Заказ"
 
 #: bika/lims/content/instrumentcertification.py:93
 msgid "Organization responsible of granting the calibration certificate"
-msgstr ""
+msgstr "Организация, выдавшая сертификат калибровки"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:51
 msgid "Orientation"
-msgstr ""
+msgstr "Ориентация"
 
 #: senaite/core/z3cform/widgets/address.py:124
 msgid "Other address"
-msgstr ""
+msgstr "Другой адрес"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:100
 #: senaite/core/skins/senaite_templates/senaite_widgets/rejectionwidget.pt:70
 msgid "Other reasons"
-msgstr ""
+msgstr "Другие причины"
 
 #: bika/lims/browser/viewlets/templates/rejected_ar_viewlet.pt:22
 msgid "Other reasons:"
-msgstr ""
+msgstr "Другие причины:"
 
-#: senaite/core/browser/dashboard/dashboard.py:183
+#: senaite/core/browser/dashboard/dashboard.py:157
 msgid "Other status"
-msgstr ""
+msgstr "Другой статус"
 
 #: senaite/core/browser/widgets/selectotherwidget.py:114
 #: senaite/core/z3cform/widgets/selectother/widget.py:138
 msgid "Other..."
-msgstr ""
+msgstr "Другое..."
 
 #: bika/lims/browser/instrument.py:733
 #: bika/lims/controlpanel/bika_instruments.py:170
 msgid "Out of date"
-msgstr ""
+msgstr "Просрочено"
 
 #: senaite/core/exportimport/instruments/importer.py:377
 msgid "Override non-empty analysis results"
-msgstr ""
+msgstr "Перезаписывать непустые результаты анализов"
 
 #: senaite/core/exportimport/instruments/importer.py:379
 msgid "Override non-empty analysis results, also with empty"
-msgstr ""
+msgstr "Перезаписывать непустые результаты анализов, в том числе пустыми"
+
+#: senaite/core/content/resultsreport.py:197
+msgid "PDF"
+msgstr "PDF"
 
 #: senaite/core/content/resultsreport.py:198
-msgid "PDF"
-msgstr ""
-
-#: senaite/core/content/resultsreport.py:199
 msgid "PDF file of the report"
-msgstr ""
+msgstr "PDF-файл отчёта"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:42
 msgid "Paperformat"
-msgstr ""
+msgstr "Формат бумаги"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:130
 msgid "Partition"
-msgstr ""
+msgstr "Партиция"
 
 #: senaite/core/browser/samples/partition_magic.py:120
 msgid "Partitioning canceled"
-msgstr ""
+msgstr "Разделение на партиции отменено"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:242
 msgid "Password"
-msgstr ""
+msgstr "Пароль"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:50
 msgid "Path identifier"
-msgstr ""
+msgstr "Идентификатор пути"
 
 #: bika/lims/browser/fields/referenceresultsfield.py:36
 #: bika/lims/browser/referencesample.py:228
 #: bika/lims/browser/widgets/referenceresultswidget.py:71
 msgid "Permitted Error %"
-msgstr ""
+msgstr "Допустимое отклонение %"
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:23
-msgid "Persistent counters used by the ID Server. Adjust a counter to change the next ID that will be issued for the matching prefix. Setting a counter to 0 removes the entry from the storage."
+msgid ""
+"Persistent counters used by the ID Server. Adjust a counter to change the "
+"next ID that will be issued for the matching prefix. Setting a counter to 0 "
+"removes the entry from the storage."
 msgstr ""
+"Постоянные счётчики, используемые сервером идентификаторов. Измените "
+"счётчик, чтобы изменить следующий выдаваемый ID для соответствующего "
+"префикса. Установка счётчика в 0 удаляет запись из хранилища."
 
 #: bika/lims/browser/clientfolder.py:81
 #: bika/lims/browser/templates/batch_publish.pt:68
 #: bika/lims/content/organisation.py:59
 msgid "Phone"
-msgstr ""
+msgstr "Телефон"
 
 #: bika/lims/content/person.py:110
 msgid "Phone (business)"
-msgstr ""
+msgstr "Телефон (рабочий)"
 
 #: bika/lims/content/person.py:126
 msgid "Phone (home)"
-msgstr ""
+msgstr "Телефон (домашний)"
 
 #: bika/lims/content/person.py:134
 msgid "Phone (mobile)"
-msgstr ""
+msgstr "Телефон (моб.)"
 
 #: bika/lims/content/instrument.py:338
 msgid "Photo image file"
-msgstr ""
+msgstr "Файл фотографии"
 
 #: bika/lims/content/instrument.py:339
 msgid "Photo of the instrument"
-msgstr ""
+msgstr "Фото инструмента"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:87
 #: senaite/core/z3cform/widgets/address.py:120
 msgid "Physical address"
-msgstr ""
+msgstr "Физический адрес"
 
 #: bika/lims/browser/publish/emailview.py:170
 msgid "Please add an email subject"
-msgstr ""
+msgstr "Пожалуйста укажите тему письма"
 
 #: bika/lims/browser/publish/emailview.py:173
 msgid "Please add an email text"
-msgstr ""
+msgstr "Пожалуйста добавьте текст письма"
 
 #: senaite/core/browser/viewlets/sample/templates/not_sampled.pt:11
-msgid "Please check that the sample has been physically collected and the value for \"Sampled Date\" field has been set in accordance."
+msgid ""
+"Please check that the sample has been physically collected and the value for"
+" \"Sampled Date\" field has been set in accordance."
 msgstr ""
+"Убедитесь, что образец был физически отобран, и значение поля 'Дата отбора' "
+"установлено соответствующим образом."
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:165
 msgid "Please click the update button after your changes."
-msgstr ""
+msgstr "После внесения изменений нажмите кнопку обновления."
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:11
 msgid "Please find attached the analysis result(s) for ${client_name}"
-msgstr ""
+msgstr "Во вложении результат(ы) анализа для ${client_name}"
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:44
 msgid "Please follow the link to the retest ${retest_id}."
-msgstr ""
+msgstr "Перейдите по ссылке на повторный тест ${retest_id}."
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:95
-msgid "Please provide a comment explaining the reason for invalidating the sample. If the email notification option is selected, the sample contact will be informed, and this comment will be included in the email content."
+msgid ""
+"Please provide a comment explaining the reason for invalidating the sample. "
+"If the email notification option is selected, the sample contact will be "
+"informed, and this comment will be included in the email content."
 msgstr ""
+"Укажите комментарий с причиной аннулирования образца. Если выбрана опция "
+"уведомления по email, контакт образца будет проинформирован, и этот "
+"комментарий будет включён в текст письма."
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:109
 msgid "Please provide the reason for invalidating the sample."
-msgstr ""
+msgstr "Укажите причину аннулирования образца."
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:213
+#: senaite/core/browser/clients/client/contacts/login_details.py:222
 msgid "Please select a User from the list"
-msgstr ""
+msgstr "Пожалуйста выберите Пользователя из списка"
 
-#: senaite/core/browser/stickers/view.py:267
+#: senaite/core/browser/stickers/view.py:257
 msgid "Please select a sticker template"
-msgstr ""
+msgstr "Выберите шаблон стикера"
 
 #: senaite/core/browser/attachment/attachment.py:224
 msgid "Please select an analysis or service for the attachment"
-msgstr ""
+msgstr "Выберите анализ или услугу для вложения"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:111
-msgid "Please select number of partitions to create and press the preview button"
+msgid ""
+"Please select number of partitions to create and press the preview button"
 msgstr ""
+"Выберите количество создаваемых партиций и нажмите кнопку предпросмотра"
 
 #: senaite/core/browser/samples/dispatch_samples.py:61
-#: senaite/core/browser/samples/dispose_samples.py:61
 msgid "Please specify a reason"
-msgstr ""
+msgstr "Укажите причину"
 
 #: bika/lims/content/analysisservice.py:183
-msgid "Please specify preservations that differ from the analysis service's default preservation per sample type here."
+msgid ""
+"Please specify preservations that differ from the analysis service's default"
+" preservation per sample type here."
 msgstr ""
+"Укажите здесь способы сохранения, отличающиеся от способа по умолчанию для "
+"услуги анализа, по типам образца."
 
 #: bika/lims/content/laboratory.py:163
-msgid "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
+msgid ""
+"Please upload the logo you are authorised to use on your website and results"
+" reports by your accreditation body. Maximum size is 175 x 175 pixels."
 msgstr ""
+"Загрузите логотип, разрешённый к использованию на вашем сайте и в отчётах с "
+"результатами вашим органом по аккредитации. Максимальный размер — 175 x 175 "
+"пикселей."
 
 #: bika/lims/content/analysisservice.py:229
-msgid "Please use the following format for select options: key1:value1|key2:value2|...|keyN:valueN"
+msgid ""
+"Please use the following format for select options: "
+"key1:value1|key2:value2|...|keyN:valueN"
 msgstr ""
+"Используйте следующий формат для вариантов выбора: "
+"key1:value1|key2:value2|...|keyN:valueN"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:71
 msgid "Please write a comment where the listed sample(s) are dispatched"
-msgstr ""
-
-#: senaite/core/browser/samples/templates/dispose_samples.pt:73
-msgid "Please write a comment where the listed sample(s) are disposed"
-msgstr ""
+msgstr "Укажите комментарий о том, куда отправлены перечисленные образцы"
 
 #: bika/lims/browser/templates/analysisservice_info.pt:96
 #: bika/lims/content/abstractbaseanalysis.py:513
 msgid "Point of Capture"
-msgstr ""
+msgstr "Место отбора пробы"
 
-#: senaite/core/content/senaitesetup.py:207
+#: senaite/core/content/senaitesetup.py:206
 msgid "Portal Type"
-msgstr ""
+msgstr "Тип портала"
 
 #: bika/lims/content/identifiertype.py:39
 msgid "Portal Types"
-msgstr ""
+msgstr "Типы портала"
 
 #: senaite/core/browser/samples/multi_results_transposed.py:97
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:75
 #: senaite/core/browser/worksheets/worksheet/analyses_transposed_listing.py:89
 msgid "Position"
-msgstr ""
+msgstr "Позиция"
 
 #: senaite/core/z3cform/widgets/address.py:121
 msgid "Postal address"
-msgstr ""
+msgstr "Почтовый адрес"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:125
 #: senaite/core/z3cform/widgets/address.py:226
 msgid "Postal code"
-msgstr ""
+msgstr "Почтовый индекс"
 
 #: senaite/core/content/samplecontainer.py:85
 msgid "Pre-preserved"
-msgstr ""
+msgstr "Предварительно законсервирован"
 
 #: senaite/core/content/samplecontainer.py:100
 msgid "Pre-preserved containers must have a preservation selected"
 msgstr ""
+"У предварительно законсервированных контейнеров должен быть выбран способ "
+"сохранения"
 
 #: bika/lims/content/abstractbaseanalysis.py:176
 msgid "Precision as number of decimals"
-msgstr ""
+msgstr "Точность как количество десятичных знаков"
 
 #: bika/lims/content/abstractbaseanalysis.py:664
-msgid "Precision as the number of significant digits according to the uncertainty. The decimal position will be given by the first number different from zero in the uncertainty, at that position the system will round up the uncertainty and results. For example, with a result of 5.243 and an uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no uncertainty range is set for the result, the system will use the fixed precision set."
+msgid ""
+"Precision as the number of significant digits according to the uncertainty. "
+"The decimal position will be given by the first number different from zero "
+"in the uncertainty, at that position the system will round up the "
+"uncertainty and results. For example, with a result of 5.243 and an "
+"uncertainty of 0.22, the system will display correctly as 5.2+-0.2. If no "
+"uncertainty range is set for the result, the system will use the fixed "
+"precision set."
 msgstr ""
+"Точность как количество значащих цифр в соответствии с неопределённостью. "
+"Позиция десятичного знака определяется первой ненулевой цифрой "
+"неопределённости; на этой позиции система округлит неопределённость и "
+"результат. Например, для результата 5.243 с неопределённостью 0.22 система "
+"корректно отобразит 5.2±0.2. Если диапазон неопределённости для результата "
+"не задан, используется установленная фиксированная точность."
 
-#: bika/lims/content/abstractbaseanalysis.py:738
+#: bika/lims/content/abstractbaseanalysis.py:735
 msgid "Predefined results"
-msgstr ""
+msgstr "Предопределённые результаты"
 
-#: bika/lims/content/bikasetup.py:313
+#: bika/lims/content/bikasetup.py:312
 msgid "Preferred decimal mark for reports."
-msgstr ""
+msgstr "Предпочитаемый разделитель целой и дробной частей чисел в отчетах"
 
-#: bika/lims/content/bikasetup.py:547
+#: bika/lims/content/bikasetup.py:546
 msgid "Preferred decimal mark for results"
-msgstr ""
+msgstr "Предпочитаемый десятичный разделитель для результатов"
 
-#: bika/lims/content/bikasetup.py:575
-msgid "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
+#: bika/lims/content/bikasetup.py:574
+msgid ""
+"Preferred layout of the results entry table in the Worksheet view. Classic "
+"layout displays the Samples in rows and the analyses in columns. Transposed "
+"layout displays the Samples in columns and the analyses in rows."
 msgstr ""
+"Предпочитаемый макет таблицы ввода результатов в просмотре рабочего листа. "
+"Классический макет отображает образцы в строках, а анализы в столбцах. "
+"Транспонированный макет отображает образцы в столбцах, а анализы в строках."
 
-#: bika/lims/content/bikasetup.py:327
+#: bika/lims/content/bikasetup.py:326
 msgid "Preferred scientific notation format for reports"
-msgstr ""
+msgstr "Предпочитаемый формат научной нотации для отчётов"
 
-#: bika/lims/content/bikasetup.py:561
+#: bika/lims/content/bikasetup.py:560
 msgid "Preferred scientific notation format for results"
-msgstr ""
+msgstr "Предпочитаемый формат научной нотации для результатов"
 
-#: senaite/core/content/senaitesetup.py:241
+#: senaite/core/content/senaitesetup.py:240
 msgid "Prefix"
-msgstr ""
+msgstr "Префикс"
 
 #: bika/lims/content/sampletype.py:157
 msgid "Prefixes can not contain spaces."
-msgstr ""
+msgstr "Префиксы не могут содержать пробелы."
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Prepublish"
-msgstr ""
+msgstr "Предварительная публикация"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:195
 #: senaite/core/content/samplecontainer.py:114
 msgid "Preservation"
-msgstr ""
+msgstr "Сохранение"
 
 #: bika/lims/content/preservation.py:45
 msgid "Preservation Category"
-msgstr ""
+msgstr "Категория сохранения"
 
 #: senaite/core/content/samplecontainer.py:117
 msgid "Preservation method of this container"
-msgstr ""
+msgstr "Способ сохранения этого контейнера"
 
 #: bika/lims/content/analysisservice.py:182
 msgid "Preservation per sample type"
-msgstr ""
+msgstr "Способ сохранения по типу образца"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Preserve"
-msgstr ""
+msgstr "Сохранить"
 
-#: senaite/core/browser/samples/view.py:234
+#: senaite/core/browser/samples/view.py:222
 msgid "Preserver"
-msgstr ""
+msgstr "Ответственный за сохранение"
 
 #: senaite/core/browser/viewlets/templates/toolbar.pt:44
 msgid "Press Ctrl+Space to trigger the Spotlight search"
-msgstr ""
+msgstr "Нажмите Ctrl+Space, чтобы запустить поиск Spotlight"
 
 #: bika/lims/content/instrumentmaintenancetask.py:163
 #: bika/lims/content/instrumentscheduledtask.py:120
 msgid "Preventive"
-msgstr ""
+msgstr "Профилактическое"
 
 #: bika/lims/content/instrument.py:212
 msgid "Preventive maintenance procedure"
-msgstr ""
+msgstr "Процедура профилактического обслуживания"
 
-#: senaite/core/browser/samples/templates/partition_magic.pt:258
+#: senaite/core/browser/samples/templates/partition_magic.pt:250
 msgid "Preview"
-msgstr ""
+msgstr "Предпросмотр"
 
-#: bika/lims/browser/analysisrequest/manage_analyses.py:88
+#: bika/lims/browser/analysisrequest/manage_analyses.py:85
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:168
 #: bika/lims/browser/templates/analysisservice_info.pt:71
 msgid "Price"
-msgstr ""
+msgstr "Цена"
 
 #: bika/lims/content/abstractbaseanalysis.py:551
 #: bika/lims/content/analysisprofile.py:112
 msgid "Price (excluding VAT)"
-msgstr ""
+msgstr "Цена (без НДС)"
 
 #: bika/lims/content/labproduct.py:54
 msgid "Price excluding VAT"
-msgstr ""
+msgstr "Цена без НДС"
 
 #: bika/lims/profiles/default/types/Pricelist.xml
 msgid "Pricelist"
-msgstr ""
+msgstr "Прейскурант"
 
 #: bika/lims/content/pricelist.py:51
 msgid "Pricelist for"
-msgstr ""
+msgstr "Прейскурант для"
 
 #: bika/lims/browser/pricelist.py:51
 #: bika/lims/profiles/default/types/PricelistFolder.xml
 msgid "Pricelists"
-msgstr ""
+msgstr "Прейскуранты"
 
-#: bika/lims/content/client.py:98
+#: bika/lims/content/client.py:94
 msgid "Primary Contact"
-msgstr ""
+msgstr "Основной контакт"
 
 #: bika/lims/browser/publish/reports_listing.py:73
 #: bika/lims/browser/templates/analysisreport_info.pt:60
 msgid "Primary Sample"
-msgstr ""
+msgstr "Основной образец"
 
-#: senaite/core/browser/samples/view.py:851
+#: senaite/core/browser/samples/view.py:703
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:140
 msgid "Print"
-msgstr ""
+msgstr "Печать"
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Print Invoice"
-msgstr ""
+msgstr "Напечатать счет"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:135
 msgid "Print Worksheet"
-msgstr ""
+msgstr "Печать рабочего листа"
 
 #: bika/lims/browser/templates/batch_publish.pt:124
 msgid "Print date:"
-msgstr ""
+msgstr "Дата печати:"
 
 #: bika/lims/profiles/default/types/Pricelist.xml
 msgid "Print pricelist"
-msgstr ""
+msgstr "Распечатать прейскурант"
 
-#: senaite/core/browser/samples/view.py:272
+#: senaite/core/browser/samples/view.py:254
 msgid "Print stickers"
-msgstr ""
+msgstr "Печать стикеров"
 
-#: senaite/core/browser/samples/view.py:259
+#: senaite/core/browser/samples/view.py:241
 msgid "Printed"
-msgstr ""
+msgstr "Напечатано"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:53
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:53
 msgid "Printed on"
-msgstr ""
+msgstr "Напечатано"
 
 #: bika/lims/content/analysisrequest.py:925
 msgid "Priority"
-msgstr ""
+msgstr "Приоритет"
 
-#: senaite/core/browser/samples/view.py:238
+#: senaite/core/browser/samples/view.py:226
 msgid "Profile"
-msgstr ""
+msgstr "Профиль"
 
 #: bika/lims/content/analysisprofile.py:64
 msgid "Profile Analyses"
-msgstr ""
+msgstr "Аналитический профиль"
 
 #: bika/lims/content/analysisrequest.py:432
 msgid "Profile Key"
-msgstr ""
+msgstr "Профиль ключ"
 
 #: bika/lims/content/analysisprofile.py:51
 msgid "Profile Keyword"
-msgstr ""
+msgstr "Ключевые слова профиля"
 
 #: bika/lims/content/analysisrequest.py:431
 msgid "Profile Name"
-msgstr ""
+msgstr "Название профиля"
 
 #: senaite/core/content/analysisprofile.py:216
 msgid "Profile keyword must be unique"
-msgstr ""
+msgstr "Ключевое слово профиля должно быть уникальным"
 
-#: senaite/core/browser/samples/view.py:134
+#: senaite/core/browser/samples/view.py:122
 msgid "Progress"
-msgstr ""
+msgstr "Прогресс"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:103
 #: senaite/core/registry/schema.py:198
 msgid "Prominent fields"
-msgstr ""
+msgstr "Основные поля"
 
-#: bika/lims/content/abstractbaseanalysis.py:868
+#: bika/lims/content/abstractbaseanalysis.py:865
 msgid "Protocol ID"
-msgstr ""
+msgstr "ID протокола"
 
 #: bika/lims/browser/clientfolder.py:75
 msgid "Province"
-msgstr ""
+msgstr "Область"
 
-#: senaite/core/content/resultsreport.py:120
+#: senaite/core/content/resultsreport.py:119
 msgid "Publication Modes"
-msgstr ""
+msgstr "Режимы публикации"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Publish"
-msgstr ""
+msgstr "Опубликовать"
 
-#: senaite/core/browser/dashboard/dashboard.py:112
-msgid "Publish Reports"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:150
-#: senaite/core/browser/samples/view.py:369
+#: senaite/core/browser/dashboard/dashboard.py:128
+#: senaite/core/browser/samples/view.py:351
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Published"
-msgstr ""
+msgstr "Опубликовано"
 
 #: bika/lims/browser/publish/reports_listing.py:86
 msgid "Published By"
-msgstr ""
+msgstr "Опубликовано"
 
 #: bika/lims/browser/publish/reports_listing.py:84
 msgid "Published Date"
-msgstr ""
+msgstr "Дата публикации"
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Published results"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:448
-msgid "Published samples whose reports have not been printed yet"
-msgstr ""
+msgstr "Опубликованные результаты"
 
 #: bika/lims/browser/workflow/client.py:122
 msgid "Published {}, "
-msgstr ""
+msgstr "Опубликовано {}, "
 
 #: senaite/core/browser/viewlets/sampleanalyses.py:76
 msgid "QC Analyses"
-msgstr ""
+msgstr "Анализы контроля качества"
 
 #: bika/lims/browser/referencesample.py:143
 msgid "QC Analysis ID"
-msgstr ""
+msgstr "ID анализа контроля качества"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "QC Results"
-msgstr ""
+msgstr "QC Результаты"
 
-#: bika/lims/browser/analyses/qc.py:55
-#: bika/lims/browser/instrument.py:554
+#: bika/lims/browser/analyses/qc.py:55 bika/lims/browser/instrument.py:554
 msgid "QC Sample ID"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:138
-msgid "Quarterly"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:128
-msgid "Quick Actions"
-msgstr ""
+msgstr "ID образца контроля качества"
 
 #: bika/lims/content/abstractbaseanalysis.py:621
 msgid "Range max"
-msgstr ""
+msgstr "Диапазон Макс"
 
 #: bika/lims/content/abstractbaseanalysis.py:620
 msgid "Range min"
-msgstr ""
+msgstr "Диапазон мин"
 
 #: bika/lims/browser/viewlets/templates/specification_non_compliant_viewlet.pt:18
 msgid "Ranges for some analyses are different from the Specification"
-msgstr ""
+msgstr "Диапазоны некоторых анализов отличаются от спецификации"
 
 #: bika/lims/browser/viewlets/templates/specification_non_compliant_viewlet.pt:29
 msgid "Re-assign the Specification if you want to restore analysis ranges."
 msgstr ""
+"Переназначьте спецификацию, если хотите восстановить диапазоны анализа."
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:256
 msgid "Re-enter the password. Make sure the passwords are identical."
-msgstr ""
+msgstr "Повторно введите пароль. Убедитесь, что пароли являются идентичными."
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:145
 msgid "Reasons for rejection"
-msgstr ""
+msgstr "Причины отклонения"
 
-#: senaite/core/browser/worksheets/view.py:348
+#: senaite/core/browser/worksheets/view.py:344
 msgid "Reassign"
-msgstr ""
+msgstr "Переназначить"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:445
 msgid "Reassignable Slot"
-msgstr ""
+msgstr "Переназначаемый слот"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Reattach"
-msgstr ""
+msgstr "Прикрепить заново"
 
-#: bika/lims/browser/analyses/view.py:1171
+#: bika/lims/browser/analyses/view.py:1170
 msgid "Recalculate"
-msgstr ""
+msgstr "Пересчитать"
 
-#: senaite/core/content/senaitesetup.py:1144
+#: senaite/core/content/senaitesetup.py:1121
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Receive"
-msgstr ""
+msgstr "Получить"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:119
-#: senaite/core/browser/samples/view.py:339
+#: senaite/core/browser/samples/view.py:321
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Received"
-msgstr ""
+msgstr "Получено"
 
-#: senaite/core/browser/dashboard/dashboard.py:420
-msgid "Received samples with analyses awaiting results"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:160
+#: senaite/core/browser/dashboard/dashboard.py:135
 msgid "Reception pending"
-msgstr ""
+msgstr "Ожидают прием"
 
-#: senaite/core/content/resultsreport.py:245
+#: senaite/core/content/resultsreport.py:244
 msgid "Recipient"
-msgstr ""
+msgstr "Получатель"
 
-#: senaite/core/content/resultsreport.py:242
+#: senaite/core/content/resultsreport.py:241
 msgid "Recipients"
-msgstr ""
+msgstr "Получатели"
 
 #: bika/lims/browser/templates/referencesample_sticker.pt:46
 #: bika/lims/content/worksheettemplate.py:57
 msgid "Reference"
-msgstr ""
+msgstr "Эталон"
 
 #: bika/lims/browser/referencesample.py:83
 msgid "Reference Analyses"
-msgstr ""
+msgstr "Референс-анализы"
 
 #: bika/lims/profiles/default/types/ReferenceAnalysis.xml
 msgid "Reference Analysis"
-msgstr ""
+msgstr "Референс-анализ"
 
 #: bika/lims/browser/referencesample.py:353
 #: bika/lims/browser/templates/referencesample_view.pt:67
 #: bika/lims/profiles/default/types/ReferenceDefinition.xml
 msgid "Reference Definition"
-msgstr ""
+msgstr "Определение эталона"
 
 #: bika/lims/controlpanel/bika_referencedefinitions.py:63
 #: bika/lims/profiles/default/types/ReferenceDefinitions.xml
 msgid "Reference Definitions"
-msgstr ""
+msgstr "Эталон: Определения"
 
 #: bika/lims/content/referencesample.py:64
 msgid "Reference ID"
-msgstr ""
+msgstr "Референс-ID"
 
 #: bika/lims/browser/instrument.py:558
 #: bika/lims/browser/templates/instrument_referenceanalyses.pt:12
 #: bika/lims/browser/worksheet/views/referencesamples.py:72
 msgid "Reference Sample"
-msgstr ""
+msgstr "Референс-образец"
 
 #: senaite/core/profiles/default/types/Supplier.xml
 msgid "Reference Samples"
-msgstr ""
+msgstr "Образцы эталона"
 
 #: bika/lims/browser/referencesample.py:202
 #: bika/lims/profiles/default/types/ReferenceSample.xml
 msgid "Reference Values"
-msgstr ""
+msgstr "Референсные значения"
 
 #: bika/lims/content/referencesample.py:98
 msgid "Reference sample values are zero or 'blank'"
-msgstr ""
+msgstr "Значения эталонного образца 0 или \"пусто\""
 
-#: senaite/core/content/senaitesetup.py:1143
+#: senaite/core/content/senaitesetup.py:1120
 msgid "Register"
-msgstr ""
+msgstr "Зарегистрировать"
 
-#: senaite/core/browser/dashboard/dashboard.py:105
-msgid "Register Samples"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:145
+#: senaite/core/browser/dashboard/dashboard.py:121
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Registered"
-msgstr ""
+msgstr "Зарегистрировано"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_batch_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_cancellable_type_workflow/definition.xml
 msgid "Reinstate"
-msgstr ""
+msgstr "Восстановить"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:149
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Reject"
-msgstr ""
+msgstr "Отклонить"
 
 #: bika/lims/profiles/default/types/RejectAnalysis.xml
 msgid "Reject Analysis"
-msgstr ""
+msgstr "Отклонить анализ"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:17
 msgid "Reject samples"
-msgstr ""
+msgstr "Отклонить образцы"
 
-#: senaite/core/browser/dashboard/dashboard.py:153
+#: senaite/core/browser/dashboard/dashboard.py:125
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:121
-#: senaite/core/browser/samples/view.py:432
+#: senaite/core/browser/samples/view.py:402
 msgid "Rejected"
-msgstr ""
+msgstr "Отклонено"
 
 #: bika/lims/browser/workflow/analysisrequest.py:98
 msgid "Rejected items: {}"
-msgstr ""
+msgstr "Отклонённые элементы: {}"
 
 #: bika/lims/browser/viewlets/templates/rejected_ar_viewlet.pt:13
 msgid "Rejected sample"
-msgstr ""
+msgstr "Отклонённый образец"
 
 #: senaite/core/browser/samples/rejection/reject_samples.py:114
 msgid "Rejected {} samples: {}"
-msgstr ""
+msgstr "Отклонено образцов: {} ({})"
 
-#: bika/lims/content/bikasetup.py:1202
+#: bika/lims/content/bikasetup.py:1201
 msgid "Rejection Reasons"
-msgstr ""
+msgstr "Причины отклонения"
 
 #: senaite/core/browser/samples/rejection/reject_samples.py:121
 msgid "Rejection cancelled"
-msgstr ""
+msgstr "Отклонение отменено"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:84
 msgid "Rejection reasons"
-msgstr ""
+msgstr "Причины отклонения"
 
 #: senaite/core/browser/samples/rejection/reject_samples.py:70
 msgid "Rejection workflow is not enabled"
-msgstr ""
+msgstr "Процесс отклонения не включён"
 
 # senaite.app.listing: Reload
 msgid "Reload"
-msgstr ""
+msgstr "Обновить"
 
 #: senaite/core/browser/modals/analysis/schema.py:122
 #: senaite/core/browser/viewlets/remarks.py:31
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:242
 msgid "Remarks"
-msgstr ""
+msgstr "Замечания"
 
 #: bika/lims/content/analysisrequest.py:1103
 msgid "Remarks and comments for this request"
-msgstr ""
+msgstr "Замечания и комментарии к этой заявке"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:672
 msgid "Remarks of {}"
-msgstr ""
+msgstr "Замечания к {}"
 
 #: bika/lims/content/instrumentcalibration.py:108
 msgid "Remarks to take into account before calibration"
-msgstr ""
+msgstr "Замечания, которые нужно учесть перед калибровкой"
 
 #: bika/lims/content/instrumentscheduledtask.py:87
 msgid "Remarks to take into account before performing the task"
-msgstr ""
+msgstr "Замечания, которые нужно учесть перед выполнением задачи"
 
 #: bika/lims/content/instrumentvalidation.py:90
 msgid "Remarks to take into account before validation"
-msgstr ""
+msgstr "Замечания, которые нужно учесть перед валидацией"
 
 #: bika/lims/content/instrumentmaintenancetask.py:94
 msgid "Remarks to take into account for maintenance process"
-msgstr ""
+msgstr "Замечания, которые нужно учесть в процессе обслуживания"
 
-#: bika/lims/browser/auditlog.py:90
-#: bika/lims/controlpanel/auditlog.py:92
+#: bika/lims/browser/auditlog.py:90 bika/lims/controlpanel/auditlog.py:92
 msgid "Remote IP"
-msgstr ""
+msgstr "IP-адрес"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:72
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Remove"
-msgstr ""
-
-#: senaite/core/browser/samples/view.py:597
-msgid "Remove this analysis from the filter"
-msgstr ""
+msgstr "Удалить"
 
 #: senaite/core/browser/idserver/view.py:126
 msgid "Removed {} key(s): {}"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — row action tooltip
-msgid "Rename filter"
-msgstr ""
+msgstr "Удалено ключей: {} ({})"
 
 #: bika/lims/content/attachment.py:80
 msgid "Render attachment in report"
-msgstr ""
+msgstr "Отображать вложение в отчёте"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:68
 msgid "Render in Report"
-msgstr ""
+msgstr "Отображать в отчёте"
 
 #: bika/lims/content/instrumentmaintenancetask.py:164
 #: bika/lims/content/instrumentscheduledtask.py:121
 msgid "Repair"
-msgstr ""
+msgstr "Ремонт"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:59
 #: bika/lims/content/analysisservice.py:226
 msgid "Report"
-msgstr ""
+msgstr "Отчет"
 
 #: bika/lims/content/instrumentcalibration.py:68
 #: bika/lims/content/instrumentvalidation.py:50
 msgid "Report Date"
-msgstr ""
+msgstr "Дата отчёта"
 
 #: bika/lims/content/instrumentcalibration.py:150
 #: bika/lims/content/instrumentvalidation.py:132
 msgid "Report ID"
-msgstr ""
+msgstr "ID отчёта"
 
 #: bika/lims/content/instrumentcalibration.py:151
 #: bika/lims/content/instrumentvalidation.py:133
 msgid "Report identification number"
-msgstr ""
+msgstr "Идентификационный номер отчёта"
 
-#: senaite/core/content/resultsreport.py:230
+#: senaite/core/content/resultsreport.py:229
 msgid "Report metadata"
-msgstr ""
+msgstr "Метаданные отчёта"
 
-#: senaite/core/content/resultsreport.py:243
+#: senaite/core/content/resultsreport.py:242
 msgid "Report recipients"
-msgstr ""
+msgstr "Получатели отчёта"
 
 #: bika/lims/content/instrumentcertification.py:194
 msgid "Report upload"
-msgstr ""
+msgstr "Загрузка отчёта"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Republish"
-msgstr ""
+msgstr "Опубликовать повторно"
 
-#: senaite/core/browser/samples/view.py:712
+#: senaite/core/browser/samples/view.py:574
 msgid "Republished after last print"
-msgstr ""
+msgstr "Переопубликовано после последней печати"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:71
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:70
 msgid "Request ID"
-msgstr ""
+msgstr "ID Запроса"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:311
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:302
 msgid "Request new analyses"
-msgstr ""
+msgstr "Запросить новые анализы"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:227
 msgid "Required"
-msgstr ""
+msgstr "Требуется"
 
 #: bika/lims/browser/fields/partitionsetupfield.py:118
 msgid "Required Volume"
-msgstr ""
+msgstr "Требуемый объем"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:198
 msgid "Reset"
-msgstr ""
-
-# senaite.app.listing: Reset-columns button tooltip
-msgid "Reset column visibility and order to the defaults"
-msgstr ""
+msgstr "Сбросить"
 
 # senaite.app.listing: Reset columns
 msgid "Reset columns"
-msgstr ""
-
-# senaite.app.listing: Column config — reset link tooltip
-msgid "Reset to default columns and order"
-msgstr ""
-
-# senaite.app.listing: Search box — undo / reset-view button tooltip
-msgid "Reset view"
-msgstr ""
+msgstr "Сбросить"
 
 #: bika/lims/browser/publish/templates/email.pt:83
 #: bika/lims/browser/templates/analysisreport_info.pt:154
 msgid "Responsibles"
-msgstr ""
+msgstr "Ответственные"
 
-#: senaite/core/api/remarks.py:483
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Restore"
-msgstr ""
+msgstr "Восстановить"
 
-#: bika/lims/content/bikasetup.py:176
+#: bika/lims/content/bikasetup.py:175
 msgid "Restrict worksheet access to assigned analysts"
-msgstr ""
+msgstr "Ограничить доступ к рабочему листу назначенными аналитиками"
 
-#: bika/lims/content/bikasetup.py:207
+#: bika/lims/content/bikasetup.py:206
 msgid "Restrict worksheet management to lab managers"
-msgstr ""
+msgstr "Ограничить управление рабочими листами менеджерами лаборатории"
 
 #: senaite/core/browser/modals/analysis/schema.py:53
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:86
 msgid "Result"
-msgstr ""
+msgstr "Результат"
 
 #: senaite/core/browser/modals/analysis/schema.py:130
 msgid "Result Capture Date"
-msgstr ""
+msgstr "Дата фиксации результата"
 
 #: bika/lims/content/abstractbaseanalysis.py:726
 msgid "Result Value"
-msgstr ""
+msgstr "Значение результата"
 
 #: bika/lims/validators.py:642
 msgid "Result Value must be a number"
-msgstr ""
+msgstr "Значение результата должно быть числом"
 
 #: bika/lims/validators.py:657
 msgid "Result Value must be unique"
-msgstr ""
+msgstr "Значение результата должно быть уникальным"
 
-#: bika/lims/browser/analyses/view.py:1527
+#: bika/lims/browser/analyses/view.py:1526
 msgid "Result in shoulder range"
-msgstr ""
+msgstr "Результат в пограничном диапазоне"
 
-#: bika/lims/browser/analyses/view.py:1524
+#: bika/lims/browser/analyses/view.py:1523
 msgid "Result out of range"
-msgstr ""
+msgstr "Результат за пределами допустимого диапазона"
 
-#: bika/lims/browser/analyses/view.py:1546
+#: bika/lims/browser/analyses/view.py:1545
 msgid "Result range is different from Specification: {}"
-msgstr ""
+msgstr "Диапазон результата отличается от спецификации: {}"
 
 #: bika/lims/content/abstractbaseanalysis.py:711
 msgid "Result type"
-msgstr ""
+msgstr "Тип результата"
 
-#: bika/lims/content/bikasetup.py:427
-msgid "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent.  The precision can be configured in individual Analysis Services."
+#: bika/lims/content/bikasetup.py:426
+msgid ""
+"Result values with at least this number of significant digits are displayed "
+"in scientific notation using the letter 'e' to indicate the exponent.  The "
+"precision can be configured in individual Analysis Services."
 msgstr ""
+"Значения результатов с числом значащих цифр не менее указанного отображаются"
+" в научной нотации с буквой 'e' для экспоненты. Точность можно настроить для"
+" отдельных услуг анализа."
 
 #: bika/lims/content/analysisservice.py:116
 msgid "Result variables"
-msgstr ""
+msgstr "Переменные результата"
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:63
 msgid "Results"
-msgstr ""
+msgstr "Результаты"
 
 #: bika/lims/content/analysisrequest.py:1369
 msgid "Results Interpretation"
-msgstr ""
+msgstr "Интерпретация результатов"
 
-#: senaite/core/browser/dashboard/dashboard.py:85
-msgid "Results Pending"
-msgstr ""
-
-#: senaite/core/content/resultsreport.py:133
+#: senaite/core/content/resultsreport.py:132
 #: senaite/core/profiles/default/types/ResultsReport.xml
 msgid "Results Report"
-msgstr ""
+msgstr "Отчёт с результатами"
 
-#: senaite/core/content/senaitesetup.py:1308
+#: senaite/core/content/senaitesetup.py:1285
 msgid "Results Reports"
-msgstr ""
+msgstr "Отчёты с результатами"
 
-#: senaite/core/browser/samples/view.py:726
+#: senaite/core/browser/samples/view.py:588
 msgid "Results have been withdrawn"
-msgstr ""
+msgstr "Результаты были отозваны"
 
 #: senaite/core/browser/viewlets/resultsinterpretation.py:39
 msgid "Results interpretation"
-msgstr ""
+msgstr "Интерпретация результатов"
 
-#: senaite/core/browser/dashboard/dashboard.py:161
+#: senaite/core/browser/dashboard/dashboard.py:123
 msgid "Results pending"
-msgstr ""
+msgstr "Ожидают результатов"
 
 #: bika/lims/content/analysisrequest.py:660
-#: bika/lims/content/preservation.py:52
-#: bika/lims/content/sampletype.py:116
+#: bika/lims/content/preservation.py:52 bika/lims/content/sampletype.py:116
 msgid "Retention Period"
-msgstr ""
+msgstr "Срок хранения"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Retest"
-msgstr ""
+msgstr "Повторный тест"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:96
 msgid "Retested"
-msgstr ""
+msgstr "Повторный анализ"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Retract"
-msgstr ""
+msgstr "Отозвать"
 
-#: senaite/core/browser/dashboard/dashboard.py:152
+#: senaite/core/browser/dashboard/dashboard.py:126
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Retracted"
-msgstr ""
+msgstr "Отозвано"
 
 #: bika/lims/browser/templates/analyses_retractedlist.pt:11
 msgid "Retracted analyses"
-msgstr ""
+msgstr "Отозванные анализы"
 
 #: bika/lims/browser/instrument.py:561
 msgid "Retractions"
-msgstr ""
+msgstr "Отзывы"
 
 #: bika/lims/browser/publish/reports_listing.py:78
 msgid "Review State"
-msgstr ""
+msgstr "Статус"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:171
 msgid "Reviewed by"
-msgstr ""
+msgstr "Проверено"
 
-#: bika/lims/browser/auditlog.py:88
-#: bika/lims/controlpanel/auditlog.py:88
+#: bika/lims/browser/auditlog.py:88 bika/lims/controlpanel/auditlog.py:88
 msgid "Roles"
-msgstr ""
+msgstr "Роли"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_worksheet_workflow/definition.xml
 msgid "Rollback"
-msgstr ""
+msgstr "Откат"
 
 #: bika/lims/browser/worksheet/views/folder.py:110
 msgid "Routine Analyses"
-msgstr ""
-
-#: bika/lims/api/snapshot.py:555
-msgid "Row ${num}"
-msgstr ""
+msgstr "Плановые анализы"
 
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE"
-msgstr ""
+msgstr "SENAITE CORE"
 
 #: senaite/core/configure.zcml:56
 msgid "SENAITE CORE Add-on"
-msgstr ""
+msgstr "Дополнение SENAITE CORE"
 
 #: bika/lims/profiles.zcml:15
 msgid "SENAITE Core 1.x (do not install)"
-msgstr ""
+msgstr "SENAITE Core 1.x (не устанавливать)"
 
 #: senaite/core/browser/frontpage/templates/frontpage.pt:6
 msgid "SENAITE LIMS"
-msgstr ""
+msgstr "SENAITE LIMS"
 
 #: senaite/core/browser/frontpage/configure.zcml:23
 msgid "SENAITE LIMS front-page"
-msgstr ""
+msgstr "Главная страница SENAITE LIMS"
 
 #: senaite/core/profiles/default/controlpanel.xml
 #: senaite/core/registry/controlpanel.py:81
 msgid "SENAITE Registry"
-msgstr ""
+msgstr "Реестр SENAITE"
 
-#: senaite/core/browser/dashboard/dashboard.py:115
 #: senaite/core/browser/setup/edit.py:38
 #: senaite/core/profiles/default/types/Setup.xml
 msgid "SENAITE Setup"
-msgstr ""
+msgstr "Настройки SENAITE"
 
 #: senaite/core/browser/frontpage/configure.zcml:23
 msgid "SENAITE front-page"
-msgstr ""
+msgstr "Главная страница SENAITE"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:326
+#: senaite/core/browser/clients/client/contacts/login_details.py:315
 msgid "SMTP server disconnected. User creation aborted."
-msgstr ""
+msgstr "SMTP-сервер отключён. Создание пользователя прервано."
 
 #: bika/lims/content/supplier.py:87
 msgid "SWIFT code"
-msgstr ""
+msgstr "Код SWIFT"
 
 #: bika/lims/content/person.py:42
 msgid "Salutation"
-msgstr ""
+msgstr "Приветствие"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:609
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:99
-#: senaite/core/content/resultsreport.py:151
+#: senaite/core/content/resultsreport.py:150
 msgid "Sample"
-msgstr ""
+msgstr "Образец"
 
 #: bika/lims/browser/analysisrequest/add2.py:2195
 msgid "Sample ${AR} was successfully created."
-msgstr ""
+msgstr "Образец ${AR} успешно создан."
 
 #: senaite/core/browser/samples/invalidate_samples.py:149
 msgid "Sample ${sample_id} has been successfully invalidated."
-msgstr ""
+msgstr "Образец ${sample_id} успешно аннулирован."
 
 #: senaite/core/browser/samples/invalidate_samples.py:139
-msgid "Sample ${sample_id} was successfully invalidated, and a notification email has been sent to the following recipients: ${recipients}."
+msgid ""
+"Sample ${sample_id} was successfully invalidated, and a notification email "
+"has been sent to the following recipients: ${recipients}."
 msgstr ""
+"Образец ${sample_id} успешно аннулирован, уведомление отправлено следующим "
+"получателям: ${recipients}."
 
 #: senaite/core/profiles/default/types/SampleCondition.xml
 msgid "Sample Condition"
-msgstr ""
+msgstr "Состояние образца"
 
 #: senaite/core/profiles/default/types/SampleConditions.xml
 msgid "Sample Conditions"
-msgstr ""
+msgstr "Образец: Условия"
 
 #: senaite/core/profiles/default/types/SampleContainer.xml
 msgid "Sample Container"
-msgstr ""
+msgstr "Контейнер образца"
 
 #: senaite/core/profiles/default/types/SampleContainers.xml
 msgid "Sample Containers"
-msgstr ""
+msgstr "Контейнеры образцов"
 
 #: senaite/core/registry/schema.py:160
 msgid "Sample Header"
-msgstr ""
+msgstr "Заголовок образца"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:105
-#: senaite/core/browser/samples/view.py:139
+#: senaite/core/browser/samples/view.py:127
 msgid "Sample ID"
-msgstr ""
+msgstr "Образец ID"
 
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:17
 msgid "Sample Invalidation"
-msgstr ""
+msgstr "Аннулирование образца"
 
 #: senaite/core/profiles/default/types/SampleMatrices.xml
 msgid "Sample Matrices"
-msgstr ""
+msgstr "Образец: Матрицы"
 
 #: senaite/core/profiles/default/types/SampleMatrix.xml
 msgid "Sample Matrix"
-msgstr ""
+msgstr "Матрица образца"
 
 #: bika/lims/content/artemplate.py:172
 msgid "Sample Partitions"
-msgstr ""
+msgstr "Партиции образца"
 
-#: senaite/core/browser/samples/view.py:217
+#: senaite/core/browser/samples/view.py:205
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:579
 #: senaite/core/profiles/default/types/SamplePoint.xml
 msgid "Sample Point"
-msgstr ""
+msgstr "Место взятия образца"
 
 #: senaite/core/profiles/default/types/SamplePoints.xml
 msgid "Sample Points"
-msgstr ""
+msgstr "Образец: Места сбора"
 
 #: senaite/core/profiles/default/types/SamplePreservation.xml
 msgid "Sample Preservation"
-msgstr ""
+msgstr "Сохранение образца"
 
 #: senaite/core/profiles/default/types/SamplePreservations.xml
 msgid "Sample Preservations"
-msgstr ""
+msgstr "Способы сохранения образца"
 
 #: bika/lims/content/analysisrequest.py:671
 msgid "Sample Rejection"
-msgstr ""
+msgstr "Отклонение образца"
 
 #: bika/lims/profiles/default/types/Client.xml
 msgid "Sample Templates"
-msgstr ""
+msgstr "Шаблоны образцов"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:155
-#: senaite/core/browser/samples/view.py:213
+#: senaite/core/browser/samples/view.py:201
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:572
 msgid "Sample Type"
-msgstr ""
+msgstr "Тип образца"
 
 #: bika/lims/content/sampletype.py:156
 msgid "Sample Type Prefix"
-msgstr ""
+msgstr "Тип префикса образца"
 
 #: senaite/core/registry/schema.py:124
 msgid "Sample View"
-msgstr ""
+msgstr "Просмотр образца"
 
 #: bika/lims/content/artemplate.py:118
 msgid "Sample collected by the laboratory"
-msgstr ""
+msgstr "Образец отобран лабораторией"
 
 #: bika/lims/browser/analysisrequest/add2.py:1992
 msgid "Sample creation cancelled"
-msgstr ""
+msgstr "Создание образца отменено"
 
 #: bika/lims/browser/workflow/analysisrequest.py:248
 msgid "Sample date required for sample %s"
-msgstr ""
+msgstr "Требуется дата образца для образца %s"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Sample due"
-msgstr ""
+msgstr "Образец ожидается"
+
+#. Dynamically built in bika/lims/browser/publish/reports_listing.py
+#. from review_state.capitalize().replace("_", " ") for state "sample_received"
+msgid "Sample received"
+msgstr "Образец получен"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:111
 msgid "Sample type"
-msgstr ""
+msgstr "Тип образца"
 
 #: senaite/core/content/interpretationtemplate.py:71
 msgid "Sample types"
-msgstr ""
+msgstr "Типы образца"
 
 #: senaite/core/registry/schema.py:125
 msgid "Sample view configuration"
-msgstr ""
+msgstr "Настройка просмотра образца"
 
 #: bika/lims/browser/viewlets/templates/primary_ar_viewlet.pt:15
 msgid "Sample with partitions"
-msgstr ""
+msgstr "Образец с партициями"
 
 #: senaite/core/profiles/default/types/SampleTemplate.xml
 msgid "SampleTemplate"
-msgstr ""
+msgstr "Шаблон образца"
 
 #: senaite/core/profiles/default/types/SampleTemplates.xml
 msgid "SampleTemplates"
-msgstr ""
+msgstr "Шаблоны образцов"
 
 #: senaite/core/profiles/default/types/SampleType.xml
 msgid "SampleType"
-msgstr ""
+msgstr "Тип образца"
 
 #: senaite/core/profiles/default/types/SampleTypes.xml
 msgid "SampleTypes"
-msgstr ""
+msgstr "Типы образцов"
 
-#: senaite/core/browser/samples/view.py:231
+#: senaite/core/browser/samples/view.py:219
 msgid "Sampler"
-msgstr ""
+msgstr "Пробоотборщик"
 
 #: bika/lims/content/analysisrequest.py:497
 msgid "Sampler for scheduled sampling"
-msgstr ""
+msgstr "Пробоотборщик для запланированного отбора проб"
 
 #: bika/lims/browser/workflow/analysisrequest.py:241
 msgid "Sampler required for sample %s"
-msgstr ""
+msgstr "Требуется пробоотборщик для образца %s"
 
-#: senaite/core/browser/dashboard/dashboard.py:457
-#: senaite/core/browser/samples/view.py:112
+#: senaite/core/browser/dashboard/dashboard.py:411
+#: senaite/core/browser/samples/view.py:100
 #: senaite/core/profiles/default/types/Samples.xml
 msgid "Samples"
-msgstr ""
+msgstr "Образцы"
 
 #: bika/lims/browser/analysisrequest/add2.py:2192
 msgid "Samples ${ARs} were successfully created."
-msgstr ""
+msgstr "Образцы ${ARs} успешно созданы."
 
 #: senaite/core/browser/samples/invalidate_samples.py:155
-msgid "Samples ${sample_ids} were successfully invalidated, with notification emails sent for the following: ${notified_ids}."
+msgid ""
+"Samples ${sample_ids} were successfully invalidated, with notification "
+"emails sent for the following: ${notified_ids}."
 msgstr ""
+"Образцы ${sample_ids} успешно аннулированы, уведомления отправлены для: "
+"${notified_ids}."
 
 #: senaite/core/browser/samples/invalidate_samples.py:164
 msgid "Samples ${sample_ids} were successfully invalidated."
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:400
-msgid "Samples awaiting collection of the sample"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:404
-msgid "Samples awaiting preservation"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:416
-msgid "Samples awaiting reception at the laboratory"
-msgstr ""
+msgstr "Образцы ${sample_ids} успешно аннулированы."
 
 #: bika/lims/content/referencesample.py:106
 #: bika/lims/content/sampletype.py:128
 msgid "Samples of this type should be treated as hazardous"
-msgstr ""
+msgstr "С образцами этого типа следует обращаться как с опасными"
 
 #: senaite/core/browser/samples/rejection/templates/rejection_report.pt:67
 msgid "Samples rejection reporting form"
-msgstr ""
+msgstr "Форма отчёта об отклонении образцов"
 
-#: senaite/core/browser/dashboard/dashboard.py:81
-msgid "Samples to Receive"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:432
-msgid "Samples whose reports have been published"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:424
-msgid "Samples whose results are awaiting verification"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:409
-msgid "Samples with a scheduled sampling date"
-msgstr ""
-
-#: senaite/core/content/senaitesetup.py:1362
+#: senaite/core/content/senaitesetup.py:1337
 msgid "Sampling"
-msgstr ""
+msgstr "Отбор проб"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:106
 msgid "Sampling Date"
-msgstr ""
+msgstr "Дата отбора"
 
-#: senaite/core/browser/samples/view.py:226
+#: senaite/core/browser/samples/view.py:214
 #: senaite/core/profiles/default/types/SamplingDeviation.xml
 msgid "Sampling Deviation"
-msgstr ""
+msgstr "Отклонение при отборе проб"
 
 #: senaite/core/profiles/default/types/SamplingDeviations.xml
 msgid "Sampling Deviations"
-msgstr ""
+msgstr "Отбор проб: Отклонения"
 
 #: bika/lims/content/samplepoint.py:83
 msgid "Sampling Frequency"
-msgstr ""
+msgstr "Частота взятия образца"
 
-#: senaite/core/browser/dashboard/dashboard.py:159
+#: senaite/core/browser/dashboard/dashboard.py:134
 msgid "Sampling scheduled"
-msgstr ""
+msgstr "Отбор проб запланирован"
 
 #: senaite/core/vocabularies/setup.py:161
 msgid "Saturday"
-msgstr ""
+msgstr "Суббота"
 
-#: senaite/core/api/remarks.py:478
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:288
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:148
+#: senaite/core/browser/samples/templates/manage_sample_fields.pt:191
 msgid "Save"
-msgstr ""
+msgstr "Сохранить"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:738
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:728
 msgid "Save and Copy"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — footer button to save the
-# current view
-msgid "Save current view"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — toggle title + menu header
-msgid "Saved filters"
-msgstr ""
+msgstr "Сохранить и скопировать"
 
 #: bika/lims/browser/workflow/__init__.py:206
 msgid "Saved items: {}"
-msgstr ""
+msgstr "Сохранённые элементы: {}"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Schedule"
-msgstr ""
+msgstr "Расписание"
 
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Schedule sampling"
-msgstr ""
+msgstr "Запланировать отбор проб"
 
-#: senaite/core/browser/samples/view.py:317
+#: senaite/core/browser/samples/view.py:299
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "Scheduled sampling"
-msgstr ""
+msgstr "Запланированный отбор проб"
 
 #: bika/lims/browser/instrument.py:400
 msgid "Scheduled task"
-msgstr ""
+msgstr "Запланированная задача"
 
 #: bika/lims/content/abstractbaseanalysis.py:95
 msgid "Scientific name"
-msgstr ""
+msgstr "Научное название"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:154
 msgid "Search"
-msgstr ""
-
-# senaite.app.listing: Column config — search input placeholder
-msgid "Search columns…"
-msgstr ""
+msgstr "Поиск"
 
 # senaite.core: Sidebar search input placeholder
 msgid "Search..."
-msgstr ""
+msgstr "Поиск..."
 
 #: bika/lims/browser/fields/coordinatefield.py:38
 msgid "Seconds"
-msgstr ""
+msgstr "Секунд"
 
-#: senaite/core/content/senaitesetup.py:1284
+#: senaite/core/content/senaitesetup.py:1261
 msgid "Security"
-msgstr ""
+msgstr "Безопасность"
 
 #: bika/lims/content/container.py:118
 msgid "Security Seal Intact Y/N"
-msgstr ""
+msgstr "Пломба цела Да/Нет"
 
 #: senaite/core/content/samplecontainer.py:122
 msgid "Security seal intact"
-msgstr ""
+msgstr "Пломба цела"
 
 #: bika/lims/content/analysisservice.py:261
 msgid "Select"
-msgstr ""
+msgstr "Выбрать"
 
 #: senaite/core/exportimport/import.pt:100
 msgid "Select Import Interface"
-msgstr ""
+msgstr "Выберите интерфейс импорта"
 
 #: senaite/core/browser/samples/templates/partition_magic.pt:215
 msgid "Select Partition Analyses"
-msgstr ""
+msgstr "Выберите анализы для партиции"
 
 #: bika/lims/content/analysisservice.py:146
-msgid "Select a default preservation for this analysis service. If the preservation depends on the sample type combination, specify a preservation per sample type in the table below"
+msgid ""
+"Select a default preservation for this analysis service. If the preservation"
+" depends on the sample type combination, specify a preservation per sample "
+"type in the table below"
 msgstr ""
+"Выберите способ сохранения по умолчанию для этой услуги анализа. Если способ"
+" сохранения зависит от типа образца, укажите его для каждого типа образца в "
+"таблице ниже"
 
 # senaite.core.browser.modals.templates.create_worksheet.pt
 msgid "Select all"
-msgstr ""
+msgstr "Выбрать все"
 
 #: bika/lims/browser/publish/templates/email.pt:168
 msgid "Select all:"
-msgstr ""
+msgstr "Выбрать все:"
 
 #: bika/lims/content/instrument.py:223
 msgid "Select an Export interface for this instrument."
-msgstr ""
+msgstr "Выберите интерфейс экспорта для этого инструмента."
 
 #: bika/lims/content/instrument.py:236
 msgid "Select an Import interface for this instrument."
-msgstr ""
+msgstr "Выберите интерфейс импорта для этого инструмента."
 
 #: bika/lims/content/artemplate.py:288
 msgid "Select analyses to include in this template"
-msgstr ""
+msgstr "Выберите анализы для включения в этот шаблон"
 
 #: senaite/core/browser/worksheets/templates/view.pt:36
 msgid "Select analyst"
-msgstr ""
+msgstr "Выбор аналитика"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:203
-msgid "Select any add-ons you want to activate immediately. You can also activate add-ons after the site has been created using the Add-ons control panel."
+msgid ""
+"Select any add-ons you want to activate immediately. You can also activate "
+"add-ons after the site has been created using the Add-ons control panel."
 msgstr ""
+"Выберите дополнения, которые нужно активировать сразу. Вы также можете "
+"активировать дополнения после создания сайта в панели управления "
+"дополнениями."
 
 #: senaite/core/exportimport/import.pt:135
 msgid "Select existing file"
-msgstr ""
+msgstr "Выберите существующий файл"
 
 #: bika/lims/content/instrumentcertification.py:85
 msgid "Select if is an in-house calibration certificate"
-msgstr ""
+msgstr "Отметьте, если это внутренний сертификат калибровки"
 
 #: bika/lims/content/analysisservice.py:88
-msgid "Select if the calculation to be used is the calculation set by default in the default method. If unselected, the calculation can be selected manually"
+msgid ""
+"Select if the calculation to be used is the calculation set by default in "
+"the default method. If unselected, the calculation can be selected manually"
 msgstr ""
+"Отметьте, если нужно использовать формулу расчёта, заданную по умолчанию в "
+"методе по умолчанию. Если не отмечено, формулу можно выбрать вручную"
 
 #: bika/lims/content/pricelist.py:76
 msgid "Select if the descriptions should be included"
-msgstr ""
+msgstr "Выберите, если описания должны быть включены"
 
 #: bika/lims/content/abstractbaseanalysis.py:393
-msgid "Select if the results for tests of this type of analysis can be set by using an instrument. If disabled, no instruments will be available for tests of this type of analysis in manage results view, even though the method selected for the test has instruments assigned."
+msgid ""
+"Select if the results for tests of this type of analysis can be set by using"
+" an instrument. If disabled, no instruments will be available for tests of "
+"this type of analysis in manage results view, even though the method "
+"selected for the test has instruments assigned."
 msgstr ""
+"Отметьте, если результаты тестов этого типа анализа можно устанавливать с "
+"помощью инструмента. Если отключено, инструменты не будут доступны для "
+"тестов этого типа в просмотре управления результатами, даже если у "
+"выбранного метода есть назначенные инструменты."
 
 #: senaite/core/browser/worksheets/templates/view.pt:66
 msgid "Select instrument"
-msgstr ""
+msgstr "Выбрать инструмент"
 
 #: senaite/core/skins/senaite_templates/senaite_widgets/rejectionwidget.pt:50
 msgid "Select reasons"
-msgstr ""
+msgstr "Выберите причины"
 
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:76
 #: senaite/core/browser/worksheets/templates/view.pt:51
 #: senaite/core/browser/worksheets/worksheet/templates/add_analyses.pt:33
 msgid "Select template"
-msgstr ""
+msgstr "Выбрать шаблон"
 
-#: bika/lims/content/bikasetup.py:270
+#: bika/lims/content/bikasetup.py:269
 msgid "Select the country the site will show by default"
-msgstr ""
+msgstr "Выберите страну, сайт будет отображать по умолчанию"
 
-#: bika/lims/content/bikasetup.py:255
+#: bika/lims/content/bikasetup.py:254
 msgid "Select the currency the site will use to display prices."
-msgstr ""
+msgstr "Выберите валюту, сайт будет использовать для отображения цены."
 
 #: bika/lims/content/analysisservice.py:166
-msgid "Select the default container to be used for this analysis service. If the container to be used depends on the sample type and preservation combination, specify the container in the sample type table below"
+msgid ""
+"Select the default container to be used for this analysis service. If the "
+"container to be used depends on the sample type and preservation "
+"combination, specify the container in the sample type table below"
 msgstr ""
+"Выберите контейнер по умолчанию для этой услуги анализа. Если контейнер "
+"зависит от сочетания типа образца и способа сохранения, укажите его в "
+"таблице типов образца ниже"
 
 #: bika/lims/profiles/default/registry.xml
-msgid "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing."
+msgid ""
+"Select the default landing page. This is used when a Client user logs into "
+"the system, or when a client is selected from the client folder listing."
 msgstr ""
+"Выберите стартовую страницу по умолчанию. Она используется при входе "
+"пользователя-клиента в систему или при выборе клиента из списка папки "
+"клиентов."
 
-#: senaite/core/content/senaitesetup.py:1152
+#: senaite/core/content/senaitesetup.py:1129
 msgid "Select the default sticker template used for automatic printing."
-msgstr ""
+msgstr "Выберите шаблон стикера по умолчанию для автоматической печати."
 
-#: bika/lims/content/bikasetup.py:1001
+#: bika/lims/content/bikasetup.py:1000
 msgid "Select the default sticker template used for automatic printing.<br/>"
-msgstr ""
+msgstr "Выберите шаблон стикера по умолчанию для автоматической печати.<br/>"
 
 #: bika/lims/content/identifiertype.py:40
 msgid "Select the types that this ID is used to identify."
-msgstr ""
+msgstr "Выберите типы, которые идентифицирует этот ID."
 
-#: senaite/core/content/senaitesetup.py:1086
-msgid "Select this to activate automatic notifications via email to the Client when a Sample is rejected."
+#: senaite/core/content/senaitesetup.py:1063
+msgid ""
+"Select this to activate automatic notifications via email to the Client when"
+" a Sample is rejected."
 msgstr ""
+"Отметьте, чтобы активировать автоматические уведомления клиента по email при"
+" отклонении образца."
 
-#: bika/lims/content/bikasetup.py:593
+#: bika/lims/content/bikasetup.py:592
 msgid "Select this to activate the dashboard as a default front page."
 msgstr ""
+"Отметьте, чтобы использовать панель управления как главную страницу по "
+"умолчанию."
 
-#: senaite/core/content/senaitesetup.py:1013
+#: senaite/core/content/senaitesetup.py:990
 msgid "Select this to activate the sample collection workflow steps."
 msgstr ""
+"Выберите эту опцию, чтобы активировать этапы рабочего процесса сбора "
+"образцов."
 
-#: senaite/core/content/senaitesetup.py:1021
-msgid "Select this to allow a Sampling Coordinator to schedule a sampling. This functionality only takes effect when 'Sampling workflow' is active"
+#: senaite/core/content/senaitesetup.py:998
+msgid ""
+"Select this to allow a Sampling Coordinator to schedule a sampling. This "
+"functionality only takes effect when 'Sampling workflow' is active"
 msgstr ""
+"Отметьте, чтобы разрешить координатору отбора проб планировать отбор проб. "
+"Действует только при активном процессе отбора проб"
 
-#: senaite/core/content/senaitesetup.py:1001
-msgid "Select this to allow dispatching samples through the 'dispatch' transition and to enable the additional 'dispatched' status. The analyses of a dispatched sample become read-only and are brought back to their previous status when the sample is restored. Disabled by default."
+#: senaite/core/content/senaitesetup.py:980
+msgid ""
+"Select this to allow the user to set an additional 'Printed' status to those"
+" Analysis Requests that have been Published. Disabled by default."
 msgstr ""
+"Отметьте, чтобы разрешить пользователю устанавливать дополнительный статус "
+"'Напечатано' для опубликованных заявок на анализ. По умолчанию отключено."
 
-#: senaite/core/content/senaitesetup.py:991
-msgid "Select this to allow disposing samples through the 'dispose' transition and to enable the additional 'disposed' status. Disabled by default."
+#: senaite/core/content/senaitesetup.py:1008
+msgid ""
+"Select to receive the samples automatically when created by lab personnel "
+"and sampling workflow is disabled. Samples created by client contacts won't "
+"be received automatically"
 msgstr ""
+"Отметьте, чтобы автоматически принимать образцы, созданные персоналом "
+"лаборатории, при отключённом процессе отбора проб. Образцы, созданные "
+"контактами клиента, автоматически приниматься не будут"
 
-#: senaite/core/content/senaitesetup.py:981
-msgid "Select this to allow the user to set an additional 'Printed' status to those Analysis Requests that have been Published. Disabled by default."
+#: bika/lims/content/bikasetup.py:722
+msgid ""
+"Select to show sample partitions to client contacts. If deactivated, "
+"partitions won't be included in listings and no info message with links to "
+"the primary sample will be displayed to client contacts."
 msgstr ""
-
-#: senaite/core/content/senaitesetup.py:1031
-msgid "Select to receive the samples automatically when created by lab personnel and sampling workflow is disabled. Samples created by client contacts won't be received automatically"
-msgstr ""
-
-#: bika/lims/content/bikasetup.py:723
-msgid "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-msgstr ""
+"Отметьте, чтобы показывать партиции образца контактам клиента. Если "
+"отключено, партиции не будут включены в списки, и контактам клиента не будет"
+" показано информационное сообщение со ссылками на основной образец."
 
 #: bika/lims/content/worksheettemplate.py:82
 msgid "Select which Analyses should be included on the Worksheet"
-msgstr ""
+msgstr "Выберете, какие анализы должны быть включены в Журнал"
 
 #: senaite/core/config/vocabularies.py:57
 msgid "Selection list"
-msgstr ""
+msgstr "Список выбора"
 
-#: bika/lims/content/abstractbaseanalysis.py:820
+#: bika/lims/content/abstractbaseanalysis.py:817
 msgid "Self-verification of results"
-msgstr ""
+msgstr "Самопроверка результатов"
 
 #: bika/lims/browser/publish/templates/email.pt:208
 msgid "Send"
-msgstr ""
+msgstr "Отправить"
 
 #: bika/lims/browser/publish/templates/email.pt:23
 msgid "Send Analysis Reports via Email"
-msgstr ""
+msgstr "Отправить отчёты по анализам по email"
 
-#: senaite/core/content/resultsreport.py:257
+#: senaite/core/content/resultsreport.py:256
 msgid "Send Log"
-msgstr ""
+msgstr "Журнал отправки"
 
-#: senaite/core/content/resultsreport.py:260
+#: senaite/core/content/resultsreport.py:259
 msgid "Send Log Entry"
-msgstr ""
+msgstr "Запись журнала отправки"
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:132
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:135
 msgid "Send an email notification to ${recipients}"
-msgstr ""
+msgstr "Отправить уведомление по email на ${recipients}"
 
 #: bika/lims/browser/templates/analysisreport_info.pt:132
 msgid "Sender"
-msgstr ""
+msgstr "Отправитель"
 
 #: bika/lims/browser/publish/reports_listing.py:91
 msgid "Sent to"
-msgstr ""
+msgstr "Отправлен"
 
 #: bika/lims/browser/fields/partitionsetupfield.py:115
 #: bika/lims/content/analysisservice.py:129
 msgid "Separate Container"
-msgstr ""
+msgstr "Отдельный контейнер"
 
-#: senaite/core/content/senaitesetup.py:217
+#: senaite/core/content/senaitesetup.py:216
 msgid "Seq Type"
-msgstr ""
+msgstr "Тип последовательности"
 
 #: bika/lims/content/instrument.py:145
 msgid "Serial No"
-msgstr ""
+msgstr "Серийный номер"
 
 #: bika/lims/browser/analysisrequest/manage_analyses.py:74
 #: bika/lims/browser/templates/analysisservice_info.pt:209
 #: bika/lims/browser/widgets/analysisprofileanalyseswidget.py:73
 msgid "Service"
-msgstr ""
+msgstr "Услуга"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
-msgid "Service cannot be deselected. Please click the info button for further details"
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:598
+msgid ""
+"Service cannot be deselected. Please click the info button for further "
+"details"
 msgstr ""
+"Услугу нельзя снять с выбора. Нажмите кнопку информации для подробностей"
 
 #: senaite/core/exportimport/instruments/importer.py:315
 msgid "Service keyword {analysis_keyword} not found"
-msgstr ""
+msgstr "Ключевое слово услуги {analysis_keyword} не найдено"
 
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:119
 msgid "Set Conditions"
-msgstr ""
+msgstr "Задать условия"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:167
 msgid "Set remarks"
-msgstr ""
+msgstr "Задать замечания"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:171
 msgid "Set remarks for selected analyses"
-msgstr ""
+msgstr "Задать замечания для выбранных анализов"
 
 #: bika/lims/content/analysisrequest.py:672
 msgid "Set the Sample Rejection workflow and the reasons"
-msgstr ""
+msgstr "Настройте процесс отклонения образца и причины"
 
 #: bika/lims/content/instrumentmaintenancetask.py:128
 msgid "Set the maintenance task as closed."
-msgstr ""
+msgstr "Отметить задачу обслуживания как закрытую."
 
-#: senaite/core/content/senaitesetup.py:1096
-msgid "Set the text for the body of the email to be sent to the Sample's client contact if the option 'Email notification on Sample rejection' is enabled. You can use reserved keywords: $sample_id, $sample_link, $reasons, $lab_address"
+#: senaite/core/content/senaitesetup.py:1073
+msgid ""
+"Set the text for the body of the email to be sent to the Sample's client "
+"contact if the option 'Email notification on Sample rejection' is enabled. "
+"You can use reserved keywords: $sample_id, $sample_link, $reasons, "
+"$lab_address"
 msgstr ""
+"Задайте текст письма, отправляемого контакту клиента образца, если включена "
+"опция 'Уведомление по email при отклонении образца'. Можно использовать "
+"зарезервированные ключевые слова: $sample_id, $sample_link, $reasons, "
+"$lab_address"
 
 #: senaite/core/registry/schema.py:40
 msgid "Settings for Clients"
-msgstr ""
+msgstr "Настройки клиентов"
 
 #: bika/lims/profiles/default/types/BikaSetup.xml
 msgid "Setup"
-msgstr ""
+msgstr "Настройка"
 
 #: bika/lims/content/storagelocation.py:78
 msgid "Shelf Code"
-msgstr ""
+msgstr "Код стеллажа"
 
 #: bika/lims/content/storagelocation.py:83
 msgid "Shelf Description"
-msgstr ""
+msgstr "Описание стеллажа"
 
 #: bika/lims/content/storagelocation.py:73
 msgid "Shelf Title"
-msgstr ""
+msgstr "Название стеллажа"
 
 #: bika/lims/config.py:84
 msgid "Shipping address"
-msgstr ""
+msgstr "Адрес доставки"
 
 #: bika/lims/content/client.py:61
-msgid "Short and unique identifier of this client. Besides fast searches by client in Samples listings, the purposes of this field depend on the laboratory needs. For instance, the Client ID can be included as part of the Sample identifier, so the lab can easily know the client a given sample belongs to by just looking to its ID."
+msgid ""
+"Short and unique identifier of this client. Besides fast searches by client "
+"in Samples listings, the purposes of this field depend on the laboratory "
+"needs. For instance, the Client ID can be included as part of the Sample "
+"identifier, so the lab can easily know the client a given sample belongs to "
+"by just looking to its ID."
 msgstr ""
+"Краткий уникальный идентификатор этого клиента. Помимо быстрого поиска по "
+"клиенту в списках образцов, назначение этого поля зависит от нужд "
+"лаборатории. Например, ID клиента может быть включён в идентификатор "
+"образца, чтобы лаборатория могла легко определить клиента по ID образца."
 
 #: bika/lims/content/method.py:160
 msgid "Short method description"
-msgstr ""
+msgstr "Краткое описание метода"
 
 #: bika/lims/content/abstractbaseanalysis.py:68
 msgid "Short title"
-msgstr ""
+msgstr "Краткое название"
 
 #: bika/lims/content/analysisrequest.py:974
 msgid "Should the analyses be excluded from the invoice?"
-msgstr ""
+msgstr "Исключать ли анализы из счёта?"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:127
 msgid "Should the default example content be added to the site?"
-msgstr ""
+msgstr "Добавить ли на сайт стандартный демонстрационный контент?"
 
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:59
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:58
 msgid "Show additional fields"
-msgstr ""
+msgstr "Показать дополнительные поля"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:394
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:385
 msgid "Show all"
-msgstr ""
-
-#: senaite/core/api/remarks.py:486
-msgid "Show history"
-msgstr ""
+msgstr "Показать все"
 
 #: senaite/core/exportimport/import.pt:186
 msgid "Show last auto import logs"
-msgstr ""
+msgstr "Показать последние журналы автоимпорта"
 
-#: senaite/core/api/remarks.py:489
+#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:80
 msgid "Show less"
-msgstr ""
+msgstr "Показать меньше"
 
-#: senaite/core/api/remarks.py:488
+#: senaite/core/skins/senaite_templates/senaite_widgets/remarkswidget.pt:79
 msgid "Show more"
-msgstr ""
+msgstr "Показать больше"
 
 #: senaite/core/registry/schema.py:173
 msgid "Show standard fields"
-msgstr ""
-
-# senaite.app.listing: Column config — plus button tooltip / aria-label
-msgid "Show this column"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:129
-msgid "Show/hide timeline"
-msgstr ""
+msgstr "Показать стандартные поля"
 
 #: bika/lims/content/labcontact.py:46
 msgid "Signature"
-msgstr ""
+msgstr "Подпись"
 
 #: senaite/core/profiles/default/types/SimpleFile.xml
 msgid "Simple File"
-msgstr ""
+msgstr "Простой файл"
 
 #: senaite/core/profiles/default/types/SimpleImage.xml
 msgid "Simple Image"
-msgstr ""
+msgstr "Простое изображение"
 
 #: bika/lims/content/storagelocation.py:43
 msgid "Site Code"
-msgstr ""
+msgstr "Код площадки"
 
 #: bika/lims/content/storagelocation.py:48
 msgid "Site Description"
-msgstr ""
+msgstr "Описание площадки"
 
-#: senaite/core/content/senaitesetup.py:314
+#: senaite/core/content/senaitesetup.py:313
 msgid "Site Logo"
-msgstr ""
+msgstr "Логотип сайта"
 
-#: senaite/core/content/senaitesetup.py:320
+#: senaite/core/content/senaitesetup.py:319
 msgid "Site Logo CSS"
-msgstr ""
+msgstr "CSS логотипа сайта"
 
 #: bika/lims/content/storagelocation.py:38
 msgid "Site Title"
-msgstr ""
+msgstr "Название площадки"
 
 #: senaite/core/browser/clients/client/attachments/view.py:67
 #: senaite/core/browser/viewlets/templates/attachments.pt:65
 msgid "Size"
-msgstr ""
+msgstr "Размер"
 
 #: senaite/core/exportimport/instruments/importer.py:648
-msgid "Skipping result for analysis '{keyword}' of sample '{sid}' with calculation '{calculation}'"
+msgid ""
+"Skipping result for analysis '{keyword}' of sample '{sid}' with calculation "
+"'{calculation}'"
 msgstr ""
+"Пропуск результата для анализа '{keyword}' образца '{sid}' с формулой "
+"расчёта '{calculation}'"
 
 #: bika/lims/profiles/default/types/AnalysisRequest.xml
 msgid "Small Sticker"
-msgstr ""
+msgstr "Мелкий стикер"
 
-#: senaite/core/content/senaitesetup.py:1161
+#: senaite/core/content/senaitesetup.py:1138
 msgid "Small Sticker Template"
-msgstr ""
+msgstr "Шаблон малого стикера"
 
 #: bika/lims/browser/auditlog.py:98
 msgid "Snapshot"
-msgstr ""
+msgstr "Снимок"
 
 #: bika/lims/browser/worksheet/views/results.py:190
-msgid "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed"
+msgid ""
+"Some analyses use out-of-date or uncalibrated instruments. Results edition "
+"not allowed"
 msgstr ""
+"Некоторые анализы используют просроченные или неоткалиброванные инструменты."
+" Редактирование результатов запрещено"
 
 #: bika/lims/content/abstractbaseanalysis.py:82
-#: bika/lims/content/analysiscategory.py:82
-#: bika/lims/content/subgroup.py:38
+#: bika/lims/content/analysiscategory.py:82 bika/lims/content/subgroup.py:38
 msgid "Sort Key"
-msgstr ""
-
-# senaite.app.listing: Column header — sort arrow tooltip / aria-label
-msgid "Sort ascending"
-msgstr ""
-
-# senaite.app.listing: Column header — sort arrow tooltip / aria-label
-msgid "Sort descending"
-msgstr ""
+msgstr "Ключ сортировки"
 
 #: bika/lims/browser/analyses/qc.py:59
 msgid "Source"
-msgstr ""
+msgstr "Источник"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:93
 msgid "Specification"
-msgstr ""
+msgstr "Спецификация"
 
 #: senaite/core/content/dynamicanalysisspec.py:50
 msgid "Specification File"
-msgstr ""
+msgstr "Файл спецификации"
 
 #: bika/lims/content/analysisrequest.py:707
 msgid "Specification Name"
-msgstr ""
+msgstr "Название спецификации"
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:18
 msgid "Specification ranges have changed since they were assigned"
-msgstr ""
+msgstr "Диапазоны спецификации изменились с момента назначения"
 
 #: bika/lims/content/analysisspec.py:90
 msgid "Specifications"
-msgstr ""
+msgstr "Спецификации"
 
-#: senaite/core/content/senaitesetup.py:1186
+#: senaite/core/content/senaitesetup.py:1163
 msgid "Specify how many copies of each sticker should be printed by default."
-msgstr ""
+msgstr "Укажите количество копий каждого стикера для печати по умолчанию."
 
 #: bika/lims/content/worksheettemplate.py:63
-msgid "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position.Where QC samples are selected, also select which Reference Sample should be used.If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
+msgid ""
+"Specify the size of the Worksheet, e.g. corresponding to a specific "
+"instrument's tray size. Then select an Analysis 'type' per Worksheet "
+"position.Where QC samples are selected, also select which Reference Sample "
+"should be used.If a duplicate analysis is selected, indicate which sample "
+"position it should be a duplicate of"
 msgstr ""
+"Укажите размер рабочего листа, например, соответствующий размеру лотка "
+"конкретного инструмента. Затем выберите 'тип' анализа для каждой позиции "
+"рабочего листа. Если выбраны образцы контроля качества, также выберите "
+"используемый референс-образец. Если выбран дублирующий анализ, укажите, "
+"дубликатом какой позиции образца он является"
 
-#: senaite/core/content/senaitesetup.py:246
+#: senaite/core/content/senaitesetup.py:245
 msgid "Split Length"
-msgstr ""
+msgstr "Длина разбиения"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:149
 #: senaite/core/registry/schema.py:205
 msgid "Standard fields"
-msgstr ""
+msgstr "Стандартные поля"
 
 #: bika/lims/browser/pricelist.py:64
 msgid "Start Date"
-msgstr ""
+msgstr "Дата начала действия"
 
 #: bika/lims/validators.py:237
 msgid "Start date must be before End Date"
-msgstr ""
+msgstr "Дата начала должна быть раньше даты окончания"
 
-#: senaite/core/browser/samples/view.py:264
+#: senaite/core/browser/samples/view.py:246
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:123
 #: senaite/core/skins/senaite_templates/senaite_widgets/addresswidget.pt:67
 msgid "State"
-msgstr ""
+msgstr "Статус"
 
-#: senaite/core/browser/dashboard/dashboard.py:127
+#: bika/lims/browser/analyses/view.py:200
 msgid "Status"
-msgstr ""
+msgstr "Статус"
 
-#: senaite/core/content/senaitesetup.py:1395
+#: senaite/core/content/senaitesetup.py:1368
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Sticker"
-msgstr ""
+msgstr "Наклейка"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Stickers preview"
-msgstr ""
+msgstr "Предварительный просмотр наклеек"
 
-# senaite.app.listing: Saved filter presets — star action tooltip when active
-msgid "Stop auto-applying"
-msgstr ""
-
-#: senaite/core/browser/samples/view.py:221
+#: senaite/core/browser/samples/view.py:209
 #: senaite/core/profiles/default/types/StorageLocation.xml
 msgid "Storage Location"
-msgstr ""
+msgstr "Место хранения"
 
 #: senaite/core/profiles/default/types/StorageLocations.xml
 msgid "Storage Locations"
-msgstr ""
+msgstr "Места хранения проб"
 
 #: senaite/core/config/vocabularies.py:55
 msgid "String"
-msgstr ""
+msgstr "Строка"
 
 #: senaite/core/profiles/default/types/SubGroup.xml
 msgid "SubGroup"
-msgstr ""
+msgstr "Подгруппа"
 
 #: senaite/core/profiles/default/types/SubGroups.xml
 msgid "SubGroups"
-msgstr ""
+msgstr "Подгруппы"
 
 #: bika/lims/content/subgroup.py:39
 msgid "Subgroups are sorted with this key in group views"
-msgstr ""
+msgstr "Подгруппы сортируются по этому ключу в просмотрах группы"
 
 #: bika/lims/browser/publish/templates/email.pt:115
 #: bika/lims/browser/templates/analysisreport_info.pt:165
 msgid "Subject"
-msgstr ""
+msgstr "Тема"
 
 #: senaite/core/exportimport/import.pt:124
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 msgid "Submit"
-msgstr ""
+msgstr "Отправить"
 
 #: senaite/core/exportimport/import.pt:114
-msgid "Submit a valid Open XML (.XLSX) file containing setup records to continue."
+msgid ""
+"Submit a valid Open XML (.XLSX) file containing setup records to continue."
 msgstr ""
+"Для продолжения загрузите корректный файл Open XML (.XLSX) с записями "
+"настроек."
 
-#: senaite/core/browser/dashboard/dashboard.py:490
-msgid "Submitted analyses awaiting verification"
-msgstr ""
-
-#: bika/lims/browser/analyses/view.py:1571
+#: bika/lims/browser/analyses/view.py:1570
 msgid "Submitted and verified by the same user: {}"
-msgstr ""
+msgstr "Отправлено и верифицировано одним пользователем: {}"
 
 #: bika/lims/browser/analyses/view.py:181
 msgid "Submitter"
-msgstr ""
+msgstr "Отправитель"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:688
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:678
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:198
 msgid "Subtotal"
-msgstr ""
+msgstr "Итого"
 
 #: senaite/core/vocabularies/setup.py:162
 msgid "Sunday"
-msgstr ""
+msgstr "Воскресенье"
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:600
 #: senaite/core/profiles/default/types/Supplier.xml
 msgid "Supplier"
-msgstr ""
+msgstr "Поставщик"
 
 #: senaite/core/profiles/default/types/Suppliers.xml
 msgid "Suppliers"
-msgstr ""
+msgstr "Поставщики"
 
 #: bika/lims/browser/worksheet/views/referencesamples.py:75
 msgid "Supported Services"
-msgstr ""
+msgstr "Поддерживаемые услуги"
 
 #: bika/lims/content/method.py:116
 msgid "Supported calculations of this method"
-msgstr ""
+msgstr "Поддерживаемые формулы расчёта этого метода"
 
 #: bika/lims/content/person.py:75
 msgid "Surname"
-msgstr ""
+msgstr "Фамилия"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:33
 msgid "Switch to classic view"
-msgstr ""
+msgstr "Переключить на стандартное представление"
 
 #: bika/lims/browser/templates/senaite-frontpage.pt:6
 msgid "Switch to dashboard"
-msgstr ""
+msgstr "Переключиться на панель управления"
 
 #: senaite/core/browser/samples/templates/multi_results.pt:25
 msgid "Switch to transposed view"
-msgstr ""
+msgstr "Переключить на транспонированное представление"
 
-#: bika/lims/content/abstractbaseanalysis.py:1089
+#: bika/lims/content/abstractbaseanalysis.py:1086
 msgid "System default"
-msgstr ""
+msgstr "Системное значение по умолчанию"
 
 #: bika/lims/browser/instrument.py:84
 msgid "Task"
-msgstr ""
+msgstr "Задача"
 
 #: bika/lims/content/instrumentcertification.py:57
 msgid "Task ID"
-msgstr ""
+msgstr "ID задачи"
 
 #. Default: "Type"
 #: bika/lims/browser/instrument.py:86
 #: bika/lims/content/instrumentscheduledtask.py:66
 msgid "Task type"
-msgstr ""
+msgstr "Тип"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:217
 msgid "Taxes"
-msgstr ""
+msgstr "Налоги"
 
 #: bika/lims/content/method.py:78
 msgid "Technical description and instructions intended for analysts"
-msgstr ""
+msgstr "Техническое описание и инструкции, предназначенные для аналитиков"
 
-#: senaite/core/browser/samples/view.py:254
+#: senaite/core/browser/samples/view.py:236
 #: senaite/core/browser/stickers/templates/stickers_preview.pt:26
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:69
 msgid "Template"
-msgstr ""
+msgstr "Шаблон"
 
 #: bika/lims/content/calculation.py:156
 msgid "Test Parameters"
-msgstr ""
+msgstr "Параметры теста"
 
 #: bika/lims/content/calculation.py:170
 msgid "Test Result"
-msgstr ""
+msgstr "Результат теста"
 
 #: senaite/core/config/vocabularies.py:56
 msgid "Text"
-msgstr ""
+msgstr "Текст"
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:5
 msgid "Thank you for your analysis request."
-msgstr ""
+msgstr "Благодарим за заявку на анализ."
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:54
-msgid "The ID of the site. This ends up as part of the URL. No special characters or spaces are allowed."
+msgid ""
+"The ID of the site. This ends up as part of the URL. No special characters "
+"or spaces are allowed."
 msgstr ""
+"ID сайта. Становится частью URL. Специальные символы и пробелы не "
+"допускаются."
 
 #: bika/lims/content/laboratory.py:65
 msgid "The Laboratory's web address"
-msgstr ""
+msgstr "веб-адрес лаборатория "
 
 #: senaite/core/browser/form/adapters/referencesample.py:46
-msgid "The Reference Sample ID cannot be changed because it is already associated with other objects, such as QC analyses."
+msgid ""
+"The Reference Sample ID cannot be changed because it is already associated "
+"with other objects, such as QC analyses."
 msgstr ""
+"ID референс-образца нельзя изменить, поскольку он уже связан с другими "
+"объектами, например анализами контроля качества."
 
 #: bika/lims/content/laboratory.py:142
 msgid "The accreditation standard that applies, e.g. ISO 17025"
-msgstr ""
+msgstr "Стандарт аккредитации , который применяется, например, ISO 17025"
 
 #: bika/lims/content/analysisprofile.py:65
 msgid "The analyses included in this profile, grouped per category"
-msgstr ""
+msgstr "Анализы, включенные в этот профиль, сгруппированных по категориям"
 
 #: bika/lims/content/instrumentcalibration.py:97
 msgid "The analyst or agent responsible of the calibration"
-msgstr ""
+msgstr "Аналитик или ответственный за калибровку"
 
 #: bika/lims/content/instrumentmaintenancetask.py:84
 msgid "The analyst or agent responsible of the maintenance"
-msgstr ""
+msgstr "Аналитик или ответственный за обслуживание"
 
 #: bika/lims/content/instrumentvalidation.py:79
 msgid "The analyst responsible of the validation"
-msgstr ""
+msgstr "Аналитик, ответственный за валидацию"
 
 #: bika/lims/browser/batch/batchbook.py:38
-msgid "The batch book allows to introduce analysis results for all samples in this batch. Please note that submitting the results for verification is only possible within samples or worksheets, because additional information like e.g. the instrument or the method need to be set additionally."
+msgid ""
+"The batch book allows to introduce analysis results for all samples in this "
+"batch. Please note that submitting the results for verification is only "
+"possible within samples or worksheets, because additional information like "
+"e.g. the instrument or the method need to be set additionally."
 msgstr ""
+"Книга партии позволяет вносить результаты анализов для всех образцов этой "
+"партии. Обратите внимание: отправка результатов на верификацию возможна "
+"только в образцах или рабочих листах, поскольку требуется указать "
+"дополнительную информацию, например инструмент или метод."
 
 #: bika/lims/content/analysisrequest.py:852
 msgid "The client side identifier of the sample"
-msgstr ""
+msgstr "Идентификатор образца со стороны клиента"
 
 #: bika/lims/content/analysisrequest.py:818
 msgid "The client side order number for this request"
-msgstr ""
+msgstr "Номер заказа этой заявки со стороны клиента"
 
 #: bika/lims/content/analysisrequest.py:835
 msgid "The client side reference for this request"
-msgstr ""
+msgstr "Референс этой заявки со стороны клиента"
 
 #: bika/lims/content/instrument.py:348
 msgid "The date the instrument was installed"
-msgstr ""
+msgstr "Дата установки инструмента"
 
 #: bika/lims/content/analysisrequest.py:623
 msgid "The date when the sample was preserved"
-msgstr ""
+msgstr "Дата консервации образца"
 
 #: bika/lims/content/analysisrequest.py:1077
 msgid "The date when the sample was received"
-msgstr ""
+msgstr "Дата приёма образца"
 
-#: bika/lims/content/client.py:230
+#: bika/lims/content/client.py:226
 msgid "The decimal mark selected in Bika Setup will be used."
-msgstr ""
+msgstr "Будет использован десятичный разделитель, выбранный в Bika Setup."
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:113
-msgid "The default timezone setting of the portal. Users will be able to set their own timezone, if available timezones are defined in the date and time settings."
+msgid ""
+"The default timezone setting of the portal. Users will be able to set their "
+"own timezone, if available timezones are defined in the date and time "
+"settings."
 msgstr ""
+"Часовой пояс портала по умолчанию. Пользователи смогут задать собственный "
+"часовой пояс, если доступные часовые пояса определены в настройках даты и "
+"времени."
 
-#: bika/lims/content/bikasetup.py:283
-msgid "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
+#: bika/lims/content/bikasetup.py:282
+msgid ""
+"The discount percentage entered here, is applied to the prices for clients "
+"flagged as 'members', normally co-operative members or associates deserving "
+"of this discount"
 msgstr ""
+"Процент скидки введен здесь, применяется к ценам для клиентов с пометкой "
+"\"член\", как правило, кооператоров или партнеров, заслуживающих этой скидки"
 
 #: bika/lims/browser/publish/emailview.py:179
-msgid "The email 'From' address is invalid. Please verify the \"Publication 'From' address\" in Setup > Notifications and/or the \"Site 'From' address\" in Site Setup > Mail."
+msgid ""
+"The email 'From' address is invalid. Please verify the \"Publication 'From' "
+"address\" in Setup > Notifications and/or the \"Site 'From' address\" in "
+"Site Setup > Mail."
 msgstr ""
+"Адрес отправителя письма недействителен. Проверьте \"Адрес отправителя "
+"публикации\" в Настройки > Уведомления и/или \"Адрес отправителя сайта\" в "
+"Настройки сайта > Почта."
 
 #: bika/lims/content/analysisrequest.py:940
 msgid "The environmental condition during sampling"
-msgstr ""
+msgstr "Условия окружающей среды при отборе проб"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:104
-msgid "The fields are always listed on top and can not be faded out. You can drag and drop any fields to the lower list to change thier visibility."
+msgid ""
+"The fields are always listed on top and can not be faded out. You can drag "
+"and drop any fields to the lower list to change thier visibility."
 msgstr ""
+"Эти поля всегда отображаются сверху и не могут быть скрыты. Вы можете "
+"перетащить любые поля в нижний список, чтобы изменить их видимость."
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:150
-msgid "The fields are listed below the promient fields and can be faded out. You can drag and drop any fields to the upper list to change their visibility."
+msgid ""
+"The fields are listed below the promient fields and can be faded out. You "
+"can drag and drop any fields to the upper list to change their visibility."
 msgstr ""
+"Эти поля отображаются под основными полями и могут быть скрыты. Вы можете "
+"перетащить любые поля в верхний список, чтобы изменить их видимость."
 
 #: bika/lims/browser/viewlets/templates/primary_ar_viewlet.pt:20
 msgid "The following partitions have been created from this Sample:"
-msgstr ""
+msgstr "Из этого образца были созданы следующие партиции:"
 
 #: senaite/core/browser/samples/templates/dispatch_samples.pt:47
 msgid "The following sample(s) will be dispatched"
-msgstr ""
+msgstr "Следующие образцы будут отправлены"
 
-#: senaite/core/browser/samples/templates/dispose_samples.pt:47
-msgid "The following sample(s) will be disposed"
+#: senaite/core/content/senaitesetup.py:298
+msgid ""
+"The global Auditlog shows all modifications of the system. When enabled, all"
+" entities will be indexed in a separate catalog. This will increase the time"
+" when objects are created or modified."
 msgstr ""
-
-#: senaite/core/content/senaitesetup.py:299
-msgid "The global Auditlog shows all modifications of the system. When enabled, all entities will be indexed in a separate catalog. This will increase the time when objects are created or modified."
-msgstr ""
+"Глобальный журнал аудита показывает все изменения системы. При включении все"
+" сущности будут индексироваться в отдельном каталоге, что увеличит время "
+"создания и изменения объектов."
 
 #: bika/lims/content/samplepoint.py:75
 msgid "The height or depth at which the sample has to be taken"
-msgstr ""
+msgstr "Высота или глубина, на которой должен быть взят образец"
 
-#: bika/lims/browser/analyses/view.py:1846
-msgid "The holding time for this sample and analysis has expired. Proceeding with the analysis may compromise the reliability of the results."
+#: bika/lims/browser/analyses/view.py:1845
+msgid ""
+"The holding time for this sample and analysis has expired. Proceeding with "
+"the analysis may compromise the reliability of the results."
 msgstr ""
+"Срок хранения для этого образца и анализа истёк. Продолжение анализа может "
+"снизить достоверность результатов."
 
-#: bika/lims/browser/analyses/view.py:1858
-msgid "The holding time for this sample and analysis is about to expire. Please complete the analysis as soon as possible to ensure data accuracy and reliability."
+#: bika/lims/browser/analyses/view.py:1857
+msgid ""
+"The holding time for this sample and analysis is about to expire. Please "
+"complete the analysis as soon as possible to ensure data accuracy and "
+"reliability."
 msgstr ""
+"Срок хранения для этого образца и анализа скоро истечёт. Завершите анализ "
+"как можно скорее для обеспечения точности и достоверности данных."
 
 #: bika/lims/content/instrument.py:309
 #: bika/lims/content/instrumentcertification.py:58
 msgid "The instrument's ID in the lab's asset register"
-msgstr ""
+msgstr "ID инструмента в реестре активов лаборатории"
 
 #: bika/lims/content/instrument.py:138
 msgid "The instrument's model number"
-msgstr ""
+msgstr "Номер модели инструмента"
 
 #: bika/lims/content/instrumentcertification.py:111
-msgid "The interval is calculated from the 'From' field and defines when the certificate expires in days. Setting this inverval overwrites the 'To' field on save."
+msgid ""
+"The interval is calculated from the 'From' field and defines when the "
+"certificate expires in days. Setting this inverval overwrites the 'To' field"
+" on save."
 msgstr ""
+"Интервал рассчитывается от поля 'С' и определяет, через сколько дней "
+"истекает срок действия сертификата. При сохранении интервал перезаписывает "
+"поле 'До'."
 
 #: senaite/core/browser/samples/invalidate_samples.py:121
 msgid "The invalidation process has been successfully cancelled."
-msgstr ""
+msgstr "Процесс аннулирования успешно отменён."
 
 #: bika/lims/browser/accreditation.py:71
 msgid "The lab is not accredited, or accreditation has not been configured. "
-msgstr ""
+msgstr "Лаборатория не аккредитована, или аккредитация не был настроена. "
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:90
 msgid "The main language of the site."
-msgstr ""
+msgstr "Основной язык сайта."
 
 #: bika/lims/content/sampletype.py:166
 msgid "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
 msgstr ""
+"Минимальный объём образца, необходимый для анализа, например '10 мл' или '1 "
+"кг'."
 
 #: senaite/core/browser/idserver/templates/numbergenerator.pt:40
-msgid "The number generator storage is empty. Counters are seeded on the first ID generation for each prefix."
+msgid ""
+"The number generator storage is empty. Counters are seeded on the first ID "
+"generation for each prefix."
 msgstr ""
+"Хранилище генератора номеров пусто. Счётчики создаются при первой генерации "
+"ID для каждого префикса."
 
-#: senaite/core/content/senaitesetup.py:1074
-msgid "The number of days before a sample expires and cannot be analysed any more. This setting can be overwritten per individual sample type in the sample types setup"
+#: senaite/core/content/senaitesetup.py:1051
+msgid ""
+"The number of days before a sample expires and cannot be analysed any more. "
+"This setting can be overwritten per individual sample type in the sample "
+"types setup"
 msgstr ""
+"Количество дней до того, как образец будет просрочен и не может быть "
+"проанализирован. Этот параметр может быть перезаписан каждый тип отдельных "
+"образцов в типы Установка образцов"
 
-#: bika/lims/content/bikasetup.py:163
-msgid "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
+#: bika/lims/content/bikasetup.py:162
+msgid ""
+"The number of minutes before a user is automatically logged off. 0 disables "
+"automatic log-off"
 msgstr ""
+"Количество минут до автоматического выхода пользователя . 0 отключает "
+"автоматический выход"
 
 #: bika/lims/content/sampletype.py:117
-msgid "The period for which un-preserved samples of this type can be kept before they expire and cannot be analysed any further"
+msgid ""
+"The period for which un-preserved samples of this type can be kept before "
+"they expire and cannot be analysed any further"
 msgstr ""
+"Период, в течение которого неконсервированные образцы этого типа могут "
+"храниться до истечения срока годности"
 
 #: bika/lims/content/analysisrequest.py:644
 msgid "The person who preserved the sample"
-msgstr ""
+msgstr "Лицо, законсервировавшее образец"
 
 #: bika/lims/content/analysisrequest.py:477
 msgid "The person who took the sample"
-msgstr ""
+msgstr "Лицо, отобравшее образец"
 
 #: bika/lims/content/abstractbaseanalysis.py:562
-msgid "The price charged per analysis for clients who qualify for bulk discounts"
-msgstr ""
+msgid ""
+"The price charged per analysis for clients who qualify for bulk discounts"
+msgstr "Цена за анализ для клиентов, имеющих право на оптовую скидку"
 
 #: bika/lims/content/analysisprofile.py:92
 msgid "The profile's commercial ID for accounting purposes."
-msgstr ""
+msgstr "Коммерческий ID профиля для бухгалтерского учёта."
 
 #: bika/lims/content/analysisprofile.py:52
-msgid "The profile's keyword is used to uniquely identify it in import files. It has to be unique, and it may not be the same as any Calculation Interim field ID."
+msgid ""
+"The profile's keyword is used to uniquely identify it in import files. It "
+"has to be unique, and it may not be the same as any Calculation Interim "
+"field ID."
 msgstr ""
+"Профиль ключевое слово используется для уникальной идентификации в файлы "
+"импорта. Он должен быть уникальным, и он не может быть таким же, как поля "
+"Код любых временных вычислений."
 
 #: bika/lims/browser/viewlets/templates/specification_non_compliant_viewlet.pt:23
-msgid "The ranges for the following analyses have been manually changed and they are no longer compliant with the ranges of the Specification:"
+msgid ""
+"The ranges for the following analyses have been manually changed and they "
+"are no longer compliant with the ranges of the Specification:"
 msgstr ""
+"Диапазоны следующих анализов были изменены вручную и больше не соответствуют"
+" диапазонам спецификации:"
 
 #: bika/lims/content/laboratory.py:153
 msgid "The reference code issued to the lab by the accreditation body"
-msgstr ""
+msgstr "Код ссылки, выданного органом аккредитации лаборатории"
 
 #: bika/lims/content/calculation.py:171
-msgid "The result after the calculation has taken place with test values.  You will need to save the calculation before this value will be calculated."
+msgid ""
+"The result after the calculation has taken place with test values.  You will"
+" need to save the calculation before this value will be calculated."
 msgstr ""
+"Результат после выполнения расчёта с тестовыми значениями. Перед расчётом "
+"этого значения нужно сохранить формулу."
 
-#: bika/lims/browser/analyses/view.py:1836
+#: bika/lims/browser/analyses/view.py:1835
 msgid "The result was captured past the holding time limit."
-msgstr ""
+msgstr "Результат был зафиксирован после истечения срока хранения."
 
 #: bika/lims/content/method.py:149
-msgid "The results for the Analysis Services that use this method can be set manually"
+msgid ""
+"The results for the Analysis Services that use this method can be set "
+"manually"
 msgstr ""
+"Результаты услуг анализа, использующих этот метод, можно устанавливать "
+"вручную"
 
 #: bika/lims/content/abstractbaseanalysis.py:514
-msgid "The results of field analyses are captured during sampling at the sample point, e.g. the temperature of a water sample in the river where it is sampled. Lab analyses are done in the laboratory"
+msgid ""
+"The results of field analyses are captured during sampling at the sample "
+"point, e.g. the temperature of a water sample in the river where it is "
+"sampled. Lab analyses are done in the laboratory"
 msgstr ""
+"Результаты анализов поля фиксируются во время отбора проб на контрольной "
+"точке, например температура образца воды в реке, где пробы отбирались. "
+"Лабораторные анализы проводятся в лаборатории"
 
 #: senaite/core/browser/viewlets/sample/templates/not_sampled.pt:8
 msgid "The sample cannot be received"
-msgstr ""
+msgstr "Образец не может быть принят"
 
 #: bika/lims/content/artemplate.py:110
 msgid "The sample is a mix of sub samples"
-msgstr ""
+msgstr "Образец является смесью суб-образцов"
 
 #: bika/lims/content/instrument.py:146
 msgid "The serial number that uniquely identifies the instrument"
-msgstr ""
+msgstr "Серийный номер, который однозначно идентифицирует инструмент"
 
-#: bika/lims/content/abstractbaseanalysis.py:869
+#: bika/lims/content/abstractbaseanalysis.py:866
 msgid "The service's analytical protocol ID"
-msgstr ""
+msgstr "ID аналитического протокола услуги"
 
-#: bika/lims/content/abstractbaseanalysis.py:857
+#: bika/lims/content/abstractbaseanalysis.py:854
 msgid "The service's commercial ID for accounting purposes"
-msgstr ""
+msgstr "Коммерческий ID услуги для бухгалтерского учёта"
 
 #: bika/lims/browser/viewlets/templates/sample_dynamic_specs_viewlet.pt:14
 msgid "The specification has a Dynamic Specification assigned"
-msgstr ""
+msgstr "У спецификации назначена динамическая спецификация"
 
 #: senaite/core/schema/emailfield.py:12
 msgid "The specified email is not valid."
-msgstr ""
+msgstr "Указанный email недействителен."
 
 #: bika/lims/content/referencesample.py:65
-msgid "The unique identifier for this reference sample. If specified, the system will use this value as the sample's ID instead of automatically generating one based on the formatting rules defined in the setup's ID server."
+msgid ""
+"The unique identifier for this reference sample. If specified, the system "
+"will use this value as the sample's ID instead of automatically generating "
+"one based on the formatting rules defined in the setup's ID server."
 msgstr ""
+"Уникальный идентификатор этого референс-образца. Если указан, система будет "
+"использовать это значение как ID образца вместо автоматической генерации по "
+"правилам форматирования сервера идентификаторов."
 
 #: bika/lims/content/abstractbaseanalysis.py:363
-msgid "The unique keyword used to identify the analysis service in import files of bulk Sample requests and results imports from instruments. It is also used to identify dependent analysis services in user defined results calculations"
+msgid ""
+"The unique keyword used to identify the analysis service in import files of "
+"bulk Sample requests and results imports from instruments. It is also used "
+"to identify dependent analysis services in user defined results calculations"
 msgstr ""
+"Уникальное ключевое слово для идентификации услуги анализа в файлах "
+"массового импорта заявок и импорта результатов из инструментов. Также "
+"используется для идентификации зависимых услуг анализа в пользовательских "
+"формулах расчёта результатов"
 
 #: bika/lims/browser/analysisrequest/add2.py:1461
 msgid "The value of field '%s' was emptied. Please select a new value."
-msgstr ""
+msgstr "Значение поля '%s' было очищено. Выберите новое значение."
 
 #: bika/lims/browser/publish/templates/email.pt:126
-msgid "The variable ${recipients} will be automatically replaced with the names and emails of the final selected recipients."
+msgid ""
+"The variable ${recipients} will be automatically replaced with the names and"
+" emails of the final selected recipients."
 msgstr ""
+"Переменная ${recipients} будет автоматически заменена именами и email "
+"итоговых выбранных получателей."
 
 #: senaite/core/browser/samples/rejection/templates/reject_samples.pt:93
 msgid "There are no pre-defined conditions set"
-msgstr ""
+msgstr "Предопределённые условия не заданы"
 
 #: bika/lims/browser/viewlets/templates/dynamic_specs_viewlet.pt:14
 msgid "This Analysis Specification has a Dynamic Specification assigned"
-msgstr ""
+msgstr "У этой спецификации анализа назначена динамическая спецификация"
 
 #: bika/lims/browser/viewlets/templates/rejected_ar_viewlet.pt:15
 msgid "This Sample has been rejected due to the following reasons:"
-msgstr ""
+msgstr "Этот образец был отклонён по следующим причинам:"
 
 #: bika/lims/browser/viewlets/templates/partition_ar_viewlet.pt:14
 msgid "This is a Partition from Sample"
-msgstr ""
+msgstr "Это партиция образца"
 
 #: bika/lims/browser/viewlets/templates/secondary_ar_viewlet.pt:15
 msgid "This is a Secondary Sample of"
-msgstr ""
+msgstr "Это вторичный образец от"
 
 #: bika/lims/browser/viewlets/templates/detached_partition_viewlet.pt:15
 msgid "This is a detached partition from Sample"
-msgstr ""
+msgstr "Это отсоединённая партиция образца"
 
-#: bika/lims/content/bikasetup.py:769
-msgid "This is the default maximum time allowed for performing analyses.  It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
+#: bika/lims/content/bikasetup.py:768
+msgid ""
+"This is the default maximum time allowed for performing analyses.  It is "
+"only used for analyses where the analysis service does not specify a "
+"turnaround time. Only laboratory workdays are considered."
 msgstr ""
+"Это максимальное время по умолчанию, допустимое для выполнения анализов. "
+"Используется только для анализов, у которых услуга анализа не определяет "
+"срок выполнения. Учитываются только рабочие дни лаборатории."
 
-#: senaite/core/content/senaitesetup.py:1061
-msgid "This is the default maximum time allowed for performing analyses. It is only used for analyses where the analysis service does not specify a turnaround time. Only laboratory workdays are considered."
+#: senaite/core/content/senaitesetup.py:1038
+msgid ""
+"This is the default maximum time allowed for performing analyses. It is only"
+" used for analyses where the analysis service does not specify a turnaround "
+"time. Only laboratory workdays are considered."
 msgstr ""
+"Это максимальное время по умолчанию, допустимое для выполнения анализов. "
+"Используется только для анализов, у которых услуга анализа не определяет "
+"срок выполнения. Учитываются только рабочие дни лаборатории."
 
 #: senaite/core/browser/worksheets/worksheet/analyses_listing.py:134
-msgid "This operation can not be undone. Are you sure you want to reject the selected analyses?"
+msgid ""
+"This operation can not be undone. Are you sure you want to reject the "
+"selected analyses?"
 msgstr ""
+"Это действие нельзя отменить. Вы уверены, что хотите отклонить выбранные "
+"анализы?"
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:14
 msgid "This report was sent to the following contacts:"
-msgstr ""
+msgstr "Этот отчёт был отправлен следующим контактам:"
 
 #: bika/lims/browser/viewlets/templates/retest_ar_viewlet.pt:19
-msgid "This sample is a retest, automatically generated following the invalidation of sample ${invalidated_id}."
+msgid ""
+"This sample is a retest, automatically generated following the invalidation "
+"of sample ${invalidated_id}."
 msgstr ""
+"Этот образец является повторным тестом, автоматически созданным после "
+"аннулирования образца ${invalidated_id}."
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:28
-msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date} for the following reason(s): ${reason}."
+msgid ""
+"This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date} "
+"for the following reason(s): ${reason}."
 msgstr ""
+"Этот образец был аннулирован пользователем ${actor_fullname} (${actor_id}) "
+"${date} по следующей причине(-ам): ${reason}."
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:38
-msgid "This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
+msgid ""
+"This sample was invalidated by ${actor_fullname} (${actor_id}) on ${date}."
 msgstr ""
+"Этот образец был аннулирован пользователем ${actor_fullname} (${actor_id}) "
+"${date}."
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:618
-msgid "This service cannot be selected to prevent the analysis from being conducted beyond the analytical holding time."
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:608
+msgid ""
+"This service cannot be selected to prevent the analysis from being conducted"
+" beyond the analytical holding time."
 msgstr ""
+"Эта услуга не может быть выбрана, чтобы предотвратить выполнение анализа "
+"после истечения срока хранения."
 
-#: senaite/core/content/senaitesetup.py:315
+#: senaite/core/content/senaitesetup.py:314
 msgid "This shows a custom logo on your SENAITE site."
-msgstr ""
+msgstr "Показывает пользовательский логотип на вашем сайте SENAITE."
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:57
 msgid "This site configuration is outdated and needs to be upgraded:"
-msgstr ""
+msgstr "Конфигурация сайта устарела и требует обновления:"
 
 #: bika/lims/content/laboratory.py:100
 msgid "This value is reported at the bottom of all published results"
-msgstr ""
+msgstr "Это значение указывается внизу всех опубликованных результатов"
 
 #: bika/lims/browser/worksheet/tools.py:84
-msgid "This worksheet has been created to replace the rejected worksheet at ${ws_id}"
+msgid ""
+"This worksheet has been created to replace the rejected worksheet at "
+"${ws_id}"
 msgstr ""
+"Этот рабочий лист создан для замены отклонённого рабочего листа ${ws_id}"
 
 #: bika/lims/browser/worksheet/tools.py:77
-msgid "This worksheet has been rejected.  The replacement worksheet is ${ws_id}"
-msgstr ""
+msgid ""
+"This worksheet has been rejected.  The replacement worksheet is ${ws_id}"
+msgstr "Этот рабочий лист отклонён. Замещающий рабочий лист — ${ws_id}"
 
 #: senaite/core/vocabularies/setup.py:159
 msgid "Thursday"
-msgstr ""
+msgstr "Четверг"
 
 #: bika/lims/browser/resultsimport/autoimportlogs.py:47
 msgid "Time"
-msgstr ""
+msgstr "Время"
 
 #: senaite/core/exportimport/import.pt:129
-msgid "Tip. Attached documents will not be loaded unless they are present in the instance."
+msgid ""
+"Tip. Attached documents will not be loaded unless they are present in the "
+"instance."
 msgstr ""
+"Совет. Прикреплённые документы не будут загружены, если они отсутствуют в "
+"инстансе."
 
-#: senaite/core/browser/controlpanel/labels/view.py:60
-#: senaite/core/browser/label/labeled_objects.py:59
+#: senaite/core/browser/controlpanel/labels/view.py:59
+#: senaite/core/browser/label/labeled_objects.py:58
 #: senaite/core/browser/widgets/referencewidget.py:55
 msgid "Title"
-msgstr ""
+msgstr "Название"
 
 #: bika/lims/content/storagelocation.py:54
 msgid "Title of location"
-msgstr ""
+msgstr "Название местоположения"
 
 #: bika/lims/controlpanel/dynamic_analysisspecs.py:35
 msgid "Title of the Folder"
-msgstr ""
+msgstr "Название папки"
 
 #: bika/lims/content/storagelocation.py:74
 msgid "Title of the shelf"
-msgstr ""
+msgstr "Название стеллажа"
 
 #: bika/lims/content/storagelocation.py:39
 msgid "Title of the site"
-msgstr ""
+msgstr "Название площадки"
 
 #: bika/lims/content/instrumentcalibration.py:88
 #: bika/lims/content/instrumentmaintenancetask.py:75
 #: bika/lims/content/instrumentvalidation.py:70
 msgid "To"
-msgstr ""
+msgstr "До"
 
-#: senaite/core/browser/samples/view.py:307
+#: senaite/core/browser/samples/view.py:289
 msgid "To Be Preserved"
-msgstr ""
+msgstr "Должны быть сохранены"
 
-#: senaite/core/browser/samples/view.py:298
+#: senaite/core/browser/samples/view.py:280
 msgid "To Be Sampled"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:93
-msgid "To be Published"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:89
-msgid "To be Verified"
-msgstr ""
+msgstr "Ожидаемый образец"
 
 #: bika/lims/content/analysiscategory.py:48
-msgid "To be displayed below each Analysis Category section on results reports."
+msgid ""
+"To be displayed below each Analysis Category section on results reports."
 msgstr ""
+"Отображается под каждым разделом категории анализа в отчётах с результатами."
 
-#: senaite/core/browser/dashboard/dashboard.py:158
+#: senaite/core/browser/dashboard/dashboard.py:133
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be preserved"
-msgstr ""
+msgstr "Должны быть сохранены"
 
-#: senaite/core/browser/dashboard/dashboard.py:441
+#: senaite/core/browser/dashboard/dashboard.py:398
 msgid "To be printed"
-msgstr ""
+msgstr "К печати"
 
-#: senaite/core/browser/dashboard/dashboard.py:157
+#: senaite/core/browser/dashboard/dashboard.py:132
 #: senaite/core/profiles/default/workflows/senaite_sample_workflow/definition.xml
 msgid "To be sampled"
-msgstr ""
+msgstr "Ожидаемые образцы"
 
-#: senaite/core/browser/dashboard/dashboard.py:148
-#: senaite/core/browser/samples/view.py:349
+#: senaite/core/browser/dashboard/dashboard.py:124
+#: senaite/core/browser/samples/view.py:331
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "To be verified"
-msgstr ""
+msgstr "На проверку"
 
 #: bika/lims/content/calculation.py:157
-msgid "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
+msgid ""
+"To test the calculation, enter values here for all calculation parameters.  "
+"This includes Interim fields defined above, as well as any services that "
+"this calculation depends on to calculate results."
 msgstr ""
+"Чтобы протестировать формулу расчёта, введите здесь значения всех параметров"
+" расчёта. Это включает промежуточные поля, определённые выше, а также любые "
+"услуги, от которых зависит расчёт результатов."
 
 #: senaite/core/registry/schema.py:174
 msgid "Toggle visibility of standard sample header fields"
-msgstr ""
+msgstr "Переключить видимость стандартных полей заголовка образца"
 
-#: senaite/core/browser/samples/view.py:650
+#: senaite/core/browser/samples/view.py:523
 msgid "Total"
-msgstr ""
+msgstr "Итого"
 
-#: bika/lims/content/analysisprofile.py:142
-#: bika/lims/content/labproduct.py:67
+#: bika/lims/content/analysisprofile.py:142 bika/lims/content/labproduct.py:67
 msgid "Total price"
-msgstr ""
+msgstr "Полная стоимость"
 
 #: bika/lims/browser/publish/emailview.py:202
 msgid "Total size of email exceeded {:.1f} MB ({:.2f} MB)"
-msgstr ""
+msgstr "Общий размер письма превысил {:.1f} МБ ({:.2f} МБ)"
 
 #: bika/lims/config.py:126
 msgid "Transposed"
-msgstr ""
+msgstr "Транспонировано"
 
 #: senaite/core/vocabularies/setup.py:157
 msgid "Tuesday"
-msgstr ""
+msgstr "Вторник"
 
 #: senaite/core/browser/clients/client/attachments/view.py:63
-#: senaite/core/browser/label/labeled_objects.py:62
+#: senaite/core/browser/label/labeled_objects.py:61
 #: senaite/core/browser/viewlets/templates/attachments.pt:64
 msgid "Type"
-msgstr ""
+msgstr "Тип"
 
 #: bika/lims/browser/fields/interimfieldsfield.py:64
 msgid "Type of control to be displayed on value entry when choices are set"
 msgstr ""
+"Тип контроля, отображаемый при вводе значения, если заданы варианты выбора"
 
 #: bika/lims/content/multifile.py:74
-msgid "Type of document (e.g. user manual, instrument specifications, image, ...)"
+msgid ""
+"Type of document (e.g. user manual, instrument specifications, image, ...)"
 msgstr ""
+"Тип документа (например, руководство пользователя, спецификации инструмента,"
+" изображение...)"
 
 #: bika/lims/content/storagelocation.py:69
 msgid "Type of location"
-msgstr ""
+msgstr "Тип местоположения"
 
 #: senaite/core/content/samplecontainer.py:73
 msgid "Type of the container"
-msgstr ""
+msgstr "Тип контейнера"
 
 #: senaite/core/browser/controlpanel/templates/setupview.pt:27
 msgid "Type to filter ..."
-msgstr ""
-
-# senaite.app.listing: Column-filter row — searchable-select placeholder
-msgid "Type to filter..."
-msgstr ""
+msgstr "Введите для фильтрации..."
 
 #: senaite/core/registry/schema.py:78
-msgid "Types that support labels directly.<br/>NOTE: In cluster setups, other instances need to be restarted manually for the changes to take place!"
+msgid ""
+"Types that support labels directly.<br/>NOTE: In cluster setups, other "
+"instances need to be restarted manually for the changes to take place!"
 msgstr ""
+"Типы, непосредственно поддерживающие метки.<br/>ПРИМЕЧАНИЕ: в кластерных "
+"конфигурациях остальные инстансы нужно перезапустить вручную для применения "
+"изменений!"
 
 #: senaite/core/registry/schema.py:77
 msgid "Types with labels"
-msgstr ""
+msgstr "Типы с метками"
 
-#: senaite/core/content/resultsreport.py:100
+#: senaite/core/content/resultsreport.py:99
 msgid "UID"
-msgstr ""
+msgstr "UID"
 
 #: bika/lims/browser/worksheet/views/printview.py:151
 msgid "Unable to load the template"
-msgstr ""
+msgstr "Не удалось загрузить шаблон"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassign"
-msgstr ""
+msgstr "Отменить назначение"
 
-#: senaite/core/browser/dashboard/dashboard.py:146
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Unassigned"
-msgstr ""
+msgstr "Не назначено"
 
 #: senaite/core/browser/modals/analysis/schema.py:61
 msgid "Uncertainty"
-msgstr ""
+msgstr "Неопределенность"
 
 #: bika/lims/content/abstractbaseanalysis.py:622
 msgid "Uncertainty value"
-msgstr ""
+msgstr "Величина неопределенности"
 
 #: bika/lims/content/department.py:45
 msgid "Unique Department ID that identifies the department"
-msgstr ""
+msgstr "Уникальный ID подразделения"
 
 #: senaite/core/browser/modals/analysis/schema.py:96
 msgid "Unit"
-msgstr ""
+msgstr "Единица"
 
 #: senaite/core/browser/clients/client/attachments/view.py:125
 msgid "Unknown"
-msgstr ""
+msgstr "Неизвестно"
 
 #: senaite/core/content/supplier.py:156
 msgid "Unknown IBAN country %s"
-msgstr ""
+msgstr "Неизвестная страна IBAN %s"
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:108
 msgid "Unlink User"
-msgstr ""
+msgstr "Отвязать пользователя"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:239
+#: senaite/core/browser/clients/client/contacts/login_details.py:228
 msgid "Unlinked User"
-msgstr ""
-
-#: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
-msgid "Unlock"
-msgstr ""
+msgstr "Отвязанный пользователь"
 
 #: senaite/core/exportimport/instruments/panalytical/omnia/axios_xrf.py:53
 msgid "Unrecognized file format ${file_format}"
-msgstr ""
+msgstr "Нераспознанный формат файла ${file_format}"
 
 #: senaite/core/exportimport/instruments/abaxis/vetscan/vs2.py:51
 #: senaite/core/exportimport/instruments/abbott/m2000rt/m2000rt.py:63
 #: senaite/core/exportimport/instruments/alere/pima/beads.py:51
 msgid "Unrecognized file format ${fileformat}"
-msgstr ""
+msgstr "Нераспознанный формат файла ${fileformat}"
 
 #: senaite/core/exportimport/instruments/horiba/jobinyvon/icp.py:57
 msgid "Unrecognized file format ${format}"
-msgstr ""
+msgstr "Нераспознанный формат файла ${format}"
 
-#: senaite/core/browser/samples/view.py:455
+#: senaite/core/browser/samples/view.py:425
 msgid "Unsassigned"
-msgstr ""
+msgstr "Не назначено"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:175
 msgid "Update Attachments"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — Update preset action tooltip
-msgid "Update preset with current view"
-msgstr ""
+msgstr "Обновить вложения"
 
 #: senaite/core/browser/idserver/view.py:122
 msgid "Updated {} key(s): {}"
-msgstr ""
+msgstr "Обновлено ключей: {} ({})"
 
 #: bika/lims/content/labcontact.py:47
-msgid "Upload a scanned signature to be used on printed analysis results reports. Ideal size is 250 pixels wide by 150 high"
+msgid ""
+"Upload a scanned signature to be used on printed analysis results reports. "
+"Ideal size is 250 pixels wide by 150 high"
 msgstr ""
+"Загрузите скан подписи для использования в печатных отчётах с результатами "
+"анализа. Оптимальный размер — 250x150 пикселей"
 
-#: bika/lims/content/client.py:254
-msgid "Upload files and images for this client. Files will be stored in the client folder and can be downloaded later."
+#: bika/lims/content/client.py:250
+msgid ""
+"Upload files and images for this client. Files will be stored in the client "
+"folder and can be downloaded later."
 msgstr ""
+"Загрузите файлы и изображения для этого клиента. Файлы будут храниться в "
+"папке клиента и доступны для скачивания позже."
 
 #: bika/lims/content/analysisprofile.py:101
 msgid "Use Analysis Profile Price"
-msgstr ""
+msgstr "Использовать цену профиля анализа"
 
-#: bika/lims/content/bikasetup.py:592
+#: bika/lims/content/bikasetup.py:591
 msgid "Use Dashboard as default front page"
-msgstr ""
+msgstr "Использовать панель управления как главную страницу по умолчанию"
 
 #: senaite/core/browser/viewlets/templates/resultsinterpretation.pt:84
 msgid "Use Template"
-msgstr ""
+msgstr "Использовать шаблон"
 
 #: bika/lims/content/analysisservice.py:87
 msgid "Use the Default Calculation of Method"
-msgstr ""
+msgstr "Использовать формулу расчёта метода по умолчанию"
 
 #: bika/lims/content/instrument.py:292
-msgid "Use this field to pass arbitrary parameters to the export/import modules."
+msgid ""
+"Use this field to pass arbitrary parameters to the export/import modules."
 msgstr ""
+"Используйте это поле для передачи произвольных параметров для экспорта / "
+"импорта модулей."
 
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:71
 #: senaite/core/browser/clients/client/contacts/view.py:74
 #: senaite/core/browser/controlpanel/contacts/view.py:62
 msgid "User Name"
-msgstr ""
+msgstr "Имя пользователя"
 
 #: bika/lims/controlpanel/bika_labcontacts.py:101
 msgid "User groups"
-msgstr ""
+msgstr "Группы пользователей"
 
 #: senaite/core/browser/user/userdatapanel.py:181
 msgid "User is linked to lab contact '${fullname}'"
-msgstr ""
+msgstr "Пользователь связан с лабораторным контактом '${fullname}'"
 
 #: senaite/core/browser/user/userdatapanel.py:192
 msgid "User is linked to the contact '${fullname}'"
-msgstr ""
+msgstr "Пользователь связан с контактом '${fullname}'"
 
 #: senaite/core/browser/user/userdatapanel.py:189
 msgid "User is linked to the global contact '${fullname}'"
-msgstr ""
+msgstr "Пользователь связан с глобальным контактом '${fullname}'"
 
-#: senaite/core/browser/clients/client/contacts/login_details.py:233
+#: senaite/core/browser/clients/client/contacts/login_details.py:217
 msgid "User linked to this Contact"
-msgstr ""
+msgstr "Пользователь, связанный с этим контактом"
 
 #: bika/lims/controlpanel/bika_labcontacts.py:98
 msgid "User name"
-msgstr ""
+msgstr "Имя пользователя"
 
-#: senaite/core/content/resultsreport.py:105
+#: senaite/core/content/resultsreport.py:104
 msgid "Username"
-msgstr ""
+msgstr "Имя пользователя"
 
-#: bika/lims/content/bikasetup.py:341
-msgid "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
+#: bika/lims/content/bikasetup.py:340
+msgid ""
+"Using too few data points does not make statistical sense. Set an acceptable"
+" minimum number of results before QC statistics will be calculated and "
+"plotted"
 msgstr ""
+"Использование слишком малого числа точек данных статистически некорректно. "
+"Установите допустимое минимальное количество результатов перед расчётом и "
+"построением статистики контроля качества"
 
-#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:702
+#: bika/lims/browser/analysisrequest/templates/ar_add2.pt:692
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:167
 #: bika/lims/content/analysisprofile.py:134
 msgid "VAT"
-msgstr ""
+msgstr "НДС"
 
 #: bika/lims/content/abstractbaseanalysis.py:575
-#: bika/lims/content/analysisprofile.py:122
-#: bika/lims/content/bikasetup.py:297
+#: bika/lims/content/analysisprofile.py:122 bika/lims/content/bikasetup.py:296
 msgid "VAT %"
-msgstr ""
+msgstr "% НДС"
 
 #: bika/lims/content/organisation.py:52
 msgid "VAT number"
-msgstr ""
+msgstr "номер НДС"
 
 #: bika/lims/browser/analyses/view.py:223
 msgid "Valid"
-msgstr ""
+msgstr "Действителен"
 
 #: bika/lims/browser/instrument.py:662
 #: bika/lims/content/instrumentcertification.py:126
 msgid "Valid from"
-msgstr ""
+msgstr "Действительно с"
 
 #: bika/lims/browser/instrument.py:663
 #: bika/lims/content/instrumentcertification.py:136
 msgid "Valid to"
-msgstr ""
+msgstr "Действителен до"
 
 #: bika/lims/content/instrumentscheduledtask.py:122
 msgid "Validation"
-msgstr ""
+msgstr "Валидация (поверка)"
 
 #: senaite/core/z3cform/error.py:32
 msgid "Validation failed."
-msgstr ""
+msgstr "Проверка не пройдена."
 
 #: bika/lims/validators.py:346
 msgid "Validation failed: '${keyword}': duplicate keyword"
-msgstr ""
+msgstr "Проверка не пройдена: '${keyword}' — повторяющееся ключевое слово"
 
 #: bika/lims/validators.py:365
-msgid "Validation failed: '${title}': This keyword is already in use by service '${used_by}'"
+msgid ""
+"Validation failed: '${title}': This keyword is already in use by service "
+"'${used_by}'"
 msgstr ""
+"Проверка не пройдена: '${title}' — это ключевое слово уже используется "
+"услугой '${used_by}'"
 
 #: bika/lims/validators.py:354
 msgid "Validation failed: '${title}': duplicate title"
-msgstr ""
+msgstr "Проверка не пройдена: '${title}' — повторяющееся название"
 
 #: bika/lims/validators.py:206
 msgid "Validation failed: '${value}' is not unique"
-msgstr ""
+msgstr "Проверка не пройдена: '${value}' не уникально"
 
 #: bika/lims/validators.py:1465
 msgid "Validation failed: '{}' is not numeric"
-msgstr ""
+msgstr "Проверка не пройдена: '{}' не является числом"
 
 #: bika/lims/validators.py:624
 msgid "Validation failed: Bearing must be E/W"
-msgstr ""
+msgstr "Ошибка контроля данных: Bearing must be E/W"
 
 #: bika/lims/validators.py:605
 msgid "Validation failed: Bearing must be N/S"
-msgstr ""
+msgstr "Ошибка контроля данных: Bearing must be N/S"
 
 #: bika/lims/validators.py:1350
 msgid "Validation failed: Could not import module '%s'"
-msgstr ""
+msgstr "Проверка не пройдена: не удалось импортировать модуль '%s'"
 
 #: bika/lims/validators.py:966
 msgid "Validation failed: Error percentage must be between 0 and 100"
-msgstr ""
+msgstr "Проверка не пройдена: процент ошибки должен быть от 0 до 100"
 
 #: bika/lims/validators.py:982
 msgid "Validation failed: Error value must be 0 or greater"
-msgstr ""
+msgstr "Проверка не пройдена: значение ошибки должно быть 0 или больше"
 
 #: bika/lims/validators.py:959
 msgid "Validation failed: Error values must be numeric"
-msgstr ""
+msgstr "Проверка не пройдена: значения ошибки должны быть числами"
 
 #: bika/lims/validators.py:499
 msgid "Validation failed: Keyword '${keyword}' is invalid"
-msgstr ""
+msgstr "Проверка не пройдена: ключевое слово '${keyword}' недействительно"
 
 #: bika/lims/validators.py:974
 msgid "Validation failed: Max values must be greater than Min values"
 msgstr ""
+"Проверка не пройдена: значения максимума должны быть больше значений "
+"минимума"
 
 #: bika/lims/validators.py:944
 msgid "Validation failed: Max values must be numeric"
-msgstr ""
+msgstr "Проверка не пройдена: значения максимума должны быть числами"
 
 #: bika/lims/validators.py:937
 msgid "Validation failed: Min values must be numeric"
-msgstr ""
+msgstr "Проверка не пройдена: значения минимума должны быть числами"
 
 #: bika/lims/validators.py:1451
-msgid "Validation failed: Please set a default value when defining a required checkbox condition."
+msgid ""
+"Validation failed: Please set a default value when defining a required "
+"checkbox condition."
 msgstr ""
+"Проверка не пройдена: задайте значение по умолчанию при определении "
+"обязательного условия флажка."
 
 #: bika/lims/validators.py:1445
-msgid "Validation failed: Please use the character '|' to separate the available options in 'Choices' subfield"
+msgid ""
+"Validation failed: Please use the character '|' to separate the available "
+"options in 'Choices' subfield"
 msgstr ""
+"Проверка не пройдена: используйте символ '|' для разделения вариантов в "
+"подполе 'Варианты'"
 
 #: bika/lims/validators.py:770
-msgid "Validation failed: PrePreserved containers must have a preservation selected."
+msgid ""
+"Validation failed: PrePreserved containers must have a preservation "
+"selected."
 msgstr ""
+"Проверка не пройдена: у предварительно законсервированных контейнеров должен"
+" быть выбран способ сохранения."
 
 #: bika/lims/validators.py:728
-msgid "Validation failed: The selection requires the following categories to be selected: ${categories}"
+msgid ""
+"Validation failed: The selection requires the following categories to be "
+"selected: ${categories}"
 msgstr ""
+"Проверка не пройдена: необходимо выбрать следующие категории: ${categories}"
 
 #: bika/lims/validators.py:1014
 msgid "Validation failed: Values must be numbers"
-msgstr ""
+msgstr "Проверка не пройдена: значения должны быть числами"
 
 #: bika/lims/validators.py:393
-msgid "Validation failed: column title '${title}' must have keyword '${keyword}'"
+msgid ""
+"Validation failed: column title '${title}' must have keyword '${keyword}'"
 msgstr ""
+"Проверка не пройдена: заголовку столбца '${title}' должно соответствовать "
+"ключевое слово '${keyword}'"
 
 #: bika/lims/validators.py:615
 msgid "Validation failed: degrees is 180; minutes must be zero"
-msgstr ""
+msgstr "Ошибка контроля данных: значение минут должно быть числовым"
 
 #: bika/lims/validators.py:620
 msgid "Validation failed: degrees is 180; seconds must be zero"
 msgstr ""
+"Ошибка контроля данных: значение градусов равно 180; секунды должны быть "
+"равны нулю."
 
 #: bika/lims/validators.py:596
 msgid "Validation failed: degrees is 90; minutes must be zero"
-msgstr ""
+msgstr "Проверка не пройдена: при 90 градусах минуты должны быть равны нулю"
 
 #: bika/lims/validators.py:601
 msgid "Validation failed: degrees is 90; seconds must be zero"
-msgstr ""
+msgstr "Проверка не пройдена: при 90 градусах секунды должны быть равны нулю"
 
 #: bika/lims/validators.py:610
 msgid "Validation failed: degrees must be 0 - 180"
-msgstr ""
+msgstr "Проверка не пройдена: градусы должны быть от 0 до 180"
 
 #: bika/lims/validators.py:591
 msgid "Validation failed: degrees must be 0 - 90"
-msgstr ""
+msgstr "Ошибка контроля данных: градус должен быть от 0 до 90"
 
 #: bika/lims/validators.py:564
 msgid "Validation failed: degrees must be numeric"
-msgstr ""
+msgstr "Ошибка контроля данных: значение градусов должно быть числовым"
 
 #: bika/lims/validators.py:405
-msgid "Validation failed: keyword '${keyword}' must have column title '${title}'"
+msgid ""
+"Validation failed: keyword '${keyword}' must have column title '${title}'"
 msgstr ""
+"Проверка не пройдена: ключевому слову '${keyword}' должен соответствовать "
+"заголовок столбца '${title}'"
 
 #: senaite/core/api/analysisservice.py:172
 msgid "Validation failed: keyword contains invalid characters"
-msgstr ""
+msgstr "Ошибка контроля данных: ключевое слово содержит недопустимые символы"
 
 #: senaite/core/api/analysisservice.py:177
 msgid "Validation failed: keyword is already in use"
-msgstr ""
+msgstr "Проверка не пройдена: ключевое слово уже используется"
 
 #: senaite/core/api/analysisservice.py:187
 msgid "Validation failed: keyword is already in use by calculation '{}'"
 msgstr ""
+"Проверка не пройдена: ключевое слово уже используется формулой расчёта '{}'"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:95
 #: bika/lims/validators.py:324
 msgid "Validation failed: keyword is required"
-msgstr ""
+msgstr "Проверка не пройдена: требуется ключевое слово"
 
 #: bika/lims/validators.py:580
 msgid "Validation failed: minutes must be 0 - 59"
-msgstr ""
+msgstr "Ошибка контроля данных: значение минут должно быть от 0 до 59"
 
 #: bika/lims/validators.py:570
 msgid "Validation failed: minutes must be numeric"
-msgstr ""
+msgstr "Ошибка контроля данных: значение минут должно быть числовым"
 
 #: bika/lims/validators.py:1042
 msgid "Validation failed: percent values must be between 0 and 100"
-msgstr ""
+msgstr "Проверка не пройдена: значения процента должны быть от 0 до 100"
 
 #: bika/lims/validators.py:1038
 msgid "Validation failed: percent values must be numbers"
-msgstr ""
+msgstr "Проверка не пройдена: значения процента должны быть числами"
 
 #: bika/lims/validators.py:584
 msgid "Validation failed: seconds must be 0 - 59"
-msgstr ""
+msgstr "Ошибка контроля данных: значение секунд должно быть от 0 до 59"
 
 #: bika/lims/validators.py:576
 msgid "Validation failed: seconds must be numeric"
-msgstr ""
+msgstr "Ошибка контроля данных: значение секунд должно быть числом"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:88
 #: bika/lims/validators.py:320
 msgid "Validation failed: title is required"
-msgstr ""
+msgstr "Проверка не пройдена: требуется название"
 
 #: bika/lims/validators.py:1456
-msgid "Validation failed: value for Choices subfield is only required for when the control type of choice is 'Select'"
+msgid ""
+"Validation failed: value for Choices subfield is only required for when the "
+"control type of choice is 'Select'"
 msgstr ""
+"Проверка не пройдена: значение подполя 'Варианты' требуется только когда тип"
+" контроля — 'Выбор'"
 
 #: bika/lims/validators.py:1438
-msgid "Validation failed: value for Choices subfield is required when the control type of choice is 'Select'"
+msgid ""
+"Validation failed: value for Choices subfield is required when the control "
+"type of choice is 'Select'"
 msgstr ""
+"Проверка не пройдена: значение подполя 'Варианты' требуется, когда тип "
+"контроля — 'Выбор'"
 
 #: senaite/core/content/analysiscategory.py:122
 #: senaite/core/content/subgroup.py:82
 msgid "Validation failed: value must be between 0 and 1000"
-msgstr ""
+msgstr "Проверка не пройдена: значение должно быть от 0 до 1000"
 
 #: senaite/core/content/analysiscategory.py:118
 #: senaite/core/content/subgroup.py:78
 msgid "Validation failed: value must be float"
-msgstr ""
+msgstr "Проверка не пройдена: значение должно быть числом с плавающей точкой"
 
 #: bika/lims/content/instrumentvalidation.py:51
 msgid "Validation report date"
-msgstr ""
+msgstr "Дата отчёта о валидации"
 
 #: bika/lims/profiles/default/types/Instrument.xml
 msgid "Validations"
-msgstr ""
+msgstr "Проверки"
 
 #: bika/lims/browser/instrument.py:318
 #: bika/lims/content/instrumentvalidation.py:78
 msgid "Validator"
-msgstr ""
+msgstr "Проверяющий"
 
 #: senaite/core/browser/worksheets/worksheet/templates/manage_results.pt:206
 msgid "Value"
-msgstr ""
+msgstr "Значение"
 
 #: senaite/core/schema/coordinatefield.py:109
 msgid "Value for degrees must be within 0 and 180"
-msgstr ""
+msgstr "Значение градусов должно быть от 0 до 180"
 
 #: senaite/core/schema/coordinatefield.py:93
 msgid "Value for degrees must be within 0 and 90"
-msgstr ""
+msgstr "Значение градусов должно быть от 0 до 90"
 
 #: senaite/core/schema/coordinatefield.py:68
 msgid "Value for minutes must be within 0 and 59"
-msgstr ""
+msgstr "Значение минут должно быть от 0 до 59"
 
 #: senaite/core/schema/coordinatefield.py:77
 msgid "Value for seconds must be within 0 and 59.9999"
-msgstr ""
+msgstr "Значение секунд должно быть от 0 до 59.9999"
 
 #: bika/lims/content/abstractanalysis.py:183
-msgid "Values can be entered here which will override the defaults specified in the Calculation Interim Fields."
+msgid ""
+"Values can be entered here which will override the defaults specified in the"
+" Calculation Interim Fields."
 msgstr ""
+"Здесь можно ввести значения, которые переопределят значения по умолчанию, "
+"указанные в промежуточных полях расчёта."
 
-#: senaite/core/browser/dashboard/dashboard.py:149
-#: senaite/core/browser/samples/view.py:359
+#: senaite/core/browser/dashboard/dashboard.py:127
+#: senaite/core/browser/samples/view.py:341
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 msgid "Verified"
-msgstr ""
+msgstr "Проверено"
 
 #: bika/lims/browser/analysisrequest/templates/invoice_content.pt:133
 msgid "Verified By"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:428
-msgid "Verified samples ready to be published"
-msgstr ""
+msgstr "Верифицировал(а)"
 
 #: senaite/core/profiles/default/workflows/senaite_analysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_duplicateanalysis_workflow/definition.xml
 #: senaite/core/profiles/default/workflows/senaite_referenceanalysis_workflow/definition.xml
 msgid "Verify"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:109
-msgid "Verify Results"
-msgstr ""
+msgstr "Верифицировать"
 
 #: bika/lims/browser/auditlog.py:80
 #: bika/lims/browser/templates/analysisservice_info.pt:174
 #: bika/lims/controlpanel/auditlog.py:72
 msgid "Version"
-msgstr ""
+msgstr "Версия"
 
 #: senaite/core/profiles/default/types/Laboratory.xml
 msgid "View"
-msgstr ""
+msgstr "Просмотр"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:52
 msgid "View your SENAITE site"
-msgstr ""
-
-# senaite.app.listing: Column config — visible-section header
-msgid "Visible"
-msgstr ""
-
-# senaite.app.listing: Column config — counter title attribute
-msgid "Visible / total columns"
-msgstr ""
+msgstr "Просмотреть ваш сайт SENAITE"
 
 #: senaite/core/registry/schema.py:213
 msgid "Visible fields"
-msgstr ""
+msgstr "Видимые поля"
 
 #: bika/lims/browser/viewlets/templates/dynamic_specs_viewlet.pt:24
 #: bika/lims/browser/viewlets/templates/sample_dynamic_specs_viewlet.pt:24
 msgid "Visit the Dynamic Specification for additional information:"
-msgstr ""
+msgstr "Перейдите к динамической спецификации для дополнительной информации:"
 
 #: bika/lims/browser/viewlets/templates/resultsranges_out_of_date_viewlet.pt:28
 msgid "Visit the Specification's changes history for additional information:"
 msgstr ""
+"Перейдите к истории изменений спецификации для дополнительной информации:"
 
 #: bika/lims/content/labproduct.py:36
 msgid "Volume"
-msgstr ""
+msgstr "Объём"
 
 #: senaite/core/browser/viewlets/sample/templates/invalidated.pt:17
 msgid "Warning"
-msgstr ""
+msgstr "Предупреждение"
 
 #: bika/lims/content/laboratory.py:132
 msgid "Web address for the accreditation body"
-msgstr ""
+msgstr "Веб-адрес органа по аккредитации"
 
 #: bika/lims/content/supplier.py:52
 msgid "Website"
-msgstr ""
+msgstr "Веб-сайт"
 
 #: senaite/core/vocabularies/setup.py:158
 msgid "Wednesday"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:136
-msgid "Weekly"
-msgstr ""
+msgstr "Сре́да"
 
 #: bika/lims/controlpanel/bika_instruments.py:91
 msgid "Weeks To Expire"
-msgstr ""
+msgstr "Недель до истечения"
 
 #: senaite/core/browser/dashboard/templates/dashboard.pt:7
 msgid "Welcome"
-msgstr ""
+msgstr "Добро пожаловать"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:14
 msgid "Welcome to SENAITE"
-msgstr ""
+msgstr "Добро пожаловать в SENAITE"
 
-#: bika/lims/content/bikasetup.py:177
-msgid "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
+#: bika/lims/content/bikasetup.py:176
+msgid ""
+"When enabled, analysts can only access worksheets to which they are "
+"assigned. When disabled, analysts have access to all worksheets."
 msgstr ""
+"Если включено, аналитики могут получить доступ только к назначенным им "
+"рабочим листам. Если отключено, аналитики имеют доступ ко всем рабочим "
+"листам."
 
-#: bika/lims/content/bikasetup.py:208
-msgid "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
+#: bika/lims/content/bikasetup.py:207
+msgid ""
+"When enabled, only lab managers can create and manage worksheets. When "
+"disabled, analysts and lab clerks can also manage worksheets. Note: This "
+"setting is automatically enabled and locked when worksheet access is "
+"restricted to assigned analysts."
 msgstr ""
+"Если включено, только менеджеры лаборатории могут создавать рабочие листы и "
+"управлять ими. Если отключено, аналитики и лаборанты также могут управлять "
+"рабочими листами. Примечание: этот параметр автоматически включается и "
+"блокируется, когда доступ к рабочим листам ограничен назначенными "
+"аналитиками."
 
-#: bika/lims/content/bikasetup.py:477
-msgid "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
+#: bika/lims/content/bikasetup.py:476
+msgid ""
+"When enabled, the sample is automatically verified as soon as all results "
+"are verified. Otherwise, users with enough privileges have to manually "
+"verify the sample afterwards. Default: enabled"
 msgstr ""
+"Если включено, образец автоматически верифицируется, как только "
+"верифицированы все результаты. В противном случае пользователи с "
+"достаточными правами должны верифицировать образец вручную впоследствии. По "
+"умолчанию: включено"
 
-#: bika/lims/content/bikasetup.py:191
-msgid "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
+#: bika/lims/content/bikasetup.py:190
+msgid ""
+"When enabled, users can submit results for analyses not assigned to them or "
+"for unassigned analyses. When disabled, users can only submit results for "
+"analyses assigned to themselves. This setting does not apply to users with "
+"role Lab Manager."
 msgstr ""
+"Если включено, пользователи могут отправлять результаты для анализов, не "
+"назначенных им, или для неназначенных анализов. Если отключено, пользователи"
+" могут отправлять результаты только для назначенных им анализов. Этот "
+"параметр не распространяется на пользователей с ролью 'Менеджер "
+"лаборатории'."
 
 #: bika/lims/content/analysisprofile.py:102
-msgid "When it's set, the system uses the analysis profile's price to quote and the system's VAT is overridden by the analysis profile's specific VAT"
+msgid ""
+"When it's set, the system uses the analysis profile's price to quote and the"
+" system's VAT is overridden by the analysis profile's specific VAT"
 msgstr ""
+"Если задано, система использует цену профиля анализа для расчёта, а "
+"системный НДС переопределяется НДС профиля анализа"
 
 #: bika/lims/content/abstractbaseanalysis.py:480
-msgid "When the results of duplicate analyses on worksheets, carried out on the same sample, differ with more than this percentage, an alert is raised"
+msgid ""
+"When the results of duplicate analyses on worksheets, carried out on the "
+"same sample, differ with more than this percentage, an alert is raised"
 msgstr ""
+"Если результаты дублирующих анализов на рабочих листах, выполненных на одном"
+" образце, отличаются больше чем на этот процент, формируется предупреждение"
 
 #: bika/lims/validators.py:518
 msgid "Wildcards for interims are not allowed: ${wildcards}"
 msgstr ""
+"Шаблоны подстановки для промежуточных полей не допускаются: ${wildcards}"
 
 #: senaite/core/browser/setup/templates/email_body_sample_publication.pt:20
 msgid "With best regards"
-msgstr ""
+msgstr "С уважением"
 
 #: bika/lims/content/instrumentcalibration.py:118
 #: bika/lims/content/instrumentmaintenancetask.py:103
 #: bika/lims/content/instrumentvalidation.py:100
 msgid "Work Performed"
-msgstr ""
+msgstr "Выполненная работа"
 
-#: bika/lims/browser/auditlog.py:94
-#: bika/lims/controlpanel/auditlog.py:99
+#: bika/lims/browser/auditlog.py:94 bika/lims/controlpanel/auditlog.py:99
 msgid "Workflow State"
-msgstr ""
+msgstr "Статус процесса"
 
 #: senaite/core/profiles/default/types/Worksheet.xml
 msgid "Worksheet"
-msgstr ""
+msgstr "Рабочий лист"
 
 #: bika/lims/content/worksheettemplate.py:62
 msgid "Worksheet Layout"
-msgstr ""
+msgstr "Макет рабочего листа"
 
 #: senaite/core/profiles/default/types/WorksheetTemplate.xml
 msgid "Worksheet Template"
-msgstr ""
+msgstr "Шаблон рабочего листа"
 
 #: senaite/core/profiles/default/types/WorksheetTemplates.xml
 msgid "Worksheet Templates"
-msgstr ""
+msgstr "Рабочий лист: Шаблоны"
 
 #: senaite/core/registry/schema.py:109
 msgid "Worksheet printing templates order"
-msgstr ""
+msgstr "Порядок шаблонов печати рабочего листа"
 
-#: senaite/core/browser/dashboard/dashboard.py:107
+#: senaite/core/browser/dashboard/dashboard.py:489
 #: senaite/core/profiles/default/types/Worksheets.xml
 msgid "Worksheets"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:531
-msgid "Worksheets that have been verified"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:526
-msgid "Worksheets whose results are awaiting verification"
-msgstr ""
+msgstr "Рабочие листы"
 
 #: senaite/core/content/supplier.py:166
 msgid "Wrong IBAN length by %s: %s"
-msgstr ""
+msgstr "Неверная длина IBAN у %s: %s"
 
 #: bika/lims/validators.py:1139
 msgid "Wrong IBAN length by %s: %sshort by %i"
-msgstr ""
-
-#: senaite/core/browser/dashboard/dashboard.py:140
-msgid "Yearly"
-msgstr ""
+msgstr "Неверная IBAN длина %s: %sсокращен до %i"
 
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:166
 #: senaite/core/browser/widgets/services_widget.py:305
 msgid "Yes"
-msgstr ""
+msgstr "Да"
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:124
 msgid "You can add another SENAITE site:"
-msgstr ""
+msgstr "Вы можете добавить ещё один сайт SENAITE:"
 
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:109
-msgid "You can change the visibility of a field by selecting or unselecting the checkbox."
-msgstr ""
+msgid ""
+"You can change the visibility of a field by selecting or unselecting the "
+"checkbox."
+msgstr "Вы можете изменить видимость поля, установив или сняв флажок."
 
 #: senaite/core/browser/viewlets/templates/auditlog_disabled.pt:17
-msgid "You can enable the global Audit Log again in the <a href=\"${DYNAMIC_CONTENT}\">Setup</a>"
+msgid ""
+"You can enable the global Audit Log again in the <a "
+"href=\"${DYNAMIC_CONTENT}\">Setup</a>"
 msgstr ""
+"Вы можете снова включить глобальный журнал аудита в <a "
+"href=\"${DYNAMIC_CONTENT}\">Настройках</a>"
 
 #: senaite/core/browser/viewlets/templates/attachments.pt:294
 msgid "You can use the browse button to select and upload a new attachment."
-msgstr ""
+msgstr "Используйте кнопку обзора, чтобы выбрать и загрузить новое вложение."
 
 #: bika/lims/browser/worksheet/tools.py:42
-msgid "You do not have sufficient privileges to view the worksheet ${worksheet_title}."
+msgid ""
+"You do not have sufficient privileges to view the worksheet "
+"${worksheet_title}."
 msgstr ""
+"У вас недостаточно прав для просмотра рабочего листа ${worksheet_title}."
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:78
 msgid "You have multiple SENAITE sites:"
-msgstr ""
+msgstr "У вас несколько сайтов SENAITE:"
 
 #: bika/lims/browser/worksheet/views/export.py:33
 msgid "You must select an instrument"
-msgstr ""
+msgstr "Вы должны выбрать инструмент"
 
 #: senaite/core/browser/install/templates/senaite-addsite.pt:159
-msgid "You normally don't need to change anything here unless you have specific reasons and know what you are doing."
+msgid ""
+"You normally don't need to change anything here unless you have specific "
+"reasons and know what you are doing."
 msgstr ""
+"Обычно здесь не требуется ничего менять, если у вас нет особых причин и вы "
+"точно понимаете, что делаете."
 
 #: senaite/core/exportimport/instruments/sysmex/xs/i500.py:77
 msgid "You should introduce a default result key."
-msgstr ""
+msgstr "Необходимо указать ключ результата по умолчанию."
 
 #: senaite/core/browser/install/templates/senaite-overview.pt:121
 msgid "Your SENAITE site has not been added yet:"
-msgstr ""
+msgstr "Ваш сайт SENAITE ещё не добавлен:"
 
 #: bika/lims/browser/templates/referencesample_view.pt:134
 msgid "activate"
-msgstr ""
+msgstr "активировать"
 
 #. Default: "Classic"
 #: senaite/core/config/worksheet.py:25
 msgid "analyses_classic_view_name"
-msgstr ""
+msgstr "Классический"
 
 #. Default: "Transposed"
 #: senaite/core/config/worksheet.py:29
 msgid "analyses_transposed_view_name"
-msgstr ""
+msgstr "Транспонировано"
 
 #. Default: "Analysis"
 #: senaite/core/config/vocabularies.py:35
 msgid "analysis_type_analysis"
-msgstr ""
+msgstr "Анализ"
 
 #. Default: "Blank"
 #: senaite/core/config/vocabularies.py:39
 msgid "analysis_type_blank"
-msgstr ""
+msgstr "Холостая проба"
 
 #. Default: "Control"
 #: senaite/core/config/vocabularies.py:43
 msgid "analysis_type_control"
-msgstr ""
+msgstr "Контроль"
 
 #. Default: "Duplicate"
 #: senaite/core/config/vocabularies.py:47
 msgid "analysis_type_duplicate"
-msgstr ""
+msgstr "Дубликат"
 
 #. Default: "Analyst must be specified."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:45
 msgid "analyst_must_be_specified_message"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — micro-tag on the default preset
-msgid "auto"
-msgstr ""
+msgstr "Необходимо указать аналитика."
 
 #: bika/lims/content/instrumentcertification.py:254
 msgid "biannually"
-msgstr ""
+msgstr "раз в два года"
 
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_column.pt:48
 #: senaite/core/browser/worksheets/worksheet/templates/print/sample_by_row.pt:48
 msgid "by"
-msgstr ""
+msgstr "от"
 
 #. in '${calc}')"
-#. Default: "keyword '${keyword}' must have column title '${title}' (defined in '${calc}')"
+#. Default: "keyword '${keyword}' must have column title '${title}' (defined
+#. in '${calc}')"
 #: senaite/core/validators/interimfields.py:151
 msgid "calcs_interims_validator_dup_keyword_error"
 msgstr ""
+"ключевому слову '${keyword}' должен соответствовать заголовок столбца "
+"'${title}' (определён в '${calc}')"
 
 #. Default: "Changes saved."
 #: senaite/core/browser/worksheets/worksheet/manage_results.py:57
 msgid "change_worksheet_result_layout_message"
-msgstr ""
+msgstr "Изменения сохранены."
 
 #. Default: "Changes saved."
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:168
 msgid "changes_saved"
-msgstr ""
+msgstr "Изменения сохранены."
 
 #. Results edition not allowed: ${inv}"
-#. Default: "Some analyses use out-of-date or uncalibrated instruments. Results edition not allowed: ${inv}"
+#. Default: "Some analyses use out-of-date or uncalibrated instruments.
+#. Results edition not allowed: ${inv}"
 #: senaite/core/browser/worksheets/worksheet/manage_results.py:214
 msgid "check_instrument_validity_message"
 msgstr ""
+"Некоторые анализы используют просроченные или неоткалиброванные инструменты."
+" Редактирование результатов запрещено: ${inv}"
 
 #. <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
-#. Default: "No valid format in choices field. Supported format is: <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
+#. Default: "No valid format in choices field. Supported format is:
+#. <value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 #: senaite/core/validators/interimfields.py:211
 msgid "choice_syntax_validation_error"
 msgstr ""
+"Неверный формат поля выбора. Поддерживаемый формат: "
+"<value-0>:<text>|<value-1>:<text>|<value-n>:<text>"
 
 #. Default: "Control type is not supported for empty choices"
 #: senaite/core/validators/interimfields.py:111
 msgid "choices_and_restype_validator_no_choices_error"
-msgstr ""
+msgstr "Тип контроля не поддерживается для пустых вариантов выбора"
 
 #. Default: "Chosen control type not supporting choices"
 #: senaite/core/validators/interimfields.py:117
 msgid "choices_and_restype_validator_not_supported_choices_error"
-msgstr ""
+msgstr "Выбранный тип контроля не поддерживает варианты выбора"
 
 #. Default: "Empty keys are not supported"
 #: senaite/core/validators/interimfields.py:169
 msgid "choices_empty_keys_validator_error"
-msgstr ""
+msgstr "Пустые ключи не поддерживаются"
 
 #. Default: "At least, two options for choices field are required"
 #: senaite/core/validators/interimfields.py:195
 msgid "choices_min_items_validator_error"
-msgstr ""
+msgstr "Для поля выбора требуется минимум два варианта"
 
 #. Default: "Duplicate keys in choices field"
 #: senaite/core/validators/interimfields.py:183
 msgid "choices_unique_keys_validator_error"
-msgstr ""
+msgstr "Повторяющиеся ключи в поле выбора"
 
 #: bika/lims/content/instrumentcertification.py:250
 msgid "daily"
-msgstr ""
+msgstr "ежедневно"
 
 #. Default: "${Y}-${m}-${d} ${I}:${M} ${p}"
 #. The variables used here are the same as used in the strftime formating.
@@ -7273,7 +7943,7 @@ msgstr ""
 #. ${b} ${d}, ${Y} ${I}:${M} ${p}
 #: ./TranslationServiceTool.py
 msgid "date_format_long"
-msgstr ""
+msgstr "${d}.${m}.${Y} ${I}:${M} ${p}"
 
 #. Default: "${Y}-${m}-${d}"
 #. The variables used here are the same as used in the strftime formating.
@@ -7284,80 +7954,82 @@ msgstr ""
 #. ${b} ${d}, ${Y}
 #: ./TranslationServiceTool.py
 msgid "date_format_short"
-msgstr ""
+msgstr "${d}.${m}.${Y}"
 
 #. Date format used with the datepicker jqueryui plugin.
 #. Please only use 'dd', 'mm', 'yy', '-', '/', '.' in this string.
 #. Default: "mm/dd/yy"
 msgid "date_format_short_datepicker"
-msgstr ""
+msgstr "дд.мм.гг"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:285
 msgid "days"
-msgstr ""
+msgstr "дней"
 
 #: bika/lims/browser/templates/referencesample_view.pt:127
 msgid "deactivate"
-msgstr ""
-
-#. Default: "Sample disposed after the retention period."
-#: senaite/core/browser/samples/templates/dispose_samples.pt:66
-msgid "default_dispose_reason"
-msgstr ""
-
-#: senaite/core/api/remarks.py:485
-msgid "deleted by {user} at {time}"
-msgstr ""
+msgstr "отключить"
 
 #. Default: "Attached labels"
-#: senaite/core/behaviors/label.py:126
+#: senaite/core/behaviors/label.py:118
 msgid "description_Labels"
-msgstr ""
+msgstr "Прикреплённые метки"
 
 #. Default: "The accreditation standard that applies, e.g. ISO 17025"
 #: senaite/core/content/laboratory.py:174
 msgid "description_accreditation"
-msgstr ""
+msgstr "Применяемый стандарт аккредитации, например ISO 17025"
 
 #. Default: "E.g. SANAS, APLAC, etc."
 #: senaite/core/content/laboratory.py:153
 msgid "description_accreditation_body"
-msgstr ""
+msgstr "Например, SANAS, APLAC и т.д."
 
 #. and results reports by your accreditation body. Maximum size is 175 x 175
 #. pixels."
-#. Default: "Please upload the logo you are authorised to use on your website and results reports by your accreditation body. Maximum size is 175 x 175 pixels."
+#. Default: "Please upload the logo you are authorised to use on your website
+#. and results reports by your accreditation body. Maximum size is 175 x 175
+#. pixels."
 #: senaite/core/content/laboratory.py:198
 msgid "description_accreditation_body_logo"
 msgstr ""
+"Загрузите логотип, разрешённый к использованию на вашем сайте и в отчётах с "
+"результатами вашим органом по аккредитации. Максимальный размер — 175 x 175 "
+"пикселей."
 
 #. Default: "Web address for the accreditation body"
 #: senaite/core/content/laboratory.py:163
 msgid "description_accreditation_body_url"
-msgstr ""
+msgstr "Веб-адрес органа по аккредитации"
 
 #. following fields are available: lab_is_accredited, lab_name, lab_country,
 #. confidence, accreditation_body_name, accreditation_standard,
 #. accreditation_reference"
-#. Default: "Enter the details of your lab's service accreditations here. The following fields are available: lab_is_accredited, lab_name, lab_country, confidence, accreditation_body_name, accreditation_standard, accreditation_reference"
+#. Default: "Enter the details of your lab's service accreditations here. The
+#. following fields are available: lab_is_accredited, lab_name, lab_country,
+#. confidence, accreditation_body_name, accreditation_standard,
+#. accreditation_reference"
 #: senaite/core/content/laboratory.py:220
 msgid "description_accreditation_page_header"
 msgstr ""
+"Введите данные об аккредитации услуг вашей лаборатории. Доступны поля: "
+"lab_is_accredited, lab_name, lab_country, confidence, "
+"accreditation_body_name, accreditation_standard, accreditation_reference"
 
 #. Default: "The reference code issued to the lab by the accreditation body"
 #: senaite/core/content/laboratory.py:186
 msgid "description_accreditation_reference"
-msgstr ""
+msgstr "Референсный код, выданный лаборатории органом по аккредитации"
 
 #. Default: "The category the analysis service belongs to"
 #: bika/lims/content/abstractbaseanalysis.py:533
 msgid "description_analysis_category"
-msgstr ""
+msgstr "Категория, к которой относится услуга анализа"
 
 #. Default: "Select the responsible department"
 #: bika/lims/content/abstractbaseanalysis.py:591
 msgid "description_analysis_department"
-msgstr ""
+msgstr "Выберите ответственное подразделение"
 
 #. registration form if the elapsed time since sample collection exceeds the
 #. holding time limit. Exceeding this time limit may result in unreliable or
@@ -7366,18 +8038,38 @@ msgstr ""
 #. reflect the sample's true composition, impacting data validity. Note: This
 #. setting does not affect the test's availability in the 'Manage Analyses'
 #. view."
-#. Default: "This service will not appear for selection on the sample registration form if the elapsed time since sample collection exceeds the holding time limit. Exceeding this time limit may result in unreliable or compromised data, as the integrity of the sample can degrade over time. Consequently, any results obtained after this period may not accurately reflect the sample's true composition, impacting data validity. Note: This setting does not affect the test's availability in the 'Manage Analyses' view."
+#. Default: "This service will not appear for selection on the sample
+#. registration form if the elapsed time since sample collection exceeds the
+#. holding time limit. Exceeding this time limit may result in unreliable or
+#. compromised data, as the integrity of the sample can degrade over time.
+#. Consequently, any results obtained after this period may not accurately
+#. reflect the sample's true composition, impacting data validity. Note: This
+#. setting does not affect the test's availability in the 'Manage Analyses'
+#. view."
 #: bika/lims/content/abstractbaseanalysis.py:457
 msgid "description_analysis_maxholdingtime"
 msgstr ""
+"Эта услуга не будет доступна для выбора в форме регистрации образца, если "
+"время с момента отбора превышает предельный срок хранения. Превышение этого "
+"срока может привести к недостоверным данным, поскольку целостность образца "
+"со временем может нарушаться. Соответственно, результаты, полученные после "
+"этого срока, могут неточно отражать истинный состав образца. Примечание: "
+"этот параметр не влияет на доступность теста в просмотре 'Управление "
+"анализами'."
 
 #. in results entry listings. Note this only applies to the options displayed
 #. in the selection list. It does not have any effect to the order in which
 #. results are displayed after being submitted"
-#. Default: "Criteria to use when result options are displayed for selection in results entry listings. Note this only applies to the options displayed in the selection list. It does not have any effect to the order in which results are displayed after being submitted"
-#: bika/lims/content/abstractbaseanalysis.py:773
+#. Default: "Criteria to use when result options are displayed for selection
+#. in results entry listings. Note this only applies to the options displayed
+#. in the selection list. It does not have any effect to the order in which
+#. results are displayed after being submitted"
+#: bika/lims/content/abstractbaseanalysis.py:770
 msgid "description_analysis_results_options_sorting"
 msgstr ""
+"Критерий, используемый при отображении вариантов результата для выбора при "
+"вводе результатов. Применяется только к отображаемому списку вариантов и не "
+"влияет на порядок отображения результатов после отправки"
 
 #. in a range with minimum of 0 and maximum of 10, where the uncertainty value
 #. is 0.5 - a result of 6.67 will be reported as 6.67 ± 0.5.<br/>You can also
@@ -7389,89 +8081,128 @@ msgstr ""
 #. 0 (or a value below 0) as the Uncertainty value.<br/>Please ensure
 #. successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 -
 #. 20.00, 20.01 - 30.00 etc."
-#. Default: "Specify the uncertainty value for a given range, e.g. for results in a range with minimum of 0 and maximum of 10, where the uncertainty value is 0.5 - a result of 6.67 will be reported as 6.67 ± 0.5.<br/>You can also specify the uncertainty value as a percentage of the result value, by adding a '%' to the value entered in the 'Uncertainty Value' column, e.g. for results in a range with minimum of 10.01 and a maximum of 100, where the uncertainty value is 2%, a result of 100 will be reported as 100 ± 2.<br/>If you don't want uncertainty to be displayed for a given range, set 0 (or a value below 0) as the Uncertainty value.<br/>Please ensure successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 - 20.00, 20.01 - 30.00 etc."
+#. Default: "Specify the uncertainty value for a given range, e.g. for results
+#. in a range with minimum of 0 and maximum of 10, where the uncertainty value
+#. is 0.5 - a result of 6.67 will be reported as 6.67 ± 0.5.<br/>You can also
+#. specify the uncertainty value as a percentage of the result value, by
+#. adding a '%' to the value entered in the 'Uncertainty Value' column, e.g.
+#. for results in a range with minimum of 10.01 and a maximum of 100, where
+#. the uncertainty value is 2%, a result of 100 will be reported as 100 ±
+#. 2.<br/>If you don't want uncertainty to be displayed for a given range, set
+#. 0 (or a value below 0) as the Uncertainty value.<br/>Please ensure
+#. successive ranges are continuous, e.g. 0.00 - 10.00 is followed by 10.01 -
+#. 20.00, 20.01 - 30.00 etc."
 #: bika/lims/content/abstractbaseanalysis.py:630
 msgid "description_analysis_uncertainty"
 msgstr ""
+"Укажите значение неопределённости для заданного диапазона. Например, для "
+"результатов в диапазоне от 0 до 10 с неопределённостью 0.5 результат 6.67 "
+"будет указан как 6.67 ± 0.5.<br/>Также можно указать неопределённость в "
+"процентах от значения результата, добавив '%' к значению в столбце 'Значение"
+" неопределённости'. Например, для диапазона от 10.01 до 100 с "
+"неопределённостью 2% результат 100 будет указан как 100 ± 2.<br/>Если не "
+"нужно отображать неопределённость для заданного диапазона, установите 0 (или"
+" значение меньше 0).<br/>Убедитесь, что последующие диапазоны непрерывны, "
+"например 0.00-10.00, затем 10.01-20.00, 20.01-30.00 и т.д."
 
 #. mg/l, ppm, dB, mV, etc."
-#. Default: "The measurement units for this analysis service' results, e.g. mg/l, ppm, dB, mV, etc."
+#. Default: "The measurement units for this analysis service' results, e.g.
+#. mg/l, ppm, dB, mV, etc."
 #: bika/lims/content/abstractbaseanalysis.py:112
 msgid "description_analysis_unit"
 msgstr ""
+"Единицы измерения результатов этой услуги анализа, например мг/л, ppm, дБ, "
+"мВ и т.д."
 
 #. Ensure to include the default unit in this list"
-#. Default: "Provide a list of units that are suitable for the analysis. Ensure to include the default unit in this list"
+#. Default: "Provide a list of units that are suitable for the analysis.
+#. Ensure to include the default unit in this list"
 #: bika/lims/content/abstractbaseanalysis.py:162
 msgid "description_analysis_unitchoices"
 msgstr ""
+"Укажите список единиц измерения, подходящих для анализа. Убедитесь, что "
+"единица измерения по умолчанию включена в этот список"
 
 #. reports."
-#. Default: "To be displayed below each Analysis Category section on results reports."
+#. Default: "To be displayed below each Analysis Category section on results
+#. reports."
 #: senaite/core/content/analysiscategory.py:64
 msgid "description_analysiscategory_comments"
 msgstr ""
+"Отображается под каждым разделом категории анализа в отчётах с результатами."
 
 #. Default: "Select the responsible department"
 #: senaite/core/content/analysiscategory.py:85
 msgid "description_analysiscategory_department"
-msgstr ""
+msgstr "Выберите ответственное подразделение"
 
 #. Duplicate values are ordered alphabetically."
-#. Default: "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
+#. Default: "Float value from 0.0 - 1000.0 indicating the sort order.
+#. Duplicate values are ordered alphabetically."
 #: senaite/core/content/analysiscategory.py:99
 msgid "description_analysiscategory_sort_key"
 msgstr ""
+"Число с плавающей точкой от 0.0 до 1000.0, задающее порядок сортировки. "
+"Повторяющиеся значения сортируются по алфавиту."
 
 #. Default: "Commercial ID used for accounting"
 #: senaite/core/content/analysisprofile.py:125
 msgid "description_analysisprofile_commercial_id"
-msgstr ""
+msgstr "Коммерческий ID для бухгалтерского учёта"
 
 #. Default: "Please provide a unique profile keyword"
 #: senaite/core/content/analysisprofile.py:94
 msgid "description_analysisprofile_profile_key"
-msgstr ""
+msgstr "Укажите уникальное ключевое слово профиля"
 
 #. Default: "Please provide the price excluding VAT"
 #: senaite/core/content/analysisprofile.py:149
 msgid "description_analysisprofile_profile_price"
-msgstr ""
+msgstr "Укажите цену без учёта НДС"
 
 #. price"
-#. Default: "Please provide the VAT in percent that is added to the profile price"
+#. Default: "Please provide the VAT in percent that is added to the profile
+#. price"
 #: senaite/core/content/analysisprofile.py:161
 msgid "description_analysisprofile_profile_vat"
-msgstr ""
+msgstr "Укажите НДС в процентах, добавляемый к цене профиля"
 
 #. profile won't be available for selection in sample creation and edit forms
 #. unless the selected sample type is one of these. If no sample type is set
 #. here, this profile will always be available for selection, regardless of
 #. the sample type of the sample."
-#. Default: "Sample types for which this analysis profile is supported. This profile won't be available for selection in sample creation and edit forms unless the selected sample type is one of these. If no sample type is set here, this profile will always be available for selection, regardless of the sample type of the sample."
+#. Default: "Sample types for which this analysis profile is supported. This
+#. profile won't be available for selection in sample creation and edit forms
+#. unless the selected sample type is one of these. If no sample type is set
+#. here, this profile will always be available for selection, regardless of
+#. the sample type of the sample."
 #: senaite/core/content/analysisprofile.py:184
 msgid "description_analysisprofile_sampletypes"
 msgstr ""
+"Типы образца, для которых поддерживается этот профиль анализа. Профиль не "
+"будет доступен для выбора в формах создания и редактирования образца, если "
+"выбранный тип образца не входит в этот список. Если тип образца не задан, "
+"профиль всегда доступен для выбора независимо от типа образца."
 
 #. Default: "Select the included analyses for this profile"
 #: senaite/core/content/analysisprofile.py:110
 msgid "description_analysisprofile_services"
-msgstr ""
+msgstr "Выберите анализы, включённые в этот профиль"
 
 #. Default: "Use profile price instead of single analyses prices"
 #: senaite/core/content/analysisprofile.py:137
 msgid "description_analysisprofile_use_profile_price"
-msgstr ""
+msgstr "Использовать цену профиля вместо цен отдельных анализов"
 
 #. Default: "Number of samples to create with the information provided"
 #: bika/lims/content/analysisrequest.py:1441
 msgid "description_analysisrequest_numsamples"
-msgstr ""
+msgstr "Количество создаваемых образцов с указанной информацией"
 
 #. Default: "Link dynamic analysis specification"
 #: bika/lims/content/analysisspec.py:72
 msgid "description_analysisspec_dynamicspec"
-msgstr ""
+msgstr "Связать динамическую спецификацию анализа"
 
 #. outside this results range will raise an alert.<br/>'Min warn' and 'Max
 #. warn' values indicate a shoulder range. Any result outside the results
@@ -7480,110 +8211,151 @@ msgstr ""
 #. be displayed in lists and results reports instead of the real result. In
 #. such case, the value set for 'Out of range comment' will be displayed in
 #. results report as well"
-#. Default: "'Min' and 'Max' values indicate a valid results range. Any result outside this results range will raise an alert.<br/>'Min warn' and 'Max warn' values indicate a shoulder range. Any result outside the results range but within the shoulder range will raise a less severe alert.<br/>If the result is out of range, the value set for '&lt; Min' or '&gt; Max' will be displayed in lists and results reports instead of the real result. In such case, the value set for 'Out of range comment' will be displayed in results report as well"
+#. Default: "'Min' and 'Max' values indicate a valid results range. Any result
+#. outside this results range will raise an alert.<br/>'Min warn' and 'Max
+#. warn' values indicate a shoulder range. Any result outside the results
+#. range but within the shoulder range will raise a less severe alert.<br/>If
+#. the result is out of range, the value set for '&lt; Min' or '&gt; Max' will
+#. be displayed in lists and results reports instead of the real result. In
+#. such case, the value set for 'Out of range comment' will be displayed in
+#. results report as well"
 #: bika/lims/content/analysisspec.py:91
 msgid "description_analysisspec_resultsrange"
 msgstr ""
+"Значения 'Минимум' и 'Максимум' определяют допустимый диапазон результатов. "
+"Любой результат за пределами этого диапазона вызовет "
+"предупреждение.<br/>Значения 'Предупр. минимум' и 'Предупр. максимум' "
+"определяют пограничный диапазон. Любой результат за пределами диапазона "
+"результатов, но в пределах пограничного диапазона, вызовет менее серьёзное "
+"предупреждение.<br/>Если результат вне диапазона, вместо реального "
+"результата в списках и отчётах будет отображаться значение, заданное для "
+"'&lt; Минимум' или '&gt; Максимум'. В этом случае в отчёте также будет "
+"отображаться значение, заданное для 'Комментарий вне диапазона'"
 
 #. Default: "Select the sample type for this specification"
 #: bika/lims/content/analysisspec.py:52
 msgid "description_analysisspec_sampletype"
-msgstr ""
+msgstr "Выберите тип образца для этой спецификации"
 
 #. Default: "Contained samples in the PDF"
 #: bika/lims/content/arreport.py:82
 msgid "description_arreport_contained_samples"
-msgstr ""
+msgstr "Образцы, содержащиеся в PDF"
 
 #. Default: "The primary sample of the PDF"
 #: bika/lims/content/arreport.py:52
 msgid "description_arreport_sample"
-msgstr ""
+msgstr "Основной образец PDF"
 
 #. Default: "Select the analysis profile for this template"
 #: bika/lims/content/artemplate.py:257
 msgid "description_artemplate_profile"
-msgstr ""
+msgstr "Выберите профиль анализа для этого шаблона"
 
 #. Default: "Select the sample point for this template"
 #: bika/lims/content/artemplate.py:58
 msgid "description_artemplate_samplepoint"
-msgstr ""
+msgstr "Выберите точку отбора проб для этого шаблона"
 
 #. Default: "Select the sample type for this template"
 #: bika/lims/content/artemplate.py:89
 msgid "description_artemplate_sampletype"
-msgstr ""
+msgstr "Выберите тип образца для этого шаблона"
 
 #. Default: "Select the type of the attachment"
 #: bika/lims/content/attachment.py:64
 msgid "description_attachment_type"
-msgstr ""
+msgstr "Выберите тип вложения"
 
 #. Default: "Assign the instrument for this log"
 #: bika/lims/content/autoimportlog.py:53
 msgid "description_autoimportlog_instrument"
-msgstr ""
+msgstr "Назначьте инструмент для этого журнала"
 
 #. Default: "The date and time when the log was created"
 #: bika/lims/content/autoimportlog.py:90
 msgid "description_autoimportlog_logtime"
-msgstr ""
+msgstr "Дата и время создания журнала"
 
 #. Default: "The logged results"
 #: bika/lims/content/autoimportlog.py:77
 msgid "description_autoimportlog_results"
-msgstr ""
+msgstr "Зафиксированные результаты"
 
 #. Default: "Select the client of this batch"
 #: bika/lims/content/batch.py:81
 msgid "description_batch_client"
-msgstr ""
+msgstr "Выберите клиента этой партии"
 
 #. entered manually for analyses"
-#. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: bika/lims/content/bikasetup.py:397
+#. Default: "If this option is activated, the result capture date can be
+#. entered manually for analyses"
+#: bika/lims/content/bikasetup.py:396
 msgid "description_bikasetup_allow_manual_result_capture_date"
 msgstr ""
+"Если этот параметр активирован, дату фиксации результата можно вводить "
+"вручную для анализов"
 
 #. departments will receive publication emails."
-#. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: bika/lims/content/bikasetup.py:854
+#. Default: "When selected, the responsible persons of all involved lab
+#. departments will receive publication emails."
+#: bika/lims/content/bikasetup.py:853
 msgid "description_bikasetup_always_cc_responsibles_in_report_emails"
 msgstr ""
+"Если выбрано, ответственные лица всех задействованных подразделений "
+"лаборатории будут получать письма о публикации."
 
 #. Default: "Group analyses by category for samples"
-#: bika/lims/content/bikasetup.py:369
+#: bika/lims/content/bikasetup.py:368
 msgid "description_bikasetup_categorizesampleanalyses"
-msgstr ""
+msgstr "Группировать анализы по категориям для образцов"
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
-#. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: bika/lims/content/bikasetup.py:690
+#. Default: "Select this to make DateSampled field required on sample
+#. creation. This functionality only takes effect when 'Sampling workflow' is
+#. not active"
+#: bika/lims/content/bikasetup.py:689
 msgid "description_bikasetup_date_sampled_required"
 msgstr ""
+"Отметьте, чтобы сделать поле 'Дата отбора' обязательным при создании "
+"образца. Действует только когда процесс отбора проб не активен"
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
-#. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: bika/lims/content/bikasetup.py:830
+#. Default: "Set the email body text to be used by default when sending out
+#. result reports to the selected recipients. You can use reserved keywords:
+#. $client_name, $recipients, $lab_name, $lab_address"
+#: bika/lims/content/bikasetup.py:829
 msgid "description_bikasetup_email_body_sample_publication"
 msgstr ""
+"Задайте текст письма по умолчанию для отправки отчётов с результатами "
+"выбранным получателям. Можно использовать ключевые слова: $client_name, "
+"$recipients, $lab_name, $lab_address"
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
-#. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: bika/lims/content/bikasetup.py:806
+#. Default: "E-mail to use as the 'From' address for outgoing e-mails when
+#. publishing results reports. This address overrides the value set at
+#. portal's 'Mail settings'."
+#: bika/lims/content/bikasetup.py:805
 msgid "description_bikasetup_email_from_sample_publication"
 msgstr ""
+"Email для использования в качестве адреса отправителя исходящих писем при "
+"публикации отчётов с результатами. Переопределяет значение, заданное в "
+"настройках почты портала."
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
-#. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: bika/lims/content/bikasetup.py:444
+#. Default: "Allow the user to directly enter results after sample creation,
+#. e.g. to enter field results immediately, or lab results, when the automatic
+#. sample reception is activated."
+#: bika/lims/content/bikasetup.py:443
 msgid "description_bikasetup_immediateresultsentry"
 msgstr ""
+"Разрешить пользователю сразу вводить результаты после создания образца, "
+"например для немедленного ввода полевых или лабораторных результатов при "
+"включённом автоматическом приёме образца."
 
 #. sent to primary contacts and laboratory managers when a sample is
 #. invalidated. The following placeholders are supported: <code title='The ID
@@ -7592,27 +8364,46 @@ msgstr ""
 #. retest'>$retest_link</code>, <code title='The reason(s) for
 #. invalidation'>$reason</code>, <code title='The address of the
 #. lab'>$lab_address</code>."
-#. Default: "Define the template for the email body that will be automatically sent to primary contacts and laboratory managers when a sample is invalidated. The following placeholders are supported: <code title='The ID of the sample'>$sample_id</code>, <code title='The ID of the sample retest'>$retest_id</code>, <code title='The link to the retest'>$retest_link</code>, <code title='The reason(s) for invalidation'>$reason</code>, <code title='The address of the lab'>$lab_address</code>."
-#: bika/lims/content/bikasetup.py:947
+#. Default: "Define the template for the email body that will be automatically
+#. sent to primary contacts and laboratory managers when a sample is
+#. invalidated. The following placeholders are supported: <code title='The ID
+#. of the sample'>$sample_id</code>, <code title='The ID of the sample
+#. retest'>$retest_id</code>, <code title='The link to the
+#. retest'>$retest_link</code>, <code title='The reason(s) for
+#. invalidation'>$reason</code>, <code title='The address of the
+#. lab'>$lab_address</code>."
+#: bika/lims/content/bikasetup.py:946
 msgid "description_bikasetup_invalidation_email_body"
 msgstr ""
+"Задайте шаблон текста письма, автоматически отправляемого основным контактам"
+" и менеджерам лаборатории при аннулировании образца. Поддерживаются "
+"плейсхолдеры: <code title='ID образца'>$sample_id</code>, <code title='ID "
+"повторного теста'>$retest_id</code>, <code title='Ссылка на повторный "
+"тест'>$retest_link</code>, <code title='Причина(-ы) "
+"аннулирования'>$reason</code>, <code title='Адрес "
+"лаборатории'>$lab_address</code>."
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
-#. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: bika/lims/content/bikasetup.py:914
+#. Default: "Specify whether providing a reason is mandatory when invalidating
+#. a sample. If enabled, the '$reason' placeholder in the sample invalidation
+#. notification email body will be replaced with the entered reason."
+#: bika/lims/content/bikasetup.py:913
 msgid "description_bikasetup_invalidation_reason_required"
 msgstr ""
+"Укажите, обязательно ли указание причины при аннулировании образца. Если "
+"включено, плейсхолдер '$reason' в тексте письма-уведомления об аннулировании"
+" образца будет заменён указанной причиной."
 
 #. Default: "Analyses are required for sample registration"
-#: bika/lims/content/bikasetup.py:383
+#: bika/lims/content/bikasetup.py:382
 msgid "description_bikasetup_sampleanalysesrequired"
-msgstr ""
+msgstr "Анализы обязательны для регистрации образца"
 
 #. Default: "Dependent services of this calculation"
 #: bika/lims/content/calculation.py:84
 msgid "description_calculation_dependentservices"
-msgstr ""
+msgstr "Зависимые услуги этой формулы расчёта"
 
 #. dynamically calculated when an analysis using this calculation is
 #. displayed.</p><p>To enter a Calculation, use standard maths operators, + -
@@ -7621,255 +8412,299 @@ msgstr ""
 #. brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of
 #. Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg],
 #. where Ca and Mg are the keywords for those two Analysis Services.</p>"
-#. Default: "<p>The formula you type here will be dynamically calculated be dynamically calculated when an analysis using this calculation is displayed.</p><p>To enter a Calculation, use standard maths operators, + - * / ( ), and all keywords available, both from other Analysis Services and the Interim Fields specified here, as variables. Enclose them in square brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg], where Ca and Mg are the keywords for those two Analysis Services.</p>"
+#. Default: "<p>The formula you type here will be dynamically calculated be
+#. dynamically calculated when an analysis using this calculation is
+#. displayed.</p><p>To enter a Calculation, use standard maths operators, + -
+#. * / ( ), and all keywords available, both from other Analysis Services and
+#. the Interim Fields specified here, as variables. Enclose them in square
+#. brackets [ ].</p><p>E.g, the calculation for Total Hardness, the total of
+#. Calcium (ppm) and Magnesium (ppm) ions in water, is entered as [Ca] + [Mg],
+#. where Ca and Mg are the keywords for those two Analysis Services.</p>"
 #: senaite/core/content/calculation.py:291
 msgid "description_calculation_formula"
 msgstr ""
-
-#. library, you can import it here. E.g. if you want to use the 'floor'
-#. function from the Python 'math' module, you add 'math' to the Module field
-#. and 'floor' to the function field. The equivalent in Python would be 'from
-#. math import floor'. In your calculation you could use then 'floor([Ca] +
-#. [Mg])'."
-#. Default: "If your formula needs a special function from an external Python library, you can import it here. E.g. if you want to use the 'floor' function from the Python 'math' module, you add 'math' to the Module field and 'floor' to the function field. The equivalent in Python would be 'from math import floor'. In your calculation you could use then 'floor([Ca] + [Mg])'."
-#: senaite/core/content/calculation.py:268
-msgid "description_calculation_imports"
-msgstr ""
+"<p>Введённая здесь формула будет динамически рассчитываться при отображении "
+"анализа, использующего эту формулу расчёта.</p><p>Для ввода формулы расчёта "
+"используйте стандартные математические операторы + - * / ( ) и все доступные"
+" ключевые слова — как из других услуг анализа, так и из промежуточных полей,"
+" указанных здесь, — в качестве переменных. Заключайте их в квадратные скобки"
+" [ ].</p><p>Например, формула общей жёсткости — суммы ионов кальция (ppm) и "
+"магния (ppm) в воде — вводится как [Ca] + [Mg], где Ca и Mg — ключевые слова"
+" этих двух услуг анализа.</p>"
 
 #. should your calculation require them. The field title specified here will
 #. be used as column headers and field descriptors where the interim fields
 #. are displayed. If 'Apply wide' is enabled the field will be shown in a
 #. selection box on the top of the worksheet, allowing to apply a specific
 #. value to all the corresponding fields on the sheet."
-#. Default: "Define interim fields such as vessel mass, dilution factors, should your calculation require them. The field title specified here will be used as column headers and field descriptors where the interim fields are displayed. If 'Apply wide' is enabled the field will be shown in a selection box on the top of the worksheet, allowing to apply a specific value to all the corresponding fields on the sheet."
+#. Default: "If your formula needs a special function from an external Python
+#. library, you can import it here. E.g. if you want to use the 'floor'
+#. function from the Python 'math' module, you add 'math' to the Module field
+#. and 'floor' to the function field. The equivalent in Python would be 'from
+#. math import floor'. In your calculation you could use then 'floor([Ca] +
+#. [Mg])'."
+#: senaite/core/content/calculation.py:268
+msgid "description_calculation_imports"
+msgstr ""
+"Если вашей формуле нужна специальная функция из внешней библиотеки Python, "
+"импортируйте её здесь. Например, чтобы использовать функцию 'floor' из "
+"модуля Python 'math', добавьте 'math' в поле 'Модуль' и 'floor' в поле "
+"'Функция'. В Python это эквивалентно 'from math import floor'. В расчёте "
+"можно использовать 'floor([Ca] + [Mg])'."
+
+#. Default: "Define interim fields such as vessel mass, dilution factors,
+#. should your calculation require them. The field title specified here will
+#. be used as column headers and field descriptors where the interim fields
+#. are displayed. If 'Apply wide' is enabled the field will be shown in a
+#. selection box on the top of the worksheet, allowing to apply a specific
+#. value to all the corresponding fields on the sheet."
 #: senaite/core/content/calculation.py:245
 msgid "description_calculation_interims"
 msgstr ""
+"Определите промежуточные поля, например массу сосуда, коэффициенты "
+"разбавления, если это требуется для расчёта. Название поля, указанное здесь,"
+" будет использовано как заголовок столбца и описание поля. Если включена "
+"опция 'Применить ко всем', поле будет показано в блоке выбора вверху "
+"рабочего листа, позволяя применить значение ко всем соответствующим полям "
+"листа."
 
 #. parameters.  This includes Interim fields defined above, as well as any
 #. services that this calculation depends on to calculate results."
-#. Default: "To test the calculation, enter values here for all calculation parameters.  This includes Interim fields defined above, as well as any services that this calculation depends on to calculate results."
+#. Default: "To test the calculation, enter values here for all calculation
+#. parameters.  This includes Interim fields defined above, as well as any
+#. services that this calculation depends on to calculate results."
 #: senaite/core/content/calculation.py:321
 msgid "description_calculation_test_params"
 msgstr ""
+"Чтобы протестировать формулу расчёта, введите здесь значения всех параметров"
+" расчёта. Это включает промежуточные поля, определённые выше, а также любые "
+"услуги, от которых зависит расчёт результатов."
 
 #. values."
-#. Default: "The result after the calculation has taken place with test values."
+#. Default: "The result after the calculation has taken place with test
+#. values."
 #: senaite/core/content/calculation.py:345
 msgid "description_calculation_test_result"
-msgstr ""
+msgstr "Результат после выполнения расчёта с тестовыми значениями."
 
 #. Default: "Select the responsible department"
 #: bika/lims/content/analysiscategory.py:62
 msgid "description_category_department"
-msgstr ""
+msgstr "Выберите ответственное подразделение"
 
 #. Default: "Always expand the selected categories"
-#: bika/lims/content/client.py:188
+#: bika/lims/content/client.py:184
 msgid "description_client_defaultcategories"
-msgstr ""
+msgstr "Всегда разворачивать выбранные категории"
 
 #. Default: "Show only selected categories"
-#: bika/lims/content/client.py:212
+#: bika/lims/content/client.py:208
 msgid "description_client_restrictcategories"
-msgstr ""
+msgstr "Показывать только выбранные категории"
 
 #. Default: "This value is reported at the bottom of all published results"
 #: senaite/core/content/laboratory.py:127
 msgid "description_confidence_level"
-msgstr ""
+msgstr "Это значение указывается внизу всех опубликованных результатов"
 
 #. Default: "Contacts in CC for new samples"
-#: senaite/core/content/contact.py:155
+#: senaite/core/content/contact.py:123
 msgid "description_contact_cccontact"
-msgstr ""
+msgstr "Контакты для копии (CC) для новых образцов"
 
 #. could be selected here."
-#. Default: "If this container is pre-preserved, then the preservation method could be selected here."
+#. Default: "If this container is pre-preserved, then the preservation method
+#. could be selected here."
 #: bika/lims/content/container.py:100
 msgid "description_container_preservation"
 msgstr ""
+"Если этот контейнер предварительно законсервирован, здесь можно выбрать "
+"способ сохранения."
 
 #. Default: "Select the type of this container"
 #: bika/lims/content/container.py:57
 msgid "description_container_type"
-msgstr ""
+msgstr "Выберите тип этого контейнера"
 
 #. Default: "${copyright} 2017-${current_year} ${senaitelims}"
 #: senaite/core/browser/viewlets/templates/footer.pt:13
 msgid "description_copyright"
-msgstr ""
+msgstr "${copyright} 2017-${current_year} ${senaitelims}"
 
 #. Default: "Please provide a unique department identifier"
 #: senaite/core/content/department.py:80
 msgid "description_department_id"
-msgstr ""
+msgstr "Укажите уникальный идентификатор подразделения"
 
 #. the 'lab contacts' setup item. Departmental managers are referenced on
 #. analysis results reports containing analyses by their department."
-#. Default: "Select a manager from the available personnel configured under the 'lab contacts' setup item. Departmental managers are referenced on analysis results reports containing analyses by their department."
+#. Default: "Select a manager from the available personnel configured under
+#. the 'lab contacts' setup item. Departmental managers are referenced on
+#. analysis results reports containing analyses by their department."
 #: senaite/core/content/department.py:106
 msgid "description_department_manager"
 msgstr ""
+"Выберите менеджера из доступного персонала, настроенного в разделе "
+"'лабораторные контакты'. Менеджеры подразделений указываются в отчётах с "
+"результатами анализов, содержащих анализы этого подразделения."
 
 #. Default: "Name of the department"
 #: senaite/core/content/department.py:52
 msgid "description_department_title"
-msgstr ""
+msgstr "Название подразделения"
 
 #. Default: "Location where the instrument is installed"
 #: bika/lims/content/instrument.py:322
 msgid "description_instrument_instrumentlocation"
-msgstr ""
+msgstr "Место установки инструмента"
 
 #. Default: "Select the type of this instrument"
 #: bika/lims/content/instrument.py:82
 msgid "description_instrument_instrumenttype"
-msgstr ""
+msgstr "Выберите тип этого инструмента"
 
 #. Default: "Select the manufacturer of this instrument"
 #: bika/lims/content/instrument.py:102
 msgid "description_instrument_manufacturer"
-msgstr ""
+msgstr "Выберите производителя этого инструмента"
 
 #. Default: "Methods that are supported by this analytical instrument"
 #: bika/lims/content/instrument.py:174
 msgid "description_instrument_methods"
-msgstr ""
+msgstr "Методы, поддерживаемые этим аналитическим инструментом"
 
 #. where the system should look for the results files while automatically
 #. importing results. Having a folder for each Instrument and inside that
 #. folder creating different folders for each of its Interfaces can be a good
 #. approach. You can use Interface codes to be sure that folder names are
 #. unique."
-#. Default: "For each interface of this instrument, you can define a folder where the system should look for the results files while automatically importing results. Having a folder for each Instrument and inside that folder creating different folders for each of its Interfaces can be a good approach. You can use Interface codes to be sure that folder names are unique."
+#. Default: "For each interface of this instrument, you can define a folder
+#. where the system should look for the results files while automatically
+#. importing results. Having a folder for each Instrument and inside that
+#. folder creating different folders for each of its Interfaces can be a good
+#. approach. You can use Interface codes to be sure that folder names are
+#. unique."
 #: bika/lims/content/instrument.py:267
 msgid "description_instrument_result_file_folder"
 msgstr ""
+"Для каждого интерфейса этого инструмента можно задать папку, в которой "
+"система будет искать файлы результатов при автоматическом импорте. Хорошей "
+"практикой является создание отдельной папки для каждого инструмента, а "
+"внутри неё — папок для каждого интерфейса. Используйте коды интерфейсов, "
+"чтобы имена папок были уникальными."
 
 #. Default: "Select the supplier of this instrument"
 #: bika/lims/content/instrument.py:122
 msgid "description_instrument_supplier"
-msgstr ""
+msgstr "Выберите поставщика этого инструмента"
 
 #. Default: "The person who performed the task"
 #: bika/lims/content/instrumentcalibration.py:130
 msgid "description_instrumentcalibration_worker"
-msgstr ""
+msgstr "Лицо, выполнившее задачу"
 
 #. Default: "The person at the supplier who prepared the certificat"
 #: bika/lims/content/instrumentcertification.py:149
 msgid "description_instrumentcertification_preparator"
-msgstr ""
+msgstr "Лицо у поставщика, подготовившее сертификат"
 
 #. Default: "The person at the supplier who approved the certificate"
 #: bika/lims/content/instrumentcertification.py:173
 msgid "description_instrumentcertification_validator"
-msgstr ""
+msgstr "Лицо у поставщика, утвердившее сертификат"
 
 #. Default: "The person who performed the task"
 #: bika/lims/content/instrumentvalidation.py:112
 msgid "description_instrumentvalidation_worker"
-msgstr ""
+msgstr "Лицо, выполнившее задачу"
 
 #. selected departments."
-#. Default: "Select a default department for this contact from one of the selected departments."
+#. Default: "Select a default department for this contact from one of the
+#. selected departments."
 #: bika/lims/content/labcontact.py:89
 msgid "description_labcontact_default_department"
 msgstr ""
+"Выберите подразделение по умолчанию для этого контакта из выбранных "
+"подразделений."
 
 #. Default: "Assigned laboratory departments"
 #: bika/lims/content/labcontact.py:62
 msgid "description_labcontact_departments"
-msgstr ""
-
-#. the default style."
-#. Default: "Hex color code used for the chip (e.g. #0d6efd). Leave empty for the default style."
-#: senaite/core/content/label.py:72
-msgid "description_label_color"
-msgstr ""
-
-#. labeled content. The cascade runs in the same transaction as the save and
-#. may take a moment on large datasets."
-#. Default: "Renaming this label rewrites the stored name on every currently labeled content. The cascade runs in the same transaction as the save and may take a moment on large datasets."
-#: senaite/core/content/label.py:45
-msgid "description_label_title"
-msgstr ""
+msgstr "Назначенные подразделения лаборатории"
 
 #. Default: "Check this box if your laboratory is accredited"
 #: senaite/core/content/laboratory.py:140
 msgid "description_laboratory_accredited"
-msgstr ""
+msgstr "Отметьте, если ваша лаборатория аккредитована"
 
 #. Default: "The Laboratory's web address"
 #: senaite/core/content/laboratory.py:101
 msgid "description_laboratory_lab_url"
-msgstr ""
+msgstr "Веб-адрес лаборатории"
 
 #. Default: "Supervisor of the Lab"
 #: bika/lims/content/laboratory.py:78
 msgid "description_laboratory_suervisor"
-msgstr ""
+msgstr "Руководитель лаборатории"
 
 #. Default: "Supervisor of the Lab"
 #: senaite/core/content/laboratory.py:77
 msgid "description_laboratory_supervisor"
-msgstr ""
+msgstr "Руководитель лаборатории"
 
 #. Default: "Please provide the price excluding VAT"
 #: senaite/core/content/labproduct.py:89
 msgid "description_labproduct_price"
-msgstr ""
+msgstr "Укажите цену без учёта НДС"
 
 #. price"
-#. Default: "Please provide the VAT in percent that is added to the labproduct price"
+#. Default: "Please provide the VAT in percent that is added to the labproduct
+#. price"
 #: senaite/core/content/labproduct.py:102
 msgid "description_labproduct_vat"
-msgstr ""
-
-#. nested and positioned as they appear on the site. Use the controls to hide,
-#. show or reorder each viewlet."
-#. Default: "The viewlet managers and their viewlets are shown in place, nested and positioned as they appear on the site. Use the controls to hide, show or reorder each viewlet."
-#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:22
-msgid "description_manage_viewlets"
-msgstr ""
+msgstr "Укажите НДС в процентах, добавляемый к цене товара лаборатории"
 
 #. Default: "Location where the document set is shelved"
 #: senaite/core/content/multifile.py:71
 msgid "description_multifile_document_location"
-msgstr ""
+msgstr "Место хранения комплекта документов"
 
 #. image, ...)"
-#. Default: "Type of document (e.g. user manual, instrument specifications, image, ...)"
+#. Default: "Type of document (e.g. user manual, instrument specifications,
+#. image, ...)"
 #: senaite/core/content/multifile.py:83
 msgid "description_multifile_document_type"
 msgstr ""
+"Тип документа (например, руководство пользователя, спецификации инструмента,"
+" изображение...)"
 
 #. Default: "File upload"
 #: senaite/core/content/multifile.py:51
 msgid "description_multifile_file"
-msgstr ""
+msgstr "Загрузка файла"
 
 #. Default: "Greeting title eg. Mr, Mrs, Dr"
 #: senaite/core/content/person.py:71
 msgid "description_person_salutation"
-msgstr ""
+msgstr "Обращение, например г-н, г-жа, д-р"
 
 #. Default: "Reference sample values are zero or 'blank'"
 #: bika/lims/content/referencedefinition.py:77
 msgid "description_referencedefinition_blank"
-msgstr ""
+msgstr "Значения референс-образца равны нулю или являются 'холостыми'"
 
 #. definition."
-#. Default: "Hazard categories that apply to samples of this reference definition."
+#. Default: "Hazard categories that apply to samples of this reference
+#. definition."
 #: bika/lims/content/referencedefinition.py:106
 msgid "description_referencedefinition_hazard_categories"
 msgstr ""
+"Категории опасности, применимые к образцам этого эталонного определения."
 
 #. Default: "Samples of this type should be treated as hazardous"
 #: bika/lims/content/referencedefinition.py:91
 msgid "description_referencedefinition_hazardous"
-msgstr ""
+msgstr "Образцы этого типа следует считать опасными"
 
 #. category. Enter minimum and maximum values to indicate a valid results
 #. range. Any result outside this range will raise an alert. The % Error field
@@ -7877,1164 +8712,1477 @@ msgstr ""
 #. against minimum and maximum values. A result out of range but still in
 #. range if the % error is taken into consideration, will raise a less severe
 #. alert."
-#. Default: "Click on Analysis Categories to see Analysis Services in each category. Enter minimum and maximum values to indicate a valid results range. Any result outside this range will raise an alert. The % Error field allows for an % uncertainty to be considered when evaluating results against minimum and maximum values. A result out of range but still in range if the % error is taken into consideration, will raise a less severe alert."
+#. Default: "Click on Analysis Categories to see Analysis Services in each
+#. category. Enter minimum and maximum values to indicate a valid results
+#. range. Any result outside this range will raise an alert. The % Error field
+#. allows for an % uncertainty to be considered when evaluating results
+#. against minimum and maximum values. A result out of range but still in
+#. range if the % error is taken into consideration, will raise a less severe
+#. alert."
 #: bika/lims/content/referencedefinition.py:55
 msgid "description_referencedefinition_referencevalues"
 msgstr ""
+"Нажмите на категории анализа, чтобы увидеть услуги анализа в каждой "
+"категории. Введите минимальное и максимальное значения для допустимого "
+"диапазона результатов. Любой результат вне этого диапазона вызовет "
+"предупреждение. Поле '% ошибки' позволяет учитывать процент неопределённости"
+" при оценке результатов относительно минимума и максимума. Результат вне "
+"диапазона, но входящий в него с учётом % ошибки, вызовет менее серьёзное "
+"предупреждение."
 
 #. inherit from the reference definition."
-#. Default: "Hazard categories for this reference sample. Leave empty to inherit from the reference definition."
+#. Default: "Hazard categories for this reference sample. Leave empty to
+#. inherit from the reference definition."
 #: bika/lims/content/referencesample.py:118
 msgid "description_referencesample_hazard_categories"
 msgstr ""
+"Категории опасности для этого референс-образца. Оставьте пустым, чтобы "
+"наследовать от эталонного определения."
 
 #. Default: "Select the manufacturer for this sample"
 #: bika/lims/content/referencesample.py:136
 msgid "description_referencesample_manufacturer"
-msgstr ""
+msgstr "Выберите производителя для этого образца"
 
 #. Default: "Select the reference definition for this sample"
 #: bika/lims/content/referencesample.py:82
 msgid "description_referencesample_referencedefinition"
-msgstr ""
+msgstr "Выберите эталонное определение для этого образца"
 
 #. the paste popup in the sample add form. Please note that the paste button
 #. will only show for the fields listed here."
-#. Default: "Add all field names that support to enter multiple values using the paste popup in the sample add form. Please note that the paste button will only show for the fields listed here."
+#. Default: "Add all field names that support to enter multiple values using
+#. the paste popup in the sample add form. Please note that the paste button
+#. will only show for the fields listed here."
 #: senaite/core/registry/schema.py:375
 msgid "description_registry_allow_multi_paste"
 msgstr ""
+"Добавьте названия всех полей, поддерживающих ввод нескольких значений через "
+"всплывающее окно вставки в форме добавления образца. Кнопка вставки "
+"отображается только для перечисленных здесь полей."
 
 #. catalogs in which these portal types should be indexed, beyond the default
 #. catalogs. A restart is required for these changes to take effect."
-#. Default: "Define the relationship between portal types and the additional catalogs in which these portal types should be indexed, beyond the default catalogs. A restart is required for these changes to take effect."
+#. Default: "Define the relationship between portal types and the additional
+#. catalogs in which these portal types should be indexed, beyond the default
+#. catalogs. A restart is required for these changes to take effect."
 #: senaite/core/registry/schema.py:278
 msgid "description_registry_catalog_mappings"
 msgstr ""
+"Определите связь между типами портала и дополнительными каталогами, в "
+"которых эти типы должны индексироваться, помимо каталогов по умолчанию. Для "
+"применения изменений требуется перезапуск."
 
 #. logs into the system, or when a client is selected from the client folder
 #. listing"
-#. Default: "Select the default landing page. This is used when a Client user logs into the system, or when a client is selected from the client folder listing"
+#. Default: "Select the default landing page. This is used when a Client user
+#. logs into the system, or when a client is selected from the client folder
+#. listing"
 #: senaite/core/registry/schema.py:51
 msgid "description_registry_client_landing_page"
 msgstr ""
+"Выберите стартовую страницу по умолчанию. Она используется при входе "
+"пользователя-клиента в систему или при выборе клиента из списка папки "
+"клиентов"
 
 #. structure of the site via Generic Setup"
-#. Default: "List of portal types to be skipped when exporting the content structure of the site via Generic Setup"
+#. Default: "List of portal types to be skipped when exporting the content
+#. structure of the site via Generic Setup"
 #: senaite/core/registry/schema.py:238
 msgid "description_registry_generic_setup_skip_export_types"
 msgstr ""
+"Список типов портала, пропускаемых при экспорте структуры содержимого сайта "
+"через Generic Setup"
 
 #. Default: "Attach import file to all Worksheet assigned analyses"
 #: senaite/core/registry/schema.py:443
 msgid "description_registry_import_analysis_attach_attachment"
-msgstr ""
+msgstr "Прикреплять файл импорта ко всем анализам, назначенным рабочему листу"
 
 #. Default: "Automatically submit analyses upon import"
 #: senaite/core/registry/schema.py:456
 msgid "description_registry_import_analysis_submit"
-msgstr ""
+msgstr "Автоматически отправлять анализы при импорте"
 
 #. in its own ZODB transaction with a per-sample retry on conflict. This
 #. reduces the chance that ID-counter or container contention aborts the whole
 #. batch on instances with many concurrent users. When disabled, the whole
 #. batch is created in a single transaction (legacy behaviour)."
-#. Default: "When enabled, each sample created from the add form is committed in its own ZODB transaction with a per-sample retry on conflict. This reduces the chance that ID-counter or container contention aborts the whole batch on instances with many concurrent users. When disabled, the whole batch is created in a single transaction (legacy behaviour)."
+#. Default: "When enabled, each sample created from the add form is committed
+#. in its own ZODB transaction with a per-sample retry on conflict. This
+#. reduces the chance that ID-counter or container contention aborts the whole
+#. batch on instances with many concurrent users. When disabled, the whole
+#. batch is created in a single transaction (legacy behaviour)."
 #: senaite/core/registry/schema.py:391
 msgid "description_registry_sample_add_commit_per_sample"
 msgstr ""
+"Если включено, каждый образец, созданный из формы добавления, фиксируется в "
+"отдельной транзакции ZODB с повторной попыткой при конфликте. Это снижает "
+"вероятность прерывания всей партии из-за конфликта счётчика ID или "
+"контейнера при большом числе одновременных пользователей. Если отключено, "
+"вся партия создаётся в одной транзакции (прежнее поведение)."
 
 #. matching the source sample structure. Each partition will be created with
 #. the same configuration (sample type, container, preservation) and analyses
 #. as the source partition."
-#. Default: "When enabled, copying a sample will also create partitions matching the source sample structure. Each partition will be created with the same configuration (sample type, container, preservation) and analyses as the source partition."
+#. Default: "When enabled, copying a sample will also create partitions
+#. matching the source sample structure. Each partition will be created with
+#. the same configuration (sample type, container, preservation) and analyses
+#. as the source partition."
 #: senaite/core/registry/schema.py:328
 msgid "description_registry_sample_add_copy_partitions"
 msgstr ""
+"Если включено, при копировании образца также создаются партиции, "
+"соответствующие структуре исходного образца. Каждая партиция создаётся с той"
+" же конфигурацией (тип образца, контейнер, способ сохранения) и анализами, "
+"что и исходная партиция."
 
 #. copying analyses to a new sample in the sample add form."
-#. Default: "Add all analyses workflow states that should be skipped when copying analyses to a new sample in the sample add form."
+#. Default: "Add all analyses workflow states that should be skipped when
+#. copying analyses to a new sample in the sample add form."
 #: senaite/core/registry/schema.py:359
 msgid "description_registry_sample_add_skip_analyses_in_states"
 msgstr ""
+"Добавьте все статусы процесса анализа, которые нужно пропускать при "
+"копировании анализов в новый образец в форме добавления образца."
 
 #. copying a sample. Only analyses that directly belong to the source sample
 #. will be copied to the new sample."
-#. Default: "When enabled, analyses from partitions will be excluded when copying a sample. Only analyses that directly belong to the source sample will be copied to the new sample."
+#. Default: "When enabled, analyses from partitions will be excluded when
+#. copying a sample. Only analyses that directly belong to the source sample
+#. will be copied to the new sample."
 #: senaite/core/registry/schema.py:344
 msgid "description_registry_sample_add_skip_partition_analyses"
 msgstr ""
+"Если включено, анализы из партиций исключаются при копировании образца. В "
+"новый образец копируются только анализы, непосредственно принадлежащие "
+"исходному образцу."
 
 #. upon sample creation. This option is disabled by default, but certain add-
 #. ons may depend on it to operate correctly."
-#. Default: "When enabled, triggers “before” and “after” transition events upon sample creation. This option is disabled by default, but certain add-ons may depend on it to operate correctly."
+#. Default: "When enabled, triggers “before” and “after” transition events
+#. upon sample creation. This option is disabled by default, but certain add-
+#. ons may depend on it to operate correctly."
 #: senaite/core/registry/schema.py:410
 msgid "description_registry_trigger_events_on_sample_creation"
 msgstr ""
+"Если включено, при создании образца запускаются события перехода 'до' и "
+"'после'. По умолчанию отключено, но некоторые дополнения могут требовать "
+"этого для корректной работы."
 
 #. Default: "Worksheet view configuration"
 #: senaite/core/registry/schema.py:99
 msgid "description_registry_worksheet_settings"
-msgstr ""
+msgstr "Настройка просмотра рабочего листа"
 
 #. Default: "Contained samples in the PDF"
-#: senaite/core/content/resultsreport.py:187
+#: senaite/core/content/resultsreport.py:186
 msgid "description_resultsreport_contained_samples"
-msgstr ""
+msgstr "Образцы, содержащиеся в PDF"
 
 #. Default: "The primary sample of the PDF"
-#: senaite/core/content/resultsreport.py:159
+#: senaite/core/content/resultsreport.py:158
 msgid "description_resultsreport_sample"
-msgstr ""
+msgstr "Основной образец PDF"
 
 #. Default: "Assign sample to a batch"
 #: bika/lims/content/analysisrequest.py:331
 msgid "description_sample_batch"
-msgstr ""
+msgstr "Назначить образец партии"
 
 #. Default: "The contacts used in CC for email notifications"
 #: bika/lims/content/analysisrequest.py:200
 msgid "description_sample_cccontact"
-msgstr ""
+msgstr "Контакты, используемые в копии (CC) для email-уведомлений"
 
 #. Default: "Select the client for this sample"
 #: bika/lims/content/analysisrequest.py:258
 msgid "description_sample_client"
-msgstr ""
+msgstr "Выберите клиента для этого образца"
 
 #. Default: "Select the primary contact for this sample"
 #: bika/lims/content/analysisrequest.py:159
 msgid "description_sample_contact"
-msgstr ""
+msgstr "Выберите основной контакт для этого образца"
 
 #. Default: "Select a container for this sample"
 #: bika/lims/content/analysisrequest.py:569
 msgid "description_sample_container"
-msgstr ""
+msgstr "Выберите контейнер для этого образца"
 
 #. Default: "The date when the sample was taken"
 #: bika/lims/content/analysisrequest.py:453
 msgid "description_sample_datesampled"
-msgstr ""
+msgstr "Дата отбора образца"
 
 #. Default: "Reference to detached sample"
 #: bika/lims/content/analysisrequest.py:1311
 msgid "description_sample_detached_from"
-msgstr ""
+msgstr "Ссылка на отсоединённый образец"
 
 #. Default: "Reference to the source sample this sample was duplicated from"
 #: bika/lims/content/analysisrequest.py:1283
 msgid "description_sample_duplicated_from"
-msgstr ""
+msgstr "Ссылка на исходный образец, из которого был создан дубликат"
 
 #. Default: "Generated invoice for this sample"
 #: bika/lims/content/analysisrequest.py:1049
 msgid "description_sample_invoice"
-msgstr ""
+msgstr "Созданный счёт для этого образца"
 
 #. Default: "Reference to parent sample"
 #: bika/lims/content/analysisrequest.py:1255
 msgid "description_sample_parent_sample"
-msgstr ""
+msgstr "Ссылка на родительский образец"
 
 #. Default: "Select the needed preservation for this sample"
 #: bika/lims/content/analysisrequest.py:600
 msgid "description_sample_preservation"
-msgstr ""
+msgstr "Выберите необходимый способ сохранения для этого образца"
 
 #. Default: "Select a sample to create a secondary Sample"
 #: bika/lims/content/analysisrequest.py:295
 msgid "description_sample_primary"
-msgstr ""
+msgstr "Выберите образец для создания вторичного образца"
 
 #. Default: "Select an analysis profile for this sample"
 #: bika/lims/content/analysisrequest.py:421
 msgid "description_sample_profiles"
-msgstr ""
+msgstr "Выберите профиль анализа для этого образца"
 
 #. sample publication report"
-#. Default: "Select an analysis specification that should be used in the sample publication report"
+#. Default: "Select an analysis specification that should be used in the
+#. sample publication report"
 #: bika/lims/content/analysisrequest.py:737
 msgid "description_sample_publicationspecification"
 msgstr ""
+"Выберите спецификацию анализа для использования в отчёте публикации образца"
 
 #. Default: "Reference to retracted sample"
 #: bika/lims/content/analysisrequest.py:1339
 msgid "description_sample_retracted"
-msgstr ""
+msgstr "Ссылка на отозванный образец"
 
 #. Default: "The condition of the sample"
 #: bika/lims/content/analysisrequest.py:900
 msgid "description_sample_samplecondition"
-msgstr ""
+msgstr "Состояние образца"
 
 #. Default: "Location where the sample was taken"
 #: bika/lims/content/analysisrequest.py:770
 msgid "description_sample_samplepoint"
-msgstr ""
+msgstr "Место отбора образца"
 
 #. Default: "Select the sample type of this sample"
 #: bika/lims/content/analysisrequest.py:541
 msgid "description_sample_sampletype"
-msgstr ""
+msgstr "Выберите тип этого образца"
 
 #. Default: "The date when the sample will be taken"
 #: bika/lims/content/analysisrequest.py:516
 msgid "description_sample_samplingdate"
-msgstr ""
+msgstr "Дата, когда образец будет отобран"
 
 #. Default: "Deviation between the sample and how it was sampled"
 #: bika/lims/content/analysisrequest.py:872
 msgid "description_sample_samplingdeviation"
-msgstr ""
+msgstr "Отклонение между образцом и способом его отбора"
 
 #. Default: "Select an analysis specification for this sample"
 #: bika/lims/content/analysisrequest.py:693
 msgid "description_sample_specification"
-msgstr ""
+msgstr "Выберите спецификацию анализа для этого образца"
 
 #. Default: "Location where the sample is kept"
 #: bika/lims/content/analysisrequest.py:794
 msgid "description_sample_storagelocation"
-msgstr ""
+msgstr "Место хранения образца"
 
 #. Default: "The assigned batch sub group of this request"
 #: bika/lims/content/analysisrequest.py:366
 msgid "description_sample_subgroup"
-msgstr ""
+msgstr "Назначенная подгруппа партии этой заявки"
 
 #. Default: "Select an analysis template for this sample"
 #: bika/lims/content/analysisrequest.py:393
 msgid "description_sample_template"
-msgstr ""
+msgstr "Выберите шаблон анализа для этого образца"
 
 #. and put together from more than one sub sample, e.g. several surface
 #. samples from a dam mixed together to be a representative sample for the
 #. dam. The default, unchecked, indicates 'grab' samples"
-#. Default: "Check this box if the samples taken at this point are 'composite' and put together from more than one sub sample, e.g. several surface samples from a dam mixed together to be a representative sample for the dam. The default, unchecked, indicates 'grab' samples"
+#. Default: "Check this box if the samples taken at this point are 'composite'
+#. and put together from more than one sub sample, e.g. several surface
+#. samples from a dam mixed together to be a representative sample for the
+#. dam. The default, unchecked, indicates 'grab' samples"
 #: senaite/core/content/samplepoint.py:147
 msgid "description_samplepoint_composite"
 msgstr ""
+"Отметьте, если образцы, отобранные в этой точке, являются 'составными' и "
+"объединены из нескольких суб-образцов, например несколько поверхностных проб"
+" плотины, смешанных в один представительный образец. По умолчанию (не "
+"отмечено) — 'разовые' образцы"
 
 #. Default: "The height or depth at which the sample has to be taken"
 #: senaite/core/content/samplepoint.py:91
 msgid "description_samplepoint_elevation"
-msgstr ""
+msgstr "Высота или глубина, на которой должен быть взят образец"
 
 #. further analysis. It plays a pivotal role in research as it can
 #. significantly influence the results and conclusions drawn from the study."
-#. Default: "The geographical point or area from which samples are taken for further analysis. It plays a pivotal role in research as it can significantly influence the results and conclusions drawn from the study."
+#. Default: "The geographical point or area from which samples are taken for
+#. further analysis. It plays a pivotal role in research as it can
+#. significantly influence the results and conclusions drawn from the study."
 #: senaite/core/content/samplepoint.py:76
 msgid "description_samplepoint_location"
 msgstr ""
+"Географическая точка или область, из которой отбираются образцы для "
+"дальнейшего анализа. Играет ключевую роль в исследовании, так как может "
+"существенно влиять на результаты и выводы."
 
 #. point. The field for the selection of a sample point in sample creation and
 #. edit forms will be filtered in accordance. Still, sample points that do not
 #. have any sample type assigned will always be available for selection,
 #. regardless of the type."
-#. Default: "The list of sample types that can be collected at this sample point. The field for the selection of a sample point in sample creation and edit forms will be filtered in accordance. Still, sample points that do not have any sample type assigned will always be available for selection, regardless of the type."
+#. Default: "The list of sample types that can be collected at this sample
+#. point. The field for the selection of a sample point in sample creation and
+#. edit forms will be filtered in accordance. Still, sample points that do not
+#. have any sample type assigned will always be available for selection,
+#. regardless of the type."
 #: bika/lims/content/samplepoint.py:98
 msgid "description_samplepoint_sampletypes"
 msgstr ""
+"Список типов образца, которые можно отбирать в этой точке. Поле выбора точки"
+" отбора в формах создания и редактирования образца будет соответствующим "
+"образом отфильтровано. При этом точки без назначенного типа образца всегда "
+"доступны для выбора, независимо от типа."
 
 #. frequency here, e.g. weekly"
-#. Default: "If a sample is taken periodically at this sample point, enter frequency here, e.g. weekly"
+#. Default: "If a sample is taken periodically at this sample point, enter
+#. frequency here, e.g. weekly"
 #: senaite/core/content/samplepoint.py:103
 msgid "description_samplepoint_sampling_frequency"
 msgstr ""
+"Если образец на этой точке отбирается периодически, укажите частоту, "
+"например еженедельно"
 
 #. point. The field for the selection of a sample point in sample creation and
 #. edit forms will be filtered in accordance. Still, sample points that do not
 #. have any sample type assigned will always be available for selection,
 #. regardless of the type."
-#. Default: "The list of sample types that can be collected at this sample point. The field for the selection of a sample point in sample creation and edit forms will be filtered in accordance. Still, sample points that do not have any sample type assigned will always be available for selection, regardless of the type."
+#. Default: "The list of sample types that can be collected at this sample
+#. point. The field for the selection of a sample point in sample creation and
+#. edit forms will be filtered in accordance. Still, sample points that do not
+#. have any sample type assigned will always be available for selection,
+#. regardless of the type."
 #: senaite/core/content/samplepoint.py:126
 msgid "description_samplepoint_sampling_sample_types"
 msgstr ""
+"Список типов образца, которые можно отбирать в этой точке. Поле выбора точки"
+" отбора в формах создания и редактирования образца будет соответствующим "
+"образом отфильтровано. При этом точки без назначенного типа образца всегда "
+"доступны для выбора, независимо от типа."
 
 #. sample is received"
-#. Default: "Automatically redirect the user to the partitions view when the sample is received"
+#. Default: "Automatically redirect the user to the partitions view when the
+#. sample is received"
 #: senaite/core/content/sampletemplate.py:258
 msgid "description_sampletemplate_auto_partition"
 msgstr ""
+"Автоматически перенаправлять пользователя на просмотр партиций при приёме "
+"образца"
 
 #. Default: "Select if the sample is a mix of sub samples"
 #: senaite/core/content/sampletemplate.py:219
 msgid "description_sampletemplate_composite"
-msgstr ""
+msgstr "Отметьте, если образец является смесью суб-образцов"
 
 #. ID'"
-#. Default: "Each line defines a new partition identified by the 'Partition ID'"
+#. Default: "Each line defines a new partition identified by the 'Partition
+#. ID'"
 #: senaite/core/content/sampletemplate.py:245
 msgid "description_sampletemplate_partitions"
 msgstr ""
+"Каждая строка определяет новую партицию, идентифицируемую по 'ID партиции'"
 
 #. Default: "Select the sample point for this template"
 #: senaite/core/content/sampletemplate.py:187
 msgid "description_sampletemplate_samplepoint"
-msgstr ""
+msgstr "Выберите точку отбора проб для этого шаблона"
 
 #. Default: "Select the sample type for this template"
 #: senaite/core/content/sampletemplate.py:209
 msgid "description_sampletemplate_sampletype"
-msgstr ""
+msgstr "Выберите тип образца для этого шаблона"
 
 #. Default: "Enable sampling workflow for the created samples"
 #: senaite/core/content/sampletemplate.py:228
 msgid "description_sampletemplate_sampling_required"
-msgstr ""
+msgstr "Включить процесс отбора проб для создаваемых образцов"
 
 #. Default: "Select the services for this template"
 #: senaite/core/content/sampletemplate.py:273
 msgid "description_sampletemplate_services"
-msgstr ""
+msgstr "Выберите услуги для этого шаблона"
 
 #. Default: "Defines the stickers to use for this sample type."
 #: senaite/core/content/sampletype.py:281
 msgid "description_sampletype_admitted_stickers_templates"
-msgstr ""
+msgstr "Определяет стикеры, используемые для этого типа образца."
 
 #. automatically assigned a container of this type, unless it has been
 #. specified in more details per analysis service"
-#. Default: "The default container type. New sample partitions are automatically assigned a container of this type, unless it has been specified in more details per analysis service"
+#. Default: "The default container type. New sample partitions are
+#. automatically assigned a container of this type, unless it has been
+#. specified in more details per analysis service"
 #: senaite/core/content/sampletype.py:258
 msgid "description_sampletype_containertype"
 msgstr ""
+"Тип контейнера по умолчанию. Новым партициям образца автоматически "
+"назначается контейнер этого типа, если иное не указано для конкретной услуги"
+" анализа"
 
 #. before they expire and cannot be analysed any further"
-#. Default: "The period for which unpreserved samples of this type can be kept before they expire and cannot be analysed any further"
+#. Default: "The period for which unpreserved samples of this type can be kept
+#. before they expire and cannot be analysed any further"
 #: senaite/core/content/sampletype.py:155
 msgid "description_sampletype_duration_period"
 msgstr ""
+"Период, в течение которого неконсервированные образцы этого типа могут "
+"храниться до истечения срока годности"
 
 #. display the appropriate pictograms in reports and lists."
-#. Default: "Hazard categories that apply to samples of this type. Used to display the appropriate pictograms in reports and lists."
+#. Default: "Hazard categories that apply to samples of this type. Used to
+#. display the appropriate pictograms in reports and lists."
 #: senaite/core/content/sampletype.py:180
 msgid "description_sampletype_hazard_categories"
 msgstr ""
+"Категории опасности, применимые к образцам этого типа. Используются для "
+"отображения соответствующих пиктограмм в отчётах и списках."
 
 #. Default: "Samples of this type should be treated as hazardous"
 #: senaite/core/content/sampletype.py:168
 msgid "description_sampletype_hazardous"
-msgstr ""
+msgstr "Образцы этого типа следует считать опасными"
 
 #. kg'."
-#. Default: "The minimum sample volume required for analysis eg. '10 ml' or '1 kg'."
+#. Default: "The minimum sample volume required for analysis eg. '10 ml' or '1
+#. kg'."
 #: senaite/core/content/sampletype.py:235
 msgid "description_sampletype_min_volume"
 msgstr ""
+"Минимальный объём образца, необходимый для анализа, например '10 мл' или '1 "
+"кг'."
 
 #. Default: "Only ASCII characters without whitespaces are allowed."
 #: senaite/core/content/sampletype.py:222
 msgid "description_sampletype_prefix"
-msgstr ""
+msgstr "Допускаются только ASCII-символы без пробелов."
 
 #. Default: "Select the sample matrix for this sample type"
 #: senaite/core/content/sampletype.py:208
 msgid "description_sampletype_samplematrix"
-msgstr ""
+msgstr "Выберите матрицу образца для этого типа образца"
 
 #. entered manually for analyses"
-#. Default: "If this option is activated, the result capture date can be entered manually for analyses"
-#: senaite/core/content/senaitesetup.py:362
+#. Default: "If this option is activated, the result capture date can be
+#. entered manually for analyses"
+#: senaite/core/content/senaitesetup.py:361
 msgid "description_senaitesetup_allow_manual_result_capture_date"
 msgstr ""
+"Если этот параметр активирован, дату фиксации результата можно вводить "
+"вручную для анализов"
 
 #. to them or for unassigned analyses. When disabled, users can only submit
 #. results for analyses assigned to themselves. This setting does not apply to
 #. users with role Lab Manager."
-#. Default: "When enabled, users can submit results for analyses not assigned to them or for unassigned analyses. When disabled, users can only submit results for analyses assigned to themselves. This setting does not apply to users with role Lab Manager."
-#: senaite/core/content/senaitesetup.py:456
+#. Default: "When enabled, users can submit results for analyses not assigned
+#. to them or for unassigned analyses. When disabled, users can only submit
+#. results for analyses assigned to themselves. This setting does not apply to
+#. users with role Lab Manager."
+#: senaite/core/content/senaitesetup.py:455
 msgid "description_senaitesetup_allow_to_submit_not_assigned"
 msgstr ""
+"Если включено, пользователи могут отправлять результаты для анализов, не "
+"назначенных им, или для неназначенных анализов. Если отключено, пользователи"
+" могут отправлять результаты только для назначенных им анализов. Этот "
+"параметр не распространяется на пользователей с ролью 'Менеджер "
+"лаборатории'."
 
 #. departments will receive publication emails."
-#. Default: "When selected, the responsible persons of all involved lab departments will receive publication emails."
-#: senaite/core/content/senaitesetup.py:289
+#. Default: "When selected, the responsible persons of all involved lab
+#. departments will receive publication emails."
+#: senaite/core/content/senaitesetup.py:288
 msgid "description_senaitesetup_always_cc_responsibles_in_report_emails"
 msgstr ""
+"Если выбрано, ответственные лица всех задействованных подразделений "
+"лаборатории будут получать письма о публикации."
 
 #. 0 disables automatic log-off"
-#. Default: "The number of minutes before a user is automatically logged off. 0 disables automatic log-off"
-#: senaite/core/content/senaitesetup.py:428
+#. Default: "The number of minutes before a user is automatically logged off.
+#. 0 disables automatic log-off"
+#: senaite/core/content/senaitesetup.py:427
 msgid "description_senaitesetup_auto_log_off"
 msgstr ""
+"Количество минут до автоматического выхода пользователя из системы. 0 "
+"отключает автоматический выход"
 
 #. results are verified. Otherwise, users with enough privileges have to
 #. manually verify the sample afterwards. Default: enabled"
-#. Default: "When enabled, the sample is automatically verified as soon as all results are verified. Otherwise, users with enough privileges have to manually verify the sample afterwards. Default: enabled"
-#: senaite/core/content/senaitesetup.py:655
+#. Default: "When enabled, the sample is automatically verified as soon as all
+#. results are verified. Otherwise, users with enough privileges have to
+#. manually verify the sample afterwards. Default: enabled"
+#: senaite/core/content/senaitesetup.py:654
 msgid "description_senaitesetup_auto_verify_samples"
 msgstr ""
+"Если включено, образец автоматически верифицируется, как только "
+"верифицированы все результаты. В противном случае пользователи с "
+"достаточными правами должны верифицировать образец вручную впоследствии. По "
+"умолчанию: включено"
 
 #. when the list is long"
-#. Default: "Group analysis services by category in the LIMS tables, helpful when the list is long"
-#: senaite/core/content/senaitesetup.py:600
+#. Default: "Group analysis services by category in the LIMS tables, helpful
+#. when the list is long"
+#: senaite/core/content/senaitesetup.py:599
 msgid "description_senaitesetup_categorise_analysis_services"
 msgstr ""
+"Группировать услуги анализа по категориям в таблицах LIMS — полезно при "
+"длинном списке"
 
 #. Default: "Group analyses by category for samples"
-#: senaite/core/content/senaitesetup.py:341
+#: senaite/core/content/senaitesetup.py:340
 msgid "description_senaitesetup_categorizesampleanalyses"
-msgstr ""
+msgstr "Группировать анализы по категориям для образцов"
 
 #. Default: "Select the currency the site will use to display prices."
-#: senaite/core/content/senaitesetup.py:497
+#: senaite/core/content/senaitesetup.py:496
 msgid "description_senaitesetup_currency"
-msgstr ""
+msgstr "Выберите валюту, используемую сайтом для отображения цен."
 
 #. Default: "Select this to activate the dashboard as a default front page."
-#: senaite/core/content/senaitesetup.py:862
+#: senaite/core/content/senaitesetup.py:861
 msgid "description_senaitesetup_dashboard_by_default"
 msgstr ""
+"Отметьте, чтобы использовать панель управления как главную страницу по "
+"умолчанию."
 
 #. creation. This functionality only takes effect when 'Sampling workflow' is
 #. not active"
-#. Default: "Select this to make DateSampled field required on sample creation. This functionality only takes effect when 'Sampling workflow' is not active"
-#: senaite/core/content/senaitesetup.py:387
+#. Default: "Select this to make DateSampled field required on sample
+#. creation. This functionality only takes effect when 'Sampling workflow' is
+#. not active"
+#: senaite/core/content/senaitesetup.py:386
 msgid "description_senaitesetup_date_sampled_required"
 msgstr ""
+"Отметьте, чтобы сделать поле 'Дата отбора' обязательным при создании "
+"образца. Действует только когда процесс отбора проб не активен"
 
 #. Default: "Preferred decimal mark for reports."
-#: senaite/core/content/senaitesetup.py:558
+#: senaite/core/content/senaitesetup.py:557
 msgid "description_senaitesetup_decimal_mark"
-msgstr ""
+msgstr "Предпочитаемый десятичный разделитель для отчётов."
 
 #. Default: "Select the country the site will show by default"
-#: senaite/core/content/senaitesetup.py:511
+#: senaite/core/content/senaitesetup.py:510
 msgid "description_senaitesetup_default_country"
-msgstr ""
+msgstr "Выберите страну, отображаемую сайтом по умолчанию"
 
 #. to create new Samples"
-#. Default: "Default value of the 'Sample count' when users click 'ADD' button to create new Samples"
-#: senaite/core/content/senaitesetup.py:745
+#. Default: "Default value of the 'Sample count' when users click 'ADD' button
+#. to create new Samples"
+#: senaite/core/content/senaitesetup.py:744
 msgid "description_senaitesetup_default_number_of_ars_to_add"
 msgstr ""
+"Значение по умолчанию для 'Количество образцов' при нажатии кнопки "
+"'ДОБАВИТЬ'"
 
 #. publishing results reports. This address overrides the value set at
 #. portal's 'Mail settings'."
-#. Default: "E-mail to use as the 'From' address for outgoing e-mails when publishing results reports. This address overrides the value set at portal's 'Mail settings'."
-#: senaite/core/content/senaitesetup.py:261
+#. Default: "E-mail to use as the 'From' address for outgoing e-mails when
+#. publishing results reports. This address overrides the value set at
+#. portal's 'Mail settings'."
+#: senaite/core/content/senaitesetup.py:260
 msgid "description_senaitesetup_email_from_sample_publication"
 msgstr ""
+"Email для использования в качестве адреса отправителя исходящих писем при "
+"публикации отчётов с результатами. Переопределяет значение, заданное в "
+"настройках почты портала."
 
 #. analysis in results entry view"
-#. Default: "If enabled, a free text field will be displayed close to each analysis in results entry view"
-#: senaite/core/content/senaitesetup.py:642
+#. Default: "If enabled, a free text field will be displayed close to each
+#. analysis in results entry view"
+#: senaite/core/content/senaitesetup.py:641
 msgid "description_senaitesetup_enable_analysis_remarks"
 msgstr ""
+"Если включено, рядом с каждым анализом при вводе результатов будет "
+"отображаться поле свободного текста"
 
 #. Default: "Analysis specifications which are edited directly on the Sample."
-#: senaite/core/content/senaitesetup.py:613
+#: senaite/core/content/senaitesetup.py:612
 msgid "description_senaitesetup_enable_ar_specs"
-msgstr ""
+msgstr "Спецификации анализа, редактируемые непосредственно в образце."
 
 #. 'Reject' option will be displayed in the actions menu."
-#. Default: "Select this to activate the rejection workflow for Samples. A 'Reject' option will be displayed in the actions menu."
-#: senaite/core/content/senaitesetup.py:759
+#. Default: "Select this to activate the rejection workflow for Samples. A
+#. 'Reject' option will be displayed in the actions menu."
+#: senaite/core/content/senaitesetup.py:758
 msgid "description_senaitesetup_enable_rejection_workflow"
 msgstr ""
+"Отметьте, чтобы включить процесс отклонения образцов. В меню действий "
+"появится опция 'Отклонить'."
 
 #. displayed in scientific notation using the letter 'e' to indicate the
 #. exponent. The precision can be configured in individual Analysis Services."
-#. Default: "Result values with at least this number of significant digits are displayed in scientific notation using the letter 'e' to indicate the exponent. The precision can be configured in individual Analysis Services."
-#: senaite/core/content/senaitesetup.py:626
+#. Default: "Result values with at least this number of significant digits are
+#. displayed in scientific notation using the letter 'e' to indicate the
+#. exponent. The precision can be configured in individual Analysis Services."
+#: senaite/core/content/senaitesetup.py:625
 msgid "description_senaitesetup_exponential_format_threshold"
 msgstr ""
+"Значения результатов с числом значащих цифр не менее указанного отображаются"
+" в научной нотации с буквой 'e' для экспоненты. Точность можно настроить для"
+" отдельных услуг анализа."
 
 #. e.g. to enter field results immediately, or lab results, when the automatic
 #. sample reception is activated."
-#. Default: "Allow the user to directly enter results after sample creation, e.g. to enter field results immediately, or lab results, when the automatic sample reception is activated."
-#: senaite/core/content/senaitesetup.py:330
+#. Default: "Allow the user to directly enter results after sample creation,
+#. e.g. to enter field results immediately, or lab results, when the automatic
+#. sample reception is activated."
+#: senaite/core/content/senaitesetup.py:329
 msgid "description_senaitesetup_immediateresultsentry"
 msgstr ""
+"Разрешить пользователю сразу вводить результаты после создания образца, "
+"например для немедленного ввода полевых или лабораторных результатов при "
+"включённом автоматическом приёме образца."
 
 #. a sample. If enabled, the '$reason' placeholder in the sample invalidation
 #. notification email body will be replaced with the entered reason."
-#. Default: "Specify whether providing a reason is mandatory when invalidating a sample. If enabled, the '$reason' placeholder in the sample invalidation notification email body will be replaced with the entered reason."
-#: senaite/core/content/senaitesetup.py:412
+#. Default: "Specify whether providing a reason is mandatory when invalidating
+#. a sample. If enabled, the '$reason' placeholder in the sample invalidation
+#. notification email body will be replaced with the entered reason."
+#: senaite/core/content/senaitesetup.py:411
 msgid "description_senaitesetup_invalidation_reason_required"
 msgstr ""
+"Укажите, обязательно ли указание причины при аннулировании образца. Если "
+"включено, плейсхолдер '$reason' в тексте письма-уведомления об аннулировании"
+" образца будет заменён указанной причиной."
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
-#. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: senaite/core/content/senaitesetup.py:875
+#. Default: "The landing page is shown for non-authenticated users if the
+#. Dashboard is not selected as the default front page. If no landing page is
+#. selected, the default frontpage is displayed."
+#: senaite/core/content/senaitesetup.py:874
 msgid "description_senaitesetup_landing_page"
 msgstr ""
+"Стартовая страница показывается неаутентифицированным пользователям, если "
+"панель управления не выбрана как главная страница по умолчанию. Если "
+"стартовая страница не выбрана, отображается страница по умолчанию."
 
 #. the value set for the field 'Number of samples' on the sample registration
 #. form"
-#. Default: "Maximum number of samples that can be created in accordance with the value set for the field 'Number of samples' on the sample registration form"
-#: senaite/core/content/senaitesetup.py:374
+#. Default: "Maximum number of samples that can be created in accordance with
+#. the value set for the field 'Number of samples' on the sample registration
+#. form"
+#: senaite/core/content/senaitesetup.py:373
 msgid "description_senaitesetup_maxnumberofsamplesadd"
 msgstr ""
+"Максимальное количество образцов, которые можно создать в соответствии со "
+"значением поля 'Количество образцов' формы регистрации"
 
 #. for clients flagged as 'members', normally co-operative members or
 #. associates deserving of this discount"
-#. Default: "The discount percentage entered here, is applied to the prices for clients flagged as 'members', normally co-operative members or associates deserving of this discount"
-#: senaite/core/content/senaitesetup.py:525
+#. Default: "The discount percentage entered here, is applied to the prices
+#. for clients flagged as 'members', normally co-operative members or
+#. associates deserving of this discount"
+#: senaite/core/content/senaitesetup.py:524
 msgid "description_senaitesetup_member_discount"
 msgstr ""
+"Указанный здесь процент скидки применяется к ценам для клиентов с отметкой "
+"'участник' — как правило, для членов кооперативов или партнёров, имеющих "
+"право на эту скидку"
 
 #. acceptable minimum number of results before QC statistics will be
 #. calculated and plotted"
-#. Default: "Using too few data points does not make statistical sense. Set an acceptable minimum number of results before QC statistics will be calculated and plotted"
-#: senaite/core/content/senaitesetup.py:584
+#. Default: "Using too few data points does not make statistical sense. Set an
+#. acceptable minimum number of results before QC statistics will be
+#. calculated and plotted"
+#: senaite/core/content/senaitesetup.py:583
 msgid "description_senaitesetup_minimum_results"
 msgstr ""
+"Использование слишком малого числа точек данных статистически некорректно. "
+"Установите допустимое минимальное количество результатов перед расчётом и "
+"построением статистики контроля качества"
 
 #. considered as 'verified'. This setting can be overrided for any Analysis in
 #. Analysis Service edit view. By default, 1"
-#. Default: "Number of required verifications before a given result being considered as 'verified'. This setting can be overrided for any Analysis in Analysis Service edit view. By default, 1"
-#: senaite/core/content/senaitesetup.py:688
+#. Default: "Number of required verifications before a given result being
+#. considered as 'verified'. This setting can be overrided for any Analysis in
+#. Analysis Service edit view. By default, 1"
+#: senaite/core/content/senaitesetup.py:687
 msgid "description_senaitesetup_number_of_required_verifications"
 msgstr ""
+"Требуемое количество верификаций, прежде чем результат будет считаться "
+"'верифицированным'. Может быть переопределено для конкретного анализа в "
+"услуге анализа. По умолчанию — 1"
 
 #. result reports to the selected recipients. You can use reserved keywords:
 #. $client_name, $recipients, $lab_name, $lab_address"
-#. Default: "Set the email body text to be used by default when sending out result reports to the selected recipients. You can use reserved keywords: $client_name, $recipients, $lab_name, $lab_address"
-#: senaite/core/content/senaitesetup.py:275
+#. Default: "Set the email body text to be used by default when sending out
+#. result reports to the selected recipients. You can use reserved keywords:
+#. $client_name, $recipients, $lab_name, $lab_address"
+#: senaite/core/content/senaitesetup.py:274
 msgid "description_senaitesetup_publication_email_text"
 msgstr ""
+"Задайте текст письма по умолчанию для отправки отчётов с результатами "
+"выбранным получателям. Можно использовать ключевые слова: $client_name, "
+"$recipients, $lab_name, $lab_address"
 
 #. rejecting a sample."
-#. Default: "Enter the predefined rejection reasons that users can select when rejecting a sample."
-#: senaite/core/content/senaitesetup.py:774
+#. Default: "Enter the predefined rejection reasons that users can select when
+#. rejecting a sample."
+#: senaite/core/content/senaitesetup.py:773
 msgid "description_senaitesetup_rejection_reasons"
 msgstr ""
+"Введите предопределённые причины отклонения, которые пользователи смогут "
+"выбрать при отклонении образца."
 
 #. When disabled, analysts and lab clerks can also manage worksheets. Note:
 #. This setting is automatically enabled and locked when worksheet access is
 #. restricted to assigned analysts."
-#. Default: "When enabled, only lab managers can create and manage worksheets. When disabled, analysts and lab clerks can also manage worksheets. Note: This setting is automatically enabled and locked when worksheet access is restricted to assigned analysts."
-#: senaite/core/content/senaitesetup.py:472
+#. Default: "When enabled, only lab managers can create and manage worksheets.
+#. When disabled, analysts and lab clerks can also manage worksheets. Note:
+#. This setting is automatically enabled and locked when worksheet access is
+#. restricted to assigned analysts."
+#: senaite/core/content/senaitesetup.py:471
 msgid "description_senaitesetup_restrict_worksheet_management"
 msgstr ""
+"Если включено, только менеджеры лаборатории могут создавать рабочие листы и "
+"управлять ими. Если отключено, аналитики и лаборанты также могут управлять "
+"рабочими листами. Примечание: этот параметр автоматически включается и "
+"блокируется, когда доступ к рабочим листам ограничен назначенными "
+"аналитиками."
 
 #. are assigned. When disabled, analysts have access to all worksheets."
-#. Default: "When enabled, analysts can only access worksheets to which they are assigned. When disabled, analysts have access to all worksheets."
-#: senaite/core/content/senaitesetup.py:442
+#. Default: "When enabled, analysts can only access worksheets to which they
+#. are assigned. When disabled, analysts have access to all worksheets."
+#: senaite/core/content/senaitesetup.py:441
 msgid "description_senaitesetup_restrict_worksheet_users_access"
 msgstr ""
+"Если включено, аналитики могут получить доступ только к назначенным им "
+"рабочим листам. Если отключено, аналитики имеют доступ ко всем рабочим "
+"листам."
 
 #. Default: "Preferred decimal mark for results"
-#: senaite/core/content/senaitesetup.py:719
+#: senaite/core/content/senaitesetup.py:718
 msgid "description_senaitesetup_results_decimal_mark"
-msgstr ""
+msgstr "Предпочитаемый десятичный разделитель для результатов"
 
 #. sample directly from an existing one via the 'Duplicate' action in the
 #. samples listing. Enabled by default."
-#. Default: "If enabled, users with sufficient privileges can create a sibling sample directly from an existing one via the 'Duplicate' action in the samples listing. Enabled by default."
-#: senaite/core/content/senaitesetup.py:969
+#. Default: "If enabled, users with sufficient privileges can create a sibling
+#. sample directly from an existing one via the 'Duplicate' action in the
+#. samples listing. Enabled by default."
+#: senaite/core/content/senaitesetup.py:968
 msgid "description_senaitesetup_sample_duplicate_enabled"
 msgstr ""
+"Если включено, пользователи с достаточными правами могут создать смежный "
+"образец напрямую из существующего через действие 'Дублировать' в списке "
+"образцов. По умолчанию включено."
 
 #. Default: "Analyses are required for sample registration"
-#: senaite/core/content/senaitesetup.py:351
+#: senaite/core/content/senaitesetup.py:350
 msgid "description_senaitesetup_sampleanalysesrequired"
-msgstr ""
+msgstr "Анализы обязательны для регистрации образца"
 
 #. order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
-#. Default: "Select which columns to display in sample analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:805
+#. Default: "Select which columns to display in sample analysis listings. The
+#. order of selection determines the display order. Unselected columns are
+#. hidden. Leave empty to show all columns in default order."
+#: senaite/core/content/senaitesetup.py:804
 msgid "description_senaitesetup_sampleview_columns_order"
 msgstr ""
+"Выберите столбцы для отображения в списках анализов образца. Порядок выбора "
+"определяет порядок отображения. Невыбранные столбцы скрыты. Оставьте пустым,"
+" чтобы показать все столбцы в порядке по умолчанию."
 
 #. Default: "Preferred scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:571
+#: senaite/core/content/senaitesetup.py:570
 msgid "description_senaitesetup_scientific_notation_report"
-msgstr ""
+msgstr "Предпочитаемый формат научной нотации для отчётов"
 
 #. Default: "Preferred scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:732
+#: senaite/core/content/senaitesetup.py:731
 msgid "description_senaitesetup_scientific_notation_results"
-msgstr ""
+msgstr "Предпочитаемый формат научной нотации для результатов"
 
 #. verify it. This setting only take effect for those users with a role
 #. assigned that allows them to verify results (by default, managers,
 #. labmanagers and verifiers). This setting can be overrided for a given
 #. Analysis in Analysis Service edit view. By default, disabled."
-#. Default: "If enabled, a user who submitted a result will also be able to verify it. This setting only take effect for those users with a role assigned that allows them to verify results (by default, managers, labmanagers and verifiers). This setting can be overrided for a given Analysis in Analysis Service edit view. By default, disabled."
-#: senaite/core/content/senaitesetup.py:670
+#. Default: "If enabled, a user who submitted a result will also be able to
+#. verify it. This setting only take effect for those users with a role
+#. assigned that allows them to verify results (by default, managers,
+#. labmanagers and verifiers). This setting can be overrided for a given
+#. Analysis in Analysis Service edit view. By default, disabled."
+#: senaite/core/content/senaitesetup.py:669
 msgid "description_senaitesetup_self_verification_enabled"
 msgstr ""
+"Если включено, пользователь, отправивший результат, также сможет его "
+"верифицировать. Действует только для пользователей с ролью, позволяющей "
+"верифицировать результаты (по умолчанию — менеджеры, менеджеры лаборатории и"
+" верификаторы). Может быть переопределено для конкретного анализа в услуге "
+"анализа. По умолчанию отключено."
 
 #. page, above the access credentials."
-#. Default: "When selected, the laboratory name will be displayedin the login page, above the access credentials."
-#: senaite/core/content/senaitesetup.py:400
+#. Default: "When selected, the laboratory name will be displayedin the login
+#. page, above the access credentials."
+#: senaite/core/content/senaitesetup.py:399
 msgid "description_senaitesetup_show_lab_name_in_login"
 msgstr ""
+"Если выбрано, название лаборатории будет отображаться на странице входа над "
+"полями учётных данных."
 
 #. deactivated, partitions won't be included in listings and no info message
 #. with links to the primary sample will be displayed to client contacts."
-#. Default: "Select to show sample partitions to client contacts. If deactivated, partitions won't be included in listings and no info message with links to the primary sample will be displayed to client contacts."
-#: senaite/core/content/senaitesetup.py:899
+#. Default: "Select to show sample partitions to client contacts. If
+#. deactivated, partitions won't be included in listings and no info message
+#. with links to the primary sample will be displayed to client contacts."
+#: senaite/core/content/senaitesetup.py:898
 msgid "description_senaitesetup_show_partitions"
 msgstr ""
+"Отметьте, чтобы показывать партиции образца контактам клиента. Если "
+"отключено, партиции не будут включены в списки, и контактам клиента не будет"
+" показано информационное сообщение со ссылками на основной образец."
 
 #. navigation. The order of selection determines the display order in the
 #. sidebar. If none are selected, all folders will be shown in the default
 #. order."
-#. Default: "Select which top-level folders should be displayed in the sidebar navigation. The order of selection determines the display order in the sidebar. If none are selected, all folders will be shown in the default order."
-#: senaite/core/content/senaitesetup.py:914
+#. Default: "Select which top-level folders should be displayed in the sidebar
+#. navigation. The order of selection determines the display order in the
+#. sidebar. If none are selected, all folders will be shown in the default
+#. order."
+#: senaite/core/content/senaitesetup.py:913
 msgid "description_senaitesetup_sidebar_folders"
 msgstr ""
+"Выберите папки верхнего уровня для отображения в боковой навигации. Порядок "
+"выбора определяет порядок отображения. Если ничего не выбрано, отображаются "
+"все папки в порядке по умолчанию."
 
 #. top-level folders, level 2 includes their children, and so on."
-#. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only top-level folders, level 2 includes their children, and so on."
-#: senaite/core/content/senaitesetup.py:933
+#. Default: "Maximum depth of the sidebar navigation tree. Level 1 shows only
+#. top-level folders, level 2 includes their children, and so on."
+#: senaite/core/content/senaitesetup.py:932
 msgid "description_senaitesetup_sidebar_navigation_depth"
 msgstr ""
+"Максимальная глубина дерева боковой навигации. Уровень 1 показывает только "
+"папки верхнего уровня, уровень 2 включает их дочерние элементы и т.д."
 
 #. navigation. If none are selected, all content types will be shown."
-#. Default: "Select which content types should be excluded from the sidebar navigation. If none are selected, all content types will be shown."
-#: senaite/core/content/senaitesetup.py:950
+#. Default: "Select which content types should be excluded from the sidebar
+#. navigation. If none are selected, all content types will be shown."
+#: senaite/core/content/senaitesetup.py:949
 msgid "description_senaitesetup_sidebar_skip_types"
 msgstr ""
+"Выберите типы содержимого, исключаемые из боковой навигации. Если ничего не "
+"выбрано, отображаются все типы."
 
 #. setting can enable/disable verifying/consecutively verifying more than once
 #. for the same user."
-#. Default: "Choose type of multiple verification for the same user. This setting can enable/disable verifying/consecutively verifying more than once for the same user."
-#: senaite/core/content/senaitesetup.py:704
+#. Default: "Choose type of multiple verification for the same user. This
+#. setting can enable/disable verifying/consecutively verifying more than once
+#. for the same user."
+#: senaite/core/content/senaitesetup.py:703
 msgid "description_senaitesetup_type_of_multi_verification"
 msgstr ""
+"Выберите тип многократной верификации для одного пользователя. Этот параметр"
+" включает/отключает повторную верификацию одним и тем же пользователем."
 
 #. system wide but can be overwritten on individual items"
-#. Default: "Enter percentage value eg. 14.0. This percentage is applied system wide but can be overwritten on individual items"
-#: senaite/core/content/senaitesetup.py:542
+#. Default: "Enter percentage value eg. 14.0. This percentage is applied
+#. system wide but can be overwritten on individual items"
+#: senaite/core/content/senaitesetup.py:541
 msgid "description_senaitesetup_vat"
 msgstr ""
+"Введите значение процента, например 14.0. Применяется во всей системе, но "
+"может быть переопределено для отдельных элементов"
 
 #. view. Classic layout displays the Samples in rows and the analyses in
 #. columns. Transposed layout displays the Samples in columns and the analyses
 #. in rows."
-#. Default: "Preferred layout of the results entry table in the Worksheet view. Classic layout displays the Samples in rows and the analyses in columns. Transposed layout displays the Samples in columns and the analyses in rows."
-#: senaite/core/content/senaitesetup.py:846
+#. Default: "Preferred layout of the results entry table in the Worksheet
+#. view. Classic layout displays the Samples in rows and the analyses in
+#. columns. Transposed layout displays the Samples in columns and the analyses
+#. in rows."
+#: senaite/core/content/senaitesetup.py:845
 msgid "description_senaitesetup_worksheet_layout"
 msgstr ""
+"Предпочитаемый макет таблицы ввода результатов в просмотре рабочего листа. "
+"Классический макет отображает образцы в строках, а анализы в столбцах. "
+"Транспонированный макет отображает образцы в столбцах, а анализы в строках."
 
 #. The order of selection determines the display order. Unselected columns are
 #. hidden. Leave empty to show all columns in default order."
-#. Default: "Select which columns to display in worksheet analysis listings. The order of selection determines the display order. Unselected columns are hidden. Leave empty to show all columns in default order."
-#: senaite/core/content/senaitesetup.py:825
+#. Default: "Select which columns to display in worksheet analysis listings.
+#. The order of selection determines the display order. Unselected columns are
+#. hidden. Leave empty to show all columns in default order."
+#: senaite/core/content/senaitesetup.py:824
 msgid "description_senaitesetup_wsview_columns_order"
 msgstr ""
+"Выберите столбцы для отображения в списках анализов рабочего листа. Порядок "
+"выбора определяет порядок отображения. Невыбранные столбцы скрыты. Оставьте "
+"пустым, чтобы показать все столбцы в порядке по умолчанию."
 
 #. Dashboard is not selected as the default front page. If no landing page is
 #. selected, the default frontpage is displayed."
-#. Default: "The landing page is shown for non-authenticated users if the Dashboard is not selected as the default front page. If no landing page is selected, the default frontpage is displayed."
-#: bika/lims/content/bikasetup.py:617
+#. Default: "The landing page is shown for non-authenticated users if the
+#. Dashboard is not selected as the default front page. If no landing page is
+#. selected, the default frontpage is displayed."
+#: bika/lims/content/bikasetup.py:616
 msgid "description_setup_landingpage"
 msgstr ""
+"Стартовая страница показывается неаутентифицированным пользователям, если "
+"панель управления не выбрана как главная страница по умолчанию. Если "
+"стартовая страница не выбрана, отображается страница по умолчанию."
 
 #. Default: "Code for the location"
 #: senaite/core/content/storagelocation.py:106
 msgid "description_storagelocation_location_code"
-msgstr ""
+msgstr "Код местоположения"
 
 #. Default: "Description of the location"
 #: senaite/core/content/storagelocation.py:118
 msgid "description_storagelocation_location_description"
-msgstr ""
+msgstr "Описание местоположения"
 
 #. Default: "Title of location"
 #: senaite/core/content/storagelocation.py:94
 msgid "description_storagelocation_location_title"
-msgstr ""
+msgstr "Название местоположения"
 
 #. Default: "Type of location"
 #: senaite/core/content/storagelocation.py:130
 msgid "description_storagelocation_location_type"
-msgstr ""
+msgstr "Тип местоположения"
 
 #. Default: "Code the the shelf"
 #: senaite/core/content/storagelocation.py:154
 msgid "description_storagelocation_shelf_code"
-msgstr ""
+msgstr "Код стеллажа"
 
 #. Default: "Description of the shelf"
 #: senaite/core/content/storagelocation.py:166
 msgid "description_storagelocation_shelf_description"
-msgstr ""
+msgstr "Описание стеллажа"
 
 #. Default: "Title of the shelf"
 #: senaite/core/content/storagelocation.py:142
 msgid "description_storagelocation_shelf_title"
-msgstr ""
+msgstr "Название стеллажа"
 
 #. Default: "Code for the site"
 #: senaite/core/content/storagelocation.py:70
 msgid "description_storagelocation_site_code"
-msgstr ""
+msgstr "Код площадки"
 
 #. Default: "Description of the site"
 #: senaite/core/content/storagelocation.py:82
 msgid "description_storagelocation_site_description"
-msgstr ""
+msgstr "Описание площадки"
 
 #. Default: "Title of the site"
 #: senaite/core/content/storagelocation.py:58
 msgid "description_storagelocation_site_title"
-msgstr ""
+msgstr "Название площадки"
 
 #. Duplicate values are ordered alphabetically."
-#. Default: "Float value from 0.0 - 1000.0 indicating the sort order. Duplicate values are ordered alphabetically."
+#. Default: "Float value from 0.0 - 1000.0 indicating the sort order.
+#. Duplicate values are ordered alphabetically."
 #: senaite/core/content/subgroup.py:60
 msgid "description_subgroup_sort_key"
 msgstr ""
+"Число с плавающей точкой от 0.0 до 1000.0, задающее порядок сортировки. "
+"Повторяющиеся значения сортируются по алфавиту."
 
 #. Default: "International Bank Account Number"
 #: senaite/core/content/supplier.py:100
 msgid "description_supplier_iban"
-msgstr ""
+msgstr "Международный номер банковского счёта (IBAN)"
 
 #. Default: "National Identification Bank Account Number"
 #: senaite/core/content/supplier.py:88
 msgid "description_supplier_nib"
-msgstr ""
+msgstr "Национальный идентификационный номер банковского счёта (NIB)"
 
 #. contact profile."
-#. Default: "User is linked to a contact. Please change your settings in the contact profile."
+#. Default: "User is linked to a contact. Please change your settings in the
+#. contact profile."
 #: senaite/core/browser/user/userdatapanel.py:82
 msgid "description_user_contact"
 msgstr ""
+"Пользователь связан с контактом. Измените настройки в профиле контакта."
 
 #. Default: "Select the preferred instrument"
 #: senaite/core/content/worksheettemplate.py:266
 msgid "description_worksheettemplate_instrument"
-msgstr ""
+msgstr "Выберите предпочитаемый инструмент"
 
 #. with the selected method.<br/>In order to apply this change to the services
 #. list, you should save the change first."
-#. Default: "Restrict the available analysis services and instruments to those with the selected method.<br/>In order to apply this change to the services list, you should save the change first."
+#. Default: "Restrict the available analysis services and instruments to those
+#. with the selected method.<br/>In order to apply this change to the services
+#. list, you should save the change first."
 #: senaite/core/content/worksheettemplate.py:240
 msgid "description_worksheettemplate_restrict_to_method"
 msgstr ""
+"Ограничить доступные услуги анализа и инструменты теми, что связаны с "
+"выбранным методом.<br/>Чтобы применить это изменение к списку услуг, сначала"
+" сохраните изменение."
 
 #. Default: "Select which Analyses should be included on the Worksheet"
 #: senaite/core/content/worksheettemplate.py:350
 msgid "description_worksheettemplate_services"
-msgstr ""
+msgstr "Выберите анализы, включаемые в рабочий лист"
 
 #. specific instrument's tray size. Then select an Analysis 'type' per
 #. Worksheet position. Where QC samples are selected, also select which
 #. Reference Sample should be used. If a duplicate analysis is selected,
 #. indicate which sample position it should be a duplicate of"
-#. Default: "Specify the size of the Worksheet, e.g. corresponding to a specific instrument's tray size. Then select an Analysis 'type' per Worksheet position. Where QC samples are selected, also select which Reference Sample should be used. If a duplicate analysis is selected, indicate which sample position it should be a duplicate of"
+#. Default: "Specify the size of the Worksheet, e.g. corresponding to a
+#. specific instrument's tray size. Then select an Analysis 'type' per
+#. Worksheet position. Where QC samples are selected, also select which
+#. Reference Sample should be used. If a duplicate analysis is selected,
+#. indicate which sample position it should be a duplicate of"
 #: senaite/core/content/worksheettemplate.py:315
 msgid "description_worksheettemplate_template_layout"
 msgstr ""
+"Укажите размер рабочего листа, например, соответствующий размеру лотка "
+"конкретного инструмента. Затем выберите 'тип' анализа для каждой позиции "
+"рабочего листа. Если выбраны образцы контроля качества, также выберите "
+"используемый референс-образец. Если выбран дублирующий анализ, укажите, "
+"дубликатом какой позиции образца он является"
 
 #. Default: "Not found Analysis position for duplicate."
 #: senaite/core/browser/form/adapters/worksheettemplate.py:114
 msgid "duplicate_reference_not_found"
-msgstr ""
+msgstr "Не найдена позиция анализа для дубликата."
 
 #. routine analysis."
-#. Default: "Duplicate in position ${dup} references this, so it must be a routine analysis."
+#. Default: "Duplicate in position ${dup} references this, so it must be a
+#. routine analysis."
 #: senaite/core/browser/form/adapters/worksheettemplate.py:164
 msgid "duplicate_reference_this_position"
 msgstr ""
+"Дубликат в позиции ${dup} ссылается на это, поэтому это должен быть плановый"
+" анализ."
 
 #. Default: "${days} days"
 #: senaite/core/z3cform/widgets/duration/display.pt:19
 msgid "duration_widget_days_number"
-msgstr ""
+msgstr "${days} дн."
 
 #. Default: "${hours} hours"
 #: senaite/core/z3cform/widgets/duration/display.pt:24
 msgid "duration_widget_hours_number"
-msgstr ""
+msgstr "${hours} ч."
 
 #. Default: "Days"
 #: senaite/core/z3cform/widgets/duration/input.pt:20
 msgid "duration_widget_label_days"
-msgstr ""
+msgstr "Дни"
 
 #. Default: "Hours"
 #: senaite/core/z3cform/widgets/duration/input.pt:30
 msgid "duration_widget_label_hours"
-msgstr ""
+msgstr "Часы"
 
 #. Default: "Minutes"
 #: senaite/core/z3cform/widgets/duration/input.pt:40
 msgid "duration_widget_label_minutes"
-msgstr ""
+msgstr "Минуты"
 
 #. Default: "Seconds"
 #: senaite/core/z3cform/widgets/duration/input.pt:50
 msgid "duration_widget_label_seconds"
-msgstr ""
+msgstr "Секунды"
 
 #. Default: "${minutes} minutes"
 #: senaite/core/z3cform/widgets/duration/display.pt:29
 msgid "duration_widget_minutes_number"
-msgstr ""
+msgstr "${minutes} мин."
 
 #. Default: "${seconds} seconds"
 #: senaite/core/z3cform/widgets/duration/display.pt:34
 msgid "duration_widget_seconds_number"
-msgstr ""
+msgstr "${seconds} сек."
 
 #. Default: "Contents of the file"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:44
 msgid "dynamic_analysisspec_description"
-msgstr ""
-
-#: senaite/core/api/remarks.py:481
-msgid "edited"
-msgstr ""
+msgstr "Содержимое файла"
 
 #. ${record_index}' (${num_samples}) is above ${max_num_samples}"
-#. Default: "The number of samples to create for the record 'Sample ${record_index}' (${num_samples}) is above ${max_num_samples}"
+#. Default: "The number of samples to create for the record 'Sample
+#. ${record_index}' (${num_samples}) is above ${max_num_samples}"
 #: bika/lims/browser/analysisrequest/add2.py:2081
 msgid "error_analyssirequest_numsamples_above_max"
 msgstr ""
+"Количество создаваемых образцов для записи 'Образец ${record_index}' "
+"(${num_samples}) превышает ${max_num_samples}"
 
 #. Default: "${name} is after ${max_date}, please correct."
 #: senaite/core/browser/fields/datetime.py:120
 msgid "error_datetime_after_max"
-msgstr ""
+msgstr "${name} позже ${max_date}, исправьте."
 
 #. Default: "${name} is before ${min_date}, please correct."
 #: senaite/core/browser/fields/datetime.py:94
 msgid "error_datetime_before_min"
-msgstr ""
+msgstr "${name} раньше ${min_date}, исправьте."
 
 #. Default: "Unable to load the template"
 #: senaite/core/browser/worksheets/worksheet/printview.py:155
 msgid "error_load_template_worksheet"
-msgstr ""
+msgstr "Не удалось загрузить шаблон"
 
 #. Default: "Location"
 #: senaite/core/content/samplepoint.py:48
 msgid "fieldset_samplepoint_location"
-msgstr ""
+msgstr "Местоположение"
 
 #. Default: "Analyses"
 #: senaite/core/content/sampletemplate.py:152
 msgid "fieldset_sampletemplate_analyses"
-msgstr ""
+msgstr "Анализы"
 
 #. Default: "Partitions"
 #: senaite/core/content/sampletemplate.py:141
 msgid "fieldset_sampletemplate_partitions"
-msgstr ""
+msgstr "Партиции"
 
 #. Default: "Validation chain internal error: ${error}"
 #: senaite/core/validators/formula.py:121
 msgid "formula_validation_chain_error"
-msgstr ""
+msgstr "Внутренняя ошибка цепочки проверки: ${error}"
 
 #. Default: "cryogenic / inert gas"
 #: senaite/core/vocabularies/hazard_categories.py:167
 msgid "hazard_ASPH01_common"
-msgstr ""
+msgstr "криогенный / инертный газ"
 
 #. Default: "Asphyxiating atmosphere"
 #: senaite/core/vocabularies/hazard_categories.py:165
 msgid "hazard_ASPH01_name"
-msgstr ""
+msgstr "Удушающая атмосфера"
 
 #. Default: "infectious / biological"
 #: senaite/core/vocabularies/hazard_categories.py:104
 msgid "hazard_BIO01_common"
-msgstr ""
+msgstr "инфекционный / биологический"
 
 #. Default: "Biohazard"
 #: senaite/core/vocabularies/hazard_categories.py:103
 msgid "hazard_BIO01_name"
-msgstr ""
+msgstr "Биологическая опасность"
 
 #. Default: "freezing / cold storage"
 #: senaite/core/vocabularies/hazard_categories.py:158
 msgid "hazard_COLD01_common"
-msgstr ""
+msgstr "заморозка / холодное хранение"
 
 #. Default: "Low temperature"
 #: senaite/core/vocabularies/hazard_categories.py:157
 msgid "hazard_COLD01_name"
-msgstr ""
+msgstr "Низкая температура"
 
 #. Default: "electric shock"
 #: senaite/core/vocabularies/hazard_categories.py:132
 msgid "hazard_ELEC01_common"
-msgstr ""
+msgstr "поражение электрическим током"
 
 #. Default: "Electricity"
 #: senaite/core/vocabularies/hazard_categories.py:131
 msgid "hazard_ELEC01_name"
-msgstr ""
+msgstr "Электричество"
 
 #. Default: "explosive"
 #: senaite/core/vocabularies/hazard_categories.py:48
 msgid "hazard_GHS01_common"
-msgstr ""
+msgstr "взрывоопасно"
 
 #. Default: "Explosive"
 #: senaite/core/vocabularies/hazard_categories.py:47
 msgid "hazard_GHS01_name"
-msgstr ""
+msgstr "Взрывчатое вещество"
 
 #. Default: "flammable"
 #: senaite/core/vocabularies/hazard_categories.py:54
 msgid "hazard_GHS02_common"
-msgstr ""
+msgstr "легковоспламеняющееся"
 
 #. Default: "Flammable"
 #: senaite/core/vocabularies/hazard_categories.py:53
 msgid "hazard_GHS02_name"
-msgstr ""
+msgstr "Легковоспламеняющееся"
 
 #. Default: "oxidizing"
 #: senaite/core/vocabularies/hazard_categories.py:60
 msgid "hazard_GHS03_common"
-msgstr ""
+msgstr "окисляющее"
 
 #. Default: "Oxidizing"
 #: senaite/core/vocabularies/hazard_categories.py:59
 msgid "hazard_GHS03_name"
-msgstr ""
+msgstr "Окисляющее вещество"
 
 #. Default: "pressurised gas"
 #: senaite/core/vocabularies/hazard_categories.py:66
 msgid "hazard_GHS04_common"
-msgstr ""
+msgstr "газ под давлением"
 
 #. Default: "Compressed gas"
 #: senaite/core/vocabularies/hazard_categories.py:65
 msgid "hazard_GHS04_name"
-msgstr ""
+msgstr "Сжатый газ"
 
 #. Default: "acid / caustic"
 #: senaite/core/vocabularies/hazard_categories.py:72
 msgid "hazard_GHS05_common"
-msgstr ""
+msgstr "кислота / едкое вещество"
 
 #. Default: "Corrosive"
 #: senaite/core/vocabularies/hazard_categories.py:71
 msgid "hazard_GHS05_name"
-msgstr ""
+msgstr "Коррозийное вещество"
 
 #. Default: "poisonous"
 #: senaite/core/vocabularies/hazard_categories.py:78
 msgid "hazard_GHS06_common"
-msgstr ""
+msgstr "ядовитое"
 
 #. Default: "Acute toxicity"
 #: senaite/core/vocabularies/hazard_categories.py:77
 msgid "hazard_GHS06_name"
-msgstr ""
+msgstr "Острая токсичность"
 
 #. Default: "harmful / irritant"
 #: senaite/core/vocabularies/hazard_categories.py:84
 msgid "hazard_GHS07_common"
-msgstr ""
+msgstr "вредное / раздражающее"
 
 #. Default: "Health hazard"
 #: senaite/core/vocabularies/hazard_categories.py:83
 msgid "hazard_GHS07_name"
-msgstr ""
+msgstr "Опасно для здоровья"
 
 #. Default: "carcinogenic / mutagenic"
 #: senaite/core/vocabularies/hazard_categories.py:90
 msgid "hazard_GHS08_common"
-msgstr ""
+msgstr "канцерогенное / мутагенное"
 
 #. Default: "Serious health hazard"
 #: senaite/core/vocabularies/hazard_categories.py:89
 msgid "hazard_GHS08_name"
-msgstr ""
+msgstr "Серьёзная опасность для здоровья"
 
 #. Default: "environmentally hazardous"
 #: senaite/core/vocabularies/hazard_categories.py:97
 msgid "hazard_GHS09_common"
-msgstr ""
+msgstr "опасно для окружающей среды"
 
 #. Default: "Environmental hazard"
 #: senaite/core/vocabularies/hazard_categories.py:96
 msgid "hazard_GHS09_name"
-msgstr ""
+msgstr "Экологическая опасность"
 
 #. Default: "heated material"
 #: senaite/core/vocabularies/hazard_categories.py:145
 msgid "hazard_HOT01_common"
-msgstr ""
+msgstr "нагретый материал"
 
 #. Default: "Hot content"
 #: senaite/core/vocabularies/hazard_categories.py:144
 msgid "hazard_HOT01_name"
-msgstr ""
+msgstr "Горячее содержимое"
 
 #. Default: "hot to touch"
 #: senaite/core/vocabularies/hazard_categories.py:139
 msgid "hazard_HSURF01_common"
-msgstr ""
+msgstr "горячо на ощупь"
 
 #. Default: "Hot surface"
 #: senaite/core/vocabularies/hazard_categories.py:138
 msgid "hazard_HSURF01_name"
-msgstr ""
+msgstr "Горячая поверхность"
 
 #. Default: "NMR / MRI"
 #: senaite/core/vocabularies/hazard_categories.py:125
 msgid "hazard_MAG01_common"
-msgstr ""
+msgstr "ЯМР / МРТ"
 
 #. Default: "Magnetic field"
 #: senaite/core/vocabularies/hazard_categories.py:124
 msgid "hazard_MAG01_name"
-msgstr ""
+msgstr "Магнитное поле"
 
 #. Default: "UV / laser / RF"
 #: senaite/core/vocabularies/hazard_categories.py:118
 msgid "hazard_NIR01_common"
-msgstr ""
+msgstr "УФ / лазер / РЧ"
 
 #. Default: "Non-ionising radiation"
 #: senaite/core/vocabularies/hazard_categories.py:117
 msgid "hazard_NIR01_name"
-msgstr ""
+msgstr "Неионизирующее излучение"
 
 #. Default: "ionising radiation"
 #: senaite/core/vocabularies/hazard_categories.py:112
 msgid "hazard_RAD01_common"
-msgstr ""
+msgstr "ионизирующее излучение"
 
 #. Default: "Radioactive"
 #: senaite/core/vocabularies/hazard_categories.py:111
 msgid "hazard_RAD01_name"
-msgstr ""
+msgstr "Радиоактивно"
 
 #. Default: "autoclave / sterilisation"
 #: senaite/core/vocabularies/hazard_categories.py:151
 msgid "hazard_STEAM01_common"
-msgstr ""
+msgstr "автоклав / стерилизация"
 
 #. Default: "Hot steam"
 #: senaite/core/vocabularies/hazard_categories.py:150
 msgid "hazard_STEAM01_name"
-msgstr ""
+msgstr "Горячий пар"
 
 #. Default: "Hazardous"
 #: senaite/core/api/hazard.py:37
 msgid "hazard_warning_label"
-msgstr ""
+msgstr "Опасно"
 
 #. Default: "Legacy Setup"
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:16
 msgid "heading_legacy_setup"
-msgstr ""
+msgstr "Устаревшие настройки"
 
 #. Default: "Re-enter the password. Make sure the passwords are identical."
 #: senaite/core/browser/user/passwordpanel.py:44
 msgid "help_confirm_password"
-msgstr ""
+msgstr "Введите пароль повторно. Убедитесь, что пароли совпадают."
 
 #. Default: "Enter full name, e.g. John Smith."
 #: senaite/core/browser/user/userdatapanel.py:65
 msgid "help_full_name_creation"
-msgstr ""
+msgstr "Введите полное имя, например Иван Иванов."
 
 #. Default: "Enter your new password."
 #: senaite/core/browser/user/passwordpanel.py:37
 msgid "help_new_password"
-msgstr ""
+msgstr "Введите новый пароль."
 
 #. Default: "Your time zone"
 #: senaite/core/browser/user/personalpreferences.py:39
 msgid "help_timezone"
-msgstr ""
+msgstr "Ваш часовой пояс"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:285
 msgid "hours"
-msgstr ""
+msgstr "часов"
 
 #. Default: "'${function}' not found in module '${module}'"
 #: senaite/core/validators/imports.py:66
 msgid "importable_function_error"
-msgstr ""
+msgstr "'${function}' не найдена в модуле '${module}'"
 
 #. Default: "Could not import module '${module}'"
 #: senaite/core/validators/imports.py:49
 msgid "importable_module_error"
-msgstr ""
+msgstr "Не удалось импортировать модуль '${module}'"
 
 #: bika/lims/browser/publish/templates/email.pt:189
 msgid "in"
-msgstr ""
+msgstr "в"
 
 #. Default: "Instrument exporter not found"
 #: senaite/core/browser/worksheets/worksheet/export.py:66
 msgid "instrument_exporter_not_found_message"
-msgstr ""
+msgstr "Экспортёр инструмента не найден"
 
 #. Default: "Interim field ${row_num}: ${message}"
 #: senaite/core/validators/interimfields.py:299
 msgid "interim_field_error"
-msgstr ""
+msgstr "Промежуточное поле ${row_num}: ${message}"
 
 #. Default: "Validation chain internal error: ${error}"
 #: senaite/core/validators/interimfields.py:278
 msgid "interims_validation_chain_error"
-msgstr ""
+msgstr "Внутренняя ошибка цепочки проверки: ${error}"
 
 #. Default: "'${field_name}' contains invalid characters"
 #: senaite/core/validators/interimfields.py:68
 msgid "invalid_characters_validator_error"
-msgstr ""
+msgstr "'${field_name}' содержит недопустимые символы"
 
 #. Default: "AnalysesServices not found for keywords: ${keywords}"
 #: senaite/core/validators/formula.py:92
 msgid "invalid_keyword_error"
-msgstr ""
+msgstr "Не найдены услуги анализа для ключевых слов: ${keywords}"
 
 #. Default: "Invalid wildcards found: ${wildcards}"
 #: senaite/core/validators/formula.py:71
 msgid "invalid_wildcards_check_error"
-msgstr ""
+msgstr "Обнаружены неверные шаблоны подстановки: ${wildcards}"
 
 #. Default: "Labels"
-#: senaite/core/behaviors/label.py:125
+#: senaite/core/behaviors/label.py:117
 msgid "label_Labels"
-msgstr ""
+msgstr "Метки"
 
 #. Default: "Add to the following groups:"
 #: senaite/core/browser/clients/client/contacts/templates/login_details.pt:276
 msgid "label_add_to_groups"
-msgstr ""
+msgstr "Добавить в следующие группы:"
 
 #. Default: "Address"
 #: senaite/core/content/person.py:197
 msgid "label_address"
-msgstr ""
+msgstr "Адрес"
 
 #. Default: "Analysis Category"
 #: bika/lims/content/abstractbaseanalysis.py:530
 msgid "label_analysis_category"
-msgstr ""
+msgstr "Категория анализа"
 
 #. Default: "Department"
 #: bika/lims/content/abstractbaseanalysis.py:588
 msgid "label_analysis_department"
-msgstr ""
+msgstr "Подразделение"
 
 #. of a parameter that can be reliably detected by a specified testing
 #. methodology with a defined level of confidence. Results below this
 #. threshold are typically reported as '< LLOD' (or 'Not Detected'),
 #. indicating that the parameter's concentration, if present, is below the
 #. detection capability of the method at a reliable level."
-#. Default: "The Lower Limit of Detection (LLOD) is the lowest concentration of a parameter that can be reliably detected by a specified testing methodology with a defined level of confidence. Results below this threshold are typically reported as '< LLOD' (or 'Not Detected'), indicating that the parameter's concentration, if present, is below the detection capability of the method at a reliable level."
+#. Default: "The Lower Limit of Detection (LLOD) is the lowest concentration
+#. of a parameter that can be reliably detected by a specified testing
+#. methodology with a defined level of confidence. Results below this
+#. threshold are typically reported as '< LLOD' (or 'Not Detected'),
+#. indicating that the parameter's concentration, if present, is below the
+#. detection capability of the method at a reliable level."
 #: bika/lims/content/abstractbaseanalysis.py:207
 msgid "label_analysis_lower_limit_of_detection_description"
 msgstr ""
+"Нижний предел обнаружения (LLOD) — минимальная концентрация параметра, "
+"которая может быть достоверно обнаружена указанной методикой испытания с "
+"определённым уровнем доверия. Результаты ниже этого порога обычно "
+"указываются как '< LLOD' (или 'Не обнаружено'), означая, что концентрация "
+"параметра, если она присутствует, ниже надёжного предела обнаружения метода."
 
 #. Default: "Lower Limit of Detection (LLOD)"
 #: bika/lims/content/abstractbaseanalysis.py:203
 msgid "label_analysis_lower_limit_of_detection_title"
-msgstr ""
+msgstr "Нижний предел обнаружения (LLOD)"
 
 #. concentration of a parameter that can be reliably and accurately measured
 #. using the specified testing methodology, with acceptable levels of
@@ -9042,35 +10190,46 @@ msgstr ""
 #. confidence and are typically reported as '< LOQ' (or 'Detected but < LOQ'),
 #. indicating that while the parameter may be present, its exact concentration
 #. cannot be determined reliably."
-#. Default: "The Lower Limit of Quantification (LLOQ) is the lowest concentration of a parameter that can be reliably and accurately measured using the specified testing methodology, with acceptable levels of precision and accuracy. Results below this value cannot be quantified with confidence and are typically reported as '< LOQ' (or 'Detected but < LOQ'), indicating that while the parameter may be present, its exact concentration cannot be determined reliably."
+#. Default: "The Lower Limit of Quantification (LLOQ) is the lowest
+#. concentration of a parameter that can be reliably and accurately measured
+#. using the specified testing methodology, with acceptable levels of
+#. precision and accuracy. Results below this value cannot be quantified with
+#. confidence and are typically reported as '< LOQ' (or 'Detected but < LOQ'),
+#. indicating that while the parameter may be present, its exact concentration
+#. cannot be determined reliably."
 #: bika/lims/content/abstractbaseanalysis.py:231
 msgid "label_analysis_lower_limit_of_quantification_description"
 msgstr ""
+"Нижний предел количественного определения (LLOQ) — минимальная концентрация "
+"параметра, которая может быть достоверно и точно измерена указанной "
+"методикой с приемлемой точностью. Результаты ниже этого значения не могут "
+"быть достоверно определены количественно и обычно указываются как '< LOQ' "
+"(или 'Обнаружено, но < LOQ')."
 
 #. Default: "Lower Limit Of Quantification (LLOQ)"
 #: bika/lims/content/abstractbaseanalysis.py:227
 msgid "label_analysis_lower_limit_of_quantification_title"
-msgstr ""
+msgstr "Нижний предел количественного определения (LLOQ)"
 
 #. Default: "Maximum holding time"
 #: bika/lims/content/abstractbaseanalysis.py:453
 msgid "label_analysis_maxholdingtime"
-msgstr ""
+msgstr "Максимальный срок хранения"
 
 #. Default: "Sorting criteria"
-#: bika/lims/content/abstractbaseanalysis.py:769
+#: bika/lims/content/abstractbaseanalysis.py:766
 msgid "label_analysis_results_options_sorting"
-msgstr ""
+msgstr "Критерий сортировки"
 
 #. Default: "Default Unit"
 #: bika/lims/content/abstractbaseanalysis.py:108
 msgid "label_analysis_unit"
-msgstr ""
+msgstr "Единица измерения по умолчанию"
 
 #. Default: "Units for Selection"
 #: bika/lims/content/abstractbaseanalysis.py:158
 msgid "label_analysis_unitchoices"
-msgstr ""
+msgstr "Единицы измерения для выбора"
 
 #. of a parameter that can be reliably measured using a specified testing
 #. methodology. Beyond this limit, results may no longer be accurate or valid
@@ -9078,2418 +10237,2410 @@ msgstr ""
 #. exceeding this threshold are typically reported as '> ULOD', indicating
 #. that the parameter's concentration is above the reliable detection range of
 #. the method."
-#. Default: "The Upper Limit of Detection (ULOD) is the highest concentration of a parameter that can be reliably measured using a specified testing methodology. Beyond this limit, results may no longer be accurate or valid due to instrument saturation or methodological limitations. Results exceeding this threshold are typically reported as '> ULOD', indicating that the parameter's concentration is above the reliable detection range of the method."
+#. Default: "The Upper Limit of Detection (ULOD) is the highest concentration
+#. of a parameter that can be reliably measured using a specified testing
+#. methodology. Beyond this limit, results may no longer be accurate or valid
+#. due to instrument saturation or methodological limitations. Results
+#. exceeding this threshold are typically reported as '> ULOD', indicating
+#. that the parameter's concentration is above the reliable detection range of
+#. the method."
 #: bika/lims/content/abstractbaseanalysis.py:277
 msgid "label_analysis_upper_limit_of_detection_description"
 msgstr ""
+"Верхний предел обнаружения (ULOD) — максимальная концентрация параметра, "
+"которая может быть достоверно измерена указанной методикой. Выше этого "
+"предела результаты могут быть неточными из-за насыщения прибора или "
+"методологических ограничений. Результаты, превышающие этот порог, обычно "
+"указываются как '> ULOD'."
 
 #. Default: "Upper Limit of Detection (ULOD)"
 #: bika/lims/content/abstractbaseanalysis.py:274
 msgid "label_analysis_upper_limit_of_detection_title"
-msgstr ""
+msgstr "Верхний предел обнаружения (ULOD)"
 
 #. concentration of a parameter that can be reliably and accurately measured
 #. using the specified testing methodology, with acceptable levels of
 #. precision and accuracy. Results above this value cannot be quantified with
 #. confidence and are typically reported as '> ULOQ', indicating that its
 #. exact concentration cannot be determined reliably."
-#. Default: "The Upper Limit of Quantification (ULOQ) is the highest concentration of a parameter that can be reliably and accurately measured using the specified testing methodology, with acceptable levels of precision and accuracy. Results above this value cannot be quantified with confidence and are typically reported as '> ULOQ', indicating that its exact concentration cannot be determined reliably."
+#. Default: "The Upper Limit of Quantification (ULOQ) is the highest
+#. concentration of a parameter that can be reliably and accurately measured
+#. using the specified testing methodology, with acceptable levels of
+#. precision and accuracy. Results above this value cannot be quantified with
+#. confidence and are typically reported as '> ULOQ', indicating that its
+#. exact concentration cannot be determined reliably."
 #: bika/lims/content/abstractbaseanalysis.py:255
 msgid "label_analysis_upper_limit_of_quantification_description"
 msgstr ""
+"Верхний предел количественного определения (ULOQ) — максимальная "
+"концентрация параметра, которая может быть достоверно и точно измерена "
+"указанной методикой. Результаты выше этого значения не могут быть достоверно"
+" определены количественно и обычно указываются как '> ULOQ'."
 
 #. Default: "Upper Limit Of Quantification (ULOQ)"
 #: bika/lims/content/abstractbaseanalysis.py:252
 msgid "label_analysis_upper_limit_of_quantification_title"
-msgstr ""
+msgstr "Верхний предел количественного определения (ULOQ)"
 
 #. Default: "Sample types"
 #: senaite/core/content/analysisprofile.py:180
 msgid "label_analysisprofile_sampletypes"
-msgstr ""
+msgstr "Типы образца"
 
 #. Default: "Number of samples"
 #: bika/lims/content/analysisrequest.py:1437
 msgid "label_analysisrequest_numsamples"
-msgstr ""
+msgstr "Количество образцов"
 
 #. Default: "Dynamic Analysis Specification"
 #: bika/lims/content/analysisspec.py:69
 msgid "label_analysisspec_dynamicspec"
-msgstr ""
+msgstr "Динамическая спецификация анализа"
 
 #. Default: "Sample Type"
 #: bika/lims/content/analysisspec.py:49
 msgid "label_analysisspec_sampletype"
-msgstr ""
+msgstr "Тип образца"
 
 #. Default: "Contained Samples"
 #: bika/lims/content/arreport.py:79
 msgid "label_arreport_contained_samples"
-msgstr ""
+msgstr "Содержащиеся образцы"
 
 #. Default: "Primary Sample"
 #: bika/lims/content/arreport.py:49
 msgid "label_arreport_sample"
-msgstr ""
+msgstr "Основной образец"
 
 #. Default: "Analysis Profile"
 #: bika/lims/content/artemplate.py:254
 msgid "label_artemplate_profile"
-msgstr ""
+msgstr "Профиль анализа"
 
 #. Default: "Sample Point"
 #: bika/lims/content/artemplate.py:55
 msgid "label_artemplate_samplepoint"
-msgstr ""
+msgstr "Точка отбора проб"
 
 #. Default: "Sample Type"
 #: bika/lims/content/artemplate.py:86
 msgid "label_artemplate_sampletype"
-msgstr ""
+msgstr "Тип образца"
 
 #. Default: "Attachment Type"
 #: bika/lims/content/attachment.py:61
 msgid "label_attachment_type"
-msgstr ""
+msgstr "Тип вложения"
 
 #. Default: "Instrument"
 #: bika/lims/content/autoimportlog.py:50
 msgid "label_autoimportlog_instrument"
-msgstr ""
+msgstr "Инструмент"
 
 #. Default: "Log Time"
 #: bika/lims/content/autoimportlog.py:87
 msgid "label_autoimportlog_logtime"
-msgstr ""
+msgstr "Время журнала"
 
 #. Default: "Results"
 #: bika/lims/content/autoimportlog.py:74
 msgid "label_autoimportlog_results"
-msgstr ""
+msgstr "Результаты"
 
 #. Default: "Client"
 #: bika/lims/content/batch.py:78
 msgid "label_batch_client"
-msgstr ""
+msgstr "Клиент"
 
 #. Default: "Allow to set the result capture date"
-#: bika/lims/content/bikasetup.py:395
+#: bika/lims/content/bikasetup.py:394
 msgid "label_bikasetup_allow_manual_result_capture_date"
-msgstr ""
+msgstr "Разрешить устанавливать дату фиксации результата"
 
 #. Default: "Always send publication email to responsibles"
-#: bika/lims/content/bikasetup.py:851
+#: bika/lims/content/bikasetup.py:850
 msgid "label_bikasetup_always_cc_responsibles_in_report_emails"
-msgstr ""
+msgstr "Всегда отправлять письмо о публикации ответственным"
 
 #. Default: "Categorize sample analyses"
-#: bika/lims/content/bikasetup.py:367
+#: bika/lims/content/bikasetup.py:366
 msgid "label_bikasetup_categorizesampleanalyses"
-msgstr ""
+msgstr "Категоризировать анализы образца"
 
 #. Default: "Date sampled required"
-#: bika/lims/content/bikasetup.py:686
+#: bika/lims/content/bikasetup.py:685
 msgid "label_bikasetup_date_sampled_required"
-msgstr ""
+msgstr "Дата отбора обязательна"
 
 #. Default: "Email body for Sample publication notifications"
-#: bika/lims/content/bikasetup.py:827
+#: bika/lims/content/bikasetup.py:826
 msgid "label_bikasetup_email_body_sample_publication"
-msgstr ""
+msgstr "Текст письма для уведомлений о публикации образца"
 
 #. Default: "Publication 'From' address"
-#: bika/lims/content/bikasetup.py:802
+#: bika/lims/content/bikasetup.py:801
 msgid "label_bikasetup_email_from_sample_publication"
-msgstr ""
+msgstr "Адрес отправителя публикации"
 
 #. Default: "Immediate results entry"
-#: bika/lims/content/bikasetup.py:442
+#: bika/lims/content/bikasetup.py:441
 msgid "label_bikasetup_immediateresultsentry"
-msgstr ""
+msgstr "Немедленный ввод результатов"
 
 #. Default: "Email body for Sample Invalidation notifications"
-#: bika/lims/content/bikasetup.py:943
+#: bika/lims/content/bikasetup.py:942
 msgid "label_bikasetup_invalidation_email_body"
-msgstr ""
+msgstr "Текст письма для уведомлений об аннулировании образца"
 
 #. Default: "Invalidation reason required"
-#: bika/lims/content/bikasetup.py:910
+#: bika/lims/content/bikasetup.py:909
 msgid "label_bikasetup_invalidation_reason_required"
-msgstr ""
+msgstr "Причина аннулирования обязательна"
 
 #. Default: "Require sample analyses"
-#: bika/lims/content/bikasetup.py:381
+#: bika/lims/content/bikasetup.py:380
 msgid "label_bikasetup_sampleanalysesrequired"
-msgstr ""
+msgstr "Требовать анализы образца"
 
 #. Default: "DependentServices"
 #: senaite/core/content/calculation.py:352
 msgid "label_calculation_dependent_services"
-msgstr ""
+msgstr "Зависимые услуги"
 
 #. Default: "Dependent services"
 #: bika/lims/content/calculation.py:81
 msgid "label_calculation_dependentservices"
-msgstr ""
+msgstr "Зависимые услуги"
 
 #. Default: "Calculation Formula"
 #: senaite/core/content/calculation.py:287
 msgid "label_calculation_formula"
-msgstr ""
+msgstr "Формула расчёта"
 
 #. Default: "Function"
 #: senaite/core/content/calculation.py:185
 msgid "label_calculation_import_function_name"
-msgstr ""
+msgstr "Функция"
 
 #. Default: "Module"
 #: senaite/core/content/calculation.py:179
 msgid "label_calculation_import_module_name"
-msgstr ""
+msgstr "Модуль"
 
 #. Default: "Additional Python Libraries"
 #: senaite/core/content/calculation.py:266
 msgid "label_calculation_imports"
-msgstr ""
+msgstr "Дополнительные библиотеки Python"
 
 #. Default: "Calculation Interim Fields"
 #: senaite/core/content/calculation.py:243
 msgid "label_calculation_interims"
-msgstr ""
+msgstr "Промежуточные поля расчёта"
 
 #. Default: "Raw Test Result"
 #: senaite/core/content/calculation.py:336
 msgid "label_calculation_raw_test_keywords"
-msgstr ""
+msgstr "Необработанный результат теста"
 
 #. Default: "Keyword"
 #: senaite/core/content/calculation.py:198
 msgid "label_calculation_test_param_keyword"
-msgstr ""
+msgstr "Ключевое слово"
 
 #. Default: "Value"
 #: senaite/core/content/calculation.py:207
 msgid "label_calculation_test_param_value"
-msgstr ""
+msgstr "Значение"
 
 #. Default: "Test Parameters"
 #: senaite/core/content/calculation.py:317
 msgid "label_calculation_test_params"
-msgstr ""
+msgstr "Параметры теста"
 
 #. Default: "Test Result"
 #: senaite/core/content/calculation.py:343
 msgid "label_calculation_test_result"
-msgstr ""
+msgstr "Результат теста"
 
 #. Default: "Department"
 #: bika/lims/content/analysiscategory.py:59
 msgid "label_category_department"
-msgstr ""
+msgstr "Подразделение"
 
 #. Default: "Default categories"
-#: bika/lims/content/client.py:185
+#: bika/lims/content/client.py:181
 msgid "label_client_defaultcategories"
-msgstr ""
+msgstr "Категории по умолчанию"
 
 #. Default: "Restrict categories"
-#: bika/lims/content/client.py:209
+#: bika/lims/content/client.py:205
 msgid "label_client_restrictcategories"
-msgstr ""
+msgstr "Ограничить категории"
 
 #. Default: "Confirm password"
 #: senaite/core/browser/user/passwordpanel.py:43
 msgid "label_confirm_password"
-msgstr ""
+msgstr "Подтвердите пароль"
 
 #. Default: "Contacts to CC"
-#: senaite/core/content/contact.py:151
+#: senaite/core/content/contact.py:119
 msgid "label_contact_cccontact"
-msgstr ""
+msgstr "Контакты для копии (CC)"
 
 #. Default: "Email Telephone Fax"
 #: senaite/core/content/person.py:137
 msgid "label_contact_information"
-msgstr ""
+msgstr "Email Телефон Факс"
 
 #. Default: "Preservation"
 #: bika/lims/content/container.py:97
 msgid "label_container_preservation"
-msgstr ""
+msgstr "Сохранение"
 
 #. Default: "Container Type"
 #: bika/lims/content/container.py:54
 msgid "label_container_type"
-msgstr ""
+msgstr "Тип контейнера"
 
 #. Default: "Manager"
 #: senaite/core/content/department.py:102
 msgid "label_department_manager"
-msgstr ""
+msgstr "Менеджер"
 
 #. edit the container itself, ${go_here}."
-#. Default: "You are editing the default view of a container. If you wanted to edit the container itself, ${go_here}."
+#. Default: "You are editing the default view of a container. If you wanted to
+#. edit the container itself, ${go_here}."
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:28
 msgid "label_edit_default_view_container"
 msgstr ""
+"Вы редактируете стандартный просмотр контейнера. Если хотите отредактировать"
+" сам контейнер, ${go_here}."
 
 #. Default: "go here"
 #: senaite/core/skins/senaite_templates/bikasetup_edit.pt:28
 msgid "label_edit_default_view_container_go_here"
-msgstr ""
+msgstr "перейдите сюда"
 
 #. Default: "Bank Details"
 #: senaite/core/content/supplier.py:72
 msgid "label_fieldset_supplier_bank_details"
-msgstr ""
+msgstr "Банковские реквизиты"
 
 #. Default: "Analyses"
 #: senaite/core/content/worksheettemplate.py:332
 msgid "label_fieldset_worksheettemplate_analyses"
-msgstr ""
+msgstr "Анализы"
 
 #. Default: "Layout"
 #: senaite/core/content/worksheettemplate.py:275
 msgid "label_fieldset_worksheettemplate_layout"
-msgstr ""
+msgstr "Макет"
 
 #. Default: "Include client contacts"
 #: senaite/core/browser/controlpanel/contacts/templates/contacts_filter.pt:10
 msgid "label_include_client_contacts"
-msgstr ""
+msgstr "Включить контакты клиента"
 
 #. Default: "Location"
 #: bika/lims/content/instrument.py:319
 msgid "label_instrument_instrumentlocation"
-msgstr ""
+msgstr "Местоположение"
 
 #. Default: "Instrument type"
 #: bika/lims/content/instrument.py:79
 msgid "label_instrument_instrumenttype"
-msgstr ""
+msgstr "Тип инструмента"
 
 #. Default: "Manufacturer"
 #: bika/lims/content/instrument.py:99
 msgid "label_instrument_manufacturer"
-msgstr ""
+msgstr "Производитель"
 
 #. Default: "Supported methods"
 #: bika/lims/content/instrument.py:172
 msgid "label_instrument_methods"
-msgstr ""
+msgstr "Поддерживаемые методы"
 
 #. Default: "Result files folders"
 #: bika/lims/content/instrument.py:265
 msgid "label_instrument_result_file_folder"
-msgstr ""
+msgstr "Папки файлов результатов"
 
 #. Default: "Supplier"
 #: bika/lims/content/instrument.py:119
 msgid "label_instrument_supplier"
-msgstr ""
+msgstr "Поставщик"
 
 #. Default: "Performed by"
 #: bika/lims/content/instrumentcalibration.py:127
 msgid "label_instrumentcalibration_worker"
-msgstr ""
+msgstr "Выполнил(а)"
 
 #. Default: "Prepared by"
 #: bika/lims/content/instrumentcertification.py:146
 msgid "label_instrumentcertification_preparator"
-msgstr ""
+msgstr "Подготовил(а)"
 
 #. Default: "Approved by"
 #: bika/lims/content/instrumentcertification.py:170
 msgid "label_instrumentcertification_validator"
-msgstr ""
+msgstr "Утвердил(а)"
 
 #. Default: "Performed by"
 #: bika/lims/content/instrumentvalidation.py:109
 msgid "label_instrumentvalidation_worker"
-msgstr ""
+msgstr "Выполнил(а)"
 
 #. Default: "Allow empty"
 #: senaite/core/schema/interimfields.py:87
 msgid "label_interim_allow_empty"
-msgstr ""
+msgstr "Разрешить пустое значение"
 
 #. Default: "Apply wide"
 #: senaite/core/schema/interimfields.py:127
 msgid "label_interim_apply_wide"
-msgstr ""
+msgstr "Применить ко всем"
 
 #. Default: "Choices"
 #: senaite/core/schema/interimfields.py:67
 msgid "label_interim_choices"
-msgstr ""
+msgstr "Варианты"
 
 #. Default: "Default value"
 #: senaite/core/schema/interimfields.py:57
 msgid "label_interim_default_value"
-msgstr ""
+msgstr "Значение по умолчанию"
 
 #. Default: "Hidden"
 #: senaite/core/schema/interimfields.py:117
 msgid "label_interim_hidden"
-msgstr ""
+msgstr "Скрыто"
 
 #. Default: "Keyword"
 #: senaite/core/schema/interimfields.py:37
 msgid "label_interim_keyword"
-msgstr ""
+msgstr "Ключевое слово"
 
 #. Default: "Report"
 #: senaite/core/schema/interimfields.py:107
 msgid "label_interim_report"
-msgstr ""
+msgstr "Отчёт"
 
 #. Default: "Result type"
 #: senaite/core/schema/interimfields.py:76
 msgid "label_interim_result_type"
-msgstr ""
+msgstr "Тип результата"
 
 #. Default: "Field title"
 #: senaite/core/schema/interimfields.py:47
 msgid "label_interim_title"
-msgstr ""
+msgstr "Название поля"
 
 #. Default: "Unit"
 #: senaite/core/schema/interimfields.py:97
 msgid "label_interim_unit"
-msgstr ""
+msgstr "Единица измерения"
 
 #. Default: "Default Department"
 #: bika/lims/content/labcontact.py:86
 msgid "label_labcontact_default_department"
-msgstr ""
+msgstr "Подразделение по умолчанию"
 
 #. Default: "Departments"
 #: bika/lims/content/labcontact.py:59
 msgid "label_labcontact_departments"
-msgstr ""
+msgstr "Подразделения"
 
 #. Default: "Supervisor"
 #: senaite/core/content/laboratory.py:73
 msgid "label_laboratory_supervisor"
-msgstr ""
+msgstr "Руководитель"
 
 #. Default: "Document ID"
 #: senaite/core/content/multifile.py:39
 msgid "label_multifile_document_id"
-msgstr ""
+msgstr "ID документа"
 
 #. Default: "Document Location"
 #: senaite/core/content/multifile.py:67
 msgid "label_multifile_document_location"
-msgstr ""
+msgstr "Расположение документа"
 
 #. Default: "Document Type"
 #: senaite/core/content/multifile.py:79
 msgid "label_multifile_document_type"
-msgstr ""
+msgstr "Тип документа"
 
 #. Default: "Document Version"
 #: senaite/core/content/multifile.py:59
 msgid "label_multifile_document_version"
-msgstr ""
+msgstr "Версия документа"
 
 #. Default: "Document"
 #: senaite/core/content/multifile.py:47
 msgid "label_multifile_file"
-msgstr ""
+msgstr "Документ"
 
 #. Default: "New password"
 #: senaite/core/browser/user/passwordpanel.py:36
 msgid "label_new_password"
-msgstr ""
+msgstr "Новый пароль"
 
 #. Default: "Fax (business)"
 #: senaite/core/content/person.py:169
 msgid "label_person_business_fax"
-msgstr ""
+msgstr "Факс (рабочий)"
 
 #. Default: "Phone (business)"
 #: senaite/core/content/person.py:160
 msgid "label_person_business_phone"
-msgstr ""
+msgstr "Телефон (рабочий)"
 
 #. Default: "Department"
 #: senaite/core/content/person.py:119
 msgid "label_person_department"
-msgstr ""
+msgstr "Подразделение"
 
 #. Default: "Description"
 #: senaite/core/content/person.py:59
 msgid "label_person_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Email Address"
 #: senaite/core/content/person.py:151
 msgid "label_person_email_address"
-msgstr ""
+msgstr "Email адрес"
 
 #. Default: "Firstname"
 #: senaite/core/content/person.py:79
 msgid "label_person_firstname"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Phone (home)"
 #: senaite/core/content/person.py:178
 msgid "label_person_home_phone"
-msgstr ""
+msgstr "Телефон (домашний)"
 
 #. Default: "Job title"
 #: senaite/core/content/person.py:111
 msgid "label_person_job_title"
-msgstr ""
+msgstr "Должность"
 
 #. Default: "Middle initial"
 #: senaite/core/content/person.py:87
 msgid "label_person_middleinitial"
-msgstr ""
+msgstr "Отчество (инициал)"
 
 #. Default: "Middle name"
 #: senaite/core/content/person.py:95
 msgid "label_person_middlename"
-msgstr ""
+msgstr "Отчество"
 
 #. Default: "Phone (mobile)"
 #: senaite/core/content/person.py:187
 msgid "label_person_mobile_phone"
-msgstr ""
+msgstr "Телефон (мобильный)"
 
 #. Default: "Physical address"
 #: senaite/core/content/person.py:210
 msgid "label_person_physical_address"
-msgstr ""
+msgstr "Физический адрес"
 
 #. Default: "Postal address"
 #: senaite/core/content/person.py:219
 msgid "label_person_postal_address"
-msgstr ""
+msgstr "Почтовый адрес"
 
 #. Default: "Salutation"
 #: senaite/core/content/person.py:67
 msgid "label_person_salutation"
-msgstr ""
+msgstr "Обращение"
 
 #. Default: "Surname"
 #: senaite/core/content/person.py:103
 msgid "label_person_surname"
-msgstr ""
+msgstr "Фамилия"
 
 #. Default: "Title"
 #: senaite/core/content/person.py:51
 msgid "label_person_title"
-msgstr ""
+msgstr "Название"
 
 #. Default: "Username"
 #: senaite/core/content/person.py:127
 msgid "label_person_username"
-msgstr ""
+msgstr "Имя пользователя"
 
 #. Default: "SENAITE is powered by"
 #: senaite/core/browser/viewlets/templates/colophon.pt:11
 msgid "label_powered_by"
-msgstr ""
+msgstr "SENAITE работает на"
 
 #. Default: "Plone & Python"
 #: senaite/core/browser/viewlets/templates/colophon.pt:12
 msgid "label_powered_by_plone"
-msgstr ""
+msgstr "Plone и Python"
 
 #. Default: "Publication preference"
-#: senaite/core/content/contact.py:131
+#: senaite/core/content/contact.py:99
 msgid "label_publication_preference"
-msgstr ""
+msgstr "Предпочтение публикации"
 
 #. Default: "Blank"
 #: bika/lims/content/referencedefinition.py:75
 msgid "label_referencedefinition_blank"
-msgstr ""
+msgstr "Холостая проба"
 
 #. Default: "Hazard categories"
 #: bika/lims/content/referencedefinition.py:104
 msgid "label_referencedefinition_hazard_categories"
-msgstr ""
+msgstr "Категории опасности"
 
 #. Default: "Hazardous"
 #: bika/lims/content/referencedefinition.py:89
 msgid "label_referencedefinition_hazardous"
-msgstr ""
+msgstr "Опасно"
 
 #. Default: "Reference Values"
 #: bika/lims/content/referencedefinition.py:53
 msgid "label_referencedefinition_referencevalues"
-msgstr ""
+msgstr "Референсные значения"
 
 #. Default: "Hazard categories"
 #: bika/lims/content/referencesample.py:116
 msgid "label_referencesample_hazard_categories"
-msgstr ""
+msgstr "Категории опасности"
 
 #. Default: "Manufacturer"
 #: bika/lims/content/referencesample.py:133
 msgid "label_referencesample_manufacturer"
-msgstr ""
+msgstr "Производитель"
 
 #. Default: "Reference Definition"
 #: bika/lims/content/referencesample.py:79
 msgid "label_referencesample_referencedefinition"
-msgstr ""
+msgstr "Эталонное определение"
 
 #. Default: "Catalog mappings"
 #: senaite/core/registry/schema.py:274
 msgid "label_registry_catalog_mappings"
-msgstr ""
+msgstr "Сопоставления каталогов"
 
 #. Default: "Portal type"
 #: senaite/core/registry/schema.py:286
 msgid "label_registry_catalog_mappings_key"
-msgstr ""
+msgstr "Тип портала"
 
 #. Default: "Catalogs"
 #: senaite/core/registry/schema.py:293
 msgid "label_registry_catalog_mappings_value"
-msgstr ""
+msgstr "Каталоги"
 
 #. Default: "Catalogs"
 #: senaite/core/registry/schema.py:265
 msgid "label_registry_catalogs_fieldset"
-msgstr ""
+msgstr "Каталоги"
 
 #. Default: "Client landing page"
 #: senaite/core/registry/schema.py:47
 msgid "label_registry_client_landing_page"
-msgstr ""
+msgstr "Стартовая страница клиента"
 
 #. Default: "Portal types to skip on content structure export"
 #: senaite/core/registry/schema.py:234
 msgid "label_registry_generic_setup_skip_export_types"
-msgstr ""
+msgstr "Типы портала, пропускаемые при экспорте структуры содержимого"
 
 #. Default: "Import"
 #: senaite/core/registry/schema.py:428
 msgid "label_registry_import"
-msgstr ""
+msgstr "Импорт"
 
 #. Default: "Attach import file to Analyses"
 #: senaite/core/registry/schema.py:439
 msgid "label_registry_import_analysis_attach_attachment"
-msgstr ""
+msgstr "Прикреплять файл импорта к анализам"
 
 #. Default: "Submit Analyses upon import"
 #: senaite/core/registry/schema.py:452
 msgid "label_registry_import_analysis_submit"
-msgstr ""
+msgstr "Отправлять анализы при импорте"
 
 #. Default: "Allow multi paste"
 #: senaite/core/registry/schema.py:371
 msgid "label_registry_sample_add_allow_multi_paste_fields"
-msgstr ""
+msgstr "Разрешить массовую вставку"
 
 #. Default: "Commit each sample in its own transaction"
 #: senaite/core/registry/schema.py:387
 msgid "label_registry_sample_add_commit_per_sample"
-msgstr ""
+msgstr "Фиксировать каждый образец в отдельной транзакции"
 
 #. Default: "Copy sample structure with partitions"
 #: senaite/core/registry/schema.py:324
 msgid "label_registry_sample_add_copy_partitions"
-msgstr ""
+msgstr "Копировать структуру образца с партициями"
 
 #. Default: "Skip analyses workflow states on copy"
 #: senaite/core/registry/schema.py:355
 msgid "label_registry_sample_add_skip_analyses_in_states"
-msgstr ""
+msgstr "Пропускать статусы процесса анализа при копировании"
 
 #. Default: "Skip partition analyses on copy"
 #: senaite/core/registry/schema.py:340
 msgid "label_registry_sample_add_skip_partition_analyses"
-msgstr ""
+msgstr "Пропускать анализы партиций при копировании"
 
 #. Default: "Samples"
 #: senaite/core/registry/schema.py:309
 msgid "label_registry_samples"
-msgstr ""
+msgstr "Образцы"
 
 #. Default: "Trigger events on sample creation"
 #: senaite/core/registry/schema.py:406
 msgid "label_registry_trigger_events_on_sample_creation"
-msgstr ""
+msgstr "Запускать события при создании образца"
 
 #. Default: "Worksheet"
 #: senaite/core/registry/schema.py:95
 msgid "label_registry_worksheet_settings"
-msgstr ""
+msgstr "Рабочий лист"
 
 #. Default: "Contained Samples"
-#: senaite/core/content/resultsreport.py:184
+#: senaite/core/content/resultsreport.py:183
 msgid "label_resultsreport_contained_samples"
-msgstr ""
+msgstr "Содержащиеся образцы"
 
 #. Default: "Primary Sample"
-#: senaite/core/content/resultsreport.py:156
+#: senaite/core/content/resultsreport.py:155
 msgid "label_resultsreport_sample"
-msgstr ""
+msgstr "Основной образец"
 
 #. Default: "Batch"
 #: bika/lims/content/analysisrequest.py:328
 msgid "label_sample_batch"
-msgstr ""
+msgstr "Партия"
 
 #. Default: "CC Contact"
 #: bika/lims/content/analysisrequest.py:197
 msgid "label_sample_cccontact"
-msgstr ""
+msgstr "Контакт для копии (CC)"
 
 #. Default: "Client"
 #: bika/lims/content/analysisrequest.py:255
 msgid "label_sample_client"
-msgstr ""
+msgstr "Клиент"
 
 #. Default: "Contact"
 #: bika/lims/content/analysisrequest.py:156
 msgid "label_sample_contact"
-msgstr ""
+msgstr "Контакт"
 
 #. Default: "Container"
 #: bika/lims/content/analysisrequest.py:566
 msgid "label_sample_container"
-msgstr ""
+msgstr "Контейнер"
 
 #. Default: "Date Sampled"
 #: bika/lims/content/analysisrequest.py:449
 msgid "label_sample_datesampled"
-msgstr ""
+msgstr "Дата отбора"
 
 #. Default: "Detached from sample"
 #: bika/lims/content/analysisrequest.py:1308
 msgid "label_sample_detached_from"
-msgstr ""
+msgstr "Отсоединён от образца"
 
 #. Default: "Duplicated from sample"
 #: bika/lims/content/analysisrequest.py:1280
 msgid "label_sample_duplicated_from"
-msgstr ""
+msgstr "Дублирован из образца"
 
 #. Default: "Invoice"
 #: bika/lims/content/analysisrequest.py:1046
 msgid "label_sample_invoice"
-msgstr ""
+msgstr "Счёт"
 
 #. Default: "Parent sample"
 #: bika/lims/content/analysisrequest.py:1252
 msgid "label_sample_parent_sample"
-msgstr ""
+msgstr "Родительский образец"
 
 #. Default: "Preservation"
 #: bika/lims/content/analysisrequest.py:597
 msgid "label_sample_preservation"
-msgstr ""
+msgstr "Сохранение"
 
 #. Default: "Primary Sample"
 #: bika/lims/content/analysisrequest.py:292
 msgid "label_sample_primary"
-msgstr ""
+msgstr "Основной образец"
 
 #. Default: "Analysis Profiles"
 #: bika/lims/content/analysisrequest.py:418
 msgid "label_sample_profiles"
-msgstr ""
+msgstr "Профили анализов"
 
 #. Default: "Publication Specification"
 #: bika/lims/content/analysisrequest.py:734
 msgid "label_sample_publicationspecification"
-msgstr ""
+msgstr "Спецификация публикации"
 
 #. Default: "Retest from sample"
 #: bika/lims/content/analysisrequest.py:1336
 msgid "label_sample_retracted"
-msgstr ""
+msgstr "Повторный тест из образца"
 
 #. Default: "Sample Condition"
 #: bika/lims/content/analysisrequest.py:897
 msgid "label_sample_samplecondition"
-msgstr ""
+msgstr "Состояние образца"
 
 #. Default: "Sample Point"
 #: bika/lims/content/analysisrequest.py:767
 msgid "label_sample_samplepoint"
-msgstr ""
+msgstr "Точка отбора проб"
 
 #. Default: "Sample Type"
 #: bika/lims/content/analysisrequest.py:538
 msgid "label_sample_sampletype"
-msgstr ""
+msgstr "Тип образца"
 
 #. Default: "Expected Sampling Date"
 #: bika/lims/content/analysisrequest.py:512
 msgid "label_sample_samplingdate"
-msgstr ""
+msgstr "Ожидаемая дата отбора"
 
 #. Default: "Sampling Deviation"
 #: bika/lims/content/analysisrequest.py:869
 msgid "label_sample_samplingdeviation"
-msgstr ""
+msgstr "Отклонение при отборе проб"
 
 #. Default: "Analysis Specification"
 #: bika/lims/content/analysisrequest.py:690
 msgid "label_sample_specification"
-msgstr ""
+msgstr "Спецификация анализа"
 
 #. Default: "Storage Location"
 #: bika/lims/content/analysisrequest.py:791
 msgid "label_sample_storagelocation"
-msgstr ""
+msgstr "Место хранения"
 
 #. Default: "Batch Sub-group"
 #: bika/lims/content/analysisrequest.py:363
 msgid "label_sample_subgroup"
-msgstr ""
+msgstr "Подгруппа партии"
 
 #. Default: "Sample Template"
 #: bika/lims/content/analysisrequest.py:390
 msgid "label_sample_template"
-msgstr ""
+msgstr "Шаблон образца"
 
 #. Default: "Sample Types"
 #: bika/lims/content/samplepoint.py:95
 msgid "label_samplepoint_sampletypes"
-msgstr ""
+msgstr "Типы образца"
 
 #. Default: "Category"
 #: senaite/core/content/samplepreservation.py:55
 msgid "label_samplepreservation_category"
-msgstr ""
+msgstr "Категория"
 
 #. Default: "Container"
 #: senaite/core/content/sampletemplate.py:81
 msgid "label_sampletemplate_partition_container"
-msgstr ""
+msgstr "Контейнер"
 
 #. Default: "Partition ID"
 #: senaite/core/content/sampletemplate.py:60
 msgid "label_sampletemplate_partition_part_id"
-msgstr ""
+msgstr "ID партиции"
 
 #. Default: "Preservation"
 #: senaite/core/content/sampletemplate.py:103
 msgid "label_sampletemplate_partition_preservation"
-msgstr ""
+msgstr "Сохранение"
 
 #. Default: "Sample Type"
 #: senaite/core/content/sampletemplate.py:125
 msgid "label_sampletemplate_partition_sampletype"
-msgstr ""
+msgstr "Тип образца"
 
 #. Default: "Partitions"
 #: senaite/core/content/sampletemplate.py:243
 msgid "label_sampletemplate_partitions"
-msgstr ""
+msgstr "Партиции"
 
 #. Default: "Sample Point"
 #: senaite/core/content/sampletemplate.py:185
 msgid "label_sampletemplate_samplepoint"
-msgstr ""
+msgstr "Точка отбора проб"
 
 #. Default: "Sample Type"
 #: senaite/core/content/sampletemplate.py:207
 msgid "label_sampletemplate_sampletype"
-msgstr ""
+msgstr "Тип образца"
 
 #. Default: "Admitted stickers for the sample type"
 #: senaite/core/content/sampletype.py:100
 msgid "label_sampletype_admitted"
-msgstr ""
+msgstr "Разрешённые стикеры для типа образца"
 
 #. Default: "Admitted sticker templates"
 #: senaite/core/content/sampletype.py:279
 msgid "label_sampletype_admitted_stickers_templates"
-msgstr ""
+msgstr "Разрешённые шаблоны стикеров"
 
 #. Default: "Default Container Type"
 #: senaite/core/content/sampletype.py:254
 msgid "label_sampletype_containertype"
-msgstr ""
+msgstr "Тип контейнера по умолчанию"
 
 #. Default: "Description"
 #: senaite/core/content/sampletype.py:142
 msgid "label_sampletype_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Default large sticker"
 #: senaite/core/content/sampletype.py:120
 msgid "label_sampletype_large_default"
-msgstr ""
+msgstr "Большой стикер по умолчанию"
 
 #. Default: "Sample Matrix"
 #: senaite/core/content/sampletype.py:204
 msgid "label_sampletype_samplematrix"
-msgstr ""
+msgstr "Матрица образца"
 
 #. Default: "Default small sticker"
 #: senaite/core/content/sampletype.py:111
 msgid "label_sampletype_small_default"
-msgstr ""
+msgstr "Малый стикер по умолчанию"
 
 #. Default: "Name"
 #: senaite/core/content/sampletype.py:134
 msgid "label_sampletype_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Save"
-#: senaite/core/browser/viewlets/templates/sampleheader.pt:187
+#: senaite/core/browser/viewlets/templates/sampleheader.pt:186
 msgid "label_save"
-msgstr ""
+msgstr "Сохранить"
 
 #. Default: "SENAITE LIMS"
 #: senaite/core/browser/viewlets/templates/footer.pt:14
 msgid "label_senaite"
-msgstr ""
+msgstr "SENAITE LIMS"
 
 #. Default: "Maximum value for 'Number of samples' field on registration"
-#: senaite/core/content/senaitesetup.py:369
+#: senaite/core/content/senaitesetup.py:368
 msgid "label_senaitesetup_maxnumberofsamplesadd"
-msgstr ""
+msgstr "Максимальное значение поля 'Количество образцов' при регистрации"
 
 #. Default: "Landing Page"
-#: bika/lims/content/bikasetup.py:614
+#: bika/lims/content/bikasetup.py:613
 msgid "label_setup_landingpage"
-msgstr ""
+msgstr "Стартовая страница"
 
 #. Default: "Item"
 #: senaite/core/browser/controlpanel/templates/setupview.pt:78
 msgid "label_setupview_item"
-msgstr ""
+msgstr "Элемент"
 
 #. Default: "Items"
 #: senaite/core/browser/controlpanel/templates/setupview.pt:81
 msgid "label_setupview_items"
-msgstr ""
+msgstr "Элементы"
 
 #. Default: "Out of range comment"
 #: bika/lims/browser/fields/resultrangefield.py:42
 #: bika/lims/browser/widgets/analysisspecificationwidget.py:136
 msgid "label_specs_rangecomment"
-msgstr ""
+msgstr "Комментарий вне диапазона"
 
 #. Default: "Time zone"
 #: senaite/core/browser/user/personalpreferences.py:38
 msgid "label_timezone"
-msgstr ""
+msgstr "Часовой пояс"
 
 #. Default: "Title"
 #: senaite/core/browser/install/templates/senaite-addsite.pt:62
 msgid "label_title"
-msgstr ""
+msgstr "Название"
 
 #. Default: "Upgrade…"
 #: senaite/core/browser/install/templates/senaite-overview.pt:67
 msgid "label_upgrade_hellip"
-msgstr ""
+msgstr "Обновление…"
 
 #. Default: "Contact"
 #: senaite/core/browser/user/userdatapanel.py:81
 msgid "label_user_contact"
-msgstr ""
+msgstr "Контакт"
 
 #. Default: "Email"
 #: senaite/core/browser/user/userdatapanel.py:70
 msgid "label_user_email"
-msgstr ""
+msgstr "Email"
 
 #. Default: "Full Name"
 #: senaite/core/browser/user/userdatapanel.py:64
 msgid "label_user_full_name"
-msgstr ""
+msgstr "Полное имя"
 
 #. Default: "Preferred instrument"
 #: senaite/core/content/worksheettemplate.py:262
 msgid "label_worksheettemplate_instrument"
-msgstr ""
+msgstr "Предпочитаемый инструмент"
 
 #. Default: "Restrict to Method"
 #: senaite/core/content/worksheettemplate.py:236
 msgid "label_worksheettemplate_restrict_to_method"
-msgstr ""
-
-#. Default: "Added ${count} label(s) to ${affected} sample(s)"
-#: senaite/core/browser/modals/manage_labels.py:185
-msgid "labels_added"
-msgstr ""
-
-#. sample(s)"
-#. Default: "Applied ${added} added and ${removed} removed across ${affected} sample(s)"
-#: senaite/core/browser/modals/manage_labels.py:174
-msgid "labels_changed"
-msgstr ""
-
-#. Default: "Removed ${count} label(s) from ${affected} sample(s)"
-#: senaite/core/browser/modals/manage_labels.py:194
-msgid "labels_removed"
-msgstr ""
+msgstr "Ограничить методом"
 
 #. Default: "Category"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:119
 msgid "listing_add_analyses_column_category_title"
-msgstr ""
+msgstr "Категория"
 
 #. Default: "Client"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:93
 msgid "listing_add_analyses_column_client"
-msgstr ""
+msgstr "Клиент"
 
 #. Default: "Order"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:102
 msgid "listing_add_analyses_column_client_order_number"
-msgstr ""
+msgstr "Заказ"
 
 #. Default: "Date Received"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:132
 msgid "listing_add_analyses_column_date_received"
-msgstr ""
+msgstr "Дата получения"
 
 #. Default: "Due Date"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:139
 msgid "listing_add_analyses_column_due_date"
-msgstr ""
+msgstr "Срок выполнения"
 
 #. Default: "Request ID"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:110
 msgid "listing_add_analyses_column_request_id"
-msgstr ""
+msgstr "ID заявки"
 
 #. Default: "Analysis"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:125
 msgid "listing_add_analyses_column_title"
-msgstr ""
+msgstr "Анализ"
 
 #. Default: "All"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:150
 msgid "listing_add_analyses_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Filter by template method"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:221
 msgid "listing_add_analyses_state_restrict_to_method"
-msgstr ""
+msgstr "Фильтр по методу шаблона"
 
 #. Default: "Filter by template services"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:203
 msgid "listing_add_analyses_state_restrict_to_services"
-msgstr ""
+msgstr "Фильтр по услугам шаблона"
 
 #. Default: "Add Analyses"
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:74
 msgid "listing_add_analyses_title"
-msgstr ""
+msgstr "Добавить анализы"
 
 #. Default: "Add Blank Reference"
 #: senaite/core/browser/worksheets/worksheet/add_blank.py:44
 msgid "listing_add_blank_title"
-msgstr ""
+msgstr "Добавить холостую пробу"
 
 #. Default: "Add Control Reference"
 #: senaite/core/browser/worksheets/worksheet/add_control.py:43
 msgid "listing_add_control_title"
-msgstr ""
+msgstr "Добавить контрольный образец"
 
 #. Default: "All"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:99
 msgid "listing_add_duplicate_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Add Duplicate"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:51
 msgid "listing_add_duplicate_title"
-msgstr ""
+msgstr "Добавить дубликат"
 
 #. Default: "Client"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:81
 msgid "listing_add_duplication_column_client"
-msgstr ""
+msgstr "Клиент"
 
 #. Default: "Date Requested"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:88
 msgid "listing_add_duplication_column_created"
-msgstr ""
+msgstr "Дата запроса"
 
 #. Default: "Request ID"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:74
 msgid "listing_add_duplication_column_request_id"
-msgstr ""
+msgstr "ID заявки"
 
 #. Default: "Position"
 #: senaite/core/browser/worksheets/worksheet/add_duplicate.py:67
 msgid "listing_add_duplication_column_title"
-msgstr ""
+msgstr "Позиция"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:50
 msgid "listing_analysiscategories_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Department"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:80
 msgid "listing_analysiscategories_column_department"
-msgstr ""
+msgstr "Подразделение"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:72
 msgid "listing_analysiscategories_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sort Key"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:87
 msgid "listing_analysiscategories_column_sort_key"
-msgstr ""
+msgstr "Ключ сортировки"
 
 #. Default: "Category"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:66
 msgid "listing_analysiscategories_column_title"
-msgstr ""
+msgstr "Категория"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:98
 msgid "listing_analysiscategories_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:114
 msgid "listing_analysiscategories_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:106
 msgid "listing_analysiscategories_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Analysis Categories"
 #: senaite/core/browser/controlpanel/analysiscategories/view.py:57
 msgid "listing_analysiscategories_title"
-msgstr ""
+msgstr "Категории анализа"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:54
 msgid "listing_analysisprofiles_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:76
 msgid "listing_analysisprofiles_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Profile Key"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:83
 msgid "listing_analysisprofiles_column_profilekey"
-msgstr ""
+msgstr "Ключ профиля"
 
 #. Default: "Sample Types"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:91
 msgid "listing_analysisprofiles_column_sampletypes"
-msgstr ""
+msgstr "Типы образца"
 
 #. Default: "Profile"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:69
 msgid "listing_analysisprofiles_column_title"
-msgstr ""
+msgstr "Профиль"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:103
 msgid "listing_analysisprofiles_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:119
 msgid "listing_analysisprofiles_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:111
 msgid "listing_analysisprofiles_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Analysis Profiles"
 #: senaite/core/browser/controlpanel/analysisprofiles/view.py:61
 msgid "listing_analysisprofiles_title"
-msgstr ""
+msgstr "Профили анализов"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:50
 msgid "listing_attachmenttypes_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:73
 msgid "listing_attachmenttypes_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:67
 msgid "listing_attachmenttypes_column_title"
-msgstr ""
+msgstr "Название"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:83
 msgid "listing_attachmenttypes_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:99
 msgid "listing_attachmenttypes_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:91
 msgid "listing_attachmenttypes_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Attachment Types"
 #: senaite/core/browser/controlpanel/attachmenttypes/view.py:57
 msgid "listing_attachmenttypes_title"
-msgstr ""
+msgstr "Типы вложений"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:50
 msgid "listing_batchlabels_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:67
 msgid "listing_batchlabels_column_title"
-msgstr ""
+msgstr "Название"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:77
 msgid "listing_batchlabels_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:93
 msgid "listing_batchlabels_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:85
 msgid "listing_batchlabels_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Batch Labels"
 #: senaite/core/browser/controlpanel/batchlabels/view.py:57
 msgid "listing_batchlabels_title"
-msgstr ""
+msgstr "Метки партии"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/calculations/view.py:51
 msgid "listing_calculation_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/calculations/view.py:75
 msgid "listing_calculation_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Formula"
 #: senaite/core/browser/controlpanel/calculations/view.py:82
 msgid "listing_calculation_formula"
-msgstr ""
+msgstr "Формула"
 
 #. Default: "Calculation"
 #: senaite/core/browser/controlpanel/calculations/view.py:68
 msgid "listing_calculation_title"
-msgstr ""
+msgstr "Формула расчёта"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/calculations/view.py:93
 msgid "listing_calculations_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/calculations/view.py:111
 msgid "listing_calculations_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/calculations/view.py:102
 msgid "listing_calculations_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Calculations"
 #: senaite/core/browser/controlpanel/calculations/view.py:58
 msgid "listing_calculations_title"
-msgstr ""
+msgstr "Формулы расчёта"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/containertypes/view.py:51
 msgid "listing_containertypes_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/containertypes/view.py:72
 msgid "listing_containertypes_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/containertypes/view.py:66
 msgid "listing_containertypes_column_title"
-msgstr ""
+msgstr "Название"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/containertypes/view.py:82
 msgid "listing_containertypes_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/containertypes/view.py:98
 msgid "listing_containertypes_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/containertypes/view.py:90
 msgid "listing_containertypes_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Container Types"
 #: senaite/core/browser/controlpanel/containertypes/view.py:58
 msgid "listing_containertypes_title"
-msgstr ""
+msgstr "Типы контейнеров"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:52
 msgid "listing_dynamic_analysisspec_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/dynamicanalysisspec.py:61
 msgid "listing_dynamic_analysisspec_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:76
 msgid "listing_dynamic_analysisspecs_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:70
 msgid "listing_dynamic_analysisspecs_column_title"
-msgstr ""
+msgstr "Название"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:86
 msgid "listing_dynamic_analysisspecs_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:102
 msgid "listing_dynamic_analysisspecs_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:94
 msgid "listing_dynamic_analysisspecs_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Dynamic Analysis Specifications"
 #: senaite/core/browser/controlpanel/dynamicanalysisspecs/view.py:61
 msgid "listing_dynamic_analysisspecs_title"
-msgstr ""
+msgstr "Динамические спецификации анализа"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:52
 msgid "listing_instrumentlocations_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:74
 msgid "listing_instrumentlocations_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Location"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:67
 msgid "listing_instrumentlocations_column_title"
-msgstr ""
+msgstr "Местоположение"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:94
 msgid "listing_instrumentlocations_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:86
 msgid "listing_instrumentlocations_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:102
 msgid "listing_instrumentlocations_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Instrument Locations"
 #: senaite/core/browser/controlpanel/instrumentlocations/view.py:58
 msgid "listing_instrumentlocations_title"
-msgstr ""
+msgstr "Расположения инструментов"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:49
 msgid "listing_instrumenttypes_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:72
 msgid "listing_instrumenttypes_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:65
 msgid "listing_instrumenttypes_column_title"
-msgstr ""
+msgstr "Название"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:83
 msgid "listing_instrumenttypes_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:101
 msgid "listing_instrumenttypes_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:92
 msgid "listing_instrumenttypes_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Instrument Types"
 #: senaite/core/browser/controlpanel/instrumenttypes/view.py:56
 msgid "listing_instrumenttypes_title"
-msgstr ""
+msgstr "Типы инструментов"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:52
 msgid "listing_interpretationtemplates_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:75
 msgid "listing_interpretationtemplates_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sample Types"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:81
 msgid "listing_interpretationtemplates_column_sampletypes"
-msgstr ""
+msgstr "Типы образца"
 
 #. Default: "Text"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:88
 msgid "listing_interpretationtemplates_column_text"
-msgstr ""
+msgstr "Текст"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:68
 msgid "listing_interpretationtemplates_column_title"
-msgstr ""
+msgstr "Название"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:99
 msgid "listing_interpretationtemplates_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:115
 msgid "listing_interpretationtemplates_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:107
 msgid "listing_interpretationtemplates_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Interpretation Templates"
 #: senaite/core/browser/controlpanel/interpretationtemplates/view.py:58
 msgid "listing_interpretationtemplates_title"
-msgstr ""
+msgstr "Шаблоны интерпретации"
 
 #. Default: "Add"
 #: view.py:49
 msgid "listing_labproduct_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Price"
 #: view.py:87
 msgid "listing_labproducts_column_price"
-msgstr ""
+msgstr "Цена"
 
 #. Default: "Product"
 #: view.py:66
 msgid "listing_labproducts_column_title"
-msgstr ""
+msgstr "Услуга"
 
 #. Default: "Total Price"
 #: view.py:102
 msgid "listing_labproducts_column_total_price"
-msgstr ""
+msgstr "Общая цена"
 
 #. Default: "Unit"
 #: view.py:80
 msgid "listing_labproducts_column_unit"
-msgstr ""
+msgstr "Единица измерения"
 
 #. Default: "VAT Amount"
 #: view.py:95
 msgid "listing_labproducts_column_vatamount"
-msgstr ""
+msgstr "Сумма НДС"
 
 #. Default: "Volume"
 #: view.py:73
 msgid "listing_labproducts_column_volume"
-msgstr ""
+msgstr "Объём"
 
 #. Default: "Active"
 #: view.py:114
 msgid "listing_labproducts_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: view.py:132
 msgid "listing_labproducts_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: view.py:123
 msgid "listing_labproducts_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Lab Products"
 #: view.py:56
 msgid "listing_labproducts_title"
-msgstr ""
+msgstr "Услуги лаборатории"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:51
 msgid "listing_manufacturers_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:80
 msgid "listing_manufacturers_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:74
 msgid "listing_manufacturers_column_title"
-msgstr ""
+msgstr "Название"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:91
 msgid "listing_manufacturers_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:107
 msgid "listing_manufacturers_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:99
 msgid "listing_manufacturers_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Manufacturers"
 #: senaite/core/browser/controlpanel/manufacturers/view.py:58
 msgid "listing_manufacturers_title"
-msgstr ""
+msgstr "Производители"
 
 #. Default: "Position"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:87
 msgid "listing_reference_samples_column_position"
-msgstr ""
+msgstr "Позиция"
 
 #. Default: "Supported Services"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:79
 msgid "listing_reference_samples_column_supported_services"
-msgstr ""
+msgstr "Поддерживаемые услуги"
 
 #. Default: "Reference Sample"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:72
 msgid "listing_reference_samples_column_title"
-msgstr ""
+msgstr "Референс-образец"
 
 #. Default: "All"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:98
 msgid "listing_reference_samples_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Add Control Reference"
 #: senaite/core/browser/worksheets/worksheet/referencesamples.py:54
 msgid "listing_reference_samples_title"
-msgstr ""
+msgstr "Добавить контрольный образец"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/suppliers/referencesamples.py:36
 msgid "listing_referencesamples_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:51
 msgid "listing_sampleconatiners_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Capacity"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:86
 msgid "listing_sampleconatiners_column_capacity"
-msgstr ""
+msgstr "Ёмкость"
 
 #. Default: "Container Type"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:79
 msgid "listing_sampleconatiners_column_containertype"
-msgstr ""
+msgstr "Тип контейнера"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:72
 msgid "listing_sampleconatiners_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Pre-preserved"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:93
 msgid "listing_sampleconatiners_column_pre_preserved"
-msgstr ""
+msgstr "Предварительно законсервирован"
 
 #. Default: "Security seal intact"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:100
 msgid "listing_sampleconatiners_column_security_seal_intact"
-msgstr ""
+msgstr "Пломба цела"
 
 #. Default: "Container"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:65
 msgid "listing_sampleconatiners_column_title"
-msgstr ""
+msgstr "Контейнер"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:111
 msgid "listing_sampleconatiners_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:127
 msgid "listing_sampleconatiners_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:119
 msgid "listing_sampleconatiners_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Sample Containers"
 #: senaite/core/browser/controlpanel/samplecontainers/view.py:56
 msgid "listing_sampleconatiners_title"
-msgstr ""
+msgstr "Контейнеры образцов"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:47
 msgid "listing_sampleconditions_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:68
 msgid "listing_sampleconditions_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sample Condition"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:62
 msgid "listing_sampleconditions_column_title"
-msgstr ""
+msgstr "Состояние образца"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:78
 msgid "listing_sampleconditions_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:96
 msgid "listing_sampleconditions_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:87
 msgid "listing_sampleconditions_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Sample Conditions"
 #: senaite/core/browser/controlpanel/sampleconditions/view.py:54
 msgid "listing_sampleconditions_title"
-msgstr ""
+msgstr "Состояния образца"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:47
 msgid "listing_samplematrices_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:68
 msgid "listing_samplematrices_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sample Matrix"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:62
 msgid "listing_samplematrices_column_title"
-msgstr ""
+msgstr "Матрица образца"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:78
 msgid "listing_samplematrices_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:94
 msgid "listing_samplematrices_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:86
 msgid "listing_samplematrices_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Sample Matrices"
 #: senaite/core/browser/controlpanel/samplematrices/view.py:54
 msgid "listing_samplematrices_title"
-msgstr ""
+msgstr "Матрицы образца"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:51
 msgid "listing_samplepoints_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:73
 msgid "listing_samplepoints_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sample Types"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:80
 msgid "listing_samplepoints_column_sampletypes"
-msgstr ""
+msgstr "Типы образца"
 
 #. Default: "Sample Point"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:66
 msgid "listing_samplepoints_column_title"
-msgstr ""
+msgstr "Точка отбора проб"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:92
 msgid "listing_samplepoints_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:108
 msgid "listing_samplepoints_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:100
 msgid "listing_samplepoints_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Sample Points"
 #: senaite/core/browser/controlpanel/samplepoints/view.py:58
 msgid "listing_samplepoints_title"
-msgstr ""
+msgstr "Точки отбора проб"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:47
 msgid "listing_samplepreservations_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:68
 msgid "listing_samplepreservations_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sample Preservation"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:62
 msgid "listing_samplepreservations_column_title"
-msgstr ""
+msgstr "Сохранение образца"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:78
 msgid "listing_samplepreservations_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:96
 msgid "listing_samplepreservations_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:87
 msgid "listing_samplepreservations_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Sample Preservations"
 #: senaite/core/browser/controlpanel/samplepreservations/view.py:54
 msgid "listing_samplepreservations_title"
-msgstr ""
+msgstr "Способы сохранения образца"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:52
 msgid "listing_sampletemplates_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:73
 msgid "listing_sampletemplates_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sample Template"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:67
 msgid "listing_sampletemplates_column_title"
-msgstr ""
+msgstr "Шаблон образца"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:83
 msgid "listing_sampletemplates_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:99
 msgid "listing_sampletemplates_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:91
 msgid "listing_sampletemplates_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Sample Templates"
 #: senaite/core/browser/controlpanel/sampletemplates/view.py:59
 msgid "listing_sampletemplates_title"
-msgstr ""
+msgstr "Шаблоны образцов"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:52
 msgid "listing_sampletypes_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Default Container"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:109
 msgid "listing_sampletypes_column_default_container"
-msgstr ""
+msgstr "Контейнер по умолчанию"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:72
 msgid "listing_sampletypes_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Hazardous"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:79
 msgid "listing_sampletypes_column_hazardous"
-msgstr ""
+msgstr "Опасно"
 
 #. Default: "Minimum Volume"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:91
 msgid "listing_sampletypes_column_min_vol"
-msgstr ""
+msgstr "Минимальный объём"
 
 #. Default: "Prefix"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:85
 msgid "listing_sampletypes_column_prefix"
-msgstr ""
+msgstr "Префикс"
 
 #. Default: "Retention Period"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:97
 msgid "listing_sampletypes_column_retention_period"
-msgstr ""
+msgstr "Срок хранения"
 
 #. Default: "SampleMatrix"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:103
 msgid "listing_sampletypes_column_sample_matrix"
-msgstr ""
+msgstr "Матрица образца"
 
 #. Default: "Sample Type"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:66
 msgid "listing_sampletypes_column_title"
-msgstr ""
+msgstr "Тип образца"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:119
 msgid "listing_sampletypes_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:135
 msgid "listing_sampletypes_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:127
 msgid "listing_sampletypes_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Sample Types"
 #: senaite/core/browser/controlpanel/sampletypes/view.py:58
 msgid "listing_sampletypes_title"
-msgstr ""
+msgstr "Типы образца"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:49
 msgid "listing_samplingdeviations_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:72
 msgid "listing_samplingdeviations_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sampling Deviation"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:65
 msgid "listing_samplingdeviations_column_title"
-msgstr ""
+msgstr "Отклонение при отборе проб"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:92
 msgid "listing_samplingdeviations_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:84
 msgid "listing_samplingdeviations_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:100
 msgid "listing_samplingdeviations_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Sampling Deviations"
 #: senaite/core/browser/controlpanel/samplingdeviations/view.py:56
 msgid "listing_samplingdeviations_title"
-msgstr ""
+msgstr "Отклонения при отборе проб"
 
 #. Default: "Calculation"
 #: senaite/core/browser/widgets/worksheettemplate_services_widget.py:70
 msgid "listing_services_column_calculation"
-msgstr ""
+msgstr "Формула расчёта"
 
 #. Default: "Hidden"
 #: senaite/core/browser/widgets/services_widget.py:112
 msgid "listing_services_column_hidden"
-msgstr ""
+msgstr "Скрыто"
 
 #. Default: "Keyword"
 #: senaite/core/browser/widgets/services_widget.py:84
 #: senaite/core/browser/widgets/worksheettemplate_services_widget.py:56
 msgid "listing_services_column_keyword"
-msgstr ""
+msgstr "Ключевое слово"
 
 #. Default: "Methods"
 #: senaite/core/browser/widgets/services_widget.py:91
 #: senaite/core/browser/widgets/worksheettemplate_services_widget.py:63
 msgid "listing_services_column_methods"
-msgstr ""
+msgstr "Методы"
 
 #. Default: "Partition"
 #: senaite/core/browser/widgets/sampletemplate_services_widget.py:51
 msgid "listing_services_column_partition"
-msgstr ""
+msgstr "Партиция"
 
 #. Default: "Price"
 #: senaite/core/browser/widgets/services_widget.py:105
 msgid "listing_services_column_price"
-msgstr ""
+msgstr "Цена"
 
 #. Default: "Service"
 #: senaite/core/browser/widgets/services_widget.py:76
 #: senaite/core/browser/widgets/worksheettemplate_services_widget.py:48
 msgid "listing_services_column_title"
-msgstr ""
+msgstr "Услуга"
 
 #. Default: "Unit"
 #: senaite/core/browser/widgets/services_widget.py:98
 msgid "listing_services_column_unit"
-msgstr ""
+msgstr "Единица измерения"
 
 #. Default: "All"
 #: senaite/core/browser/widgets/services_widget.py:127
 msgid "listing_services_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:49
 msgid "listing_storagelocations_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:75
 msgid "listing_storagelocations_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Location Code"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:104
 msgid "listing_storagelocations_column_location_code"
-msgstr ""
+msgstr "Код местоположения"
 
 #. Default: "Location Title"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:97
 msgid "listing_storagelocations_column_location_title"
-msgstr ""
+msgstr "Название местоположения"
 
 #. Default: "Shelf Code"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:118
 msgid "listing_storagelocations_column_shelf_code"
-msgstr ""
+msgstr "Код стеллажа"
 
 #. Default: "Shelf Title"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:111
 msgid "listing_storagelocations_column_shelf_title"
-msgstr ""
+msgstr "Название стеллажа"
 
 #. Default: "Site Code"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:90
 msgid "listing_storagelocations_column_site_code"
-msgstr ""
+msgstr "Код площадки"
 
 #. Default: "Site Title"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:83
 msgid "listing_storagelocations_column_site_title"
-msgstr ""
+msgstr "Название площадки"
 
 #. Default: "Storage Location"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:68
 msgid "listing_storagelocations_column_title"
-msgstr ""
+msgstr "Место хранения"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:129
 msgid "listing_storagelocations_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:147
 msgid "listing_storagelocations_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:138
 msgid "listing_storagelocations_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Storage Locations"
 #: senaite/core/browser/controlpanel/storagelocations/view.py:55
 msgid "listing_storagelocations_title"
-msgstr ""
+msgstr "Места хранения"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/subgroups/view.py:51
 msgid "listing_subgroup_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/subgroups/view.py:73
 msgid "listing_subgroups_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sort Key"
 #: senaite/core/browser/controlpanel/subgroups/view.py:80
 msgid "listing_subgroups_column_sortkey"
-msgstr ""
+msgstr "Ключ сортировки"
 
 #. Default: "Title"
 #: senaite/core/browser/controlpanel/subgroups/view.py:67
 msgid "listing_subgroups_column_title"
-msgstr ""
+msgstr "Название"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/subgroups/view.py:91
 msgid "listing_subgroups_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/subgroups/view.py:109
 msgid "listing_subgroups_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/subgroups/view.py:100
 msgid "listing_subgroups_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Sub-Groups"
 #: senaite/core/browser/controlpanel/subgroups/view.py:58
 msgid "listing_subgroups_title"
-msgstr ""
+msgstr "Подгруппы"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:51
 msgid "listing_suppliercontacts_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Business Phone"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:79
 msgid "listing_suppliercontacts_column_businessphone"
-msgstr ""
+msgstr "Рабочий телефон"
 
 #. Default: "Email Address"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:73
 msgid "listing_suppliercontacts_column_emailaddress"
-msgstr ""
+msgstr "Email адрес"
 
 #. Default: "Fax"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:91
 msgid "listing_suppliercontacts_column_fax"
-msgstr ""
+msgstr "Факс"
 
 #. Default: "FullName"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:67
 msgid "listing_suppliercontacts_column_fullname"
-msgstr ""
+msgstr "Полное имя"
 
 #. Default: "Mobile Phone"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:85
 msgid "listing_suppliercontacts_column_mobilephone"
-msgstr ""
+msgstr "Мобильный телефон"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:101
 msgid "listing_suppliercontacts_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Contacts"
 #: senaite/core/browser/controlpanel/suppliers/contacts.py:58
 msgid "listing_suppliercontacts_title"
-msgstr ""
+msgstr "Контакты"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/suppliers/view.py:54
 msgid "listing_suppliers_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Email"
 #: senaite/core/browser/controlpanel/suppliers/view.py:77
 msgid "listing_suppliers_column_email"
-msgstr ""
+msgstr "Email"
 
 #. Default: "Fax"
 #: senaite/core/browser/controlpanel/suppliers/view.py:91
 msgid "listing_suppliers_column_fax"
-msgstr ""
+msgstr "Факс"
 
 #. Default: "Name"
 #: senaite/core/browser/controlpanel/suppliers/view.py:70
 msgid "listing_suppliers_column_name"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Phone"
 #: senaite/core/browser/controlpanel/suppliers/view.py:84
 msgid "listing_suppliers_column_phone"
-msgstr ""
+msgstr "Телефон"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/suppliers/view.py:102
 msgid "listing_suppliers_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/suppliers/view.py:118
 msgid "listing_suppliers_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/suppliers/view.py:110
 msgid "listing_suppliers_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Suppliers"
 #: senaite/core/browser/controlpanel/suppliers/view.py:61
 msgid "listing_suppliers_title"
-msgstr ""
+msgstr "Поставщики"
 
 #. Default: "Add"
-#: senaite/core/browser/worksheets/view.py:67
+#: senaite/core/browser/worksheets/view.py:63
 msgid "listing_worksheets_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Analyst"
-#: senaite/core/browser/worksheets/view.py:118
+#: senaite/core/browser/worksheets/view.py:114
 msgid "listing_worksheets_column_analyst"
-msgstr ""
+msgstr "Аналитик"
 
 #. Default: "Created"
-#: senaite/core/browser/worksheets/view.py:150
+#: senaite/core/browser/worksheets/view.py:146
 msgid "listing_worksheets_column_created"
-msgstr ""
+msgstr "Создано"
 
 #. Default: "Routine Analyses"
-#: senaite/core/browser/worksheets/view.py:144
+#: senaite/core/browser/worksheets/view.py:140
 msgid "listing_worksheets_column_number_analyses"
-msgstr ""
+msgstr "Плановые анализы"
 
 #. Default: "QC Analyses"
-#: senaite/core/browser/worksheets/view.py:138
+#: senaite/core/browser/worksheets/view.py:134
 msgid "listing_worksheets_column_number_qc_analyses"
-msgstr ""
+msgstr "Анализы контроля качества"
 
 #. Default: "Samples"
-#: senaite/core/browser/worksheets/view.py:132
+#: senaite/core/browser/worksheets/view.py:128
 msgid "listing_worksheets_column_number_samples"
-msgstr ""
+msgstr "Образцы"
 
 #. Default: "Progress"
-#: senaite/core/browser/worksheets/view.py:105
+#: senaite/core/browser/worksheets/view.py:101
 msgid "listing_worksheets_column_progress"
-msgstr ""
+msgstr "Прогресс"
 
 #. Default: "State"
-#: senaite/core/browser/worksheets/view.py:157
+#: senaite/core/browser/worksheets/view.py:153
 msgid "listing_worksheets_column_state_title"
-msgstr ""
+msgstr "Статус"
 
 #. Default: "Template"
-#: senaite/core/browser/worksheets/view.py:125
+#: senaite/core/browser/worksheets/view.py:121
 msgid "listing_worksheets_column_template_title"
-msgstr ""
+msgstr "Шаблон"
 
 #. Default: "Worksheet"
-#: senaite/core/browser/worksheets/view.py:111
+#: senaite/core/browser/worksheets/view.py:107
 msgid "listing_worksheets_column_title"
-msgstr ""
+msgstr "Рабочий лист"
 
 #. Default: "Active"
-#: senaite/core/browser/worksheets/view.py:168
+#: senaite/core/browser/worksheets/view.py:164
 msgid "listing_worksheets_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
-#: senaite/core/browser/worksheets/view.py:227
+#: senaite/core/browser/worksheets/view.py:223
 msgid "listing_worksheets_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Mine"
-#: senaite/core/browser/worksheets/view.py:248
+#: senaite/core/browser/worksheets/view.py:244
 msgid "listing_worksheets_state_mine"
-msgstr ""
+msgstr "Мои"
 
 #. Default: "Open"
-#: senaite/core/browser/worksheets/view.py:185
+#: senaite/core/browser/worksheets/view.py:181
 msgid "listing_worksheets_state_open"
-msgstr ""
+msgstr "Открыто"
 
 #. Default: "To be verified"
-#: senaite/core/browser/worksheets/view.py:199
+#: senaite/core/browser/worksheets/view.py:195
 msgid "listing_worksheets_state_to_be_verified"
-msgstr ""
+msgstr "Ожидает верификации"
 
 #. Default: "Verified"
-#: senaite/core/browser/worksheets/view.py:213
+#: senaite/core/browser/worksheets/view.py:209
 msgid "listing_worksheets_state_verified"
-msgstr ""
+msgstr "Верифицировано"
 
 #. Default: "Worksheets"
-#: senaite/core/browser/worksheets/view.py:75
+#: senaite/core/browser/worksheets/view.py:71
 msgid "listing_worksheets_title"
-msgstr ""
+msgstr "Рабочие листы"
 
 #. Default: "Add"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:54
 msgid "listing_worksheettemplates_action_add"
-msgstr ""
+msgstr "Добавить"
 
 #. Default: "Description"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:77
 msgid "listing_worksheettemplates_column_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Instrument"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:91
 msgid "listing_worksheettemplates_column_instrument"
-msgstr ""
+msgstr "Инструмент"
 
 #. Default: "Method"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:84
 msgid "listing_worksheettemplates_column_method"
-msgstr ""
+msgstr "Метод"
 
 #. Default: "Name"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:70
 msgid "listing_worksheettemplates_column_name"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Active"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:103
 msgid "listing_worksheettemplates_state_active"
-msgstr ""
+msgstr "Активно"
 
 #. Default: "All"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:119
 msgid "listing_worksheettemplates_state_all"
-msgstr ""
+msgstr "Все"
 
 #. Default: "Inactive"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:111
 msgid "listing_worksheettemplates_state_inactive"
-msgstr ""
+msgstr "Неактивно"
 
 #. Default: "Worksheet Templates"
 #: senaite/core/browser/controlpanel/worksheettemplates/view.py:61
 msgid "listing_worksheettemplates_title"
-msgstr ""
+msgstr "Шаблоны рабочих листов"
 
 #: bika/lims/controlpanel/bika_analysisservices.py:285
 msgid "minutes"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — dirty indicator on the applied
-# preset
-msgid "modified"
-msgstr ""
+msgstr "минут"
 
 #: bika/lims/content/instrumentcertification.py:252
 msgid "monthly"
-msgstr ""
+msgstr "ежемесячно"
 
 #. Default: "No analyses added to this worksheet."
 #: senaite/core/browser/worksheets/worksheet/add_analyses.py:177
 msgid "no_analyses_added_to_this_worksheet"
-msgstr ""
+msgstr "В этот рабочий лист не были добавлены анализы."
 
 #. Default: "No analyses were added"
 #: senaite/core/browser/worksheets/worksheet/view.py:39
 msgid "no_analyses_were_added_message"
-msgstr ""
+msgstr "Анализы не были добавлены"
 
 #. Default: "Instrument has no data interface selected"
 #: senaite/core/browser/worksheets/worksheet/export.py:47
 msgid "no_data_instrument_message"
-msgstr ""
+msgstr "У инструмента не выбран интерфейс данных"
 
 #. Default: "Keyword '${duplicate}' duplicate found for a Analysis Service"
 #: senaite/core/validators/interimfields.py:97
 msgid "no_dup_service_keyword_validator_error"
-msgstr ""
+msgstr "Найден дубликат ключевого слова '${duplicate}' для услуги анализа"
 
 #. Default: "'${duplicate}' duplicates found"
 #: senaite/core/validators/interimfields.py:83
 msgid "no_dups_values_validator_error"
-msgstr ""
+msgstr "Найдены дубликаты '${duplicate}'"
 
 #. Default: "Wildcards for  are not allowed: ${wildcards}"
 #: senaite/core/validators/formula.py:45
 msgid "no_wildcards__error"
-msgstr ""
+msgstr "Шаблоны подстановки не допускаются: ${wildcards}"
 
 #. Default: "'${field_name}' is required"
 #: senaite/core/validators/interimfields.py:54
 msgid "non_blank_validator_error"
-msgstr ""
+msgstr "'${field_name}' обязательно"
 
 #. view."
-#. Default: "Layout view '${view}' not found. Set '${default}' as layout view."
+#. Default: "Layout view '${view}' not found. Set '${default}' as layout
+#. view."
 #: senaite/core/browser/worksheets/worksheet/manage_results.py:66
 msgid "not_found_worksheet_layout_message"
 msgstr ""
+"Представление макета '${view}' не найдено. Установлено '${default}' как "
+"представление макета."
 
 #. Default: "Set"
 #: senaite/core/browser/form/adapters/worksheettemplate.py:239
 msgid "num_of_positions_button_title"
-msgstr ""
+msgstr "Задать"
 
-#: senaite/core/browser/dashboard/dashboard.py:607
+#: senaite/core/browser/dashboard/dashboard.py:544
 msgid "of"
-msgstr ""
-
-#: senaite/core/api/remarks.py:494
-msgid "original"
-msgstr ""
+msgstr "из"
 
 #: bika/lims/browser/publish/templates/email.pt:30
 msgid "overview"
-msgstr ""
-
-# senaite.app.listing: Saved filter presets — menu subtitle
-msgid "per listing"
-msgstr ""
+msgstr "обзор"
 
 #: bika/lims/content/instrumentcertification.py:253
 msgid "quarterly"
-msgstr ""
+msgstr "ежеквартально"
 
 #: bika/lims/content/instrumentscheduledtask.py:137
 msgid "repeating every"
-msgstr ""
+msgstr "повторять каждые"
 
 #: bika/lims/content/instrumentscheduledtask.py:138
 msgid "repeatperiod"
-msgstr ""
+msgstr "Интервал повторений"
 
 #. Default: "Not detected"
 #: bika/lims/content/abstractanalysis.py:1120
 msgid "result_below_llod"
-msgstr ""
+msgstr "Не обнаружено"
 
 #. Default: "Detected but < ${LLOQ}"
 #: bika/lims/content/abstractanalysis.py:1131
 msgid "result_below_lloq"
-msgstr ""
+msgstr "Обнаружено, но < ${LLOQ}"
 
 #. Default: "Field Preservation"
 #: senaite/core/config/vocabularies.py:24
 msgid "sample_preservation_category_vocab_field"
-msgstr ""
+msgstr "Полевое сохранение"
 
 #. Default: "Lab Preservation"
 #: senaite/core/config/vocabularies.py:28
 msgid "sample_preservation_category_vocab_lab"
-msgstr ""
+msgstr "Лабораторное сохранение"
 
 #. Default: "Only ASCII characters in prefix allowed"
 #: senaite/core/content/sampletype.py:88
 msgid "sampletype_prefix_ascii_validator_message"
-msgstr ""
+msgstr "В префиксе допускаются только символы ASCII"
 
 #. Default: "No whitespaces in prefix allowed"
 #: senaite/core/content/sampletype.py:81
 msgid "sampletype_prefix_no_whitespace_validator_message"
-msgstr ""
+msgstr "В префиксе не допускаются пробелы"
 
 #. Default: "You must select an instrument"
 #: senaite/core/browser/worksheets/worksheet/export.py:37
 msgid "select_instrument_message"
-msgstr ""
+msgstr "Необходимо выбрать инструмент"
 
 #. Default: "Condition"
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:35
 msgid "set_analysis_conditions_colname_condition"
-msgstr ""
+msgstr "Условие"
 
 #. Default: "Show in report"
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:37
 msgid "set_analysis_conditions_colname_report"
-msgstr ""
+msgstr "Показывать в отчёте"
 
 #. Default: "Value"
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:36
 msgid "set_analysis_conditions_colname_value"
-msgstr ""
+msgstr "Значение"
 
 #. Default: "Folder to import the instrument results from"
 #: bika/lims/content/instrument.py:250
 msgid "subfield_label_instrument_import_folder"
-msgstr ""
+msgstr "Папка для импорта результатов инструмента"
 
 #. Default: "Interface Code"
 #: bika/lims/content/instrument.py:248
 msgid "subfield_label_instrument_interface_name"
-msgstr ""
+msgstr "Код интерфейса"
 
 #. Default: "This sample has been dispatched by ${actor} on ${date}"
 #: senaite/core/browser/viewlets/templates/sample_dispatched_viewlet.pt:14
 msgid "this_sample_has_been_dispatched_by"
-msgstr ""
-
-#. Default: "This sample has been disposed by ${actor} on ${date}"
-#: senaite/core/browser/viewlets/templates/sample_disposed_viewlet.pt:14
-msgid "this_sample_has_been_disposed_by"
-msgstr ""
+msgstr "Этот образец был отправлен пользователем ${actor} ${date}"
 
 #. Default: "${I}:${M} ${p}"
 #. The variables used here are the same as used in the strftime formating.
@@ -11500,1093 +12651,1255 @@ msgstr ""
 #. ${I}:${M} ${p}
 #: ./TranslationServiceTool.py
 msgid "time_format"
-msgstr ""
+msgstr "${I}:${M} ${p}"
 
 #. Default: "Accreditation"
 #: senaite/core/content/laboratory.py:170
 msgid "title_accreditation"
-msgstr ""
+msgstr "Аккредитация"
 
 #. Default: "Accreditation Body Abbreviation"
 #: senaite/core/content/laboratory.py:149
 msgid "title_accreditation_body"
-msgstr ""
+msgstr "Сокращение органа аккредитации"
 
 #. Default: "Accreditation Logo"
 #: senaite/core/content/laboratory.py:195
 msgid "title_accreditation_body_logo"
-msgstr ""
+msgstr "Логотип аккредитации"
 
 #. Default: "Accreditation Body URL"
 #: senaite/core/content/laboratory.py:160
 msgid "title_accreditation_body_url"
-msgstr ""
+msgstr "URL органа аккредитации"
 
 #. Default: "Accreditation page header"
 #: senaite/core/content/laboratory.py:216
 msgid "title_accreditation_page_header"
-msgstr ""
+msgstr "Заголовок страницы аккредитации"
 
 #. Default: "Accreditation Reference"
 #: senaite/core/content/laboratory.py:182
 msgid "title_accreditation_reference"
-msgstr ""
+msgstr "Референс аккредитации"
 
 #. Default: "Address"
 #: senaite/core/content/laboratory.py:88
 #: senaite/core/content/organization.py:82
 msgid "title_addresses_tab"
-msgstr ""
+msgstr "Адрес"
 
 #. Default: "Comments"
 #: senaite/core/content/analysiscategory.py:60
 msgid "title_analysiscategory_comments"
-msgstr ""
+msgstr "Комментарии"
 
 #. Default: "Department"
 #: senaite/core/content/analysiscategory.py:81
 msgid "title_analysiscategory_department"
-msgstr ""
+msgstr "Подразделение"
 
 #. Default: "Description"
 #: senaite/core/content/analysiscategory.py:52
 msgid "title_analysiscategory_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sort Key"
 #: senaite/core/content/analysiscategory.py:95
 msgid "title_analysiscategory_sort_key"
-msgstr ""
+msgstr "Ключ сортировки"
 
 #. Default: "Name"
 #: senaite/core/content/analysiscategory.py:44
 msgid "title_analysiscategory_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Commercial ID"
 #: senaite/core/content/analysisprofile.py:121
 msgid "title_analysisprofile_commercial_id"
-msgstr ""
+msgstr "Коммерческий ID"
 
 #. Default: "Description"
 #: senaite/core/content/analysisprofile.py:82
 msgid "title_analysisprofile_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Profile Keyword"
 #: senaite/core/content/analysisprofile.py:90
 msgid "title_analysisprofile_profile_key"
-msgstr ""
+msgstr "Ключевое слово профиля"
 
 #. Default: "Price (excluding VAT)"
 #: senaite/core/content/analysisprofile.py:145
 msgid "title_analysisprofile_profile_price"
-msgstr ""
+msgstr "Цена (без НДС)"
 
 #. Default: "VAT %"
 #: senaite/core/content/analysisprofile.py:157
 msgid "title_analysisprofile_profile_vat"
-msgstr ""
+msgstr "НДС, %"
 
 #. Default: "Profile Analyses"
 #: senaite/core/content/analysisprofile.py:106
 msgid "title_analysisprofile_services"
-msgstr ""
+msgstr "Анализы профиля"
 
 #. Default: "Name"
 #: senaite/core/content/analysisprofile.py:74
 msgid "title_analysisprofile_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Use analysis profile price"
 #: senaite/core/content/analysisprofile.py:133
 msgid "title_analysisprofile_use_profile_price"
-msgstr ""
+msgstr "Использовать цену профиля анализа"
 
 #. Default: "Analyst"
 #: senaite/core/permissions/localroles.py:30
 msgid "title_analyst_role"
-msgstr ""
+msgstr "Аналитик"
 
 #. Default: "Description"
 #: senaite/core/content/attachmenttype.py:44
 msgid "title_attachmenttype_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/attachmenttype.py:36
 msgid "title_attachmenttype_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Bank Details"
 #: senaite/core/content/organization.py:110
 msgid "title_bank_details_tab"
-msgstr ""
+msgstr "Банковские реквизиты"
 
 #. Default: "Name"
 #: senaite/core/content/batchlabel.py:36
 msgid "title_batchlabel_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "This site was built using the Plone Open Source CMS/WCM."
 #: senaite/core/browser/viewlets/templates/colophon.pt:12
 msgid "title_built_with_plone"
 msgstr ""
+"Этот сайт создан с использованием Plone — CMS/WCM с открытым исходным кодом."
 
 #. Default: "Description"
 #: senaite/core/content/calculation.py:228
 msgid "title_calculation_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/calculation.py:220
 msgid "title_calculation_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Confidence Level %"
 #: senaite/core/content/laboratory.py:123
 msgid "title_confidence_level"
-msgstr ""
+msgstr "Уровень доверия, %"
 
 #. Default: "Description"
 #: senaite/core/content/containertype.py:44
 msgid "title_containertype_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/containertype.py:36
 msgid "title_containertype_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Copyright"
 #: senaite/core/browser/viewlets/templates/footer.pt:11
 msgid "title_copyright"
-msgstr ""
+msgstr "Авторские права"
 
 #. Default: "Description"
 #: senaite/core/content/department.py:60
 msgid "title_department_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Department ID"
 #: senaite/core/content/department.py:76
 msgid "title_department_id"
-msgstr ""
+msgstr "ID подразделения"
 
 #. Default: "Name"
 #: senaite/core/content/department.py:48
 msgid "title_department_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "No instrument"
 #: senaite/core/vocabularies/instruments.py:43
 msgid "title_instrument_no_instrument"
-msgstr ""
+msgstr "Без инструмента"
 
 #. Default: "Description"
 #: senaite/core/content/instrumentlocation.py:44
 msgid "title_instrumentlocation_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/instrumentlocation.py:36
 msgid "title_instrumentlocation_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Description"
 #: senaite/core/content/instrumenttype.py:44
 msgid "title_instrumenttype_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/instrumenttype.py:36
 msgid "title_instrumenttype_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Description"
 #: senaite/core/content/interpretationtemplate.py:51
 msgid "title_interpretationtemplate_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/interpretationtemplate.py:43
 msgid "title_interpretationtemplate_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Lab Clerk"
 #: senaite/core/permissions/localroles.py:44
 msgid "title_lab_clerk_role"
-msgstr ""
+msgstr "Лаборант"
 
 #. Default: "Lab Manager"
 #: senaite/core/permissions/localroles.py:79
 msgid "title_lab_manager_role"
-msgstr ""
-
-#. Default: "Color"
-#: senaite/core/content/label.py:68
-msgid "title_label_color"
-msgstr ""
+msgstr "Менеджер лаборатории"
 
 #. Default: "Description"
-#: senaite/core/content/label.py:56
+#: senaite/core/content/label.py:46
 msgid "title_label_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
-#: senaite/core/content/label.py:41
+#: senaite/core/content/label.py:38
 msgid "title_label_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Laboratory Accredited"
 #: senaite/core/content/laboratory.py:136
 msgid "title_laboratory_accredited"
-msgstr ""
+msgstr "Лаборатория аккредитована"
 
 #. Default: "Lab URL"
 #: senaite/core/content/laboratory.py:98
 msgid "title_laboratory_lab_url"
-msgstr ""
+msgstr "URL лаборатории"
 
 #. Default: "Description"
 #: senaite/core/content/labproduct.py:60
 msgid "title_labproduct_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Price (excluding VAT)"
 #: senaite/core/content/labproduct.py:85
 msgid "title_labproduct_price"
-msgstr ""
+msgstr "Цена (без НДС)"
 
 #. Default: "Name"
 #: senaite/core/content/labproduct.py:52
 msgid "title_labproduct_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Total Price"
 #: senaite/core/content/labproduct.py:123
 msgid "title_labproduct_total_price"
-msgstr ""
+msgstr "Общая цена"
 
 #. Default: "Unit"
 #: senaite/core/content/labproduct.py:76
 msgid "title_labproduct_unit"
-msgstr ""
+msgstr "Единица измерения"
 
 #. Default: "VAT %"
 #: senaite/core/content/labproduct.py:98
 msgid "title_labproduct_vat"
-msgstr ""
+msgstr "НДС, %"
 
 #. Default: "VAT"
 #: senaite/core/content/labproduct.py:114
 msgid "title_labproduct_vat_amount"
-msgstr ""
+msgstr "НДС"
 
 #. Default: "Volume"
 #: senaite/core/content/labproduct.py:68
 msgid "title_labproduct_volume"
-msgstr ""
+msgstr "Объём"
 
 #. Default: "Blank Reference"
 #: senaite/core/content/worksheettemplate.py:132
 msgid "title_layout_record_blank_ref"
-msgstr ""
+msgstr "Холостая проба"
 
 #. Default: "Control Reference"
 #: senaite/core/content/worksheettemplate.py:158
 msgid "title_layout_record_control_ref"
-msgstr ""
+msgstr "Контрольный образец"
 
 #. Default: "Duplicate Of"
 #: senaite/core/content/worksheettemplate.py:191
 msgid "title_layout_record_dup"
-msgstr ""
+msgstr "Дубликат от"
 
 #. Default: "Duplicate Of"
 #: senaite/core/content/worksheettemplate.py:180
 msgid "title_layout_record_dup_proxy"
-msgstr ""
+msgstr "Дубликат от"
 
 #. Default: "Position"
 #: senaite/core/content/worksheettemplate.py:96
 msgid "title_layout_record_pos"
-msgstr ""
+msgstr "Позиция"
 
 #. Default: "Reference"
 #: senaite/core/content/worksheettemplate.py:169
 msgid "title_layout_record_reference_proxy"
-msgstr ""
+msgstr "Референс"
 
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheettemplate.py:106
 msgid "title_layout_record_type"
-msgstr ""
-
-#. Default: "Manage Viewlets"
-#: senaite/core/browser/viewlets/templates/manage-viewlets.pt:18
-msgid "title_manage_viewlets"
-msgstr ""
+msgstr "Тип анализа"
 
 #. Default: "Manager"
 #: senaite/core/permissions/localroles.py:86
 msgid "title_manager_role"
-msgstr ""
+msgstr "Менеджер"
 
 #. Default: "Description"
 #: senaite/core/content/manufacturer.py:44
 msgid "title_manufacturer_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/manufacturer.py:36
 msgid "title_manufacturer_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Not specified"
 #: senaite/core/vocabularies/methods.py:43
 msgid "title_method_not_specified"
-msgstr ""
+msgstr "Не указано"
 
 #. Default: "Bank Branch"
 #: senaite/core/content/organization.py:156
 msgid "title_organization_account_bank_branch"
-msgstr ""
+msgstr "Отделение банка"
 
 #. Default: "Bank Name"
 #: senaite/core/content/organization.py:148
 msgid "title_organization_account_bank_name"
-msgstr ""
+msgstr "Название банка"
 
 #. Default: "Account Name"
 #: senaite/core/content/organization.py:132
 msgid "title_organization_account_name"
-msgstr ""
+msgstr "Название счёта"
 
 #. Default: "Account Number"
 #: senaite/core/content/organization.py:140
 msgid "title_organization_account_number"
-msgstr ""
+msgstr "Номер счёта"
 
 #. Default: "Account Type"
 #: senaite/core/content/organization.py:124
 msgid "title_organization_account_type"
-msgstr ""
+msgstr "Тип счёта"
 
 #. Default: "Email"
 #: senaite/core/content/organization.py:93
 msgid "title_organization_email"
-msgstr ""
+msgstr "Email"
 
 #. Default: "Fax"
 #: senaite/core/content/organization.py:73
 msgid "title_organization_fax"
-msgstr ""
+msgstr "Факс"
 
 #. Default: "Name"
 #: senaite/core/content/organization.py:47
 msgid "title_organization_name"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Phone"
 #: senaite/core/content/organization.py:64
 msgid "title_organization_phone"
-msgstr ""
+msgstr "Телефон"
 
 #. Default: "VAT number"
 #: senaite/core/content/organization.py:55
 msgid "title_organization_tax_number"
-msgstr ""
+msgstr "Номер НДС"
 
 #. Default: "Owner"
 #: senaite/core/permissions/localroles.py:37
 msgid "title_owner_role"
-msgstr ""
+msgstr "Владелец"
 
 #. Default: "Preserver"
 #: senaite/core/permissions/localroles.py:51
 msgid "title_preserver_role"
-msgstr ""
+msgstr "Ответственный за сохранение"
 
 #. Default: "Publisher"
 #: senaite/core/permissions/localroles.py:58
 msgid "title_publisher_role"
-msgstr ""
+msgstr "Публикатор"
 
 #. Default: "Required"
 #: senaite/core/browser/modals/templates/set_analysis_conditions.pt:47
 #: senaite/core/browser/samples/templates/invalidate_samples.pt:91
 #: senaite/core/browser/samples/templates/manage_sample_fields.pt:137
 msgid "title_required"
-msgstr ""
+msgstr "Обязательно"
 
 #. Default: "Description"
 #: senaite/core/content/samplecondition.py:44
 msgid "title_samplecondition_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/samplecondition.py:36
 msgid "title_samplecondition_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Description"
 #: senaite/core/content/samplecontainer.py:52
 msgid "title_samplecontainer_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/samplecontainer.py:44
 msgid "title_samplecontainer_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Description"
 #: senaite/core/content/samplematrix.py:44
 msgid "title_samplematrix_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/samplematrix.py:36
 msgid "title_samplematrix_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Attachment"
 #: senaite/core/content/samplepoint.py:159
 msgid "title_samplepoint_attachment_file"
-msgstr ""
+msgstr "Вложение"
 
 #. Default: "Composite"
 #: senaite/core/content/samplepoint.py:143
 msgid "title_samplepoint_composite"
-msgstr ""
+msgstr "Составной"
 
 #. Default: "Description"
 #: senaite/core/content/samplepoint.py:64
 msgid "title_samplepoint_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Elevation"
 #: senaite/core/content/samplepoint.py:87
 msgid "title_samplepoint_elevation"
-msgstr ""
+msgstr "Высота"
 
 #. Default: "Location"
 #: senaite/core/content/samplepoint.py:72
 msgid "title_samplepoint_location"
-msgstr ""
+msgstr "Местоположение"
 
 #. Default: "Sampling Frequency"
 #: senaite/core/content/samplepoint.py:99
 msgid "title_samplepoint_sampling_frequency"
-msgstr ""
+msgstr "Частота отбора проб"
 
 #. Default: "Sample Types"
 #: senaite/core/content/samplepoint.py:122
 msgid "title_samplepoint_sampling_sample_types"
-msgstr ""
+msgstr "Типы образца"
 
 #. Default: "Name"
 #: senaite/core/content/samplepoint.py:56
 msgid "title_samplepoint_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Description"
 #: senaite/core/content/samplepreservation.py:47
 msgid "title_samplepreservation_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/samplepreservation.py:39
 msgid "title_samplepreservation_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Sampler"
 #: senaite/core/permissions/localroles.py:65
 msgid "title_sampler_role"
-msgstr ""
+msgstr "Пробоотборщик"
 
 #. Default: "Auto-partition on sample reception"
 #: senaite/core/content/sampletemplate.py:256
 msgid "title_sampletemplate_auto_partition"
-msgstr ""
+msgstr "Автоматическое разделение при приёме образца"
 
 #. Default: "Composite"
 #: senaite/core/content/sampletemplate.py:217
 msgid "title_sampletemplate_composite"
-msgstr ""
+msgstr "Составной"
 
 #. Default: "Description"
 #: senaite/core/content/sampletemplate.py:167
 msgid "title_sampletemplate_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sample collected by the laboratory"
 #: senaite/core/content/sampletemplate.py:226
 msgid "title_sampletemplate_sampling_required"
-msgstr ""
+msgstr "Образец отобран лабораторией"
 
 #. Default: "Services"
 #: senaite/core/content/sampletemplate.py:269
 msgid "title_sampletemplate_services"
-msgstr ""
+msgstr "Услуги"
 
 #. Default: "Name"
 #: senaite/core/content/sampletemplate.py:161
 msgid "title_sampletemplate_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Retention Period"
 #: senaite/core/content/sampletype.py:151
 msgid "title_sampletype_duration_period"
-msgstr ""
+msgstr "Срок хранения"
 
 #. Default: "Hazard categories"
 #: senaite/core/content/sampletype.py:178
 msgid "title_sampletype_hazard_categories"
-msgstr ""
+msgstr "Категории опасности"
 
 #. Default: "Hazardous"
 #: senaite/core/content/sampletype.py:166
 msgid "title_sampletype_hazardous"
-msgstr ""
+msgstr "Опасно"
 
 #. Default: "Minimum Volume"
 #: senaite/core/content/sampletype.py:231
 msgid "title_sampletype_min_volume"
-msgstr ""
+msgstr "Минимальный объём"
 
 #. Default: "Sample Type Prefix"
 #: senaite/core/content/sampletype.py:218
 msgid "title_sampletype_prefix"
-msgstr ""
+msgstr "Префикс типа образца"
 
 #. Default: "Description"
 #: senaite/core/content/samplingdeviation.py:44
 msgid "title_samplingdeviation_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Name"
 #: senaite/core/content/samplingdeviation.py:36
 msgid "title_samplingdeviation_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Allow to set the result capture date"
-#: senaite/core/content/senaitesetup.py:360
+#: senaite/core/content/senaitesetup.py:359
 msgid "title_senaitesetup_allow_manual_result_capture_date"
-msgstr ""
+msgstr "Разрешить устанавливать дату фиксации результата"
 
 #. Default: "Allow submission of results for unassigned analyses"
-#: senaite/core/content/senaitesetup.py:452
+#: senaite/core/content/senaitesetup.py:451
 msgid "title_senaitesetup_allow_to_submit_not_assigned"
-msgstr ""
+msgstr "Разрешить отправку результатов для неназначенных анализов"
 
 #. Default: "Always send publication email to responsibles"
-#: senaite/core/content/senaitesetup.py:286
+#: senaite/core/content/senaitesetup.py:285
 msgid "title_senaitesetup_always_cc_responsibles_in_report_emails"
-msgstr ""
+msgstr "Всегда отправлять письмо о публикации ответственным"
 
 #. Default: "Automatic log-off"
-#: senaite/core/content/senaitesetup.py:424
+#: senaite/core/content/senaitesetup.py:423
 msgid "title_senaitesetup_auto_log_off"
-msgstr ""
+msgstr "Автоматический выход из системы"
 
 #. Default: "Automatic verification of samples"
-#: senaite/core/content/senaitesetup.py:651
+#: senaite/core/content/senaitesetup.py:650
 msgid "title_senaitesetup_auto_verify_samples"
-msgstr ""
+msgstr "Автоматическая верификация образцов"
 
 #. Default: "Categorise analysis services"
-#: senaite/core/content/senaitesetup.py:596
+#: senaite/core/content/senaitesetup.py:595
 msgid "title_senaitesetup_categorise_analysis_services"
-msgstr ""
+msgstr "Категоризировать услуги анализа"
 
 #. Default: "Categorize sample analyses"
-#: senaite/core/content/senaitesetup.py:339
+#: senaite/core/content/senaitesetup.py:338
 msgid "title_senaitesetup_categorizesampleanalyses"
-msgstr ""
+msgstr "Категоризировать анализы образца"
 
 #. Default: "Currency"
-#: senaite/core/content/senaitesetup.py:493
+#: senaite/core/content/senaitesetup.py:492
 msgid "title_senaitesetup_currency"
-msgstr ""
+msgstr "Валюта"
 
 #. Default: "Use Dashboard as default front page"
-#: senaite/core/content/senaitesetup.py:858
+#: senaite/core/content/senaitesetup.py:857
 msgid "title_senaitesetup_dashboard_by_default"
-msgstr ""
+msgstr "Использовать панель управления как главную страницу по умолчанию"
 
 #. Default: "Date sampled required"
-#: senaite/core/content/senaitesetup.py:384
+#: senaite/core/content/senaitesetup.py:383
 msgid "title_senaitesetup_date_sampled_required"
-msgstr ""
+msgstr "Дата отбора обязательна"
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:554
+#: senaite/core/content/senaitesetup.py:553
 msgid "title_senaitesetup_decimal_mark"
-msgstr ""
+msgstr "Десятичный разделитель по умолчанию"
 
 #. Default: "Country"
-#: senaite/core/content/senaitesetup.py:507
+#: senaite/core/content/senaitesetup.py:506
 msgid "title_senaitesetup_default_country"
-msgstr ""
+msgstr "Страна"
 
 #. Default: "Default count of Sample to add."
-#: senaite/core/content/senaitesetup.py:741
+#: senaite/core/content/senaitesetup.py:740
 msgid "title_senaitesetup_default_number_of_ars_to_add"
-msgstr ""
+msgstr "Количество образцов для добавления по умолчанию."
 
 #. Default: "Publication 'From' address"
-#: senaite/core/content/senaitesetup.py:257
+#: senaite/core/content/senaitesetup.py:256
 msgid "title_senaitesetup_email_from_sample_publication"
-msgstr ""
+msgstr "Адрес отправителя публикации"
 
 #. Default: "Add a remarks field to all analyses"
-#: senaite/core/content/senaitesetup.py:638
+#: senaite/core/content/senaitesetup.py:637
 msgid "title_senaitesetup_enable_analysis_remarks"
-msgstr ""
+msgstr "Добавить поле замечаний ко всем анализам"
 
 #. Default: "Enable Sample Specifications"
-#: senaite/core/content/senaitesetup.py:609
+#: senaite/core/content/senaitesetup.py:608
 msgid "title_senaitesetup_enable_ar_specs"
-msgstr ""
+msgstr "Включить спецификации образца"
 
 #. Default: "Enable the rejection workflow"
-#: senaite/core/content/senaitesetup.py:755
+#: senaite/core/content/senaitesetup.py:754
 msgid "title_senaitesetup_enable_rejection_workflow"
-msgstr ""
+msgstr "Включить процесс отклонения"
 
 #. Default: "Exponential format threshold"
-#: senaite/core/content/senaitesetup.py:622
+#: senaite/core/content/senaitesetup.py:621
 msgid "title_senaitesetup_exponential_format_threshold"
-msgstr ""
+msgstr "Порог экспоненциального формата"
 
 #. Default: "Invalidation reason required"
-#: senaite/core/content/senaitesetup.py:409
+#: senaite/core/content/senaitesetup.py:408
 msgid "title_senaitesetup_invalidation_reason_required"
-msgstr ""
+msgstr "Причина аннулирования обязательна"
 
 #. Default: "Landing Page"
-#: senaite/core/content/senaitesetup.py:871
+#: senaite/core/content/senaitesetup.py:870
 msgid "title_senaitesetup_landing_page"
-msgstr ""
+msgstr "Стартовая страница"
 
 #. Default: "Member discount %"
-#: senaite/core/content/senaitesetup.py:521
+#: senaite/core/content/senaitesetup.py:520
 msgid "title_senaitesetup_member_discount"
-msgstr ""
+msgstr "Скидка для участников, %"
 
 #. Default: "Minimum number of results for QC stats calculations"
-#: senaite/core/content/senaitesetup.py:580
+#: senaite/core/content/senaitesetup.py:579
 msgid "title_senaitesetup_minimum_results"
 msgstr ""
+"Минимальное количество результатов для расчёта статистики контроля качества"
 
 #. Default: "Number of required verifications"
-#: senaite/core/content/senaitesetup.py:684
+#: senaite/core/content/senaitesetup.py:683
 msgid "title_senaitesetup_number_of_required_verifications"
-msgstr ""
+msgstr "Требуемое количество верификаций"
 
 #. Default: "Publication Email Text"
-#: senaite/core/content/senaitesetup.py:273
+#: senaite/core/content/senaitesetup.py:272
 msgid "title_senaitesetup_publication_email_text"
-msgstr ""
+msgstr "Текст письма публикации"
 
 #. Default: "Rejection reasons"
-#: senaite/core/content/senaitesetup.py:770
+#: senaite/core/content/senaitesetup.py:769
 msgid "title_senaitesetup_rejection_reasons"
-msgstr ""
+msgstr "Причины отклонения"
 
 #. Default: "Restrict worksheet management to lab managers"
-#: senaite/core/content/senaitesetup.py:468
+#: senaite/core/content/senaitesetup.py:467
 msgid "title_senaitesetup_restrict_worksheet_management"
-msgstr ""
+msgstr "Ограничить управление рабочими листами менеджерами лаборатории"
 
 #. Default: "Restrict worksheet access to assigned analysts"
-#: senaite/core/content/senaitesetup.py:438
+#: senaite/core/content/senaitesetup.py:437
 msgid "title_senaitesetup_restrict_worksheet_users_access"
-msgstr ""
+msgstr "Ограничить доступ к рабочему листу назначенными аналитиками"
 
 #. Default: "Default decimal mark"
-#: senaite/core/content/senaitesetup.py:715
+#: senaite/core/content/senaitesetup.py:714
 msgid "title_senaitesetup_results_decimal_mark"
-msgstr ""
+msgstr "Десятичный разделитель по умолчанию"
 
 #. Default: "Allow sample duplication"
-#: senaite/core/content/senaitesetup.py:965
+#: senaite/core/content/senaitesetup.py:964
 msgid "title_senaitesetup_sample_duplicate_enabled"
-msgstr ""
+msgstr "Разрешить дублирование образца"
 
 #. Default: "Require sample analyses"
-#: senaite/core/content/senaitesetup.py:349
+#: senaite/core/content/senaitesetup.py:348
 msgid "title_senaitesetup_sampleanalysesrequired"
-msgstr ""
+msgstr "Требовать анализы образца"
 
 #. Default: "Sample view analysis columns"
-#: senaite/core/content/senaitesetup.py:801
+#: senaite/core/content/senaitesetup.py:800
 msgid "title_senaitesetup_sampleview_columns_order"
-msgstr ""
+msgstr "Столбцы анализа в просмотре образца"
 
 #. Default: "Default scientific notation format for reports"
-#: senaite/core/content/senaitesetup.py:567
+#: senaite/core/content/senaitesetup.py:566
 msgid "title_senaitesetup_scientific_notation_report"
-msgstr ""
+msgstr "Формат научной нотации по умолчанию для отчётов"
 
 #. Default: "Default scientific notation format for results"
-#: senaite/core/content/senaitesetup.py:728
+#: senaite/core/content/senaitesetup.py:727
 msgid "title_senaitesetup_scientific_notation_results"
-msgstr ""
+msgstr "Формат научной нотации по умолчанию для результатов"
 
 #. Default: "Allow self-verification of results"
-#: senaite/core/content/senaitesetup.py:666
+#: senaite/core/content/senaitesetup.py:665
 msgid "title_senaitesetup_self_verification_enabled"
-msgstr ""
+msgstr "Разрешить самоверификацию результатов"
 
 #. Default: "Display laboratory name in the login page"
-#: senaite/core/content/senaitesetup.py:397
+#: senaite/core/content/senaitesetup.py:396
 msgid "title_senaitesetup_show_lab_name_in_login"
-msgstr ""
+msgstr "Показывать название лаборатории на странице входа"
 
 #. Default: "Display sample partitions to clients"
-#: senaite/core/content/senaitesetup.py:895
+#: senaite/core/content/senaitesetup.py:894
 msgid "title_senaitesetup_show_partitions"
-msgstr ""
+msgstr "Показывать партиции образца клиентам"
 
 #. Default: "Include and display pricing information"
-#: senaite/core/content/senaitesetup.py:485
+#: senaite/core/content/senaitesetup.py:484
 msgid "title_senaitesetup_show_prices"
-msgstr ""
+msgstr "Включить и отображать информацию о ценах"
 
 #. Default: "Sidebar navigation folders"
-#: senaite/core/content/senaitesetup.py:910
+#: senaite/core/content/senaitesetup.py:909
 msgid "title_senaitesetup_sidebar_folders"
-msgstr ""
+msgstr "Папки боковой навигации"
 
 #. Default: "Sidebar navigation depth"
-#: senaite/core/content/senaitesetup.py:929
+#: senaite/core/content/senaitesetup.py:928
 msgid "title_senaitesetup_sidebar_navigation_depth"
-msgstr ""
+msgstr "Глубина боковой навигации"
 
 #. Default: "Sidebar skipped portal types"
-#: senaite/core/content/senaitesetup.py:946
+#: senaite/core/content/senaitesetup.py:945
 msgid "title_senaitesetup_sidebar_skip_types"
-msgstr ""
+msgstr "Типы портала, пропускаемые в боковой навигации"
 
 #. Default: "Multi Verification type"
-#: senaite/core/content/senaitesetup.py:700
+#: senaite/core/content/senaitesetup.py:699
 msgid "title_senaitesetup_type_of_multi_verification"
-msgstr ""
+msgstr "Тип многократной верификации"
 
 #. Default: "VAT %"
-#: senaite/core/content/senaitesetup.py:538
+#: senaite/core/content/senaitesetup.py:537
 msgid "title_senaitesetup_vat"
-msgstr ""
+msgstr "НДС, %"
 
 #. Default: "Default layout in worksheet view"
-#: senaite/core/content/senaitesetup.py:842
+#: senaite/core/content/senaitesetup.py:841
 msgid "title_senaitesetup_worksheet_layout"
-msgstr ""
+msgstr "Макет по умолчанию в просмотре рабочего листа"
 
 #. Default: "Worksheet view analysis columns"
-#: senaite/core/content/senaitesetup.py:821
+#: senaite/core/content/senaitesetup.py:820
 msgid "title_senaitesetup_wsview_columns_order"
-msgstr ""
+msgstr "Столбцы анализа в просмотре рабочего листа"
 
 #. Default: "Service UID"
 #: senaite/core/content/worksheettemplate.py:86
 msgid "title_service_uid"
-msgstr ""
+msgstr "UID услуги"
 
 #. Default: "Description"
 #: senaite/core/content/storagelocation.py:46
 msgid "title_storagelocation_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Location Code"
 #: senaite/core/content/storagelocation.py:102
 msgid "title_storagelocation_location_code"
-msgstr ""
+msgstr "Код местоположения"
 
 #. Default: "Location Description"
 #: senaite/core/content/storagelocation.py:114
 msgid "title_storagelocation_location_description"
-msgstr ""
+msgstr "Описание местоположения"
 
 #. Default: "Location Title"
 #: senaite/core/content/storagelocation.py:90
 msgid "title_storagelocation_location_title"
-msgstr ""
+msgstr "Название местоположения"
 
 #. Default: "Location Type"
 #: senaite/core/content/storagelocation.py:126
 msgid "title_storagelocation_location_type"
-msgstr ""
+msgstr "Тип местоположения"
 
 #. Default: "Shelf Code"
 #: senaite/core/content/storagelocation.py:150
 msgid "title_storagelocation_shelf_code"
-msgstr ""
+msgstr "Код стеллажа"
 
 #. Default: "Shelf Description"
 #: senaite/core/content/storagelocation.py:162
 msgid "title_storagelocation_shelf_description"
-msgstr ""
+msgstr "Описание стеллажа"
 
 #. Default: "Shelf Title"
 #: senaite/core/content/storagelocation.py:138
 msgid "title_storagelocation_shelf_title"
-msgstr ""
+msgstr "Название стеллажа"
 
 #. Default: "Site Code"
 #: senaite/core/content/storagelocation.py:66
 msgid "title_storagelocation_site_code"
-msgstr ""
+msgstr "Код площадки"
 
 #. Default: "Site Description"
 #: senaite/core/content/storagelocation.py:78
 msgid "title_storagelocation_site_description"
-msgstr ""
+msgstr "Описание площадки"
 
 #. Default: "Site Title"
 #: senaite/core/content/storagelocation.py:54
 msgid "title_storagelocation_site_title"
-msgstr ""
+msgstr "Название площадки"
 
 #. Default: "Address"
 #: senaite/core/content/storagelocation.py:38
 msgid "title_storagelocation_title"
-msgstr ""
+msgstr "Адрес"
 
 #. Default: "Description"
 #: senaite/core/content/subgroup.py:48
 msgid "title_subgroup_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Sort Key"
 #: senaite/core/content/subgroup.py:56
 msgid "title_subgroup_sort_key"
-msgstr ""
+msgstr "Ключ сортировки"
 
 #. Default: "Name"
 #: senaite/core/content/subgroup.py:40
 msgid "title_subgroup_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "IBAN"
 #: senaite/core/content/supplier.py:96
 msgid "title_supplier_iban"
-msgstr ""
+msgstr "IBAN"
 
 #. Default: "Lab Account Number"
 #: senaite/core/content/supplier.py:47
 msgid "title_supplier_lab_contact_number"
-msgstr ""
+msgstr "Номер лабораторного счёта"
 
 #. Default: "NIB"
 #: senaite/core/content/supplier.py:84
 msgid "title_supplier_nib"
-msgstr ""
+msgstr "NIB"
 
 #. Default: "Remarks"
 #: senaite/core/content/supplier.py:55
 msgid "title_supplier_remarks"
-msgstr ""
+msgstr "Замечания"
 
 #. Default: "SWIFT code"
 #: senaite/core/content/supplier.py:108
 msgid "title_supplier_swift_code"
-msgstr ""
+msgstr "Код SWIFT"
 
 #. Default: "Website"
 #: senaite/core/content/supplier.py:63
 msgid "title_supplier_website"
-msgstr ""
+msgstr "Веб-сайт"
 
 #. Default: "Verifier"
 #: senaite/core/permissions/localroles.py:72
 msgid "title_verifier_role"
-msgstr ""
+msgstr "Верификатор"
 
 #. Default: "Analyses"
 #: senaite/core/content/worksheet.py:165
 msgid "title_worksheet_analyses"
-msgstr ""
+msgstr "Анализы"
 
 #. Default: "Analyst"
 #: senaite/core/content/worksheet.py:187
 msgid "title_worksheet_analyst"
-msgstr ""
+msgstr "Аналитик"
 
 #. Default: "Description"
 #: senaite/core/content/worksheet.py:136
 msgid "title_worksheet_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Instrument"
 #: senaite/core/content/worksheet.py:197
 msgid "title_worksheet_instrument"
-msgstr ""
+msgstr "Инструмент"
 
 #. Default: "Layout"
 #: senaite/core/content/worksheet.py:154
 msgid "title_worksheet_layout"
-msgstr ""
+msgstr "Макет"
 
 #. Default: "Analysis"
 #: senaite/core/content/worksheet.py:110
 msgid "title_worksheet_layout_analysis"
-msgstr ""
+msgstr "Анализ"
 
 #. Default: "Analysis Type"
 #: senaite/core/content/worksheet.py:90
 msgid "title_worksheet_layout_analysis_type"
-msgstr ""
+msgstr "Тип анализа"
 
 #. Default: "Container"
 #: senaite/core/content/worksheet.py:100
 msgid "title_worksheet_layout_container"
-msgstr ""
+msgstr "Контейнер"
 
 #. Default: "Position"
 #: senaite/core/content/worksheet.py:81
 msgid "title_worksheet_layout_position"
-msgstr ""
+msgstr "Позиция"
 
 #. Default: "Method"
 #: senaite/core/content/worksheet.py:176
 msgid "title_worksheet_method"
-msgstr ""
+msgstr "Метод"
 
 #. Default: "Remarks"
 #: senaite/core/content/worksheet.py:209
 msgid "title_worksheet_remarks"
-msgstr ""
+msgstr "Замечания"
 
 #. Default: "Results Layout"
 #: senaite/core/content/worksheet.py:217
 msgid "title_worksheet_results_layout"
-msgstr ""
+msgstr "Макет результатов"
 
 #. Default: "Name"
 #: senaite/core/content/worksheet.py:127
 msgid "title_worksheet_title"
-msgstr ""
+msgstr "Имя"
 
 #. Default: "Worksheet Template"
 #: senaite/core/content/worksheet.py:144
 msgid "title_worksheet_worksheettemplate"
-msgstr ""
+msgstr "Шаблон рабочего листа"
 
 #. Default: "Description"
 #: senaite/core/content/worksheettemplate.py:213
 msgid "title_worksheettemplate_description"
-msgstr ""
+msgstr "Описание"
 
 #. Default: "Number of Positions"
 #: senaite/core/content/worksheettemplate.py:290
 msgid "title_worksheettemplate_num_of_positions"
-msgstr ""
+msgstr "Количество позиций"
 
 #. Default: "Analysis Services"
 #: senaite/core/content/worksheettemplate.py:346
 msgid "title_worksheettemplate_services"
-msgstr ""
+msgstr "Услуги анализа"
 
 #. Default: "Worksheet Layout"
 #: senaite/core/content/worksheettemplate.py:311
 msgid "title_worksheettemplate_template_layout"
-msgstr ""
+msgstr "Макет рабочего листа"
 
 #. Default: "Name"
 #: senaite/core/content/worksheettemplate.py:205
 msgid "title_worksheettemplate_title"
-msgstr ""
+msgstr "Имя"
 
 #: bika/lims/content/instrumentscheduledtask.py:140
 msgid "until"
-msgstr ""
+msgstr "пока не"
 
 #. Lower Limit of Quantification (LLOQ)."
-#. Default: "The Lower Limit of Detection (LLOD) cannot be greater than the Lower Limit of Quantification (LLOQ)."
+#. Default: "The Lower Limit of Detection (LLOD) cannot be greater than the
+#. Lower Limit of Quantification (LLOQ)."
 #: bika/lims/validators.py:1491
 msgid "validator_llod_above_lloq"
 msgstr ""
+"Нижний предел обнаружения (LLOD) не может быть больше нижнего предела "
+"количественного определения (LLOQ)."
 
 #. or equal to the Upper Limit of Quantification (ULOQ)."
-#. Default: "The Lower Limit of Quantification (LLOQ) cannot be greater than or equal to the Upper Limit of Quantification (ULOQ)."
+#. Default: "The Lower Limit of Quantification (LLOQ) cannot be greater than
+#. or equal to the Upper Limit of Quantification (ULOQ)."
 #: bika/lims/validators.py:1519
 msgid "validator_lloq_above_uloq"
 msgstr ""
+"Нижний предел количественного определения (LLOQ) не может быть больше или "
+"равен верхнему пределу количественного определения (ULOQ)."
 
 #. associated with other objects, such as QC analyses."
-#. Default: "The Reference Sample ID cannot be changed because it is already associated with other objects, such as QC analyses."
+#. Default: "The Reference Sample ID cannot be changed because it is already
+#. associated with other objects, such as QC analyses."
 #: bika/lims/validators.py:1586
 msgid "validator_referencesample_id_children"
 msgstr ""
+"ID референс-образца нельзя изменить, поскольку он уже связан с другими "
+"объектами, например анализами контроля качества."
 
 #. Default: "A Reference Sample with the ID '%s' already exists."
 #: bika/lims/validators.py:1601
 msgid "validator_referencesample_id_exists"
-msgstr ""
+msgstr "Референс-образец с ID '%s' уже существует."
 
 #. letters, numbers, underscores ('_'), or hyphens ('-'), and verify that no
 #. other Reference Sample with the same ID already exists."
-#. Default: "The Reference Sample ID is invalid. Ensure it contains only letters, numbers, underscores ('_'), or hyphens ('-'), and verify that no other Reference Sample with the same ID already exists."
+#. Default: "The Reference Sample ID is invalid. Ensure it contains only
+#. letters, numbers, underscores ('_'), or hyphens ('-'), and verify that no
+#. other Reference Sample with the same ID already exists."
 #: bika/lims/validators.py:1576
 msgid "validator_referencesample_id_invalid"
 msgstr ""
+"ID референс-образца недействителен. Убедитесь, что он содержит только буквы,"
+" цифры, знаки подчёркивания ('_') или дефисы ('-'), и проверьте, что другой "
+"референс-образец с таким же ID не существует."
 
 #. the Upper Limit of Detection (ULOD)."
-#. Default: "The Upper Limit of Quantification (LLOQ) cannot be greater than the Upper Limit of Detection (ULOD)."
+#. Default: "The Upper Limit of Quantification (LLOQ) cannot be greater than
+#. the Upper Limit of Detection (ULOD)."
 #: bika/lims/validators.py:1547
 msgid "validator_uloq_above_ulod"
 msgstr ""
+"Верхний предел количественного определения (LLOQ) не может быть больше "
+"верхнего предела обнаружения (ULOD)."
 
-#: bika/lims/browser/analyses/view.py:1588
+#: bika/lims/browser/analyses/view.py:1587
 msgid "verification(s) pending"
-msgstr ""
+msgstr "проверка(и) в ожидании"
 
 #: bika/lims/content/instrumentcertification.py:251
 msgid "weekly"
-msgstr ""
+msgstr "еженедельно"
 
 #. Default: "Created worksheet ${ws_id}"
 #: senaite/core/browser/modals/sample.py:67
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:63
 msgid "worksheet_created"
-msgstr ""
+msgstr "Создан рабочий лист ${ws_id}"
 
 #. Default: "Worksheet not created."
 #: senaite/core/browser/worksheets/worksheet/add_worksheet.py:56
 msgid "worksheet_not_created"
-msgstr ""
+msgstr "Рабочий лист не создан."
 
 #: bika/lims/content/instrumentcertification.py:255
 msgid "yearly"
-msgstr ""
+msgstr "ежегодно"
 
 #: senaite/core/exportimport/instruments/importer.py:783
-msgid "{request_id}: calculated result for '{analysis_keyword}': '{analysis_result}'"
+msgid ""
+"{request_id}: calculated result for '{analysis_keyword}': "
+"'{analysis_result}'"
 msgstr ""
+"{request_id}: рассчитан результат для '{analysis_keyword}': "
+"'{analysis_result}'"
 
 #: senaite/core/exportimport/instruments/importer.py:532
 msgid "{request_id}: {keywords} imported sucessfully"
-msgstr ""
+msgstr "{request_id}: {keywords} успешно импортированы"
 
 #: senaite/core/exportimport/instruments/importer.py:731
 msgid "{sid} Updated field '{field}' with '{value}'"
-msgstr ""
+msgstr "{sid}: поле '{field}' обновлено значением '{value}'"
 
 #: senaite/core/exportimport/instruments/importer.py:613
 msgid "{sid} result for '{analysis_keyword}:{interim_keyword}': '{value}'"
 msgstr ""
+"{sid}: результат для '{analysis_keyword}:{interim_keyword}': '{value}'"
 
 #: senaite/core/exportimport/instruments/importer.py:680
 msgid "{sid} result for '{keyword}': '{result}'"
-msgstr ""
+msgstr "{sid}: результат для '{keyword}': '{result}'"
 
-#: bika/lims/browser/analyses/view.py:628
+#: bika/lims/browser/analyses/view.py:627
 msgid "{} (Out of date)"
-msgstr ""
+msgstr "{} (просрочено)"
 
 #: bika/lims/controlpanel/bika_instruments.py:173
 msgid "{} weeks and {} day(s)"
-msgstr ""
+msgstr "{} недели и {} день"
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Samples to Receive"
+msgstr "Образцы к приёму"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Results Pending"
+msgstr "Ожидают результатов"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "To be Verified"
+msgstr "На проверку"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "To be Published"
+msgstr "К публикации"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Open Worksheets"
+msgstr "Открытые рабочие листы"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Register Samples"
+msgstr "Регистрация образцов"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Verify Results"
+msgstr "Проверить результаты"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Publish Reports"
+msgstr "Опубликовать отчёты"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Samples awaiting collection of the sample"
+msgstr "Образцы, ожидающие отбора пробы"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Samples awaiting preservation"
+msgstr "Образцы, ожидающие консервации"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Samples with a scheduled sampling date"
+msgstr "Образцы с запланированной датой отбора"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Samples awaiting reception at the laboratory"
+msgstr "Образцы, ожидающие приёма в лаборатории"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Received samples with analyses awaiting results"
+msgstr "Полученные образцы с анализами, ожидающими результатов"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Samples whose results are awaiting verification"
+msgstr "Образцы, результаты которых ожидают проверки"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Verified samples ready to be published"
+msgstr "Проверенные образцы, готовые к публикации"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Samples whose reports have been published"
+msgstr "Образцы, отчёты по которым опубликованы"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Published samples whose reports have not been printed yet"
+msgstr "Опубликованные образцы, отчёты которых ещё не распечатаны"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Analyses not yet assigned to a worksheet"
+msgstr "Анализы, ещё не назначенные в рабочий лист"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Analyses assigned to a worksheet, awaiting results"
+msgstr "Анализы, назначенные в рабочий лист, ожидают результатов"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Submitted analyses awaiting verification"
+msgstr "Отправленные анализы, ожидающие проверки"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Analyses that have been verified"
+msgstr "Проверенные анализы"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Analyses included in a published report"
+msgstr "Анализы, включённые в опубликованный отчёт"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Open worksheets with analyses awaiting results"
+msgstr "Открытые рабочие листы с анализами, ожидающими результатов"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Worksheets whose results are awaiting verification"
+msgstr "Рабочие листы, результаты которых ожидают проверки"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py
+msgid "Worksheets that have been verified"
+msgstr "Проверенные рабочие листы"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "Quick Actions"
+msgstr "Быстрые действия"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "No data for the selected period"
+msgstr "Нет данных за выбранный период"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "No actions available. Please contact your laboratory manager to get permissions assigned."
+msgstr "Нет доступных действий. Обратитесь к руководителю лаборатории для назначения прав доступа."
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "to"
+msgstr "по"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "(updated every 2 hours)"
+msgstr "(обновляется каждые 2 часа)"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "Daily"
+msgstr "Ежедневно"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "Weekly"
+msgstr "Еженедельно"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "Monthly"
+msgstr "Ежемесячно"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "Quarterly"
+msgstr "Ежеквартально"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "Biannual"
+msgstr "Раз в полгода"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "Yearly"
+msgstr "Ежегодно"
+
+#. Dynamically built/collected in senaite/core/browser/dashboard/dashboard.py (get_js_labels, for dashboard.js chrome strings)
+msgid "Show/hide timeline"
+msgstr "Показать/скрыть таймлайн"
+


### PR DESCRIPTION
## Summary

Fills in the remaining untranslated strings in the `ru` and `ru_RU`
locales for both the `senaite.core` and `plone` (plonelocales-shipped
fallback) message catalogs, taking them from partial coverage to fully
translated (`ru/senaite.core.po` was 526/2619 translated, `ru/plone.po`
53/200, `ru_RU` was 0% on both files before this change).

Also adds `msgid`/`msgstr` entries for a handful of strings that were
missing from the catalog entirely (not just untranslated), because
they're built dynamically in code rather than being static
template/TAL content — e.g.
`review_state.capitalize().replace("_", " ")` in
`bika/lims/browser/publish/reports_listing.py`, and the dashboard
card/tooltip strings newly wrapped in `_()` by the companion PR #3009
("Fix dashboard i18n: translations never reach the JSON payload").

## How this was translated

Assembled by cross-referencing untranslated entries (`msgattrib
--untranslated`) plus the `#. Default: "..."` comments for id-style
msgids, against a manually curated English→Russian glossary
(~1850 unique strings), keeping the terminology already established in
the partially-translated source consistent throughout (`Sample` →
`Образец`, `Client` → `Клиент`, `Department` → `Подразделение`,
`Instrument` → `Инструмент`, etc.). Placeholders (`${...}`, `%s`, `{}`)
are preserved unchanged.

## Scope / notes for reviewers

This is a large, mechanical diff by nature (translation catalog fill),
not a code change — happy to split by file/domain, or route through
Transifex/Weblate instead if that's this project's preferred channel
for translation contributions (I didn't find a `.tx/`or Weblate config
in the repo, so opened directly as a PR). `senaite.storage`,
`senaite.impress`, `senaite.ldap`, `senaite.databox` still have no
`ru/` catalog at all (out of scope here — would need a fresh
`.pot`→`.po`, not filling an existing one).