### PR TITLE
Remove stale uid_catalog records that break lookups by UID

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #3012 Remove stale uid_catalog records that break lookups by UID
 - #2995 Add interactive upgrade, catalog and user console scripts
 - #3008 Filter sidebar root folders by permission instead of by catalog
 - #3007 Fix empty sticker template selection when printing stickers from a listing

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -1042,7 +1042,20 @@ def get_brain_by_uid(uid, default=None):
 
     # try to find the object with the reference catalog first
     brains = uc(UID=uid)
-    if len(brains) != 1:
+    if len(brains) > 1:
+        # More than one catalog record claims this UID. The object is there,
+        # but it cannot be told apart, so the lookup has to fail. Log it as
+        # such: an "object not found" further up the stack is misleading and
+        # sends the reader looking for a missing object instead of a broken
+        # catalog.
+        paths = sorted(map(lambda brain: brain.getPath(), brains))
+        logger.error(
+            "Found %s records in the uid_catalog for UID '%s': %s. The "
+            "catalog is inconsistent, most likely because of stale records "
+            "left behind by a content migration."
+            % (len(brains), uid, ", ".join(paths)))
+        return default
+    if not brains:
         return default
     return brains[0]
 

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -511,6 +511,27 @@ def move_object(obj, destination, check_constraints=True):
     return obj
 
 
+def get_uid_catalog_path(obj):
+    """Return the path an object has to be cataloged under in uid_catalog
+
+    Archetypes content is cataloged relative to the portal, Dexterity
+    content under the absolute path. Getting this wrong leaves a second
+    record for the same object behind, which makes every lookup by UID
+    ambiguous.
+
+    :param obj: object to get the uid_catalog path for
+    :type obj: ATContentType/DexterityContentType
+    :returns: the path the object belongs to in the uid_catalog
+    """
+    if is_at_content(obj):
+        # the uids of uid_catalog are relative paths to portal root
+        # see Products.Archetypes.UIDCatalog.UIDResolver.catalog_object
+        return getRelURL(get_tool(UID_CATALOG), obj.getPhysicalPath())
+    # DX content is cataloged below the absolute path, as it is done in
+    # `plone.app.referenceablebehavior.uidcatalog`
+    return "/".join(obj.getPhysicalPath())
+
+
 def uncatalog_object(obj, recursive=False):
     """Un-catalog the object from all catalogs
 
@@ -549,19 +570,9 @@ def catalog_object(obj, recursive=False):
     :param recursive: recursively catalog all child objects
     :type obj: ATContentType/DexterityContentType
     """
-    if is_at_content(obj):
-        # the uids of uid_catalog are relative paths to portal root
-        # see Products.Archetypes.UIDCatalog.UIDResolver.catalog_object
+    if is_at_content(obj) or is_dexterity_content(obj):
         uc = get_tool(UID_CATALOG)
-        rel_url = getRelURL(uc, obj.getPhysicalPath())
-        uc.catalog_object(obj, rel_url)
-
-    elif is_dexterity_content(obj):
-        # we catalog the object here below the absolute path, as it is done in
-        # `plone.app.referencablebehavior.uidcatalog``
-        uc = get_tool(UID_CATALOG)
-        abs_url = "/".join(obj.getPhysicalPath())
-        uc.catalog_object(obj, abs_url)
+        uc.catalog_object(obj, get_uid_catalog_path(obj))
 
     # reindex in registered catalogs
     obj.reindexObject()

--- a/src/senaite/core/profiles/default/metadata.xml
+++ b/src/senaite/core/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2754</version>
+  <version>2755</version>
   <dependencies>
     <dependency>profile-Products.ATContentTypes:base</dependency>
     <dependency>profile-senaite.impress:default</dependency>

--- a/src/senaite/core/upgrade/utils.py
+++ b/src/senaite/core/upgrade/utils.py
@@ -34,6 +34,7 @@ from Persistence import PersistentMapping
 from plone.dexterity.fti import DexterityFTI
 from plone.dexterity.fti import register as register_dx_fti
 from plone.dexterity.interfaces import IDexterityFTI
+from Products.Archetypes.utils import getRelURL
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import get_installer
 from Products.ZCatalog.ProgressHandler import ZLogHandler
@@ -381,6 +382,94 @@ def catalog_object(obj):
     """Catalog the object
     """
     obj.reindexObject()
