### PR TITLE
Fix analyses with empty multi-valued results can be submitted

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
-- #3015 Prevent submission of analyses with empty multi-valued results
+- #3015 Fix analyses with empty multi-valued results can be submitted
 - #3014 Fix AT to DX upgrade failing with undefined property 'add_permission'
 - #3001 Skip read-only fields when validating objects on create/update
 - #2994 Migrate Method content type to Dexterity

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.7.0 (unreleased)
 ------------------
 
+- #3015 Prevent submission of analyses with empty multi-valued results
 - #3014 Fix AT to DX upgrade failing with undefined property 'add_permission'
 - #3001 Skip read-only fields when validating objects on create/update
 - #2994 Migrate Method content type to Dexterity

--- a/src/bika/lims/api/__init__.py
+++ b/src/bika/lims/api/__init__.py
@@ -2018,6 +2018,36 @@ def to_int(value, default=_marker):
         fail("Value %s cannot be converted to int" % repr(value))
 
 
+def to_bool(value, default=False):
+    """Converts the passed in value to a boolean
+
+    Boolean-like strings, such as "true", "yes", "on" or "1" are converted to
+    True, while "false", "no", "off", "0" and empty strings are converted to
+    False. Values of any other type are evaluated following the Python's
+    truthiness rules, except for None, that is converted to the default value
+
+    :param value: The value to be converted to a boolean
+    :param default: Value to return when the value cannot be evaluated
+    :returns: The boolean representation of the passed in value
+    :rtype: bool
+    """
+    if isinstance(value, bool):
+        return value
+
+    if value is None:
+        return default
+
+    if is_string(value):
+        val = value.strip().lower()
+        if val in ["y", "yes", "1", "true", "on"]:
+            return True
+        if val in ["n", "no", "0", "false", "off", ""]:
+            return False
+        return default
+
+    return bool(value)
+
+
 def is_floatable(value):
     """Checks if the passed in value is a valid floatable number
 

--- a/src/bika/lims/api/analysis.py
+++ b/src/bika/lims/api/analysis.py
@@ -177,6 +177,26 @@ def is_out_of_range(brain_or_object, result=_marker):
     return True, not in_shoulder
 
 
+def is_empty_result(value):
+    """Checks if the passed in result value is empty
+
+    Multi-valued results, either from the result field or from a result
+    variable (interim), are stored as a JSON list with the selected values.
+    Therefore, values like `"[]"` or `'[""]'` are considered empty as well
+
+    :param value: The raw value of a result or of a result variable
+    :returns: True if the value is empty or all its values are empty
+    :rtype: bool
+    """
+    for val in api.to_list(value):
+        if val is None:
+            continue
+        if api.is_string(val) and not val.strip():
+            continue
+        return False
+    return True
+
+
 def get_formatted_interval(analysis_or_results_range, default=_marker):
     """Returns a string representation of the interval defined by the results
     range passed in

--- a/src/bika/lims/api/analysis.py
+++ b/src/bika/lims/api/analysis.py
@@ -177,12 +177,42 @@ def is_out_of_range(brain_or_object, result=_marker):
     return True, not in_shoulder
 
 
-def is_empty_result(value):
-    """Checks if the passed in result value is empty
+def is_empty_result(brain_or_object):
+    """Checks if the analysis passed in does not have a result set
 
-    Multi-valued results, either from the result field or from a result
-    variable (interim), are stored as a JSON list with the selected values.
-    Therefore, values like `"[]"` or `'[""]'` are considered empty as well
+    An analysis is considered without result when its result is empty, or
+    when the value of any of its result variables (interims) that does not
+    allow empty values is empty
+
+    :param brain_or_object: A single catalog brain or content object
+    :type brain_or_object: ATContentType/DexterityContentType/CatalogBrain
+    :returns: True if the analysis does not have a result set
+    :rtype: bool
+    """
+    analysis = api.get_object(brain_or_object)
+    if not IAnalysis.providedBy(analysis) and \
+            not IReferenceAnalysis.providedBy(analysis):
+        api.fail("{} is not supported. Needs to be IAnalysis or "
+                 "IReferenceAnalysis".format(repr(analysis)))
+
+    if is_empty_value(analysis.getResult()):
+        return True
+
+    for interim in analysis.getInterimFields():
+        if api.to_bool(interim.get("allow_empty", False)):
+            continue
+
+        if is_empty_value(interim.get("value")):
+            return True
+
+    return False
+
+
+def is_empty_value(value):
+    """Checks if the raw value of a result or of a result variable is empty
+
+    Multi-valued results are stored as a JSON list with the selected values,
+    so values like `"[]"` or `'[""]'` are considered empty as well
 
     :param value: The raw value of a result or of a result variable
     :returns: True if the value is empty or all its values are empty

--- a/src/bika/lims/api/analysis.py
+++ b/src/bika/lims/api/analysis.py
@@ -177,16 +177,17 @@ def is_out_of_range(brain_or_object, result=_marker):
     return True, not in_shoulder
 
 
-def is_empty_result(brain_or_object):
-    """Checks if the analysis passed in does not have a result set
+def is_result_complete(brain_or_object):
+    """Checks if the analysis passed in has all its results captured
 
-    An analysis is considered without result when its result is empty, or
-    when the value of any of its result variables (interims) that does not
-    allow empty values is empty
+    The result of an analysis is considered complete when the result itself
+    is not empty and none of its result variables (interims), except for
+    those that allow empty values, is empty
 
     :param brain_or_object: A single catalog brain or content object
     :type brain_or_object: ATContentType/DexterityContentType/CatalogBrain
