### PR TITLE
Fix AT to DX upgrade failing with undefined property 'add_permission'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #3014 Fix AT to DX upgrade failing with undefined property 'add_permission'
 - #3001 Skip read-only fields when validating objects on create/update
 - #2994 Migrate Method content type to Dexterity
 - #2991 Replace the jQuery DataGrid handler with a ReactJS widget

--- a/src/senaite/core/upgrade/v02_07_000.py
+++ b/src/senaite/core/upgrade/v02_07_000.py
@@ -93,6 +93,7 @@ profile = "profile-{0}:default".format(product)
 
 REMOVE_AT_TYPES = [
     "ARReport",
+    "AuditLog",
     "Contact",
     "Laboratory",
     "Calculation",
@@ -276,9 +277,14 @@ def migrate_auditlog_to_dx(tool):
     """
     logger.info("Convert AuditLog to Dexterity ...")
 
-    # remove the AT type and re-import the DX FTI
-    remove_at_portal_types(tool, ["AuditLog"])
-    tool.runImportStepFromProfile(profile, "typeinfo")
+    # Flush *all* pending AT FTIs, not only the AuditLog one: the typeinfo
+    # step below imports every type of the profile, and applying a DX FTI
+    # over a type that is still Archetypes in the database fails with
+    # `ValueError: undefined property 'add_permission'`
+    remove_at_portal_types(tool, REMOVE_AT_TYPES)
+
+    # re-import the DX FTIs
+    import_typeinfo(tool, profile)
 
     # the legacy AT folder lived in `bika_setup`; the DX one now lives in
     # the new SENAITE setup
@@ -2992,7 +2998,7 @@ def migrate_methods_to_dx(tool):
     remove_at_portal_types(tool, REMOVE_AT_TYPES)
 
     # run required import steps
-    tool.runImportStepFromProfile(profile, "typeinfo")
+    import_typeinfo(tool, profile)
     tool.runImportStepFromProfile(profile, "workflow")
 
     # the methods folder is no longer a top-level sidebar folder


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Upgrading a database from 2.6 to 2.7 aborts with:

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 666, in __call__
  Module Products.CMFPlone.controlpanel.browser.quickinstaller, line 399, in upgrade_product
  Module Products.GenericSetup.tool, line 1202, in upgradeProfile
  Module Products.GenericSetup.upgrade, line 185, in doStep
  Module senaite.core.upgrade.v02_07_000, line 281, in migrate_auditlog_to_dx
  Module Products.GenericSetup.tool, line 375, in runImportStepFromProfile
  Module Products.GenericSetup.tool, line 1323, in _doRunImportStep
   - __traceback_info__: typeinfo
  Module Products.CMFCore.exportimport.typeinfo, line 222, in importTypesTool
  Module Products.GenericSetup.utils, line 933, in importObjects
   - __traceback_info__: portal_types
  Module Products.GenericSetup.utils, line 929, in importObjects
   - __traceback_info__: types/Method
  Module Products.GenericSetup.utils, line 530, in _importBody
  Module Products.CMFCore.exportimport.typeinfo, line 61, in _importNode
  Module Products.GenericSetup.utils, line 762, in _initProperties
ValueError: undefined property 'add_permission'
```

`add_permission` is a property of `plone.dexterity.fti.DexterityFTI` only; the Archetypes FTIs of `Products.CMFCore` do not define it. The error is therefore raised whenever a Dexterity `types/*.xml` is imported over a type that is still Archetypes in the database.

That is what the `typeinfo` import step does: it walks *every* type of the profile, and `_initObjects` only creates an FTI when the id is missing — it never replaces an existing one whose `meta_type` differs. So a leftover AT FTI is not swapped for its DX counterpart, it is fed the DX body and blows up.

The upgrade steps guard against this by flushing the pending AT FTIs with `remove_at_portal_types(tool, REMOVE_AT_TYPES)` right before importing the type information (the same traceback is already documented for `Contact` in `import_registry`). Two places do not:

* `migrate_auditlog_to_dx` (2755 → 2756) removes only the `AuditLog` type and then imports the whole `typeinfo` step. `Method` becomes Dexterity one step later, in `migrate_methods_to_dx` (2756 → 2757), so at that point `portal_types/Method` is still Archetypes and the import fails.

* `AuditLog` itself is missing from `REMOVE_AT_TYPES`. Its FTI moved from the Archetypes profile of `bika.lims` to the Dexterity one of `senaite.core`, so on a database below 2756 *any* earlier step that imports the type information fails the same way on `types/AuditLog` — the first being `migrate_contacts_to_dx` (2710 → 2711).

Both steps also called `runImportStepFromProfile(profile, "typeinfo")` directly instead of the `import_typeinfo` helper, even though they create Dexterity content right afterwards (`api.create` for the audit log folder, `createContent` per method). Without the `register_missing_dx_ftis` call that the helper performs, a partially-completed upgrade makes that content creation fail with a `ComponentLookupError`.

## Current behavior before PR

Upgrading from 2.6 aborts with `ValueError: undefined property 'add_permission'`, leaving the instance mid-upgrade.

## Desired behavior after PR is merged

The type information is imported only after every obsolete Archetypes FTI has been flushed, so the 2.6 to 2.7 upgrade runs to completion.

* `AuditLog` is added to `REMOVE_AT_TYPES`.
* `migrate_auditlog_to_dx` flushes `REMOVE_AT_TYPES` instead of just `["AuditLog"]`.
* `migrate_auditlog_to_dx` and `migrate_methods_to_dx` use `import_typeinfo` like the other nine migration steps.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