+
+
+def get_uid_catalog_path(catalog, obj):
+    """Return the path an object has to be cataloged under in uid_catalog
+
+    Archetypes content is cataloged relative to the portal, Dexterity
+    content under the absolute path.
+
+    :param catalog: the uid_catalog tool
+    :param obj: the object to get the path for
+    :returns: the path the object belongs to in the uid_catalog
+    """
+    if api.is_at_content(obj):
+        return getRelURL(catalog, obj.getPhysicalPath())
+    return "/".join(obj.getPhysicalPath())
+
+
+def resolve_uid_catalog_path(portal, path):
+    """Return the object a uid_catalog path points to
+
+    Both path conventions are accepted. Returns `None` when the path does
+    not resolve, or resolves to another object through acquisition.
+
+    :param portal: the portal object
+    :param path: a path as stored in the uid_catalog
+    :returns: the object or None
+    """
+    portal_path = "/".join(portal.getPhysicalPath())
+    relative = path
+    if relative.startswith("%s/" % portal_path):
+        relative = relative[len(portal_path) + 1:]
+    obj = portal.unrestrictedTraverse(str(relative), None)
+    if obj is None:
+        return None
+    # traversal acquires, so make sure we got the object the path names
+    if "/".join(obj.getPhysicalPath()) != "%s/%s" % (portal_path, relative):
+        return None
+    return obj
+
+
+def expects_relative_path(fti):
+    """Check whether content of the given type is cataloged relative
+
+    Archetypes types carry the product they come from, Dexterity ones do
+    not.
+
+    :param fti: the type information of the content type
+    :returns: True for Archetypes content types
+    """
+    return bool(getattr(fti, "product", None))
+
+
+def is_stale_uid_catalog_path(types_tool, catalog, path, rid):
+    """Check whether a uid_catalog record sits under the wrong path
+
+    Decided on the metadata of the record alone, so that the objects
+    behind the records do not have to be woken up.
+
+    :param types_tool: the portal_types tool
+    :param catalog: the uid_catalog tool
+    :param path: a path as stored in the uid_catalog
+    :param rid: the record id of the path
+    :returns: True if the record has to be re-cataloged, None if the type
+              of the record is unknown and nothing can be decided
+    """
+    metadata = catalog._catalog.getMetadataForRID(rid)
+    fti = types_tool.getTypeInfo(metadata.get("portal_type"))
+    if fti is None:
+        # no type information to decide with, leave the record alone
+        return None
+    return path.startswith("/") == expects_relative_path(fti)
+
+
+def repair_uid_catalog_path(portal, catalog, path):
+    """Drop a stale record and catalog the object under the correct path
+
+    :param portal: the portal object
+    :param catalog: the uid_catalog tool
+    :param path: a path as stored in the uid_catalog
+    """
+    obj = resolve_uid_catalog_path(portal, path)
+    catalog.uncatalog_object(path)
+    if obj is None:
+        logger.info("Removed orphan uid_catalog record '%s'" % path)
+        return
+    target = get_uid_catalog_path(catalog, obj)
+    catalog.catalog_object(obj, target)
+    logger.info("Re-cataloged '%s' as '%s'" % (path, target))
 
 
 def delete_object(obj):

--- a/src/senaite/core/upgrade/utils.py
+++ b/src/senaite/core/upgrade/utils.py
@@ -34,7 +34,6 @@ from Persistence import PersistentMapping
 from plone.dexterity.fti import DexterityFTI
 from plone.dexterity.fti import register as register_dx_fti
 from plone.dexterity.interfaces import IDexterityFTI
-from Products.Archetypes.utils import getRelURL
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import get_installer
 from Products.ZCatalog.ProgressHandler import ZLogHandler
@@ -384,21 +383,6 @@ def catalog_object(obj):
     obj.reindexObject()
 
 