-    :returns: True if the analysis does not have a result set
+    :returns: True if the result and all the required result variables of the
+              analysis have a value
     :rtype: bool
     """
     analysis = api.get_object(brain_or_object)
@@ -195,20 +196,20 @@ def is_empty_result(brain_or_object):
         api.fail("{} is not supported. Needs to be IAnalysis or "
                  "IReferenceAnalysis".format(repr(analysis)))
 
-    if is_empty_value(analysis.getResult()):
-        return True
+    if is_empty_result_value(analysis.getResult()):
+        return False
 
     for interim in analysis.getInterimFields():
         if api.to_bool(interim.get("allow_empty", False)):
             continue
 
-        if is_empty_value(interim.get("value")):
-            return True
+        if is_empty_result_value(interim.get("value")):
+            return False
 
-    return False
+    return True
 
 
-def is_empty_value(value):
+def is_empty_result_value(value):
     """Checks if the raw value of a result or of a result variable is empty
 
     Multi-valued results are stored as a JSON list with the selected values,

--- a/src/bika/lims/api/analysis.py
+++ b/src/bika/lims/api/analysis.py
@@ -56,10 +56,8 @@ def is_out_of_range(brain_or_object, result=_marker):
     :rtype: (bool, bool)
     """
     analysis = api.get_object(brain_or_object)
-    if not IAnalysis.providedBy(analysis) and \
-            not IReferenceAnalysis.providedBy(analysis):
-        api.fail("{} is not supported. Needs to be IAnalysis or "
-                 "IReferenceAnalysis".format(repr(analysis)))
+    if not is_analysis(analysis) and not is_reference_analysis(analysis):
+        api.fail("{} is not supported.".format(repr(analysis)))
 
     if result is _marker:
         result = api.safe_getattr(analysis, "getResult", None)
@@ -68,7 +66,7 @@ def is_out_of_range(brain_or_object, result=_marker):
         # Empty result
         return False, False
 
-    if IDuplicateAnalysis.providedBy(analysis):
+    if is_duplicate_analysis(analysis):
         # Result range for duplicate analyses is calculated from the original
         # result, applying a variation % in shoulders. If the analysis has
         # result options enabled or string results enabled, system returns an
@@ -297,8 +295,7 @@ def is_retracted(brain_or_object):
     """
     analysis = api.get_object(brain_or_object)
     if not is_analysis(analysis) and not is_reference_analysis(analysis):
-        api.fail("{} is not supported. Needs to be IAnalysis or "
-                 "IReferenceAnalysis".format(repr(analysis)))
+        api.fail("{} is not supported.".format(repr(analysis)))
     return IRetracted.providedBy(analysis)
 
 
@@ -310,8 +307,7 @@ def is_rejected(brain_or_object):
     """
     analysis = api.get_object(brain_or_object)
     if not is_analysis(analysis) and not is_reference_analysis(analysis):
-        api.fail("{} is not supported. Needs to be IAnalysis or "
-                 "IReferenceAnalysis".format(repr(analysis)))
+        api.fail("{} is not supported.".format(repr(analysis)))
     return IRejected.providedBy(analysis)
 
 
@@ -323,8 +319,7 @@ def is_retested(brain_or_object):
     """
     analysis = api.get_object(brain_or_object)
     if not is_analysis(analysis) and not is_reference_analysis(analysis):
-        api.fail("{} is not supported. Needs to be IAnalysis or "
-                 "IReferenceAnalysis".format(repr(analysis)))
+        api.fail("{} is not supported.".format(repr(analysis)))
     return analysis.isRetested()
 
 

--- a/src/bika/lims/api/analysis.py
+++ b/src/bika/lims/api/analysis.py
@@ -177,57 +177,6 @@ def is_out_of_range(brain_or_object, result=_marker):
     return True, not in_shoulder
 
 
