### PR TITLE
usergroups disable保存失效bug

### DIFF
--- a/src/senaite/core/browser/usergroup/usergroups_usersoverview.py
+++ b/src/senaite/core/browser/usergroup/usergroups_usersoverview.py
@@ -136,3 +136,26 @@ class UsersOverviewControlPanel(BaseView):
         # XXX: Maybe we could index local role assignments in the future?
         for client in self.get_clients():
             mtool.deleteLocalRoles(client, member_ids, reindex=0, recursive=0)
+<<<<<<< Updated upstream
+=======
+
+    def manageUser(self, users=[], resetpassword=[], delete=[]):
+        """接管保存逻辑，忽略物理删除，仅维护禁用状态
+        """
+        # 中文注释：基类 __call__ 会把表单中所有 users.*:records 字段解析成
+        # request.form['users'] 下的 record 对象列表（Zope 的 records 类型会
+        # 剥掉 :records 后缀并按点号分组，users.disabled:records 会作为
+        # disabled 属性挂到同一条 users.id:records 记录上）。因此不能再用
+        # form.get("users.disabled:records") 这种带后缀的键读取（真实请求中
+        # 永远取不到），直接遍历基类传入的 users 参数，取记录的 id / disabled
+        # 属性即可。
+        for user in (users or []):
+            user_id = getattr(user, "id", None)
+            if not user_id:
+                continue
+            set_account_disabled(user_id, bool(getattr(user, "disabled", None)))
+
+        # 即使有人手工伪造 delete:list 提交，也不再执行物理删除。
+        return super(UsersOverviewControlPanel, self).manageUser(
+            users, resetpassword, [])
+>>>>>>> Stashed changes


### PR DESCRIPTION
修复内容
manageUser 改为直接遍历基类 __call__ 传入的 users 参数
（即 form["users"] 的 record 对象列表），取记录的 id / disabled 属性：

    for user in (users or []):
        user_id = getattr(user, "id", None)
        if not user_id:
            continue
        set_account_disabled(user_id, bool(getattr(user, "disabled", None)))

## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR

## Desired behavior after PR is merged

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