-def get_uid_catalog_path(catalog, obj):
-    """Return the path an object has to be cataloged under in uid_catalog
-
-    Archetypes content is cataloged relative to the portal, Dexterity
-    content under the absolute path.
-
-    :param catalog: the uid_catalog tool
-    :param obj: the object to get the path for
-    :returns: the path the object belongs to in the uid_catalog
-    """
-    if api.is_at_content(obj):
-        return getRelURL(catalog, obj.getPhysicalPath())
-    return "/".join(obj.getPhysicalPath())
-
-
 def resolve_uid_catalog_path(portal, path):
     """Return the object a uid_catalog path points to
 
@@ -467,7 +451,7 @@ def repair_uid_catalog_path(portal, catalog, path):
     if obj is None:
         logger.info("Removed orphan uid_catalog record '%s'" % path)
         return
-    target = get_uid_catalog_path(catalog, obj)
+    target = api.get_uid_catalog_path(obj)
     catalog.catalog_object(obj, target)
     logger.info("Re-cataloged '%s' as '%s'" % (path, target))
 

--- a/src/senaite/core/upgrade/utils.py
+++ b/src/senaite/core/upgrade/utils.py
@@ -369,18 +369,16 @@ def copy_workflow_history(src, target):
 def uncatalog_object(obj):
     """Uncatalog the object for all catalogs
     """
-    # uncatalog from registered catalogs
-    obj.unindexObject()
-    # explicitly uncatalog from uid_catalog
-    uid_catalog = api.get_tool("uid_catalog")
-    url = "/".join(obj.getPhysicalPath()[2:])
-    uid_catalog.uncatalog_object(url)
+    # this used to build the path by hand and only ever removed the record
+    # under the relative path, which left the record of a Dexterity object
+    # behind. `api.uncatalog_object` removes both path variations.
+    api.uncatalog_object(obj)
 
 
 def catalog_object(obj):
     """Catalog the object
     """
-    obj.reindexObject()
+    api.catalog_object(obj)
 
 
 def resolve_uid_catalog_path(portal, path):

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -38,7 +38,6 @@ from plone.app.blob.field import BlobWrapper
 from plone.dexterity.utils import createContent
 from plone.namedfile.file import NamedBlobFile
 from plone.namedfile.interfaces import INamed
-from Products.Archetypes.utils import getRelURL
 from Products.CMFEditions.interfaces import IVersioned
 from senaite.core import logger
 from senaite.core.api import dtime
@@ -73,10 +72,12 @@ from senaite.core.upgrade.utils import blob_to_named_file
 from senaite.core.upgrade.utils import copy_snapshots
 from senaite.core.upgrade.utils import delete_object
 from senaite.core.upgrade.utils import import_typeinfo
+from senaite.core.upgrade.utils import is_stale_uid_catalog_path
 from senaite.core.upgrade.utils import iter_senaite_catalogs
 from senaite.core.upgrade.utils import permanently_allow_type_for
 from senaite.core.upgrade.utils import rebuild_index
 from senaite.core.upgrade.utils import remove_at_portal_types
+from senaite.core.upgrade.utils import repair_uid_catalog_path
 from senaite.core.upgrade.utils import uncatalog_object
 from senaite.core.upgrade.v02_06_000 import get_setup_folder
 from zope.annotation.interfaces import IAnnotations
@@ -102,94 +103,6 @@ PORTAL_FOLDER_ITEMS = {
     # ID: ID, Title, FTI
     "worksheets": ("worksheets", "Worksheets", "Worksheets"),
 }
-
-
-def get_uid_catalog_path(catalog, obj):
-    """Return the path an object has to be cataloged under in uid_catalog
-
-    Archetypes content is cataloged relative to the portal, Dexterity
-    content under the absolute path.
-
-    :param catalog: the uid_catalog tool
-    :param obj: the object to get the path for
-    :returns: the path the object belongs to in the uid_catalog
-    """
-    if api.is_at_content(obj):
-        return getRelURL(catalog, obj.getPhysicalPath())
-    return "/".join(obj.getPhysicalPath())
-
-
-def resolve_uid_catalog_path(portal, path):
-    """Return the object a uid_catalog path points to
-
-    Both path conventions are accepted. Returns `None` when the path does
-    not resolve, or resolves to another object through acquisition.
-
-    :param portal: the portal object
-    :param path: a path as stored in the uid_catalog
-    :returns: the object or None
-    """
-    portal_path = "/".join(portal.getPhysicalPath())
-    relative = path
-    if relative.startswith("%s/" % portal_path):
-        relative = relative[len(portal_path) + 1:]
-    obj = portal.unrestrictedTraverse(str(relative), None)
-    if obj is None:
-        return None
-    # traversal acquires, so make sure we got the object the path names
-    if "/".join(obj.getPhysicalPath()) != "%s/%s" % (portal_path, relative):
-        return None
-    return obj
-
-
-def expects_relative_path(fti):
-    """Check whether content of the given type is cataloged relative
-
-    Archetypes types carry the product they come from, Dexterity ones do
-    not.
-
-    :param fti: the type information of the content type
-    :returns: True for Archetypes content types
-    """
-    return bool(getattr(fti, "product", None))
-
-
-def is_stale_uid_catalog_path(types_tool, catalog, path, rid):
-    """Check whether a uid_catalog record sits under the wrong path
-
-    Decided on the metadata of the record alone, so that the objects
-    behind the records do not have to be woken up.
-
-    :param types_tool: the portal_types tool
-    :param catalog: the uid_catalog tool
-    :param path: a path as stored in the uid_catalog
-    :param rid: the record id of the path
-    :returns: True if the record has to be re-cataloged, None if the type
-              of the record is unknown and nothing can be decided
-    """
-    metadata = catalog._catalog.getMetadataForRID(rid)
-    fti = types_tool.getTypeInfo(metadata.get("portal_type"))
-    if fti is None:
-        # no type information to decide with, leave the record alone
-        return None
-    return path.startswith("/") == expects_relative_path(fti)
-
-
-def repair_uid_catalog_path(portal, catalog, path):
-    """Drop a stale record and catalog the object under the correct path
-
-    :param portal: the portal object
-    :param catalog: the uid_catalog tool
-    :param path: a path as stored in the uid_catalog
-    """
-    obj = resolve_uid_catalog_path(portal, path)
-    catalog.uncatalog_object(path)
-    if obj is None:
-        logger.info("Removed orphan uid_catalog record '%s'" % path)
-        return
-    target = get_uid_catalog_path(catalog, obj)
-    catalog.catalog_object(obj, target)
-    logger.info("Re-cataloged '%s' as '%s'" % (path, target))
 
 
 @upgradestep(product, version)

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -38,6 +38,7 @@ from plone.app.blob.field import BlobWrapper
 from plone.dexterity.utils import createContent
 from plone.namedfile.file import NamedBlobFile
 from plone.namedfile.interfaces import INamed
+from Products.Archetypes.utils import getRelURL
 from Products.CMFEditions.interfaces import IVersioned
 from senaite.core import logger
 from senaite.core.api import dtime
@@ -101,6 +102,146 @@ PORTAL_FOLDER_ITEMS = {
     # ID: ID, Title, FTI
     "worksheets": ("worksheets", "Worksheets", "Worksheets"),
 }
+
+
+def get_uid_catalog_path(catalog, obj):
+    """Return the path an object has to be cataloged under in uid_catalog
+
+    Archetypes content is cataloged relative to the portal, Dexterity
+    content under the absolute path.
+
+    :param catalog: the uid_catalog tool
+    :param obj: the object to get the path for
+    :returns: the path the object belongs to in the uid_catalog
+    """
+    if api.is_at_content(obj):
+        return getRelURL(catalog, obj.getPhysicalPath())
+    return "/".join(obj.getPhysicalPath())
+
+
+def resolve_uid_catalog_path(portal, path):
+    """Return the object a uid_catalog path points to
+
+    Both path conventions are accepted. Returns `None` when the path does
+    not resolve, or resolves to another object through acquisition.
+
+    :param portal: the portal object
+    :param path: a path as stored in the uid_catalog
+    :returns: the object or None
+    """
+    portal_path = "/".join(portal.getPhysicalPath())
+    relative = path
+    if relative.startswith("%s/" % portal_path):
+        relative = relative[len(portal_path) + 1:]
+    obj = portal.unrestrictedTraverse(str(relative), None)
+    if obj is None:
+        return None
+    # traversal acquires, so make sure we got the object the path names
+    if "/".join(obj.getPhysicalPath()) != "%s/%s" % (portal_path, relative):
+        return None
+    return obj
+
+
+def expects_relative_path(fti):
+    """Check whether content of the given type is cataloged relative
+
+    Archetypes types carry the product they come from, Dexterity ones do
+    not.
+
+    :param fti: the type information of the content type
+    :returns: True for Archetypes content types
+    """
+    return bool(getattr(fti, "product", None))
+
+
+def is_stale_uid_catalog_path(types_tool, catalog, path, rid):
+    """Check whether a uid_catalog record sits under the wrong path
+
+    Decided on the metadata of the record alone, so that the objects
+    behind the records do not have to be woken up.
+
+    :param types_tool: the portal_types tool
+    :param catalog: the uid_catalog tool
+    :param path: a path as stored in the uid_catalog
+    :param rid: the record id of the path
+    :returns: True if the record has to be re-cataloged, None if the type
+              of the record is unknown and nothing can be decided
+    """
+    metadata = catalog._catalog.getMetadataForRID(rid)
+    fti = types_tool.getTypeInfo(metadata.get("portal_type"))
+    if fti is None:
+        # no type information to decide with, leave the record alone
+        return None
+    return path.startswith("/") == expects_relative_path(fti)
+
+
+def repair_uid_catalog_path(portal, catalog, path):
+    """Drop a stale record and catalog the object under the correct path
+
+    :param portal: the portal object
+    :param catalog: the uid_catalog tool
+    :param path: a path as stored in the uid_catalog
+    """
+    obj = resolve_uid_catalog_path(portal, path)
+    catalog.uncatalog_object(path)
+    if obj is None:
+        logger.info("Removed orphan uid_catalog record '%s'" % path)
+        return
+    target = get_uid_catalog_path(catalog, obj)
+    catalog.catalog_object(obj, target)
+    logger.info("Re-cataloged '%s' as '%s'" % (path, target))
+
+
+@upgradestep(product, version)
+def remove_stale_uid_catalog_records(tool):
+    """Remove uid_catalog records that sit under the wrong path
+
+    The AT to DX migrations created the Dexterity object first, which
+    `plone.app.referenceablebehavior` catalogs under the absolute path with
+    the throwaway uuid of `createContent`, and copied the UID of the
+    Archetypes source only afterwards. The `uncatalog_object` of that time
+    only tried the relative path, so the record under the absolute path
+    survived, carrying a UID that belongs to nothing.
+
+    Such a record stays unnoticed until the object is edited: the Dexterity
+    modified handler then re-catalogs it under the absolute path, now with
+    the real UID. From that moment on `uid_catalog(UID=...)` returns two
+    brains, `api.get_brain_by_uid` cannot tell them apart and returns
+    nothing, and every lookup through the SuperModel fails.
+
+    Records are matched against the path convention of their object, so
+    both halves of an already collided pair and the ones still waiting to
+    collide are cleaned up.
+    """
+    logger.info("Removing stale uid_catalog records ...")
+
+    portal = tool.aq_inner.aq_parent
+    catalog = api.get_tool("uid_catalog", context=portal)
+    types_tool = api.get_tool("portal_types", context=portal)
+
+    # take a snapshot, the catalog is modified while repairing
+    records = list(catalog._catalog.uids.items())
+    total = len(records)
+    stale = []
+    skipped = 0
+
+    for num, (path, rid) in enumerate(records):
+        if num and num % 10000 == 0:
+            logger.info("Checking uid_catalog record %s/%s" % (num, total))
+        is_stale = is_stale_uid_catalog_path(types_tool, catalog, path, rid)
+        if is_stale is None:
+            skipped += 1
+        elif is_stale:
+            stale.append(path)
+
+    logger.info("Found %s stale records out of %s" % (len(stale), total))
+    if skipped:
+        logger.info("Skipped %s records of an unknown portal type" % skipped)
+
+    for path in stale:
+        repair_uid_catalog_path(portal, catalog, path)
+
+    logger.info("Removing stale uid_catalog records [DONE]")
 
 
 @upgradestep(product, version)

--- a/src/senaite/core/upgrade/v02_07_000.zcml
+++ b/src/senaite/core/upgrade/v02_07_000.zcml
@@ -3,6 +3,17 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="SENAITE.CORE 2.7.0: Remove stale uid_catalog records"
+      description="Remove uid_catalog records that sit under a path that does
+                   not match the convention of their object. The AT to DX
+                   migrations left such records behind, and they break every
+                   lookup by UID as soon as the object is edited."
+      source="2754"
+      destination="2755"
+      handler=".v02_07_000.remove_stale_uid_catalog_records"
+      profile="senaite.core:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.CORE 2.7.0: Hide unused viewlets"
       description="Hide the analytics, keywords, next/previous navigation and
                    related items viewlets, which are not used in SENAITE, by


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The AT to DX migrations shipped with 2.6 leave records behind in the `uid_catalog`. The Dexterity object is created first, and `plone.app.referenceablebehavior.added_handler` catalogs it under its **absolute** path, carrying the throwaway uuid that `createContent` assigned. The UID of the Archetypes source is copied only afterwards, and the `uncatalog_object` of that time only tried the **relative** path. The record under the absolute path therefore survives, pointing at the object but indexed under a UID that belongs to nothing.

Such a record is invisible for as long as nobody touches the object. The moment it is edited, the Dexterity modified handler re-catalogs it under the absolute path, now with the real UID. From then on `uid_catalog(UID=...)` returns two brains, `api.get_brain_by_uid` cannot tell them apart and returns nothing, and every lookup through the SuperModel fails. The visible symptom is a report that no longer renders, with `Error: None is not supported` raised from `api.get_object(None)`, because `SuperModel.instance` resolved to `None`.

The code path itself was fixed in #2896 (May 2026), but nothing repairs the data. Every installation migrated to 2.6 before that fix still carries these records, and every one of them is a landmine that goes off on the next edit of a Department, a SampleCondition, a SamplePreservation or any other type migrated that way.

Note that the existing `cleanup_uid_catalog` step from 2.6 does not catch them: it detects duplicates by comparing `brain.UID`, and the two records of a pair that has not collided yet carry *different* UIDs. It would only ever repair a pair that already broke, and being a one shot upgrade step it does not run again anyway.

## Current behavior before PR

Records that sit under the wrong path convention stay in the `uid_catalog` indefinitely. Once one of them is activated by an edit, lookups by UID for that object fail silently: `api.get_brain_by_uid` returns the default because `len(brains) != 1`, without any indication that the object exists and the catalog is simply ambiguous. The warning that eventually surfaces further up the stack reads `No object found for UID '...'`, which sends the reader looking for a missing object rather than for a broken catalog.

The path convention itself is spelled out in several places at once: inline in `api.catalog_object`, again in `api.uncatalog_object`, and a third time in `senaite.core.upgrade.utils.uncatalog_object`, which builds the path by hand with `getPhysicalPath()[2:]` and so only ever removes the relative record. That last one is the exact construct that caused the problem in the first place.

## Desired behavior after PR is merged

A new upgrade step `remove_stale_uid_catalog_records` removes them. Instead of comparing UIDs, it matches every record against the path convention its content type requires: Archetypes content is cataloged relative to the portal, Dexterity content under the absolute path, decided from `fti.product`. That catches both halves of an already collided pair and, more importantly, the ones still waiting to collide.

The check reads the `portal_type` from the catalog metadata, so no object has to be woken up to decide. Only actual repair cases are resolved and re-cataloged. Records whose portal type is unknown cannot be decided and are left alone, and their number is logged rather than passed over silently.

`api.get_brain_by_uid` now distinguishes the two failure modes and logs an error naming the colliding paths when more than one record claims a UID. The return value is unchanged.

The convention now lives in one place, `api.get_uid_catalog_path(obj)`. `api.catalog_object` uses it, which collapses its two near identical branches into one, and the upgrade utils use it instead of keeping their own copy. `senaite.core.upgrade.utils.uncatalog_object` and its counterpart `catalog_object` now delegate to `api.uncatalog_object` and `api.catalog_object`, so no migration builds catalog paths by hand any more.

## Test plan

Verified against a production database of 14 GB with 511401 `uid_catalog` records, migrated to 2.6 in February 2024:

- The scan flags 13 records (7 Departments, 4 SampleConditions, 2 SamplePreservations) and skips 58 whose portal type is no longer registered. The full pass takes 3.5 seconds, since no object is woken up to decide.
- After the step, no path is present under both conventions any more, the scan flags nothing, and all 13 objects resolve to exactly one record. The catalog goes from 511402 to 511389 records: the 13 relative records are dropped and the 13 absolute ones updated in place, with no new records created.
- Publishing the sample that triggered the original error renders again, with the department title back in the report header.
- Confirmed on the same database that the historic revisions of the UID index entry show the second rid appearing exactly when the object was edited, 18 months after the record was created by the migration.

`bin/test-senaite -s senaite.core` passes with 191 tests, 0 failures, 0 errors.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html