### PR TITLE
Add a doctest for api.get_uid_catalog_path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #3013 Add a doctest for api.get_uid_catalog_path
 - #3012 Remove stale uid_catalog records that break lookups by UID
 - #2995 Add interactive upgrade, catalog and user console scripts
 - #3008 Filter sidebar root folders by permission instead of by catalog

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -2461,6 +2461,51 @@ Convert to list
     [u'[1, 2, 3]', u'b', u'c']
 
 
+Get the uid_catalog path of an object
+.....................................
+
+The `uid_catalog` keys AT and DX content with different path
+conventions: AT content is keyed by the path **relative** to the portal
+root, while DX content is keyed by the **absolute** path. This function
+returns the path an object belongs to, so that no code has to build it
+by hand:
+
+    >>> uc = api.get_tool("uid_catalog")
+
+The client is AT content, so its relative path is returned:
+
+    >>> at_path = api.get_uid_catalog_path(client)
+    >>> at_path == "/".join(client.getPhysicalPath()[2:])
+    True
+
+And that is the path the object is really keyed by:
+
+    >>> at_path in uc._catalog.uids
+    True
+
+For Dexterity content the absolute path is returned instead:
+
+    >>> path_obj = api.create(
+    ...     portal.setup.sampletypes, "SampleType",
+    ...     title="Path Test SampleType", Prefix="PTS")
+    >>> dx_path = api.get_uid_catalog_path(path_obj)
+    >>> dx_path == "/".join(path_obj.getPhysicalPath())
+    True
+
+    >>> dx_path in uc._catalog.uids
+    True
+
+The two conventions never yield the same path. Cataloging an object
+under the wrong one leaves a second record behind, which makes every
+lookup by UID for that object ambiguous:
+
+    >>> at_path == "/".join(client.getPhysicalPath())
+    False
+
+    >>> dx_path == "/".join(path_obj.getPhysicalPath()[2:])
+    False
+
+
 Un-catalog an object
 ....................
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Follow up to #3012, which introduced `api.get_uid_catalog_path(obj)` as the single place that knows how the `uid_catalog` keys content: Archetypes content by the path relative to the portal root, Dexterity content by the absolute path. Every other function in `bika.lims.api` is covered by `API.rst`, this one was not.

## Current behavior before PR

`api.get_uid_catalog_path` has no doctest. The convention it encodes is only exercised indirectly, through the `catalog_object` and `uncatalog_object` sections, so a regression in the helper itself would only surface as a confusing failure somewhere downstream.

## Desired behavior after PR is merged

`API.rst` gets a section right before "Un-catalog an object", where the convention it establishes is used by the sections that follow. It asserts both branches, that the returned path is the one the object is really keyed by in the catalog, and that the two conventions never yield the same path for a given object, which is what keeps a single object from being cataloged twice.

No production code is touched. `bin/test-senaite -s senaite.core -t API` passes with 25 tests, 0 failures, 0 errors.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html