-def is_result_complete(brain_or_object):
-    """Checks if the analysis passed in has all its results captured
-
-    The result of an analysis is considered complete when the result itself
-    is not empty and none of its result variables (interims), except for
-    those that allow empty values, is empty
-
-    :param brain_or_object: A single catalog brain or content object
-    :type brain_or_object: ATContentType/DexterityContentType/CatalogBrain
-    :returns: True if the result and all the required result variables of the
-              analysis have a value
-    :rtype: bool
-    """
-    analysis = api.get_object(brain_or_object)
-    if not IAnalysis.providedBy(analysis) and \
-            not IReferenceAnalysis.providedBy(analysis):
-        api.fail("{} is not supported. Needs to be IAnalysis or "
-                 "IReferenceAnalysis".format(repr(analysis)))
-
-    if is_empty_result_value(analysis.getResult()):
-        return False
-
-    for interim in analysis.getInterimFields():
-        if api.to_bool(interim.get("allow_empty", False)):
-            continue
-
-        if is_empty_result_value(interim.get("value")):
-            return False
-
-    return True
-
-
-def is_empty_result_value(value):
-    """Checks if the raw value of a result or of a result variable is empty
-
-    Multi-valued results are stored as a JSON list with the selected values,
-    so values like `"[]"` or `'[""]'` are considered empty as well
-
-    :param value: The raw value of a result or of a result variable
-    :returns: True if the value is empty or all its values are empty
-    :rtype: bool
-    """
-    for val in api.to_list(value):
-        if val is None:
-            continue
-        if api.is_string(val) and not val.strip():
-            continue
-        return False
-    return True
-
-
 def get_formatted_interval(analysis_or_results_range, default=_marker):
     """Returns a string representation of the interval defined by the results
     range passed in
@@ -377,6 +326,58 @@ def is_retested(brain_or_object):
         api.fail("{} is not supported. Needs to be IAnalysis or "
                  "IReferenceAnalysis".format(repr(analysis)))
     return analysis.isRetested()
+
+
+def is_result_complete(brain_or_object):
+    """Checks if the analysis passed in has all its results captured
+
+    The result of an analysis is considered complete when the result itself
+    is not empty and none of its result variables (interims), except for
+    those that allow empty values, is empty
+
+    :param brain_or_object: A single catalog brain or content object
+    :type brain_or_object: ATContentType/DexterityContentType/CatalogBrain
+    :returns: True if the result and all the required result variables of the
+              analysis have a value
+    :rtype: bool
+    """
+    analysis = api.get_object(brain_or_object)
+    if not is_analysis(analysis) and not is_reference_analysis(analysis):
+        api.fail("{} is not supported.".format(repr(analysis)))
+
+    result = analysis.getResult()
+    if is_empty_result_value(result):
+        return False
+
+    for interim in analysis.getInterimFields():
+        allow_empty = interim.get("allow_empty", False)
+        if api.to_bool(allow_empty):
+            continue
+
+        value = interim.get("value")
+        if is_empty_result_value(value):
+            return False
+
+    return True
+
+
+def is_empty_result_value(value):
+    """Checks if the raw value of a result or of a result variable is empty
+
+    Multi-valued results are stored as a JSON list with the selected values,
+    so values like `"[]"` or `'[""]'` are considered empty as well
+
+    :param value: The raw value of a result or of a result variable
+    :returns: True if the value is empty or all its values are empty
+    :rtype: bool
+    """
+    for val in api.to_list(value):
+        if val is None:
+            continue
+        if api.is_string(val) and not val.strip():
+            continue
+        return False
+    return True
 
 
 def get_dependencies(brain_or_object, with_retests=False, recursive=False):

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -1183,8 +1183,8 @@ class AnalysesView(ListingView):
                 continue
 
             interim_value = interim_field.get("value", "")
-            interim_allow_empty = api.to_bool(
-                interim_field.get("allow_empty", False))
+            interim_allow_empty = interim_field.get("allow_empty", False)
+            interim_allow_empty = api.to_bool(interim_allow_empty)
             interim_unit = interim_field.get("unit", "")
 
             # Get the interim's formatted value

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -1183,7 +1183,8 @@ class AnalysesView(ListingView):
                 continue
 
             interim_value = interim_field.get("value", "")
-            interim_allow_empty = interim_field.get("allow_empty") == "on"
+            interim_allow_empty = api.to_bool(
+                interim_field.get("allow_empty", False))
             interim_unit = interim_field.get("unit", "")
 
             # Get the interim's formatted value

--- a/src/bika/lims/workflow/analysis/guards.py
+++ b/src/bika/lims/workflow/analysis/guards.py
@@ -22,7 +22,7 @@ from bika.lims import api
 from bika.lims import logger
 from bika.lims import workflow as wf
 from bika.lims.api import security
-from bika.lims.api.analysis import is_empty_result
+from bika.lims.api.analysis import is_result_complete
 from bika.lims.interfaces import ISubmitted
 from bika.lims.interfaces import IVerified
 from bika.lims.interfaces.analysis import IRequestAnalysis
@@ -134,9 +134,9 @@ def guard_reinstate(analysis):
 def guard_submit(analysis):
     """Return whether the transition "submit" can be performed or not
     """
-    # Cannot submit without a result, either because the result is empty or
-    # because a result variable that does not allow empty values is empty
-    if is_empty_result(analysis):
+    # Cannot submit unless the result and all the required result variables
+    # have a value
+    if not is_result_complete(analysis):
         return False
 
     # Cannot submit if attachment not set, but is required

--- a/src/bika/lims/workflow/analysis/guards.py
+++ b/src/bika/lims/workflow/analysis/guards.py
@@ -134,17 +134,10 @@ def guard_reinstate(analysis):
 def guard_submit(analysis):
     """Return whether the transition "submit" can be performed or not
     """
-    # Cannot submit without a result
-    if is_empty_result(analysis.getResult()):
+    # Cannot submit without a result, either because the result is empty or
+    # because a result variable that does not allow empty values is empty
+    if is_empty_result(analysis):
         return False
-
-    # Cannot submit with interims without value
-    for interim in analysis.getInterimFields():
-        if api.to_bool(interim.get("allow_empty", False)):
-            continue
-
-        if is_empty_result(interim.get("value")):
-            return False
 
     # Cannot submit if attachment not set, but is required
     if not analysis.getAttachment():

--- a/src/bika/lims/workflow/analysis/guards.py
+++ b/src/bika/lims/workflow/analysis/guards.py
@@ -22,6 +22,7 @@ from bika.lims import api
 from bika.lims import logger
 from bika.lims import workflow as wf
 from bika.lims.api import security
+from bika.lims.api.analysis import is_empty_result
 from bika.lims.interfaces import ISubmitted
 from bika.lims.interfaces import IVerified
 from bika.lims.interfaces.analysis import IRequestAnalysis
@@ -134,16 +135,15 @@ def guard_submit(analysis):
     """Return whether the transition "submit" can be performed or not
     """
     # Cannot submit without a result
-    if not analysis.getResult():
+    if is_empty_result(analysis.getResult()):
         return False
 
     # Cannot submit with interims without value
     for interim in analysis.getInterimFields():
-        true_values = ("true", "1", "on", "True", True, 1)
-        if interim.get("allow_empty", False) in true_values:
+        if api.to_bool(interim.get("allow_empty", False)):
             continue
 
-        if interim.get("value") in [None, ""]:
+        if is_empty_result(interim.get("value")):
             return False
 
     # Cannot submit if attachment not set, but is required

--- a/src/senaite/core/tests/doctests/API.rst
+++ b/src/senaite/core/tests/doctests/API.rst
@@ -1863,6 +1863,51 @@ With default fallback:
     2
 
 
+Convert to a boolean
+....................
+
+Boolean-like strings are evaluated case-insensitively:
+
+    >>> api.to_bool("true"), api.to_bool("True"), api.to_bool("TRUE")
+    (True, True, True)
+
+    >>> api.to_bool("yes"), api.to_bool("on"), api.to_bool("1")
+    (True, True, True)
+
+    >>> api.to_bool("false"), api.to_bool("no"), api.to_bool("off")
+    (False, False, False)
+
+    >>> api.to_bool("0"), api.to_bool(""), api.to_bool("  ")
+    (False, False, False)
+
+Booleans are returned as-is:
+
+    >>> api.to_bool(True), api.to_bool(False)
+    (True, False)
+
+Values of any other type follow the Python's truthiness rules:
+
+    >>> api.to_bool(1), api.to_bool(0)
+    (True, False)
+
+    >>> api.to_bool([1]), api.to_bool([])
+    (True, False)
+
+With default fallback for values that cannot be evaluated:
+
+    >>> api.to_bool(None)
+    False
+
+    >>> api.to_bool(None, True)
+    True
+
+    >>> api.to_bool("maybe")
+    False
+
+    >>> api.to_bool("maybe", True)
+    True
+
+
 Convert float to string
 .......................
 

--- a/src/senaite/core/tests/doctests/API_analysis.rst
+++ b/src/senaite/core/tests/doctests/API_analysis.rst
@@ -22,11 +22,11 @@ Needed Imports:
     >>> from bika.lims.api.analysis import get_dependents
     >>> from bika.lims.api.analysis import get_formatted_interval
     >>> from bika.lims.api.analysis import is_analysis
-    >>> from bika.lims.api.analysis import is_empty_result
-    >>> from bika.lims.api.analysis import is_empty_value
+    >>> from bika.lims.api.analysis import is_empty_result_value
     >>> from bika.lims.api.analysis import is_out_of_range
     >>> from bika.lims.api.analysis import is_reference_analysis
     >>> from bika.lims.api.analysis import is_rejected
+    >>> from bika.lims.api.analysis import is_result_complete
     >>> from bika.lims.api.analysis import is_retested
     >>> from bika.lims.api.analysis import is_retracted
     >>> from bika.lims.content.analysisrequest import AnalysisRequest
@@ -1047,8 +1047,8 @@ The same should work for dependencies:
     ['Cu-1', 'Fe-1']
 
 
-Check if an analysis has an empty result
-........................................
+Check if the result of an analysis is complete
+..............................................
 
 Create a numeric service and a service with a multiple selection list of
 result options:
@@ -1060,29 +1060,29 @@ result options:
     ...     {"ResultValue": "2", "ResultText": "Option 2"}])
     >>> Zn.setResultType("multiselect")
 
-An analysis without result set is considered empty:
+The result of an analysis without a result set is not complete:
 
     >>> sample = new_sample([api.get_uid(Ni)])
     >>> analysis = sample.getAnalyses(full_objects=True)[0]
-    >>> is_empty_result(analysis)
-    True
-
-    >>> analysis.setResult(12)
-    >>> is_empty_result(analysis)
+    >>> is_result_complete(analysis)
     False
 
-A result of zero is not an empty result:
+    >>> analysis.setResult(12)
+    >>> is_result_complete(analysis)
+    True
+
+A result of zero is a valid result:
 
     >>> analysis.setResult(0)
     >>> analysis.getResult()
     '0'
 
-    >>> is_empty_result(analysis)
-    False
+    >>> is_result_complete(analysis)
+    True
 
 Multi-valued results are stored as a JSON list with the selected values, so
-they are empty when no option is selected, or when all the selected values
-are empty:
+they are not complete when no option is selected, or when all the selected
+values are empty:
 
     >>> sample = new_sample([api.get_uid(Zn)])
     >>> analysis = sample.getAnalyses(full_objects=True)[0]
@@ -1090,16 +1090,16 @@ are empty:
     >>> analysis.getResult()
     '[]'
 
-    >>> is_empty_result(analysis)
-    True
+    >>> is_result_complete(analysis)
+    False
 
     >>> analysis.setResult(["", ""])
-    >>> is_empty_result(analysis)
-    True
+    >>> is_result_complete(analysis)
+    False
 
     >>> analysis.setResult(["1", ""])
-    >>> is_empty_result(analysis)
-    False
+    >>> is_result_complete(analysis)
+    True
 
 Result variables (interims) are taken into account as well:
 
@@ -1108,12 +1108,12 @@ Result variables (interims) are taken into account as well:
     >>> analysis.setResult(12)
     >>> analysis.setInterimFields([
     ...     {"keyword": "interim_1", "title": "Interim 1"}])
-    >>> is_empty_result(analysis)
-    True
+    >>> is_result_complete(analysis)
+    False
 
     >>> analysis.setInterimValue("interim_1", 0)
-    >>> is_empty_result(analysis)
-    False
+    >>> is_result_complete(analysis)
+    True
 
 And so are multi-valued result variables:
 
@@ -1122,12 +1122,12 @@ And so are multi-valued result variables:
     ...     "result_type": "multiselect",
     ...     "choices": "1:Option 1|2:Option 2"}])
     >>> analysis.setInterimValue("interim_1", [""])
-    >>> is_empty_result(analysis)
-    True
+    >>> is_result_complete(analysis)
+    False
 
     >>> analysis.setInterimValue("interim_1", ["2"])
-    >>> is_empty_result(analysis)
-    False
+    >>> is_result_complete(analysis)
+    True
 
 Result variables that allow empty values are not evaluated, no matter whether
 the setting is stored as a boolean, like the Dexterity types do, or as the
@@ -1139,20 +1139,20 @@ the setting is stored as a boolean, like the Dexterity types do, or as the
     ...     analysis.setInterimFields(interims)
 
     >>> analysis.setInterimValue("interim_1", [])
-    >>> is_empty_result(analysis)
-    True
+    >>> is_result_complete(analysis)
+    False
 
     >>> set_allow_empty(analysis, "on")
-    >>> is_empty_result(analysis)
-    False
+    >>> is_result_complete(analysis)
+    True
 
     >>> set_allow_empty(analysis, True)
-    >>> is_empty_result(analysis)
-    False
+    >>> is_result_complete(analysis)
+    True
 
     >>> set_allow_empty(analysis, False)
-    >>> is_empty_result(analysis)
-    True
+    >>> is_result_complete(analysis)
+    False
 
 
 Check if a raw result value is empty
@@ -1160,51 +1160,51 @@ Check if a raw result value is empty
 
 Single values are empty when no value is set:
 
-    >>> is_empty_value(None)
+    >>> is_empty_result_value(None)
     True
 
-    >>> is_empty_value("")
+    >>> is_empty_result_value("")
     True
 
-    >>> is_empty_value("  ")
+    >>> is_empty_result_value("  ")
     True
 
-    >>> is_empty_value("12")
+    >>> is_empty_result_value("12")
     False
 
 A value of zero is not empty:
 
-    >>> is_empty_value("0")
+    >>> is_empty_result_value("0")
     False
 
-    >>> is_empty_value(0)
+    >>> is_empty_result_value(0)
     False
 
 Multi-valued results are stored as a JSON list with the selected values, so
 they are empty when the list is empty or when all its values are empty:
 
-    >>> is_empty_value("[]")
+    >>> is_empty_result_value("[]")
     True
 
-    >>> is_empty_value('[""]')
+    >>> is_empty_result_value('[""]')
     True
 
-    >>> is_empty_value('["", ""]')
+    >>> is_empty_result_value('["", ""]')
     True
 
-    >>> is_empty_value('["1", ""]')
+    >>> is_empty_result_value('["1", ""]')
     False
 
-    >>> is_empty_value('["0"]')
+    >>> is_empty_result_value('["0"]')
     False
 
 Lists are supported as well, even if not JSON-serialized:
 
-    >>> is_empty_value([])
+    >>> is_empty_result_value([])
     True
 
-    >>> is_empty_value(["", None])
+    >>> is_empty_result_value(["", None])
     True
 
-    >>> is_empty_value(["1"])
+    >>> is_empty_result_value(["1"])
     False

--- a/src/senaite/core/tests/doctests/API_analysis.rst
+++ b/src/senaite/core/tests/doctests/API_analysis.rst
@@ -22,6 +22,7 @@ Needed Imports:
     >>> from bika.lims.api.analysis import get_dependents
     >>> from bika.lims.api.analysis import get_formatted_interval
     >>> from bika.lims.api.analysis import is_analysis
+    >>> from bika.lims.api.analysis import is_empty_result
     >>> from bika.lims.api.analysis import is_out_of_range
     >>> from bika.lims.api.analysis import is_reference_analysis
     >>> from bika.lims.api.analysis import is_rejected
@@ -1043,3 +1044,59 @@ The same should work for dependencies:
     >>> dependencies = get_dependencies(au_analysis, recursive=True)
     >>> list(sorted(map(api.get_id, dependencies)))
     ['Cu-1', 'Fe-1']
+
+
+Check if a result value is empty
+................................
+
+Single-valued results are empty when no value is set:
+
+    >>> is_empty_result(None)
+    True
+
+    >>> is_empty_result("")
+    True
+
+    >>> is_empty_result("  ")
+    True
+
+    >>> is_empty_result("12")
+    False
+
+A result of zero is not an empty result:
+
+    >>> is_empty_result("0")
+    False
+
+    >>> is_empty_result(0)
+    False
+
+Multi-valued results are stored as a JSON list with the selected values, so
+they are empty when no value is selected, or when all the selected values are
+empty:
+
+    >>> is_empty_result("[]")
+    True
+
+    >>> is_empty_result('[""]')
+    True
+
+    >>> is_empty_result('["", ""]')
+    True
+
+    >>> is_empty_result('["1", ""]')
+    False
+
+    >>> is_empty_result('["0"]')
+    False
+
+Lists are supported as well, even if not JSON-serialized:
+
+    >>> is_empty_result([])
+    True
+
+    >>> is_empty_result(["", None])
+    True
+
+    >>> is_empty_result(["1"])
+    False

--- a/src/senaite/core/tests/doctests/API_analysis.rst
+++ b/src/senaite/core/tests/doctests/API_analysis.rst
@@ -23,6 +23,7 @@ Needed Imports:
     >>> from bika.lims.api.analysis import get_formatted_interval
     >>> from bika.lims.api.analysis import is_analysis
     >>> from bika.lims.api.analysis import is_empty_result
+    >>> from bika.lims.api.analysis import is_empty_value
     >>> from bika.lims.api.analysis import is_out_of_range
     >>> from bika.lims.api.analysis import is_reference_analysis
     >>> from bika.lims.api.analysis import is_rejected
@@ -1046,57 +1047,164 @@ The same should work for dependencies:
     ['Cu-1', 'Fe-1']
 
 
-Check if a result value is empty
-................................
+Check if an analysis has an empty result
+........................................
 
-Single-valued results are empty when no value is set:
+Create a numeric service and a service with a multiple selection list of
+result options:
 
-    >>> is_empty_result(None)
+    >>> Ni = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Nickel", Keyword="Ni", Category=category.UID())
+    >>> Zn = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Zinc", Keyword="Zn", Category=category.UID())
+    >>> Zn.setResultOptions([
+    ...     {"ResultValue": "1", "ResultText": "Option 1"},
+    ...     {"ResultValue": "2", "ResultText": "Option 2"}])
+    >>> Zn.setResultType("multiselect")
+
+An analysis without result set is considered empty:
+
+    >>> sample = new_sample([api.get_uid(Ni)])
+    >>> analysis = sample.getAnalyses(full_objects=True)[0]
+    >>> is_empty_result(analysis)
     True
 
-    >>> is_empty_result("")
-    True
-
-    >>> is_empty_result("  ")
-    True
-
-    >>> is_empty_result("12")
+    >>> analysis.setResult(12)
+    >>> is_empty_result(analysis)
     False
 
 A result of zero is not an empty result:
 
-    >>> is_empty_result("0")
-    False
+    >>> analysis.setResult(0)
+    >>> analysis.getResult()
+    '0'
 
-    >>> is_empty_result(0)
+    >>> is_empty_result(analysis)
     False
 
 Multi-valued results are stored as a JSON list with the selected values, so
-they are empty when no value is selected, or when all the selected values are
-empty:
+they are empty when no option is selected, or when all the selected values
+are empty:
 
-    >>> is_empty_result("[]")
+    >>> sample = new_sample([api.get_uid(Zn)])
+    >>> analysis = sample.getAnalyses(full_objects=True)[0]
+    >>> analysis.setResult([])
+    >>> analysis.getResult()
+    '[]'
+
+    >>> is_empty_result(analysis)
     True
 
-    >>> is_empty_result('[""]')
+    >>> analysis.setResult(["", ""])
+    >>> is_empty_result(analysis)
     True
 
-    >>> is_empty_result('["", ""]')
-    True
-
-    >>> is_empty_result('["1", ""]')
+    >>> analysis.setResult(["1", ""])
+    >>> is_empty_result(analysis)
     False
 
-    >>> is_empty_result('["0"]')
+Result variables (interims) are taken into account as well:
+
+    >>> sample = new_sample([api.get_uid(Ni)])
+    >>> analysis = sample.getAnalyses(full_objects=True)[0]
+    >>> analysis.setResult(12)
+    >>> analysis.setInterimFields([
+    ...     {"keyword": "interim_1", "title": "Interim 1"}])
+    >>> is_empty_result(analysis)
+    True
+
+    >>> analysis.setInterimValue("interim_1", 0)
+    >>> is_empty_result(analysis)
+    False
+
+And so are multi-valued result variables:
+
+    >>> analysis.setInterimFields([{
+    ...     "keyword": "interim_1", "title": "Interim 1",
+    ...     "result_type": "multiselect",
+    ...     "choices": "1:Option 1|2:Option 2"}])
+    >>> analysis.setInterimValue("interim_1", [""])
+    >>> is_empty_result(analysis)
+    True
+
+    >>> analysis.setInterimValue("interim_1", ["2"])
+    >>> is_empty_result(analysis)
+    False
+
+Result variables that allow empty values are not evaluated, no matter whether
+the setting is stored as a boolean, like the Dexterity types do, or as the
+`"on"` value the Archetypes' records widget submits:
+
+    >>> def set_allow_empty(analysis, allow_empty):
+    ...     interims = analysis.getInterimFields()
+    ...     interims[0]["allow_empty"] = allow_empty
+    ...     analysis.setInterimFields(interims)
+
+    >>> analysis.setInterimValue("interim_1", [])
+    >>> is_empty_result(analysis)
+    True
+
+    >>> set_allow_empty(analysis, "on")
+    >>> is_empty_result(analysis)
+    False
+
+    >>> set_allow_empty(analysis, True)
+    >>> is_empty_result(analysis)
+    False
+
+    >>> set_allow_empty(analysis, False)
+    >>> is_empty_result(analysis)
+    True
+
+
+Check if a raw result value is empty
+....................................
+
+Single values are empty when no value is set:
+
+    >>> is_empty_value(None)
+    True
+
+    >>> is_empty_value("")
+    True
+
+    >>> is_empty_value("  ")
+    True
+
+    >>> is_empty_value("12")
+    False
+
+A value of zero is not empty:
+
+    >>> is_empty_value("0")
+    False
+
+    >>> is_empty_value(0)
+    False
+
+Multi-valued results are stored as a JSON list with the selected values, so
+they are empty when the list is empty or when all its values are empty:
+
+    >>> is_empty_value("[]")
+    True
+
+    >>> is_empty_value('[""]')
+    True
+
+    >>> is_empty_value('["", ""]')
+    True
+
+    >>> is_empty_value('["1", ""]')
+    False
+
+    >>> is_empty_value('["0"]')
     False
 
 Lists are supported as well, even if not JSON-serialized:
 
-    >>> is_empty_result([])
+    >>> is_empty_value([])
     True
 
-    >>> is_empty_result(["", None])
+    >>> is_empty_value(["", None])
     True
 
-    >>> is_empty_result(["1"])
+    >>> is_empty_value(["1"])
     False

--- a/src/senaite/core/tests/doctests/API_analysis.rst
+++ b/src/senaite/core/tests/doctests/API_analysis.rst
@@ -1155,6 +1155,34 @@ the setting is stored as a boolean, like the Dexterity types do, or as the
     False
 
 
+Reference analyses (blanks and controls) and duplicates are supported too:
+
+    >>> control = controls[0]
+    >>> control.setResult("")
+    >>> is_result_complete(control)
+    False
+
+    >>> control.setResult(10)
+    >>> is_result_complete(control)
+    True
+
+    >>> duplicate = duplicates[0]
+    >>> duplicate.setResult("")
+    >>> is_result_complete(duplicate)
+    False
+
+    >>> duplicate.setResult(10)
+    >>> is_result_complete(duplicate)
+    True
+
+Objects that are not analyses are not supported:
+
+    >>> is_result_complete(sample)
+    Traceback (most recent call last):
+    ...
+    APIError: ... is not supported.
+
+
 Check if a raw result value is empty
 ....................................
 

--- a/src/senaite/core/tests/doctests/AnalysesListingResultVariables.rst
+++ b/src/senaite/core/tests/doctests/AnalysesListingResultVariables.rst
@@ -1,0 +1,130 @@
+Result variables in the analyses listing
+----------------------------------------
+
+Result variables (interims) with choices set are rendered as a selection
+list. Whether an empty option is offered depends on the `allow_empty`
+setting of the result variable.
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t AnalysesListingResultVariables
+
+
+Test Setup
+..........
+
+Needed Imports:
+
+    >>> from bika.lims import api
+    >>> from bika.lims.browser.analyses.view import AnalysesView
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+    >>> from bika.lims.workflow import doActionFor as do_action_for
+    >>> from DateTime import DateTime
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+
+Functional Helpers:
+
+    >>> def new_sample(services):
+    ...     values = {
+    ...         "Client": client.UID(),
+    ...         "Contact": contact.UID(),
+    ...         "DateSampled": date_now,
+    ...         "SampleType": sampletype.UID()}
+    ...     service_uids = map(api.get_uid, services)
+    ...     sample = create_analysisrequest(client, request, values, service_uids)
+    ...     transitioned = do_action_for(sample, "receive")
+    ...     return sample
+
+    >>> def get_choices(sample, keyword):
+    ...     view = AnalysesView(sample, request)
+    ...     view.update()
+    ...     items = view.folderitems()
+    ...     choices = items[0].get("choices", {}).get(keyword, [])
+    ...     return [choice["ResultValue"] for choice in choices]
+
+    >>> def set_interim(analysis, **kwargs):
+    ...     interim = {"keyword": "interim_1", "title": "Interim 1"}
+    ...     interim.update(kwargs)
+    ...     analysis.setInterimFields([interim])
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = portal.setup
+    >>> bikasetup = portal.bika_setup
+    >>> date_now = DateTime().strftime("%Y-%m-%d")
+
+We need to create some basic objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ["LabManager"])
+    >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH")
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(setup.sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> labcontact = api.create(bikasetup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = api.create(setup.analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> Cu = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Category=category.UID())
+
+
+Multi-valued result variables
+.............................
+
+Create a sample and set a multi-valued result variable that does not allow
+empty values. No empty option is offered, so the analyst is forced to select
+at least one of the choices:
+
+    >>> sample = new_sample([Cu])
+    >>> analysis = sample.getAnalyses(full_objects=True)[0]
+    >>> set_interim(analysis, result_type="multiselect",
+    ...             choices="1:Option 1|2:Option 2", allow_empty=False)
+    >>> get_choices(sample, "interim_1")
+    ['1', '2']
+
+When the result variable allows empty values, the empty option is offered.
+Dexterity types store this setting as a boolean:
+
+    >>> set_interim(analysis, result_type="multiselect",
+    ...             choices="1:Option 1|2:Option 2", allow_empty=True)
+    >>> get_choices(sample, "interim_1")
+    ['', '1', '2']
+
+While the Archetypes' records widget submits it as `"on"`:
+
+    >>> set_interim(analysis, result_type="multiselect",
+    ...             choices="1:Option 1|2:Option 2", allow_empty="on")
+    >>> get_choices(sample, "interim_1")
+    ['', '1', '2']
+
+A result variable for which the setting was never submitted does not allow
+empty values:
+
+    >>> set_interim(analysis, result_type="multiselect",
+    ...             choices="1:Option 1|2:Option 2")
+    >>> get_choices(sample, "interim_1")
+    ['1', '2']
+
+
+Single-valued result variables
+..............................
+
+For single-valued result variables without a value set, the empty option is
+always offered, so the default value is not silently captured as a result:
+
+    >>> set_interim(analysis, result_type="select",
+    ...             choices="1:Option 1|2:Option 2", allow_empty=False)
+    >>> get_choices(sample, "interim_1")
+    ['', '1', '2']
+
+But not when a value is already set and empty values are not allowed:
+
+    >>> set_interim(analysis, result_type="select", value="2",
+    ...             choices="1:Option 1|2:Option 2", allow_empty=False)
+    >>> get_choices(sample, "interim_1")
+    ['1', '2']
+
+    >>> set_interim(analysis, result_type="select", value="2",
+    ...             choices="1:Option 1|2:Option 2", allow_empty=True)
+    >>> get_choices(sample, "interim_1")
+    ['', '1', '2']

--- a/src/senaite/core/tests/doctests/WorkflowAnalysisSubmit.rst
+++ b/src/senaite/core/tests/doctests/WorkflowAnalysisSubmit.rst
@@ -547,6 +547,153 @@ And again, the Analysis Request will follow:
     'to_be_verified'
 
 
+Submission of results with multiple values
+..........................................
+
+Multi-valued results, either from the result field or from a result variable
+(interim), are stored as a JSON list with the selected values. Therefore, a
+result without any value selected is stored as an empty list, that has to be
+considered as an empty result as well.
+
+Create a service with a multiple selection list of result options:
+
+    >>> Zn = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Zinc", Keyword="Zn", Category=category.UID())
+    >>> Zn.setResultOptions([
+    ...     {"ResultValue": "1", "ResultText": "Option 1"},
+    ...     {"ResultValue": "2", "ResultText": "Option 2"}])
+    >>> Zn.setResultType("multiselect")
+
+Create an Analysis Request:
+
+    >>> ar = new_ar([Zn])
+    >>> analysis = ar.getAnalyses(full_objects=True)[0]
+
+Cannot submit when no option is selected:
+
+    >>> analysis.setResult([])
+    >>> analysis.getResult()
+    '[]'
+
+    >>> transitioned = do_action_for(analysis, "submit")
+    >>> transitioned[0]
+    False
+
+    >>> api.get_workflow_status_of(analysis)
+    'unassigned'
+
+Neither when the selection contains empty values only:
+
+    >>> analysis.setResult(["", ""])
+    >>> analysis.getResult()
+    '["", ""]'
+
+    >>> transitioned = do_action_for(analysis, "submit")
+    >>> transitioned[0]
+    False
+
+    >>> api.get_workflow_status_of(analysis)
+    'unassigned'
+
+But it will work as soon as at least one option is selected:
+
+    >>> analysis.setResult(["1", ""])
+    >>> transitioned = do_action_for(analysis, "submit")
+    >>> transitioned[0]
+    True
+
+    >>> api.get_workflow_status_of(analysis)
+    'to_be_verified'
+
+The same applies to multi-valued result variables (interims):
+
+    >>> Zn.setInterimFields([{
+    ...     "keyword": "interim_1", "title": "Interim 1",
+    ...     "result_type": "multiselect",
+    ...     "choices": "1:Option 1|2:Option 2"}])
+    >>> ar = new_ar([Zn])
+    >>> analysis = ar.getAnalyses(full_objects=True)[0]
+    >>> analysis.setResult(["1"])
+
+Cannot submit when no value is selected for the result variable:
+
+    >>> analysis.setInterimValue("interim_1", [])
+    >>> analysis.getInterimValue("interim_1")
+    '[]'
+
+    >>> transitioned = do_action_for(analysis, "submit")
+    >>> transitioned[0]
+    False
+
+    >>> api.get_workflow_status_of(analysis)
+    'unassigned'
+
+Neither when the selection contains empty values only:
+
+    >>> analysis.setInterimValue("interim_1", [""])
+    >>> analysis.getInterimValue("interim_1")
+    '[""]'
+
+    >>> transitioned = do_action_for(analysis, "submit")
+    >>> transitioned[0]
+    False
+
+    >>> api.get_workflow_status_of(analysis)
+    'unassigned'
+
+But it will work as soon as at least one value is selected:
+
+    >>> analysis.setInterimValue("interim_1", ["2"])
+    >>> transitioned = do_action_for(analysis, "submit")
+    >>> transitioned[0]
+    True
+
+    >>> api.get_workflow_status_of(analysis)
+    'to_be_verified'
+
+
+Submission of results for result variables that allow empty values
+..................................................................
+
+Result variables can be configured to allow empty values, either with the
+boolean value the Dexterity types store or with the `"on"` value the
+Archetypes' records widget submits:
+
+    >>> ar = new_ar([Zn])
+    >>> analysis = ar.getAnalyses(full_objects=True)[0]
+    >>> analysis.setResult(["1"])
+    >>> analysis.setInterimValue("interim_1", [])
+
+    >>> transitioned = do_action_for(analysis, "submit")
+    >>> transitioned[0]
+    False
+
+    >>> def set_allow_empty(analysis, allow_empty):
+    ...     interims = analysis.getInterimFields()
+    ...     interims[0]["allow_empty"] = allow_empty
+    ...     analysis.setInterimFields(interims)
+
+    >>> set_allow_empty(analysis, "on")
+    >>> transitioned = do_action_for(analysis, "submit")
+    >>> transitioned[0]
+    True
+
+    >>> api.get_workflow_status_of(analysis)
+    'to_be_verified'
+
+    >>> ar = new_ar([Zn])
+    >>> analysis = ar.getAnalyses(full_objects=True)[0]
+    >>> analysis.setResult(["1"])
+    >>> analysis.setInterimValue("interim_1", [""])
+    >>> set_allow_empty(analysis, True)
+
+    >>> transitioned = do_action_for(analysis, "submit")
+    >>> transitioned[0]
+    True
+
+    >>> api.get_workflow_status_of(analysis)
+    'to_be_verified'
+
+
 Submission of results for analyses with interim calculation
 ...........................................................
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Analyses with multi-valued results can be submitted without any value selected, and the sample can then be verified and published with no result at all. This affects both multi-valued results (result options of type `multiselect`, `multiselect_duplicates` or `multichoice`) and result variables (interims) with the equivalent `result_type`.

## Current behavior before PR

Multi-valued results are serialized by `setResult` and `setInterimValue` as a JSON list with the selected values, so an empty selection is stored as the string `"[]"`, or as `'[""]'` when the empty option is submitted. The submit guard evaluated emptiness as follows:

```python
    if not analysis.getResult():
        return False
    ...
    if interim.get("value") in [None, ""]:
        return False
```

Both stored values are non-empty strings, so the guard let the analysis through. The analyses listing already resolved multi-valued interims correctly in `get_formatted_interim` (via `api.to_list`), so the guard was simply out of sync with the formatter that renders the very same values.

The `allow_empty` setting of a result variable was also evaluated inconsistently: the submit guard accepted several truthy spellings through a local tuple, while the analyses listing compared against `"on"` only. Since the migration of Calculation to Dexterity stores that subfield as a boolean, the listing stopped offering the empty option for result variables that allow empty values.

## Desired behavior after PR is merged

An analysis cannot be submitted unless its result, and every result variable that does not allow empty values, has a value. Empty multi-valued results such as `[]`, `[""]` and `["", ""]` are recognized as empty, while valid values, including `0`, are still accepted. `allow_empty` is evaluated the same way everywhere.

Added to `bika.lims.api`:

- `to_bool(value, default=False)`

Added to `bika.lims.api.analysis`:

- `is_result_complete(brain_or_object)`, that returns whether the analysis passed in has its result and all its required result variables captured
- `is_empty_result_value(value)`, that returns whether the raw value of a result or of a result variable is empty, multi-valued ones included

Both the submit guard and the analyses listing rely on them, so the storage format of a result is no longer a detail every caller has to know about.

As a drive-by, the guard clauses in `bika.lims.api.analysis` now reuse the module's own `is_analysis`, `is_reference_analysis` and `is_duplicate_analysis` predicates instead of checking the interfaces directly, with the shorter error message used elsewhere in the api.

Tests: `WorkflowAnalysisSubmit.rst` covers the submission of empty and non-empty multi-valued results and result variables, `API_analysis.rst` covers the new functions on routine, reference and duplicate analyses, `API.rst` covers `to_bool`, and the new `AnalysesListingResultVariables.rst` covers the options offered for result variables with choices in the analyses listing.

Note for add-ons: a result variable that may legitimately be left empty has to declare `allow_empty`. This was already the case for values stored as an empty string, and applies now to empty multi-valued selections as well. `senaite.ast` has one such case, the `Report extrapolated` interim, that its own guard adapter already skips.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
